### PR TITLE
#904 Support advanced POJO/JSON extraction features

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
@@ -130,7 +130,11 @@ public class ServiceOutputParser {
             }
             jsonSchema.append(format("\"%s\": (%s),\n", name, descriptionFor(field, visited)));
         }
-        jsonSchema.delete(jsonSchema.lastIndexOf(","), jsonSchema.lastIndexOf(",")+1);
+
+        int trailingCommaIndex = jsonSchema.lastIndexOf(",");
+        if (trailingCommaIndex > 0) {
+            jsonSchema.delete(trailingCommaIndex, trailingCommaIndex +1);
+        }
         jsonSchema.append("}");
         return jsonSchema.toString();
     }

--- a/langchain4j/src/test/java/dev/langchain4j/service/ServiceOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/ServiceOutputParserTest.java
@@ -232,6 +232,10 @@ class ServiceOutputParserTest {
         private PersonWithParentArray[] parents;
     }
 
+    static class ClassWithNoFields {
+
+    }
+
     @Test
     void outputFormatInstructions_PersonWithParentArray() {
         String formatInstructions = ServiceOutputParser.outputFormatInstructions(PersonWithParentArray.class);
@@ -246,6 +250,15 @@ class ServiceOutputParserTest {
                             "\"parents\": (type: array of dev.langchain4j.service.ServiceOutputParserTest$PersonWithParentArray)\n" +
                             "})\n" +
                         "}");
+    }
+
+    @Test
+    void outputFormatInstructions_ClassWithNoFields() {
+        String formatInstructions = ServiceOutputParser.outputFormatInstructions(ClassWithNoFields.class);
+
+        assertThat(formatInstructions).isEqualTo("\n" +
+                "You must answer strictly in the following JSON format: {\n" +
+                "}");
     }
 
     static class PersonWithMotherAndFather {


### PR DESCRIPTION
<!-- Thank you so much for your contribution! -->
<!-- Please fill in all the sections below. -->
<!-- Please note that PRs without tests will be rejected. -->

## Context
<!-- Please provide some context so that it is clear why this change is required. -->
This was tested and seen that the POJO/JSON Extraction works perfectly. Sample test scenario was derived from the [feedback-analyzer](https://github.com/LizeRaes/feedback-analyzer/blob/main/src/main/java/engineering/epic/datastorageobjects/AtomicFeedback.java) repository.

I also took care of an edge case (where we have a class without fields) which was not handled. without this change, we would have exceptions as shown in the screenshot below:

<img width="1096" alt="Screenshot 2024-04-18 at 22 16 55" src="https://github.com/langchain4j/langchain4j/assets/11083332/8604ea00-6a81-4619-b8f7-06e5cd2480e6">


## Checklist
Before submitting this PR, please check the following points:
- [x] I have added unit and integration tests for my change
- [x] All unit and integration tests in the module I have added/changed are green
- [ x All unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules are green
