### PR TITLE
Add AnthropicStreamingChatModel

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicApi.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicApi.java
@@ -1,10 +1,8 @@
 package dev.langchain4j.model.anthropic;
 
+import okhttp3.ResponseBody;
 import retrofit2.Call;
-import retrofit2.http.Body;
-import retrofit2.http.Header;
-import retrofit2.http.Headers;
-import retrofit2.http.POST;
+import retrofit2.http.*;
 
 interface AnthropicApi {
 
@@ -15,4 +13,11 @@ interface AnthropicApi {
     Call<AnthropicCreateMessageResponse> createMessage(@Header(X_API_KEY) String apiKey,
                                                        @Header("anthropic-version") String version,
                                                        @Body AnthropicCreateMessageRequest request);
+
+    @POST("messages")
+    @Streaming
+    @Headers({"content-type: application/json"})
+    Call<ResponseBody> streamingMessages(@Header(X_API_KEY) String apiKey,
+                                     @Header("anthropic-version") String version,
+                                     @Body AnthropicCreateMessageRequest request);
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicCreateMessageResponse.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicCreateMessageResponse.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.anthropic;
 
 import lombok.Builder;
 import lombok.Getter;
+import okhttp3.internal.ws.RealWebSocket;
 
 import java.util.List;
 
@@ -17,6 +18,8 @@ class AnthropicCreateMessageResponse {
     private final String stopReason;
     private final String stopSequence;
     private final Usage usage;
+    private final Message message;
+    private final Delta delta;
 
     @Getter
     @Builder
@@ -32,5 +35,18 @@ class AnthropicCreateMessageResponse {
 
         private final int inputTokens;
         private final int outputTokens;
+    }
+
+    @Getter
+    @Builder
+    static class Delta {
+        private final String type;
+        private final String  text;
+    }
+
+    @Getter
+    @Builder
+    static class Message {
+        private final Usage usage;
     }
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -1,0 +1,88 @@
+package dev.langchain4j.model.anthropic;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import lombok.Builder;
+
+import java.time.Duration;
+import java.util.List;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.model.anthropic.AnthropicMapper.toAnthropicMessages;
+import static dev.langchain4j.model.anthropic.AnthropicMapper.toAnthropicSystemPrompt;
+
+public class AnthropicStreamingChatModel implements StreamingChatLanguageModel {
+
+    private final AnthropicClient client;
+    private final String modelName;
+    private final Double temperature;
+    private final Double topP;
+    private final Integer topK;
+    private final int maxTokens;
+    private final List<String> stopSequences;
+
+    /**
+     * Constructs an instance of an {@code AnthropicChatModel} with the specified parameters.
+     *
+     * @param baseUrl       The base URL of the Anthropic API. Default: "https://api.anthropic.com/v1/"
+     * @param apiKey        The API key for authentication with the Anthropic API.
+     * @param version       The version of the Anthropic API. Default: "2023-06-01"
+     * @param modelName     The name of the Anthropic model to use. Default: "claude-3-sonnet-20240229"
+     * @param temperature   The temperature
+     * @param topP          The top-P
+     * @param topK          The top-K
+     * @param maxTokens     The maximum number of tokens to generate. Default: 1024
+     * @param stopSequences The custom text sequences that will cause the model to stop generating
+     * @param timeout       The timeout for API requests. Default: 60 seconds*
+     * @param logRequests   Whether to log the content of API requests using SLF4J. Default: false
+     * @param logResponses  Whether to log the content of API responses using SLF4J. Default: false
+     */
+    @Builder
+    private AnthropicStreamingChatModel(String baseUrl,
+                                        String apiKey,
+                                        String version,
+                                        String modelName,
+                                        Double temperature,
+                                        Double topP,
+                                        Integer topK,
+                                        Integer maxTokens,
+                                        List<String> stopSequences,
+                                        Duration timeout,
+                                        Boolean logRequests,
+                                        Boolean logResponses) {
+        this.client = AnthropicClient.builder()
+                .baseUrl(getOrDefault(baseUrl, "https://api.anthropic.com/v1/"))
+                .apiKey(apiKey)
+                .version(getOrDefault(version, "2023-06-01"))
+                .timeout(getOrDefault(timeout, Duration.ofSeconds(60)))
+                .logRequests(getOrDefault(logRequests, false))
+                .logResponses(getOrDefault(logResponses, false))
+                .build();
+        this.modelName = getOrDefault(modelName, "claude-3-sonnet-20240229");
+        this.temperature = temperature;
+        this.topP = topP;
+        this.topK = topK;
+        this.maxTokens = getOrDefault(maxTokens, 1024);
+        this.stopSequences = stopSequences;
+    }
+
+    @Override
+    public void generate(List<ChatMessage> messages, StreamingResponseHandler<AiMessage> handler) {
+        AnthropicCreateMessageRequest request = AnthropicCreateMessageRequest.builder()
+                .model(modelName)
+                .messages(toAnthropicMessages(ensureNotEmpty(messages, "messages")))
+                .system(toAnthropicSystemPrompt(messages))
+                .maxTokens(maxTokens)
+                .stopSequences(stopSequences)
+                .stream(true)
+                .temperature(temperature)
+                .topP(topP)
+                .topK(topK)
+                .build();
+
+        client.streamingMessages(request, handler);
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelTest.java
@@ -1,0 +1,121 @@
+package dev.langchain4j.model.anthropic;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.concurrent.CompletableFuture;
+
+import static dev.langchain4j.data.message.UserMessage.userMessage;
+import static dev.langchain4j.model.output.FinishReason.STOP;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AnthropicStreamingChatModelTest {
+
+    StreamingChatLanguageModel model = AnthropicStreamingChatModel.builder()
+            .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+            .logRequests(true)
+            .logResponses(true)
+            .build();
+
+    @BeforeEach
+    void beforeEach() throws InterruptedException {
+        Thread.sleep(10_000L); // to avoid hitting rate limits
+    }
+
+    @Test
+    void should_stream_answer() throws Exception {
+        String userMessage = "What is the capital of Germany?";
+        CompletableFuture<Response<AiMessage>> futureResponse = new CompletableFuture<>();
+        model.generate(userMessage, streamHandler(futureResponse));
+
+        Response<AiMessage> response = futureResponse.get(30, SECONDS);
+        assertThat(response.content().text()).contains("Berlin");
+
+        TokenUsage tokenUsage = response.tokenUsage();
+        assertThat(tokenUsage.inputTokenCount()).isEqualTo(14);
+        assertThat(tokenUsage.outputTokenCount()).isGreaterThan(0);
+        assertThat(tokenUsage.totalTokenCount())
+                .isEqualTo(tokenUsage.inputTokenCount() + tokenUsage.outputTokenCount());
+
+        assertThat(response.finishReason()).isEqualTo(STOP);
+    }
+
+    @Test
+    void should_respect_numPredict() throws Exception {
+        int numPredict = 1; // max output tokens
+        StreamingChatLanguageModel model = AnthropicStreamingChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .maxTokens(numPredict)
+                .build();
+        UserMessage userMessage = UserMessage.from("What is the capital of Germany?");
+        CompletableFuture<Response<AiMessage>> futureResponse = new CompletableFuture<>();
+        model.generate(singletonList(userMessage), streamHandler(futureResponse));
+        Response<AiMessage> response = futureResponse.get(30, SECONDS);
+        assertThat(response.content().text()).doesNotContain("Berlin");
+        assertThat(response.tokenUsage().outputTokenCount()).isBetween(numPredict, numPredict);
+    }
+
+    @Test
+    void should_respect_system_message() throws Exception {
+        SystemMessage systemMessage = SystemMessage.from("You are a professional translator into German language");
+        UserMessage userMessage = UserMessage.from("Translate: I love you");
+        CompletableFuture<Response<AiMessage>> futureResponse = new CompletableFuture<>();
+        model.generate(asList(systemMessage, userMessage), streamHandler(futureResponse));
+        Response<AiMessage> response = futureResponse.get(30, SECONDS);
+        assertThat(response.content().text()).containsIgnoringCase("liebe");
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @EnumSource(AnthropicChatModelName.class)
+    void should_support_all_string_model_names(AnthropicChatModelName modelName) {
+
+        StreamingChatLanguageModel model = AnthropicStreamingChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName.toString())
+                .maxTokens(3)
+                .build();
+
+        UserMessage userMessage = userMessage("Hi");
+        CompletableFuture<Response<AiMessage>> futureResponse = new CompletableFuture<>();
+        model.generate(singletonList(userMessage), streamHandler(futureResponse));
+        Response<AiMessage> response = futureResponse.get(30, SECONDS);
+        assertThat(response.content().text()).isNotBlank();
+    }
+
+    @NotNull
+    private static StreamingResponseHandler<AiMessage> streamHandler(CompletableFuture<Response<AiMessage>> futureResponse) {
+        return new StreamingResponseHandler<AiMessage>() {
+            @Override
+            public void onNext(String token) {
+                System.out.println("onNext: '" + token + "'");
+            }
+
+            @Override
+            public void onComplete(Response<AiMessage> response) {
+                System.out.println("onComplete: '" + response + "'");
+                futureResponse.complete(response);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                futureResponse.completeExceptionally(error);
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Follow up of [integration with Anthropic](https://github.com/langchain4j/langchain4j/pull/727) to include streaming chat model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for handling streaming messages in the Anthropic API.
	- Added functionality for streaming messages and improved error handling in the Anthropic client.
	- New classes `Message` and `Delta` added for better message response handling.
	- Implemented a streaming chat language model for generating AI responses based on user messages.
- **Tests**
	- Added tests for the new streaming chat language model, covering functionality such as streaming answers and handling different types of system messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->