### PR TITLE
[ci] let the compliance check run on all modules

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,7 @@ jobs:
           distribution: 'temurin'
         # Check we only rely on permissive licenses in the main parts of the library:
       - name: License Compliance
-        run: mvn -P compliance -pl langchain4j,langchain4j-core,langchain4j-spring-boot-starter org.honton.chas:license-maven-plugin:compliance
+        run: mvn -P compliance org.honton.chas:license-maven-plugin:compliance
 
 # TODO's
 #  - setup integration tests

--- a/langchain4j-weaviate/pom.xml
+++ b/langchain4j-weaviate/pom.xml
@@ -36,6 +36,19 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.honton.chas</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <!-- The weaviate client has a BSD-3 license, see https://github.com/weaviate/java-client/blob/main/LICENSE -->
+                    <skipCompliance>true</skipCompliance>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <licenses>
         <license>
             <name>Apache-2.0</name>


### PR DESCRIPTION
Some leftovers from an earlier (and now incorrect) CI configuration.

Modules that don't need to comply with the licenses need to deactivate the relevant plugin on a case-by-case basis.