### PR TITLE
enable langchain4j-graal build in workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,6 +26,15 @@ jobs:
       - name: Build modules requiring JDK 11
         run: mvn --batch-mode install -DskipITs -pl langchain4j-opensearch
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Build modules requiring JDK 17
+        run: mvn --batch-mode install -DskipTests -DskipITs -pl langchain4j-graal
+
   # For checking some compliance things (require a recent JDK due to plugins so in a separate step)
   compliance:
     runs-on: ubuntu-latest
@@ -42,7 +51,7 @@ jobs:
         run: mvn -P compliance org.honton.chas:license-maven-plugin:compliance
 
 # TODO's
-# - enable JDK 17 build for langchain4j-graal
+# - enable JDK 17 unit tests for langchain4j-graal
 # - setup integration tests
 # - these require an openAI (and hugging face, etc) token
 # - do so that they always run for commits on main


### PR DESCRIPTION
langchain4j-graal  build can be enabled in workflow. 
The compile is fast. only take fews second.