### PR TITLE
Add basic ErrorProne config to langchain4j-core.

### DIFF
--- a/langchain4j-core/.mvn/jvm.config
+++ b/langchain4j-core/.mvn/jvm.config
@@ -1,0 +1,11 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -79,6 +79,20 @@
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
                         <arg>-Xplugin:ErrorProne</arg>
+                        <!--
+                         * See https://errorprone.info/docs/installation
+                         + See also .mvn/jvm.config
+                         +-->
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                     </compilerArgs>
                     <annotationProcessorPaths>
                         <path>

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -68,6 +68,32 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                    <encoding>UTF-8</encoding>
+                    <compilerArgs>
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>-Xplugin:ErrorProne</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>2.24.1</version>
+                        </path>
+                        <!-- Other annotation processors go here.
+
+                        If 'annotationProcessorPaths' is set, processors will no longer be
+                        discovered on the regular -classpath; see also 'Using Error Prone
+                        together with other annotation processors' below. -->
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -76,6 +76,7 @@
                     <source>8</source>
                     <target>8</target>
                     <encoding>UTF-8</encoding>
+                    <fork>true</fork>
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
                         <arg>-Xplugin:ErrorProne</arg>

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/GsonJsonCodecTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/GsonJsonCodecTest.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 class GsonJsonCodecTest implements WithAssertions {
     public static class Example {
@@ -29,6 +30,11 @@ class GsonJsonCodecTest implements WithAssertions {
             Example example = (Example) o;
             return age == example.age &&
                     name.equals(example.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, age);
         }
     }
 
@@ -99,6 +105,11 @@ class GsonJsonCodecTest implements WithAssertions {
             DateExample that = (DateExample) o;
             return localDate.equals(that.localDate) &&
                     localDateTime.equals(that.localDateTime);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(localDate, localDateTime);
         }
     }
 


### PR DESCRIPTION
See [ErrorProne](https://errorprone.info/index)

- Runs during `mvn verify`.
- fix for two extant issues.
- Stricter tests could be enabled later.