### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,9 +24,9 @@ jobs:
             included_modules: ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java_version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java_version }}
           distribution: 'temurin'


### PR DESCRIPTION
In the GitHub Actions workflow:

- Update actions/checkout to the latest version
- Update actions/setup-java to the latest version (Java 21 already works but is undocumented, the next version it will be thanks to https://github.com/actions/setup-java/pull/538 😀)