### PR TITLE
Introduce SPI for creating Mistral AI Client

### DIFF
--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/DefaultMistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/DefaultMistralAiClient.java
@@ -1,0 +1,220 @@
+package dev.langchain4j.model.mistralai;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+import lombok.Builder;
+import okhttp3.OkHttpClient;
+import okhttp3.ResponseBody;
+import okhttp3.sse.EventSource;
+import okhttp3.sse.EventSourceListener;
+import okhttp3.sse.EventSources;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.model.mistralai.DefaultMistralAiHelper.finishReasonFrom;
+import static dev.langchain4j.model.mistralai.DefaultMistralAiHelper.tokenUsageFrom;
+
+class DefaultMistralAiClient extends MistralAiClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMistralAiClient.class);
+    private static final Gson GSON = new GsonBuilder()
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+            .setPrettyPrinting()
+            .create();
+
+    private final MistralAiApi mistralAiApi;
+    private final OkHttpClient okHttpClient;
+    private final boolean logStreamingResponses;
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends MistralAiClient.Builder<DefaultMistralAiClient, Builder> {
+
+        public DefaultMistralAiClient build() {
+            return new DefaultMistralAiClient(this);
+        }
+    }
+
+    DefaultMistralAiClient(Builder builder) {
+        OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
+                .callTimeout(builder.timeout)
+                .connectTimeout(builder.timeout)
+                .readTimeout(builder.timeout)
+                .writeTimeout(builder.timeout);
+
+        okHttpClientBuilder.addInterceptor(new MistralAiApiKeyInterceptor(builder.apiKey));
+
+        if (builder.logRequests) {
+            okHttpClientBuilder.addInterceptor(new MistralAiRequestLoggingInterceptor());
+        }
+
+        if (builder.logResponses) {
+            okHttpClientBuilder.addInterceptor(new MistralAiResponseLoggingInterceptor());
+        }
+
+        this.logStreamingResponses = builder.logResponses;
+        this.okHttpClient = okHttpClientBuilder.build();
+
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(formattedUrlForRetrofit(builder.baseUrl))
+                .client(okHttpClient)
+                .addConverterFactory(GsonConverterFactory.create(GSON))
+                .build();
+
+        mistralAiApi = retrofit.create(MistralAiApi.class);
+    }
+
+    private static String formattedUrlForRetrofit(String baseUrl) {
+        return baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+    }
+
+    @Override
+    public MistralAiChatCompletionResponse chatCompletion(MistralAiChatCompletionRequest request) {
+        try {
+            retrofit2.Response<MistralAiChatCompletionResponse> retrofitResponse
+                    = mistralAiApi.chatCompletion(request).execute();
+            if (retrofitResponse.isSuccessful()) {
+                return retrofitResponse.body();
+            } else {
+                throw toException(retrofitResponse);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void streamingChatCompletion(MistralAiChatCompletionRequest request, StreamingResponseHandler<AiMessage> handler) {
+        EventSourceListener eventSourceListener = new EventSourceListener() {
+            final StringBuffer contentBuilder = new StringBuffer();
+            TokenUsage tokenUsage;
+            FinishReason finishReason;
+
+            @Override
+            public void onOpen(EventSource eventSource, okhttp3.Response response) {
+                if (logStreamingResponses) {
+                    LOGGER.debug("onOpen()");
+                }
+            }
+
+            @Override
+            public void onEvent(EventSource eventSource, String id, String type, String data) {
+                if (logStreamingResponses) {
+                    LOGGER.debug("onEvent() {}", data);
+                }
+                if ("[DONE]".equals(data)) {
+                    Response<AiMessage> response = Response.from(
+                            AiMessage.from(contentBuilder.toString()),
+                            tokenUsage,
+                            finishReason
+                    );
+                    handler.onComplete(response);
+                } else {
+                    try {
+                        MistralAiChatCompletionResponse chatCompletionResponse = GSON.fromJson(data, MistralAiChatCompletionResponse.class);
+                        MistralAiChatCompletionChoice choice = chatCompletionResponse.getChoices().get(0);
+                        String chunk = choice.getDelta().getContent();
+                        contentBuilder.append(chunk);
+                        handler.onNext(chunk);
+
+                        MistralAiUsage usageInfo = chatCompletionResponse.getUsage();
+                        if (usageInfo != null) {
+                            this.tokenUsage = tokenUsageFrom(usageInfo);
+                        }
+
+                        String finishReasonString = choice.getFinishReason();
+                        if (finishReasonString != null) {
+                            this.finishReason = finishReasonFrom(finishReasonString);
+                        }
+                    } catch (Exception e) {
+                        handler.onError(e);
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(EventSource eventSource, Throwable t, okhttp3.Response response) {
+                if (logStreamingResponses) {
+                    LOGGER.debug("onFailure()", t);
+                }
+
+                if (t != null) {
+                    handler.onError(t);
+                } else {
+                    handler.onError(new RuntimeException(String.format("status code: %s; body: %s", response.code(), response.body())));
+                }
+            }
+
+            @Override
+            public void onClosed(EventSource eventSource) {
+                if (logStreamingResponses) {
+                    LOGGER.debug("onClosed()");
+                }
+            }
+        };
+
+        EventSources.createFactory(this.okHttpClient)
+                .newEventSource(
+                        mistralAiApi.streamingChatCompletion(request).request(),
+                        eventSourceListener);
+    }
+
+    @Override
+    public MistralAiEmbeddingResponse embedding(MistralAiEmbeddingRequest request) {
+        try {
+            retrofit2.Response<MistralAiEmbeddingResponse> retrofitResponse
+                    = mistralAiApi.embedding(request).execute();
+            if (retrofitResponse.isSuccessful()) {
+                return retrofitResponse.body();
+            } else {
+                throw toException(retrofitResponse);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public MistralAiModelResponse listModels() {
+        try {
+            retrofit2.Response<MistralAiModelResponse> retrofitResponse
+                    = mistralAiApi.models().execute();
+            if (retrofitResponse.isSuccessful()) {
+                return retrofitResponse.body();
+            } else {
+                throw toException(retrofitResponse);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private RuntimeException toException(retrofit2.Response<?> retrofitResponse) throws IOException {
+        int code = retrofitResponse.code();
+        if (code >= 400) {
+            ResponseBody errorBody = retrofitResponse.errorBody();
+            if (errorBody != null) {
+                String errorBodyString = errorBody.string();
+                String errorMessage = String.format("status code: %s; body: %s", code, errorBodyString);
+                LOGGER.error("Error response: {}", errorMessage);
+                return new RuntimeException(errorMessage);
+            }
+        }
+        return new RuntimeException(retrofitResponse.message());
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/DefaultMistralAiHelper.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/DefaultMistralAiHelper.java
@@ -15,7 +15,7 @@ import static dev.langchain4j.model.output.FinishReason.LENGTH;
 import static dev.langchain4j.model.output.FinishReason.STOP;
 import static java.util.stream.Collectors.toList;
 
-class DefaultMistralAiHelper {
+public class DefaultMistralAiHelper {
 
     static final String MISTRALAI_API_URL = "https://api.mistral.ai/v1";
     static final String MISTRALAI_API_CREATE_EMBEDDINGS_ENCODING_FORMAT = "float";
@@ -64,7 +64,7 @@ class DefaultMistralAiHelper {
         throw new IllegalArgumentException("Unknown message type: " + message.type());
     }
 
-    static TokenUsage tokenUsageFrom(MistralAiUsage mistralAiUsage) {
+    public static TokenUsage tokenUsageFrom(MistralAiUsage mistralAiUsage) {
         if (mistralAiUsage == null) {
             return null;
         }
@@ -75,7 +75,7 @@ class DefaultMistralAiHelper {
         );
     }
 
-    static FinishReason finishReasonFrom(String mistralAiFinishReason) {
+    public static FinishReason finishReasonFrom(String mistralAiFinishReason) {
         if (mistralAiFinishReason == null) {
             return null;
         }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatCompletionChoice.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatCompletionChoice.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-class MistralAiChatCompletionChoice {
+public class MistralAiChatCompletionChoice {
 
     private Integer index;
     private MistralAiChatMessage message;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatCompletionRequest.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatCompletionRequest.java
@@ -11,7 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-class MistralAiChatCompletionRequest {
+public class MistralAiChatCompletionRequest {
 
     private String model;
     private List<MistralAiChatMessage> messages;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatCompletionResponse.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatCompletionResponse.java
@@ -11,7 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-class MistralAiChatCompletionResponse {
+public class MistralAiChatCompletionResponse {
 
     private String id;
     private String object;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatMessage.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatMessage.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-class MistralAiChatMessage {
+public class MistralAiChatMessage {
 
     private MistralAiRole role;
     private String content;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiClient.java
@@ -1,216 +1,85 @@
 package dev.langchain4j.model.mistralai;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.StreamingResponseHandler;
-import dev.langchain4j.model.output.FinishReason;
-import dev.langchain4j.model.output.Response;
-import dev.langchain4j.model.output.TokenUsage;
-import lombok.Builder;
-import okhttp3.OkHttpClient;
-import okhttp3.ResponseBody;
-import okhttp3.sse.EventSource;
-import okhttp3.sse.EventSourceListener;
-import okhttp3.sse.EventSources;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import retrofit2.Retrofit;
-import retrofit2.converter.gson.GsonConverterFactory;
-
-import java.io.IOException;
+import dev.langchain4j.spi.ServiceHelper;
 import java.time.Duration;
 
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-import static dev.langchain4j.model.mistralai.DefaultMistralAiHelper.finishReasonFrom;
-import static dev.langchain4j.model.mistralai.DefaultMistralAiHelper.tokenUsageFrom;
+public abstract class MistralAiClient {
 
-class MistralAiClient {
+    public abstract MistralAiChatCompletionResponse chatCompletion(MistralAiChatCompletionRequest request);
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MistralAiClient.class);
-    private static final Gson GSON = new GsonBuilder()
-            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-            .setPrettyPrinting()
-            .create();
+    public abstract void streamingChatCompletion(MistralAiChatCompletionRequest request, StreamingResponseHandler<AiMessage> handler);
 
-    private final MistralAiApi mistralAiApi;
-    private final OkHttpClient okHttpClient;
-    private final boolean logStreamingResponses;
+    public abstract MistralAiEmbeddingResponse embedding(MistralAiEmbeddingRequest request);
 
-    @Builder
-    MistralAiClient(String baseUrl,
-                    String apiKey,
-                    Duration timeout,
-                    Boolean logRequests,
-                    Boolean logResponses) {
+    public abstract MistralAiModelResponse listModels();
 
-        OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
-                .callTimeout(timeout)
-                .connectTimeout(timeout)
-                .readTimeout(timeout)
-                .writeTimeout(timeout);
-
-        if (isNullOrBlank(apiKey)) {
-            throw new IllegalArgumentException("MistralAI API Key must be defined. " +
-                    "It can be generated here: https://console.mistral.ai/user/api-keys/");
+    @SuppressWarnings("rawtypes")
+    public static MistralAiClient.Builder builder() {
+        for (MistralAiClientBuilderFactory factory : ServiceHelper.loadFactories(MistralAiClientBuilderFactory.class)) {
+            return factory.get();
         }
-
-        okHttpClientBuilder.addInterceptor(new MistralAiApiKeyInterceptor(apiKey));
-
-        if (logRequests) {
-            okHttpClientBuilder.addInterceptor(new MistralAiRequestLoggingInterceptor());
-        }
-
-        if (logResponses) {
-            okHttpClientBuilder.addInterceptor(new MistralAiResponseLoggingInterceptor());
-        }
-
-        this.logStreamingResponses = logResponses;
-        this.okHttpClient = okHttpClientBuilder.build();
-
-        Retrofit retrofit = new Retrofit.Builder()
-                .baseUrl(formattedUrlForRetrofit(baseUrl))
-                .client(okHttpClient)
-                .addConverterFactory(GsonConverterFactory.create(GSON))
-                .build();
-
-        mistralAiApi = retrofit.create(MistralAiApi.class);
+        // fallback to the default
+        return DefaultMistralAiClient.builder();
     }
 
-    private static String formattedUrlForRetrofit(String baseUrl) {
-        return baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
-    }
+    @SuppressWarnings("unchecked")
+    public abstract static class Builder<T extends MistralAiClient, B extends Builder<T, B>> {
+        public String baseUrl;
+        public String apiKey;
+        public Duration timeout;
+        public Boolean logRequests;
+        public Boolean logResponses;
 
-    MistralAiChatCompletionResponse chatCompletion(MistralAiChatCompletionRequest request) {
-        try {
-            retrofit2.Response<MistralAiChatCompletionResponse> retrofitResponse
-                    = mistralAiApi.chatCompletion(request).execute();
-            if (retrofitResponse.isSuccessful()) {
-                return retrofitResponse.body();
-            } else {
-                throw toException(retrofitResponse);
+        public abstract T build();
+
+        public B baseUrl(String baseUrl) {
+            if (baseUrl == null || baseUrl.trim().isEmpty()) {
+                throw new IllegalArgumentException("baseUrl cannot be null or empty");
             }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+            this.baseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+            return (B) this;
         }
-    }
 
-    void streamingChatCompletion(MistralAiChatCompletionRequest request, StreamingResponseHandler<AiMessage> handler) {
-        EventSourceListener eventSourceListener = new EventSourceListener() {
-            final StringBuffer contentBuilder = new StringBuffer();
-            TokenUsage tokenUsage;
-            FinishReason finishReason;
-
-            @Override
-            public void onOpen(EventSource eventSource, okhttp3.Response response) {
-                if (logStreamingResponses) {
-                    LOGGER.debug("onOpen()");
-                }
+        public B apiKey(String apiKey) {
+            if (apiKey == null || apiKey.trim().isEmpty()) {
+                throw new IllegalArgumentException("MistralAI API Key must be defined. It can be generated here: https://console.mistral.ai/user/api-keys");
             }
-
-            @Override
-            public void onEvent(EventSource eventSource, String id, String type, String data) {
-                if (logStreamingResponses) {
-                    LOGGER.debug("onEvent() {}", data);
-                }
-                if ("[DONE]".equals(data)) {
-                    Response<AiMessage> response = Response.from(
-                            AiMessage.from(contentBuilder.toString()),
-                            tokenUsage,
-                            finishReason
-                    );
-                    handler.onComplete(response);
-                } else {
-                    try {
-                        MistralAiChatCompletionResponse chatCompletionResponse = GSON.fromJson(data, MistralAiChatCompletionResponse.class);
-                        MistralAiChatCompletionChoice choice = chatCompletionResponse.getChoices().get(0);
-                        String chunk = choice.getDelta().getContent();
-                        contentBuilder.append(chunk);
-                        handler.onNext(chunk);
-
-                        MistralAiUsage usageInfo = chatCompletionResponse.getUsage();
-                        if (usageInfo != null) {
-                            this.tokenUsage = tokenUsageFrom(usageInfo);
-                        }
-
-                        String finishReasonString = choice.getFinishReason();
-                        if (finishReasonString != null) {
-                            this.finishReason = finishReasonFrom(finishReasonString);
-                        }
-                    } catch (Exception e) {
-                        handler.onError(e);
-                        throw new RuntimeException(e);
-                    }
-                }
-            }
-
-            @Override
-            public void onFailure(EventSource eventSource, Throwable t, okhttp3.Response response) {
-                if (logStreamingResponses) {
-                    LOGGER.debug("onFailure()", t);
-                }
-
-                if (t != null) {
-                    handler.onError(t);
-                } else {
-                    handler.onError(new RuntimeException(String.format("status code: %s; body: %s", response.code(), response.body())));
-                }
-            }
-
-            @Override
-            public void onClosed(EventSource eventSource) {
-                if (logStreamingResponses) {
-                    LOGGER.debug("onClosed()");
-                }
-            }
-        };
-
-        EventSources.createFactory(this.okHttpClient)
-                .newEventSource(
-                        mistralAiApi.streamingChatCompletion(request).request(),
-                        eventSourceListener);
-    }
-
-    MistralAiEmbeddingResponse embedding(MistralAiEmbeddingRequest request) {
-        try {
-            retrofit2.Response<MistralAiEmbeddingResponse> retrofitResponse
-                    = mistralAiApi.embedding(request).execute();
-            if (retrofitResponse.isSuccessful()) {
-                return retrofitResponse.body();
-            } else {
-                throw toException(retrofitResponse);
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+            this.apiKey = apiKey;
+            return (B) this;
         }
-    }
 
-    MistralAiModelResponse listModels() {
-        try {
-            retrofit2.Response<MistralAiModelResponse> retrofitResponse
-                    = mistralAiApi.models().execute();
-            if (retrofitResponse.isSuccessful()) {
-                return retrofitResponse.body();
-            } else {
-                throw toException(retrofitResponse);
+        public B timeout(Duration timeout) {
+            if (timeout == null) {
+                throw new IllegalArgumentException("callTimeout cannot be null");
             }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+            this.timeout = timeout;
+            return (B) this;
         }
-    }
 
-    private RuntimeException toException(retrofit2.Response<?> retrofitResponse) throws IOException {
-        int code = retrofitResponse.code();
-        if (code >= 400) {
-            ResponseBody errorBody = retrofitResponse.errorBody();
-            if (errorBody != null) {
-                String errorBodyString = errorBody.string();
-                String errorMessage = String.format("status code: %s; body: %s", code, errorBodyString);
-                LOGGER.error("Error response: {}", errorMessage);
-                return new RuntimeException(errorMessage);
-            }
+        public B logRequests() {
+            return logRequests(true);
         }
-        return new RuntimeException(retrofitResponse.message());
+
+        public B logRequests(Boolean logRequests) {
+            if (logRequests == null) {
+                logRequests = false;
+            }
+            this.logRequests = logRequests;
+            return (B) this;
+        }
+
+        public B logResponses() {
+            return logResponses(true);
+        }
+
+        public B logResponses(Boolean logResponses) {
+            if (logResponses == null) {
+                logResponses = false;
+            }
+            this.logResponses = logResponses;
+            return (B) this;
+        }
     }
 }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiClientBuilderFactory.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiClientBuilderFactory.java
@@ -1,0 +1,7 @@
+package dev.langchain4j.model.mistralai;
+
+import java.util.function.Supplier;
+
+@SuppressWarnings("rawtypes")
+public interface MistralAiClientBuilderFactory extends Supplier<MistralAiClient.Builder> {
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiDeltaMessage.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiDeltaMessage.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-class MistralAiDeltaMessage {
+public class MistralAiDeltaMessage {
 
     private MistralAiRole role;
     private String content;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiEmbeddingRequest.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiEmbeddingRequest.java
@@ -11,7 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-class MistralAiEmbeddingRequest {
+public class MistralAiEmbeddingRequest {
 
     private String model;
     private List<String> input;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiEmbeddingResponse.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiEmbeddingResponse.java
@@ -11,7 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-class MistralAiEmbeddingResponse {
+public class MistralAiEmbeddingResponse {
 
     private String id;
     private String object;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModelResponse.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModelResponse.java
@@ -11,7 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-class MistralAiModelResponse {
+public class MistralAiModelResponse {
 
     private String object;
     private List<MistralAiModelCard> data;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiRole.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiRole.java
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 
 @Getter
-enum MistralAiRole {
+public enum MistralAiRole {
 
     @SerializedName("system") SYSTEM,
     @SerializedName("user") USER,

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiUsage.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiUsage.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-class MistralAiUsage {
+public class MistralAiUsage {
 
     private Integer promptTokens;
     private Integer totalTokens;


### PR DESCRIPTION
This is very similar to what is done for OpenAI and it will directly enable [this](https://github.com/quarkiverse/quarkus-langchain4j/issues/371) 

cc @langchain4j 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new client for interacting with Mistral AI services, enabling chat completions, streaming chat completions, embeddings, and model listings.
- **Refactor**
	- Updated `MistralAiClient` to an abstract class with enhanced functionality and a new builder method for configuration.
- **Chores**
	- Changed access modifiers of several classes and methods from package-private to public, improving their usability across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->