### PR TITLE
Fix out-of-bounds error in jsonStructure method

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
@@ -130,7 +130,12 @@ public class ServiceOutputParser {
             }
             jsonSchema.append(format("\"%s\": (%s),\n", name, descriptionFor(field, visited)));
         }
-        jsonSchema.delete(jsonSchema.lastIndexOf(","), jsonSchema.lastIndexOf(",")+1);
+
+		int lastCommaIndex = jsonSchema.lastIndexOf(",");
+		if (lastCommaIndex != -1) {
+			jsonSchema.delete(lastCommaIndex, lastCommaIndex + 1);
+		}
+
         jsonSchema.append("}");
         return jsonSchema.toString();
     }


### PR DESCRIPTION
Added a conditional check to prevent the StringBuilder from attempting to delete a comma at an invalid index, which occurs when no declared fields exists. This prevents the "Range out of bounds" runtime exception.

<!-- Thank you so much for your contribution! -->
<!-- Please fill in all the sections below. -->
<!-- Please note that PRs without tests will be rejected. -->

## Context
<!-- Please provide some context so that it is clear why this change is required. -->
Fix out-of-bounds error in jsonStructure method while attempting to delete the last comma.

For example while creating jsonStructure for javax.money.CurrencyUnit, following runtime error is thrown:
`Range [-1, 0) out of bounds for length 2`

## Change
<!-- Please describe the changed you made. -->
Made deletion conditional.
