### PR TITLE
Add Support for OpenSearch as Embedding Store

### DIFF
--- a/langchain4j-opensearch/pom.xml
+++ b/langchain4j-opensearch/pom.xml
@@ -24,13 +24,13 @@
         </dependency>
 
         <dependency>
-            <groupId>org.opensearch.client</groupId>
-            <artifactId>opensearch-java</artifactId>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.opensearch.client</groupId>
-            <artifactId>opensearch-rest-client</artifactId>
+            <artifactId>opensearch-java</artifactId>
         </dependency>
 
         <dependency>

--- a/langchain4j-opensearch/pom.xml
+++ b/langchain4j-opensearch/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-parent</artifactId>
+        <version>0.23.0</version>
+        <relativePath>../langchain4j-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-opensearch</artifactId>
+    <packaging>jar</packaging>
+
+    <name>LangChain4j integration with OpenSearch</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensearch.client</groupId>
+            <artifactId>opensearch-java</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensearch.client</groupId>
+            <artifactId>opensearch-rest-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensearch</groupId>
+            <artifactId>opensearch-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+</project>

--- a/langchain4j-opensearch/pom.xml
+++ b/langchain4j-opensearch/pom.xml
@@ -34,6 +34,21 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>opensearch</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/Document.java
+++ b/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/Document.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.store.embedding.opensearch;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * OpenSearch document object, for the purpose of construct document object from embedding and text segment
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+class Document {
+
+    private float[] values;
+    private String text;
+    private Map<String, String> metadata;
+    
+}

