### PR TITLE
[FEATURE] Allow adding custom headers to OpeanAi client

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
@@ -15,6 +15,7 @@ import lombok.Builder;
 
 import java.net.Proxy;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -67,7 +68,8 @@ public class OpenAiChatModel implements ChatLanguageModel, TokenCountEstimator {
                            Proxy proxy,
                            Boolean logRequests,
                            Boolean logResponses,
-                           Tokenizer tokenizer) {
+                           Tokenizer tokenizer,
+                           Map<String, String> customHeaders) {
 
         baseUrl = getOrDefault(baseUrl, OPENAI_URL);
         if (OPENAI_DEMO_API_KEY.equals(apiKey)) {
@@ -88,6 +90,7 @@ public class OpenAiChatModel implements ChatLanguageModel, TokenCountEstimator {
                 .logRequests(logRequests)
                 .logResponses(logResponses)
                 .userAgent(DEFAULT_USER_AGENT)
+                .customHeaders(customHeaders)
                 .build();
         this.modelName = getOrDefault(modelName, GPT_3_5_TURBO);
         this.temperature = getOrDefault(temperature, 0.7);

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiEmbeddingModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiEmbeddingModel.java
@@ -15,6 +15,7 @@ import lombok.Builder;
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import static dev.langchain4j.internal.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
@@ -48,7 +49,8 @@ public class OpenAiEmbeddingModel implements EmbeddingModel, TokenCountEstimator
                                 Proxy proxy,
                                 Boolean logRequests,
                                 Boolean logResponses,
-                                Tokenizer tokenizer) {
+                                Tokenizer tokenizer,
+                                Map<String, String> customHeaders) {
 
         baseUrl = getOrDefault(baseUrl, OPENAI_URL);
         if (OPENAI_DEMO_API_KEY.equals(apiKey)) {
@@ -69,6 +71,7 @@ public class OpenAiEmbeddingModel implements EmbeddingModel, TokenCountEstimator
                 .logRequests(logRequests)
                 .logResponses(logResponses)
                 .userAgent(DEFAULT_USER_AGENT)
+                .customHeaders(customHeaders)
                 .build();
         this.modelName = getOrDefault(modelName, TEXT_EMBEDDING_ADA_002);
         this.dimensions = dimensions;

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
@@ -14,6 +14,7 @@ import java.net.Proxy;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static dev.langchain4j.internal.RetryUtils.withRetry;
@@ -70,7 +71,8 @@ public class OpenAiImageModel implements ImageModel {
             Boolean logRequests,
             Boolean logResponses,
             Boolean withPersisting,
-            Path persistTo
+            Path persistTo,
+            Map<String, String> customHeaders
     ) {
         timeout = getOrDefault(timeout, ofSeconds(60));
 
@@ -87,7 +89,8 @@ public class OpenAiImageModel implements ImageModel {
                 .logRequests(getOrDefault(logRequests, false))
                 .logResponses(getOrDefault(logResponses, false))
                 .userAgent(DEFAULT_USER_AGENT)
-                .persistTo(persistTo);
+                .persistTo(persistTo)
+                .customHeaders(customHeaders);
 
         if (withPersisting != null && withPersisting) {
             cBuilder.withPersisting();

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiLanguageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiLanguageModel.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 
 import java.net.Proxy;
 import java.time.Duration;
+import java.util.Map;
 
 import static dev.langchain4j.internal.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
@@ -45,7 +46,8 @@ public class OpenAiLanguageModel implements LanguageModel, TokenCountEstimator {
                                Proxy proxy,
                                Boolean logRequests,
                                Boolean logResponses,
-                               Tokenizer tokenizer) {
+                               Tokenizer tokenizer,
+                               Map<String, String> customHeaders) {
 
         timeout = getOrDefault(timeout, ofSeconds(60));
 
@@ -61,6 +63,7 @@ public class OpenAiLanguageModel implements LanguageModel, TokenCountEstimator {
                 .logRequests(logRequests)
                 .logResponses(logResponses)
                 .userAgent(DEFAULT_USER_AGENT)
+                .customHeaders(customHeaders)
                 .build();
         this.modelName = getOrDefault(modelName, GPT_3_5_TURBO_INSTRUCT);
         this.temperature = getOrDefault(temperature, 0.7);

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import static dev.langchain4j.internal.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
@@ -42,7 +43,8 @@ public class OpenAiModerationModel implements ModerationModel {
                                  Integer maxRetries,
                                  Proxy proxy,
                                  Boolean logRequests,
-                                 Boolean logResponses) {
+                                 Boolean logResponses,
+                                 Map<String, String> customHeaders) {
 
         baseUrl = getOrDefault(baseUrl, OPENAI_URL);
         if (OPENAI_DEMO_API_KEY.equals(apiKey)) {
@@ -63,6 +65,7 @@ public class OpenAiModerationModel implements ModerationModel {
                 .logRequests(logRequests)
                 .logResponses(logResponses)
                 .userAgent(DEFAULT_USER_AGENT)
+                .customHeaders(customHeaders)
                 .build();
         this.modelName = getOrDefault(modelName, TEXT_MODERATION_LATEST);
         this.maxRetries = getOrDefault(maxRetries, 3);

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -70,7 +70,8 @@ public class OpenAiStreamingChatModel implements StreamingChatLanguageModel, Tok
                                     Proxy proxy,
                                     Boolean logRequests,
                                     Boolean logResponses,
-                                    Tokenizer tokenizer) {
+                                    Tokenizer tokenizer,
+                                    Map<String, String> customHeaders) {
 
         timeout = getOrDefault(timeout, ofSeconds(60));
 
@@ -86,6 +87,7 @@ public class OpenAiStreamingChatModel implements StreamingChatLanguageModel, Tok
                 .logRequests(logRequests)
                 .logStreamingResponses(logResponses)
                 .userAgent(DEFAULT_USER_AGENT)
+                .customHeaders(customHeaders)
                 .build();
         this.modelName = getOrDefault(modelName, GPT_3_5_TURBO);
         this.temperature = getOrDefault(temperature, 0.7);

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingLanguageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingLanguageModel.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 
 import java.net.Proxy;
 import java.time.Duration;
+import java.util.Map;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.DEFAULT_USER_AGENT;
@@ -44,7 +45,8 @@ public class OpenAiStreamingLanguageModel implements StreamingLanguageModel, Tok
                                         Proxy proxy,
                                         Boolean logRequests,
                                         Boolean logResponses,
-                                        Tokenizer tokenizer) {
+                                        Tokenizer tokenizer,
+                                        Map<String, String> customHeaders) {
 
         timeout = getOrDefault(timeout, ofSeconds(60));
 
@@ -60,6 +62,7 @@ public class OpenAiStreamingLanguageModel implements StreamingLanguageModel, Tok
                 .logRequests(logRequests)
                 .logStreamingResponses(logResponses)
                 .userAgent(DEFAULT_USER_AGENT)
+                .customHeaders(customHeaders)
                 .build();
         this.modelName = getOrDefault(modelName, GPT_3_5_TURBO_INSTRUCT);
         this.temperature = getOrDefault(temperature, 0.7);


### PR DESCRIPTION
<!-- Thank you so much for your contribution! -->

## Context
<!-- Please provide some context so that it is clear why this change is required. -->
Allow to pass custom headers to httpClient in builder of OpeanAI models.
This allows for integration of some third party services like i.e. helicone.ai that serve as a proxy for OpeanAI request.

## Checklist
Before submitting this PR, please check the following points:
- [x] I have added unit and integration tests for my change
- [x] All unit and integration tests in the module I have added/changed are green
- [x] All unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules are green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [x] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [x] I have added my new module in the [BOM](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-bom/pom.xml) (only when a new module is added)
