### PR TITLE
Update to actions/checkout@v4 and actions/setup-java@v4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,9 +38,9 @@ jobs:
   compliance:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'


### PR DESCRIPTION
Update to actions/checkout@v4 and actions/setup-java@v4 as Node.js 16 actions are deprecated