--- a/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStore.java
+++ b/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStore.java
@@ -1,0 +1,326 @@
+package dev.langchain4j.store.embedding.opensearch;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestClientBuilder;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch._types.InlineScript;
+import org.opensearch.client.opensearch._types.mapping.Property;
+import org.opensearch.client.opensearch._types.mapping.TextProperty;
+import org.opensearch.client.opensearch._types.mapping.TypeMapping;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.ScriptScoreQuery;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.endpoints.BooleanResponse;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static dev.langchain4j.internal.Utils.*;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Represents an <a href="https://opensearch.org/">OpenSearch</a> index as an
+ * embedding store. This implementation uses K-NN and the cosinesimil space type.
+ */
+public class OpenSearchEmbeddingStore implements EmbeddingStore<TextSegment> {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenSearchEmbeddingStore.class);
+
+    private final String indexName;
+    private final OpenSearchClient client;
+
+    /**
+     * Creates an instance of OpenSearchEmbeddingStore.
+     *
+     * @param serverUrl OpenSearch Server URL
+     * @param apiKey    OpenSearch API key (optional)
+     * @param userName  OpenSearch userName (optional)
+     * @param password  OpenSearch password (optional)
+     * @param indexName OpenSearch index name (optional). Default value: "default"
+     */
+    public OpenSearchEmbeddingStore(String serverUrl,
+                                       String apiKey,
+                                       String userName,
+                                       String password,
+                                       String indexName) {
+
+        HttpHost host = HttpHost.create(serverUrl);
+        RestClientBuilder rcb = RestClient.builder(host);
+
+        if (!isNullOrBlank(userName) && !isNullOrBlank(password)) {
+            BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(new AuthScope(host), new UsernamePasswordCredentials(userName, password));
+            rcb.setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
+                @Override
+                public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+                    return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                }
+            });
+        }
+
+        if (!isNullOrBlank(apiKey)) {
+            Header[] defaultHeaders = new Header[]{
+                new BasicHeader("Authorization", "ApiKey " + apiKey)
+            };
+            rcb.setDefaultHeaders(defaultHeaders);
+        }
+
+        RestClient restClient = rcb.build();
+        OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+        
+        this.client = new OpenSearchClient(transport);
+        this.indexName = ensureNotNull(indexName, "indexName");
+
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String serverUrl;
+        private String apiKey;
+        private String userName;
+        private String password;
+        private String indexName = "default";
+
+        public Builder serverUrl(String serverUrl) {
+            this.serverUrl = serverUrl;
+            return this;
+        }
+
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public Builder userName(String userName) {
+            this.userName = userName;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder indexName(String indexName) {
+            this.indexName = indexName;
+            return this;
+        }
+
+        public OpenSearchEmbeddingStore build() {
+            return new OpenSearchEmbeddingStore(serverUrl, apiKey, userName, password, indexName);
+        }
+
+    }
+
+    @Override
+    public String add(Embedding embedding) {
+        String id = randomUUID();
+        add(id, embedding);
+        return id;
+    }
+
+    @Override
+    public void add(String id, Embedding embedding) {
+        addInternal(id, embedding, null);
+    }
+
+    @Override
+    public String add(Embedding embedding, TextSegment textSegment) {
+        String id = randomUUID();
+        addInternal(id, embedding, textSegment);
+        return id;
+    }
+
+    @Override
+    public List<String> addAll(List<Embedding> embeddings) {
+        List<String> ids = embeddings.stream()
+                .map(ignored -> randomUUID())
+                .collect(toList());
+        addAllInternal(ids, embeddings, null);
+        return ids;
+    }
+
+    @Override
+    public List<String> addAll(List<Embedding> embeddings, List<TextSegment> embedded) {
+        List<String> ids = embeddings.stream()
+                .map(ignored -> randomUUID())
+                .collect(toList());
+        addAllInternal(ids, embeddings, embedded);
+        return ids;
+    }
+
+    /**
+     * This implementation uses the exact k-NN with scoring script to calculate
+     * See https://opensearch.org/docs/latest/search-plugins/knn/knn-score-script/
+     */
+    @Override
+    public List<EmbeddingMatch<TextSegment>> findRelevant(Embedding referenceEmbedding, int maxResults, double minScore) {
+        List<EmbeddingMatch<TextSegment>> matches = null;
+        try {
+            ScriptScoreQuery scriptScoreQuery = buildDefaultScriptScoreQuery(referenceEmbedding.vector(), (float) minScore);
+            SearchResponse<Document> response = client.search(
+                SearchRequest.of(s -> s.index(indexName)
+                    .query(n -> n.scriptScore(scriptScoreQuery))
+                    .size(maxResults)),
+                Document.class
+            );
+            matches = toEmbeddingMatch(response);
+        } catch (IOException ex) {
+            log.error("[I/O OpenSearch Exception]", ex);
+            throw new OpenSearchRequestFailedException(ex.getMessage());
+        }
+        return matches;
+    }
+
+    private ScriptScoreQuery buildDefaultScriptScoreQuery(float[] vector, float minScore) throws JsonProcessingException {
+
+        return ScriptScoreQuery.of(q -> q.minScore(minScore)
+            .query(Query.of(qu -> qu.matchAll(m -> m)))
+            .script(s -> s.inline(InlineScript.of(i -> i
+                .source("knn_score")
+                .lang("knn")
+                .params("field", JsonData.of("values"))
+                .params("query_value", JsonData.of(vector))
+                .params("space_type", JsonData.of("cosinesimil")))))
+            .boost(0.5f));
+
+            // ===> From the OpenSearch documentation:
+            // "Cosine similarity returns a number between -1 and 1, and because OpenSearch
+            // relevance scores can't be below 0, the k-NN plugin adds 1 to get the final score."
+            // See https://opensearch.org/docs/latest/search-plugins/knn/knn-score-script
+            // Thus, the query applies a boost of `0.5` to keep score in the range [0, 1]
+
+    }
+
+    private void addInternal(String id, Embedding embedding, TextSegment embedded) {
+        addAllInternal(singletonList(id), singletonList(embedding), embedded == null ? null : singletonList(embedded));
+    }
+
+    private void addAllInternal(List<String> ids, List<Embedding> embeddings, List<TextSegment> embedded) {
+
+        if (isCollectionEmpty(ids) || isCollectionEmpty(embeddings)) {
+            log.info("[do not add empty embeddings to opensearch]");
+            return;
+        }
+
+        ensureTrue(ids.size() == embeddings.size(), "ids size is not equal to embeddings size");
+        ensureTrue(embedded == null || embeddings.size() == embedded.size(), "embeddings size is not equal to embedded size");
+
+        try {
+            createIndexIfNotExist(embeddings.get(0).dimensions());
+            bulk(ids, embeddings, embedded);
+        } catch (IOException ex) {
+            log.error("[I/O OpenSearch Exception]", ex);
+            throw new OpenSearchRequestFailedException(ex.getMessage());
+        }
+
+    }
+
+    private void createIndexIfNotExist(int dimension) throws IOException {
+        BooleanResponse response = client.indices().exists(c -> c.index(indexName));
+        if (!response.value()) {
+            client.indices()
+                .create(c -> c.index(indexName)
+                .settings(s -> s.knn(true))
+                .mappings(getDefaultMappings(dimension)));
+        }
+    }
+
+    private TypeMapping getDefaultMappings(int dimension) {
+        Map<String, Property> properties = new HashMap<>(4);
+        properties.put("text", Property.of(p -> p.text(TextProperty.of(t -> t))));
+        properties.put("values", Property.of(p -> p.knnVector(
+            k -> k.dimension(dimension)
+        )));
+        return TypeMapping.of(c -> c.properties(properties));
+    }
+
+    private void bulk(List<String> ids, List<Embedding> embeddings, List<TextSegment> embedded) throws IOException {
+
+        int size = ids.size();
+        BulkRequest.Builder bulkBuilder = new BulkRequest.Builder();
+
+        for (int i = 0; i < size; i++) {
+            int finalI = i;
+            Document document = Document.builder()
+                    .values(embeddings.get(i).vector())
+                    .text(embedded == null ? null : embedded.get(i).text())
+                    .metadata(embedded == null ? null : Optional.ofNullable(embedded.get(i).metadata())
+                        .map(Metadata::asMap)
+                        .orElse(null))
+                    .build();
+            bulkBuilder.operations(op -> op.index(
+                idx -> idx
+                    .index(indexName)
+                    .id(ids.get(finalI))
+                    .document(document)
+            ));
+        }
+
+        BulkResponse bulkResponse = client.bulk(bulkBuilder.build());
+
+        if (bulkResponse.errors()) {
+            for (BulkResponseItem item : bulkResponse.items()) {
+                if (item.error() != null) {
+                    ErrorCause errorCause = item.error();
+                    if (errorCause != null) {
+                        throw new OpenSearchRequestFailedException(
+                            "type: " + errorCause.type() + "," +
+                            "reason: " + errorCause.reason());
+                    }
+                }
+            }
+        }
+
+    }
+
+    private List<EmbeddingMatch<TextSegment>> toEmbeddingMatch(SearchResponse<Document> response) {
+        return response.hits().hits().stream()
+            .map(hit -> Optional.ofNullable(hit.source())
+                .map(document -> new EmbeddingMatch<>(
+                    hit.score(),
+                    hit.id(),
+                    new Embedding(document.getValues()),
+                    document.getText() == null
+                        ? null
+                        : TextSegment.from(document.getText(), new Metadata(document.getMetadata()))
+                )).orElse(null))
+        .collect(toList());
+    }
+
+}

