### PR TITLE
AIService: support template placeholders for parameters annotated wit…

### DIFF
--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesIT.java
@@ -147,6 +147,26 @@ public class AiServicesIT {
                         "You must answer strictly in the following format: yyyy-MM-ddTHH:mm:ss")));
     }
 
+    interface TextOperator {
+        String doAnythingWithText(@UserMessage String userMessage, @V("text") String text);
+    }
+
+    @Test
+    void test_extract_date_from_text() {
+        TextOperator textOperator = AiServices.create(TextOperator.class, chatLanguageModel);
+
+        String text = "The tranquility pervaded the evening of 1968, just fifteen minutes shy of midnight, following the celebrations of Independence Day.";
+
+        String dateTime = textOperator.doAnythingWithText("Extract date and time from {{text}}", text);
+        System.out.println(dateTime);
+
+        assertThat(dateTime).contains("1968");
+        assertThat(dateTime).contains("fifteen minutes shy of midnight");
+
+        verify(chatLanguageModel).generate(singletonList(userMessage(
+                "Extract date and time from " + text)));
+    }
+
 
     enum Sentiment {
         POSITIVE, NEUTRAL, NEGATIVE


### PR DESCRIPTION

<!-- Thank you so much for your contribution! -->
<!-- Please fill in all the sections below. -->
<!-- Please note that PRs without tests will be rejected. -->

## Context
<!-- Please provide some context so that it is clear why this change is required. -->
For Issue #903. The goal of this task is to support template placeholders for parameters annotated with `@UserMessage`.
## Change
<!-- Please describe the changed you made. -->
When generating UserMessage template, we will first check if there is any `@UserMessage` annotation on top of the method. If not, we will then check if there is any parameter annotated with `@UserMessage`, and we will use the value of that parameter as the user message template.

## Checklist
Before submitting this PR, please check the following points:
- [x] I have added unit and integration tests for my change
- [x] All unit and integration tests in the module I have added/changed are green
- [x] All unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules are green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added my new module in the [BOM](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-bom/pom.xml) (only when a new module is added)

## Checklist for adding new embedding store integration
- [ ] I have added a {NameOfIntegration}EmbeddingStoreIT that extends from either EmbeddingStoreIT or EmbeddingStoreWithFilteringIT
