### PR TITLE
Make Mistral tool related enums public

### DIFF
--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiToolChoiceName.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiToolChoiceName.java
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 
 @Getter
-enum MistralAiToolChoiceName {
+public enum MistralAiToolChoiceName {
 
     @SerializedName("auto") AUTO,
     @SerializedName("any") ANY,

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiToolType.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiToolType.java
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 
 @Getter
-enum MistralAiToolType {
+public enum MistralAiToolType {
 
     @SerializedName("function") FUNCTION;
 


### PR DESCRIPTION
This allows integrations to customize how they serialized