### PR TITLE
Make PromptTemplateFactory.Input a FunctionalInterface.

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/model/input/PromptTemplate.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/input/PromptTemplate.java
@@ -44,18 +44,7 @@ public class PromptTemplate {
     }
 
     PromptTemplate(String template, Clock clock) {
-        this.template = FACTORY.create(new PromptTemplateFactory.Input() {
-
-            @Override
-            public String getTemplate() {
-                return template;
-            }
-
-            @Override
-            public String getName() {
-                return "template";
-            }
-        });
+        this.template = FACTORY.create(() -> template);
         this.clock = ensureNotNull(clock, "clock");
     }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/spi/prompt/PromptTemplateFactory.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/spi/prompt/PromptTemplateFactory.java
@@ -10,7 +10,7 @@ public interface PromptTemplateFactory {
 
         String getTemplate();
 
-        String getName();
+        default String getName() { return "template"; }
     }
 
     interface Template {

--- a/langchain4j-core/src/test/java/dev/langchain4j/spi/prompt/PromptTemplateFactoryTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/spi/prompt/PromptTemplateFactoryTest.java
@@ -1,0 +1,13 @@
+package dev.langchain4j.spi.prompt;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+class PromptTemplateFactoryTest implements WithAssertions {
+    @Test
+    public void test_Input_defaults() {
+        PromptTemplateFactory.Input input = () -> "template";
+        assertThat(input.getName()).isEqualTo("template");
+    }
+
+}


### PR DESCRIPTION
Simplifies the (currently one) caller, and cleans up coverage analysis.