### PR TITLE
Beautifying Maven output

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-code-execution-engine-graalvm-polyglot</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with GraalVM Polyglot/Truffle</name>
+    <name>LangChain4j :: Integration :: GraalVM Polyglot/Truffle</name>
     <description>Implementation of JavaScript and Python code execution engines and tools using GraalVM Polyglot/Truffle</description>
 
     <properties>

--- a/document-loaders/langchain4j-document-loader-amazon-s3/pom.xml
+++ b/document-loaders/langchain4j-document-loader-amazon-s3/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>langchain4j-document-loader-amazon-s3</artifactId>
-    <name>LangChain4j Amazon S3 document loader</name>
+    <name>LangChain4j :: Document loader :: Amazon S3</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>langchain4j-document-loader-azure-storage-blob</artifactId>
-    <name>LangChain4j Azure Blob Storage document loader</name>
+    <name>LangChain4j :: Document loader :: Azure Blob Storage</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/document-loaders/langchain4j-document-loader-github/pom.xml
+++ b/document-loaders/langchain4j-document-loader-github/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>langchain4j-document-loader-github</artifactId>
-    <name>LangChain4j GitHub document loader</name>
+    <name>LangChain4j :: Document loader :: GitHub</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/document-loaders/langchain4j-document-loader-tencent-cos/pom.xml
+++ b/document-loaders/langchain4j-document-loader-tencent-cos/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>langchain4j-document-loader-tencent-cos</artifactId>
-    <name>LangChain4j Tencent COS document loader</name>
+    <name>LangChain4j :: Document loader :: Tencent COS</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/document-parsers/langchain4j-document-parser-apache-pdfbox/pom.xml
+++ b/document-parsers/langchain4j-document-parser-apache-pdfbox/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>langchain4j-document-parser-apache-pdfbox</artifactId>
-    <name>LangChain4j Apache PDFBox document parser</name>
+    <name>LangChain4j :: Document parser :: Apache PDFBox</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/document-parsers/langchain4j-document-parser-apache-poi/pom.xml
+++ b/document-parsers/langchain4j-document-parser-apache-poi/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>langchain4j-document-parser-apache-poi</artifactId>
-    <name>LangChain4j Apache POI document parser</name>
+    <name>LangChain4j :: Document parser :: Apache POI</name>
     <packaging>jar</packaging>
 
     <properties>

--- a/langchain4j-azure-ai-search/pom.xml
+++ b/langchain4j-azure-ai-search/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-azure-ai-search</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Azure AI Search</name>
+    <name>LangChain4j :: Integration :: Azure AI Search</name>
 
     <dependencies>
 

--- a/langchain4j-azure-open-ai/pom.xml
+++ b/langchain4j-azure-open-ai/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-azure-open-ai</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Azure OpenAI</name>
+    <name>LangChain4j :: Integration :: Azure OpenAI</name>
 
     <dependencies>
 

--- a/langchain4j-bedrock/pom.xml
+++ b/langchain4j-bedrock/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>langchain4j-bedrock</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Amazon Bedrock</name>
+    <name>LangChain4j :: Integration :: Amazon Bedrock</name>
 
     <dependencies>
         <dependency>

--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>langchain4j-bom</artifactId>
     <packaging>pom</packaging>
 
-    <name>LangChain4j BOM</name>
+    <name>LangChain4j :: BOM</name>
     <description>Bill of Materials POM for getting full, complete set of compatible versions of LangChain4j modules</description>
 
     <dependencyManagement>

--- a/langchain4j-cassandra/pom.xml
+++ b/langchain4j-cassandra/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>langchain4j-cassandra</artifactId>
-    <name>LangChain4j integration with Cassandra and AstraDb</name>
+    <name>LangChain4j :: Integration :: Cassandra and AstraDb</name>
     <description>Some dependencies have a "Public Domain" license</description>
 
     <parent>

