### PR TITLE
[PoC] Implement a state machine in the AiServices

### DIFF
--- a/langchain4j/pom.xml
+++ b/langchain4j/pom.xml
@@ -54,6 +54,13 @@
 
         <dependency>
             <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-ollama</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceContext.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceContext.java
@@ -8,6 +8,7 @@ import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.rag.RetrievalAugmentor;
+import dev.langchain4j.statemachine.StateManager;
 
 import java.util.List;
 import java.util.Map;
@@ -29,12 +30,18 @@ public class AiServiceContext {
 
     public RetrievalAugmentor retrievalAugmentor;
 
+    public StateManager stateManager;
+
     public AiServiceContext(Class<?> aiServiceClass) {
         this.aiServiceClass = aiServiceClass;
     }
 
     public boolean hasChatMemory() {
         return chatMemories != null;
+    }
+
+    public boolean hasState() {
+        return stateManager != null;
     }
 
     public ChatMemory chatMemory(Object memoryId) {

--- a/langchain4j/src/main/java/dev/langchain4j/statemachine/State.java
+++ b/langchain4j/src/main/java/dev/langchain4j/statemachine/State.java
@@ -1,0 +1,4 @@
+package dev.langchain4j.statemachine;
+
+public interface State {
+}

--- a/langchain4j/src/main/java/dev/langchain4j/statemachine/StateMachineContext.java
+++ b/langchain4j/src/main/java/dev/langchain4j/statemachine/StateMachineContext.java
@@ -1,0 +1,5 @@
+package dev.langchain4j.statemachine;
+
+public interface StateMachineContext {
+
+}

--- a/langchain4j/src/main/java/dev/langchain4j/statemachine/StateManager.java
+++ b/langchain4j/src/main/java/dev/langchain4j/statemachine/StateManager.java
@@ -1,0 +1,51 @@
+package dev.langchain4j.statemachine;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class StateManager {
+    private final StateMachineContext context;
+
+    private final State initialState;
+    private State currentState;
+
+    private final BiFunction<State, StateMachineContext, State> stateManager;
+
+    private Function<State, String> stateToSystemMessage;
+    private Function<State, String> stateToUserMessage;
+
+    public StateManager(StateMachineContext stateMachineContext, State initialState, BiFunction<State, StateMachineContext, State> stateManager) {
+        this.context = stateMachineContext;
+
+        this.initialState = initialState;
+        this.currentState = initialState;
+
+        this.stateManager = stateManager;
+    }
+
+    public void setStateToSystemMessage(Function<State, String> stateToSystemMessage) {
+        this.stateToSystemMessage = stateToSystemMessage;
+    }
+
+    public void setStateToUserMessage(Function<State, String> stateToUserMessage) {
+        this.stateToUserMessage = stateToUserMessage;
+    }
+
+    public Optional<String> getSystemMessage() {
+        return stateToSystemMessage != null ?
+                Optional.of(stateToSystemMessage.apply(currentState)) :
+                Optional.empty();
+    }
+
+    public Optional<String> getUserMessage() {
+        return stateToUserMessage != null ?
+                Optional.of(stateToUserMessage.apply(currentState)) :
+                Optional.empty();
+    }
+
+    public State nextState() {
+        currentState = stateManager.apply(currentState, context);
+        return currentState;
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithStatesTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithStatesTest.java
@@ -1,0 +1,240 @@
+package dev.langchain4j.service;
+
+import java.time.Duration;
+import java.util.Scanner;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.ollama.OllamaChatModel;
+import dev.langchain4j.statemachine.State;
+import dev.langchain4j.statemachine.StateMachineContext;
+
+import static dev.langchain4j.service.AiServicesWithStatesTest.AirlineChatState.*;
+
+class AiServicesWithStatesTest {
+
+    interface Agent {
+        String chat(String userMessage);
+    }
+
+    enum AirlineChatState implements State {
+        EXTRACT_CUSTOMER("<SYS>>You are a chat bot of an airline company. Your goal is asking questions to gather information " +
+                                 "about a customer<</SYS>>",
+                         "Ask question to the customer regarding his name and age. +++ {{it}} +++ "),
+
+        EXTRACT_FLIGHT("<<SYS>>You are a chat bot of an airline company. Your goal is asking questions to gather information " +
+                               "about the customer's flight and which problems he had with it<</SYS>>",
+                       "Ask question to the customer regarding the number of the flight and its eventual delay. +++ {{it}} +++ "),
+        CALCULATE_REFUND("", "");
+
+        private final String systemMessage;
+        private final String userMessage;
+
+        AirlineChatState(String systemMessage, String userMessage) {
+            this.systemMessage = systemMessage;
+            this.userMessage = userMessage;
+        }
+
+        public String getSystemMessage() {
+            return systemMessage;
+        }
+
+        public String getUserMessage() {
+            return userMessage;
+        }
+    }
+
+    public static void main(String[] args) {
+
+        ChatLanguageModel chatLanguageModel = OllamaChatModel.builder()
+                .baseUrl("http://localhost:11434")
+                .modelName("mistral")
+                .temperature(0.1)
+                .timeout(Duration.ofMinutes(3))
+                .build();
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(20);
+        AirlineChatContext context = new AirlineChatContext();
+
+        Agent agent = AiServices.builder(Agent.class)
+                .chatLanguageModel(chatLanguageModel)
+                .chatMemory(chatMemory)
+                .states(context, EXTRACT_CUSTOMER, AiServicesWithStatesTest::nextState)
+                .systemMessages(s -> ((AirlineChatState)s).getSystemMessage())
+                .userMessages(s -> ((AirlineChatState)s).getUserMessage())
+                .build();
+
+        CustomerExtractor customerExtractor = AiServices.builder(CustomerExtractor.class)
+                .chatLanguageModel(chatLanguageModel)
+                .build();
+
+        FlightExtractor flightExtractor = AiServices.builder(FlightExtractor.class)
+                .chatLanguageModel(chatLanguageModel)
+                .build();
+
+        Scanner scanner = new Scanner(System.in);
+
+        while (!context.isComplete()) {
+            System.out.print("User: ");
+            String userMessage = scanner.nextLine();
+
+            if ("exit".equalsIgnoreCase(userMessage)) {
+                break;
+            }
+
+            if (context.getCustomer() == null) {
+                try {
+                    Customer customer = customerExtractor.extractData(userMessage);
+                    if (customer != null && customer.isValid()) {
+                        System.out.println("Extracted " + customer);
+                        context.setCustomer(customer);
+                    }
+                } catch (Exception ignore) { }
+            } else if (context.getFlight() == null) {
+                try {
+                    Flight flight = flightExtractor.extractData(userMessage);
+                    if (flight != null && flight.isValid()) {
+                        System.out.println("Extracted " + flight);
+                        context.setFlight(flight);
+                    }
+                } catch (Exception ignore) { }
+            }
+
+            String agentMessage = context.isComplete() ?
+                    "You are eligible for a refund of $" + context.getRefund() :
+                    agent.chat(userMessage);
+            System.out.println("Agent: " + agentMessage);
+
+        }
+
+        scanner.close();
+    }
+
+    private static State nextState(State currentState, StateMachineContext context) {
+        if (currentState == EXTRACT_CUSTOMER && ((AirlineChatContext) context).getCustomer() != null) {
+            return EXTRACT_FLIGHT;
+        }
+        if (currentState == EXTRACT_FLIGHT && ((AirlineChatContext) context).getFlight() != null) {
+            return CALCULATE_REFUND;
+        }
+        return currentState;
+    }
+
+    public interface Validated {
+        boolean isValid();
+    }
+
+    public static class Customer implements Validated {
+        public final String firstName;
+        public final String lastName;
+        public final int age;
+
+        public Customer(String firstName, String lastName, int age) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.age = age;
+        }
+
+        @Override
+        public String toString() {
+            return "Customer {" +
+                    " firstName = \"" + firstName + "\"" +
+                    ", lastName = \"" + lastName + "\"" +
+                    ", age = " + age +
+                    " }";
+        }
+
+        public String getFullName() {
+            return firstName + " " + lastName;
+        }
+
+        @Override
+        public boolean isValid() {
+            return firstName != null && !firstName.isEmpty() && age > 0;
+        }
+    }
+
+    public static class Flight implements Validated {
+
+        public final String number;
+        public final int delayInMinutes;
+
+        public Flight(String number, int delayInMinutes) {
+            this.number = number;
+            this.delayInMinutes = delayInMinutes;
+        }
+
+        @Override
+        public String toString() {
+            return "Flight {" +
+                    " number = \"" + number + "\"" +
+                    ", delayInMinutes = " + delayInMinutes +
+                    " }";
+        }
+
+        @Override
+        public boolean isValid() {
+            return number != null && !number.isEmpty() && delayInMinutes > 0;
+        }
+    }
+
+    interface CustomerExtractor {
+
+        @UserMessage("Extract information about a customer from this text '{{it}}'. The response must contain only the JSON with customer's data and without any other sentence.")
+        Customer extractData(String text);
+    }
+
+    interface FlightExtractor {
+        @UserMessage("Extract information about a flight from this text '{{it}}'. The response must contain only the JSON with flight's data and without any other sentence.")
+        Flight extractData(String text);
+    }
+
+    public static class AirlineChatContext implements StateMachineContext {
+
+        private Customer customer;
+
+        private Flight flight;
+
+        public Customer getCustomer() {
+            return customer;
+        }
+
+        public void setCustomer(Customer customer) {
+            this.customer = customer;
+        }
+
+        public Flight getFlight() {
+            return flight;
+        }
+
+        public void setFlight(Flight flight) {
+            this.flight = flight;
+        }
+
+        public boolean isComplete() {
+            return customer != null && flight != null;
+        }
+
+        public double getRefund() {
+            if (flight.delayInMinutes < 60) {
+                return 0;
+            }
+            double refund = flight.delayInMinutes * 2;
+            if (customer.age > 65) {
+                refund = refund * 1.1;
+            }
+            return refund;
+        }
+
+        @Override
+        public String toString() {
+            return "SessionData{" +
+                    "customer=" + customer +
+                    ", flight=" + flight +
+                    '}';
+        }
+    }
+
+}


### PR DESCRIPTION
For now this is only a PoC to start a discussion around the possibility of implementing a state machine inside the AiServces. This pull request is a complete rework of [this other one](https://github.com/langchain4j/langchain4j/pull/672) and tries to put my proposal at work using the same use case that I implemented [here](https://github.com/mariofusco/quarkus-drools-llm?tab=readme-ov-file#the-airline-chatbot-example).

In my opinion the original pull request was a bit inflexible, trying to model all the states and possible transactions among them inside the AiServices itself, and this also led to a more cumbersome API. The idea here is that how the transactions among the different states are modeled should be totally external to the AiServices. This increased flexibility also allows to model the state machine with other external tools, like a rule engine in my case. 

Note that this pull request (like the original one) still lacks the possibility to define a state machine for each user/conversation, but I believe this could be implemented with an id-based mechanism, very similar to the one already used for the chat memory. Moreover, since in my test example I'm using ollama that doesn't support tools, I didn't try to put also them under the control of the state machine, but once we agreed on the implementation this could also be added in a relatively easy way.

While working on this feature however I realized that probably also the concept of a proper state machine is quite over-engineered for the langchain4j needs, and what would be necessary is more simply a way to make system and user messages (and eventually tools) configurable in a programmatic way. I developed this idea in [another pull request](https://github.com/langchain4j/langchain4j/pull/862).