### PR TITLE
Fix a token usage statistical issue in DefaultAiServices

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -8,7 +8,7 @@ import dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -73,7 +73,7 @@ public class MessageWindowChatMemory implements ChatMemory {
 
     @Override
     public List<ChatMessage> messages() {
-        List<ChatMessage> messages = new ArrayList<>(store.getMessages(id));
+        List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
         ensureCapacity(messages, maxMessages);
         return messages;
     }

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
@@ -9,7 +9,7 @@ import dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -77,7 +77,7 @@ public class TokenWindowChatMemory implements ChatMemory {
 
     @Override
     public List<ChatMessage> messages() {
-        List<ChatMessage> messages = new ArrayList<>(store.getMessages(id));
+        List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
         ensureCapacity(messages, maxTokens, tokenizer);
         return messages;
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -152,7 +152,7 @@ class DefaultAiServices<T> extends AiServices<T> {
                                 context.chatMemory(memoryId).add(response.content());
                             }
 
-                            tokenUsage.add(response.tokenUsage());
+                            tokenUsage = tokenUsage.add(response.tokenUsage());
                             toolExecutionRequest = response.content().toolExecutionRequest();
                             if (toolExecutionRequest == null) {
                                 break;


### PR DESCRIPTION
The statistical logic on token usage is consistent with AiServiceStreamingResponseHandler.

And more:
When it comes to rolling messages in MessageWindowChatMemory/TokenWindowChatMemory, LinkedList offers superior performance. ArrayList moves all the elements when the first element is deleted.