### PR TITLE
Bump com.azure:azure-ai-openai from 1.0.0-beta.8 to 1.0.0-beta.10

### DIFF
--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAIResponsibleAIIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAIResponsibleAIIT.java
@@ -80,7 +80,7 @@ public class AzureOpenAIResponsibleAIIT {
         AzureOpenAiImageModel model = AzureOpenAiImageModel.builder()
                 .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
                 .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-                .deploymentName("dall-e-3")
+                .deploymentName("dall-e-3-30")
                 .logRequestsAndResponses(true)
                 .build();
 
@@ -98,7 +98,7 @@ public class AzureOpenAIResponsibleAIIT {
         LanguageModel model = AzureOpenAiLanguageModel.builder()
                 .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
                 .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-                .deploymentName("gpt-35-turbo-instruct")
+                .deploymentName("gpt-35-turbo-instruct-0914")
                 .tokenizer(new AzureOpenAiTokenizer(GPT_3_5_TURBO_INSTRUCT))
                 .temperature(0.0)
                 .maxTokens(20)
@@ -170,7 +170,7 @@ public class AzureOpenAIResponsibleAIIT {
         StreamingLanguageModel model = AzureOpenAiStreamingLanguageModel.builder()
                 .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
                 .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-                .deploymentName("gpt-35-turbo-instruct")
+                .deploymentName("gpt-35-turbo-instruct-0914")
                 .tokenizer(new AzureOpenAiTokenizer(GPT_3_5_TURBO_INSTRUCT))
                 .temperature(0.0)
                 .maxTokens(20)

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiEmbeddingModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiEmbeddingModelIT.java
@@ -25,7 +25,7 @@ class AzureOpenAiEmbeddingModelIT {
     EmbeddingModel model = AzureOpenAiEmbeddingModel.builder()
             .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
             .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-            .deploymentName("text-embedding-ada-002")
+            .deploymentName("text-embedding-ada-002-2")
             .tokenizer(new AzureOpenAiTokenizer(TEXT_EMBEDDING_ADA_002))
             .logRequestsAndResponses(true)
             .build();
@@ -73,7 +73,7 @@ class AzureOpenAiEmbeddingModelIT {
 
     @ParameterizedTest(name = "Testing model {0}")
     @EnumSource(value = AzureOpenAiEmbeddingModelName.class,
-            mode = EXCLUDE, names = "TEXT_EMBEDDING_ADA_002_2")
+            mode = EXCLUDE, names = {"TEXT_EMBEDDING_ADA_002_2", "TEXT_EMBEDDING_3_SMALL", "TEXT_EMBEDDING_3_SMALL_1", "TEXT_EMBEDDING_3_LARGE", "TEXT_EMBEDDING_ADA_002", "TEXT_EMBEDDING_ADA_002_1"})
     void should_support_all_string_model_names(AzureOpenAiEmbeddingModelName modelName) {
 
         // given

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiImageModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiImageModelIT.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 
 public class AzureOpenAiImageModelIT {
 
@@ -26,7 +27,7 @@ public class AzureOpenAiImageModelIT {
         AzureOpenAiImageModel model = AzureOpenAiImageModel.builder()
                 .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
                 .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-                .deploymentName("dall-e-3")
+                .deploymentName("dall-e-3-30")
                 .logRequestsAndResponses(true)
                 .build();
 
@@ -50,7 +51,7 @@ public class AzureOpenAiImageModelIT {
         AzureOpenAiImageModel model = AzureOpenAiImageModel.builder()
                 .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
                 .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-                .deploymentName("dall-e-3")
+                .deploymentName("dall-e-3-30")
                 .logRequestsAndResponses(false) // The image is big, so we don't want to log it by default
                 .responseFormat(ImageGenerationResponseFormat.BASE64.toString())
                 .build();
@@ -75,7 +76,7 @@ public class AzureOpenAiImageModelIT {
     }
 
     @ParameterizedTest(name = "Testing model {0}")
-    @EnumSource(AzureOpenAiImageModelName.class)
+    @EnumSource(value = AzureOpenAiImageModelName.class, mode = EXCLUDE, names = "DALL_E_3")
     void should_support_all_string_model_names(AzureOpenAiImageModelName modelName) {
 
         // given

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiLanguageModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiLanguageModelIT.java
@@ -22,7 +22,7 @@ class AzureOpenAiLanguageModelIT {
     LanguageModel model = AzureOpenAiLanguageModel.builder()
             .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
             .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-            .deploymentName("gpt-35-turbo-instruct")
+            .deploymentName("gpt-35-turbo-instruct-0914")
             .tokenizer(new AzureOpenAiTokenizer(GPT_3_5_TURBO_INSTRUCT))
             .temperature(0.0)
             .maxTokens(20)
@@ -59,7 +59,7 @@ class AzureOpenAiLanguageModelIT {
 
     @ParameterizedTest(name = "Testing model {0}")
     @EnumSource(value = AzureOpenAiLanguageModelName.class,
-            mode = EXCLUDE, names = {"TEXT_DAVINCI_002", "TEXT_DAVINCI_002_1"})
+            mode = EXCLUDE, names = {"GPT_3_5_TURBO_INSTRUCT", "TEXT_DAVINCI_002", "TEXT_DAVINCI_002_1"})
     void should_support_all_string_model_names(AzureOpenAiLanguageModelName modelName) {
 
         // given

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelIT.java
@@ -47,6 +47,8 @@ class AzureOpenAiStreamingChatModelIT {
 
     Percentage tokenizerPrecision = withPercentage(5);
 
+    public long STREAMING_TIMEOUT = 120;
+
     @ParameterizedTest(name = "Deployment name {0} using {1} with async client set to {2}")
     @CsvSource({
             "gpt-4o,        gpt-4o, true",
@@ -90,8 +92,8 @@ class AzureOpenAiStreamingChatModelIT {
             }
         });
 
-        String answer = futureAnswer.get(30, SECONDS);
-        Response<AiMessage> response = futureResponse.get(30, SECONDS);
+        String answer = futureAnswer.get(STREAMING_TIMEOUT, SECONDS);
+        Response<AiMessage> response = futureResponse.get(STREAMING_TIMEOUT, SECONDS);
 
         assertThat(answer).contains("Paris");
         assertThat(response.content().text()).isEqualTo(answer);
@@ -154,8 +156,8 @@ class AzureOpenAiStreamingChatModelIT {
             }
         });
 
-        String answer = futureAnswer.get(30, SECONDS);
-        Response<AiMessage> response = futureResponse.get(30, SECONDS);
+        String answer = futureAnswer.get(STREAMING_TIMEOUT, SECONDS);
+        Response<AiMessage> response = futureResponse.get(STREAMING_TIMEOUT, SECONDS);
 
         assertThat(answer).contains("Paris");
         assertThat(response.content().text()).isEqualTo(answer);
@@ -241,7 +243,7 @@ class AzureOpenAiStreamingChatModelIT {
             }
         });
 
-        Response<AiMessage> response = futureResponse.get(30, SECONDS);
+        Response<AiMessage> response = futureResponse.get(STREAMING_TIMEOUT, SECONDS);
 
         AiMessage aiMessage = response.content();
         assertThat(aiMessage.text()).isNull();
@@ -282,7 +284,7 @@ class AzureOpenAiStreamingChatModelIT {
             }
         });
 
-        Response<AiMessage> response2 = futureResponse2.get(30, SECONDS);
+        Response<AiMessage> response2 = futureResponse2.get(STREAMING_TIMEOUT, SECONDS);
         AiMessage aiMessage2 = response2.content();
 
         // then
@@ -356,7 +358,7 @@ class AzureOpenAiStreamingChatModelIT {
             }
         });
 
-        Response<AiMessage> response = futureResponse.get(30, SECONDS);
+        Response<AiMessage> response = futureResponse.get(STREAMING_TIMEOUT, SECONDS);
 
         AiMessage aiMessage = response.content();
         assertThat(aiMessage.text()).isNull();
@@ -402,7 +404,7 @@ class AzureOpenAiStreamingChatModelIT {
             }
         });
 
-        Response<AiMessage> response2 = futureResponse2.get(30, SECONDS);
+        Response<AiMessage> response2 = futureResponse2.get(STREAMING_TIMEOUT, SECONDS);
         AiMessage aiMessage2 = response2.content();
 
         // then
@@ -560,7 +562,7 @@ class AzureOpenAiStreamingChatModelIT {
 
         // when
         model.generate(userMessage, handler);
-        String content = future.get(5, SECONDS);
+        String content = future.get(STREAMING_TIMEOUT, SECONDS);
 
         // then
         assertThat(content).contains("Access denied due to invalid subscription key or wrong API endpoint");

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingLanguageModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingLanguageModelIT.java
@@ -22,7 +22,7 @@ class AzureOpenAiStreamingLanguageModelIT {
     StreamingLanguageModel model = AzureOpenAiStreamingLanguageModel.builder()
             .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
             .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-            .deploymentName("gpt-35-turbo-instruct")
+            .deploymentName("gpt-35-turbo-instruct-0914")
             .tokenizer(new AzureOpenAiTokenizer(GPT_3_5_TURBO_INSTRUCT))
             .temperature(0.0)
             .maxTokens(20)

--- a/langchain4j-azure-open-ai/src/test/script/deploy-azure-openai-models.sh
+++ b/langchain4j-azure-open-ai/src/test/script/deploy-azure-openai-models.sh
@@ -5,9 +5,9 @@
 
 echo "Setting up environment variables..."
 echo "----------------------------------"
-PROJECT="langchain4j-eastus"
+PROJECT="langchain4j-swedencentral"
 RESOURCE_GROUP="rg-$PROJECT"
-LOCATION="eastus"
+LOCATION="swedencentral"
 AI_SERVICE="ai-$PROJECT"
 TAG="$PROJECT"
 
@@ -38,18 +38,6 @@ az cognitiveservices account create \
 # Chat Models
 echo "Deploying Chat Models"
 echo "====================="
-
-echo "Deploying a gpt-35-turbo-0301 model..."
-echo "----------------------"
-az cognitiveservices account deployment create \
-  --name "$AI_SERVICE" \
-  --resource-group "$RESOURCE_GROUP" \
-  --deployment-name "gpt-35-turbo-0301" \
-  --model-name "gpt-35-turbo" \
-  --model-version "0125"  \
-  --model-format "OpenAI" \
-  --sku-capacity 1 \
-  --sku-name "Standard"
 
 echo "Deploying a gpt-35-turbo-0613 model..."
 echo "----------------------"
@@ -95,30 +83,6 @@ az cognitiveservices account deployment create \
   --deployment-name "gpt-4-0613" \
   --model-name "gpt-4" \
   --model-version "0613"  \
-  --model-format "OpenAI" \
-  --sku-capacity 1 \
-  --sku-name "Standard"
-
-echo "Deploying a gpt-4-0125-preview model..."
-echo "----------------------"
-az cognitiveservices account deployment create \
-  --name "$AI_SERVICE" \
-  --resource-group "$RESOURCE_GROUP" \
-  --deployment-name "gpt-4-0125-preview" \
-  --model-name "gpt-4" \
-  --model-version "0125-preview"  \
-  --model-format "OpenAI" \
-  --sku-capacity 1 \
-  --sku-name "Standard"
-
-echo "Deploying a gpt-4-1106-preview model..."
-echo "----------------------"
-az cognitiveservices account deployment create \
-  --name "$AI_SERVICE" \
-  --resource-group "$RESOURCE_GROUP" \
-  --deployment-name "gpt-4-1106-preview" \
-  --model-name "gpt-4" \
-  --model-version "1106-preview"  \
   --model-format "OpenAI" \
   --sku-capacity 1 \
   --sku-name "Standard"
@@ -175,18 +139,6 @@ az cognitiveservices account deployment create \
 echo "Deploying Embedding Models"
 echo "=========================="
 
-echo "Deploying a text-embedding-ada-002-1 model..."
-echo "----------------------"
-az cognitiveservices account deployment create \
-  --name "$AI_SERVICE" \
-  --resource-group "$RESOURCE_GROUP" \
-  --deployment-name "text-embedding-ada-002-1" \
-  --model-name "text-embedding-ada-002" \
-  --model-version "1"  \
-  --model-format "OpenAI" \
-  --sku-capacity 1 \
-  --sku-name "Standard"
-
 echo "Deploying a text-embedding-ada-002-2 model..."
 echo "----------------------"
 az cognitiveservices account deployment create \
@@ -195,18 +147,6 @@ az cognitiveservices account deployment create \
   --deployment-name "text-embedding-ada-002-2" \
   --model-name "text-embedding-ada-002" \
   --model-version "2"  \
-  --model-format "OpenAI" \
-  --sku-capacity 1 \
-  --sku-name "Standard"
-
-echo "Deploying a text-embedding-3-small-1 model..."
-echo "----------------------"
-az cognitiveservices account deployment create \
-  --name "$AI_SERVICE" \
-  --resource-group "$RESOURCE_GROUP" \
-  --deployment-name "text-embedding-3-small-1" \
-  --model-name "text-embedding-3-small" \
-  --model-version "1"  \
   --model-format "OpenAI" \
   --sku-capacity 1 \
   --sku-name "Standard"
@@ -226,18 +166,6 @@ az cognitiveservices account deployment create \
 # Image Models
 echo "Deploying Image Models"
 echo "======================"
-
-echo "Deploying a dall-e-3 model..."
-echo "----------------------"
-az cognitiveservices account deployment create \
-  --name "$AI_SERVICE" \
-  --resource-group "$RESOURCE_GROUP" \
-  --deployment-name "dall-e-2-20" \
-  --model-name "dall-e-2" \
-  --model-version "2.0"  \
-  --model-format "OpenAI" \
-  --sku-capacity 1 \
-  --sku-name "Standard"
 
 echo "Deploying a dall-e-3 model..."
 echo "----------------------"

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>1714382357</project.build.outputTimestamp>
         <openai4j.version>0.17.0</openai4j.version>
-        <azure-ai-openai.version>1.0.0-beta.8</azure-ai-openai.version>
+        <azure-ai-openai.version>1.0.0-beta.10</azure-ai-openai.version>
         <azure-ai-search.version>11.6.6</azure-ai-search.version>
         <azure.storage-blob.version>12.26.1</azure.storage-blob.version>
         <azure.storage-common.version>12.25.1</azure.storage-common.version>


### PR DESCRIPTION
- Bump com.azure:azure-ai-openai from 1.0.0-beta.8 to 1.0.0-beta.10
- Migrate to Sweden Central
- Fix several tests using the same as https://github.com/langchain4j/langchain4j/pull/1022

This skips version 1.0.0-beta.9 because of an important bug, see https://github.com/langchain4j/langchain4j/pull/1247 for more information