### PR TITLE
Throw error if more than one retriever/contentRetriever/retrievalAugm…

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -118,6 +118,10 @@ public abstract class AiServices<T> {
 
     protected final AiServiceContext context;
 
+    private boolean retrieverSet = false;
+    private boolean contentRetrieverSet = false;
+    private boolean retrievalAugmentorSet = false;
+
     protected AiServices(AiServiceContext context) {
         this.context = context;
     }
@@ -311,7 +315,11 @@ public abstract class AiServices<T> {
      */
     @Deprecated
     public AiServices<T> retriever(Retriever<TextSegment> retriever) {
+        if(contentRetrieverSet || retrievalAugmentorSet) {
+            throw illegalConfiguration("Only one out of [retriever, contentRetriever, retrievalAugmentor] can be set");
+        }
         if (retriever != null) {
+            retrieverSet = true;
             return contentRetriever(retriever.toContentRetriever());
         }
         return this;
@@ -331,6 +339,10 @@ public abstract class AiServices<T> {
      * @return builder
      */
     public AiServices<T> contentRetriever(ContentRetriever contentRetriever) {
+        if(retrieverSet || retrievalAugmentorSet) {
+            throw illegalConfiguration("Only one out of [retriever, contentRetriever, retrievalAugmentor] can be set");
+        }
+        contentRetrieverSet = true;
         context.retrievalAugmentor = DefaultRetrievalAugmentor.builder()
                 .contentRetriever(ensureNotNull(contentRetriever, "contentRetriever"))
                 .build();
@@ -344,6 +356,10 @@ public abstract class AiServices<T> {
      * @return builder
      */
     public AiServices<T> retrievalAugmentor(RetrievalAugmentor retrievalAugmentor) {
+        if(retrieverSet || contentRetrieverSet) {
+            throw illegalConfiguration("Only one out of [retriever, contentRetriever, retrievalAugmentor] can be set");
+        }
+        retrievalAugmentorSet = true;
         context.retrievalAugmentor = ensureNotNull(retrievalAugmentor, "retrievalAugmentor");
         return this;
     }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesBuilderTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesBuilderTest.java
@@ -1,0 +1,96 @@
+package dev.langchain4j.service;
+
+import dev.langchain4j.exception.IllegalConfigurationException;
+import dev.langchain4j.rag.RetrievalAugmentor;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.retriever.Retriever;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verify that the AIServices builder doesn't allow setting more than out of
+ * (retriever, contentRetriever, retrievalAugmentor).
+ */
+public class AiServicesBuilderTest {
+
+    @Test
+    public void testRetrieverAndContentRetriever() {
+        Retriever retriever = mock(Retriever.class);
+        ContentRetriever contentRetriever = mock(ContentRetriever.class);
+
+        assertThrows(IllegalConfigurationException.class, () -> {
+            AiServices.builder(AiServices.class)
+                    .retriever(retriever)
+                    .contentRetriever(contentRetriever)
+                    .build();
+        });
+    }
+
+    @Test
+    public void testRetrieverAndRetrievalAugmentor() {
+        Retriever retriever = mock(Retriever.class);
+        RetrievalAugmentor retrievalAugmentor = mock(RetrievalAugmentor.class);
+
+        assertThrows(IllegalConfigurationException.class, () -> {
+            AiServices.builder(AiServices.class)
+                    .retriever(retriever)
+                    .retrievalAugmentor(retrievalAugmentor)
+                    .build();
+        });
+    }
+
+    @Test
+    public void testContentRetrieverAndRetrievalAugmentor() {
+        ContentRetriever contentRetriever = mock(ContentRetriever.class);
+        RetrievalAugmentor retrievalAugmentor = mock(RetrievalAugmentor.class);
+
+        assertThrows(IllegalConfigurationException.class, () -> {
+            AiServices.builder(AiServices.class)
+                    .contentRetriever(contentRetriever)
+                    .retrievalAugmentor(retrievalAugmentor)
+                    .build();
+        });
+    }
+
+    @Test
+    public void testContentRetrieverAndRetriever() {
+        Retriever retriever = mock(Retriever.class);
+        ContentRetriever contentRetriever = mock(ContentRetriever.class);
+
+        assertThrows(IllegalConfigurationException.class, () -> {
+            AiServices.builder(AiServices.class)
+                    .contentRetriever(contentRetriever)
+                    .retriever(retriever)
+                    .build();
+        });
+    }
+
+    @Test
+    public void testRetrievalAugmentorAndRetriever() {
+        Retriever retriever = mock(Retriever.class);
+        RetrievalAugmentor retrievalAugmentor = mock(RetrievalAugmentor.class);
+
+        assertThrows(IllegalConfigurationException.class, () -> {
+            AiServices.builder(AiServices.class)
+                    .retrievalAugmentor(retrievalAugmentor)
+                    .retriever(retriever)
+                    .build();
+        });
+    }
+
+    @Test
+    public void testRetrievalAugmentorAndContentRetriever() {
+        ContentRetriever contentRetriever = mock(ContentRetriever.class);
+        RetrievalAugmentor retrievalAugmentor = mock(RetrievalAugmentor.class);
+
+        assertThrows(IllegalConfigurationException.class, () -> {
+            AiServices.builder(AiServices.class)
+                    .retrievalAugmentor(retrievalAugmentor)
+                    .contentRetriever(contentRetriever)
+                    .build();
+        });
+    }
+
+}


### PR DESCRIPTION
…entor are set

As we discussed in https://github.com/quarkiverse/quarkus-langchain4j/pull/353#discussion_r1516119442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced AI services with new validation rules to ensure exclusive setting of components, improving system stability and predictability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->