### PR TITLE
Open up access to ServiceOutputParser#jsonStructure

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
@@ -118,7 +118,7 @@ public class ServiceOutputParser {
         return "\nYou must answer strictly in the following JSON format: " + jsonStructure(returnType, new HashSet<>());
     }
 
-    private static String jsonStructure(Class<?> structured, Set<Class<?>> visited) {
+    public static String jsonStructure(Class<?> structured, Set<Class<?>> visited) {
         StringBuilder jsonSchema = new StringBuilder();
 
         jsonSchema.append("{\n");


### PR DESCRIPTION
This is useful in Quarkus, so we can add better support for `List<SomeType> ` (although we will eventually probably end up writing our own since we have all the generic type information and can expand more types)