### PR TITLE
fix pinecone QueryRequest usage, upgrade from 0.2.1 to 0.6.0

### DIFF
--- a/langchain4j-pinecone/pom.xml
+++ b/langchain4j-pinecone/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.pinecone</groupId>
             <artifactId>pinecone-client</artifactId>
-            <version>0.2.3</version>
+            <version>0.6.0</version>
             <exclusions>
                 <!-- due to CVE-2022-41915 vulnerability -->
                 <exclusion>

--- a/langchain4j-pinecone/src/main/java/dev/langchain4j/store/embedding/pinecone/PineconeEmbeddingStore.java
+++ b/langchain4j-pinecone/src/main/java/dev/langchain4j/store/embedding/pinecone/PineconeEmbeddingStore.java
@@ -148,23 +148,15 @@ public class PineconeEmbeddingStore implements EmbeddingStore<TextSegment> {
     @Override
     public List<EmbeddingMatch<TextSegment>> findRelevant(Embedding referenceEmbedding, int maxResults, double minScore) {
 
-        QueryVector queryVector = QueryVector
-                .newBuilder()
-                .addAllValues(referenceEmbedding.vectorAsList())
-                .setTopK(maxResults)
-                .setNamespace(nameSpace)
-                .build();
-
         QueryRequest queryRequest = QueryRequest
                 .newBuilder()
-                .addQueries(queryVector)
+                .addAllVector(referenceEmbedding.vectorAsList())
+                .setNamespace(nameSpace)
                 .setTopK(maxResults)
                 .build();
 
         List<String> matchedVectorIds = connection.getBlockingStub()
                 .query(queryRequest)
-                .getResultsList()
-                .get(0)
                 .getMatchesList()
                 .stream()
                 .map(ScoredVector::getId)

--- a/langchain4j-pinecone/src/test/java/dev/langchain4j/store/embedding/pinecone/PineconeEmbeddingStoreIT.java
+++ b/langchain4j-pinecone/src/test/java/dev/langchain4j/store/embedding/pinecone/PineconeEmbeddingStoreIT.java
@@ -5,7 +5,10 @@ import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreWithoutMetadataIT;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.util.concurrent.TimeUnit;
 
 import static dev.langchain4j.internal.Utils.randomUUID;
 
@@ -14,8 +17,8 @@ class PineconeEmbeddingStoreIT extends EmbeddingStoreWithoutMetadataIT {
 
     EmbeddingStore<TextSegment> embeddingStore = PineconeEmbeddingStore.builder()
             .apiKey(System.getenv("PINECONE_API_KEY"))
-            .environment("northamerica-northeast1-gcp")
-            .projectId("19a129b")
+            .environment("gcp-starter")
+            .projectId("6furl0x")
             .index("test")
             .nameSpace(randomUUID())
             .build();
@@ -30,5 +33,11 @@ class PineconeEmbeddingStoreIT extends EmbeddingStoreWithoutMetadataIT {
     @Override
     protected EmbeddingModel embeddingModel() {
         return embeddingModel;
+    }
+
+    @Override
+    @SneakyThrows
+    protected void awaitUntilPersisted() {
+        TimeUnit.SECONDS.sleep(20);
     }
 }


### PR DESCRIPTION
when i test  langchain4j-pinecone, the pinecone server respone  error Info
```
 The 'queries' parameter has been deprecated.
```
ref to  [this](https://community.pinecone.io/t/invalid-argument-the-queries-parameter-has-been-deprecated-java/3719) , then i fixed it.


