### PR TITLE
CompressingQueryTransformer NullPointException

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/query/transformer/CompressingQueryTransformer.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/query/transformer/CompressingQueryTransformer.java
@@ -65,7 +65,7 @@ public class CompressingQueryTransformer implements QueryTransformer {
     public Collection<Query> transform(Query query) {
 
         List<ChatMessage> chatMemory = query.metadata().chatMemory();
-        if (chatMemory.isEmpty()) {
+        if (chatMemory ==null || chatMemory.isEmpty()) {
             // no need to compress if there are no previous messages
             return singletonList(query);
         }

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/query/transformer/CompressingQueryTransformer.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/query/transformer/CompressingQueryTransformer.java
@@ -65,7 +65,7 @@ public class CompressingQueryTransformer implements QueryTransformer {
     public Collection<Query> transform(Query query) {
 
         List<ChatMessage> chatMemory = query.metadata().chatMemory();
-        if (chatMemory ==null || chatMemory.isEmpty()) {
+        if (chatMemory == null || chatMemory.isEmpty()) {
             // no need to compress if there are no previous messages
             return singletonList(query);
         }


### PR DESCRIPTION
Visit CompressingQueryTransformer transform method to query. The metadata () when no memory context model of null pointer error
<img width="1426" alt="image" src="https://github.com/langchain4j/langchain4j/assets/50910542/8398b365-31ab-4907-8ee9-0958d9f4a836">
