### PR TITLE
Fix @UserMessage does not work

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/model/input/Prompt.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/input/Prompt.java
@@ -46,6 +46,14 @@ public class Prompt {
     }
 
     /**
+     * Convert this prompt to a UserMessage with specified userName.
+     * @return the UserMessage.
+     */
+    public UserMessage toUserMessage(String userName) {
+        return userMessage(userName, text);
+    }
+
+    /**
      * Convert this prompt to a UserMessage.
      * @return the UserMessage.
      */

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/DefaultRetrievalAugmentor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/DefaultRetrievalAugmentor.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.supplyAsync;

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/injector/DefaultContentInjector.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/injector/DefaultContentInjector.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static dev.langchain4j.data.message.UserMessage.userMessage;
 import static dev.langchain4j.internal.Utils.*;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
@@ -79,6 +80,10 @@ public class DefaultContentInjector implements ContentInjector {
         }
 
         Prompt prompt = createPrompt(chatMessage, contents);
+        if (chatMessage instanceof UserMessage && isNotNullOrBlank(((UserMessage)chatMessage).name())) {
+            return prompt.toUserMessage(((UserMessage)chatMessage).name());
+        }
+
         return prompt.toUserMessage();
     }
 
@@ -98,6 +103,9 @@ public class DefaultContentInjector implements ContentInjector {
         }
 
         Prompt prompt = createPrompt(userMessage, contents);
+        if (isNotNullOrBlank(userMessage.name())) {
+            return prompt.toUserMessage(userMessage.name());
+        }
         return prompt.toUserMessage();
     }
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/input/PromptTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/input/PromptTest.java
@@ -24,6 +24,8 @@ class PromptTest implements WithAssertions {
                 .isEqualTo(systemMessage("abc"));
         assertThat(p.toUserMessage())
                 .isEqualTo(userMessage("abc"));
+        assertThat(p.toUserMessage("userName"))
+                .isEqualTo(userMessage("userName", "abc"));
         assertThat(p.toAiMessage())
                 .isEqualTo(aiMessage("abc"));
     }

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
@@ -136,7 +136,7 @@ class DefaultRetrievalAugmentorTest {
                 .executor(executor)
                 .build();
 
-        UserMessage userMessage = UserMessage.from("userName", "query");
+        UserMessage userMessage = UserMessage.from("query");
 
         Metadata metadata = Metadata.from(userMessage, null, null);
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
@@ -136,7 +136,7 @@ class DefaultRetrievalAugmentorTest {
                 .executor(executor)
                 .build();
 
-        UserMessage userMessage = UserMessage.from("query");
+        UserMessage userMessage = UserMessage.from("userName", "query");
 
         Metadata metadata = Metadata.from(userMessage, null, null);
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/injector/DefaultContentInjectorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/injector/DefaultContentInjectorTest.java
@@ -61,6 +61,28 @@ class DefaultContentInjectorTest {
     }
 
     @Test
+    void should_inject_single_content_with_userName() {
+        // given
+        UserMessage userMessage = UserMessage.from("ape", "Tell me about bananas.");
+
+        List<Content> contents = singletonList(Content.from("Bananas are awesome!"));
+
+        ContentInjector injector = new DefaultContentInjector();
+
+        // when
+        UserMessage injected = injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected.text()).isEqualTo(
+                "Tell me about bananas.\n" +
+                        "\n" +
+                        "Answer using the following information:\n" +
+                        "Bananas are awesome!"
+        );
+        assertThat(injected.name()).isEqualTo("ape");
+    }
+
+    @Test
     void should_inject_single_content_with_metadata() {
 
         // given

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Future;
 import static dev.langchain4j.exception.IllegalConfigurationException.illegalConfiguration;
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.Exceptions.runtime;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.service.ServiceOutputParser.outputFormatInstructions;
 import static dev.langchain4j.service.ServiceOutputParser.parse;
 
@@ -117,7 +118,12 @@ class DefaultAiServices<T> extends AiServices<T> {
                             }
                         }
                         String outputFormatInstructions = outputFormatInstructions(returnType);
-                        userMessage = UserMessage.from(userMessage.text() + outputFormatInstructions);
+                        String text = userMessage.singleText() + outputFormatInstructions;
+                        if (isNotNullOrBlank(userMessage.name())) {
+                            userMessage = UserMessage.from(userMessage.name(), text);
+                        } else {
+                            userMessage = UserMessage.from(text);
+                        }
 
                         if (context.hasChatMemory()) {
                             ChatMemory chatMemory = context.chatMemory(memoryId);


### PR DESCRIPTION
Fixes bug https://github.com/langchain4j/langchain4j/issues/694 
propagates userName from UserMessage where possible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced message processing to conditionally create or modify `UserMessage` objects based on the presence of a user's name, improving personalized interactions.
- **Tests**
	- Added and modified test cases to validate new message augmentation functionalities and content injection with usernames, ensuring reliability and expected behavior in user message processing.
- **Refactor**
	- Utilized utility functions for more efficient and cleaner checks on user message attributes, streamlining the handling of chat memory and user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->