### PR TITLE
Bump dashscope-sdk-java from 2.10.1 to 2.13.0.

### DIFF
--- a/langchain4j-dashscope/pom.xml
+++ b/langchain4j-dashscope/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dashscope-sdk-java</artifactId>
-            <version>2.10.1</version>
+            <version>2.13.0</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenChatModel.java
+++ b/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenChatModel.java
@@ -20,7 +20,7 @@ import lombok.Builder;
 
 import java.util.List;
 
-import static com.alibaba.dashscope.aigc.generation.models.QwenParam.ResultFormat.MESSAGE;
+import static com.alibaba.dashscope.aigc.conversation.ConversationParam.ResultFormat.MESSAGE;
 import static dev.langchain4j.model.dashscope.QwenHelper.*;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 

--- a/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenLanguageModel.java
+++ b/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenLanguageModel.java
@@ -14,7 +14,7 @@ import lombok.Builder;
 
 import java.util.List;
 
-import static com.alibaba.dashscope.aigc.generation.models.QwenParam.ResultFormat.MESSAGE;
+import static com.alibaba.dashscope.aigc.generation.GenerationParam.ResultFormat.MESSAGE;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.model.dashscope.QwenHelper.*;
 import static dev.langchain4j.model.dashscope.QwenModelName.QWEN_PLUS;

--- a/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenModelName.java
+++ b/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenModelName.java
@@ -9,8 +9,14 @@ public class QwenModelName {
     public static final String QWEN_TURBO = "qwen-turbo";  // Qwen base model, 4k context.
     public static final String QWEN_PLUS = "qwen-plus";  // Qwen plus model, 8k context.
     public static final String QWEN_MAX = "qwen-max";  // Qwen max model, 200-billion-parameters, 8k context.
-    public static final String QWEN_7B_CHAT = "qwen-7b-chat";  // Qwen open sourced 7-billion-parameters version
-    public static final String QWEN_14B_CHAT = "qwen-14b-chat";  // Qwen open sourced 14-billion-parameters version
+    public static final String QWEN_MAX_LONGCONTEXT = "qwen-max-longcontext";  // Qwen max model, 200-billion-parameters, 30k context.
+    public static final String QWEN_7B_CHAT = "qwen-7b-chat";  // Qwen open sourced 7-billion-parameters model
+    public static final String QWEN_14B_CHAT = "qwen-14b-chat";  // Qwen open sourced 14-billion-parameters model
+    public static final String QWEN_72B_CHAT = "qwen-72b-chat";  // Qwen open sourced 72-billion-parameters model
+    public static final String QWEN1_5_7B_CHAT = "qwen1.5-7b-chat";  // Qwen open sourced 7-billion-parameters model (v1.5)
+    public static final String QWEN1_5_14B_CHAT = "qwen1.5-14b-chat";  // Qwen open sourced 14-billion-parameters model (v1.5)
+    public static final String QWEN1_5_32B_CHAT = "qwen1.5-32b-chat";  // Qwen open sourced 32-billion-parameters model (v1.5)
+    public static final String QWEN1_5_72B_CHAT = "qwen1.5-72b-chat";  // Qwen open sourced 72-billion-parameters model (v1.5)
     public static final String QWEN_VL_PLUS = "qwen-vl-plus";  // Qwen multi-modal model, supports image and text information.
     public static final String QWEN_VL_MAX = "qwen-vl-max";  // Qwen multi-modal model, offers optimal performance on a wider range of complex tasks.
 

--- a/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenStreamingChatModel.java
+++ b/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenStreamingChatModel.java
@@ -21,7 +21,7 @@ import lombok.Builder;
 
 import java.util.List;
 
-import static com.alibaba.dashscope.aigc.generation.models.QwenParam.ResultFormat.MESSAGE;
+import static com.alibaba.dashscope.aigc.conversation.ConversationParam.ResultFormat.MESSAGE;
 import static dev.langchain4j.model.dashscope.QwenHelper.toQwenMessages;
 import static dev.langchain4j.model.dashscope.QwenHelper.toQwenMultiModalMessages;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;

--- a/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenStreamingLanguageModel.java
+++ b/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenStreamingLanguageModel.java
@@ -17,7 +17,7 @@ import lombok.Builder;
 
 import java.util.List;
 
-import static com.alibaba.dashscope.aigc.generation.models.QwenParam.ResultFormat.MESSAGE;
+import static com.alibaba.dashscope.aigc.generation.GenerationParam.ResultFormat.MESSAGE;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.model.dashscope.QwenModelName.QWEN_PLUS;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;

--- a/langchain4j-dashscope/src/test/java/dev/langchain4j/model/dashscope/QwenTestHelper.java
+++ b/langchain4j-dashscope/src/test/java/dev/langchain4j/model/dashscope/QwenTestHelper.java
@@ -23,6 +23,12 @@ public class QwenTestHelper {
                 Arguments.of(QwenModelName.QWEN_PLUS),
                 Arguments.of(QwenModelName.QWEN_MAX),
                 Arguments.of(QwenModelName.QWEN_MAX_LONGCONTEXT),
+                Arguments.of(QwenModelName.QWEN_7B_CHAT),
+                Arguments.of(QwenModelName.QWEN_14B_CHAT),
+                Arguments.of(QwenModelName.QWEN_72B_CHAT),
+                Arguments.of(QwenModelName.QWEN1_5_7B_CHAT),
+                Arguments.of(QwenModelName.QWEN1_5_14B_CHAT),
+                Arguments.of(QwenModelName.QWEN1_5_32B_CHAT),
                 Arguments.of(QwenModelName.QWEN1_5_72B_CHAT)
         );
     }