--- a/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStore.java
+++ b/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStore.java
@@ -210,7 +210,7 @@ public class OpenSearchEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         public OpenSearchEmbeddingStore build() {
-            if (!isNullOrBlank(serviceName) || !isNullOrBlank(region) || options != null) {
+            if (!isNullOrBlank(serviceName) && !isNullOrBlank(region) && options != null) {
                 return new OpenSearchEmbeddingStore(
                     serverUrl, serviceName, region, options, indexName
                 );

--- a/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStore.java
+++ b/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStore.java
@@ -131,9 +131,9 @@ public class OpenSearchEmbeddingStore implements EmbeddingStore<TextSegment> {
      * OpenSearch clusters running as a fully managed service at AWS.
      *
      * @param serverUrl   OpenSearch Server URL.
-     * @param apiKey      OpenSearch API key (optional)
      * @param serviceName The AWS signing service name, one of `es` (Amazon OpenSearch) or `aoss` (Amazon OpenSearch Serverless).
      * @param region      The AWS region for which requests will be signed. This should typically match the region in `serverUrl`.
+     * @param options     The options to establish connection with the service. It must include which credentials should be used.
      * @param indexName   OpenSearch index name (optional). Default value: "default"
      */
     public OpenSearchEmbeddingStore(String serverUrl,
@@ -144,14 +144,9 @@ public class OpenSearchEmbeddingStore implements EmbeddingStore<TextSegment> {
 
         Region selectedRegion = Region.of(region);
 
-        AwsSdk2TransportOptions selectedOptions = options;
-        if (selectedOptions == null) {
-            selectedOptions = AwsSdk2TransportOptions.builder().build();
-        }
-
         SdkHttpClient httpClient = ApacheHttpClient.builder().build();
         OpenSearchTransport transport = new AwsSdk2Transport(
-            httpClient, serverUrl, serviceName, selectedRegion, selectedOptions
+            httpClient, serverUrl, serviceName, selectedRegion, options
         );
 
         this.client = new OpenSearchClient(transport);

--- a/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchRequestFailedException.java
+++ b/langchain4j-opensearch/src/main/java/dev/langchain4j/store/embedding/opensearch/OpenSearchRequestFailedException.java
@@ -1,0 +1,17 @@
+package dev.langchain4j.store.embedding.opensearch;
+
+class OpenSearchRequestFailedException extends RuntimeException {
+
+    public OpenSearchRequestFailedException() {
+        super();
+    }
+
+    public OpenSearchRequestFailedException(String message) {
+        super(message);
+    }
+
+    public OpenSearchRequestFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+}

--- a/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStoreAWSTest.java
+++ b/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStoreAWSTest.java
@@ -1,0 +1,273 @@
+package dev.langchain4j.store.embedding.opensearch;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.transport.aws.AwsSdk2TransportOptions;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.CosineSimilarity;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.RelevanceScore;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+
+@Disabled("Needs OpenSearch running with AWS")
+public class OpenSearchEmbeddingStoreAWSTest {
+
+    /**
+     * To run the tests locally, you have to provide an Amazon OpenSearch domain. The code uses
+     * the credentials stored locally in your machine. For more information about how to configure
+     * your credentials locally, see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html.
+     */
+
+    private final String domainEndpoint = "your-generated-domain-endpoint-with-no-https.us-east-1.es.amazonaws.com";
+    private final ProfileCredentialsProvider credentials = ProfileCredentialsProvider.create("default");
+
+    private final AwsSdk2TransportOptions transportOptions = AwsSdk2TransportOptions.builder()
+        .setCredentials(credentials)
+        .build();
+
+    private final EmbeddingStore<TextSegment> embeddingStore = OpenSearchEmbeddingStore.builder()
+        .serverUrl(domainEndpoint)
+        .serviceName("es")
+        .region("us-east-1")
+        .options(transportOptions)
+        .indexName(randomUUID())
+        .build();
+
+    private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    @Test
+    void should_add_embedding() throws InterruptedException {
+
+        Embedding embedding = embeddingModel.embed(randomUUID()).content();
+        String id = embeddingStore.add(embedding);
+        assertThat(id).isNotNull();
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
+        assertThat(relevant).hasSize(1);
+
+        EmbeddingMatch<TextSegment> match = relevant.get(0);
+        assertThat(match.score()).isCloseTo(1, withPercentage(1));
+        assertThat(match.embeddingId()).isEqualTo(id);
+        assertThat(match.embedding()).isEqualTo(embedding);
+        assertThat(match.embedded()).isNull();
+
+    }
+
+    @Test
+    void should_add_embedding_with_id() throws InterruptedException {
+
+        String id = randomUUID();
+        Embedding embedding = embeddingModel.embed(randomUUID()).content();
+        embeddingStore.add(id, embedding);
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
+        assertThat(relevant).hasSize(1);
+
+        EmbeddingMatch<TextSegment> match = relevant.get(0);
+        assertThat(match.score()).isCloseTo(1, withPercentage(1));
+        assertThat(match.embeddingId()).isEqualTo(id);
+        assertThat(match.embedding()).isEqualTo(embedding);
+        assertThat(match.embedded()).isNull();
+
+    }
+
+    @Test
+    void should_add_embedding_with_segment() throws InterruptedException {
+
+        TextSegment segment = TextSegment.from(randomUUID());
+        Embedding embedding = embeddingModel.embed(segment.text()).content();
+
+        String id = embeddingStore.add(embedding, segment);
+        assertThat(id).isNotNull();
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
+        assertThat(relevant).hasSize(1);
+
+        EmbeddingMatch<TextSegment> match = relevant.get(0);
+        assertThat(match.score()).isCloseTo(1, withPercentage(1));
+        assertThat(match.embeddingId()).isEqualTo(id);
+        assertThat(match.embedding()).isEqualTo(embedding);
+        assertThat(match.embedded()).isEqualTo(segment);
+
+    }
+
+    @Test
+    void should_add_embedding_with_segment_with_metadata() throws InterruptedException {
+
+        TextSegment segment = TextSegment.from(randomUUID(), Metadata.from("test-key", "test-value"));
+        Embedding embedding = embeddingModel.embed(segment.text()).content();
+
+        String id = embeddingStore.add(embedding, segment);
+        assertThat(id).isNotNull();
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
+        assertThat(relevant).hasSize(1);
+
+        EmbeddingMatch<TextSegment> match = relevant.get(0);
+        assertThat(match.score()).isCloseTo(1, withPercentage(1));
+        assertThat(match.embeddingId()).isEqualTo(id);
+        assertThat(match.embedding()).isEqualTo(embedding);
+        assertThat(match.embedded()).isEqualTo(segment);
+
+    }
+
+    @Test
+    void should_add_multiple_embeddings() throws InterruptedException {
+
+        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
+        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
+
+        List<String> ids = embeddingStore.addAll(asList(firstEmbedding, secondEmbedding));
+        assertThat(ids).hasSize(2);
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
+        assertThat(relevant).hasSize(2);
+
+        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
+        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
+        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
+        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
+        assertThat(firstMatch.embedded()).isNull();
+
+        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
+        assertThat(secondMatch.score()).isBetween(0d, 1d);
+        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
+        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
+        assertThat(secondMatch.embedded()).isNull();
+
+    }
+
+    @Test
+    void should_add_multiple_embeddings_with_segments() throws InterruptedException {
+
+        TextSegment firstSegment = TextSegment.from(randomUUID());
+        Embedding firstEmbedding = embeddingModel.embed(firstSegment.text()).content();
+        TextSegment secondSegment = TextSegment.from(randomUUID());
+        Embedding secondEmbedding = embeddingModel.embed(secondSegment.text()).content();
+
+        List<String> ids = embeddingStore.addAll(
+                asList(firstEmbedding, secondEmbedding),
+                asList(firstSegment, secondSegment)
+        );
+        assertThat(ids).hasSize(2);
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
+        assertThat(relevant).hasSize(2);
+
+        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
+        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
+        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
+        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
+        assertThat(firstMatch.embedded()).isEqualTo(firstSegment);
+
+        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
+        assertThat(secondMatch.score()).isBetween(0d, 1d);
+        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
+        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
+        assertThat(secondMatch.embedded()).isEqualTo(secondSegment);
+
+    }
+
+    @Test
+    void should_find_with_min_score() throws InterruptedException {
+
+        String firstId = randomUUID();
+        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
+        embeddingStore.add(firstId, firstEmbedding);
+
+        String secondId = randomUUID();
+        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
+        embeddingStore.add(secondId, secondEmbedding);
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
+        assertThat(relevant).hasSize(2);
+        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
+        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
+        assertThat(firstMatch.embeddingId()).isEqualTo(firstId);
+        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
+        assertThat(secondMatch.score()).isBetween(0d, 1d);
+        assertThat(secondMatch.embeddingId()).isEqualTo(secondId);
+
+        List<EmbeddingMatch<TextSegment>> relevant2 = embeddingStore.findRelevant(
+                firstEmbedding,
+                10,
+                secondMatch.score() - 0.01
+        );
+        assertThat(relevant2).hasSize(2);
+        assertThat(relevant2.get(0).embeddingId()).isEqualTo(firstId);
+        assertThat(relevant2.get(1).embeddingId()).isEqualTo(secondId);
+
+        List<EmbeddingMatch<TextSegment>> relevant3 = embeddingStore.findRelevant(
+                firstEmbedding,
+                10,
+                secondMatch.score()
+        );
+        assertThat(relevant3).hasSize(2);
+        assertThat(relevant3.get(0).embeddingId()).isEqualTo(firstId);
+        assertThat(relevant3.get(1).embeddingId()).isEqualTo(secondId);
+
+        List<EmbeddingMatch<TextSegment>> relevant4 = embeddingStore.findRelevant(
+                firstEmbedding,
+                10,
+                secondMatch.score() + 0.01
+        );
+        assertThat(relevant4).hasSize(1);
+        assertThat(relevant4.get(0).embeddingId()).isEqualTo(firstId);
+
+    }
+
+    @Test
+    void should_return_correct_score() throws InterruptedException {
+
+        Embedding embedding = embeddingModel.embed("hello").content();
+
+        String id = embeddingStore.add(embedding);
+        assertThat(id).isNotNull();
+
+        Embedding referenceEmbedding = embeddingModel.embed("hi").content();
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(referenceEmbedding, 1);
+        assertThat(relevant).hasSize(1);
+
+        EmbeddingMatch<TextSegment> match = relevant.get(0);
+        assertThat(match.score()).isCloseTo(
+                RelevanceScore.fromCosineSimilarity(CosineSimilarity.between(embedding, referenceEmbedding)),
+                withPercentage(1)
+        );
+
+    }
+
+    public static String randomUUID() {
+        return UUID.randomUUID().toString();
+    }
+
+}

--- a/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStoreLocalTest.java
+++ b/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStoreLocalTest.java
@@ -11,7 +11,6 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.RelevanceScore;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opensearch.testcontainers.OpensearchContainer;
@@ -25,8 +24,8 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Percentage.withPercentage;
 
-@Disabled("needs OpenSearch to be running locally")
-class OpenSearchEmbeddingStoreTest {
+@Disabled("Needs OpenSearch running locally")
+class OpenSearchEmbeddingStoreLocalTest {
 
     /**
      * To run the tests locally, you don't need to have OpenSearch up-and-running. This implementation
@@ -34,29 +33,20 @@ class OpenSearchEmbeddingStoreTest {
      * if you just execute the tests then a container will be spun up automatically for you.
      */
 
-    private static final String OPENSEARCH_FULL_IMAGE =
-        "opensearchproject/opensearch:2.10.0";
-
     @Container
     private static final OpensearchContainer opensearch =
-        new OpensearchContainer(DockerImageName.parse(OPENSEARCH_FULL_IMAGE));
+        new OpensearchContainer(DockerImageName.parse("opensearchproject/opensearch:2.10.0"));
 
-    private EmbeddingStore<TextSegment> embeddingStore;
+    private final EmbeddingStore<TextSegment> embeddingStore = OpenSearchEmbeddingStore.builder()
+        .serverUrl(opensearch.getHttpHostAddress())
+        .indexName(randomUUID())
+        .build();
+
     private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
 
     @BeforeAll
     static void startOpenSearch() {
         opensearch.start();
-    }
-
-    @BeforeEach
-    void setupOpenSearchEmbeddingStore() {
-        if (embeddingStore == null) {
-            embeddingStore = OpenSearchEmbeddingStore.builder()
-                .serverUrl(opensearch.getHttpHostAddress())
-                .indexName(randomUUID())
-                .build();
-        }
     }
 
     @Test

--- a/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStoreTest.java
+++ b/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStoreTest.java
@@ -1,0 +1,280 @@
+package dev.langchain4j.store.embedding.opensearch;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.CosineSimilarity;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.RelevanceScore;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+
+@Disabled("needs OpenSearch to be running locally")
+class OpenSearchEmbeddingStoreTest {
+
+    /**
+     * To run the tests locally, you don't need to have OpenSearch up-and-running. This implementation
+     * uses TestContainers (https://testcontainers.com) and the built-in support for OpenSearch. Thus,
+     * if you just execute the tests then a container will be spun up automatically for you.
+     */
+
+    private static final String OPENSEARCH_FULL_IMAGE =
+        "opensearchproject/opensearch:2.9.0";
+
+    @Container
+    private static final OpensearchContainer opensearch =
+        new OpensearchContainer(DockerImageName.parse(OPENSEARCH_FULL_IMAGE));
+
+    private EmbeddingStore<TextSegment> embeddingStore;
+    private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    @BeforeAll
+    static void startOpenSearch() {
+        opensearch.start();
+    }
+
+    @BeforeEach
+    void setupOpenSearchEmbeddingStore() {
+        if (embeddingStore == null) {
+            embeddingStore = OpenSearchEmbeddingStore.builder()
+                .serverUrl(opensearch.getHttpHostAddress())
+                .indexName(randomUUID())
+                .build();
+        }
+    }
+
+    @Test
+    void should_add_embedding() throws InterruptedException {
+
+        Embedding embedding = embeddingModel.embed(randomUUID()).content();
+        String id = embeddingStore.add(embedding);
+        assertThat(id).isNotNull();
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
+        assertThat(relevant).hasSize(1);
+
+        EmbeddingMatch<TextSegment> match = relevant.get(0);
+        assertThat(match.score()).isCloseTo(1, withPercentage(1));
+        assertThat(match.embeddingId()).isEqualTo(id);
+        assertThat(match.embedding()).isEqualTo(embedding);
+        assertThat(match.embedded()).isNull();
+
+    }
+
+    @Test
+    void should_add_embedding_with_id() throws InterruptedException {
+
+        String id = randomUUID();
+        Embedding embedding = embeddingModel.embed(randomUUID()).content();
+        embeddingStore.add(id, embedding);
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
+        assertThat(relevant).hasSize(1);
+
+        EmbeddingMatch<TextSegment> match = relevant.get(0);
+        assertThat(match.score()).isCloseTo(1, withPercentage(1));
+        assertThat(match.embeddingId()).isEqualTo(id);
+        assertThat(match.embedding()).isEqualTo(embedding);
+        assertThat(match.embedded()).isNull();
+
+    }
+
+    @Test
+    void should_add_embedding_with_segment() throws InterruptedException {
+
+        TextSegment segment = TextSegment.from(randomUUID());
+        Embedding embedding = embeddingModel.embed(segment.text()).content();
+
+        String id = embeddingStore.add(embedding, segment);
+        assertThat(id).isNotNull();
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
+        assertThat(relevant).hasSize(1);
+
+        EmbeddingMatch<TextSegment> match = relevant.get(0);
+        assertThat(match.score()).isCloseTo(1, withPercentage(1));
+        assertThat(match.embeddingId()).isEqualTo(id);
+        assertThat(match.embedding()).isEqualTo(embedding);
+        assertThat(match.embedded()).isEqualTo(segment);
+
+    }
+
+    @Test
+    void should_add_embedding_with_segment_with_metadata() throws InterruptedException {
+
+        TextSegment segment = TextSegment.from(randomUUID(), Metadata.from("test-key", "test-value"));
+        Embedding embedding = embeddingModel.embed(segment.text()).content();
+
+        String id = embeddingStore.add(embedding, segment);
+        assertThat(id).isNotNull();
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
+        assertThat(relevant).hasSize(1);
+
+        EmbeddingMatch<TextSegment> match = relevant.get(0);
+        assertThat(match.score()).isCloseTo(1, withPercentage(1));
+        assertThat(match.embeddingId()).isEqualTo(id);
+        assertThat(match.embedding()).isEqualTo(embedding);
+        assertThat(match.embedded()).isEqualTo(segment);
+
+    }
+
+    @Test
+    void should_add_multiple_embeddings() throws InterruptedException {
+
+        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
+        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
+
+        List<String> ids = embeddingStore.addAll(asList(firstEmbedding, secondEmbedding));
+        assertThat(ids).hasSize(2);
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
+        assertThat(relevant).hasSize(2);
+
+        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
+        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
+        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
+        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
+        assertThat(firstMatch.embedded()).isNull();
+
+        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
+        assertThat(secondMatch.score()).isBetween(0d, 1d);
+        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
+        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
+        assertThat(secondMatch.embedded()).isNull();
+
+    }
+
+    @Test
+    void should_add_multiple_embeddings_with_segments() throws InterruptedException {
+
+        TextSegment firstSegment = TextSegment.from(randomUUID());
+        Embedding firstEmbedding = embeddingModel.embed(firstSegment.text()).content();
+        TextSegment secondSegment = TextSegment.from(randomUUID());
+        Embedding secondEmbedding = embeddingModel.embed(secondSegment.text()).content();
+
+        List<String> ids = embeddingStore.addAll(
+                asList(firstEmbedding, secondEmbedding),
+                asList(firstSegment, secondSegment)
+        );
+        assertThat(ids).hasSize(2);
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
+        assertThat(relevant).hasSize(2);
+
+        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
+        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
+        assertThat(firstMatch.embeddingId()).isEqualTo(ids.get(0));
+        assertThat(firstMatch.embedding()).isEqualTo(firstEmbedding);
+        assertThat(firstMatch.embedded()).isEqualTo(firstSegment);
+
+        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
+        assertThat(secondMatch.score()).isBetween(0d, 1d);
+        assertThat(secondMatch.embeddingId()).isEqualTo(ids.get(1));
+        assertThat(secondMatch.embedding()).isEqualTo(secondEmbedding);
+        assertThat(secondMatch.embedded()).isEqualTo(secondSegment);
+
+    }
+
+    @Test
+    void should_find_with_min_score() throws InterruptedException {
+
+        String firstId = randomUUID();
+        Embedding firstEmbedding = embeddingModel.embed(randomUUID()).content();
+        embeddingStore.add(firstId, firstEmbedding);
+
+        String secondId = randomUUID();
+        Embedding secondEmbedding = embeddingModel.embed(randomUUID()).content();
+        embeddingStore.add(secondId, secondEmbedding);
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(firstEmbedding, 10);
+        assertThat(relevant).hasSize(2);
+        EmbeddingMatch<TextSegment> firstMatch = relevant.get(0);
+        assertThat(firstMatch.score()).isCloseTo(1, withPercentage(1));
+        assertThat(firstMatch.embeddingId()).isEqualTo(firstId);
+        EmbeddingMatch<TextSegment> secondMatch = relevant.get(1);
+        assertThat(secondMatch.score()).isBetween(0d, 1d);
+        assertThat(secondMatch.embeddingId()).isEqualTo(secondId);
+
+        List<EmbeddingMatch<TextSegment>> relevant2 = embeddingStore.findRelevant(
+                firstEmbedding,
+                10,
+                secondMatch.score() - 0.01
+        );
+        assertThat(relevant2).hasSize(2);
+        assertThat(relevant2.get(0).embeddingId()).isEqualTo(firstId);
+        assertThat(relevant2.get(1).embeddingId()).isEqualTo(secondId);
+
+        List<EmbeddingMatch<TextSegment>> relevant3 = embeddingStore.findRelevant(
+                firstEmbedding,
+                10,
+                secondMatch.score()
+        );
+        assertThat(relevant3).hasSize(2);
+        assertThat(relevant3.get(0).embeddingId()).isEqualTo(firstId);
+        assertThat(relevant3.get(1).embeddingId()).isEqualTo(secondId);
+
+        List<EmbeddingMatch<TextSegment>> relevant4 = embeddingStore.findRelevant(
+                firstEmbedding,
+                10,
+                secondMatch.score() + 0.01
+        );
+        assertThat(relevant4).hasSize(1);
+        assertThat(relevant4.get(0).embeddingId()).isEqualTo(firstId);
+
+    }
+
+    @Test
+    void should_return_correct_score() throws InterruptedException {
+
+        Embedding embedding = embeddingModel.embed("hello").content();
+
+        String id = embeddingStore.add(embedding);
+        assertThat(id).isNotNull();
+
+        Embedding referenceEmbedding = embeddingModel.embed("hi").content();
+
+        Thread.sleep(2000);
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(referenceEmbedding, 1);
+        assertThat(relevant).hasSize(1);
+
+        EmbeddingMatch<TextSegment> match = relevant.get(0);
+        assertThat(match.score()).isCloseTo(
+                RelevanceScore.fromCosineSimilarity(CosineSimilarity.between(embedding, referenceEmbedding)),
+                withPercentage(1)
+        );
+
+    }
+
+}

--- a/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStoreTest.java
+++ b/langchain4j-opensearch/src/test/java/dev/langchain4j/store/embedding/opensearch/OpenSearchEmbeddingStoreTest.java
@@ -35,7 +35,7 @@ class OpenSearchEmbeddingStoreTest {
      */
 
     private static final String OPENSEARCH_FULL_IMAGE =
-        "opensearchproject/opensearch:2.9.0";
+        "opensearchproject/opensearch:2.10.0";
 
     @Container
     private static final OpensearchContainer opensearch =

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -35,8 +35,8 @@
         <tinylog.version>2.6.2</tinylog.version>
         <spring-boot.version>2.7.14</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
+        <httpclient5.version>5.2.1</httpclient5.version>
         <opensearch-java.version>2.6.0</opensearch-java.version>
-        <opensearch-rest.version>2.10.0</opensearch-rest.version>
         <opensearch-containers.version>2.0.0</opensearch-containers.version>
         <elastic.version>8.9.0</elastic.version>
         <jackson.version>2.12.7.1</jackson.version>
@@ -197,15 +197,15 @@
             </dependency>
 
             <dependency>
-                <groupId>org.opensearch.client</groupId>
-                <artifactId>opensearch-java</artifactId>
-                <version>${opensearch-java.version}</version>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${httpclient5.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensearch.client</groupId>
-                <artifactId>opensearch-rest-client</artifactId>
-                <version>${opensearch-rest.version}</version>
+                <artifactId>opensearch-java</artifactId>
+                <version>${opensearch-java.version}</version>
             </dependency>
 
             <dependency>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -28,11 +28,16 @@
         <slf4j-api.version>2.0.7</slf4j-api.version>
         <gson.version>2.10.1</gson.version>
         <junit.version>5.9.3</junit.version>
+        <junit-jupiter.version>5.10.0</junit-jupiter.version>
+        <testcontainers.version>1.19.1</testcontainers.version>
         <mockito.version>4.11.0</mockito.version>
         <assertj.version>3.24.2</assertj.version>
         <tinylog.version>2.6.2</tinylog.version>
         <spring-boot.version>2.7.14</spring-boot.version>
         <snakeyaml.version>2.0</snakeyaml.version>
+        <opensearch-java.version>2.6.0</opensearch-java.version>
+        <opensearch-rest.version>2.10.0</opensearch-rest.version>
+        <opensearch-containers.version>2.0.0</opensearch-containers.version>
         <elastic.version>8.9.0</elastic.version>
         <jackson.version>2.12.7.1</jackson.version>
         <jedis.version>5.0.0</jedis.version>
@@ -120,6 +125,30 @@
             </dependency>
 
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit-jupiter.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${testcontainers.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${testcontainers.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensearch</groupId>
+                <artifactId>opensearch-testcontainers</artifactId>
+                <version>${opensearch-containers.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
@@ -165,6 +194,18 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensearch.client</groupId>
+                <artifactId>opensearch-java</artifactId>
+                <version>${opensearch-java.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensearch.client</groupId>
+                <artifactId>opensearch-rest-client</artifactId>
+                <version>${opensearch-rest.version}</version>
             </dependency>
 
             <dependency>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -37,6 +37,8 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <httpclient5.version>5.2.1</httpclient5.version>
         <opensearch-java.version>2.6.0</opensearch-java.version>
+        <aws-java-sdk-core.version>1.12.564</aws-java-sdk-core.version>
+        <aws-opensearch.version>2.20.161</aws-opensearch.version>
         <opensearch-containers.version>2.0.0</opensearch-containers.version>
         <elastic.version>8.9.0</elastic.version>
         <jackson.version>2.12.7.1</jackson.version>
@@ -206,6 +208,24 @@
                 <groupId>org.opensearch.client</groupId>
                 <artifactId>opensearch-java</artifactId>
                 <version>${opensearch-java.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>opensearch</artifactId>
+                <version>${aws-opensearch.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-core</artifactId>
+                <version>${aws-java-sdk-core.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>apache-client</artifactId>
+                <version>${aws-opensearch.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <!-- embedding stores -->
         <module>langchain4j-cassandra</module>
         <module>langchain4j-chroma</module>
+        <module>langchain4j-opensearch</module>
         <module>langchain4j-elasticsearch</module>
         <module>langchain4j-milvus</module>
         <module>langchain4j-pinecone</module>


### PR DESCRIPTION
This PR contains the implementation of an integration with [OpenSearch](https://opensearch.org/). As one of the growing vector databases in the open source world, adding support for it to this project makes total sense. This implementation includes:

1. A complete implementation of the `EmbeddingStore` interface.
2. Unit tests for the major use cases a store must implement correctly.
3. Usage of [TestContainers](https://testcontainers.com/) to automate the execution of backends.

I'm looking forward to your review and any suggestions you may have.