### PR TITLE
fix(langchain4j-zhipu-ai): Fix baseUrl misconfiguration in ZhipuAiClient builder

### DIFF
--- a/langchain4j-zhipu-ai/src/main/java/dev/langchain4j/model/zhipu/ZhipuAiClient.java
+++ b/langchain4j-zhipu-ai/src/main/java/dev/langchain4j/model/zhipu/ZhipuAiClient.java
@@ -230,7 +230,7 @@ public class ZhipuAiClient {
         private boolean logResponses;
 
         private Builder() {
-            this.baseUrl = "https://aip.baidubce.com/";
+            this.baseUrl = "https://open.bigmodel.cn/";
             this.callTimeout = Duration.ofSeconds(60L);
             this.connectTimeout = Duration.ofSeconds(60L);
             this.readTimeout = Duration.ofSeconds(60L);


### PR DESCRIPTION
Fix baseUrl misconfiguration in ZhipuAiClient builder

<!-- Thank you so much for your contribution! -->

## Context
<!-- Please provide some context so that it is clear why this change is required. -->
This commit addresses an issue where the baseUrl in the builder of ZhipuAiClient was not properly configured in Module langchain4j-zhipu-ai. This misconfiguration could potentially lead to confusion or errors when using the client directly. By correcting the baseUrl configuration, this commit ensures consistent and accurate behavior of the client.

## Change
<!-- Please describe the changed you made. -->
Change the baseUrl value in `dev.langchain4j.model.zhipu.ZhipuAiClient.Builder` from `https://aip.baidubce.com/` to `https://open.bigmodel.cn/` 

## Checklist
Before submitting this PR, please check the following points:
- [ ] I have added unit and integration tests for my change
- [ ] All unit and integration tests in the module I have added/changed are green
- [ ] All unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules are green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added my new module in the [BOM](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-bom/pom.xml) (only when a new module is added)
