### PR TITLE
Use ElasticsearchContainer in Elasticsearch IT

### DIFF
--- a/langchain4j-elasticsearch/pom.xml
+++ b/langchain4j-elasticsearch/pom.xml
@@ -69,6 +69,17 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <licenses>

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreIT.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreIT.java
@@ -6,21 +6,21 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreIT;
 import lombok.SneakyThrows;
-import org.junit.jupiter.api.Disabled;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static dev.langchain4j.internal.Utils.randomUUID;
 
-@Disabled("needs Elasticsearch to be running locally")
+@Testcontainers
 class ElasticsearchEmbeddingStoreIT extends EmbeddingStoreIT {
 
-    /**
-     * First start elasticsearch locally:
-     * docker pull docker.elastic.co/elasticsearch/elasticsearch:8.9.0
-     * docker run -d -p 9200:9200 -p 9300:9300 -e discovery.type=single-node -e xpack.security.enabled=false docker.elastic.co/elasticsearch/elasticsearch:8.9.0
-     */
+    @Container
+    private static final ElasticsearchContainer elasticsearch = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.9.0")
+            .withEnv("xpack.security.enabled", "false");
 
     EmbeddingStore<TextSegment> embeddingStore = ElasticsearchEmbeddingStore.builder()
-            .serverUrl("http://localhost:9200")
+            .serverUrl(elasticsearch.getHttpHostAddress())
             .indexName(randomUUID())
             .dimension(384)
             .build();


### PR DESCRIPTION
Current test execution depends on a running elasticserach instance,
which depends on a manual execution of docker command. This commit
introduces testcontainers as in other modules to run such instance
along with tests, improving DevEx.
