### PR TITLE
Adds a test to check that the API version is set to the latest if incorrect

### DIFF
--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
@@ -46,6 +46,15 @@ class InternalAzureOpenAiHelperTest {
     }
 
     @Test
+    void getOpenAIServiceVersionShouldReturnLatestVersionIfIncorrect() {
+        String serviceVersion = "1901-01-01";
+
+        OpenAIServiceVersion version = InternalAzureOpenAiHelper.getOpenAIServiceVersion(serviceVersion);
+
+        assertEquals(OpenAIServiceVersion.getLatest().getVersion(), version.getVersion());
+    }
+
+    @Test
     void toOpenAiMessagesShouldReturnCorrectMessages() {
         List<ChatMessage> messages = new ArrayList<>();
         messages.add(new UserMessage("test-user", "test-message"));


### PR DESCRIPTION
Adds a test to check that if the Azure API version is incorrect, then the latest is used.

If you look at `InternalAzureOpenAiHelper.getOpenAIServiceVersion()` method, you see that it looks is the `serviceVersion` is in the allowed list. If not, then the latest version is used.