### PR TITLE
Fix for issue #1108

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
@@ -44,7 +45,7 @@ public class MessageWindowChatMemory implements ChatMemory {
     private final ChatMemoryStore store;
 
     private MessageWindowChatMemory(Builder builder) {
-        this.id = ensureNotNull(builder.id, "id");
+        this.id = builder.id == null ? UUID.randomUUID() : builder.id;
         this.maxMessages = ensureGreaterThanZero(builder.maxMessages, "maxMessages");
         this.store = ensureNotNull(builder.store, "store");
     }
@@ -120,13 +121,13 @@ public class MessageWindowChatMemory implements ChatMemory {
 
     public static class Builder {
 
-        private Object id = "default";
+        private Object id = null;
         private Integer maxMessages;
         private ChatMemoryStore store = new InMemoryChatMemoryStore();
 
         /**
          * @param id The ID of the {@link ChatMemory}.
-         *           If not provided, a "default" will be used.
+         *           If not provided, a random UUID will be used.
          * @return builder
          */
         public Builder id(Object id) {


### PR DESCRIPTION
<!-- Thank you so much for your contribution! -->
<!-- Please fill in all the sections below. -->

<!-- Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples. -->
<!-- Please note that PRs with breaking changes will be rejected. -->
<!-- Please note that PRs without tests will be rejected. -->

<!-- Please note that PRs will be reviewed based on the priority of the issues they address. -->
<!-- We ask for your patience. We are doing our best to review your PR as quickly as possible. -->
<!-- Please refrain from pinging and asking when it will be reviewed. Thank you for understanding! -->


## Issue
Solves [#1108](https://github.com/langchain4j/langchain4j/issues/1108).

## Change
- The default value of `id` in `MessageWindowChatMemory.Builder` is null.
- The constructor of `MessageWindowChatMemory` checks for null `id` value. If it is `null`, then it will generate a random UUID.
- Updated the documentation for `MessageWindowChatMemory.Builder.id()`.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
