### PR TITLE
[FEATURE] Remove transitive log4j dependency from langchain4j-documen…

### DIFF
--- a/document-parsers/langchain4j-document-parser-apache-tika/pom.xml
+++ b/document-parsers/langchain4j-document-parser-apache-tika/pom.xml
@@ -36,6 +36,33 @@
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers-standard-package</artifactId>
             <version>${apache-tika.version}</version>
+            <exclusions>
+                <exclusion>  
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.22.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.22.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.20.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
…t-parser-apache-tika module

<!-- Thank you so much for your contribution! -->
<!-- Please fill in all the sections below. -->
<!-- Please note that PRs without tests will be rejected. -->

## Context
Fixes #832 

## Change
I removed the transitive dependency log4j-api from tika-parsers-standard-package

and added explicit dependency to log4j-api, log4j-core and log4j-slf4j2-impl, like done for document-loader github and document-loader azure storage blob.

I don't think a unit/integration test is required for this.

## Checklist
Before submitting this PR, please check the following points:
- [ ] I have added unit and integration tests for my change
- [ ] All unit and integration tests in the module I have added/changed are green
- [ ] All unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules are green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added my new module in the [BOM](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-bom/pom.xml) (only when a new module is added)

## Checklist for adding new embedding store integration
- [ ] I have added a {NameOfIntegration}EmbeddingStoreIT that extends from either EmbeddingStoreIT or EmbeddingStoreWithFilteringIT
