### PR TITLE
fix: remove high severity vulnerability in pinecone pom

### DIFF
--- a/langchain4j-pinecone/pom.xml
+++ b/langchain4j-pinecone/pom.xml
@@ -35,12 +35,23 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-codec</artifactId>
                 </exclusion>
+                <!-- due to CVE-2023-44487 vulnerability -->
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http2</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
             <version>4.1.98.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.100.Final</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Hi, this PR updates the pom of langchain4j-pinecone to remove a newly discovered high severity [CVE-2023-44487 vulnerability](https://www.cve.org/CVERecord?id=CVE-2023-44487)