### PR TITLE
[BUG-1339] - removed trailing commas from tool execution request argu…

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolExecutionRequestUtil.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolExecutionRequestUtil.java
@@ -4,6 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Utility class for {@link ToolExecutionRequest}.
@@ -42,6 +44,20 @@ public class ToolExecutionRequestUtil {
      * @return map
      */
     public static Map<String, Object> argumentsAsMap(String arguments) {
-        return GSON.fromJson(arguments, MAP_TYPE);
+        return GSON.fromJson(removeTrailingComma(arguments), MAP_TYPE);
+    }
+
+    /**
+     * Removes trailing commas before closing braces or brackets in JSON strings.
+     * @param json the JSON string
+     * @return the corrected JSON string
+     */
+    private static String removeTrailingComma(String json) {
+        if (json == null || json.isEmpty()) {
+            return json;
+        }
+        Pattern pattern = Pattern.compile(",(\\s*[}\\]])");
+        Matcher matcher = pattern.matcher(json);
+        return matcher.replaceAll("$1");
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolExecutionRequestUtilTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolExecutionRequestUtilTest.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.agent.tool;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.internal.LinkedTreeMap;
+import java.util.ArrayList;
+import java.util.List;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
@@ -20,5 +25,48 @@ class ToolExecutionRequestUtilTest implements WithAssertions {
                 .isEqualTo("bar");
         assertThat((Number) ToolExecutionRequestUtil.argument(request, "qux"))
                 .isEqualTo(12.0);
+    }
+
+    @Test
+    public void test_argument_comma() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                                                           .id("id")
+                                                           .name("name")
+                                                           .arguments("{\"foo\":\"bar\", \"qux\": 12,}")
+                                                           .build();
+
+        assertThat(ToolExecutionRequestUtil.argumentsAsMap(request.arguments()))
+              .containsEntry("foo", "bar")
+              .containsEntry("qux", 12.0);
+
+        assertThat((String) ToolExecutionRequestUtil.argument(request, "foo"))
+              .isEqualTo("bar");
+        assertThat((Number) ToolExecutionRequestUtil.argument(request, "qux"))
+              .isEqualTo(12.0);
+    }
+
+    @Test
+    public void test_argument_comma_array() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                                                           .id("id")
+                                                           .name("name")
+                                                           .arguments(
+                                                                 "{\"key\":[{\"foo\":\"bar\", \"qux\": 12,},{\"foo\":\"bar\", \"qux\": 12,},]}")
+                                                           .build();
+
+        assertThat(ToolExecutionRequestUtil.argumentsAsMap(request.arguments()))
+              .containsKey("key");
+
+        assertTrue(ToolExecutionRequestUtil.argument(request, "key") instanceof ArrayList);
+
+        List<Object> keys = ToolExecutionRequestUtil.argument(request, "key");
+
+        keys.forEach(key -> {
+            assertTrue(key instanceof LinkedTreeMap);
+            assertTrue(((LinkedTreeMap<?, ?>) key).containsKey("foo"));
+            assertTrue(((LinkedTreeMap<?, ?>) key).containsKey("qux"));
+            assertThat(((LinkedTreeMap<?, ?>) key).get("foo")).isEqualTo("bar");
+            assertThat(((LinkedTreeMap<?, ?>) key).get("qux")).isEqualTo(12.0);
+        });
     }
 }


### PR DESCRIPTION
As per https://github.com/langchain4j/langchain4j/issues/1339#issuecomment-2186074825 
Removed trailing commasa from arguments of tool execution request before parsing it as JSON.

## Issue
https://github.com/langchain4j/langchain4j/issues/1339#issuecomment-2186074825


## Change
Removed trailing commasa from arguments of tool execution request before parsing it as JSON.


## General checklist
- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
