### PR TITLE
[build] run workflows on open PR instead of just push

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,6 @@
 name: Java CI
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
So that external PRs get the tests run as well