### PR TITLE
Implement remove methods for InMemoryEmbeddingStore

### DIFF
--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
@@ -1,0 +1,119 @@
+package dev.langchain4j.store.embedding;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.filter.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
+    @BeforeEach
+    void beforeEach() {
+        embeddingStore().removeAll();
+    }
+
+    @Test
+    void remove_by_id() {
+        Embedding embedding = embeddingModel().embed("hello").content();
+        Embedding embedding2 = embeddingModel().embed("hello2").content();
+        Embedding embedding3 = embeddingModel().embed("hello3").content();
+
+        String id = embeddingStore().add(embedding);
+        String id2 = embeddingStore().add(embedding2);
+        String id3 = embeddingStore().add(embedding3);
+
+        assertThat(id).isNotBlank();
+        assertThat(id2).isNotBlank();
+        assertThat(id3).isNotBlank();
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        assertThat(relevant).hasSize(3);
+
+        embeddingStore().remove(id);
+
+        relevant = embeddingStore().findRelevant(embedding, 10);
+        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
+        assertThat(relevantIds).hasSize(2);
+        assertThat(relevantIds).containsExactly(id2, id3);
+    }
+
+    @Test
+    void remove_all_by_ids() {
+        Embedding embedding = embeddingModel().embed("hello").content();
+        Embedding embedding2 = embeddingModel().embed("hello2").content();
+        Embedding embedding3 = embeddingModel().embed("hello3").content();
+
+        String id = embeddingStore().add(embedding);
+        String id2 = embeddingStore().add(embedding2);
+        String id3 = embeddingStore().add(embedding3);
+
+        embeddingStore().removeAll(Arrays.asList(id2, id3));
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
+        assertThat(relevant).hasSize(1);
+        assertThat(relevantIds).containsExactly(id);
+    }
+
+    @Test
+    void remove_all_by_ids_null() {
+        assertThatThrownBy(() -> embeddingStore().removeAll((Collection<String>) null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ids cannot be null or empty");
+    }
+
+    @Test
+    void remove_all_by_filter() {
+        Metadata metadata = Metadata.metadata("id", "1");
+        TextSegment segment = TextSegment.from("matching", metadata);
+        Embedding embedding = embeddingModel().embed(segment).content();
+        embeddingStore().add(embedding, segment);
+
+        Embedding embedding2 = embeddingModel().embed("hello2").content();
+        Embedding embedding3 = embeddingModel().embed("hello3").content();
+
+        String id2 = embeddingStore().add(embedding2, new TextSegment("hello2", new Metadata()));
+        String id3 = embeddingStore().add(embedding3, new TextSegment("hello3", new Metadata()));
+
+        embeddingStore().removeAll(metadataKey("id").isEqualTo("1"));
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
+        assertThat(relevantIds).hasSize(2);
+        assertThat(relevantIds).containsExactly(id2, id3);
+    }
+
+    @Test
+    void remove_all_by_filter_not_matching() {
+        Embedding embedding = embeddingModel().embed("hello").content();
+        Embedding embedding2 = embeddingModel().embed("hello2").content();
+        Embedding embedding3 = embeddingModel().embed("hello3").content();
+
+        embeddingStore().add(embedding, new TextSegment("hello", new Metadata()));
+        embeddingStore().add(embedding2, new TextSegment("hello2", new Metadata()));
+        embeddingStore().add(embedding3, new TextSegment("hello3", new Metadata()));
+
+        embeddingStore().removeAll(metadataKey("unknown").isEqualTo("1"));
+
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
+        assertThat(relevantIds).hasSize(3);
+    }
+
+    @Test
+    void remove_all_by_filter_null() {
+        assertThatThrownBy(() -> embeddingStore().removeAll((Filter) null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("filter cannot be null");
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
@@ -36,12 +36,12 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
         assertThat(id2).isNotBlank();
         assertThat(id3).isNotBlank();
 
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<EmbeddingMatch<TextSegment>> relevant = findRelevant(embedding);
         assertThat(relevant).hasSize(3);
 
         embeddingStore().remove(id);
 
-        relevant = embeddingStore().findRelevant(embedding, 10);
+        relevant = findRelevant(embedding);
         List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
         assertThat(relevantIds).hasSize(2);
         assertThat(relevantIds).containsExactly(id2, id3);
@@ -59,7 +59,7 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
 
         embeddingStore().removeAll(Arrays.asList(id2, id3));
 
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<EmbeddingMatch<TextSegment>> relevant = findRelevant(embedding);
         List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
         assertThat(relevant).hasSize(1);
         assertThat(relevantIds).containsExactly(id);
@@ -87,7 +87,7 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
 
         embeddingStore().removeAll(metadataKey("id").isEqualTo("1"));
 
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<EmbeddingMatch<TextSegment>> relevant = findRelevant(embedding);
         List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
         assertThat(relevantIds).hasSize(2);
         assertThat(relevantIds).containsExactly(id2, id3);
@@ -105,7 +105,7 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
 
         embeddingStore().removeAll(metadataKey("unknown").isEqualTo("1"));
 
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore().findRelevant(embedding, 10);
+        List<EmbeddingMatch<TextSegment>> relevant = findRelevant(embedding);
         List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
         assertThat(relevantIds).hasSize(3);
     }
@@ -115,5 +115,15 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
         assertThatThrownBy(() -> embeddingStore().removeAll((Filter) null))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("filter cannot be null");
+    }
+
+    List<EmbeddingMatch<TextSegment>> findRelevant(Embedding embedding) {
+        EmbeddingSearchRequest embeddingSearchRequest = EmbeddingSearchRequest
+                .builder()
+                .queryEmbedding(embedding)
+                .maxResults(10)
+                .build();
+
+        return embeddingStore().search(embeddingSearchRequest).matches();
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithRemovalIT.java
@@ -82,8 +82,8 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
         Embedding embedding2 = embeddingModel().embed("hello2").content();
         Embedding embedding3 = embeddingModel().embed("hello3").content();
 
-        String id2 = embeddingStore().add(embedding2, new TextSegment("hello2", new Metadata()));
-        String id3 = embeddingStore().add(embedding3, new TextSegment("hello3", new Metadata()));
+        String id2 = embeddingStore().add(embedding2);
+        String id3 = embeddingStore().add(embedding3);
 
         embeddingStore().removeAll(metadataKey("id").isEqualTo("1"));
 
@@ -99,9 +99,9 @@ public abstract class EmbeddingStoreWithRemovalIT extends EmbeddingStoreIT{
         Embedding embedding2 = embeddingModel().embed("hello2").content();
         Embedding embedding3 = embeddingModel().embed("hello3").content();
 
-        embeddingStore().add(embedding, new TextSegment("hello", new Metadata()));
-        embeddingStore().add(embedding2, new TextSegment("hello2", new Metadata()));
-        embeddingStore().add(embedding3, new TextSegment("hello3", new Metadata()));
+        embeddingStore().add(embedding);
+        embeddingStore().add(embedding2);
+        embeddingStore().add(embedding3);
 
         embeddingStore().removeAll(metadataKey("unknown").isEqualTo("1"));
 

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreRemoveIT.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreRemoveIT.java
@@ -7,6 +7,7 @@ import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
 import dev.langchain4j.store.embedding.filter.Filter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Testcontainers
-public class PgVectorEmbeddingStoreRemoveIT {
+public class PgVectorEmbeddingStoreRemoveIT extends EmbeddingStoreWithRemovalIT {
 
     @Container
     static PostgreSQLContainer<?> pgVector = new PostgreSQLContainer<>("pgvector/pgvector:pg15");
@@ -41,103 +42,13 @@ public class PgVectorEmbeddingStoreRemoveIT {
 
     EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
 
-    @BeforeEach
-    void beforeEach() {
-        embeddingStore.removeAll();
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
     }
 
-    @Test
-    void remove_by_id() {
-        Embedding embedding = embeddingModel.embed("hello").content();
-        Embedding embedding2 = embeddingModel.embed("hello2").content();
-        Embedding embedding3 = embeddingModel.embed("hello3").content();
-
-        String id = embeddingStore.add(embedding);
-        String id2 = embeddingStore.add(embedding2);
-        String id3 = embeddingStore.add(embedding3);
-
-        assertThat(id).isNotBlank();
-        assertThat(id2).isNotBlank();
-        assertThat(id3).isNotBlank();
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        assertThat(relevant).hasSize(3);
-
-        embeddingStore.remove(id);
-
-        relevant = embeddingStore.findRelevant(embedding, 10);
-        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
-        assertThat(relevantIds).hasSize(2);
-        assertThat(relevantIds).containsExactly(id2, id3);
-    }
-
-    @Test
-    void remove_all_by_ids() {
-        Embedding embedding = embeddingModel.embed("hello").content();
-        Embedding embedding2 = embeddingModel.embed("hello2").content();
-        Embedding embedding3 = embeddingModel.embed("hello3").content();
-
-        String id = embeddingStore.add(embedding);
-        String id2 = embeddingStore.add(embedding2);
-        String id3 = embeddingStore.add(embedding3);
-
-        embeddingStore.removeAll(Arrays.asList(id2, id3));
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
-        assertThat(relevant).hasSize(1);
-        assertThat(relevantIds).containsExactly(id);
-    }
-
-    @Test
-    void remove_all_by_ids_null() {
-        assertThatThrownBy(() -> embeddingStore.removeAll((Collection<String>) null))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("ids cannot be null or empty");
-    }
-
-    @Test
-    void remove_all_by_filter() {
-        Metadata metadata = Metadata.metadata("id", "1");
-        TextSegment segment = TextSegment.from("matching", metadata);
-        Embedding embedding = embeddingModel.embed(segment).content();
-        embeddingStore.add(embedding, segment);
-
-        Embedding embedding2 = embeddingModel.embed("hello2").content();
-        Embedding embedding3 = embeddingModel.embed("hello3").content();
-
-        String id2 = embeddingStore.add(embedding2);
-        String id3 = embeddingStore.add(embedding3);
-
-        embeddingStore.removeAll(metadataKey("id").isEqualTo("1"));
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
-        assertThat(relevantIds).hasSize(2);
-        assertThat(relevantIds).containsExactly(id2, id3);
-    }
-
-    @Test
-    void remove_all_by_filter_not_matching() {
-        Embedding embedding = embeddingModel.embed("hello").content();
-        Embedding embedding2 = embeddingModel.embed("hello2").content();
-        Embedding embedding3 = embeddingModel.embed("hello3").content();
-
-        embeddingStore.add(embedding);
-        embeddingStore.add(embedding2);
-        embeddingStore.add(embedding3);
-
-        embeddingStore.removeAll(metadataKey("unknown").isEqualTo("1"));
-
-        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(embedding, 10);
-        List<String> relevantIds = relevant.stream().map(EmbeddingMatch::embeddingId).collect(Collectors.toList());
-        assertThat(relevantIds).hasSize(3);
-    }
-
-    @Test
-    void remove_all_by_filter_null() {
-        assertThatThrownBy(() -> embeddingStore.removeAll((Filter) null))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("filter cannot be null");
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
+++ b/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
@@ -17,6 +17,7 @@ import java.util.stream.IntStream;
 
 import static dev.langchain4j.internal.Utils.randomUUID;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.nio.file.StandardOpenOption.CREATE;
@@ -102,11 +103,15 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
 
     @Override
     public void removeAll(Collection<String> ids) {
+        ensureNotEmpty(ids, "ids");
+
         entries.removeIf(entry -> ids.contains(entry.id));
     }
 
     @Override
     public void removeAll(Filter filter) {
+        ensureNotNull(filter, "filter");
+
         entries.removeIf(entry -> {
             if (entry.embedded instanceof TextSegment) {
                 return filter.test(((TextSegment) entry.embedded).metadata());

--- a/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
+++ b/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
@@ -115,6 +115,8 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
         entries.removeIf(entry -> {
             if (entry.embedded instanceof TextSegment) {
                 return filter.test(((TextSegment) entry.embedded).metadata());
+            } else if (entry.embedded == null) {
+                return false;
             } else {
                 throw new UnsupportedOperationException("Not supported yet.");
             }

--- a/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
+++ b/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
@@ -96,6 +96,32 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
     }
 
     @Override
+    public void remove(String id) {
+        entries.removeIf(entry -> entry.id.equals(id));
+    }
+
+    @Override
+    public void removeAll(Collection<String> ids) {
+        entries.removeIf(entry -> ids.contains(entry.id));
+    }
+
+    @Override
+    public void removeAll(Filter filter) {
+        entries.removeIf(entry -> {
+            if (entry.embedded instanceof TextSegment) {
+                return filter.test(((TextSegment) entry.embedded).metadata());
+            } else {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
+        });
+    }
+
+    @Override
+    public void removeAll() {
+        entries.clear();
+    }
+
+    @Override
     public EmbeddingSearchResult<Embedded> search(EmbeddingSearchRequest embeddingSearchRequest) {
 
         Comparator<EmbeddingMatch<Embedded>> comparator = comparingDouble(EmbeddingMatch::score);

--- a/langchain4j/src/test/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStoreRemovalTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStoreRemovalTest.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.store.embedding.inmemory;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
+
+public class InMemoryEmbeddingStoreRemovalTest extends EmbeddingStoreWithRemovalIT {
+    EmbeddingStore<TextSegment> embeddingStore = new InMemoryEmbeddingStore<>();
+
+    EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+
+    @Override
+    protected EmbeddingModel embeddingModel() {
+        return embeddingModel;
+    }
+}


### PR DESCRIPTION
<!-- Thank you so much for your contribution! -->
<!-- Please fill in all the sections below. -->

<!-- Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples. -->
<!-- Please note that PRs with breaking changes will be rejected. -->
<!-- Please note that PRs without tests will be rejected. -->

<!-- Please note that PRs will be reviewed based on the priority of the issues they address. -->
<!-- We ask for your patience. We are doing our best to review your PR as quickly as possible. -->
<!-- Please refrain from pinging and asking when it will be reviewed. Thank you for understanding! -->


## Issue
[https://github.com/langchain4j/langchain4j/issues/301](https://github.com/langchain4j/langchain4j/issues/301)


## Change
I've implemented remove methods for InMemoryEmbeddingStore.

Current problems:
1. I'm not completely sure how to test all of this. And, as I've seen, you don't fully test it too)
2. There is a very nasty problem with `removeAll(Filter filter)` . Let me try to break it in small pieces:
   1. `EmbeddingStore`'s are parametrized with `Embedded` type parameter.
   2. `removeAll(Filter filter)` method in `EmbeddingStore` accepts `Filter`.
   3. `Filter` accepts `Metadata` object.
   4. `Metadata` object is stored in `TextSegment`.
   5. `TextSegment` is usually what is `Embedded`. But it's not guaranteed.

How my pull request deals with this problem: 
1) for every entry in `InMemoryEmbeddingStore` check the type of `Embedded`. 
2) If it's a `TextSegment`, then proceed.
3) If it's not, then raise `UnsupportedOperationException`.
The issue with this strategy is that we perform the check for every entry. I haven't found a way in Java to check the type of type parameter (because it's erasured in runtime). (*In C++, for example, there are `constexpr if`, `<type_traits>`, `std::is_same<U, V>`, explicit specialization, etc.*)

We could solve this problem if `InMemoryEmbeddingStore` would support only `TextSegment` as `Embedded`, but that's a breaking change.

I could also not implement this method, but, I really really need it in my project (if we chose to stick with `InMemoryEmbeddingStore`).
  


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)


## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
