### PR TITLE
[CI] Add maven test github action, add Clock to PromptTemplate, separate some tests to Integration Tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,22 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Test
+        run: mvn --batch-mode test
+
+# TODO's
+#  - setup integration tests
+#     - these require an openAI (and hugging face, etc) token
+#     - do so that they always run for commits on main
+#     - make the running be manually triggered for PRs (we don't want to burn through credits)

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/input/PromptTemplateTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/input/PromptTemplateTest.java
@@ -2,9 +2,7 @@ package dev.langchain4j.model.input;
 
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.time.*;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,7 +13,7 @@ class PromptTemplateTest {
     @Test
     void should_create_prompt_from_template_with_single_variable() {
 
-        PromptTemplate promptTemplate = new PromptTemplate("My name is {{it}}.");
+        PromptTemplate promptTemplate = PromptTemplate.from("My name is {{it}}.");
 
         Prompt prompt = promptTemplate.apply("Klaus");
 
@@ -25,7 +23,7 @@ class PromptTemplateTest {
     @Test
     void should_create_prompt_from_template_with_multiple_variables() {
 
-        PromptTemplate promptTemplate = new PromptTemplate("My name is {{name}} {{surname}}.");
+        PromptTemplate promptTemplate = PromptTemplate.from("My name is {{name}} {{surname}}.");
 
         Map<String, Object> variables = new HashMap<>();
         variables.put("name", "Klaus");
@@ -41,7 +39,7 @@ class PromptTemplateTest {
     @Test
     void should_provide_date_automatically() {
 
-        PromptTemplate promptTemplate = new PromptTemplate("My name is {{it}} and today is {{current_date}}");
+        PromptTemplate promptTemplate = PromptTemplate.from("My name is {{it}} and today is {{current_date}}");
 
         Prompt prompt = promptTemplate.apply("Klaus");
 
@@ -51,20 +49,24 @@ class PromptTemplateTest {
     @Test
     void should_provide_time_automatically() {
 
-        PromptTemplate promptTemplate = new PromptTemplate("My name is {{it}} and now is {{current_time}}");
+        Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+
+        PromptTemplate promptTemplate = PromptTemplate.from("My name is {{it}} and now is {{current_time}}", clock);
 
         Prompt prompt = promptTemplate.apply("Klaus");
 
-        assertThat(prompt.text()).isEqualTo("My name is Klaus and now is " + LocalTime.now());
+        assertThat(prompt.text()).isEqualTo("My name is Klaus and now is " + LocalTime.now(clock));
     }
 
     @Test
     void should_provide_date_and_time_automatically() {
 
-        PromptTemplate promptTemplate = new PromptTemplate("My name is {{it}} and now is {{current_date_time}}");
+        Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+
+        PromptTemplate promptTemplate = PromptTemplate.from("My name is {{it}} and now is {{current_date_time}}", clock);
 
         Prompt prompt = promptTemplate.apply("Klaus");
 
-        assertThat(prompt.text()).isEqualTo("My name is Klaus and now is " + LocalDateTime.now());
+        assertThat(prompt.text()).isEqualTo("My name is Klaus and now is " + LocalDateTime.now(clock));
     }
 }

--- a/langchain4j/pom.xml
+++ b/langchain4j/pom.xml
@@ -208,6 +208,20 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <!-- failsafe will be in charge of running the integration tests (everything that ends in IT) -->
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 
@@ -239,7 +253,6 @@
                 </plugins>
             </build>
         </profile>
-
     </profiles>
 
 </project>

--- a/langchain4j/src/main/java/dev/langchain4j/chain/ConversationalRetrievalChain.java
+++ b/langchain4j/src/main/java/dev/langchain4j/chain/ConversationalRetrievalChain.java
@@ -28,7 +28,7 @@ public class ConversationalRetrievalChain implements Chain<String, String> {
 
     private static final DocumentSplitter DEFAULT_DOCUMENT_SPLITTER = new ParagraphSplitter();
     private static final EmbeddingStore<DocumentSegment> DEFAULT_EMBEDDING_STORE = new InMemoryEmbeddingStore();
-    private static final PromptTemplate DEFAULT_PROMPT_TEMPLATE = new PromptTemplate("Answer the following question to the best of your ability: {{question}}\n\nBase your answer on the following information:\n{{information}}");
+    private static final PromptTemplate DEFAULT_PROMPT_TEMPLATE = PromptTemplate.from("Answer the following question to the best of your ability: {{question}}\n\nBase your answer on the following information:\n{{information}}");
 
     private final DocumentLoader documentLoader;
     private final DocumentSplitter documentSplitter;

--- a/langchain4j/src/test/java/dev/langchain4j/model/huggingface/HuggingFaceChatModelIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/model/huggingface/HuggingFaceChatModelIT.java
@@ -12,7 +12,7 @@ import static dev.langchain4j.model.huggingface.HuggingFaceModelName.TII_UAE_FAL
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class HuggingFaceChatModelTest {
+class HuggingFaceChatModelIT {
 
     @Test
     public void testWhenNullAccessToken() {

--- a/langchain4j/src/test/java/dev/langchain4j/model/huggingface/HuggingFaceEmbeddingModelIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/model/huggingface/HuggingFaceEmbeddingModelIT.java
@@ -10,7 +10,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class HuggingFaceEmbeddingModelTest {
+class HuggingFaceEmbeddingModelIT {
 
     HuggingFaceEmbeddingModel model = HuggingFaceEmbeddingModel.builder()
             .accessToken(System.getenv("HF_API_KEY"))

--- a/langchain4j/src/test/java/dev/langchain4j/model/huggingface/HuggingFaceLanguageModelIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/model/huggingface/HuggingFaceLanguageModelIT.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class HuggingFaceLanguageModelTest {
+class HuggingFaceLanguageModelIT {
 
     @Test
     public void testWhenNullAccessToken() {

--- a/langchain4j/src/test/java/dev/langchain4j/model/openai/OpenAiModerationModelIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/model/openai/OpenAiModerationModelIT.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class OpenAiModerationModelTest {
+class OpenAiModerationModelIT {
 
     ModerationModel model = OpenAiModerationModel.builder()
             .apiKey(System.getenv("OPENAI_API_KEY"))

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesIT.java
@@ -27,7 +27,7 @@ import java.util.List;
 import static dev.langchain4j.data.message.AiMessage.aiMessage;
 import static dev.langchain4j.data.message.SystemMessage.systemMessage;
 import static dev.langchain4j.data.message.UserMessage.userMessage;
-import static dev.langchain4j.service.AiServicesTest.Sentiment.POSITIVE;
+import static dev.langchain4j.service.AiServicesIT.Sentiment.POSITIVE;
 import static java.time.Month.JULY;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class AiServicesTest {
+public class AiServicesIT {
 
     @Spy
     ChatLanguageModel chatLanguageModel = OpenAiChatModel.builder()


### PR DESCRIPTION
This PR:
 - adds a github action for running _unit tests_
 - tests that require an OpenAI/HuggingFace token and hit their API are now considered integration tests (and have been renamed to end in `IT`)
 - integration tests are now run through a separate goal (`mvn integration-test`) via the `maven-failsafe-plugin`
 - to fix the `PromptTemplate` tests a `Clock` has been added to that class. Its constructor is now private: whether this is the convention we want to follow can be discussed