### PR TITLE
fix Example with Spring Boot url typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please see examples of how LangChain4j can be used in [langchain4j-examples](htt
 
 - [Examples in plain Java](https://github.com/langchain4j/langchain4j-examples/tree/main/other-examples/src/main/java)
 - [Examples with Quarkus](https://github.com/quarkiverse/quarkus-langchain4j/tree/main/samples) (uses [quarkus-langchain4j](https://github.com/quarkiverse/quarkus-langchain4j) dependency)
-- [Example with Spring Boot](https://github.com/langchain4j/langchain4j-examples/blob/main/spring-boot-example/src/test/java/dev/example/CustomerSupportApplicationTest.java)
+- [Example with Spring Boot](https://github.com/langchain4j/langchain4j-examples/tree/main/spring-boot-example/src/main/java)
 
 ## Documentation
 Documentation can be found [here](https://docs.langchain4j.dev).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please see examples of how LangChain4j can be used in [langchain4j-examples](htt
 
 - [Examples in plain Java](https://github.com/langchain4j/langchain4j-examples/tree/main/other-examples/src/main/java)
 - [Examples with Quarkus](https://github.com/quarkiverse/quarkus-langchain4j/tree/main/samples) (uses [quarkus-langchain4j](https://github.com/quarkiverse/quarkus-langchain4j) dependency)
-- [Example with Spring Boot](https://github.com/langchain4j/langchain4j-examples/tree/main/spring-boot-example/src/main/java)
+- [Example with Spring Boot](https://github.com/langchain4j/langchain4j-examples/tree/main/spring-boot-example/src/main/java/dev/langchain4j/example)
 
 ## Documentation
 Documentation can be found [here](https://docs.langchain4j.dev).


### PR DESCRIPTION
<!-- Thank you so much for your contribution! -->
<!-- Please fill in all the sections below. -->
<!-- Please note that PRs without tests will be rejected. -->

## Context
fix `Example with Spring Boot` url typo in [README](https://github.com/langchain4j/langchain4j/blob/main/README.md)

## Change
fix `Example with Spring Boot` url typo in [README](https://github.com/langchain4j/langchain4j/blob/main/README.md)

`langchain4j-example` and `langchain4j` are different repo, so I think the url of example link the java dir will more reasonable and stable

## Checklist
Before submitting this PR, please check the following points:
**No code changes**

## Checklist for adding new embedding store integration
**No code changes**