--- a/langchain4j-chatglm/pom.xml
+++ b/langchain4j-chatglm/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>langchain4j-chatglm</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with ChatGLM</name>
+    <name>LangChain4j :: Integration :: ChatGLM</name>
 
     <dependencies>
         <dependency>

--- a/langchain4j-chroma/pom.xml
+++ b/langchain4j-chroma/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-chroma</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Chroma</name>
+    <name>LangChain4j :: Integration :: Chroma</name>
 
     <dependencies>
 

--- a/langchain4j-cohere/pom.xml
+++ b/langchain4j-cohere/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>langchain4j-cohere</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Cohere</name>
+    <name>LangChain4j :: Integration :: Cohere</name>
 
     <dependencies>
         <dependency>

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -19,7 +19,7 @@
     <artifactId>langchain4j-core</artifactId>
     <packaging>jar</packaging>
 
-    <name>langchain4j-core</name>
+    <name>LangChain4j :: Core</name>
     <description>Core classes and interfaces of LangChain4j</description>
 
     <dependencies>

--- a/langchain4j-dashscope/pom.xml
+++ b/langchain4j-dashscope/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-dashscope</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with DashScope</name>
+    <name>LangChain4j :: Integration :: DashScope</name>
 
     <dependencies>
 

--- a/langchain4j-elasticsearch/pom.xml
+++ b/langchain4j-elasticsearch/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-elasticsearch</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Elasticsearch</name>
+    <name>LangChain4j :: Integration :: Elasticsearch</name>
 
     <dependencies>
         <dependency>

--- a/langchain4j-hugging-face/pom.xml
+++ b/langchain4j-hugging-face/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-hugging-face</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Hugging Face</name>
+    <name>LangChain4j :: Integration :: Hugging Face</name>
 
     <dependencies>
 

--- a/langchain4j-local-ai/pom.xml
+++ b/langchain4j-local-ai/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-local-ai</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with LocalAI</name>
+    <name>LangChain4j :: Integration :: LocalAI</name>
 
     <dependencies>
 

--- a/langchain4j-milvus/pom.xml
+++ b/langchain4j-milvus/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>langchain4j-milvus</artifactId>
-    <name>LangChain4j integration with Milvus</name>
+    <name>LangChain4j :: Integration :: Milvus</name>
 
     <dependencies>
 

--- a/langchain4j-mistral-ai/pom.xml
+++ b/langchain4j-mistral-ai/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>langchain4j-mistral-ai</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with MistralAI</name>
+    <name>LangChain4j :: Integration :: MistralAI</name>
 
     <dependencies>
 

--- a/langchain4j-neo4j/pom.xml
+++ b/langchain4j-neo4j/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-neo4j</artifactId>
     
     <packaging>jar</packaging>
-    <name>LangChain4j integration with Neo4j Vector Index</name>
+    <name>LangChain4j :: Integration :: Neo4j Vector Index</name>
 
     <description>Requires Java 17</description>
 

--- a/langchain4j-ollama/pom.xml
+++ b/langchain4j-ollama/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>langchain4j-ollama</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Ollama</name>
+    <name>LangChain4j :: Integration :: Ollama</name>
 
     <properties>
         <skipOllamaITs>false</skipOllamaITs>

--- a/langchain4j-open-ai/pom.xml
+++ b/langchain4j-open-ai/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-open-ai</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with OpenAI</name>
+    <name>LangChain4j :: Integration :: OpenAI</name>
 
     <dependencies>
 

--- a/langchain4j-opensearch/pom.xml
+++ b/langchain4j-opensearch/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-opensearch</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with OpenSearch</name>
+    <name>LangChain4j :: Integration :: OpenSearch</name>
     <description>Requires Java 11</description>
 
     <properties>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -9,7 +9,7 @@
     <version>0.27.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>langchain4j parent POM</name>
+    <name>LangChain4j :: Parent POM</name>
     <description>Parent POM for langchain4j submodules</description>
     <url>https://github.com/langchain4j/langchain4j</url>
 

