### PR TITLE
Add new ChatMemory implementation to be used for stateful data extraction

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/UserMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/UserMessage.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.data.message;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static dev.langchain4j.data.message.ChatMessageType.USER;
@@ -26,6 +27,9 @@ public class UserMessage implements ChatMessage {
 
     private final String name;
     private final List<Content> contents;
+
+    private String template;
+    private Map<String, Object> variables;
 
     /**
      * Creates a {@link UserMessage} from a text.
@@ -136,6 +140,24 @@ public class UserMessage implements ChatMessage {
      */
     public boolean hasSingleText() {
         return contents.size() == 1 && contents.get(0) instanceof TextContent;
+    }
+
+    public UserMessage fromTemplate(String template) {
+        this.template = template;
+        return this;
+    }
+
+    public String template() {
+        return template;
+    }
+
+    public UserMessage withVariables(Map<String, Object> variables) {
+        this.variables = variables;
+        return this;
+    }
+
+    public Map<String, Object> variables() {
+        return variables;
     }
 
     /**

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/UserMessagesConcatChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/UserMessagesConcatChatMemory.java
@@ -1,0 +1,160 @@
+package dev.langchain4j.memory.chat;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.model.input.Prompt;
+import dev.langchain4j.model.input.PromptTemplate;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+/**
+ * This chat memory operates a concatenation of all users prompts and it is designed to be used
+ * for a stateful data extraction.
+ * <p>
+ * Once added, a {@link SystemMessage} is always retained.
+ * Only one {@code SystemMessage} can be held at a time.
+ * If a new {@code SystemMessage} with the same content is added, it is ignored.
+ * If a new {@code SystemMessage} with different content is added, the previous {@code SystemMessage} is removed.
+ * <p>
+ * There is only one {@link UserMessage} at time that at each interaction is recreated from the PromptTemplate using as
+ * variables the concatenation of the values of those variables during the entire lifespan of the memory.
+ * <p>
+ * All {@link AiMessage}s are discarded.
+ * <p>
+ * The state of chat memory is stored in {@link ChatMemoryStore} ({@link InMemoryChatMemoryStore} is used by default).
+ */
+public class UserMessagesConcatChatMemory implements ChatMemory {
+
+    private static final Logger log = LoggerFactory.getLogger(UserMessagesConcatChatMemory.class);
+
+    private final Object id;
+    private final ChatMemoryStore store;
+
+    private UserMessagesConcatChatMemory(Builder builder) {
+        this.id = ensureNotNull(builder.id, "id");
+        this.store = ensureNotNull(builder.store, "store");
+    }
+
+    @Override
+    public Object id() {
+        return id;
+    }
+
+    @Override
+    public void add(ChatMessage message) {
+        List<ChatMessage> messages = messages();
+
+        if (message instanceof SystemMessage) {
+            Optional<SystemMessage> systemMessage = findSystemMessage(messages);
+            if (systemMessage.isPresent()) {
+                if (systemMessage.get().equals(message)) {
+                    return; // do not add the same system message
+                } else {
+                    messages.remove(systemMessage.get()); // need to replace existing system message
+                }
+            }
+            messages.add(message);
+
+        } else if (message instanceof UserMessage) {
+            Optional<UserMessage> userMessage = findUserMessage(messages);
+            if (userMessage.isPresent()) {
+                messages.remove(userMessage.get()); // need to replace existing user message
+                messages.add(concatUserMessages(userMessage.get(), (UserMessage) message));
+            } else {
+                messages.add(message);
+            }
+        }
+
+        store.updateMessages(id, messages);
+    }
+
+    private static UserMessage concatUserMessages(UserMessage oldMessage, UserMessage newMessage) {
+        Map<String, Object> oldVars = oldMessage.variables();
+        Map<String, Object> newVars = newMessage.variables();
+
+        Map<String, Object> concatVars = new HashMap<>(oldVars);
+        newVars.forEach((key, value) -> concatVars.compute(key, (k, v) -> v == null ? value : v + ". " + value));
+
+        Prompt prompt = PromptTemplate.from(newMessage.template()).apply(concatVars);
+        UserMessage concatMessage = newMessage.name() != null ? UserMessage.from(newMessage.name(), prompt.text()) : UserMessage.from(prompt.text());
+        return concatMessage.fromTemplate(newMessage.template()).withVariables(concatVars);
+    }
+
+    private static Optional<SystemMessage> findSystemMessage(List<ChatMessage> messages) {
+        return messages.stream()
+                .filter(message -> message instanceof SystemMessage)
+                .map(message -> (SystemMessage) message)
+                .findAny();
+    }
+
+    private static Optional<UserMessage> findUserMessage(List<ChatMessage> messages) {
+        return messages.stream()
+                .filter(message -> message instanceof UserMessage)
+                .map(message -> (UserMessage) message)
+                .findAny();
+    }
+
+    @Override
+    public List<ChatMessage> messages() {
+        List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
+        return messages;
+    }
+
+    @Override
+    public void clear() {
+        store.deleteMessages(id);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Object id = "default";
+        private ChatMemoryStore store = new InMemoryChatMemoryStore();
+
+        /**
+         * @param id The ID of the {@link ChatMemory}.
+         *           If not provided, a "default" will be used.
+         * @return builder
+         */
+        public Builder id(Object id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * @param store The chat memory store responsible for storing the chat memory state.
+         *              If not provided, an {@link InMemoryChatMemoryStore} will be used.
+         * @return builder
+         */
+        public Builder chatMemoryStore(ChatMemoryStore store) {
+            this.store = store;
+            return this;
+        }
+
+        public UserMessagesConcatChatMemory build() {
+            return new UserMessagesConcatChatMemory(this);
+        }
+    }
+
+    public static UserMessagesConcatChatMemory build() {
+        return builder().build();
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesExtractorMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesExtractorMemoryTest.java
@@ -1,0 +1,82 @@
+package dev.langchain4j.service;
+
+import java.time.Duration;
+import java.util.Scanner;
+
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.UserMessagesConcatChatMemory;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.ollama.OllamaChatModel;
+
+public class AiServicesExtractorMemoryTest {
+
+    public static void main(String[] args) {
+
+        ChatLanguageModel chatLanguageModel = OllamaChatModel.builder()
+                .baseUrl("http://localhost:11434")
+                .modelName("mistral")
+                .temperature(0.1)
+                .timeout(Duration.ofMinutes(3))
+                .build();
+
+        ChatMemory chatMemory = UserMessagesConcatChatMemory.build();
+
+        CustomerExtractor customerExtractor = AiServices.builder(CustomerExtractor.class)
+                .chatLanguageModel(chatLanguageModel)
+                .chatMemory(chatMemory)
+                .build();
+
+        Scanner scanner = new Scanner(System.in);
+        Customer customer = null;
+
+        while (customer == null || !customer.isValid()) {
+            System.out.print("User: ");
+            String userMessage = scanner.nextLine();
+
+            try {
+                customer = customerExtractor.extractData(userMessage);
+            } catch (Exception ignore) {
+                ignore.printStackTrace();
+            }
+        }
+
+        System.out.println("Extracted " + customer);
+
+        scanner.close();
+    }
+
+    public static class Customer {
+        public final String firstName;
+        public final String lastName;
+        public final int age;
+
+        public Customer(String firstName, String lastName, int age) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.age = age;
+        }
+
+        @Override
+        public String toString() {
+            return "Customer {" +
+                    " firstName = \"" + firstName + "\"" +
+                    ", lastName = \"" + lastName + "\"" +
+                    ", age = " + age +
+                    " }";
+        }
+
+        public String getFullName() {
+            return firstName + " " + lastName;
+        }
+
+        public boolean isValid() {
+            return firstName != null && !firstName.isEmpty() && age > 0;
+        }
+    }
+
+    interface CustomerExtractor {
+
+        @UserMessage("Extract information about a customer from this text '{{it}}'. The response must contain only the JSON with customer's data and without any other sentence.")
+        Customer extractData(String text);
+    }
+}


### PR DESCRIPTION
This pull request implements the `ChatMemory` that I have discussed and proposed [here](https://github.com/langchain4j/langchain4j/pull/862#discussion_r1557626867). This should be a good fit to be used for stateful data extraction, so for instance the included test case produces the following output:
```
User: hi
User: my name is Mario Fusco
User: I'm 50
Extracted Customer { firstName = "Mario", lastName = "Fusco", age = 50 }
```
In essence what this `ChatMemory` does is simply concatenating the values of variables sent by a user at each iteration, recreating at each step the user message from the original prompt template and those concatenated variables. In this way the user message sent to the LLM at the 3rd prompt of my example above will be something like:

"Extract information about a customer from this text 'hi. my name is Mario Fusco. I'm 50'. The response must contain only the JSON with customer's data and without any other sentence. You must answer strictly in the following JSON format: {\n"firstName": (type: string),\n"lastName": (type: string),\n"age": (type: integer)"

In order to implement this feature I had to add to the `UserMessage` both the prompt template and the set of variables from which it has been created. I believe that carrying those information can be useful also beyond the specific needs of this pull request. In reality probably it would be an ever better design if the `UserMessage` would know how to render itself and use the `PromptTemplate` internally instead of having a text populated from the outside as it does now. I'm open to also implement this further improvement, but for now I just wanted to demonstrate the general idea with the smallest possible set of changes.

/cc @sebastienblanc 