### PR TITLE
[streaming] add a .shutdown() method to the StreamingChatLanguageModel interface

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModel.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModel.java
@@ -596,4 +596,9 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatLanguageModel
             }
         }
     }
+
+    @Override
+    public void shutdown() {
+        // no-op (this implementation's client has no shutdown method).
+    }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/StreamingChatLanguageModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/StreamingChatLanguageModel.java
@@ -60,4 +60,10 @@ public interface StreamingChatLanguageModel {
     default void generate(List<ChatMessage> messages, ToolSpecification toolSpecification, StreamingResponseHandler<AiMessage> handler) {
         throw new IllegalArgumentException("Tools are currently not supported by this model");
     }
+
+    /**
+     * Releases resources that were acquired or created by the implementation,
+     * such as request executors or connections to remote services.
+     */
+    void shutdown();
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/StreamingChatLanguageModelTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/StreamingChatLanguageModelTest.java
@@ -21,6 +21,10 @@ class StreamingChatLanguageModelTest implements WithAssertions {
             Response<AiMessage> response = new Response<>(new AiMessage(lastMessage.text().toUpperCase(Locale.ROOT)));
             handler.onComplete(response);
         }
+
+        public void shutdown() {
+            // no-op
+        }
     }
 
     public static final class CollectorResponseHandler<T> implements StreamingResponseHandler<T> {
@@ -88,4 +92,6 @@ class StreamingChatLanguageModelTest implements WithAssertions {
             assertThat(response.finishReason()).isNull();
         }
     }
+
+
 }

--- a/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenStreamingChatModel.java
+++ b/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenStreamingChatModel.java
@@ -189,4 +189,10 @@ public class QwenStreamingChatModel implements StreamingChatLanguageModel {
             // By default with Lombok it becomes package private
         }
     }
+
+    @Override
+    public void shutdown() {
+        // no-op: unclear if resources in this class can be closed?
+    }
+
 }

--- a/langchain4j-local-ai/src/main/java/dev/langchain4j/model/localai/LocalAiStreamingChatModel.java
+++ b/langchain4j-local-ai/src/main/java/dev/langchain4j/model/localai/LocalAiStreamingChatModel.java
@@ -143,4 +143,9 @@ public class LocalAiStreamingChatModel implements StreamingChatLanguageModel {
             // By default with Lombok it becomes package private
         }
     }
+
+    @Override
+    public void shutdown() {
+        client.shutdown();
+    }
 }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiClient.java
@@ -9,6 +9,7 @@ import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import lombok.Builder;
+import okhttp3.Cache;
 import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;
 import okhttp3.sse.EventSource;
@@ -212,5 +213,19 @@ class MistralAiClient {
             }
         }
         return new RuntimeException(retrofitResponse.message());
+    }
+
+    public void shutdown() {
+        okHttpClient.dispatcher().executorService().shutdown();
+        okHttpClient.connectionPool().evictAll();
+        Cache cache = okHttpClient.cache();
+
+        if (cache != null) {
+            try {
+                cache.close();
+            } catch (IOException e) {
+                LOGGER.error("Failed to close cache", e);
+            }
+        }
     }
 }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModel.java
@@ -106,4 +106,9 @@ public class MistralAiStreamingChatModel implements StreamingChatLanguageModel {
 
         client.streamingChatCompletion(request, handler);
     }
+
+    @Override
+    public void shutdown() {
+        client.shutdown();
+    }
 }

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaStreamingChatModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaStreamingChatModel.java
@@ -86,4 +86,9 @@ public class OllamaStreamingChatModel implements StreamingChatLanguageModel {
             // By default with Lombok it becomes package private
         }
     }
+
+    @Override
+    public void shutdown() {
+        client.shutdown();
+    }
 }

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -208,4 +208,9 @@ public class OpenAiStreamingChatModel implements StreamingChatLanguageModel, Tok
             return this;
         }
     }
+
+    @Override
+    public void shutdown() {
+        client.shutdown();
+    }
 }

--- a/langchain4j-qianfan/src/main/java/dev/langchain4j/model/qianfan/QianfanStreamingChatModel.java
+++ b/langchain4j-qianfan/src/main/java/dev/langchain4j/model/qianfan/QianfanStreamingChatModel.java
@@ -157,4 +157,9 @@ public class QianfanStreamingChatModel implements StreamingChatLanguageModel  {
             // By default with Lombok it becomes package private
         }
     }
+
+    @Override
+    public void shutdown() {
+        client.shutdown();
+    }
 }

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/VertexAiGeminiStreamingChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/VertexAiGeminiStreamingChatModel.java
@@ -99,4 +99,9 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatLanguageMo
             // By default with Lombok it becomes package private
         }
     }
+
+    @Override
+    public void shutdown() {
+        // no-op – No close/shutdown methods exposed and the wrapped
+    }
 }


### PR DESCRIPTION
Adds a `.shutdown()` method to the `StreamingChatLanguageModel` interface: this allows callers to request implementations to release or close any resources that they acquired.

The need for this is best illustrated with the current [OpenAI streaming example](https://github.com/langchain4j/langchain4j-examples/blob/337186583f4dc5e4e122b0cdf0a42ddb586c7fe0/tutorials/src/main/java/_04_Streaming.java#L5): 

When the example is run, it will output `Done streaming` but the program won't terminate before another minute or so.

I assume that this is due to the underlying `OkHttpClient` that has an Executor that keeps running.

### Approach

I chose to _not_ add a default `shutdown()` implementation to the interface to force any implementation to ask "are there resources we should free when this needs to shut down).

For a few implementation it is unclear if resources would need to be closes, and/or some changes in external dependencies might be required.

### Testing

Tested against the [StreamingExample](https://github.com/langchain4j/langchain4j-examples/blob/b64efcb6aafdc3b763295c740ae37546a0b475aa/other-examples/src/main/java/StreamingExamples.java#L16) from the example repository: adding `.shutdown()` at the end of the main method causes the program to properly exit as soon as the method is complete.