### PR TITLE
Use Testcontainers in Chroma IT

### DIFF
--- a/langchain4j-chroma/pom.xml
+++ b/langchain4j-chroma/pom.xml
@@ -64,6 +64,18 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <licenses>

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreIT.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreIT.java
@@ -5,22 +5,21 @@ import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreIT;
-import org.junit.jupiter.api.Disabled;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static dev.langchain4j.internal.Utils.randomUUID;
 
-@Disabled("needs Chroma running locally")
+@Testcontainers
 class ChromaEmbeddingStoreIT extends EmbeddingStoreIT {
 
-    /**
-     * First ensure you have Chroma running locally. If not, then:
-     * - Execute "docker pull ghcr.io/chroma-core/chroma:0.4.6"
-     * - Execute "docker run -d -p 8000:8000 ghcr.io/chroma-core/chroma:0.4.6"
-     * - Wait until Chroma is ready to serve (may take a few minutes)
-     */
+    @Container
+    private static final GenericContainer<?> chroma = new GenericContainer<>("ghcr.io/chroma-core/chroma:0.4.6")
+            .withExposedPorts(8000);
 
     EmbeddingStore<TextSegment> embeddingStore = ChromaEmbeddingStore.builder()
-            .baseUrl("http://localhost:8000")
+            .baseUrl(String.format("http://%s:%d", chroma.getHost(), chroma.getMappedPort(8000)))
             .collectionName(randomUUID())
             .build();
 


### PR DESCRIPTION
Use `GenericContainer` to run `ghcr.io/chroma-core/chroma` along with
tests. No manual steps are required to execute them.
