### PR TITLE
Removing incorrect end comma in jsonStructure for POJO extracting AI Services

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
@@ -14,7 +14,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static dev.langchain4j.exception.IllegalConfigurationException.illegalConfiguration;
 import static java.lang.String.format;
@@ -85,7 +84,7 @@ public class ServiceOutputParser {
             return new HashSet<>(asList(text.split("\n")));
         }
 
-        return Json.fromJson(text.replaceAll("\",\\\\n}","\"\\\\n}"), returnType);
+        return Json.fromJson(text, returnType);
     }
 
     public static String outputFormatInstructions(Class<?> returnType) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
@@ -14,6 +14,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static dev.langchain4j.exception.IllegalConfigurationException.illegalConfiguration;
 import static java.lang.String.format;
@@ -84,7 +85,7 @@ public class ServiceOutputParser {
             return new HashSet<>(asList(text.split("\n")));
         }
 
-        return Json.fromJson(text, returnType);
+        return Json.fromJson(text.replaceAll("\",\\\\n}","\"\\\\n}"), returnType);
     }
 
     public static String outputFormatInstructions(Class<?> returnType) {
@@ -130,6 +131,7 @@ public class ServiceOutputParser {
             }
             jsonSchema.append(format("\"%s\": (%s),\n", name, descriptionFor(field, visited)));
         }
+        jsonSchema.delete(jsonSchema.lastIndexOf(","), jsonSchema.lastIndexOf(",")+1);
         jsonSchema.append("}");
         return jsonSchema.toString();
     }

--- a/langchain4j/src/test/java/dev/langchain4j/service/ServiceOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/ServiceOutputParserTest.java
@@ -1,13 +1,11 @@
 package dev.langchain4j.service;
 
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.model.output.Response;
-import dev.langchain4j.model.output.structured.Description;
 import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.Calendar;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/ServiceOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/ServiceOutputParserTest.java
@@ -1,11 +1,13 @@
 package dev.langchain4j.service;
 
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.structured.Description;
 import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.Calendar;
-import java.util.List;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +27,7 @@ class ServiceOutputParserTest {
                 "\nYou must answer strictly in the following JSON format: {\n" +
                         "\"firstName\": (type: string),\n" +
                         "\"lastName\": (type: string),\n" +
-                        "\"birthDate\": (type: date string (2023-12-31)),\n" +
+                        "\"birthDate\": (type: date string (2023-12-31))\n" +
                         "}");
     }
 
@@ -43,7 +45,7 @@ class ServiceOutputParserTest {
                 "\nYou must answer strictly in the following JSON format: {\n" +
                         "\"firstName\": (type: array of string),\n" +
                         "\"lastName\": (type: string),\n" +
-                        "\"birthDate\": (type: date string (2023-12-31)),\n" +
+                        "\"birthDate\": (type: date string (2023-12-31))\n" +
                         "}");
     }
 
@@ -61,7 +63,7 @@ class ServiceOutputParserTest {
                 "\nYou must answer strictly in the following JSON format: {\n" +
                         "\"firstName\": (type: array of string),\n" +
                         "\"lastName\": (type: string),\n" +
-                        "\"birthDate\": (type: date string (2023-12-31)),\n" +
+                        "\"birthDate\": (type: date string (2023-12-31))\n" +
                         "}");
     }
 
@@ -79,7 +81,7 @@ class ServiceOutputParserTest {
                 "\nYou must answer strictly in the following JSON format: {\n" +
                         "\"firstName\": (type: string),\n" +
                         "\"lastName\": (type: string),\n" +
-                        "\"birthDate\": (type: java.util.Calendar),\n" +
+                        "\"birthDate\": (type: java.util.Calendar)\n" +
                         "}");
     }
 
@@ -98,7 +100,7 @@ class ServiceOutputParserTest {
                 "\nYou must answer strictly in the following JSON format: {\n" +
                         "\"firstName\": (type: string),\n" +
                         "\"lastName\": (type: string),\n" +
-                        "\"birthDate\": (type: date string (2023-12-31)),\n" +
+                        "\"birthDate\": (type: date string (2023-12-31))\n" +
                         "}");
     }
 
