### PR TITLE
Fix reflection bug that broke tests during coverage.

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
@@ -122,7 +122,12 @@ public class ServiceOutputParser {
         StringBuilder jsonSchema = new StringBuilder();
         jsonSchema.append("{\n");
         for (Field field : structured.getDeclaredFields()) {
-            jsonSchema.append(format("\"%s\": (%s),\n", field.getName(), descriptionFor(field)));
+            String name = field.getName();
+            if (name.equals("__$hits$__")) {
+                // Skip coverage instrumentation field.
+                continue;
+            }
+            jsonSchema.append(format("\"%s\": (%s),\n", name, descriptionFor(field)));
         }
         jsonSchema.append("}");
         return jsonSchema.toString();


### PR DESCRIPTION
Coverage analysis injects tracking fields, which can show up in `getDeclaredFields()`; this removes the field `__$hits$__` when present.