--- a/langchain4j-dashscope/src/test/java/dev/langchain4j/model/dashscope/QwenTestHelper.java
+++ b/langchain4j-dashscope/src/test/java/dev/langchain4j/model/dashscope/QwenTestHelper.java
@@ -20,14 +20,26 @@ public class QwenTestHelper {
     public static Stream<Arguments> languageModelNameProvider() {
         return Stream.of(
                 Arguments.of(QwenModelName.QWEN_TURBO),
-                Arguments.of(QwenModelName.QWEN_PLUS)
+                Arguments.of(QwenModelName.QWEN_PLUS),
+                Arguments.of(QwenModelName.QWEN_MAX),
+                Arguments.of(QwenModelName.QWEN_MAX_LONGCONTEXT),
+                Arguments.of(QwenModelName.QWEN1_5_72B_CHAT)
         );
     }
 
     public static Stream<Arguments> nonMultimodalChatModelNameProvider() {
         return Stream.of(
                 Arguments.of(QwenModelName.QWEN_TURBO),
-                Arguments.of(QwenModelName.QWEN_PLUS)
+                Arguments.of(QwenModelName.QWEN_PLUS),
+                Arguments.of(QwenModelName.QWEN_MAX),
+                Arguments.of(QwenModelName.QWEN_MAX_LONGCONTEXT),
+                Arguments.of(QwenModelName.QWEN_7B_CHAT),
+                Arguments.of(QwenModelName.QWEN_14B_CHAT),
+                Arguments.of(QwenModelName.QWEN_72B_CHAT),
+                Arguments.of(QwenModelName.QWEN1_5_7B_CHAT),
+                Arguments.of(QwenModelName.QWEN1_5_14B_CHAT),
+                Arguments.of(QwenModelName.QWEN1_5_32B_CHAT),
+                Arguments.of(QwenModelName.QWEN1_5_72B_CHAT)
         );
     }
 


### PR DESCRIPTION
## Context
Bump dashscope-sdk-java from 2.10.1 to 2.13.0, which includes bug fixes and introduces support for the function-call feature.

## Change
The dashscope-sdk-java version, more qwen model names, and tests for them.

## Checklist
Before submitting this PR, please check the following points:
- [x] I have added unit and integration tests for my change
- [x] All unit and integration tests in the module I have added/changed are green
- [x] All unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules are green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added my new module in the [BOM](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-bom/pom.xml) (only when a new module is added)

## Checklist for adding new embedding store integration
- [ ] I have added a {NameOfIntegration}EmbeddingStoreIT that extends from either EmbeddingStoreIT or EmbeddingStoreWithFilteringIT
