### PR TITLE
Allow HtmlTextExtractor to extract relative links from document

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/data/document/transformer/HtmlTextExtractor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/data/document/transformer/HtmlTextExtractor.java
@@ -10,7 +10,10 @@ import org.jsoup.nodes.TextNode;
 import org.jsoup.select.NodeVisitor;
 
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import static dev.langchain4j.data.document.Document.URL;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static org.jsoup.internal.StringUtil.in;
@@ -22,6 +25,8 @@ import static org.jsoup.select.NodeTraversor.traverse;
  * Also, multiple CSS selectors can be specified to extract metadata from desired elements.
  */
 public class HtmlTextExtractor implements DocumentTransformer {
+
+    private static final Logger log = LoggerFactory.getLogger(HtmlTextExtractor.class);
 
     private final String cssSelector;
     private final Map<String, String> metadataCssSelectors;
@@ -53,7 +58,8 @@ public class HtmlTextExtractor implements DocumentTransformer {
     @Override
     public Document transform(Document document) {
         String html = document.text();
-        org.jsoup.nodes.Document jsoupDocument = Jsoup.parse(html);
+        String baseUrl = document.metadata(URL) != null ? document.metadata(URL) : "";
+        org.jsoup.nodes.Document jsoupDocument = Jsoup.parse(html, baseUrl);
 
         String text;
         if (cssSelector != null) {
@@ -111,8 +117,13 @@ public class HtmlTextExtractor implements DocumentTransformer {
             String name = node.nodeName();
             if (in(name, "br", "dd", "dt", "p", "h1", "h2", "h3", "h4", "h5", "h6"))
                 textBuilder.append("\n");
-            else if (includeLinks && name.equals("a"))
-                textBuilder.append(format(" <%s>", node.absUrl("href")));
+            else if (includeLinks && name.equals("a")) {
+                String link = node.absUrl("href");
+                if (link.isEmpty() && node.baseUri().isEmpty()) {
+                    log.warn("No 'URL' metadata found for document. Link will be empty");
+                }
+                textBuilder.append(format(" <%s>", link));
+            }
         }
 
         @Override

--- a/langchain4j/src/test/java/dev/langchain4j/data/document/transformer/HtmlTextExtractorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/data/document/transformer/HtmlTextExtractorTest.java
@@ -20,6 +20,12 @@ class HtmlTextExtractorTest {
             "</body>" +
             "</html>";
 
+    private static final String SAMPLE_HTML_WITH_RELATIVE_LINKS = "<html>" +
+            "<body>" +
+            "<p>Follow the link <a href=\"/menu1\">here</a>.</p>" +
+            "</body>" +
+            "</html>";
+
     @Test
     void should_extract_all_text_from_html() {
 
@@ -94,5 +100,47 @@ class HtmlTextExtractorTest {
                         " * Item two"
         );
         assertThat(transformedDocument.metadata().asMap()).isEmpty();
+    }
+
+    @Test
+    void should_extract_text_with_absolute_links_from_html_with_relative_links_and_url_metadata() {
+        HtmlTextExtractor transformer = new HtmlTextExtractor(null, null, true);
+        Document htmlDocument = Document.from(SAMPLE_HTML_WITH_RELATIVE_LINKS);
+        htmlDocument.metadata().add(Document.URL, "https://example.org/page.html");
+
+        Document transformedDocument = transformer.transform(htmlDocument);
+
+        assertThat(transformedDocument.text()).isEqualTo(
+                "Follow the link here <https://example.org/menu1>."
+        );
+        assertThat(transformedDocument.metadata().asMap())
+            .containsEntry(Document.URL, "https://example.org/page.html")
+            .hasSize(1);
+    }
+
+    @Test
+    void should_extract_text_with_absolute_links_from_html_with_absolute_links_and_url_metadata() {
+        HtmlTextExtractor transformer = new HtmlTextExtractor(null, null, true);
+        Document htmlDocument = Document.from(SAMPLE_HTML);
+        htmlDocument.metadata().add(Document.URL, "https://other.example.org/page.html");
+
+        Document transformedDocument = transformer.transform(htmlDocument);
+
+        assertThat(transformedDocument.text()).isEqualTo(
+            "Title\n" +
+                "\n" +
+                "Paragraph 1\n" +
+                "Something\n" +
+                "\n" +
+                "Paragraph 2\n" +
+                "\n" +
+                "More details here <http://example.org>.\n" +
+                "List:\n" +
+                " * Item one\n" +
+                " * Item two"
+        );
+        assertThat(transformedDocument.metadata().asMap())
+            .containsEntry(Document.URL, "https://other.example.org/page.html")
+            .hasSize(1);
     }
 }


### PR DESCRIPTION
By default `org.jsoup.parser` uses `""` base url while parsing HTML document. This results in empty links from HtmlTextExtractor if relative link is used in raw html, 
```    
public static Document parse(String html) {
        return Parser.parse(html, "");
}
```

ex. extracted text with links from  
`<a href="/menu1">here</a>` results in `here <>` 
but 
`<a href="http://example.org/menu1">here</a>` results in `here <http://example.org/menu1>` 

changes utilize document metadata to provide base url.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced text extraction from HTML content to include better link handling and metadata preservation.
- **Tests**
	- Added tests for the improved HTML text extraction process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->