### PR TITLE
feat: add ChatMemoryStore file implementation

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/store/memory/chat/FileChatMemoryStore.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/memory/chat/FileChatMemoryStore.java
@@ -1,0 +1,119 @@
+package dev.langchain4j.store.memory.chat;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+import static dev.langchain4j.internal.Exceptions.runtime;
+
+/**
+ * Implementation of {@link ChatMemoryStore} that stores state of {@link dev.langchain4j.memory.ChatMemory} (chat messages) a local file.
+ * <p>
+ * This mechanism is more reliable than {@link InMemoryChatMemoryStore}.
+ */
+public class FileChatMemoryStore implements ChatMemoryStore {
+    private static final Logger log = LoggerFactory.getLogger(FileChatMemoryStore.class);
+
+    private final String storageDirectory;
+
+    public static final String FILE_EXTENSION = ".json";
+
+    /**
+     * Constructor for FileChatMemoryStore.
+     *
+     * @param storageDirectory Folder path where msg is stored.
+     */
+    public FileChatMemoryStore(String storageDirectory) {
+        Path directoryPath = Paths.get(storageDirectory);
+        if (Files.exists(directoryPath)) {
+            if (!Files.isDirectory(directoryPath)) {
+                throw illegalArgument("Storage directory path exists but is a file: %s", storageDirectory);
+            }
+        } else {
+            try {
+                Files.createDirectories(directoryPath);
+            } catch (IOException e) {
+                log.error("Failed to create directory: {}", directoryPath, e);
+                throw runtime("Something is wrong, Failed to create folder %s", storageDirectory);
+            }
+            log.debug("Created directory {} to store messages", storageDirectory);
+        }
+        this.storageDirectory = storageDirectory;
+    }
+
+    public String getStorageDirectory() {
+        return storageDirectory;
+    }
+
+    @Override
+    public List<ChatMessage> getMessages(Object memoryId) {
+        Path memoryFilePath = Paths.get(storageDirectory, memoryId + FILE_EXTENSION);
+        if (Files.notExists(memoryFilePath)) {
+            return Collections.emptyList();
+        }
+        byte[] bytes;
+        try {
+            bytes = Files.readAllBytes(memoryFilePath);
+        } catch (IOException e) {
+            log.warn("Loading messages from file {} failed.", memoryFilePath);
+            return Collections.emptyList();
+        }
+        String fileContent = new String(bytes, StandardCharsets.UTF_8);
+        return ChatMessageDeserializer.messagesFromJson(fileContent);
+    }
+
+    @Override
+    public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+        Path memoryFilePath = Paths.get(storageDirectory, memoryId + FILE_EXTENSION);
+        // TODO：Maybe it would be better to store it item by item.
+        String messagesToJson = ChatMessageSerializer.messagesToJson(messages);
+        try {
+            Files.write(memoryFilePath, messagesToJson.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw runtime("Update messages to file {} failed.", memoryFilePath);
+        }
+    }
+
+    @Override
+    public void deleteMessages(Object memoryId) {
+        Path memoryFilePath = Paths.get(storageDirectory, memoryId + FILE_EXTENSION);
+        try {
+            Files.deleteIfExists(memoryFilePath);
+        } catch (IOException e) {
+            log.warn("Delete memory file {} failed", memoryFilePath);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String storageDirectory = System.getProperty("java.io.tmpdir");
+
+        /**
+         * @param storageDirectory Local folder path where messages are stored.
+         * @return builder
+         */
+        public Builder storageDirectory(String storageDirectory) {
+            this.storageDirectory = storageDirectory;
+            return this;
+        }
+
+        public FileChatMemoryStore build() {
+            return new FileChatMemoryStore(storageDirectory);
+        }
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/memory/chat/FileChatMemoryStoreTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/memory/chat/FileChatMemoryStoreTest.java
@@ -1,0 +1,122 @@
+package dev.langchain4j.store.memory.chat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+import dev.langchain4j.data.message.UserMessage;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mockStatic;
+
+class FileChatMemoryStoreTest implements WithAssertions {
+
+    static final String randomDirName = UUID.randomUUID().toString();
+    static final String tempStorageDirectory = System.getProperty("java.io.tmpdir");
+
+    static final Path directoryPath = Paths.get(tempStorageDirectory, randomDirName);
+    static final Path memoryFilePath =
+            Paths.get(tempStorageDirectory, randomDirName, "foo" + FileChatMemoryStore.FILE_EXTENSION);
+
+    @AfterAll
+    static void clear() throws IOException {
+        Files.deleteIfExists(directoryPath);
+    }
+
+    @Test
+    public void testConstructor() {
+        FileChatMemoryStore fixedDirStore = new FileChatMemoryStore(directoryPath.toString());
+        FileChatMemoryStore notExistDirStore = FileChatMemoryStore.builder()
+                .storageDirectory(directoryPath.toString())
+                .build();
+
+        assertThat(fixedDirStore.getStorageDirectory()).endsWith(notExistDirStore.getStorageDirectory());
+        assertThat(new File(notExistDirStore.getStorageDirectory())).exists();
+    }
+
+    @Test
+    public void testStore() {
+        FileChatMemoryStore store = FileChatMemoryStore.builder().build();
+
+        assertThat(store.getMessages("foo")).isEmpty();
+
+        store.updateMessages("foo", Arrays.asList(new UserMessage("abc def"), new AiMessage("ghi jkl")));
+
+        assertThat(store.getMessages("foo")).containsExactly(new UserMessage("abc def"), new AiMessage("ghi jkl"));
+
+        store.deleteMessages("foo");
+
+        assertThat(store.getMessages("foo")).isEmpty();
+    }
+
+    @Test
+    void illegalArgumentExceptionTest() throws IOException {
+        File tempFile = File.createTempFile("temp", ".txt");
+        String tempFileAbsolutePath = tempFile.getAbsolutePath();
+        IllegalArgumentException illegalArgumentException =
+                catchIllegalArgumentException(() -> new FileChatMemoryStore(tempFileAbsolutePath));
+        assertThat(illegalArgumentException).isNotNull();
+    }
+
+    @Test
+    void createDriExceptionTest() {
+        FileChatMemoryStore.Builder builder = FileChatMemoryStore.builder().storageDirectory(directoryPath.toString());
+
+        try (MockedStatic<Files> mockFiles = mockStatic(Files.class)) {
+            mockFiles.when(() -> Files.createDirectories(directoryPath)).thenThrow(IOException.class);
+            RuntimeException runtimeException = catchRuntimeException(builder::build);
+            assertThat(runtimeException).isNotNull();
+        }
+    }
+
+    @Test
+    void writeExceptionTest() {
+        List<ChatMessage> messages = Arrays.asList(new UserMessage("abc def"), new AiMessage("ghi jkl"));
+        String messagesToJson = ChatMessageSerializer.messagesToJson(messages);
+
+        FileChatMemoryStore.Builder builder = FileChatMemoryStore.builder().storageDirectory(directoryPath.toString());
+        try (MockedStatic<Files> mockFiles = mockStatic(Files.class)) {
+            FileChatMemoryStore store = builder.build();
+            mockFiles
+                    .when(() -> Files.write(memoryFilePath, messagesToJson.getBytes(StandardCharsets.UTF_8)))
+                    .thenThrow(IOException.class);
+            RuntimeException runtimeException = catchRuntimeException(() -> store.updateMessages("foo", messages));
+            assertThat(runtimeException).isNotNull();
+        }
+    }
+
+    @Test
+    void readExceptionTest() {
+        FileChatMemoryStore.Builder builder = FileChatMemoryStore.builder().storageDirectory(directoryPath.toString());
+        try (MockedStatic<Files> mockFiles = mockStatic(Files.class)) {
+            mockFiles.when(() -> Files.readAllBytes(memoryFilePath)).thenThrow(IOException.class);
+            FileChatMemoryStore store = builder.build();
+            List<ChatMessage> messages = store.getMessages("foo");
+            assertThat(messages).isEmpty();
+        }
+    }
+
+    @Test
+    void delDriExceptionTest() {
+        FileChatMemoryStore store = FileChatMemoryStore.builder()
+                .storageDirectory(directoryPath.toString())
+                .build();
+        try (MockedStatic<Files> mockFiles = mockStatic(Files.class)) {
+            mockFiles.when(() -> Files.deleteIfExists(memoryFilePath)).thenThrow(IOException.class);
+            Throwable throwable = catchThrowable(() -> store.deleteMessages("foo"));
+            assertThat(throwable).isNull();
+        }
+    }
+}


### PR DESCRIPTION
## Context
The current project only has an in-memory implementation for `ChatMemoryStore`.  To ensure message persistence, I added a file-based "FileChatMemoryStore" to store chat messages.

## Change
Added the `FileChatMemoryStore` class, which implements the `ChatMemoryStore` interface. This class allows storing chat messages in the local file system. Additionally, a test class, `FileChatMemoryStoreTest`, has been added to ensure the correctness of the `FileChatMemoryStore` implementation.

## Checklist
Before submitting this PR, please check the following points:
- [x] I have added unit and integration tests for my change
- [x] All unit and integration tests in the module I have added/changed are green
- [x] All unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules are green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added my new module in the [BOM](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-bom/pom.xml) (only when a new module is added)