### PR TITLE
Add `langchain4j-embeddings-all-minilm-l6-v2-q` to the BOM

### DIFF
--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -104,7 +104,7 @@
                 <artifactId>langchain4j-mistral-ai</artifactId>
                 <version>${project.version}</version>
             </dependency>
-          
+
             <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-cohere</artifactId>

--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -203,6 +203,14 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- embeddings -->
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- code execution engines -->
 
             <dependency>


### PR DESCRIPTION
Which seems needed as otherwise the version is not right:

https://mvnrepository.com/artifact/dev.langchain4j/langchain4j-bom/0.26.1

You can see that the `langchain4j-embeddings-all-minilm-l6-v2-q` artifact is referenced by version 0.25.0 instead of 0.26.1.

I'm not sure this is the right fix here?

cc @langchain4j, @Martin7-1