### PR TITLE
Make some aspects of the project swappable by external integrations

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolExecutionRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolExecutionRequest.java
@@ -1,19 +1,9 @@
 package dev.langchain4j.agent.tool;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.Map;
+import static dev.langchain4j.internal.Utils.quoted;
 import java.util.Objects;
 
-import static dev.langchain4j.internal.Utils.quoted;
-
 public class ToolExecutionRequest {
-
-    private static final Gson GSON = new Gson();
-    private static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() {
-    }.getType();
 
     private final String name;
     private final String arguments;
@@ -29,15 +19,6 @@ public class ToolExecutionRequest {
 
     public String arguments() {
         return arguments;
-    }
-
-    public Map<String, Object> argumentsAsMap() {
-        return GSON.fromJson(arguments, MAP_TYPE);
-    }
-
-    public <T> T argument(String name) {
-        Map<String, Object> arguments = argumentsAsMap();
-        return (T) arguments.get(name);
     }
 
     @Override

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolExecutionRequestUtil.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolExecutionRequestUtil.java
@@ -1,0 +1,21 @@
+package dev.langchain4j.agent.tool;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+public class ToolExecutionRequestUtil {
+    public static final Gson GSON = new Gson();
+    public static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() {
+    }.getType();
+
+    public static <T> T argument(ToolExecutionRequest toolExecutionRequest, String name) {
+        Map<String, Object> arguments = argumentsAsMap(toolExecutionRequest.arguments()); // TODO cache
+        return (T) arguments.get(name);
+    }
+
+    public static Map<String, Object> argumentsAsMap(String arguments) {
+        return GSON.fromJson(arguments, MAP_TYPE);
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/input/MustachePromptTemplateFactory.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/input/MustachePromptTemplateFactory.java
@@ -1,0 +1,35 @@
+package dev.langchain4j.model.input;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import dev.langchain4j.spi.prompt.PromptTemplateFactory;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Map;
+
+class MustachePromptTemplateFactory implements PromptTemplateFactory {
+
+    private static final MustacheFactory MUSTACHE_FACTORY = new DefaultMustacheFactory();
+
+    @Override
+    public MustacheTemplate create(PromptTemplateFactory.Input input) {
+        StringReader stringReader = new StringReader(input.getTemplate());
+        return new MustacheTemplate(MUSTACHE_FACTORY.compile(stringReader, input.getName()));
+    }
+
+    static class MustacheTemplate implements Template {
+
+        private final Mustache mustache;
+
+        MustacheTemplate(Mustache mustache) {
+            this.mustache = mustache;
+        }
+
+        public String render(Map<String, Object> vars) {
+            StringWriter writer = new StringWriter();
+            mustache.execute(writer, vars);
+            return writer.toString();
+        }
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/input/structured/DefaultStructuredPromptFactory.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/input/structured/DefaultStructuredPromptFactory.java
@@ -1,0 +1,51 @@
+package dev.langchain4j.model.input.structured;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
+import com.google.gson.reflect.TypeToken;
+import dev.langchain4j.model.input.Prompt;
+import dev.langchain4j.model.input.PromptTemplate;
+import dev.langchain4j.spi.prompt.structured.StructuredPromptFactory;
+import java.util.Map;
+
+public class DefaultStructuredPromptFactory implements StructuredPromptFactory {
+    private static final Gson GSON = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
+
+    public Prompt toPrompt(Object structuredPrompt) {
+        validate(structuredPrompt);
+
+        StructuredPrompt annotation = structuredPrompt.getClass().getAnnotation(StructuredPrompt.class);
+
+        String promptTemplateString = String.join(annotation.delimiter(), annotation.value());
+        PromptTemplate promptTemplate = PromptTemplate.from(promptTemplateString);
+
+        Map<String, Object> variables = extractVariables(structuredPrompt);
+
+        return promptTemplate.apply(variables);
+    }
+
+    private void validate(Object structuredPrompt) {
+        if (structuredPrompt == null) {
+            throw new IllegalArgumentException("Structured prompt cannot be null");
+        }
+
+        String structuredPromptClassName = structuredPrompt.getClass().getName();
+
+        StructuredPrompt structuredPromptAnnotation = structuredPrompt.getClass().getAnnotation(StructuredPrompt.class);
+        if (structuredPromptAnnotation == null) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s should be annotated with @StructuredPrompt to be used as a structured prompt",
+                            structuredPromptClassName
+                    )
+            );
+        }
+    }
+
+    private static Map<String, Object> extractVariables(Object structuredPrompt) {
+        String json = GSON.toJson(structuredPrompt);
+        TypeToken<Map<String, Object>> mapType = new TypeToken<Map<String, Object>>() {};
+        return GSON.fromJson(json, mapType);
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/input/structured/StructuredPromptProcessor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/input/structured/StructuredPromptProcessor.java
@@ -1,51 +1,23 @@
 package dev.langchain4j.model.input.structured;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.ToNumberPolicy;
-import com.google.gson.reflect.TypeToken;
 import dev.langchain4j.model.input.Prompt;
-import dev.langchain4j.model.input.PromptTemplate;
-import java.util.Map;
+import dev.langchain4j.spi.ServiceHelper;
+import dev.langchain4j.spi.prompt.structured.StructuredPromptFactory;
 
 public class StructuredPromptProcessor {
 
-  private static final Gson GSON = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
+    private static final StructuredPromptFactory FACTORY = factory();
 
-  public static Prompt toPrompt(Object structuredPrompt) {
-    validate(structuredPrompt);
-
-    StructuredPrompt annotation = structuredPrompt.getClass().getAnnotation(StructuredPrompt.class);
-
-    String promptTemplateString = String.join(annotation.delimiter(), annotation.value());
-    PromptTemplate promptTemplate = PromptTemplate.from(promptTemplateString);
-
-    Map<String, Object> variables = extractVariables(structuredPrompt);
-
-    return promptTemplate.apply(variables);
-  }
-
-  private static void validate(Object structuredPrompt) {
-    if (structuredPrompt == null) {
-      throw new IllegalArgumentException("Structured prompt cannot be null");
+    private static StructuredPromptFactory factory() {
+        for (StructuredPromptFactory factory : ServiceHelper.loadFactories(StructuredPromptFactory.class)) {
+            return factory;
+        }
+        // fallback to the default
+        return new DefaultStructuredPromptFactory();
     }
 
-    String structuredPromptClassName = structuredPrompt.getClass().getName();
-
-    StructuredPrompt structuredPromptAnnotation = structuredPrompt.getClass().getAnnotation(StructuredPrompt.class);
-    if (structuredPromptAnnotation == null) {
-      throw new IllegalArgumentException(
-        String.format(
-          "%s should be annotated with @StructuredPrompt to be used as a structured prompt",
-          structuredPromptClassName
-        )
-      );
+    public static Prompt toPrompt(Object structuredPrompt) {
+        return FACTORY.toPrompt(structuredPrompt);
     }
-  }
 
-  private static Map<String, Object> extractVariables(Object structuredPrompt) {
-    String json = GSON.toJson(structuredPrompt);
-    TypeToken<Map<String, Object>> mapType = new TypeToken<Map<String, Object>>() {};
-    return GSON.fromJson(json, mapType);
-  }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/spi/ServiceHelper.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/spi/ServiceHelper.java
@@ -1,0 +1,42 @@
+package dev.langchain4j.spi;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+
+public class ServiceHelper {
+
+
+  public static <T> Collection<T> loadFactories(Class<T> clazz) {
+    return loadFactories(clazz, null);
+  }
+
+  public static <T> Collection<T> loadFactories(Class<T> clazz, ClassLoader classLoader) {
+    List<T> list = new ArrayList<>();
+    ServiceLoader<T> factories;
+    if (classLoader != null) {
+      factories = ServiceLoader.load(clazz, classLoader);
+    } else {
+      // this is equivalent to:
+      // ServiceLoader.load(clazz, TCCL);
+      factories = ServiceLoader.load(clazz);
+    }
+    if (factories.iterator().hasNext()) {
+      factories.iterator().forEachRemaining(list::add);
+      return list;
+    } else {
+      // By default ServiceLoader.load uses the TCCL, this may not be enough in environment dealing with
+      // classloaders differently such as OSGi. So we should try to use the  classloader having loaded this
+      // class. In OSGi it would be the bundle exposing vert.x and so have access to all its classes.
+      factories = ServiceLoader.load(clazz, ServiceHelper.class.getClassLoader());
+      if (factories.iterator().hasNext()) {
+        factories.iterator().forEachRemaining(list::add);
+        return list;
+      } else {
+        return Collections.emptyList();
+      }
+    }
+  }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/spi/prompt/PromptTemplateFactory.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/spi/prompt/PromptTemplateFactory.java
@@ -1,0 +1,19 @@
+package dev.langchain4j.spi.prompt;
+
+import java.util.Map;
+
+public interface PromptTemplateFactory {
+
+    Template create(Input input);
+
+    interface Input {
+
+        String getTemplate();
+
+        String getName();
+    }
+
+    interface Template {
+        String render(Map<String, Object> vars);
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/spi/prompt/structured/StructuredPromptFactory.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/spi/prompt/structured/StructuredPromptFactory.java
@@ -1,0 +1,8 @@
+package dev.langchain4j.spi.prompt.structured;
+
+import dev.langchain4j.model.input.Prompt;
+
+public interface StructuredPromptFactory {
+
+    Prompt toPrompt(Object structuredPrompt);
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agent/tool/ToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agent/tool/ToolExecutor.java
@@ -28,7 +28,7 @@ public class ToolExecutor {
 
         // TODO ensure this method never throws exceptions
 
-        Object[] arguments = prepareArguments(toolExecutionRequest.argumentsAsMap());
+        Object[] arguments = prepareArguments(ToolExecutionRequestUtil.argumentsAsMap(toolExecutionRequest.arguments()));
         try {
             String result = execute(arguments);
             log.debug("Tool execution result: {}", result);


### PR DESCRIPTION
# Purpose

This purpose of this pull request is to make it possible for advanced integrators to swap out some of the dependencies with others.

For a first iteration, I did not want to require current consumers of this library to have to make any changes - for them this pull requests changes nothing whatsoever.
This means that I did not do any sort of of changes to the structure or name of the Maven modules. I believe that if we want to do that, if can be done at a latter point.

# Changes

## Gson

All this change does is move Gson out of the model classes. This is needed by integrations that plan to exclude Gson from the classpath, so that the models can continue to be loaded without incurring ClassLoading issues.

## Template SPI

I introduced `PromptTemplateFactory` which can be used for integrations to supply their own version of the template engine.
Implementations are loaded using Java's ServiceLoader mechanism and if none are found, the default `MustachePromptTemplateFactory` is used.

I have leveraged this SPI my Quarkus integration [here](https://github.com/geoand/quarkus-langchain4j/blob/487711af4c7b465dbc40b90314c67de712ab8a15/runtime/src/main/java/io/quarkiverse/langchain4j/QuarkusPromptTemplateFactory.java).

## Make OpenAiStreamingResponseBuilder thread-safe

This class needs to be thread safe because it is called when a streaming result comes back
and there is no guarantee that this thread will be the same as the one that initiated the request

## Improve Javadoc of `@V`

This simply generalizes the condition under which `@V` is not necessary