### PR TITLE
Fix #833: DocumentByParagraphSplitter regex JDK version adaptation

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/DocumentByParagraphSplitter.java
+++ b/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/DocumentByParagraphSplitter.java
@@ -54,7 +54,7 @@ public class DocumentByParagraphSplitter extends HierarchicalDocumentSplitter {
 
     @Override
     public String[] split(String text) {
-        return text.split("\\s*\\R\\s*\\R\\s*"); // additional whitespaces are ignored
+        return text.split("\\s*(?>\\R)\\s*(?>\\R)\\s*"); // additional whitespaces are ignored
     }
 
     @Override


### PR DESCRIPTION
## Context
See [#833](https://github.com/langchain4j/langchain4j/issues/833)

## Change
`DocumentByParagraphSplitter` split regular expression

## Checklist
Before submitting this PR, please check the following points:
- [x] I have added unit and integration tests for my change
- [x] All unit and integration tests in the module I have added/changed are green
- [x] All unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules are green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added my new module in the [BOM](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-bom/pom.xml) (only when a new module is added)
