### PR TITLE
fix bug: AiMessage text content is not copied when toolCalls are pres…

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/AiMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/AiMessage.java
@@ -137,6 +137,17 @@ public class AiMessage implements ChatMessage {
     }
 
     /**
+     * Create a new {@link AiMessage} with the given text and tool execution requests.
+     *
+     * @param text the text of the message.
+     * @param toolExecutionRequests the tool execution requests of the message.
+     * @return the new {@link AiMessage}.
+     */
+    public static AiMessage from(String text, List<ToolExecutionRequest> toolExecutionRequests) {
+        return new AiMessage(text, toolExecutionRequests);
+    }
+
+    /**
      * Create a new {@link AiMessage} with the given text.
      *
      * @param text the text of the message.
@@ -164,5 +175,16 @@ public class AiMessage implements ChatMessage {
      */
     public static AiMessage aiMessage(List<ToolExecutionRequest> toolExecutionRequests) {
         return from(toolExecutionRequests);
+    }
+
+    /**
+     * Create a new {@link AiMessage} with the given text and tool execution requests.
+     *
+     * @param text the text of the message.
+     * @param toolExecutionRequests the tool execution requests of the message.
+     * @return the new {@link AiMessage}.
+     */
+    public static AiMessage aiMessage(String text, List<ToolExecutionRequest> toolExecutionRequests) {
+        return from(text, toolExecutionRequests);
     }
 }

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/InternalOpenAiHelper.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/InternalOpenAiHelper.java
@@ -17,7 +17,6 @@ import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import static dev.ai4j.openai4j.chat.ContentType.IMAGE_URL;
@@ -218,7 +217,7 @@ public class InternalOpenAiHelper {
                     .collect(toList());
             return isNullOrEmpty(text) ?
                     aiMessage(toolExecutionRequests) :
-                    new AiMessage(text, toolExecutionRequests);
+                    aiMessage(text, toolExecutionRequests);
         }
 
         FunctionCall functionCall = assistantMessage.functionCall();
@@ -229,7 +228,7 @@ public class InternalOpenAiHelper {
                     .build();
             return isNullOrEmpty(text) ?
                     aiMessage(toolExecutionRequest) :
-                    new AiMessage(text, singletonList(toolExecutionRequest));
+                    aiMessage(text, singletonList(toolExecutionRequest));
         }
 
         return aiMessage(text);


### PR DESCRIPTION
## Issue

https://github.com/langchain4j/langchain4j/issues/986


## Change

When OpenAI returns both content and tool_calls, keep them all instead of just keeping the tool_calls.


## General checklist

- [x] There are no breaking changes
- [x] I have added unit and integration tests for my change
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation

