### PR TITLE
Fix function without params for Azure Open AI

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
@@ -16,7 +16,6 @@ import com.azure.core.http.policy.HttpLogOptions;
 import com.azure.core.http.policy.RetryOptions;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.HttpClientOptions;
-import com.azure.identity.DefaultAzureCredentialBuilder;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolParameters;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -167,10 +166,15 @@ class InternalAzureOpenAiHelper {
         return functionDefinition;
     }
 
+    private static final Map<String, Object> NO_PARAMETER_DATA = new HashMap<>();
+    static {
+        NO_PARAMETER_DATA.put("type", "object");
+        NO_PARAMETER_DATA.put("properties", new HashMap<>());
+    }
     private static BinaryData toOpenAiParameters(ToolParameters toolParameters) {
         Parameters parameters = new Parameters();
         if (toolParameters == null) {
-            return BinaryData.fromString("{}");
+            return BinaryData.fromObject(NO_PARAMETER_DATA);
         }
         parameters.setProperties(toolParameters.properties());
         parameters.setRequired(toolParameters.required());

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelIT.java
@@ -123,7 +123,7 @@ public class AzureOpenAiChatModelIT {
         Response<AiMessage> response = model.generate(Collections.singletonList(userMessage), toolSpecification);
 
         AiMessage aiMessage = response.content();
-        assertThat(aiMessage.text()).isBlank();
+        assertThat(aiMessage.text()).isNull();
 
         assertThat(aiMessage.toolExecutionRequests()).hasSize(1);
         ToolExecutionRequest toolExecutionRequest = aiMessage.toolExecutionRequests().get(0);
@@ -189,7 +189,7 @@ public class AzureOpenAiChatModelIT {
         Response<AiMessage> response = model.generate(Collections.singletonList(userMessage), noArgToolSpec);
 
         AiMessage aiMessage = response.content();
-        assertThat(aiMessage.text()).isBlank();
+        assertThat(aiMessage.text()).isNull();
 
         assertThat(aiMessage.toolExecutionRequests()).hasSize(1);
         ToolExecutionRequest toolExecutionRequest = aiMessage.toolExecutionRequests().get(0);

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelIT.java
@@ -182,7 +182,7 @@ public class AzureOpenAiChatModelIT {
         String toolName = "getCurrentDateAndTime";
 
         ToolSpecification noArgToolSpec = ToolSpecification.builder()
-                .name("getCurrentDateAndTime")
+                .name(toolName)
                 .description("Get the current date and time")
                 .build();
 

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelIT.java
@@ -114,13 +114,13 @@ public class AzureOpenAiChatModelIT {
         // This test will use the function called "getCurrentWeather" which is defined below.
         String toolName = "getCurrentWeather";
 
-        ToolSpecification weatherToolSpec = ToolSpecification.builder()
+        ToolSpecification toolSpecification = ToolSpecification.builder()
                 .name(toolName)
                 .description("Get the current weather")
                 .parameters(getToolParameters())
                 .build();
 
-        Response<AiMessage> response = model.generate(Collections.singletonList(userMessage), weatherToolSpec);
+        Response<AiMessage> response = model.generate(Collections.singletonList(userMessage), toolSpecification);
 
         AiMessage aiMessage = response.content();
         assertThat(aiMessage.text()).isBlank();


### PR DESCRIPTION
Tools without parameters were not correctly serialized to json for Azure Open AI.
Change the json for the `parameters` property from `{}` to 
`{"type": "object", "properties": {}}` according to docs [here](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/function-calling?tabs=python#using-function-in-the-chat-completions-api-deprecated). 

fixes #442 