### PR TITLE
Feat: Adding Memory Id to Tool Method Call

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolMemoryId.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolMemoryId.java
@@ -1,0 +1,14 @@
+package dev.langchain4j.agent.tool;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Memory id passed to the tool internally during execution.
+ */
+@Retention(RUNTIME)
+@Target(PARAMETER)
+public @interface ToolMemoryId { }

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
@@ -33,6 +33,11 @@ public class ToolSpecifications {
                 .description(description);
 
         for (Parameter parameter : method.getParameters()) {
+            // ignore memory id
+            if (parameter.isAnnotationPresent(ToolMemoryId.class)) {
+                continue;
+            }
+
             builder.addParameter(parameter.getName(), toJsonSchemaProperties(parameter));
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/agent/tool/ToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agent/tool/ToolExecutor.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.agent.tool;
 
 import dev.langchain4j.internal.Json;
-import dev.langchain4j.service.MemoryId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +67,7 @@ public class ToolExecutor {
 
         for (int i = 0; i < parameters.length; i++) {
             // Set memoryId if parameter is annotated as such
-            if (parameters[i].isAnnotationPresent(MemoryId.class)) {
+            if (parameters[i].isAnnotationPresent(ToolMemoryId.class)) {
                 arguments[i] = memoryId;
                 continue;
             }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -62,7 +62,7 @@ class AiServiceStreamingResponseHandler implements StreamingResponseHandler<AiMe
         ToolExecutionRequest toolExecutionRequest = response.content().toolExecutionRequest();
         if (toolExecutionRequest != null) {
             ToolExecutor toolExecutor = context.toolExecutors.get(toolExecutionRequest.name());
-            String toolExecutionResult = toolExecutor.execute(toolExecutionRequest);
+            String toolExecutionResult = toolExecutor.execute(toolExecutionRequest, memoryId);
             ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.from(
                     toolExecutionRequest.name(),
                     toolExecutionResult

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -422,7 +422,7 @@ public class AiServices<T> {
                             }
 
                             ToolExecutor toolExecutor = context.toolExecutors.get(toolExecutionRequest.name());
-                            String toolExecutionResult = toolExecutor.execute(toolExecutionRequest);
+                            String toolExecutionResult = toolExecutor.execute(toolExecutionRequest, memoryId);
                             ToolExecutionResultMessage toolExecutionResultMessage
                                     = toolExecutionResultMessage(toolExecutionRequest.name(), toolExecutionResult);
 

--- a/langchain4j/src/test/java/dev/langchain4j/agent/tool/ToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/agent/tool/ToolExecutorTest.java
@@ -219,7 +219,7 @@ class ToolExecutorTest {
 
         ToolExecutor toolExecutor = new ToolExecutor(testTool, TestTool.class.getDeclaredMethod(methodName, arg0Type, arg1Type));
 
-        String result = toolExecutor.execute(request);
+        String result = toolExecutor.execute(request, "DEFAULT");
 
         assertThat(result).isEqualTo(expectedResult);
     }
@@ -231,7 +231,7 @@ class ToolExecutorTest {
 
         ToolExecutor toolExecutor = new ToolExecutor(testTool, TestTool.class.getDeclaredMethod(methodName, arg0Type, arg1Type));
 
-        assertThatThrownBy(() -> toolExecutor.execute(request))
+        assertThatThrownBy(() -> toolExecutor.execute(request, "DEFAULT"))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining(expectedError);
     }


### PR DESCRIPTION
Implemented a new annotation `@ToolMemoryId` (naming debatable, but wanted to make it different to `@MemoryId`). If a tool method parameter is annotated as such, the `ToolExecutor` will pass the memory id annotated with `@MemoryId` from the prompt method interface to the tool method. That enables tools to securely access the identifier for individual users without relying on the used LLM service to pass the correct user id back as `@P` annotated tool parameter.