### PR TITLE
#725: PR 1 / 4:  Addresses `EnumOutputParser` not being called

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -28,10 +28,11 @@ import static dev.langchain4j.exception.IllegalConfigurationException.illegalCon
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.Exceptions.runtime;
 import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
-import static dev.langchain4j.service.ServiceOutputParser.outputFormatInstructions;
-import static dev.langchain4j.service.ServiceOutputParser.parse;
+
 
 class DefaultAiServices<T> extends AiServices<T> {
+
+    private final ServiceOutputParser serviceOutputParser = new ServiceOutputParser(new DefaultOutputParserFactory());
 
     private static final int MAX_SEQUENTIAL_TOOL_EXECUTIONS = 10;
 
@@ -117,7 +118,7 @@ class DefaultAiServices<T> extends AiServices<T> {
                                 returnType = Class.forName(typeArg.getTypeName());
                             }
                         }
-                        String outputFormatInstructions = outputFormatInstructions(returnType);
+                        String outputFormatInstructions = serviceOutputParser.outputFormatInstructions(returnType);
                         String text = userMessage.singleText() + outputFormatInstructions;
                         if (isNotNullOrBlank(userMessage.name())) {
                             userMessage = UserMessage.from(userMessage.name(), text);
@@ -197,7 +198,7 @@ class DefaultAiServices<T> extends AiServices<T> {
                         }
 
                         response = Response.from(response.content(), tokenUsageAccumulator, response.finishReason());
-                        Object parsedResponse = parse(response, returnType);
+                        Object parsedResponse = serviceOutputParser.parse(response, returnType);
 
                         if (isReturnTypeResult) {
                             return Result.builder()

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultOutputParserFactory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultOutputParserFactory.java
@@ -1,0 +1,65 @@
+package dev.langchain4j.service;
+
+import dev.langchain4j.model.output.*;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class DefaultOutputParserFactory implements OutputParserFactory {
+
+    private static final Map<Class<?>, OutputParser<?>> OUTPUT_PARSERS = new HashMap<>();
+
+    static {
+        OUTPUT_PARSERS.put(boolean.class, new BooleanOutputParser());
+        OUTPUT_PARSERS.put(Boolean.class, new BooleanOutputParser());
+
+        OUTPUT_PARSERS.put(byte.class, new ByteOutputParser());
+        OUTPUT_PARSERS.put(Byte.class, new ByteOutputParser());
+
+        OUTPUT_PARSERS.put(short.class, new ShortOutputParser());
+        OUTPUT_PARSERS.put(Short.class, new ShortOutputParser());
+
+        OUTPUT_PARSERS.put(int.class, new IntOutputParser());
+        OUTPUT_PARSERS.put(Integer.class, new IntOutputParser());
+
+        OUTPUT_PARSERS.put(long.class, new LongOutputParser());
+        OUTPUT_PARSERS.put(Long.class, new LongOutputParser());
+
+        OUTPUT_PARSERS.put(BigInteger.class, new BigIntegerOutputParser());
+
+        OUTPUT_PARSERS.put(float.class, new FloatOutputParser());
+        OUTPUT_PARSERS.put(Float.class, new FloatOutputParser());
+
+        OUTPUT_PARSERS.put(double.class, new DoubleOutputParser());
+        OUTPUT_PARSERS.put(Double.class, new DoubleOutputParser());
+
+        OUTPUT_PARSERS.put(BigDecimal.class, new BigDecimalOutputParser());
+
+        OUTPUT_PARSERS.put(Date.class, new DateOutputParser());
+        OUTPUT_PARSERS.put(LocalDate.class, new LocalDateOutputParser());
+        OUTPUT_PARSERS.put(LocalTime.class, new LocalTimeOutputParser());
+        OUTPUT_PARSERS.put(LocalDateTime.class, new LocalDateTimeOutputParser());
+    }
+
+    @Override
+    public Optional<OutputParser<?>> get(Class<?> returnType) {
+        if (returnType.isEnum()) {
+            return Optional.of(new EnumOutputParser(returnType.asSubclass(Enum.class)));
+        }
+
+        OutputParser<?> outputParser = OUTPUT_PARSERS.get(returnType);
+        if (outputParser != null) {
+            return Optional.of(outputParser);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/OutputParserFactory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/OutputParserFactory.java
@@ -1,0 +1,9 @@
+package dev.langchain4j.service;
+
+import dev.langchain4j.model.output.OutputParser;
+
+import java.util.Optional;
+
+public interface OutputParserFactory {
+    Optional<OutputParser<?>> get(Class<?> returnType);
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/ServiceOutputParser.java
@@ -8,11 +8,6 @@ import dev.langchain4j.model.output.structured.Description;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.*;
 
 import static dev.langchain4j.exception.IllegalConfigurationException.illegalConfiguration;
@@ -21,41 +16,13 @@ import static java.util.Arrays.asList;
 
 public class ServiceOutputParser {
 
-    private static final Map<Class<?>, OutputParser<?>> OUTPUT_PARSERS = new HashMap<>();
+    OutputParserFactory outputParserFactory;
 
-    static {
-        OUTPUT_PARSERS.put(boolean.class, new BooleanOutputParser());
-        OUTPUT_PARSERS.put(Boolean.class, new BooleanOutputParser());
-
-        OUTPUT_PARSERS.put(byte.class, new ByteOutputParser());
-        OUTPUT_PARSERS.put(Byte.class, new ByteOutputParser());
-
-        OUTPUT_PARSERS.put(short.class, new ShortOutputParser());
-        OUTPUT_PARSERS.put(Short.class, new ShortOutputParser());
-
-        OUTPUT_PARSERS.put(int.class, new IntOutputParser());
-        OUTPUT_PARSERS.put(Integer.class, new IntOutputParser());
-
-        OUTPUT_PARSERS.put(long.class, new LongOutputParser());
-        OUTPUT_PARSERS.put(Long.class, new LongOutputParser());
-
-        OUTPUT_PARSERS.put(BigInteger.class, new BigIntegerOutputParser());
-
-        OUTPUT_PARSERS.put(float.class, new FloatOutputParser());
-        OUTPUT_PARSERS.put(Float.class, new FloatOutputParser());
-
-        OUTPUT_PARSERS.put(double.class, new DoubleOutputParser());
-        OUTPUT_PARSERS.put(Double.class, new DoubleOutputParser());
-
-        OUTPUT_PARSERS.put(BigDecimal.class, new BigDecimalOutputParser());
-
-        OUTPUT_PARSERS.put(Date.class, new DateOutputParser());
-        OUTPUT_PARSERS.put(LocalDate.class, new LocalDateOutputParser());
-        OUTPUT_PARSERS.put(LocalTime.class, new LocalTimeOutputParser());
-        OUTPUT_PARSERS.put(LocalDateTime.class, new LocalDateTimeOutputParser());
+    public ServiceOutputParser(OutputParserFactory outputParserFactory) {
+        this.outputParserFactory = outputParserFactory;
     }
 
-    public static Object parse(Response<AiMessage> response, Class<?> returnType) {
+    public Object parse(Response<AiMessage> response, Class<?> returnType) {
 
         if (returnType == Response.class) {
             return response;
@@ -71,9 +38,9 @@ public class ServiceOutputParser {
             return text;
         }
 
-        OutputParser<?> outputParser = OUTPUT_PARSERS.get(returnType);
-        if (outputParser != null) {
-            return outputParser.parse(text);
+        Optional<OutputParser<?>> optionalOutputParser = outputParserFactory.get(returnType);
+        if (optionalOutputParser.isPresent()) {
+            return optionalOutputParser.get().parse(text);
         }
 
         if (returnType == List.class) {
@@ -87,7 +54,7 @@ public class ServiceOutputParser {
         return Json.fromJson(text, returnType);
     }
 
-    public static String outputFormatInstructions(Class<?> returnType) {
+    public String outputFormatInstructions(Class<?> returnType) {
 
         if (returnType == String.class
                 || returnType == AiMessage.class
@@ -105,9 +72,9 @@ public class ServiceOutputParser {
             return "\nYou must answer strictly in the following format: " + formatInstructions;
         }
 
-        OutputParser<?> outputParser = OUTPUT_PARSERS.get(returnType);
-        if (outputParser != null) {
-            String formatInstructions = outputParser.formatInstructions();
+        Optional<OutputParser<?>> outputParser = outputParserFactory.get(returnType);
+        if (outputParser.isPresent()) {
+            String formatInstructions = outputParser.get().formatInstructions();
             return "\nYou must answer strictly in the following format: " + formatInstructions;
         }
 


### PR DESCRIPTION
## Issue

#725 PR 1 / 4: Addresses `EnumOutputParser` not being called.

## Change

Fixed `EnumOutputParser` not being called.

Introduced new unit test which makes sure that correct output parsers are being called (including the one above).

Note that I had to refactor `DefaultAiServices` by extracting logic for picking up the correct `OutputParser` based on the returned type in order to cover my changes with unit test.

## General checklist

- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
