### PR TITLE
langchain4j/model.output coverage tests.

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/model/output/DateOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/model/output/DateOutputParser.java
@@ -11,6 +11,13 @@ public class DateOutputParser implements OutputParser<Date> {
 
     @Override
     public Date parse(String string) {
+        string = string.trim();
+
+        // SimpleDateFormat silently accepts dd-MM-yyyy; but parses it strangely.
+        if (string.indexOf("-") != 4 || string.indexOf("-", 5) != 7) {
+            throw new RuntimeException("Invalid date format: " + string);
+        }
+
         try {
             return SIMPLE_DATE_FORMAT.parse(string);
         } catch (ParseException e) {

--- a/langchain4j/src/main/java/dev/langchain4j/model/output/EnumOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/model/output/EnumOutputParser.java
@@ -1,9 +1,8 @@
 package dev.langchain4j.model.output;
 
-import dev.langchain4j.internal.Json;
-
 import java.util.Arrays;
 
+@SuppressWarnings("rawtypes")
 public class EnumOutputParser implements OutputParser<Enum> {
 
     private final Class<? extends Enum> enumClass;
@@ -14,7 +13,12 @@ public class EnumOutputParser implements OutputParser<Enum> {
 
     @Override
     public Enum parse(String string) {
-        return Json.fromJson(string, enumClass);
+        for (Enum enumConstant : enumClass.getEnumConstants()) {
+            if (enumConstant.name().equalsIgnoreCase(string)) {
+                return enumConstant;
+            }
+        }
+        throw new RuntimeException("Unknown enum value: " + string);
     }
 
     @Override

--- a/langchain4j/src/main/java/dev/langchain4j/model/output/LocalDateOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/model/output/LocalDateOutputParser.java
@@ -13,6 +13,6 @@ public class LocalDateOutputParser implements OutputParser<LocalDate> {
 
     @Override
     public String formatInstructions() {
-        return "2023-12-31";
+        return "yyyy-MM-dd";
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/model/output/LocalDateTimeOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/model/output/LocalDateTimeOutputParser.java
@@ -13,6 +13,6 @@ public class LocalDateTimeOutputParser implements OutputParser<LocalDateTime> {
 
     @Override
     public String formatInstructions() {
-        return "2023-12-31T23:59:59";
+        return "yyyy-MM-ddTHH:mm:ss";
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/model/output/LocalTimeOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/model/output/LocalTimeOutputParser.java
@@ -13,6 +13,6 @@ public class LocalTimeOutputParser implements OutputParser<LocalTime> {
 
     @Override
     public String formatInstructions() {
-        return "23:59:59";
+        return "HH:mm:ss";
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/model/output/OutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/model/output/OutputParserTest.java
@@ -78,7 +78,8 @@ class OutputParserTest implements WithAssertions {
 
         // TODO: this is a bug; we silently miss-parses alternate formats.
         assertThat(parser.parse("01-12-2020"))
-                .isEqualTo(new Date(-1893, Calendar.MAY, 12));
+                .isInstanceOf(Date.class)
+                .hasYear(7);
 
         assertThatExceptionOfType(RuntimeException.class)
                 .isThrownBy(() -> parser.parse("red"));

--- a/langchain4j/src/test/java/dev/langchain4j/model/output/OutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/model/output/OutputParserTest.java
@@ -76,13 +76,9 @@ class OutputParserTest implements WithAssertions {
                 .isEqualTo(parser.parse("2020-01-12"))
                 .isEqualTo(new Date(120, Calendar.JANUARY, 12));
 
-        // TODO: this is a bug; we silently miss-parses alternate formats.
-        assertThat(parser.parse("01-12-2020"))
-                .isInstanceOf(Date.class)
-                .hasYear(7);
-
         assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(() -> parser.parse("red"));
+                .isThrownBy(() -> parser.parse("01-12-2020"))
+                .withMessage("Invalid date format: 01-12-2020");
     }
 
     @Test
@@ -109,16 +105,18 @@ class OutputParserTest implements WithAssertions {
                 .isEqualTo("one of [A, B, C]");
 
         assertThat(parser.parse("A"))
+                .isEqualTo(parser.parse("a"))
                 .isEqualTo(Enum.A);
         assertThat(parser.parse("B"))
+                .isEqualTo(parser.parse("b"))
                 .isEqualTo(Enum.B);
         assertThat(parser.parse("C"))
+                .isEqualTo(parser.parse("c"))
                 .isEqualTo(Enum.C);
 
-        // TODO: potential bugs?
-        assertThat(parser.parse("D"))
-                .isEqualTo(parser.parse("a"))
-                .isNull();
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parser.parse("D"))
+                .withMessage("Unknown enum value: D");
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/model/output/OutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/model/output/OutputParserTest.java
@@ -189,8 +189,8 @@ class OutputParserTest implements WithAssertions {
                 .isEqualTo(parser.parse("12:34:56"))
                 .isEqualTo(LocalTime.of(12, 34, 56));
 
-        assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(() -> parser.parse("12:34:56.789"));
+        assertThat(parser.parse("12:34:56.789"))
+                .isEqualTo(LocalTime.of(12, 34, 56, 789_000_000));
 
         assertThatExceptionOfType(RuntimeException.class)
                 .isThrownBy(() -> parser.parse("red"));

--- a/langchain4j/src/test/java/dev/langchain4j/model/output/OutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/model/output/OutputParserTest.java
@@ -1,0 +1,222 @@
+package dev.langchain4j.model.output;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Calendar;
+import java.util.Date;
+
+
+class OutputParserTest implements WithAssertions {
+    @Test
+    public void test_BigDecimal() {
+        BigDecimalOutputParser parser = new BigDecimalOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("floating point number");
+
+        assertThat(parser.parse("3.14")).isEqualTo(new BigDecimal("3.14"));
+
+        assertThatExceptionOfType(NumberFormatException.class)
+                .isThrownBy(() -> parser.parse("3.14.15"));
+    }
+
+    @Test
+    public void test_BigInteger() {
+        BigIntegerOutputParser parser = new BigIntegerOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("integer number");
+
+        assertThat(parser.parse("42")).isEqualTo(42);
+
+        assertThatExceptionOfType(NumberFormatException.class)
+                .isThrownBy(() -> parser.parse("42.0"));
+    }
+
+    @Test
+    public void test_Boolean() {
+        BooleanOutputParser parser = new BooleanOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("one of [true, false]");
+
+        assertThat(parser.parse("true"))
+                .isEqualTo(parser.parse("TRUE"))
+                .isEqualTo(true);
+        assertThat(parser.parse("false"))
+                .isEqualTo(parser.parse("FALSE"))
+                // surprising, but how Boolean.parseBoolean works
+                .isEqualTo(parser.parse("yes"))
+                .isEqualTo(false);
+    }
+
+    @Test
+    public void test_Byte() {
+        ByteOutputParser parser = new ByteOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("integer number in range [-128, 127]");
+
+        assertThat(parser.parse("42")).isEqualTo((byte) 42);
+        assertThat(parser.parse("-42")).isEqualTo((byte) -42);
+
+        assertThatExceptionOfType(NumberFormatException.class)
+                .isThrownBy(() -> parser.parse("42.0"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void test_Date() {
+        DateOutputParser parser = new DateOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("yyyy-MM-dd");
+
+        assertThat(parser.parse("2020-01-12"))
+                .isEqualTo(parser.parse("2020-01-12"))
+                .isEqualTo(new Date(120, Calendar.JANUARY, 12));
+
+        // TODO: this is a bug; we silently miss-parses alternate formats.
+        assertThat(parser.parse("01-12-2020"))
+                .isEqualTo(new Date(-1893, Calendar.MAY, 12));
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parser.parse("red"));
+    }
+
+    @Test
+    public void test_Double() {
+        DoubleOutputParser parser = new DoubleOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("floating point number");
+
+        assertThat(parser.parse("3.14")).isEqualTo(3.14);
+
+        assertThatExceptionOfType(NumberFormatException.class)
+                .isThrownBy(() -> parser.parse("3.14.15"));
+    }
+
+    public enum Enum {
+        A, B, C
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void test_Enum() {
+        EnumOutputParser parser = new EnumOutputParser(Enum.class);
+        assertThat(parser.formatInstructions())
+                .isEqualTo("one of [A, B, C]");
+
+        assertThat(parser.parse("A"))
+                .isEqualTo(Enum.A);
+        assertThat(parser.parse("B"))
+                .isEqualTo(Enum.B);
+        assertThat(parser.parse("C"))
+                .isEqualTo(Enum.C);
+
+        // TODO: potential bugs?
+        assertThat(parser.parse("D"))
+                .isEqualTo(parser.parse("a"))
+                .isNull();
+    }
+
+    @Test
+    public void test_Float() {
+        FloatOutputParser parser = new FloatOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("floating point number");
+
+        assertThat(parser.parse("3.14")).isEqualTo(3.14f);
+
+        assertThatExceptionOfType(NumberFormatException.class)
+                .isThrownBy(() -> parser.parse("3.14.15"));
+    }
+
+    @Test
+    public void test_Integer() {
+        IntOutputParser parser = new IntOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("integer number");
+
+        assertThat(parser.parse("42")).isEqualTo(42);
+
+        assertThatExceptionOfType(NumberFormatException.class)
+                .isThrownBy(() -> parser.parse("42.0"));
+    }
+
+    @Test
+    public void test_LocalDate() {
+        LocalDateOutputParser parser = new LocalDateOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("yyyy-MM-dd");
+
+        assertThat(parser.parse("2020-01-12"))
+                .isEqualTo(parser.parse("2020-01-12"))
+                .isEqualTo(LocalDate.of(2020, 1, 12));
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parser.parse("01-12-2020"));
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parser.parse("red"));
+    }
+
+    @Test
+    public void test_LocalDateTime() {
+        LocalDateTimeOutputParser parser = new LocalDateTimeOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("yyyy-MM-ddTHH:mm:ss");
+
+        assertThat(parser.parse("2020-01-12T12:34:56"))
+                .isEqualTo(parser.parse("2020-01-12T12:34:56"))
+                .isEqualTo(LocalDateTime.of(2020, 1, 12, 12, 34, 56));
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parser.parse("01-12-2020T12:34:56"));
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parser.parse("red"));
+    }
+
+    @Test
+    public void test_LocalTime() {
+        LocalTimeOutputParser parser = new LocalTimeOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("HH:mm:ss");
+
+        assertThat(parser.parse("12:34:56"))
+                .isEqualTo(parser.parse("12:34:56"))
+                .isEqualTo(LocalTime.of(12, 34, 56));
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parser.parse("12:34:56.789"));
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parser.parse("red"));
+    }
+
+    @Test
+    public void test_Long() {
+        LongOutputParser parser = new LongOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("integer number");
+
+        assertThat(parser.parse("42")).isEqualTo(42L);
+
+        assertThatExceptionOfType(NumberFormatException.class)
+                .isThrownBy(() -> parser.parse("42.0"));
+    }
+
+    @Test
+    public void test_Short() {
+        ShortOutputParser parser = new ShortOutputParser();
+        assertThat(parser.formatInstructions())
+                .isEqualTo("integer number in range [-32768, 32767]");
+
+        assertThat(parser.parse("42")).isEqualTo((short) 42);
+        assertThat(parser.parse("-42")).isEqualTo((short) -42);
+
+        assertThatExceptionOfType(NumberFormatException.class)
+                .isThrownBy(() -> parser.parse("42.0"));
+    }
+}


### PR DESCRIPTION
Noticed weirdness in the errors for DateOutputParser and EnumOutputParser.

Expanded EnumOutputParser to be case-insensitive.
Restricted DateOutputParser to the expected format.