--- a/langchain4j-pgvector/pom.xml
+++ b/langchain4j-pgvector/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>langchain4j-pgvector</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with PGVector</name>
+    <name>LangChain4j :: Integration :: PGVector</name>
     <description>It uses the pgvector-java library</description>
 
     <dependencies>

--- a/langchain4j-pinecone/pom.xml
+++ b/langchain4j-pinecone/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>langchain4j-pinecone</artifactId>
-    <name>LangChain4j integration with Pinecone</name>
+    <name>LangChain4j :: Integration :: Pinecone</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/langchain4j-qdrant/pom.xml
+++ b/langchain4j-qdrant/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>langchain4j-qdrant</artifactId>
-    <name>LangChain4j integration with Qdrant</name>
+    <name>LangChain4j :: Integration :: Qdrant</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/langchain4j-qianfan/pom.xml
+++ b/langchain4j-qianfan/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-qianfan</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Qianfan</name>
+    <name>LangChain4j :: Integration :: Qianfan</name>
 
     <dependencies>
 

--- a/langchain4j-redis/pom.xml
+++ b/langchain4j-redis/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-redis</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Redis</name>
+    <name>LangChain4j :: Integration :: Redis</name>
 
     <dependencies>
 

--- a/langchain4j-vearch/pom.xml
+++ b/langchain4j-vearch/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>langchain4j-vearch</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Vearch</name>
+    <name>LangChain4j :: Integration :: Vearch</name>
 
     <properties>
         <skipVearchITs>false</skipVearchITs>

--- a/langchain4j-vertex-ai-gemini/pom.xml
+++ b/langchain4j-vertex-ai-gemini/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-vertex-ai-gemini</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Google Vertex AI Gemini</name>
+    <name>LangChain4j :: Integration :: Google Vertex AI Gemini</name>
 
     <properties>
         <skipVertexAiGeminiITs>false</skipVertexAiGeminiITs>

--- a/langchain4j-vertex-ai/pom.xml
+++ b/langchain4j-vertex-ai/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-vertex-ai</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Google Vertex AI</name>
+    <name>LangChain4j :: Integration :: Google Vertex AI</name>
 
     <dependencies>
 

--- a/langchain4j-vespa/pom.xml
+++ b/langchain4j-vespa/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-vespa</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Vespa</name>
+    <name>LangChain4j :: Integration :: Vespa</name>
     <description>
         Vespa is a fully featured search engine and vector database.
         Integration with LangChain4j uses:

--- a/langchain4j-weaviate/pom.xml
+++ b/langchain4j-weaviate/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j-weaviate</artifactId>
     <packaging>jar</packaging>
 
-    <name>LangChain4j integration with Weaviate</name>
+    <name>LangChain4j :: Integration :: Weaviate</name>
     <description>Uses io.weaviate.client library which has a BSD 3-Clause license:
         https://github.com/weaviate/java-client/blob/main/LICENSE
     </description>

--- a/langchain4j/pom.xml
+++ b/langchain4j/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>langchain4j</artifactId>
     <packaging>jar</packaging>
 
-    <name>langchain4j</name>
+    <name>LangChain4j</name>
     <description>Java implementation of LangChain: Integrate your Java application with countless AI tools and services
         smoothly
     </description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <artifactId>langchain4j-aggregator</artifactId>
     <version>0.27.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+    <name>LangChain4j :: Aggregator</name>
 
     <modules>
 


### PR DESCRIPTION
Looking at the Maven output I thought it could benefit from a little renaming. I just changed the `<name>` in the `pom.xml`, nothing more. The output is like this at the moment:

![Screenshot 2024-01-30 at 16 26 53](https://github.com/langchain4j/langchain4j/assets/729277/940886d1-565e-416f-a58e-91f609fc0c00)

It could look like this if this PR is merged:

![Screenshot 2024-01-30 at 16 42 38](https://github.com/langchain4j/langchain4j/assets/729277/f8787af2-b869-4e95-90bd-72bce5622737)

Just a personal taste. Let me know if you like it or not (or want to change it). If not, just discard it, it's fine ;o)