### PR TITLE
[CI] automated license check as part of CI (Apache 2.0/MIT/Eclipse)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,6 +15,20 @@ jobs:
       - name: Test
         run: mvn --batch-mode test
 
+  # For checking some compliance things (require a recent JDK due to plugins so in a separate step)
+  compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+        # Check we only rely on permissive licenses in the main parts of the library:
+      - name: License Compliance
+        run: mvn -P compliance -pl langchain4j,langchain4j-core,langchain4j-spring-boot-starter org.honton.chas:license-maven-plugin:compliance
+
 # TODO's
 #  - setup integration tests
 #     - these require an openAI (and hugging face, etc) token

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -173,6 +173,48 @@
             </build>
         </profile>
 
+        <profile>
+            <id>compliance</id>
+            <activation>
+                <property>
+                    <name>compliance</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.honton.chas</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <version>0.0.3</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>compliance</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <scopes>compile,runtime,provided,test</scopes>
+                            <acceptableLicenses>
+                                <license>
+                                    <name>(Apache License, Version 2\.0)|(Apache-2\.0)</name>
+                                    <url>https?://www\.apache\.org/licenses/LICENSE-2\.0</url>
+                                </license>
+                                <license>
+                                    <name>(The MIT License|MIT License)</name>
+                                    <url>(https?://opensource.org/licenses/MIT|https://projectlombok.org/LICENSE)</url>
+                                </license>
+                                <license>
+                                    <name>Eclipse Public License v2.0</name>
+                                    <url>https?://www.eclipse.org/legal/epl-v20\.html</url>
+                                </license>
+                            </acceptableLicenses>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 
 </project>

--- a/langchain4j-spring-boot-starter/pom.xml
+++ b/langchain4j-spring-boot-starter/pom.xml
@@ -130,7 +130,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 
@@ -158,6 +157,48 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>compliance</id>
+            <activation>
+                <property>
+                    <name>compliance</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.honton.chas</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <version>0.0.3</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>compliance</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <scopes>compile,runtime,provided,test</scopes>
+                            <acceptableLicenses>
+                                <license>
+                                    <name>(Apache License, Version 2\.0)|(Apache-2\.0)|(The Apache Software License, Version 2\.0)</name>
+                                    <url>https?://www\.apache\.org/licenses/LICENSE-2\.0</url>
+                                </license>
+                                <license>
+                                    <name>(The MIT License|MIT License)</name>
+                                    <url>(https?://opensource.org/licenses/MIT|https://projectlombok.org/LICENSE)</url>
+                                </license>
+                                <license>
+                                    <name>Eclipse Public License v2.0</name>
+                                    <url>https?://www.eclipse.org/legal/epl-v20\.html</url>
+                                </license>
+                            </acceptableLicenses>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/langchain4j/pom.xml
+++ b/langchain4j/pom.xml
@@ -253,6 +253,48 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>compliance</id>
+            <activation>
+                <property>
+                    <name>compliance</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.honton.chas</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <version>0.0.3</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>compliance</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <scopes>compile,runtime,provided,test</scopes>
+                            <acceptableLicenses>
+                                <license>
+                                    <name>(Apache License, Version 2\.0)|(Apache-2\.0)|(The Apache Software License, Version 2\.0)</name>
+                                    <url>https?://www\.apache\.org/licenses/LICENSE-2\.0</url>
+                                </license>
+                                <license>
+                                    <name>(The MIT License|MIT License)</name>
+                                    <url>(https?://opensource.org/licenses/MIT|https://projectlombok.org/LICENSE)</url>
+                                </license>
+                                <license>
+                                    <name>Eclipse Public License v2.0</name>
+                                    <url>https?://www.eclipse.org/legal/epl-v20\.html</url>
+                                </license>
+                            </acceptableLicenses>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
The title says it all. Relying on [this maven plugin](https://github.com/chonton/license-maven-plugin) for it.

Note that this adds a separate build step because we need a more recent JDK to run the needed plugin.