### PR TITLE
Add type to array parameter in tool specification

### DIFF
--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.agent.tool;
 
+import static dev.langchain4j.agent.tool.JsonSchemaProperty.items;
+
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
@@ -43,10 +45,18 @@ class ToolSpecificationsTest implements WithAssertions {
                 Double p15,
                 @P("bigger") BigDecimal p16,
                 String[] p17,
-                List<String> p18,
-                Set<String> p19,
-                E p20,
-                Object p21
+                Integer[] p18,
+                Boolean[] p19,
+                int[] p20,
+                boolean[] p21,
+                List<Integer> p22,
+                Set<BigDecimal> p23,
+                Collection<String> p24,
+                List p25,
+                Set p26,
+                Collection p27,
+                E p28,
+                Object p29
                 ) {
             return 42;
         }
@@ -63,26 +73,34 @@ class ToolSpecificationsTest implements WithAssertions {
 
     private static Method getF() throws NoSuchMethodException {
         return Wrapper.class.getMethod("f",
-                String.class,
+                String.class,//0
                 boolean.class,
                 Boolean.class,
                 byte.class,
                 Byte.class,
-                short.class,
+                short.class,//5
                 Short.class,
                 int.class,
                 Integer.class,
                 long.class,
-                Long.class,
+                Long.class, //10
                 BigInteger.class,
                 float.class,
                 Float.class,
                 double.class,
-                Double.class,
+                Double.class, //15
                 BigDecimal.class,
                 String[].class,
+                Integer[].class,
+                Boolean[].class,
+                int[].class,//20
+                boolean[].class,
                 List.class,
                 Set.class,
+                Collection.class,
+                List.class,//25
+                Set.class,
+                Collection.class,
                 E.class,
                 Object.class);
     }
@@ -131,7 +149,7 @@ class ToolSpecificationsTest implements WithAssertions {
 
         Map<String, Map<String, Object>> properties = ts.parameters().properties();
 
-        assertThat(properties).hasSize(22);
+        assertThat(properties).hasSize(30);
         assertThat(properties)
                 .containsEntry("arg0", mapOf("type", "string", "description", "foo"))
                         .containsEntry("arg1", mapOf("type", "boolean"))
@@ -150,13 +168,21 @@ class ToolSpecificationsTest implements WithAssertions {
                         .containsEntry("arg14", mapOf("type", "number"))
                         .containsEntry("arg15", mapOf("type", "number"))
                         .containsEntry("arg16", mapOf("type", "number", "description", "bigger"))
-                        .containsEntry("arg17", mapOf("type", "array"))
-                        .containsEntry("arg18", mapOf("type", "array"))
-                        .containsEntry("arg19", mapOf("type", "array"))
-                        .containsEntry("arg21", mapOf("type", "object"));
+                        .containsEntry("arg17", mapOf("type", "array", "items", mapOf("type", "string")))
+                        .containsEntry("arg18", mapOf("type", "array", "items", mapOf("type", "integer")))
+                        .containsEntry("arg19", mapOf("type", "array", "items", mapOf("type", "boolean")))
+                        .containsEntry("arg20", mapOf("type", "array", "items", mapOf("type", "integer")))
+                        .containsEntry("arg21", mapOf("type", "array", "items", mapOf("type", "boolean")))
+                        .containsEntry("arg22", mapOf("type", "array", "items", mapOf("type", "integer")))
+                        .containsEntry("arg23", mapOf("type", "array", "items", mapOf("type", "number")))
+                        .containsEntry("arg24", mapOf("type", "array", "items", mapOf("type", "string")))
+                        .containsEntry("arg25", mapOf("type", "array", "items", mapOf("type", "object")))
+                        .containsEntry("arg26", mapOf("type", "array", "items", mapOf("type", "object")))
+                        .containsEntry("arg27", mapOf("type", "array", "items", mapOf("type", "object")))
+                        .containsEntry("arg29", mapOf("type", "object"));
 
-        assertThat(properties.get("arg20")).containsEntry("type", "string");
-        assertThat(Arrays.equals((Object[]) properties.get("arg20").get("enum"), new E[]{E.A, E.B, E.C})).isTrue();
+        assertThat(properties.get("arg28")).containsEntry("type", "string");
+        assertThat(Arrays.equals((Object[]) properties.get("arg28").get("enum"), new E[]{E.A, E.B, E.C})).isTrue();
 
         assertThat(ts.parameters().required())
                 .containsExactly("arg0",
@@ -180,7 +206,16 @@ class ToolSpecificationsTest implements WithAssertions {
                         "arg18",
                         "arg19",
                         "arg20",
-                        "arg21");
+                        "arg21",
+                        "arg22",
+                        "arg23",
+                        "arg24",
+                        "arg25",
+                        "arg26",
+                        "arg27",
+                        "arg28",
+                        "arg29"
+                    );
     }
 
     @Test
@@ -234,15 +269,15 @@ class ToolSpecificationsTest implements WithAssertions {
                         JsonSchemaProperty.description("bigger"));
 
         assertThat(ToolSpecifications.toJsonSchemaProperties(ps[17]))
-                .containsExactly(JsonSchemaProperty.ARRAY);
+                .containsExactly(JsonSchemaProperty.ARRAY, items(JsonSchemaProperty.STRING));
         assertThat(ToolSpecifications.toJsonSchemaProperties(ps[18]))
-                .containsExactly(JsonSchemaProperty.ARRAY);
+                .containsExactly(JsonSchemaProperty.ARRAY, items(JsonSchemaProperty.INTEGER));
         assertThat(ToolSpecifications.toJsonSchemaProperties(ps[19]))
-                .containsExactly(JsonSchemaProperty.ARRAY);
+                .containsExactly(JsonSchemaProperty.ARRAY, items(JsonSchemaProperty.BOOLEAN));
 
         {
             List<JsonSchemaProperty> properties = new ArrayList<>();
-            ToolSpecifications.toJsonSchemaProperties(ps[20]).forEach(properties::add);
+            ToolSpecifications.toJsonSchemaProperties(ps[28]).forEach(properties::add);
 
             assertThat(properties.get(0))
                     .isEqualTo(JsonSchemaProperty.STRING);
@@ -250,7 +285,7 @@ class ToolSpecificationsTest implements WithAssertions {
             assertThat(Arrays.equals((Object[]) properties.get(1).value(), new E[]{E.A, E.B, E.C})).isTrue();
         }
 
-        assertThat(ToolSpecifications.toJsonSchemaProperties(ps[21]))
+        assertThat(ToolSpecifications.toJsonSchemaProperties(ps[29]))
                 .containsExactly(JsonSchemaProperty.OBJECT);
     }
 


### PR DESCRIPTION
This PR introduces typed array parameters for tool specification, which is currently fails with some APIs with next error (OpenAI example):

> WARN: Exception was thrown on attempt 1 of 3: dev.ai4j.openai4j.OpenAiHttpException: {
>   "error": {
>     "message": "Invalid schema for function 'xxxx': In context=('properties', 'arg0'), array schema missing items",
>     "type": "invalid_request_error",
>     "param": null,
>     "code": null
>   }
> }

New test covers use case scenario that requires array parameter to be used for tool, and that was failing with error above prior the change.
