### PR TITLE
Draft: [BUG 1340] Updates naming of keys prefix and index in RedisEmbeddingStore

### DIFF
--- a/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStore.java
+++ b/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStore.java
@@ -63,7 +63,7 @@ public class RedisEmbeddingStore implements EmbeddingStore<TextSegment> {
         this.client = user == null ? new JedisPooled(host, port) : new JedisPooled(host, port, user, password);
         this.schema = RedisSchema.builder()
                 .prefix(toPrefix(getOrDefault(name, "embedding")))
-                .indexName(toIndex(getOrDefault(name, "embedding-index")))
+                .indexName(toIndexName(getOrDefault(name, "embedding-index")))
                 .dimension(dimension)
                 .metadataKeys(metadataKeys)
                 .build();
@@ -77,7 +77,7 @@ public class RedisEmbeddingStore implements EmbeddingStore<TextSegment> {
         return name + ":";
     }
 
-    private static String toIndex(String name) {
+    private static String toIndexName(String name) {
         return name + "-index";
     }
 

--- a/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStore.java
+++ b/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStore.java
@@ -271,7 +271,7 @@ public class RedisEmbeddingStore implements EmbeddingStore<TextSegment> {
         
         /**
          * @param name The name of the store (optional). Used for prefix and index name generation. 
-         * Default value: "embedding:".
+         * Default value: "embedding".
          * @return builder
          */
         public Builder name(String name) {

--- a/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStore.java
+++ b/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStore.java
@@ -268,6 +268,15 @@ public class RedisEmbeddingStore implements EmbeddingStore<TextSegment> {
             return this;
         }
 
+        /**
+         * @param indexName The name of the index (optional). Default value: "embedding-index".
+         * @deprecated use {@link #name(String)} instead. Method does not modify the Redis index name.
+         * Default value is used for the name of the index.
+         */
+        @Deprecated
+        public Builder indexName(String name) {
+            return this;
+        }
         
         /**
          * @param name The name of the store (optional). Used for prefix and index name generation. 

--- a/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStore.java
+++ b/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStore.java
@@ -63,7 +63,7 @@ public class RedisEmbeddingStore implements EmbeddingStore<TextSegment> {
         this.client = user == null ? new JedisPooled(host, port) : new JedisPooled(host, port, user, password);
         this.schema = RedisSchema.builder()
                 .prefix(toPrefix(getOrDefault(name, "embedding")))
-                .indexName(toIndexName(getOrDefault(name, "embedding-index")))
+                .indexName(toIndexName(getOrDefault(name, "embedding")))
                 .dimension(dimension)
                 .metadataKeys(metadataKeys)
                 .build();

--- a/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisSchema.java
+++ b/langchain4j-redis/src/main/java/dev/langchain4j/store/embedding/redis/RedisSchema.java
@@ -27,8 +27,7 @@ class RedisSchema {
     /* Redis schema field settings */
 
     private String indexName;
-    @Builder.Default
-    private String prefix = "embedding:";
+    private String prefix;
     @Builder.Default
     private String vectorFieldName = "vector";
     @Builder.Default

--- a/langchain4j-redis/src/test/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStoreIT.java
+++ b/langchain4j-redis/src/test/java/dev/langchain4j/store/embedding/redis/RedisEmbeddingStoreIT.java
@@ -1,18 +1,24 @@
 package dev.langchain4j.store.embedding.redis;
 
 import com.redis.testcontainers.RedisContainer;
+import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreIT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import redis.clients.jedis.JedisPooled;
+import org.junit.jupiter.api.Test;
 
 import static com.redis.testcontainers.RedisStackContainer.DEFAULT_IMAGE_NAME;
 import static com.redis.testcontainers.RedisStackContainer.DEFAULT_TAG;
 import static dev.langchain4j.internal.Utils.randomUUID;
+import java.util.List;
 
 class RedisEmbeddingStoreIT extends EmbeddingStoreIT {
 
@@ -34,17 +40,7 @@ class RedisEmbeddingStoreIT extends EmbeddingStoreIT {
 
     @Override
     protected void clearStore() {
-        try (JedisPooled jedis = new JedisPooled(redis.getHost(), redis.getFirstMappedPort())) {
-            jedis.flushDB(); // TODO fix: why redis returns embeddings from different indexes?
-        }
-
-        embeddingStore = RedisEmbeddingStore.builder()
-                .host(redis.getHost())
-                .port(redis.getFirstMappedPort())
-                .indexName(randomUUID())
-                .dimension(384)
-                .metadataKeys(createMetadata().toMap().keySet())
-                .build();
+        embeddingStore = createStore(randomUUID());
     }
 
     @Override
@@ -56,4 +52,47 @@ class RedisEmbeddingStoreIT extends EmbeddingStoreIT {
     protected EmbeddingModel embeddingModel() {
         return embeddingModel;
     }
+    
+    @Test
+    void should_find_embedding_in_proper_store() {
+       final EmbeddingStore<TextSegment> firstStore = createStore("first-store");
+       final EmbeddingStore<TextSegment> secondStore = createStore("second-store");
+
+       Embedding embedding = embeddingModel().embed("hello").content();
+
+       String id = firstStore.add(embedding);
+       assertThat(id).isNotBlank();
+
+       awaitUntilPersisted();
+
+       List<EmbeddingMatch<TextSegment>> relevant = firstStore.findRelevant(embedding, 10);
+       assertThat(relevant).hasSize(1);
+       assertThat(secondStore.findRelevant(embedding, 10)).hasSize(0);
+       
+       EmbeddingMatch<TextSegment> match = relevant.get(0);
+       assertThat(match.score()).isCloseTo(1, withPercentage(1));
+       assertThat(match.embeddingId()).isEqualTo(id);
+       assertThat(match.embedding()).isEqualTo(embedding);
+       assertThat(match.embedded()).isNull();
+
+       // new API
+       assertThat(firstStore.search(EmbeddingSearchRequest.builder()
+               .queryEmbedding(embedding)
+               .maxResults(10)
+               .build()).matches()).isEqualTo(relevant);
+       assertThat(secondStore.search(EmbeddingSearchRequest.builder()
+               .queryEmbedding(embedding)
+               .maxResults(10)
+               .build()).matches()).hasSize(0);
+    }
+    
+    private EmbeddingStore<TextSegment> createStore(String name) {
+      return RedisEmbeddingStore.builder()
+          .host(redis.getHost())
+          .port(redis.getFirstMappedPort())
+          .name(name)
+          .dimension(384)
+          .metadataKeys(createMetadata().toMap().keySet())
+          .build();      
+  }      
 }


### PR DESCRIPTION
## Issue
Fixes https://github.com/langchain4j/langchain4j/issues/1340


## Change

For creation of the **RedisEmbeddingStore**, field 'name' was created and is used instead of 'indexName'. 
'name' field is used to create indexName and key prefix for **RedisSchema**.
Redis index name and key prefix are now connected, as both uses provided name as a base.
Default values were kept as in the original implemention, to keep backward compatibility.
Integration test was added in the RedisEmbeddingStoreIT, as issue with indexes is specific to the Redis.

With this implementation, if unique storage name is used, Redis embedding store would only return results from current store.


## General checklist
- [X] There are no breaking changes
- [ ] ?_(only integration test)_ I have added unit and integration tests for my change 
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] ?_(tests that required api key were skipped, rest green)_ I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] ?_(previously persisted data can be used with default name, after fix new stores would use custom name)_ I have manually verified that the `RedisEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
