### PR TITLE
Use Testcontainers Vector Database modules

### DIFF
--- a/langchain4j-chroma/pom.xml
+++ b/langchain4j-chroma/pom.xml
@@ -66,7 +66,7 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
+            <artifactId>chromadb</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreIT.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreIT.java
@@ -5,7 +5,7 @@ import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreIT;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.chromadb.ChromaDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -15,11 +15,10 @@ import static dev.langchain4j.internal.Utils.randomUUID;
 class ChromaEmbeddingStoreIT extends EmbeddingStoreIT {
 
     @Container
-    private static final GenericContainer<?> chroma = new GenericContainer<>("ghcr.io/chroma-core/chroma:0.4.6")
-            .withExposedPorts(8000);
+    private static final ChromaDBContainer chroma = new ChromaDBContainer("ghcr.io/chroma-core/chroma:0.4.6");
 
     EmbeddingStore<TextSegment> embeddingStore = ChromaEmbeddingStore.builder()
-            .baseUrl(String.format("http://%s:%d", chroma.getHost(), chroma.getMappedPort(8000)))
+            .baseUrl(chroma.getEndpoint())
             .collectionName(randomUUID())
             .build();
 

--- a/langchain4j-milvus/pom.xml
+++ b/langchain4j-milvus/pom.xml
@@ -67,7 +67,7 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
+            <artifactId>milvus</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreIT.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreIT.java
@@ -9,12 +9,9 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreWithoutMetadataIT;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.MinIOContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.milvus.MilvusContainer;
 
 import java.util.List;
 
@@ -27,36 +24,11 @@ import static org.assertj.core.data.Percentage.withPercentage;
 @Testcontainers
 class MilvusEmbeddingStoreIT extends EmbeddingStoreWithoutMetadataIT {
 
-    private static final Network network = Network.newNetwork();
-
-    private static final MinIOContainer minio = new MinIOContainer("minio/minio:RELEASE.2023-03-20T20-16-18Z")
-            .withNetwork(network)
-            .withNetworkAliases("minio");
-
-    private static final GenericContainer<?> etcd = new GenericContainer<>("quay.io/coreos/etcd:v3.5.5")
-            .withNetwork(network)
-            .withNetworkAliases("etcd")
-            .withCommand("etcd", "-advertise-client-urls=http://127.0.0.1:2379", "-listen-client-urls=http://0.0.0.0:2379",
-                    "--data-dir=/etcd")
-            .withEnv("ETCD_AUTO_COMPACTION_MODE", "revision")
-            .withEnv("ETCD_AUTO_COMPACTION_RETENTION", "1000")
-            .withEnv("ETCD_QUOTA_BACKEND_BYTES", "4294967296")
-            .withEnv("ETCD_SNAPSHOT_COUNT", "50000")
-            .waitingFor(Wait.forLogMessage(".*ready to serve client requests.*", 1));
-
     @Container
-    private static final GenericContainer<?> milvus = new GenericContainer<>("milvusdb/milvus:v2.3.1")
-            .withExposedPorts(19530)
-            .dependsOn(minio, etcd)
-            .withNetwork(network)
-            .withCommand("milvus", "run", "standalone")
-            .withEnv("ETCD_ENDPOINTS", "etcd:2379")
-            .withEnv("MINIO_ADDRESS", "minio:9000")
-            .waitingFor(Wait.forLogMessage(".*Proxy successfully started.*\\s", 1));
+    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.3.1");
 
     EmbeddingStore<TextSegment> embeddingStore = MilvusEmbeddingStore.builder()
-            .host(milvus.getHost())
-            .port(milvus.getMappedPort(19530))
+            .uri(milvus.getEndpoint())
             .collectionName("collection_" + randomUUID().replace("-", ""))
             .dimension(384)
             .retrieveEmbeddingsOnSearch(true)

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -32,7 +32,7 @@
         <slf4j-api.version>2.0.7</slf4j-api.version>
         <gson.version>2.10.1</gson.version>
         <junit.version>5.10.0</junit.version>
-        <testcontainers.version>1.19.2</testcontainers.version>
+        <testcontainers.version>1.19.6</testcontainers.version>
         <bytebuddy.version>1.14.10</bytebuddy.version>
         <mockito.version>4.11.0</mockito.version>
         <assertj.version>3.24.2</assertj.version>

--- a/langchain4j-qdrant/pom.xml
+++ b/langchain4j-qdrant/pom.xml
@@ -62,6 +62,12 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>qdrant</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>

--- a/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStoreIT.java
+++ b/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStoreIT.java
@@ -11,9 +11,9 @@ import io.qdrant.client.grpc.Collections.Distance;
 import io.qdrant.client.grpc.Collections.VectorParams;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.qdrant.QdrantContainer;
 
 import java.util.concurrent.ExecutionException;
 
@@ -29,8 +29,7 @@ class QdrantEmbeddingStoreIT extends EmbeddingStoreIT {
   private static QdrantEmbeddingStore embeddingStore;
 
   @Container
-  private static final GenericContainer<?> qdrant =
-      new GenericContainer<>("qdrant/qdrant:latest").withExposedPorts(grpcPort);
+  private static final QdrantContainer qdrant = new QdrantContainer("qdrant/qdrant:latest");
 
   EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
 

--- a/langchain4j-weaviate/pom.xml
+++ b/langchain4j-weaviate/pom.xml
@@ -72,6 +72,12 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>weaviate</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>

--- a/langchain4j-weaviate/src/test/java/dev/langchain4j/store/embedding/weaviate/LocalWeaviateEmbeddingStoreIT.java
+++ b/langchain4j-weaviate/src/test/java/dev/langchain4j/store/embedding/weaviate/LocalWeaviateEmbeddingStoreIT.java
@@ -5,9 +5,9 @@ import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreWithoutMetadataIT;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.weaviate.WeaviateContainer;
 
 import static dev.langchain4j.internal.Utils.randomUUID;
 
@@ -15,13 +15,10 @@ import static dev.langchain4j.internal.Utils.randomUUID;
 class LocalWeaviateEmbeddingStoreIT extends EmbeddingStoreWithoutMetadataIT {
 
     @Container
-    static GenericContainer<?> weaviate = new GenericContainer<>("semitechnologies/weaviate:latest")
-            .withEnv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true")
-            .withEnv("PERSISTENCE_DATA_PATH", "/var/lib/weaviate")
+    static WeaviateContainer weaviate = new WeaviateContainer("semitechnologies/weaviate:latest")
             .withEnv("QUERY_DEFAULTS_LIMIT", "25")
             .withEnv("DEFAULT_VECTORIZER_MODULE", "none")
-            .withEnv("CLUSTER_HOSTNAME", "node1")
-            .withExposedPorts(8080);
+            .withEnv("CLUSTER_HOSTNAME", "node1");
 
     EmbeddingStore<TextSegment> embeddingStore = WeaviateEmbeddingStore.builder()
             .scheme("http")


### PR DESCRIPTION
Testcontainers 1.19.6 has released 4 new modules for vector databases
(ChromaDB, Milvus, Qdrant, Weaviate)
