### PR TITLE
Include metadata for custom Spring Boot properties

### DIFF
--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -199,6 +199,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-configuration-processor</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
                 <version>${httpclient5.version}</version>

--- a/langchain4j-spring-boot-starter/pom.xml
+++ b/langchain4j-spring-boot-starter/pom.xml
@@ -48,6 +48,12 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 
     <licenses>


### PR DESCRIPTION
Add the Spring Boot Configuration Processor dependency to the Spring Boot starter to generate metadata
about the LangChain4J custom properties.

Fixes gh-250