### PR TITLE
Support GTP-4o with Azure OpenAI

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiModelName.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiModelName.java
@@ -11,13 +11,14 @@ public class AzureOpenAiModelName {
     public static final String GPT_3_5_TURBO_16K = "gpt-3.5-turbo-16k"; // alias for the latest model
     public static final String GPT_3_5_TURBO_16K_0613 = "gpt-3.5-turbo-16k-0613"; // 16k context, functions
 
-    public static final String GPT_4 = "gpt-4"; // alias for the latest model
+    public static final String GPT_4 = "gpt-4"; // alias for the latest gpt-4
     public static final String GPT_4_1106_PREVIEW = "gpt-4-1106-preview"; // 8k context
     public static final String GPT_4_0613 = "gpt-4-0613"; // 8k context, functions
 
     public static final String GPT_4_32K = "gpt-4-32k"; // alias for the latest model
     public static final String GPT_4_32K_0613 = "gpt-4-32k-0613"; // 32k context, functions
 
+    public static final String GPT_4_O = "gpt-4o"; // alias for the latest gpt-4o model
 
     // Use with AzureOpenAiLanguageModel and AzureOpenAiStreamingLanguageModel
     public static final String TEXT_DAVINCI_002 = "text-davinci-002";

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAIResponsibleAIIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAIResponsibleAIIT.java
@@ -33,8 +33,7 @@ public class AzureOpenAIResponsibleAIIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void chat_message_should_trigger_content_filter_for_violence(String deploymentName, String gptVersion) {
 
@@ -56,8 +55,7 @@ public class AzureOpenAIResponsibleAIIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void chat_message_should_trigger_content_filter_for_self_harm(String deploymentName, String gptVersion) {
 
@@ -118,8 +116,7 @@ public class AzureOpenAIResponsibleAIIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void streaming_chat_message_should_trigger_content_filter_for_violence(String deploymentName, String gptVersion) throws Exception {
 
@@ -167,8 +164,7 @@ public class AzureOpenAIResponsibleAIIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void streaming_language_should_trigger_content_filter_for_violence(String deploymentName, String gptVersion) throws Exception {
 

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelIT.java
@@ -42,8 +42,7 @@ public class AzureOpenAiChatModelIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void should_generate_answer_and_return_token_usage_and_finish_reason_stop(String deploymentName, String gptVersion) {
 
@@ -72,8 +71,7 @@ public class AzureOpenAiChatModelIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void should_generate_answer_and_return_token_usage_and_finish_reason_length(String deploymentName, String gptVersion) {
 
@@ -103,8 +101,7 @@ public class AzureOpenAiChatModelIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void should_call_function_with_argument(String deploymentName, String gptVersion) {
 
@@ -170,8 +167,7 @@ public class AzureOpenAiChatModelIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void should_call_function_with_no_argument(String deploymentName, String gptVersion) {
         ChatLanguageModel model = AzureOpenAiChatModel.builder()
@@ -205,8 +201,7 @@ public class AzureOpenAiChatModelIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void should_call_three_functions_in_parallel(String deploymentName, String gptVersion) throws Exception {
 
@@ -284,8 +279,7 @@ public class AzureOpenAiChatModelIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void should_use_json_format(String deploymentName, String gptVersion) {
         ChatLanguageModel model = AzureOpenAiChatModel.builder()

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelIT.java
@@ -45,10 +45,8 @@ class AzureOpenAiStreamingChatModelIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1} with async client set to {2}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo, true",
-            "gpt-35-turbo, gpt-3.5-turbo, false",
-            "gpt-4,        gpt-4, true",
-            "gpt-4,        gpt-4, false"
+            "gpt-4o,        gpt-4o, true",
+            "gpt-4o,        gpt-4o, false"
     })
     void should_stream_answer(String deploymentName, String gptVersion, boolean useAsyncClient) throws Exception {
 
@@ -104,10 +102,8 @@ class AzureOpenAiStreamingChatModelIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1} with custom async client set to {2} ")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo, true",
-            "gpt-35-turbo, gpt-3.5-turbo, false",
-            "gpt-4,        gpt-4, true",
-            "gpt-4,        gpt-4, false"
+            "gpt-4o,        gpt-4o, true",
+            "gpt-4o,        gpt-4o, false"
     })
     void should_custom_models_work(String deploymentName, String gptVersion, boolean useCustomAsyncClient) throws Exception {
 
@@ -169,7 +165,7 @@ class AzureOpenAiStreamingChatModelIT {
     }
 
     @ParameterizedTest(name = "Deployment name {0}")
-    @ValueSource(strings = {"gpt-35-turbo", "gpt-4"})
+    @ValueSource(strings = {"gpt-4o"})
     void should_use_json_format(String deploymentName) {
 
         StreamingChatLanguageModel model = AzureOpenAiStreamingChatModel.builder()
@@ -195,8 +191,7 @@ class AzureOpenAiStreamingChatModelIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void should_call_function_with_argument(String deploymentName, String gptVersion) throws Exception {
 
@@ -301,8 +296,7 @@ class AzureOpenAiStreamingChatModelIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1}")
     @CsvSource({
-            "gpt-35-turbo, gpt-3.5-turbo",
-            "gpt-4,        gpt-4"
+            "gpt-4o,        gpt-4o"
     })
     void should_call_three_functions_in_parallel(String deploymentName, String gptVersion) throws Exception {
 

--- a/langchain4j-azure-open-ai/src/test/script/deploy-azure-openai-models.sh
+++ b/langchain4j-azure-open-ai/src/test/script/deploy-azure-openai-models.sh
@@ -7,9 +7,9 @@ echo "Setting up environment variables..."
 echo "----------------------------------"
 PROJECT="langchain4j"
 RESOURCE_GROUP="rg-$PROJECT"
-LOCATION="swedencentral"
-TAG="$PROJECT"
+LOCATION="eastus"
 AI_SERVICE="ai-$PROJECT"
+TAG="$PROJECT"
 
 echo "Creating the resource group..."
 echo "------------------------------"
@@ -28,21 +28,9 @@ az cognitiveservices account create \
   --tags system="$TAG" \
   --kind "OpenAI" \
   --sku "S0"
-  
+
 # If you want to know the available models, run the following Azure CLI command:
 # az cognitiveservices account list-models --resource-group "$RESOURCE_GROUP" --name "$AI_SERVICE" -o table  
-
-echo "Deploying a gpt-35-turbo model..."
-echo "----------------------"
-az cognitiveservices account deployment create \
-  --name "$AI_SERVICE" \
-  --resource-group "$RESOURCE_GROUP" \
-  --deployment-name "gpt-35-turbo" \
-  --model-name "gpt-35-turbo" \
-  --model-version "1106"  \
-  --model-format "OpenAI" \
-  --sku-capacity 120 \
-  --sku-name "Standard"
 
 echo "Deploying a gpt-35-turbo-instruct model..."
 echo "----------------------"
@@ -56,14 +44,14 @@ az cognitiveservices account deployment create \
   --sku-capacity 120 \
   --sku-name "Standard"
 
-echo "Deploying a gpt-4 model..."
+echo "Deploying a gpt-4o model..."
 echo "----------------------"
 az cognitiveservices account deployment create \
   --name "$AI_SERVICE" \
   --resource-group "$RESOURCE_GROUP" \
-  --deployment-name "gpt-4" \
-  --model-name "gpt-4" \
-  --model-version "1106-Preview"  \
+  --deployment-name "gpt-4o" \
+  --model-name "gpt-4o" \
+  --model-version "2024-05-13"  \
   --model-format "OpenAI" \
   --sku-capacity 10 \
   --sku-name "Standard"


### PR DESCRIPTION
GPT-4o on Azure OpenAI was announced at Build yesterday, and it's already working with LangChain4J!

This shows that the current code works with GPT-4o (all integration tests are green on my side), with 2 downsides for the moment:

- It's not available in the Sweden Central region, which I typically use as there are more models there: this is why I'm using East US, and had to remove GPT 3.5 Turbo which isn't available there (then, GPT-4o basically replaces both GPT 3.5 Turbo and GPT 4, so it makes sense)
- The CLI commands in the `deploy-azure-openai-models.sh` script currently complains that the API version isn't correct, as it's not updated yet. It should be super soon, and otherwise the trick is to create it using the Azure AI Studio.

Those 2 issues should be very temporary.