### PR TITLE
[FEATURE] #734 Add missing foundational Bedrock models

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAI21LabsChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAI21LabsChatModel.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class BedrockAI21LabsChatModel extends AbstractBedrockChatModel<BedrockAI21LabsChatModelResponse> {
 
     @Builder.Default
-    private final Types model = Types.J2MidV2;
+    private final String model = Types.J2MidV2.getValue();
     @Builder.Default
     private final Map<String, Object> countPenalty = of("scale", 0);
     @Builder.Default
@@ -40,7 +40,7 @@ public class BedrockAI21LabsChatModel extends AbstractBedrockChatModel<BedrockAI
 
     @Override
     protected String getModelId() {
-        return model.getValue();
+        return model;
     }
 
     @Override

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicCompletionChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicCompletionChatModel.java
@@ -10,7 +10,8 @@ import java.util.Map;
 
 @Getter
 @SuperBuilder
-public class BedrockAnthropicChatModel extends AbstractBedrockChatModel<BedrockAnthropicChatModelResponse> {
+public class BedrockAnthropicCompletionChatModel extends AbstractBedrockChatModel<BedrockAnthropicCompletionChatModelResponse> {
+    
     private static final String DEFAULT_ANTHROPIC_VERSION = "bedrock-2023-05-31";
 
     @Builder.Default
@@ -18,11 +19,11 @@ public class BedrockAnthropicChatModel extends AbstractBedrockChatModel<BedrockA
     @Builder.Default
     private final String anthropicVersion = DEFAULT_ANTHROPIC_VERSION;
     @Builder.Default
-    private final Types model = Types.AnthropicClaudeV2;
+    private final String model = Types.AnthropicClaudeV2.getValue();
 
     @Override
     protected String getModelId() {
-        return model.getValue();
+        return model;
     }
 
     @Override
@@ -41,8 +42,8 @@ public class BedrockAnthropicChatModel extends AbstractBedrockChatModel<BedrockA
     }
 
     @Override
-    public Class<BedrockAnthropicChatModelResponse> getResponseClassType() {
-        return BedrockAnthropicChatModelResponse.class;
+    public Class<BedrockAnthropicCompletionChatModelResponse> getResponseClassType() {
+        return BedrockAnthropicCompletionChatModelResponse.class;
     }
 
     /**
@@ -53,13 +54,13 @@ public class BedrockAnthropicChatModel extends AbstractBedrockChatModel<BedrockA
         AnthropicClaudeInstantV1("anthropic.claude-instant-v1"),
         AnthropicClaudeV1("anthropic.claude-v1"),
         AnthropicClaudeV2("anthropic.claude-v2"),
-        AnthropicClaudeV2_1("anthropic.claude-v2:1");
+        AnthropicClaudeV2_1("anthropic.claude-v2:1"),
+        AnthropicClaude3SonnetV1("anthropic.claude-3-sonnet-20240229-v1:0");
 
         private final String value;
 
         Types(String modelID) {
             this.value = modelID;
         }
-
     }
 }

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicCompletionChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicCompletionChatModelResponse.java
@@ -1,0 +1,41 @@
+package dev.langchain4j.model.bedrock;
+
+import dev.langchain4j.model.bedrock.internal.BedrockChatModelResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Bedrock Anthropic Text Completions API Invoke response
+ * <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-text-completion.html">...</a>
+ */
+@Getter
+@Setter
+public class BedrockAnthropicCompletionChatModelResponse implements BedrockChatModelResponse {
+    
+    private String completion;
+    private String stop_reason;
+
+    @Override
+    public String getOutputText() {
+        return completion;
+    }
+
+    @Override
+    public FinishReason getFinishReason() {
+        switch (stop_reason) {
+            case "stop_sequence":
+                return FinishReason.STOP;
+            case "max_tokens":
+                return FinishReason.LENGTH;
+            default:
+                throw new IllegalArgumentException("Unknown stop reason: " + stop_reason);
+        }
+    }
+
+    @Override
+    public TokenUsage getTokenUsage() {
+        return null;
+    }
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicContent.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicContent.java
@@ -1,0 +1,25 @@
+package dev.langchain4j.model.bedrock;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BedrockAnthropicContent {
+  
+  private String type;
+  private String text;
+  private BedrockAnthropicImageSource source;
+  
+  public BedrockAnthropicContent(String type, String text) {
+    this.type = type;
+    this.text = text;
+  }
+  
+  public BedrockAnthropicContent(String type, BedrockAnthropicImageSource source) {
+    this.type = type;
+    this.source = source;
+  }
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicImageSource.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicImageSource.java
@@ -1,0 +1,15 @@
+package dev.langchain4j.model.bedrock;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class BedrockAnthropicImageSource {
+  
+  private String type;
+  private String media_type;
+  private String data;
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessage.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessage.java
@@ -1,0 +1,15 @@
+package dev.langchain4j.model.bedrock;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class BedrockAnthropicMessage {
+  
+  private String role;
+  private List<BedrockAnthropicContent> content;
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessageChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessageChatModel.java
@@ -1,0 +1,149 @@
+package dev.langchain4j.model.bedrock;
+
+import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static java.util.stream.Collectors.joining;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageType;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.internal.Json;
+import dev.langchain4j.model.bedrock.internal.AbstractBedrockChatModel;
+import dev.langchain4j.model.output.Response;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
+
+@Getter
+@SuperBuilder
+public class BedrockAnthropicMessageChatModel extends AbstractBedrockChatModel<BedrockAnthropicMessageChatModelResponse> {
+    
+    private static final String DEFAULT_ANTHROPIC_VERSION = "bedrock-2023-05-31";
+    
+    @Builder.Default
+    private final int topK = 250;
+    @Builder.Default
+    private final String anthropicVersion = DEFAULT_ANTHROPIC_VERSION;
+    @Builder.Default
+    private final String model = Types.AnthropicClaude3SonnetV1.getValue();
+    
+    @Override
+    protected String getModelId() {
+        return model;
+    }
+    
+    @Override
+    protected Map<String, Object> getRequestParameters(String prompt) {
+        final Map<String, Object> parameters = new HashMap<>(9);
+        parameters.put("max_tokens", getMaxTokens());
+        parameters.put("temperature", getTemperature());
+        parameters.put("top_k", topK);
+        parameters.put("top_p", getTopP());
+        parameters.put("stop_sequences", getStopSequences());
+        parameters.put("anthropic_version", anthropicVersion);
+        return parameters;
+    }
+    
+    @Override
+    public Response<AiMessage> generate(List<ChatMessage> messages) {
+        final String system = getAnthropicSystemPrompt(messages);
+        
+        List<BedrockAnthropicMessage> formattedMessages = getAnthropicMessages(messages);
+        
+        Map<String, Object> parameters = getRequestParameters(null);
+        parameters.put("messages", formattedMessages);
+        parameters.put("system", system);
+        
+        final String body = Json.toJson(parameters);
+        
+        InvokeModelResponse invokeModelResponse = withRetry(() -> invoke(body), getMaxRetries());
+        final String response = invokeModelResponse.body().asUtf8String();
+        BedrockAnthropicMessageChatModelResponse result = Json.fromJson(response, getResponseClassType());
+        
+        return new Response<>(new AiMessage(result.getOutputText()),
+            result.getTokenUsage(),
+            result.getFinishReason());
+    }
+    
+    private List<BedrockAnthropicMessage> getAnthropicMessages(List<ChatMessage> messages) {
+        return messages.stream()
+            .filter(message -> message.type() != ChatMessageType.SYSTEM)
+            .map(message -> new BedrockAnthropicMessage(getAnthropicRole(message), getAnthropicContent(message)))
+            .collect(Collectors.toList());
+    }
+    
+    private List<BedrockAnthropicContent> getAnthropicContent(ChatMessage message) {
+        if (message instanceof AiMessage) {
+            return Collections.singletonList(new BedrockAnthropicContent("text", ((AiMessage) message).text()));
+        } else if (message instanceof UserMessage) {
+            return ((UserMessage) message).contents().stream()
+                .map(BedrockAnthropicMessageChatModel::mapContentToAnthropic)
+                .collect(Collectors.toList());
+        } else {
+            throw new IllegalArgumentException("Unknown message type: " + message.type());
+        }
+    }
+    
+    private static BedrockAnthropicContent mapContentToAnthropic(Content content) {
+        if (content instanceof TextContent) {
+            return new BedrockAnthropicContent("text", ((TextContent) content).text());
+        } else if (content instanceof ImageContent) {
+            ImageContent imageContent = (ImageContent) content;
+            if (imageContent.image().url() != null) {
+                throw new IllegalArgumentException("Anthropic does not support images as URLs, only as Base64-encoded strings");
+            }
+            BedrockAnthropicImageSource imageSource = new BedrockAnthropicImageSource(
+                "base64",
+                ensureNotBlank(imageContent.image().mimeType(), "mimeType"),
+                ensureNotBlank(imageContent.image().base64Data(), "base64Data")
+            );
+            return new BedrockAnthropicContent("image", imageSource);
+        } else {
+            throw new IllegalArgumentException("Unknown content type: " + content);
+        }
+    }
+    
+    private String getAnthropicSystemPrompt(List<ChatMessage> messages) {
+        return messages.stream()
+            .filter(message -> message.type() == ChatMessageType.SYSTEM)
+            .map(ChatMessage::text)
+            .collect(joining("\n"));
+    }
+    
+    private String getAnthropicRole(ChatMessage message) {
+        return message.type() == ChatMessageType.AI ? "assistant" : "user";
+    }
+    
+    @Override
+    public Class<BedrockAnthropicMessageChatModelResponse> getResponseClassType() {
+        return BedrockAnthropicMessageChatModelResponse.class;
+    }
+
+    /**
+     * Bedrock Anthropic model ids
+     */
+    @Getter
+    public enum Types {
+        AnthropicClaudeInstantV1("anthropic.claude-instant-v1"),
+        AnthropicClaudeV2("anthropic.claude-v2"),
+        AnthropicClaudeV2_1("anthropic.claude-v2:1"),
+        AnthropicClaude3SonnetV1("anthropic.claude-3-sonnet-20240229-v1:0"),
+        AnthropicClaude3HaikuV1("anthropic.claude-3-haiku-20240307-v1:0");
+
+        private final String value;
+
+        Types(String modelID) {
+            this.value = modelID;
+        }
+    }
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessageChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessageChatModelResponse.java
@@ -1,0 +1,62 @@
+package dev.langchain4j.model.bedrock;
+
+import dev.langchain4j.model.bedrock.internal.BedrockChatModelResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Bedrock Anthropic Messages API Invoke response
+ * <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html">...</a>
+ */
+@Getter
+@Setter
+public class BedrockAnthropicMessageChatModelResponse implements BedrockChatModelResponse {
+    
+    private String id;
+    private String model;
+    private String type;
+    private String role;
+    private List<BedrockAnthropicContent> content;
+    private String stop_reason;
+    private String stop_sequence;
+    private BedrockAnthropicUsage usage;
+    
+    @Getter
+    @Setter
+    public static class BedrockAnthropicUsage {
+        private int input_tokens;
+        private int output_tokens;
+    }
+
+    @Override
+    public String getOutputText() {
+        return content.stream().map(BedrockAnthropicContent::getText).collect(Collectors.joining("\n\n"));
+    }
+
+    @Override
+    public FinishReason getFinishReason() {
+        switch (stop_reason) {
+        case "end_turn":
+          case "stop_sequence":
+            return FinishReason.STOP;
+          case "max_tokens":
+                return FinishReason.LENGTH;
+            default:
+                throw new IllegalArgumentException("Unknown stop reason: " + stop_reason);
+        }
+    }
+
+    @Override
+    public TokenUsage getTokenUsage() {
+      if (usage != null) {
+          int totalTokenCount = usage.input_tokens + usage.output_tokens;
+          return new TokenUsage(usage.input_tokens, usage.output_tokens, totalTokenCount);
+      } else {
+          return null;
+      }
+    }
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereChatModel.java
@@ -23,7 +23,7 @@ public class BedrockCohereChatModel extends AbstractBedrockChatModel<BedrockCohe
     @Builder.Default
     private final int topK = 0;
     @Builder.Default
-    private final Types model = Types.CommandTextV14;
+    private final String model = Types.CommandTextV14.getValue();
 
     @Override
     protected Map<String, Object> getRequestParameters(String prompt) {
@@ -42,7 +42,7 @@ public class BedrockCohereChatModel extends AbstractBedrockChatModel<BedrockCohe
 
     @Override
     protected String getModelId() {
-        return model.getValue();
+        return model;
     }
 
     @Override

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockLlamaChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockLlamaChatModel.java
@@ -1,0 +1,55 @@
+package dev.langchain4j.model.bedrock;
+
+import dev.langchain4j.model.bedrock.internal.AbstractBedrockChatModel;
+import dev.langchain4j.model.bedrock.internal.BedrockChatModelResponse;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class BedrockLlamaChatModel extends AbstractBedrockChatModel<BedrockLlamaChatModelResponse> {
+
+    @Builder.Default
+    private final String model = Types.MetaLlama2Chat70B.getValue();
+
+    @Override
+    protected String getModelId() {
+        return model;
+    }
+
+    @Override
+    protected Map<String, Object> getRequestParameters(String prompt) {
+        final Map<String, Object> parameters = new HashMap<>(7);
+
+        parameters.put("prompt", prompt);
+        parameters.put("max_gen_len", getMaxTokens());
+        parameters.put("temperature", getTemperature());
+        parameters.put("top_p", getTopP());
+
+        return parameters;
+    }
+
+    @Override
+    public Class<BedrockLlamaChatModelResponse> getResponseClassType() {
+        return BedrockLlamaChatModelResponse.class;
+    }
+
+    /**
+     * Bedrock Llama model ids
+     */
+    @Getter
+    public enum Types {
+        MetaLlama2Chat13B("meta.llama2-13b-chat-v1"),
+        MetaLlama2Chat70B("meta.llama2-70b-chat-v1");
+
+        private final String value;
+
+        Types(String modelID) {
+            this.value = modelID;
+        }
+
+    }
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockLlamaChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockLlamaChatModelResponse.java
@@ -1,0 +1,42 @@
+package dev.langchain4j.model.bedrock;
+
+import dev.langchain4j.model.bedrock.internal.BedrockChatModelResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Bedrock Llama Invoke response
+ */
+@Getter
+@Setter
+public class BedrockLlamaChatModelResponse implements BedrockChatModelResponse {
+    
+    private String generation;
+    private int prompt_token_count;
+    private int generation_token_count;
+    private String stop_reason;
+
+    @Override
+    public String getOutputText() {
+        return generation;
+    }
+
+    @Override
+    public FinishReason getFinishReason() {
+        switch (stop_reason) {
+            case "stop":
+                return FinishReason.STOP;
+            case "length":
+                return FinishReason.LENGTH;
+            default:
+                throw new IllegalArgumentException("Unknown stop reason: " + stop_reason);
+        }
+    }
+
+    @Override
+    public TokenUsage getTokenUsage() {
+        return new TokenUsage(prompt_token_count, generation_token_count);
+    }
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAIChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAIChatModel.java
@@ -1,0 +1,102 @@
+package dev.langchain4j.model.bedrock;
+
+import static dev.langchain4j.internal.RetryUtils.withRetry;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.internal.Json;
+import dev.langchain4j.model.bedrock.internal.AbstractBedrockChatModel;
+import dev.langchain4j.model.output.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
+
+@Getter
+@SuperBuilder
+public class BedrockMistralAIChatModel extends AbstractBedrockChatModel<BedrockMistralAIChatModelResponse> {
+    
+    @Builder.Default
+    private final int topK = 200;
+    @Builder.Default
+    private final String model = Types.Mistral7bInstructV0_2.getValue();
+
+    @Override
+    protected String getModelId() {
+        return model;
+    }
+
+    @Override
+    protected Map<String, Object> getRequestParameters(String prompt) {
+        final Map<String, Object> parameters = new HashMap<>(7);
+
+        parameters.put("prompt", prompt);
+        parameters.put("max_tokens", getMaxTokens());
+        parameters.put("temperature", getTemperature());
+        parameters.put("top_p", getTopP());
+        parameters.put("top_k", topK);
+        parameters.put("stop", getStopSequences());
+
+        return parameters;
+    }
+    
+    @Override
+    public Response<AiMessage> generate(List<ChatMessage> messages) {
+        String prompt = buildPrompt(messages);
+        
+        final Map<String, Object> requestParameters = getRequestParameters(prompt);
+        final String body = Json.toJson(requestParameters);
+        
+        InvokeModelResponse invokeModelResponse = withRetry(() -> invoke(body), getMaxRetries());
+        final String response = invokeModelResponse.body().asUtf8String().trim();
+        final BedrockMistralAIChatModelResponse result = Json.fromJson(response, getResponseClassType());
+        
+        return new Response<>(new AiMessage(result.getOutputText()),
+            result.getTokenUsage(),
+            result.getFinishReason());
+    }
+    
+    private String buildPrompt(List<ChatMessage> messages) {
+        StringBuilder promptBuilder = new StringBuilder();
+        promptBuilder.append("<s>");
+        
+        for (ChatMessage message : messages) {
+          switch (message.type()) {
+            case USER:
+              promptBuilder.append("[INST] ").append(message.text()).append(" [/INST]");
+              break;
+            case AI:
+              promptBuilder.append(" ").append(message.text()).append(" ");
+              break;
+            default:
+              throw new IllegalArgumentException("Bedrock Mistral AI does not support the message type: " + message.type());
+          }
+        }
+        
+        promptBuilder.append("</s>");
+        return promptBuilder.toString();
+    }
+    
+    @Override
+    public Class<BedrockMistralAIChatModelResponse> getResponseClassType() {
+        return BedrockMistralAIChatModelResponse.class;
+    }
+
+    /**
+     * Bedrock Mistral model ids
+     */
+    @Getter
+    public enum Types {
+        Mistral7bInstructV0_2("mistral.mistral-7b-instruct-v0:2"),
+        MistralMixtral8x7bInstructV0_1("mistral.mixtral-8x7b-instruct-v0:1");
+
+        private final String value;
+
+        Types(String modelID) {
+            this.value = modelID;
+        }
+    }
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAIChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAIChatModel.java
@@ -17,7 +17,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 
 @Getter
 @SuperBuilder
-public class BedrockMistralAIChatModel extends AbstractBedrockChatModel<BedrockMistralAIChatModelResponse> {
+public class BedrockMistralAiChatModel extends AbstractBedrockChatModel<BedrockMistralAIChatModelResponse> {
     
     @Builder.Default
     private final int topK = 200;

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAIChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAIChatModelResponse.java
@@ -3,29 +3,38 @@ package dev.langchain4j.model.bedrock;
 import dev.langchain4j.model.bedrock.internal.BedrockChatModelResponse;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Bedrock Anthropic Invoke response
+ * Bedrock Mistral AI Invoke response
  */
 @Getter
 @Setter
-public class BedrockAnthropicChatModelResponse implements BedrockChatModelResponse {
-    private String completion;
-    private String stop_reason;
+public class BedrockMistralAIChatModelResponse implements BedrockChatModelResponse {
+    
+    private List<Output> outputs;
+    
+    @Getter
+    @Setter
+    public static class Output {
+        private String text;
+        private String stop_reason;
+    }
 
     @Override
     public String getOutputText() {
-        return completion;
+        return outputs.get(0).text;
     }
 
     @Override
     public FinishReason getFinishReason() {
+        String stop_reason = outputs.get(0).stop_reason;
         switch (stop_reason) {
-            case "stop_sequence":
+            case "stop":
                 return FinishReason.STOP;
-            case "max_tokens":
+            case "length":
                 return FinishReason.LENGTH;
             default:
                 throw new IllegalArgumentException("Unknown stop reason: " + stop_reason);

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAIChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAIChatModelResponse.java
@@ -12,7 +12,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-public class BedrockMistralAIChatModelResponse implements BedrockChatModelResponse {
+public class BedrockMistralAiChatModelResponse implements BedrockChatModelResponse {
     
     private List<Output> outputs;
     

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStabilityAIChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStabilityAIChatModel.java
@@ -48,7 +48,7 @@ public class BedrockStabilityAIChatModel extends AbstractBedrockChatModel<Bedroc
     }
 
     @Builder.Default
-    private final Types model = Types.StableDiffuseXlV0;
+    private final String model = Types.StableDiffuseXlV1.getValue();
     @Builder.Default
     private final int cfgScale = 10;
     @Builder.Default
@@ -87,7 +87,7 @@ public class BedrockStabilityAIChatModel extends AbstractBedrockChatModel<Bedroc
 
     @Override
     protected String getModelId() {
-        return model.getValue();
+        return model;
     }
 
     @Override
@@ -96,11 +96,12 @@ public class BedrockStabilityAIChatModel extends AbstractBedrockChatModel<Bedroc
     }
 
     /**
-     * Bedrock Amazon Titan model ids
+     * Bedrock Amazon Stability AI model ids
      */
     @Getter
     public enum Types {
-        StableDiffuseXlV0("stability.stable-diffusion-xl-v0");
+        StableDiffuseXlV0("stability.stable-diffusion-xl-v0"),
+        StableDiffuseXlV1("stability.stable-diffusion-xl-v1");
 
         private final String value;
 

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockTitanChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockTitanChatModel.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public class BedrockTitanChatModel extends AbstractBedrockChatModel<BedrockTitanChatModelResponse> {
 
     @Builder.Default
-    private final Types model = Types.TitanTextExpressV1;
+    private final String model = Types.TitanTextExpressV1.getValue();
 
     @Override
     protected Map<String, Object> getRequestParameters(String prompt) {
@@ -36,7 +36,7 @@ public class BedrockTitanChatModel extends AbstractBedrockChatModel<BedrockTitan
 
     @Override
     protected String getModelId() {
-        return model.getValue();
+        return model;
     }
 
     @Override

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockTitanEmbeddingModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockTitanEmbeddingModel.java
@@ -19,11 +19,11 @@ public class BedrockTitanEmbeddingModel extends AbstractBedrockEmbeddingModel<Be
     private final static String MODEL_ID = "amazon.titan-embed-text-v1";
 
     @Builder.Default
-    private final Types model = Types.TitanEmbedTextV1;
+    private final String model = Types.TitanEmbedTextV1.getValue();
 
     @Override
     protected String getModelId() {
-        return model.getValue();
+        return model;
     }
 
     @Override

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatModelIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatModelIT.java
@@ -1,28 +1,137 @@
 package dev.langchain4j.model.bedrock;
 
+import static dev.langchain4j.internal.Utils.readBytes;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.bedrock.BedrockMistralAIChatModel.Types;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.regions.Region;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class BedrockChatModelIT {
-
+    
+    private static final String CAT_IMAGE_URL = "https://upload.wikimedia.org/wikipedia/commons/e/e9/Felis_silvestris_silvestris_small_gradual_decrease_of_quality.png";
+    
     @Test
     @Disabled("To run this test, you must have provide your own access key, secret, region")
-    void testBedrockAnthropicChatModel() {
+    void testBedrockAnthropicV3SonnetChatModel() {
+        
+        BedrockAnthropicMessageChatModel bedrockChatModel = BedrockAnthropicMessageChatModel
+            .builder()
+            .temperature(0.50f)
+            .maxTokens(300)
+            .region(Region.US_EAST_1)
+            .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3SonnetV1.getValue())
+            .maxRetries(1)
+            .build();
+        
+        assertThat(bedrockChatModel).isNotNull();
+        
+        Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
+        
+        assertThat(response).isNotNull();
+        assertThat(response.content().text()).isNotBlank();
+        assertThat(response.tokenUsage()).isNotNull();
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
+    }
+    
+    @Test
+    @Disabled("To run this test, you must have provide your own access key, secret, region")
+    void testBedrockAnthropicV3SonnetChatModelImageContent() {
+        
+        BedrockAnthropicMessageChatModel bedrockChatModel = BedrockAnthropicMessageChatModel
+            .builder()
+            .temperature(0.50f)
+            .maxTokens(300)
+            .region(Region.US_EAST_1)
+            .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3SonnetV1.getValue())
+            .maxRetries(1)
+            .build();
+        
+        assertThat(bedrockChatModel).isNotNull();
+        
+        String base64Data = Base64.getEncoder().encodeToString(readBytes(CAT_IMAGE_URL));
+        ImageContent imageContent = ImageContent.from(base64Data, "image/png");
+        UserMessage userMessage = UserMessage.from(imageContent);
+        
+        Response<AiMessage> response = bedrockChatModel.generate(userMessage);
+        
+        assertThat(response).isNotNull();
+        assertThat(response.content().text()).isNotBlank();
+        assertThat(response.tokenUsage()).isNotNull();
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
+    }
+    
+    @Test
+    @Disabled("To run this test, you must have provide your own access key, secret, region")
+    void testBedrockAnthropicV3HaikuChatModel() {
+        
+        BedrockAnthropicMessageChatModel bedrockChatModel = BedrockAnthropicMessageChatModel
+            .builder()
+            .temperature(0.50f)
+            .maxTokens(300)
+            .region(Region.US_EAST_1)
+            .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3HaikuV1.getValue())
+            .maxRetries(1)
+            .build();
+        
+        assertThat(bedrockChatModel).isNotNull();
+        
+        Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
+        
+        assertThat(response).isNotNull();
+        assertThat(response.content().text()).isNotBlank();
+        assertThat(response.tokenUsage()).isNotNull();
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
+    }
+    
+    @Test
+    @Disabled("To run this test, you must have provide your own access key, secret, region")
+    void testBedrockAnthropicV3HaikuChatModelImageContent() {
+        
+        BedrockAnthropicMessageChatModel bedrockChatModel = BedrockAnthropicMessageChatModel
+            .builder()
+            .temperature(0.50f)
+            .maxTokens(300)
+            .region(Region.US_EAST_1)
+            .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3HaikuV1.getValue())
+            .maxRetries(1)
+            .build();
+        
+        assertThat(bedrockChatModel).isNotNull();
+        
+        String base64Data = Base64.getEncoder().encodeToString(readBytes(CAT_IMAGE_URL));
+        ImageContent imageContent = ImageContent.from(base64Data, "image/png");
+        UserMessage userMessage = UserMessage.from(imageContent);
+        
+        Response<AiMessage> response = bedrockChatModel.generate(userMessage);
+        
+        assertThat(response).isNotNull();
+        assertThat(response.content().text()).isNotBlank();
+        assertThat(response.tokenUsage()).isNotNull();
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
+    }
+    
+    @Test
+    @Disabled("To run this test, you must have provide your own access key, secret, region")
+    void testBedrockAnthropicV2ChatModelEnumModelType() {
 
-        BedrockAnthropicChatModel bedrockChatModel = BedrockAnthropicChatModel
+        BedrockAnthropicCompletionChatModel bedrockChatModel = BedrockAnthropicCompletionChatModel
                 .builder()
                 .temperature(0.50f)
                 .maxTokens(300)
                 .region(Region.US_EAST_1)
-                .model(BedrockAnthropicChatModel.Types.AnthropicClaudeV2)
+                .model(BedrockAnthropicCompletionChatModel.Types.AnthropicClaudeV2.getValue())
                 .maxRetries(1)
                 .build();
 
@@ -33,7 +142,30 @@ public class BedrockChatModelIT {
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.tokenUsage()).isNull();
-        assertThat(response.finishReason()).isEqualTo(FinishReason.STOP);
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
+    }
+    
+    @Test
+    @Disabled("To run this test, you must have provide your own access key, secret, region")
+    void testBedrockAnthropicV2ChatModelStringModelType() {
+        
+        BedrockAnthropicCompletionChatModel bedrockChatModel = BedrockAnthropicCompletionChatModel
+            .builder()
+            .temperature(0.50f)
+            .maxTokens(300)
+            .region(Region.US_EAST_1)
+            .model("anthropic.claude-v2")
+            .maxRetries(1)
+            .build();
+        
+        assertThat(bedrockChatModel).isNotNull();
+        
+        Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
+        
+        assertThat(response).isNotNull();
+        assertThat(response.content().text()).isNotBlank();
+        assertThat(response.tokenUsage()).isNull();
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
 
     @Test
@@ -45,7 +177,7 @@ public class BedrockChatModelIT {
                 .temperature(0.50f)
                 .maxTokens(300)
                 .region(Region.US_EAST_1)
-                .model(BedrockTitanChatModel.Types.TitanTextExpressV1)
+                .model(BedrockTitanChatModel.Types.TitanTextExpressV1.getValue())
                 .maxRetries(1)
                 .build();
 
@@ -61,8 +193,7 @@ public class BedrockChatModelIT {
         assertThat(tokenUsage.inputTokenCount()).isEqualTo(14);
         assertThat(tokenUsage.outputTokenCount()).isGreaterThan(1);
         assertThat(tokenUsage.totalTokenCount()).isGreaterThan(15);
-
-        assertThat(response.finishReason()).isEqualTo(FinishReason.STOP);
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
 
     @Test
@@ -84,8 +215,7 @@ public class BedrockChatModelIT {
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.tokenUsage()).isNull();
-        
-        assertThat(response.finishReason()).isEqualTo(FinishReason.STOP);
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
 
     @Test
@@ -108,7 +238,101 @@ public class BedrockChatModelIT {
         assertThat(response).isNotNull();
         assertThat(response.content().text()).isNotBlank();
         assertThat(response.tokenUsage()).isNull();
-
-        assertThat(response.finishReason()).isEqualTo(FinishReason.STOP);
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
+    }
+    
+    @Test
+    @Disabled("To run this test, you must have provide your own access key, secret, region")
+    void testBedrockLlama13BChatModel() {
+        
+        BedrockLlamaChatModel bedrockChatModel = BedrockLlamaChatModel
+            .builder()
+            .temperature(0.50f)
+            .maxTokens(300)
+            .region(Region.US_EAST_1)
+            .model(BedrockLlamaChatModel.Types.MetaLlama2Chat13B.getValue())
+            .maxRetries(1)
+            .build();
+        
+        assertThat(bedrockChatModel).isNotNull();
+        
+        Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
+        
+        assertThat(response).isNotNull();
+        assertThat(response.content().text()).isNotBlank();
+        assertThat(response.tokenUsage()).isNotNull();
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
+    }
+    
+    @Test
+    @Disabled("To run this test, you must have provide your own access key, secret, region")
+    void testBedrockLlama70BChatModel() {
+        
+        BedrockLlamaChatModel bedrockChatModel = BedrockLlamaChatModel
+            .builder()
+            .temperature(0.50f)
+            .maxTokens(300)
+            .region(Region.US_EAST_1)
+            .model(BedrockLlamaChatModel.Types.MetaLlama2Chat70B.getValue())
+            .maxRetries(1)
+            .build();
+        
+        assertThat(bedrockChatModel).isNotNull();
+        
+        Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
+        
+        assertThat(response).isNotNull();
+        assertThat(response.content().text()).isNotBlank();
+        assertThat(response.tokenUsage()).isNotNull();
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
+    }
+    
+    @Test
+    @Disabled("To run this test, you must have provide your own access key, secret, region")
+    void testBedrockMistralAI7bInstructChatModel() {
+        
+        BedrockMistralAIChatModel bedrockChatModel = BedrockMistralAIChatModel
+            .builder()
+            .temperature(0.50f)
+            .maxTokens(300)
+            .region(Region.US_EAST_1)
+            .model(Types.Mistral7bInstructV0_2.getValue())
+            .maxRetries(1)
+            .build();
+        
+        assertThat(bedrockChatModel).isNotNull();
+        
+        List<ChatMessage> messages = Arrays.asList(
+            UserMessage.from("hi, how are you doing"),
+            AiMessage.from("I am an AI model so I don't have feelings"),
+            UserMessage.from("Ok no worries, tell me story about a man who wears a tin hat."));
+        
+        Response<AiMessage> response = bedrockChatModel.generate(messages);
+        
+        assertThat(response).isNotNull();
+        assertThat(response.content().text()).isNotBlank();
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
+    }
+    
+    @Test
+    @Disabled("To run this test, you must have provide your own access key, secret, region")
+    void testBedrockMistralAIMixtral8x7bInstructChatModel() {
+        
+        BedrockMistralAIChatModel bedrockChatModel = BedrockMistralAIChatModel
+            .builder()
+            .temperature(0.50f)
+            .maxTokens(300)
+            .region(Region.US_EAST_1)
+            .model(Types.MistralMixtral8x7bInstructV0_1.getValue())
+            .maxRetries(1)
+            .build();
+        
+        assertThat(bedrockChatModel).isNotNull();
+        
+        Response<AiMessage> response = bedrockChatModel.generate(UserMessage.from("hi, how are you doing?"));
+        
+        assertThat(response).isNotNull();
+        assertThat(response.content().text()).isNotBlank();
+        assertThat(response.finishReason()).isIn(FinishReason.STOP, FinishReason.LENGTH);
     }
 }

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockEmbeddingIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockEmbeddingIT.java
@@ -23,7 +23,7 @@ public class BedrockEmbeddingIT {
                 .builder()
                 .region(Region.US_EAST_1)
                 .maxRetries(1)
-                .model(BedrockTitanEmbeddingModel.Types.TitanEmbedTextV1)
+                .model(BedrockTitanEmbeddingModel.Types.TitanEmbedTextV1.getValue())
                 .build();
 
         assertThat(embeddingModel).isNotNull();


### PR DESCRIPTION
This PR addresses issue https://github.com/langchain4j/langchain4j/issues/734:

- Added functionality to pass in strings & enums as model ID. 
- Added Llama and Mistral AI models. 
- Added Anthropic Message API model

I've tried to follow the code style of the current implementation. Please let me know if you'd like any changes and I'll get them done ASAP :)