### PR TITLE
Fix the check whether retriever is already set

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -319,8 +319,9 @@ public abstract class AiServices<T> {
             throw illegalConfiguration("Only one out of [retriever, contentRetriever, retrievalAugmentor] can be set");
         }
         if (retriever != null) {
+            AiServices<T> withContentRetriever = contentRetriever(retriever.toContentRetriever());
             retrieverSet = true;
-            return contentRetriever(retriever.toContentRetriever());
+            return withContentRetriever;
         }
         return this;
     }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesBuilderTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesBuilderTest.java
@@ -5,6 +5,7 @@ import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.retriever.Retriever;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -18,6 +19,9 @@ public class AiServicesBuilderTest {
     @Test
     public void testRetrieverAndContentRetriever() {
         Retriever retriever = mock(Retriever.class);
+        Mockito.when(retriever.toContentRetriever()).thenReturn((query) -> {
+            throw new RuntimeException("Should not be called");
+        });
         ContentRetriever contentRetriever = mock(ContentRetriever.class);
 
         assertThrows(IllegalConfigurationException.class, () -> {
@@ -31,6 +35,9 @@ public class AiServicesBuilderTest {
     @Test
     public void testRetrieverAndRetrievalAugmentor() {
         Retriever retriever = mock(Retriever.class);
+        Mockito.when(retriever.toContentRetriever()).thenReturn((query) -> {
+            throw new RuntimeException("Should not be called");
+        });
         RetrievalAugmentor retrievalAugmentor = mock(RetrievalAugmentor.class);
 
         assertThrows(IllegalConfigurationException.class, () -> {


### PR DESCRIPTION
Fixes the problem described in https://github.com/langchain4j/langchain4j/pull/710#issuecomment-1985891002 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved consistency in setting retriever-related configurations in AI services.
	- Updated test methods in `AiServicesBuilderTest.java` to use `Mockito.when` for throwing exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->