### PR TITLE
Ability to specify the task type for calculating embeddings

### DIFF
--- a/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingInstance.java
+++ b/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingInstance.java
@@ -2,9 +2,19 @@ package dev.langchain4j.model.vertexai;
 
 class VertexAiEmbeddingInstance {
 
-    private final String content;
+    private String content;
+    private String title;
+    private VertexAiEmbeddingModel.TaskType task_type;
 
     VertexAiEmbeddingInstance(String content) {
         this.content = content;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setTaskType(VertexAiEmbeddingModel.TaskType taskType) {
+        this.task_type = taskType;
     }
 }

--- a/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModel.java
+++ b/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModel.java
@@ -134,11 +134,13 @@ public class VertexAiEmbeddingModel implements EmbeddingModel {
                 List<Value> instances = new ArrayList<>();
                 for (TextSegment segment : batch) {
                     VertexAiEmbeddingInstance embeddingInstance = new VertexAiEmbeddingInstance(segment.text());
-                    // Title metadata is used for calculating embeddings for document retrieval
-                    embeddingInstance.setTitle(segment.metadata(titleMetadataKey));
                     // Specify the type of embedding task when specified
                     if (this.taskType != null) {
                         embeddingInstance.setTaskType(taskType);
+                        if (this.taskType.equals(TaskType.RETRIEVAL_DOCUMENT)) {
+                            // Title metadata is used for calculating embeddings for document retrieval
+                            embeddingInstance.setTitle(segment.metadata(titleMetadataKey));
+                        }
                     }
 
                     Value.Builder instanceBuilder = Value.newBuilder();

--- a/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModel.java
+++ b/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModel.java
@@ -70,6 +70,7 @@ public class VertexAiEmbeddingModel implements EmbeddingModel {
     private final Integer maxSegmentsPerBatch;
     private final Integer maxTokensPerBatch;
     private final TaskType taskType;
+    private final String titleMetadataKey;
 
     public enum TaskType {
         RETRIEVAL_QUERY, RETRIEVAL_DOCUMENT, SEMANTIC_SIMILARITY, CLASSIFICATION, CLUSTERING
@@ -83,7 +84,8 @@ public class VertexAiEmbeddingModel implements EmbeddingModel {
                                   Integer maxRetries,
                                   Integer maxSegmentsPerBatch,
                                   Integer maxTokensPerBatch,
-                                  TaskType taskType) {
+                                  TaskType taskType,
+                                  String titleMetadataKey) {
 
         this.endpointName = EndpointName.ofProjectLocationPublisherModelName(
             ensureNotBlank(project, "project"),
@@ -112,6 +114,7 @@ public class VertexAiEmbeddingModel implements EmbeddingModel {
             getOrDefault(maxTokensPerBatch, DEFAULT_MAX_TOKENS_PER_BATCH), "maxTokensPerBatch");
 
         this.taskType = taskType;
+        this.titleMetadataKey = getOrDefault(titleMetadataKey, "title");
     }
 
     @Override
@@ -132,7 +135,7 @@ public class VertexAiEmbeddingModel implements EmbeddingModel {
                 for (TextSegment segment : batch) {
                     VertexAiEmbeddingInstance embeddingInstance = new VertexAiEmbeddingInstance(segment.text());
                     // Title metadata is used for calculating embeddings for document retrieval
-                    embeddingInstance.setTitle(segment.metadata("title"));
+                    embeddingInstance.setTitle(segment.metadata(titleMetadataKey));
                     // Specify the type of embedding task when specified
                     if (this.taskType != null) {
                         embeddingInstance.setTaskType(taskType);
@@ -287,6 +290,7 @@ public class VertexAiEmbeddingModel implements EmbeddingModel {
         private Integer maxSegmentsPerBatch;
         private Integer maxTokensPerBatch;
         private TaskType taskType;
+        private String titleMetadataKey;
 
         public Builder endpoint(String endpoint) {
             this.endpoint = endpoint;
@@ -333,6 +337,11 @@ public class VertexAiEmbeddingModel implements EmbeddingModel {
             return this;
         }
 
+        public Builder titleMetadataKey(String titleMetadataKey) {
+            this.titleMetadataKey = titleMetadataKey;
+            return this;
+        }
+
         public VertexAiEmbeddingModel build() {
             return new VertexAiEmbeddingModel(
                     endpoint,
@@ -343,7 +352,8 @@ public class VertexAiEmbeddingModel implements EmbeddingModel {
                     maxRetries,
                     maxSegmentsPerBatch,
                     maxTokensPerBatch,
-                    taskType);
+                    taskType,
+                    titleMetadataKey);
         }
     }
 }

--- a/langchain4j-vertex-ai/src/test/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModelIT.java
+++ b/langchain4j-vertex-ai/src/test/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModelIT.java
@@ -231,5 +231,31 @@ class VertexAiEmbeddingModelIT {
         Response<Embedding> embeddedSegForRetrieval = model.embed(segmentForRetrieval);
 
         assertThat(embeddedSegForRetrieval.content().dimension()).isEqualTo(768);
+
+        // Choose a custom metadata key instead of "title"
+        // as the embedding model requires "title" to be used only for RETRIEVAL_DOCUMENT
+
+        Metadata metadataCustomTitleKey = new Metadata();
+        metadataCustomTitleKey.add("customTitle", "Text embeddings");
+
+        TextSegment segmentForRetrievalWithCustomKey = new TextSegment("Text embeddings can be used to represent both the " +
+            "user's query and the universe of documents in a high-dimensional vector space. Documents " +
+            "that are more semantically similar to the user's query will have a shorter distance in the " +
+            "vector space, and can be ranked higher in the search results.", metadataCustomTitleKey);
+
+        model = VertexAiEmbeddingModel.builder()
+            .endpoint(System.getenv("GCP_VERTEXAI_ENDPOINT"))
+            .project(System.getenv("GCP_PROJECT_ID"))
+            .location(System.getenv("GCP_LOCATION"))
+            .publisher("google")
+            .modelName("textembedding-gecko@003")
+            .maxRetries(3)
+            .taskType(RETRIEVAL_DOCUMENT)
+            .titleMetadataKey("customTitle")
+            .build();
+
+        Response<Embedding> embeddedSegForRetrievalWithCustomKey = model.embed(segmentForRetrievalWithCustomKey);
+
+        assertThat(embeddedSegForRetrievalWithCustomKey.content().dimension()).isEqualTo(768);
     }
 }

--- a/langchain4j-vertex-ai/src/test/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModelIT.java
+++ b/langchain4j-vertex-ai/src/test/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModelIT.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static dev.langchain4j.internal.Json.toJson;
 import static dev.langchain4j.model.vertexai.VertexAiEmbeddingModel.TaskType.*;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/langchain4j-vertex-ai/src/test/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModelIT.java
+++ b/langchain4j-vertex-ai/src/test/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModelIT.java
@@ -257,5 +257,21 @@ class VertexAiEmbeddingModelIT {
         Response<Embedding> embeddedSegForRetrievalWithCustomKey = model.embed(segmentForRetrievalWithCustomKey);
 
         assertThat(embeddedSegForRetrievalWithCustomKey.content().dimension()).isEqualTo(768);
+
+        // Check we can use "title" metadata when not using RETRIEVAL_DOCUMENT task
+
+        model = VertexAiEmbeddingModel.builder()
+            .endpoint(System.getenv("GCP_VERTEXAI_ENDPOINT"))
+            .project(System.getenv("GCP_PROJECT_ID"))
+            .location(System.getenv("GCP_LOCATION"))
+            .publisher("google")
+            .modelName("textembedding-gecko@003")
+            .maxRetries(3)
+            .titleMetadataKey("customTitle")
+            .build();
+
+        Response<Embedding> embeddedSegTitleKeyNoRetrieval = model.embed(segmentForRetrieval);
+
+        assertThat(embeddedSegTitleKeyNoRetrieval.content().dimension()).isEqualTo(768);
     }
 }

--- a/langchain4j-vertex-ai/src/test/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModelIT.java
+++ b/langchain4j-vertex-ai/src/test/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModelIT.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.vertexai;
 
+import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -7,11 +8,10 @@ import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
+import static dev.langchain4j.internal.Json.toJson;
+import static dev.langchain4j.model.vertexai.VertexAiEmbeddingModel.TaskType.*;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -161,5 +161,76 @@ class VertexAiEmbeddingModelIT {
         List<Embedding> embeddings = model.embedAll(segments).content();
 
         assertThat(embeddings.size()).isEqualTo(1234);
+    }
+
+    @Test
+    void testEmbeddingTask() {
+        // Semantic similarity embedding
+
+        VertexAiEmbeddingModel model = VertexAiEmbeddingModel.builder()
+            .endpoint(System.getenv("GCP_VERTEXAI_ENDPOINT"))
+            .project(System.getenv("GCP_PROJECT_ID"))
+            .location(System.getenv("GCP_LOCATION"))
+            .publisher("google")
+            .modelName("textembedding-gecko@003")
+            .maxRetries(3)
+            .taskType(SEMANTIC_SIMILARITY)
+            .build();
+
+        String text = "Embeddings for Text is the name for the model that supports text embeddings. " +
+            "Text embeddings are a NLP technique that converts textual data into numerical vectors " +
+            "that can be processed by machine learning algorithms, especially large models. `" +
+            "These vector representations are designed to capture the semantic meaning and context " +
+            "of the words they represent.";
+
+        Response<Embedding> embeddedText = model.embed(text);
+
+        assertThat(embeddedText.content().dimension()).isEqualTo(768);
+
+        // Text classification embedding
+
+        TextSegment segment2 = new TextSegment("Text Classification: Training a model that maps " +
+            "the text embeddings to the correct category labels (e.g., cat vs. dog, spam vs. not spam). " +
+            "Once the model is trained, it can be used to classify new text inputs into one or more " +
+            "categories based on their embeddings.",
+            new Metadata());
+
+        model = VertexAiEmbeddingModel.builder()
+            .endpoint(System.getenv("GCP_VERTEXAI_ENDPOINT"))
+            .project(System.getenv("GCP_PROJECT_ID"))
+            .location(System.getenv("GCP_LOCATION"))
+            .publisher("google")
+            .modelName("textembedding-gecko@003")
+            .maxRetries(3)
+            .taskType(CLASSIFICATION)
+            .build();
+
+        Response<Embedding> embeddedSegForClassif = model.embed(segment2);
+
+        assertThat(embeddedSegForClassif.content().dimension()).isEqualTo(768);
+
+        // Document retrieval embedding
+
+        Metadata metadata = new Metadata();
+        metadata.add("title", "Text embeddings");
+
+        TextSegment segmentForRetrieval = new TextSegment("Text embeddings can be used to represent both the " +
+            "user's query and the universe of documents in a high-dimensional vector space. Documents " +
+            "that are more semantically similar to the user's query will have a shorter distance in the " +
+            "vector space, and can be ranked higher in the search results.", metadata);
+
+        model = VertexAiEmbeddingModel.builder()
+            .endpoint(System.getenv("GCP_VERTEXAI_ENDPOINT"))
+            .project(System.getenv("GCP_PROJECT_ID"))
+            .location(System.getenv("GCP_LOCATION"))
+            .publisher("google")
+            .modelName("textembedding-gecko@003")
+            .maxRetries(3)
+            .taskType(RETRIEVAL_DOCUMENT)
+            .build();
+
+        Response<Embedding> embeddedSegForRetrieval = model.embed(segmentForRetrieval);
+
+        assertThat(embeddedSegForRetrieval.content().dimension()).isEqualTo(768);
     }
 }


### PR DESCRIPTION
It's possible to customize different kinds of tasks for embedding:

- `RETRIEVAL_QUERY`
- `RETRIEVAL_DOCUMENT`
- `SEMANTIC_SIMILARITY`
- `CLASSIFICATION, CLUSTERING`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced `TaskType` enum for specifying task types in embedding instances, enhancing customization for retrieval, similarity, classification, and clustering tasks.
	- Added `taskType` parameter to the constructor for setting task type in embedding instances.

- **Tests**
	- Added tests for semantic similarity, text classification, and document retrieval embeddings using different task types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->