### PR TITLE
refactor(redis): improve init logic for JedisPooled client

### DIFF
--- a/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStore.java
+++ b/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStore.java
@@ -76,7 +76,12 @@ public class RedisEmbeddingStore implements EmbeddingStore<TextSegment> {
         ensureNotNull(port, "port");
         ensureNotNull(dimension, "dimension");
 
-        this.client = user == null ? new JedisPooled(host, port) : new JedisPooled(host, port, user, password);
+        if (password != null) {
+            ensureNotBlank(password, "password");
+            this.client = new JedisPooled(host, port, user, password);
+        } else {
+            this.client = new JedisPooled(host, port);
+        }
         this.schema = RedisSchema.builder()
             .indexName(getOrDefault(indexName, "embedding-index"))
             .prefix(getOrDefault(prefix, "embedding:"))

--- a/langchain4j-redis/src/main/java/dev/langchain4j/store/memory/chat/redis/RedisChatMemoryStore.java
+++ b/langchain4j-redis/src/main/java/dev/langchain4j/store/memory/chat/redis/RedisChatMemoryStore.java
@@ -9,7 +9,9 @@ import redis.clients.jedis.JedisPooled;
 import java.util.ArrayList;
 import java.util.List;
 
-import static dev.langchain4j.internal.ValidationUtils.*;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 public class RedisChatMemoryStore implements ChatMemoryStore {
 
@@ -19,14 +21,13 @@ public class RedisChatMemoryStore implements ChatMemoryStore {
                                 Integer port,
                                 String user,
                                 String password) {
-        String finalHost = ensureNotBlank(host, "host");
-        int finalPort = ensureNotNull(port, "port");
-        if (user != null) {
-            String finalUser = ensureNotBlank(user, "user");
-            String finalPassword = ensureNotBlank(password, "password");
-            this.client = new JedisPooled(finalHost, finalPort, finalUser, finalPassword);
+        ensureNotBlank(host, "host");
+        ensureNotNull(port, "port");
+        if (password != null) {
+            ensureNotBlank(password, "password");
+            this.client = new JedisPooled(host, port, user, password);
         } else {
-            this.client = new JedisPooled(finalHost, finalPort);
+            this.client = new JedisPooled(host, port);
         }
     }
 

--- a/langchain4j-redis/src/test/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStoreIT.java
+++ b/langchain4j-redis/src/test/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStoreIT.java
@@ -8,14 +8,20 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreIT;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.exceptions.JedisAccessControlException;
+import redis.clients.jedis.exceptions.JedisDataException;
 
 import static com.redis.testcontainers.RedisStackContainer.DEFAULT_IMAGE_NAME;
 import static com.redis.testcontainers.RedisStackContainer.DEFAULT_TAG;
 import static dev.langchain4j.internal.Utils.randomUUID;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RedisEmbeddingStoreIT extends EmbeddingStoreIT {
 
-    static RedisContainer redis = new RedisContainer(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG));
+    static RedisContainer redis = new RedisContainer(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG))
+            .withEnv("REDIS_ARGS", "--requirepass redis-stack");
 
     EmbeddingStore<TextSegment> embeddingStore;
 
@@ -36,6 +42,8 @@ class RedisEmbeddingStoreIT extends EmbeddingStoreIT {
         embeddingStore = RedisEmbeddingStore.builder()
             .host(redis.getHost())
             .port(redis.getFirstMappedPort())
+            // We can ignore username when using the `default` user.
+            .password("redis-stack")
             .indexName(randomUUID())
             .prefix(randomUUID() + ":")
             .dimension(384)
@@ -51,5 +59,44 @@ class RedisEmbeddingStoreIT extends EmbeddingStoreIT {
     @Override
     protected EmbeddingModel embeddingModel() {
         return embeddingModel;
+    }
+
+    @Test
+    public void testAuthPass() {
+        assertThatNoException().isThrownBy(() -> RedisEmbeddingStore.builder()
+                .host(redis.getHost())
+                .port(redis.getFirstMappedPort())
+                .password("redis-stack")
+                .indexName(randomUUID())
+                .dimension(384)
+                .metadataKeys(createMetadata().toMap().keySet())
+                .build());
+    }
+
+    @Test
+    public void testUnauthorized() {
+        assertThatThrownBy(() -> RedisEmbeddingStore.builder()
+                        .host(redis.getHost())
+                        .port(redis.getFirstMappedPort())
+                        .indexName(randomUUID())
+                        .dimension(384)
+                        .metadataKeys(createMetadata().toMap().keySet())
+                        .build())
+                .isInstanceOf(JedisDataException.class)
+                .hasMessageContaining("NOAUTH Authentication required.");
+    }
+
+    @Test
+    public void testAuthenticationFailed() {
+        assertThatThrownBy(() -> RedisEmbeddingStore.builder()
+                        .port(redis.getFirstMappedPort())
+                        .host(redis.getHost())
+                        .password("wrong-password")
+                        .indexName(randomUUID())
+                        .dimension(384)
+                        .metadataKeys(createMetadata().toMap().keySet())
+                        .build())
+                .isInstanceOf(JedisAccessControlException.class)
+                .hasMessageContaining("WRONGPASS invalid username-password pair or user is disabled.");
     }
 }


### PR DESCRIPTION
The Redis AUTH command can use it in two forms. [redis-security-acl](https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/):

After redis 6.0:
```bash
AUTH <username> <password>
```

Before redis 6.0:
```bash
AUTH <password>
```

So I think it is more reasonable to judge whether `password` is null when initializing the redis client.
