### PR TITLE
Docs: Updated the redundant base route from `/docs` to `/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Please see examples of how LangChain4j can be used in [langchain4j-examples](htt
 Documentation can be found [here](https://docs.langchain4j.dev).
 
 ## Tutorials
-Tutorials can be found [here](https://docs.langchain4j.dev/docs/tutorials).
+Tutorials can be found [here](https://docs.langchain4j.dev/tutorials).
 
 ## Useful Materials
 - [Intro to Large Language Models](https://www.youtube.com/watch?v=zjkBMFhNj_g) by [Andrej Karpathy](https://www.youtube.com/@AndrejKarpathy)
@@ -296,23 +296,23 @@ See example [here](https://github.com/langchain4j/langchain4j-examples/blob/main
     
     System.out.println(answer); // Hello! How can I assist you today?
     ```
-## Supported LLM Integrations ([Docs](https://docs.langchain4j.dev/docs/category/integrations))
-| Provider                                                                                                | Native Image     | [Completion](https://docs.langchain4j.dev/docs/category/language-models) | [Streaming](https://docs.langchain4j.dev/docs/integrations/language-models/response-streaming)  | [Async Completion](https://docs.langchain4j.dev/docs/category/language-models) | [Async Streaming](https://docs.langchain4j.dev/docs/integrations/language-models/response-streaming) | [Embedding](https://docs.langchain4j.dev/docs/category/embedding-models) | [Image Generation](https://docs.langchain4j.dev/docs/category/image-models) | [ReRanking](https://docs.langchain4j.dev/docs/category/reranking-models) 
+## Supported LLM Integrations ([Docs](https://docs.langchain4j.dev/category/integrations))
+| Provider                                                                                                | Native Image     | [Completion](https://docs.langchain4j.dev/category/language-models) | [Streaming](https://docs.langchain4j.dev/integrations/language-models/response-streaming)  | [Async Completion](https://docs.langchain4j.dev/category/language-models) | [Async Streaming](https://docs.langchain4j.dev/integrations/language-models/response-streaming) | [Embedding](https://docs.langchain4j.dev/category/embedding-models) | [Image Generation](https://docs.langchain4j.dev/category/image-models) | [ReRanking](https://docs.langchain4j.dev/category/reranking-models) 
 |---------------------------------------------------------------------------------------------------------| ------------- | ----------- | ------------- | --------- |--------------------------------| ------------ |---------------------------------------------------------------------------------------------|---------------|
-| [OpenAI](https://docs.langchain4j.dev/docs/integrations/language-models/openai)                         |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |                                                                                               
-| [Azure OpenAI](https://docs.langchain4j.dev/docs/integrations/language-models/azure-openai)             |  | ✅ | ✅ |  |   | ✅ | ✅ | 
-| [Hugging Face](https://docs.langchain4j.dev/docs/integrations/language-models/huggingface)              |  | ✅ |  | ✅ |  | ✅ |  |  |
-| [Amazon Bedrock](https://docs.langchain4j.dev/docs/integrations/language-models/amazon-bedrock)         |  | ✅ |  |  |  | ✅ |
-| [Google Vertex AI Gemini](https://docs.langchain4j.dev/docs/integrations/language-models/google-gemini) |  | ✅ | ✅ | ✅ | ✅ |  |  |
-| [Google Vertex AI](https://docs.langchain4j.dev/docs/integrations/language-models/google-palm)          | ✅ | ✅ |  | ✅ |  | ✅ | ✅ |
-| [Mistral AI](https://docs.langchain4j.dev/docs/integrations/language-models/mistralai)                  |  | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [DashScope](https://docs.langchain4j.dev/docs/integrations/language-models/dashscope)                   |  | ✅ | ✅ |  | ✅ | ✅ |
-| [LocalAI](https://docs.langchain4j.dev/docs/integrations/language-models/localai)                       |  | ✅ | ✅ | ✅ |  | ✅ |  |
-| [Ollama](https://docs.langchain4j.dev/docs/integrations/language-models/ollama)                         |  | ✅ | ✅ | ✅ | ✅ | ✅ |  |
-| [Cohere](https://docs.langchain4j.dev/docs/integrations/reranking-models/cohere)                        |  |  |  |  |  |  |  | ✅ |
-| [Qianfan](https://docs.langchain4j.dev/docs/integrations/language-models/qianfan)                       |  | ✅ | ✅ | ✅ | ✅ | ✅ |  |
-| [ChatGLM](https://docs.langchain4j.dev/docs/integrations/language-models/chatglm)                       |  | ✅ |  |  |  |  |
-| [Nomic](https://docs.langchain4j.dev/docs/integrations/language-models/nomic)                           |  |  |  |  |  | ✅ |  |
+| [OpenAI](https://docs.langchain4j.dev/integrations/language-models/openai)                         |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |                                                                                               
+| [Azure OpenAI](https://docs.langchain4j.dev/integrations/language-models/azure-openai)             |  | ✅ | ✅ |  |   | ✅ | ✅ | 
+| [Hugging Face](https://docs.langchain4j.dev/integrations/language-models/huggingface)              |  | ✅ |  | ✅ |  | ✅ |  |  |
+| [Amazon Bedrock](https://docs.langchain4j.dev/integrations/language-models/amazon-bedrock)         |  | ✅ |  |  |  | ✅ |
+| [Google Vertex AI Gemini](https://docs.langchain4j.dev/integrations/language-models/google-gemini) |  | ✅ | ✅ | ✅ | ✅ |  |  |
+| [Google Vertex AI](https://docs.langchain4j.dev/integrations/language-models/google-palm)          | ✅ | ✅ |  | ✅ |  | ✅ | ✅ |
+| [Mistral AI](https://docs.langchain4j.dev/integrations/language-models/mistralai)                  |  | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [DashScope](https://docs.langchain4j.dev/integrations/language-models/dashscope)                   |  | ✅ | ✅ |  | ✅ | ✅ |
+| [LocalAI](https://docs.langchain4j.dev/integrations/language-models/localai)                       |  | ✅ | ✅ | ✅ |  | ✅ |  |
+| [Ollama](https://docs.langchain4j.dev/integrations/language-models/ollama)                         |  | ✅ | ✅ | ✅ | ✅ | ✅ |  |
+| [Cohere](https://docs.langchain4j.dev/integrations/reranking-models/cohere)                        |  |  |  |  |  |  |  | ✅ |
+| [Qianfan](https://docs.langchain4j.dev/integrations/language-models/qianfan)                       |  | ✅ | ✅ | ✅ | ✅ | ✅ |  |
+| [ChatGLM](https://docs.langchain4j.dev/integrations/language-models/chatglm)                       |  | ✅ |  |  |  |  |
+| [Nomic](https://docs.langchain4j.dev/integrations/language-models/nomic)                           |  |  |  |  |  | ✅ |  |
 
 ## Disclaimer
 

--- a/docs/docs/get-started.md
+++ b/docs/docs/get-started.md
@@ -68,7 +68,7 @@ String answer = model.generate("Say 'Hello World'");
 System.out.println(answer); // Hello World
 ```
 
-Find step-by-step tutorials with more complex examples [here](/docs/category/tutorials).
+Find step-by-step tutorials with more complex examples [here](/category/tutorials).
 
 ## Highlights
 

--- a/docs/docs/integrations/embedding-models/mistralai.md
+++ b/docs/docs/integrations/embedding-models/mistralai.md
@@ -104,10 +104,10 @@ Response: I like football.
 
 Of course, you can combine MistralAI Embeddings with RAG (Retrieval-Augmented Generation) techniques.
 
-In [RAG](/docs/tutorials/rag) you will learn how to use RAG techniques for ingestion, retrieval and Advanced Retrieval with LangChain4j.
+In [RAG](/tutorials/rag) you will learn how to use RAG techniques for ingestion, retrieval and Advanced Retrieval with LangChain4j.
 
 A lot of parameters are set behind the scenes, such as timeout, model type and model parameters.
-In [Set Model Parameters](/docs/tutorials/model-parameters) you will learn how to set these parameters explicitly.
+In [Set Model Parameters](/tutorials/model-parameters) you will learn how to set these parameters explicitly.
 
 ### More examples
 If you want to check more examples, you can find them in the [langchain4j-examples](https://github.com/langchain4j/langchain4j-examples) project.

--- a/docs/docs/integrations/language-models/mistralai.md
+++ b/docs/docs/integrations/language-models/mistralai.md
@@ -119,12 +119,12 @@ You can see that output below is streamed in real-time.
 "Why do Java developers wear glasses? Because they can't C#"
 ```
 
-Of course, you can combine MistralAI chat completion with other features like [Set Model Parameters](/docs/tutorials/model-parameters) and [Chat Memory](/docs/tutorials/chat-memory) to get more accurate responses.
+Of course, you can combine MistralAI chat completion with other features like [Set Model Parameters](/tutorials/model-parameters) and [Chat Memory](/tutorials/chat-memory) to get more accurate responses.
 
-In [Chat Memory](/docs/tutorials/chat-memory) you will learn how to pass along your chat history, so the LLM knows what has been said before. If you don't pass the chat history, like in this simple example, the LLM will not know what has been said before, so it won't be able to correctly answer the second question ('What did I just ask?').
+In [Chat Memory](/tutorials/chat-memory) you will learn how to pass along your chat history, so the LLM knows what has been said before. If you don't pass the chat history, like in this simple example, the LLM will not know what has been said before, so it won't be able to correctly answer the second question ('What did I just ask?').
 
 A lot of parameters are set behind the scenes, such as timeout, model type and model parameters.
-In [Set Model Parameters](/docs/tutorials/model-parameters) you will learn how to set these parameters explicitly.
+In [Set Model Parameters](/tutorials/model-parameters) you will learn how to set these parameters explicitly.
 
 ### More examples
 If you want to check more MistralAI examples, you can find them in the [langchain4j-examples/mistral-ai-examples](https://github.com/langchain4j/langchain4j-examples/tree/main/mistral-ai-examples) project.

--- a/docs/docs/integrations/language-models/openai.md
+++ b/docs/docs/integrations/language-models/openai.md
@@ -87,7 +87,7 @@ A lot of parameters are set behind the scenes, such as timeout, model type and m
 In [Set Model Parameters](set-model-parameters) you will learn how to set these parameters explicitly.
 
 If you want to use another LLM, langchain4j has integrations with all major model providers (Google Vertex and Gemini, Azure OpenAI, ...) and (local) model wrappers (HuggingFace, Ollama, LocalAI).
-All integrations with examples and tutorials are listed under [Integrations](/docs/category/integrations).
+All integrations with examples and tutorials are listed under [Integrations](/category/integrations).
 
 In this easy example, the output is returned as a complete String. If you want to print the output token by token, use [Streaming](response-streaming).
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -87,7 +87,7 @@ You have complete control over how to combine them, but you will need to write m
 which hides all the complexity and boilerplate from you.
 You still have the flexibility to adjust and fine-tune the behavior, but it is done in a declarative manner.
 
-[![](/img/langchain4j-components.png)](/docs/intro)
+[![](/img/langchain4j-components.png)](/intro)
 
 ### Library Structure
 LangChain4j features a modular design, comprising:
@@ -97,14 +97,14 @@ LangChain4j features a modular design, comprising:
   You can use the `langchain4j-xyz` modules independently. For additional features, simply import the main `langchain4j` dependency.
 
 ### Tutorials (User Guide)
-Discover inspiring [use cases](/docs/tutorials#need-inspiration) or follow our step-by-step introduction to LangChain4j features under [Tutorials](/docs/category/tutorials).
+Discover inspiring [use cases](/tutorials#need-inspiration) or follow our step-by-step introduction to LangChain4j features under [Tutorials](/category/tutorials).
 
 You will get a tour of all LangChain4j functionality in steps of increasing complexity. All steps are demonstrated with complete code examples and code explanation.
 
 ### Integrations and Models
 LangChain4j offers ready-to-use integrations with models of OpenAI, HuggingFace, Google, Azure, and many more. 
 It has document loaders for all common document types, and integrations with plenty of embedding models and embedding stores, to facilitate retrieval-augmented generation and AI-powered classification.
-All integrations are listed [here](/docs/category/integrations).
+All integrations are listed [here](/category/integrations).
 
 ### Code examples
 

--- a/docs/docs/tutorials/3-model-parameters.md
+++ b/docs/docs/tutorials/3-model-parameters.md
@@ -21,7 +21,7 @@ For example, OpenAI API's parameters can be found at https://platform.openai.com
 | `frequencyPenalty` | Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.           | `Double`  |
 | `...`              | ...                                                                                                                                                                                                  | `...`     |
 
-For the full list of parameters in OpenAI LLMs, see the [OpenAI Language Model page](/docs/integrations/language-models/openai).
+For the full list of parameters in OpenAI LLMs, see the [OpenAI Language Model page](/integrations/language-models/openai).
 Full lists of parameters and default values per model can be found under the separate model pages
 (under Integration, Language Model and Image Model).
 
@@ -45,7 +45,7 @@ In this case of an OpenAI Chat Model for example, some of the defaults are
 | `logResponses` | false         |
 | `...`          | ...           |
 
-Defaults for all models can be found on the pages of the respective providers under [Integrations](/docs/integrations).
+Defaults for all models can be found on the pages of the respective providers under [Integrations](/integrations).
 
 ## Builder
 We can set every available parameter of the model using the builder pattern as follows:
@@ -75,7 +75,7 @@ and your changes are automatically ported to the code.
 The DEV UI can be accessed by running your Quarkus application with the command `quarkus dev`,
 then you can find it on localhost:8080/q/dev-ui (or wherever you deploy your application).
 
-[![](/img/quarkus-dev-ui-parameters.png)](/docs/tutorials/set-model-parameters)
+[![](/img/quarkus-dev-ui-parameters.png)](/tutorials/set-model-parameters)
 
 ## Setting Parameters in Spring Boot
 LangChain4j parameters in Spring Boot applications can be set in the `application.properties` file as follows:

--- a/docs/docs/tutorials/rag.md
+++ b/docs/docs/tutorials/rag.md
@@ -8,16 +8,16 @@ RAG can be split in 2 parst: ingestion and retrieval.
 
 ## Ingestion
 
-[![](/img/rag-ingestion.png)](/docs/tutorials/rag)
+[![](/img/rag-ingestion.png)](/tutorials/rag)
 
 ## Retrieval
 
-[![](/img/rag-retrieval.png)](/docs/tutorials/rag)
+[![](/img/rag-retrieval.png)](/tutorials/rag)
 
 ## Advanced Retrieval
 
 More [info here](https://github.com/langchain4j/langchain4j/pull/538).
-[![](/img/advanced-rag.png)](/docs/tutorials/rag)
+[![](/img/advanced-rag.png)](/tutorials/rag)
 
 ## Examples
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -20,7 +20,7 @@ const config = {
     url: 'https://langchain4j.github.io/',
     // Set the /<baseUrl>/ pathname under which your site is served
     // For GitHub pages deployment, it is often '/<projectName>/'
-    baseUrl: '/langchain4j/',
+    baseUrl: '/',
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -20,7 +20,7 @@ const config = {
     url: 'https://langchain4j.github.io/',
     // Set the /<baseUrl>/ pathname under which your site is served
     // For GitHub pages deployment, it is often '/<projectName>/'
-    baseUrl: '/',
+    baseUrl: '/langchain4j/',
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -41,6 +41,8 @@ const config = {
             /** @type {import('@docusaurus/preset-classic').Options} */
             ({
                 docs: {
+                    path: 'docs',
+                    routeBasePath: '', // change this to any URL route you'd want. For example: `home` - if you want /home/intro.
                     sidebarPath: './sidebars.js',
                     // Please change this to your repo.
                     // Remove this to remove the "edit this page" links.
@@ -84,8 +86,8 @@ const config = {
                         position: 'left',
                         label: 'Introduction',
                     },
-                    {to: '/docs/tutorials', label: 'Tutorials', position: 'left'},
-                    {to: '/docs/category/integrations', label: 'Integrations', position: 'left'},
+                    {to: '/tutorials', label: 'Tutorials', position: 'left'},
+                    {to: '/category/integrations', label: 'Integrations', position: 'left'},
                     {
                         href: 'https://docs.langchain4j.dev/apidocs/index.html',
                         label: 'Javadoc',
@@ -107,7 +109,7 @@ const config = {
                         items: [
                             {
                                 label: 'Tutorials',
-                                to: '/docs/tutorials',
+                                to: '/tutorials',
                             },
                         ],
                     },


### PR DESCRIPTION
The redundant base route `/docs` has been updated to `/`. Also, all the links used in the docs markdown files have been updated accordingly. 
Please verify if everything looks fine.

Thanks!