### PR TITLE
Update ModelListener API to be more integration friendly

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/listener/ChatLanguageModelRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/listener/ChatLanguageModelRequest.java
@@ -17,7 +17,7 @@ import static dev.langchain4j.internal.Utils.copyIfNotNull;
  * intended to be used with {@link ModelListener}.
  */
 @Experimental
-public class ChatLanguageModelRequest {
+public class ChatLanguageModelRequest implements ModelListener.OnRequestResult<ChatLanguageModelRequest> {
 
     private final String model;
     private final Double temperature;
@@ -63,5 +63,10 @@ public class ChatLanguageModelRequest {
 
     public List<ToolSpecification> toolSpecifications() {
         return toolSpecifications;
+    }
+
+    @Override
+    public ChatLanguageModelRequest request() {
+        return this;
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/listener/ModelListener.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/listener/ModelListener.java
@@ -11,7 +11,7 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
  * such as {@link ChatLanguageModel}, {@link StreamingChatLanguageModel}, {@link EmbeddingModel}, etc.
  */
 @Experimental
-public interface ModelListener<Request, Response> {
+public interface ModelListener<Request, RequestResult extends ModelListener.OnRequestResult<Request>, Response> {
 
     /**
      * This method is called before the request is sent to the model.
@@ -19,8 +19,8 @@ public interface ModelListener<Request, Response> {
      * @param request The request to the model.
      */
     @Experimental
-    default void onRequest(Request request) {
-
+    default RequestResult onRequest(Request request) {
+        return null;
     }
 
     /**
@@ -30,7 +30,7 @@ public interface ModelListener<Request, Response> {
      * @param request  The request this response corresponds to.
      */
     @Experimental
-    default void onResponse(Response response, Request request) {
+    default void onResponse(Response response, RequestResult request) {
 
     }
 
@@ -45,7 +45,14 @@ public interface ModelListener<Request, Response> {
      * @param request  The request this error corresponds to.
      */
     @Experimental
-    default void onError(Throwable error, Response response, Request request) {
+    default void onError(Throwable error, Response response, RequestResult request) {
 
+    }
+
+    /**
+     * This name is horrible, and should be replaced by something better
+     */
+    interface OnRequestResult<Request> {
+        Request request();
     }
 }

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiChatModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiChatModelIT.java
@@ -487,18 +487,19 @@ class OpenAiChatModelIT {
         AtomicReference<ChatLanguageModelRequest> requestReference = new AtomicReference<>();
         AtomicReference<ChatLanguageModelResponse> responseReference = new AtomicReference<>();
 
-        ModelListener<ChatLanguageModelRequest, ChatLanguageModelResponse> modelListener =
-                new ModelListener<ChatLanguageModelRequest, ChatLanguageModelResponse>() {
+        ModelListener<ChatLanguageModelRequest, ChatLanguageModelRequest, ChatLanguageModelResponse> modelListener =
+                new ModelListener<ChatLanguageModelRequest, ChatLanguageModelRequest, ChatLanguageModelResponse>() {
 
                     @Override
-                    public void onRequest(ChatLanguageModelRequest request) {
+                    public ChatLanguageModelRequest onRequest(ChatLanguageModelRequest request) {
                         requestReference.set(request);
+                        return request;
                     }
 
                     @Override
                     public void onResponse(ChatLanguageModelResponse response, ChatLanguageModelRequest request) {
                         responseReference.set(response);
-                        assertThat(request).isSameAs(requestReference.get());
+                        assertThat(request.request()).isSameAs(requestReference.get());
                     }
 
                     @Override
@@ -566,12 +567,13 @@ class OpenAiChatModelIT {
         AtomicReference<ChatLanguageModelRequest> requestReference = new AtomicReference<>();
         AtomicReference<Throwable> errorReference = new AtomicReference<>();
 
-        ModelListener<ChatLanguageModelRequest, ChatLanguageModelResponse> modelListener =
-                new ModelListener<ChatLanguageModelRequest, ChatLanguageModelResponse>() {
+        ModelListener<ChatLanguageModelRequest, ChatLanguageModelRequest, ChatLanguageModelResponse> modelListener =
+                new ModelListener<ChatLanguageModelRequest, ChatLanguageModelRequest, ChatLanguageModelResponse>() {
 
                     @Override
-                    public void onRequest(ChatLanguageModelRequest request) {
+                    public ChatLanguageModelRequest onRequest(ChatLanguageModelRequest request) {
                         requestReference.set(request);
+                        return request;
                     }
 
                     @Override
@@ -585,7 +587,7 @@ class OpenAiChatModelIT {
                                         ChatLanguageModelRequest request) {
                         errorReference.set(error);
                         assertThat(response).isNull();
-                        assertThat(request).isSameAs(requestReference.get());
+                        assertThat(request.request()).isSameAs(requestReference.get());
                     }
                 };
 

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingChatModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingChatModelIT.java
@@ -653,12 +653,13 @@ class OpenAiStreamingChatModelIT {
         AtomicReference<ChatLanguageModelRequest> requestReference = new AtomicReference<>();
         AtomicReference<ChatLanguageModelResponse> responseReference = new AtomicReference<>();
 
-        ModelListener<ChatLanguageModelRequest, ChatLanguageModelResponse> modelListener =
-                new ModelListener<ChatLanguageModelRequest, ChatLanguageModelResponse>() {
+        ModelListener<ChatLanguageModelRequest, ChatLanguageModelRequest, ChatLanguageModelResponse> modelListener =
+                new ModelListener<ChatLanguageModelRequest, ChatLanguageModelRequest, ChatLanguageModelResponse>() {
 
                     @Override
-                    public void onRequest(ChatLanguageModelRequest request) {
+                    public ChatLanguageModelRequest onRequest(ChatLanguageModelRequest request) {
                         requestReference.set(request);
+                        return request;
                     }
 
                     @Override
@@ -734,12 +735,13 @@ class OpenAiStreamingChatModelIT {
         AtomicReference<ChatLanguageModelRequest> requestReference = new AtomicReference<>();
         AtomicReference<Throwable> errorReference = new AtomicReference<>();
 
-        ModelListener<ChatLanguageModelRequest, ChatLanguageModelResponse> modelListener =
-                new ModelListener<ChatLanguageModelRequest, ChatLanguageModelResponse>() {
+        ModelListener<ChatLanguageModelRequest, ChatLanguageModelRequest, ChatLanguageModelResponse> modelListener =
+                new ModelListener<ChatLanguageModelRequest, ChatLanguageModelRequest, ChatLanguageModelResponse>() {
 
                     @Override
-                    public void onRequest(ChatLanguageModelRequest request) {
+                    public ChatLanguageModelRequest onRequest(ChatLanguageModelRequest request) {
                         requestReference.set(request);
+                        return request;
                     }
 
                     @Override
@@ -753,7 +755,7 @@ class OpenAiStreamingChatModelIT {
                                         ChatLanguageModelRequest request) {
                         errorReference.set(error);
                         assertThat(response).isNull(); // can be non-null if it fails in the middle of streaming
-                        assertThat(request).isSameAs(requestReference.get());
+                        assertThat(request.request()).isSameAs(requestReference.get());
                     }
                 };
 


### PR DESCRIPTION
The idea here is to allow the onRequest method to return an object which will then be passed along to the
response and error methods.
This allows for integrations to attach anything they need when the request is made and access it when the response or error methods are called.

On the implementation side this looks a little
awkward because of the generics, but the upside
is that for users / integrators of `ModelListener`,
the signature of the class and methods provide very good hints on how to implement them

This follows up on the discussion I started [here](https://github.com/langchain4j/langchain4j/pull/1058#issuecomment-2126939188).