### PR TITLE
Use Testcontainers for Weaviate IT

### DIFF
--- a/langchain4j-weaviate/pom.xml
+++ b/langchain4j-weaviate/pom.xml
@@ -70,6 +70,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/langchain4j-weaviate/src/main/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStore.java
+++ b/langchain4j-weaviate/src/main/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStore.java
@@ -2,6 +2,7 @@ package dev.langchain4j.store.embedding.weaviate;
 
 import static dev.langchain4j.internal.Utils.*;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static io.weaviate.client.v1.data.replication.model.ConsistencyLevel.QUORUM;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
@@ -66,7 +67,7 @@ public class WeaviateEmbeddingStore implements EmbeddingStore<TextSegment> {
   ) {
     try {
       Config config = new Config(ensureNotBlank(scheme, "scheme"), ensureNotBlank(host, "host"));
-      this.client = WeaviateAuthClient.apiKey(config, ensureNotBlank(apiKey, "apiKey"));
+      this.client = WeaviateAuthClient.apiKey(config, ensureNotNull(apiKey, "apiKey"));
     } catch (AuthException e) {
       throw new IllegalArgumentException(e);
     }

--- a/langchain4j-weaviate/src/test/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStoreIT.java
+++ b/langchain4j-weaviate/src/test/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStoreIT.java
@@ -5,17 +5,29 @@ import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreWithoutMetadataIT;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static dev.langchain4j.internal.Utils.randomUUID;
 
-@EnabledIfEnvironmentVariable(named = "WEAVIATE_API_KEY", matches = ".+")
+@Testcontainers
 class WeaviateEmbeddingStoreIT extends EmbeddingStoreWithoutMetadataIT {
 
+    @Container
+    static GenericContainer<?> weaviate = new GenericContainer<>("semitechnologies/weaviate:1.22.4")
+            .withEnv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true")
+            .withEnv("PERSISTENCE_DATA_PATH", "/var/lib/weaviate")
+            .withEnv("QUERY_DEFAULTS_LIMIT", "25")
+            .withEnv("DEFAULT_VECTORIZER_MODULE", "none")
+            .withEnv("CLUSTER_HOSTNAME", "node1")
+            .withExposedPorts(8080);
+
     EmbeddingStore<TextSegment> embeddingStore = WeaviateEmbeddingStore.builder()
-            .apiKey(System.getenv("WEAVIATE_API_KEY"))
-            .scheme("https")
-            .host("test-am8ocede.weaviate.network")
+            .apiKey("")
+            .scheme("http")
+            .host(String.format("%s:%d", weaviate.getHost(), weaviate.getMappedPort(8080)))
             .objectClass("Test" + randomUUID().replace("-", ""))
             .build();
 


### PR DESCRIPTION
Run `semitechnologies/weaviate` image using `GenericContainer` and
allow rapid feeback when using Weaviate. Relax `apiKey` constraint
to allow empty value for testing purposes.
