### PR TITLE
add bedrock bom

### DIFF
--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -72,6 +72,11 @@
                 <artifactId>langchain4j-ollama</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-bedrock</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- embedding stores -->
             <dependency>


### PR DESCRIPTION
Hi! It seems like new `langchain4j-bedrock` module is not included in `langchain4j-bom`, so I add it.