@@ -127,8 +129,8 @@ class ServiceOutputParserTest {
                         "\"address\": (type: dev.langchain4j.service.ServiceOutputParserTest$Address: {\n" +
                         "\"streetNumber\": (type: integer),\n" +
                         "\"street\": (type: string),\n" +
-                        "\"city\": (type: string),\n" +
-                        "}),\n" +
+                        "\"city\": (type: string)\n" +
+                        "})\n" +
                         "}");
     }
 
@@ -151,8 +153,8 @@ class ServiceOutputParserTest {
                         "\"address\": (type: array of dev.langchain4j.service.ServiceOutputParserTest$Address: {\n" +
                         "\"streetNumber\": (type: integer),\n" +
                         "\"street\": (type: string),\n" +
-                        "\"city\": (type: string),\n" +
-                        "}),\n" +
+                        "\"city\": (type: string)\n" +
+                        "})\n" +
                         "}");
     }
 
@@ -175,8 +177,8 @@ class ServiceOutputParserTest {
                         "\"address\": (type: array of dev.langchain4j.service.ServiceOutputParserTest$Address: {\n" +
                         "\"streetNumber\": (type: integer),\n" +
                         "\"street\": (type: string),\n" +
-                        "\"city\": (type: string),\n" +
-                        "}),\n" +
+                        "\"city\": (type: string)\n" +
+                        "})\n" +
                         "}");
     }
 
@@ -200,7 +202,7 @@ class ServiceOutputParserTest {
                 "\nYou must answer strictly in the following JSON format: {\n" +
                         "\"firstName\": (type: string),\n" +
                         "\"lastName\": (type: string),\n" +
-                        "\"birthDate\": (type: date string (2023-12-31)),\n" +
+                        "\"birthDate\": (type: date string (2023-12-31))\n" +
                         "}");
     }
 
@@ -221,8 +223,8 @@ class ServiceOutputParserTest {
                         "\"parents\": (type: array of dev.langchain4j.service.ServiceOutputParserTest$PersonWithParents: {\n" +
                             "\"firstName\": (type: string),\n" +
                             "\"lastName\": (type: string),\n" +
-                            "\"parents\": (type: array of dev.langchain4j.service.ServiceOutputParserTest$PersonWithParents),\n" +
-                            "}),\n" +
+                            "\"parents\": (type: array of dev.langchain4j.service.ServiceOutputParserTest$PersonWithParents)\n" +
+                            "})\n" +
                         "}");
     }
 
@@ -243,8 +245,8 @@ class ServiceOutputParserTest {
                         "\"parents\": (type: array of dev.langchain4j.service.ServiceOutputParserTest$PersonWithParentArray: {\n" +
                             "\"firstName\": (type: string),\n" +
                             "\"lastName\": (type: string),\n" +
-                            "\"parents\": (type: array of dev.langchain4j.service.ServiceOutputParserTest$PersonWithParentArray),\n" +
-                            "}),\n" +
+                            "\"parents\": (type: array of dev.langchain4j.service.ServiceOutputParserTest$PersonWithParentArray)\n" +
+                            "})\n" +
                         "}");
     }
 
@@ -267,9 +269,9 @@ class ServiceOutputParserTest {
                             "\"firstName\": (type: string),\n" +
                             "\"lastName\": (type: string),\n" +
                             "\"mother\": (type: dev.langchain4j.service.ServiceOutputParserTest$PersonWithMotherAndFather),\n" +
-                            "\"father\": (type: dev.langchain4j.service.ServiceOutputParserTest$PersonWithMotherAndFather),\n" +
+                            "\"father\": (type: dev.langchain4j.service.ServiceOutputParserTest$PersonWithMotherAndFather)\n" +
                         "}),\n" +
-                        "\"father\": (type: dev.langchain4j.service.ServiceOutputParserTest$PersonWithMotherAndFather),\n" +
+                        "\"father\": (type: dev.langchain4j.service.ServiceOutputParserTest$PersonWithMotherAndFather)\n" +
                         "}");
     }
 


### PR DESCRIPTION
## Context
I noted that for more complex POJO object, the JSON returned by the LLM often contained a last comma before closing bracket, making the JSON invalid and resulting in an error while parsing it. I traced it back to the proposed jsonStructure that is part of the SystemMessage, sending a wrong format to the LLM.

## Change
Removed the last comma that shouldn't be there in the jsonStructure + updated the unit tests
