### PR TITLE
Mistral AI - Make Client configurable via ChatModel

### DIFF
--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatModel.java
@@ -45,27 +45,29 @@ public class MistralAiChatModel implements ChatLanguageModel {
     /**
      * Constructs a MistralAiChatModel with the specified parameters.
      *
-     * @param baseUrl      the base URL of the Mistral AI API. It uses the default value if not specified
-     * @param apiKey       the API key for authentication
-     * @param modelName    the name of the Mistral AI model to use
-     * @param temperature  the temperature parameter for generating chat responses
-     * @param topP         the top-p parameter for generating chat responses
-     * @param maxTokens    the maximum number of new tokens to generate in a chat response
-     * @param safePrompt   a flag indicating whether to use a safe prompt for generating chat responses
-     * @param randomSeed   the random seed for generating chat responses
-     * @param responseFormat the response format for generating chat responses.
-     *                       <p>
-     *                       Current values supported are "text" and "json_object".
-     * @param timeout      the timeout duration for API requests
-     *                     <p>
-     *                     The default value is 60 seconds
-     * @param logRequests  a flag indicating whether to log API requests
-     * @param logResponses a flag indicating whether to log API responses
-     * @param maxRetries   the maximum number of retries for API requests. It uses the default value 3 if not specified
+     * @param mistralAiClient   the client to interact with Mistral AI.
+     * @param baseUrl           the base URL of the Mistral AI API. It uses the default value if not specified
+     * @param apiKey            the API key for authentication
+     * @param modelName         the name of the Mistral AI model to use
+     * @param temperature       the temperature parameter for generating chat responses
+     * @param topP              the top-p parameter for generating chat responses
+     * @param maxTokens         the maximum number of new tokens to generate in a chat response
+     * @param safePrompt        a flag indicating whether to use a safe prompt for generating chat responses
+     * @param randomSeed        the random seed for generating chat responses
+     * @param responseFormat    the response format for generating chat responses.
+     *                          <p>
+     *                          Current values supported are "text" and "json_object".
+     * @param timeout           the timeout duration for API requests
+     *                          <p>
+     *                          The default value is 60 seconds
+     * @param logRequests       a flag indicating whether to log API requests
+     * @param logResponses      a flag indicating whether to log API responses
+     * @param maxRetries        the maximum number of retries for API requests. It uses the default value 3 if not specified
      */
     @Builder
-    public MistralAiChatModel(String baseUrl,
-                              String apiKey,
+    public MistralAiChatModel(MistralAiClient mistralAiClient,
+                              @Deprecated String baseUrl,
+                              @Deprecated String apiKey,
                               String modelName,
                               Double temperature,
                               Double topP,
@@ -73,12 +75,12 @@ public class MistralAiChatModel implements ChatLanguageModel {
                               Boolean safePrompt,
                               Integer randomSeed,
                               String responseFormat,
-                              Duration timeout,
-                              Boolean logRequests,
-                              Boolean logResponses,
-                              Integer maxRetries) {
-
-        this.client = MistralAiClient.builder()
+                              @Deprecated Duration timeout,
+                              @Deprecated Boolean logRequests,
+                              @Deprecated Boolean logResponses,
+                              Integer maxRetries
+    ) {
+        this.client = mistralAiClient != null ? mistralAiClient : MistralAiClient.builder()
                 .baseUrl(getOrDefault(baseUrl, "https://api.mistral.ai/v1"))
                 .apiKey(apiKey)
                 .timeout(getOrDefault(timeout, Duration.ofSeconds(60)))
@@ -96,11 +98,23 @@ public class MistralAiChatModel implements ChatLanguageModel {
     }
 
     /**
+     * Creates a MistralAiChatModel with the specified Client.
+     *
+     * @param mistralAiClient the client to interact with Mistral AI.
+     * @return a MistralAiChatModel instance
+     */
+    public static MistralAiChatModel withClient(MistralAiClient mistralAiClient) {
+        return builder().mistralAiClient(mistralAiClient).build();
+    }
+
+    /**
      * Creates a MistralAiChatModel with the specified API key.
      *
      * @param apiKey the API key for authentication
      * @return a MistralAiChatModel instance
+     * @deprecated pass a MistralAiClient object using withClient()
      */
+    @Deprecated // Use withClient() instead.
     public static MistralAiChatModel withApiKey(String apiKey) {
         return builder().apiKey(apiKey).build();
     }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiEmbeddingModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiEmbeddingModel.java
@@ -33,25 +33,28 @@ public class MistralAiEmbeddingModel extends DimensionAwareEmbeddingModel {
     /**
      * Constructs a new MistralAiEmbeddingModel instance.
      *
-     * @param baseUrl      the base URL of the Mistral AI API. It use a default value if not specified
-     * @param apiKey       the API key for authentication
-     * @param modelName    the name of the embedding model. It uses a default value if not specified
-     * @param timeout      the timeout duration for API requests. It uses a default value of 60 seconds if not specified
-     *                     <p>
-     *                     The default value is 60 seconds
-     * @param logRequests  a flag indicating whether to log API requests
-     * @param logResponses a flag indicating whether to log API responses
-     * @param maxRetries   the maximum number of retries for API requests. It uses a default value of 3 if not specified
+     * @param mistralAiClient   the client to interact with Mistral AI.
+     * @param baseUrl           the base URL of the Mistral AI API. It use a default value if not specified
+     * @param apiKey            the API key for authentication
+     * @param modelName         the name of the embedding model. It uses a default value if not specified
+     * @param timeout           the timeout duration for API requests. It uses a default value of 60 seconds if not specified
+     *                          <p>
+     *                          The default value is 60 seconds
+     * @param logRequests       a flag indicating whether to log API requests
+     * @param logResponses      a flag indicating whether to log API responses
+     * @param maxRetries        the maximum number of retries for API requests. It uses a default value of 3 if not specified
      */
     @Builder
-    public MistralAiEmbeddingModel(String baseUrl,
-                                   String apiKey,
+    public MistralAiEmbeddingModel(MistralAiClient mistralAiClient,
+                                   @Deprecated String baseUrl,
+                                   @Deprecated String apiKey,
                                    String modelName,
-                                   Duration timeout,
-                                   Boolean logRequests,
-                                   Boolean logResponses,
-                                   Integer maxRetries) {
-        this.client = MistralAiClient.builder()
+                                   @Deprecated Duration timeout,
+                                   @Deprecated Boolean logRequests,
+                                   @Deprecated Boolean logResponses,
+                                   Integer maxRetries
+    ) {
+        this.client = mistralAiClient != null ? mistralAiClient : MistralAiClient.builder()
                 .baseUrl(getOrDefault(baseUrl, "https://api.mistral.ai/v1"))
                 .apiKey(apiKey)
                 .timeout(getOrDefault(timeout, Duration.ofSeconds(60)))
@@ -63,11 +66,23 @@ public class MistralAiEmbeddingModel extends DimensionAwareEmbeddingModel {
     }
 
     /**
+     * Creates a MistralAiEmbeddingModel with the specified Client.
+     *
+     * @param mistralAiClient the client to interact with Mistral AI.
+     * @return a MistralAiEmbeddingModel instance
+     */
+    public static MistralAiEmbeddingModel withClient(MistralAiClient mistralAiClient) {
+        return builder().mistralAiClient(mistralAiClient).build();
+    }
+
+    /**
      * Creates a new MistralAiEmbeddingModel instance with the specified API key.
      *
      * @param apiKey the Mistral AI API key for authentication
      * @return a new MistralAiEmbeddingModel instance
+     * @deprecated pass a MistralAiClient object using withClient()
      */
+    @Deprecated // Use withClient() instead.
     public static MistralAiEmbeddingModel withApiKey(String apiKey) {
         return builder().apiKey(apiKey).build();
     }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModels.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModels.java
@@ -26,21 +26,23 @@ public class MistralAiModels {
     /**
      * Constructs a new instance of MistralAiModels.
      *
-     * @param baseUrl      the base URL of the Mistral AI API. It uses the default value if not specified
-     * @param apiKey       the API key for authentication
-     * @param timeout      the timeout duration for API requests. It uses the default value of 60 seconds if not specified
-     * @param logRequests  a flag whether to log raw HTTP requests
-     * @param logResponses a flag whether to log raw HTTP responses
-     * @param maxRetries   the maximum number of retries for API requests. It uses the default value of 3 if not specified
+     * @param mistralAiClient   the client to interact with Mistral AI.
+     * @param baseUrl           the base URL of the Mistral AI API. It uses the default value if not specified
+     * @param apiKey            the API key for authentication
+     * @param timeout           the timeout duration for API requests. It uses the default value of 60 seconds if not specified
+     * @param logRequests       a flag whether to log raw HTTP requests
+     * @param logResponses      a flag whether to log raw HTTP responses
+     * @param maxRetries        the maximum number of retries for API requests. It uses the default value of 3 if not specified
      */
     @Builder
-    public MistralAiModels(String baseUrl,
-                           String apiKey,
-                           Duration timeout,
-                           Boolean logRequests,
-                           Boolean logResponses,
+    public MistralAiModels(MistralAiClient mistralAiClient,
+                           @Deprecated String baseUrl,
+                           @Deprecated String apiKey,
+                           @Deprecated Duration timeout,
+                           @Deprecated Boolean logRequests,
+                           @Deprecated Boolean logResponses,
                            Integer maxRetries) {
-        this.client = MistralAiClient.builder()
+        this.client = mistralAiClient != null ? mistralAiClient : MistralAiClient.builder()
                 .baseUrl(getOrDefault(baseUrl, "https://api.mistral.ai/v1"))
                 .apiKey(apiKey)
                 .timeout(getOrDefault(timeout, Duration.ofSeconds(60)))
@@ -51,11 +53,23 @@ public class MistralAiModels {
     }
 
     /**
+     * Creates a MistralAiModels with the specified Client.
+     *
+     * @param mistralAiClient the client to interact with Mistral AI.
+     * @return a MistralAiModels instance
+     */
+    public static MistralAiModels withClient(MistralAiClient mistralAiClient) {
+        return builder().mistralAiClient(mistralAiClient).build();
+    }
+
+    /**
      * Creates a new instance of MistralAiModels with the specified API key.
      *
      * @param apiKey the API key for authentication
      * @return a new instance of MistralAiModels
+     * @deprecated pass a MistralAiClient object using withClient()
      */
+    @Deprecated // Use withClient() instead.
     public static MistralAiModels withApiKey(String apiKey) {
         return builder().apiKey(apiKey).build();
     }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModel.java
@@ -42,23 +42,25 @@ public class MistralAiStreamingChatModel implements StreamingChatLanguageModel {
     /**
      * Constructs a MistralAiStreamingChatModel with the specified parameters.
      *
-     * @param baseUrl      the base URL of the Mistral AI API. It uses the default value if not specified
-     * @param apiKey       the API key for authentication
-     * @param modelName    the name of the Mistral AI model to use
-     * @param temperature  the temperature parameter for generating chat responses
-     * @param topP         the top-p parameter for generating chat responses
-     * @param maxTokens    the maximum number of new tokens to generate in a chat response
-     * @param safePrompt   a flag indicating whether to use a safe prompt for generating chat responses
-     * @param randomSeed   the random seed for generating chat responses
-     *                     (if not specified, a random number is used)
-     * @param responseFormat the response format for generating chat responses. Current values supported are "text" and "json_object".
-     * @param logRequests  a flag indicating whether to log raw HTTP requests
-     * @param logResponses a flag indicating whether to log raw HTTP responses
-     * @param timeout      the timeout duration for API requests
+     * @param mistralAiClient   the client to interact with Mistral AI.
+     * @param baseUrl           the base URL of the Mistral AI API. It uses the default value if not specified
+     * @param apiKey            the API key for authentication
+     * @param modelName         the name of the Mistral AI model to use
+     * @param temperature       the temperature parameter for generating chat responses
+     * @param topP              the top-p parameter for generating chat responses
+     * @param maxTokens         the maximum number of new tokens to generate in a chat response
+     * @param safePrompt        a flag indicating whether to use a safe prompt for generating chat responses
+     * @param randomSeed        the random seed for generating chat responses
+     *                          (if not specified, a random number is used)
+     * @param responseFormat    the response format for generating chat responses. Current values supported are "text" and "json_object".
+     * @param logRequests       a flag indicating whether to log raw HTTP requests
+     * @param logResponses      a flag indicating whether to log raw HTTP responses
+     * @param timeout           the timeout duration for API requests
      */
     @Builder
-    public MistralAiStreamingChatModel(String baseUrl,
-                                       String apiKey,
+    public MistralAiStreamingChatModel(MistralAiClient mistralAiClient,
+                                       @Deprecated String baseUrl,
+                                       @Deprecated String apiKey,
                                        String modelName,
                                        Double temperature,
                                        Double topP,
@@ -66,11 +68,11 @@ public class MistralAiStreamingChatModel implements StreamingChatLanguageModel {
                                        Boolean safePrompt,
                                        Integer randomSeed,
                                        String responseFormat,
-                                       Boolean logRequests,
-                                       Boolean logResponses,
-                                       Duration timeout) {
-
-        this.client = MistralAiClient.builder()
+                                       @Deprecated Boolean logRequests,
+                                       @Deprecated Boolean logResponses,
+                                       @Deprecated Duration timeout
+    ) {
+        this.client = mistralAiClient != null ? mistralAiClient : MistralAiClient.builder()
                 .baseUrl(getOrDefault(baseUrl, "https://api.mistral.ai/v1"))
                 .apiKey(apiKey)
                 .timeout(getOrDefault(timeout, Duration.ofSeconds(60)))
@@ -87,11 +89,23 @@ public class MistralAiStreamingChatModel implements StreamingChatLanguageModel {
     }
 
     /**
+     * Creates a MistralAiStreamingChatModel with the specified Client.
+     *
+     * @param mistralAiClient the client to interact with Mistral AI.
+     * @return a MistralAiStreamingChatModel instance
+     */
+    public static MistralAiStreamingChatModel withClient(MistralAiClient mistralAiClient) {
+        return builder().mistralAiClient(mistralAiClient).build();
+    }
+
+    /**
      * Creates a MistralAiStreamingChatModel with the specified API key.
      *
      * @param apiKey the API key for authentication
      * @return a MistralAiStreamingChatModel instance
+     * @deprecated pass a MistralAiClient object using withClient()
      */
+    @Deprecated // Use withClient() instead.
     public static MistralAiStreamingChatModel withApiKey(String apiKey) {
         return builder().apiKey(apiKey).build();
     }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiClient.java
@@ -27,11 +27,11 @@ public abstract class MistralAiClient {
 
     @SuppressWarnings("unchecked")
     public abstract static class Builder<T extends MistralAiClient, B extends Builder<T, B>> {
-        public String baseUrl;
+        public String baseUrl = "https://api.mistral.ai/v1";
         public String apiKey;
-        public Duration timeout;
-        public Boolean logRequests;
-        public Boolean logResponses;
+        public Duration timeout = Duration.ofSeconds(60);
+        public Boolean logRequests = false;
+        public Boolean logResponses = false;
 
         public abstract T build();
 

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelIT.java
@@ -8,6 +8,7 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiResponseFormatType;
+import dev.langchain4j.model.mistralai.internal.client.MistralAiClient;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import org.junit.jupiter.api.Test;
@@ -31,11 +32,9 @@ class MistralAiChatModelIT {
             .build();
 
     ChatLanguageModel mistralLargeModel = MistralAiChatModel.builder()
-            .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+            .mistralAiClient(defaultMistralAiClient())
             .modelName(MistralAiChatModelName.MISTRAL_LARGE_LATEST)
             .temperature(0.1)
-            .logRequests(true)
-            .logResponses(true)
             .build();
 
     ChatLanguageModel defaultModel = MistralAiChatModel.builder()
@@ -46,11 +45,9 @@ class MistralAiChatModelIT {
             .build();
 
     ChatLanguageModel openMixtral8x22BModel = MistralAiChatModel.builder()
-            .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+            .mistralAiClient(defaultMistralAiClient())
             .modelName(MistralAiChatModelName.OPEN_MIXTRAL_8X22B)
             .temperature(0.1)
-            .logRequests(true)
-            .logResponses(true)
             .build();
 
     @Test
@@ -79,7 +76,7 @@ class MistralAiChatModelIT {
 
         // given
         ChatLanguageModel model = MistralAiChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .maxTokens(4)
                 .build();
 
@@ -106,7 +103,7 @@ class MistralAiChatModelIT {
     void should_generate_system_prompt_to_enforce_guardrails() {
         // given
         ChatLanguageModel model = MistralAiChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .safePrompt(true)
                 .temperature(0.0)
                 .build();
@@ -160,11 +157,9 @@ class MistralAiChatModelIT {
 
         // given - Mistral Small = Mistral-8X7B
         ChatLanguageModel model = MistralAiChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .modelName(MistralAiChatModelName.OPEN_MIXTRAL_8x7B)
                 .temperature(0.1)
-                .logRequests(true)
-                .logResponses(true)
                 .build();
 
         UserMessage userMessage = userMessage("Quelle est la capitale du Pérou?");
@@ -189,11 +184,9 @@ class MistralAiChatModelIT {
 
         // given - Mistral Small = Mistral-8X7B
         ChatLanguageModel model = MistralAiChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .modelName(MistralAiChatModelName.OPEN_MIXTRAL_8x7B)
                 .temperature(0.1)
-                .logRequests(true)
-                .logResponses(true)
                 .build();
 
         UserMessage userMessage = userMessage("¿Cuál es la capital de Perú?");
@@ -218,11 +211,9 @@ class MistralAiChatModelIT {
 
         // given - Mistral Medium 2312.
         ChatLanguageModel model = MistralAiChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .modelName(MistralAiChatModelName.MISTRAL_MEDIUM_LATEST)
                 .maxTokens(10)
-                .logRequests(true)
-                .logResponses(true)
                 .build();
 
         UserMessage userMessage = userMessage("What is the capital of Peru?");
@@ -388,12 +379,10 @@ class MistralAiChatModelIT {
         String expectedJson = "{\"transactionId\":\"T123\",\"status\":\"paid\"}";
 
         ChatLanguageModel mistralLargeModel = MistralAiChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .modelName(MistralAiChatModelName.MISTRAL_LARGE_LATEST)
                 .temperature(0.1)
                 .responseFormat(MistralAiResponseFormatType.JSON_OBJECT)
-                .logRequests(true)
-                .logResponses(true)
                 .build();
 
         // when
@@ -462,4 +451,13 @@ class MistralAiChatModelIT {
 
         assertThat(response2.finishReason()).isEqualTo(STOP);
     }
+
+    private MistralAiClient defaultMistralAiClient() {
+        return MistralAiClient.builder()
+                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+    }
+
 }

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiEmbeddingModelIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiEmbeddingModelIT.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.mistralai;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.mistralai.internal.client.MistralAiClient;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import org.junit.jupiter.api.Test;
@@ -15,9 +16,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MistralAiEmbeddingModelIT {
 
     EmbeddingModel model = MistralAiEmbeddingModel.builder()
-            .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
-            .logRequests(true)
-            .logResponses(true)
+            .mistralAiClient(MistralAiClient.builder()
+                    .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                    .logRequests(true)
+                    .logResponses(true)
+                    .build())
             .build();
 
     @Test
@@ -61,6 +64,6 @@ class MistralAiEmbeddingModelIT {
         assertThat(tokenUsage.totalTokenCount()).isEqualTo(7 + 8);
 
         assertThat(response.finishReason()).isNull();
-
     }
+
 }

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiModelsIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiModelsIT.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.model.mistralai;
 
 import dev.langchain4j.model.mistralai.internal.api.MistralAiModelCard;
+import dev.langchain4j.model.mistralai.internal.client.MistralAiClient;
 import dev.langchain4j.model.output.Response;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class MistralAiModelsIT {
 
-    MistralAiModels models = MistralAiModels.withApiKey(System.getenv("MISTRAL_AI_API_KEY"));
+    MistralAiModels models = MistralAiModels.withClient(MistralAiClient.builder()
+            .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+            .build());
 
     //https://docs.mistral.ai/models/
     @Test
@@ -24,4 +27,5 @@ class MistralAiModelsIT {
         assertThat(response.content()).extracting("object").contains("model");
         assertThat(response.content()).extracting("permission").isNotNull();
     }
+
 }

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModelIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModelIT.java
@@ -9,6 +9,7 @@ import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.TestStreamingResponseHandler;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiResponseFormatType;
+import dev.langchain4j.model.mistralai.internal.client.MistralAiClient;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import org.junit.jupiter.api.Test;
@@ -32,11 +33,9 @@ class MistralAiStreamingChatModelIT {
             .build();
 
     StreamingChatLanguageModel mistralLargeStreamingModel = MistralAiStreamingChatModel.builder()
-            .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+            .mistralAiClient(defaultMistralAiClient())
             .modelName(MistralAiChatModelName.MISTRAL_LARGE_LATEST)
             .temperature(0.1)
-            .logRequests(true)
-            .logResponses(true)
             .build();
 
     StreamingChatLanguageModel defaultModel = MistralAiStreamingChatModel.builder()
@@ -47,11 +46,9 @@ class MistralAiStreamingChatModelIT {
             .build();
 
     StreamingChatLanguageModel openMixtral8x22BModel = MistralAiStreamingChatModel.builder()
-            .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+            .mistralAiClient(defaultMistralAiClient())
             .modelName(MistralAiChatModelName.OPEN_MIXTRAL_8X22B)
             .temperature(0.1)
-            .logRequests(true)
-            .logResponses(true)
             .build();
 
     @Test
@@ -83,7 +80,7 @@ class MistralAiStreamingChatModelIT {
 
         // given
         StreamingChatLanguageModel model = MistralAiStreamingChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .maxTokens(10)
                 .build();
 
@@ -113,7 +110,7 @@ class MistralAiStreamingChatModelIT {
 
         // given
         StreamingChatLanguageModel model = MistralAiStreamingChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .safePrompt(true)
                 .temperature(0.0)
                 .build();
@@ -170,7 +167,7 @@ class MistralAiStreamingChatModelIT {
 
         // given - Mistral Small = Mistral-8X7B
         StreamingChatLanguageModel model = MistralAiStreamingChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .modelName(MistralAiChatModelName.MISTRAL_SMALL_LATEST)
                 .temperature(0.1)
                 .build();
@@ -199,7 +196,7 @@ class MistralAiStreamingChatModelIT {
 
         // given - Mistral Small = Mistral-8X7B
         StreamingChatLanguageModel model = MistralAiStreamingChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .modelName(MistralAiChatModelName.MISTRAL_SMALL_LATEST)
                 .temperature(0.1)
                 .build();
@@ -228,7 +225,7 @@ class MistralAiStreamingChatModelIT {
 
         // given - Mistral Medium = currently relies on an internal prototype model.
         StreamingChatLanguageModel model = MistralAiStreamingChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .modelName(MistralAiChatModelName.MISTRAL_MEDIUM_LATEST)
                 .maxTokens(10)
                 .build();
@@ -473,12 +470,10 @@ class MistralAiStreamingChatModelIT {
         String expectedJson = "{\"transactionId\":\"T123\",\"status\":\"paid\"}";
 
         StreamingChatLanguageModel mistralLargeStreamingModel = MistralAiStreamingChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .modelName(MistralAiChatModelName.MISTRAL_LARGE_LATEST)
                 .temperature(0.1)
                 .responseFormat(MistralAiResponseFormatType.JSON_OBJECT)
-                .logRequests(true)
-                .logResponses(true)
                 .build();
 
         // when
@@ -494,7 +489,7 @@ class MistralAiStreamingChatModelIT {
     void bugfix_1218_allow_blank() {
         // given
         StreamingChatLanguageModel model = MistralAiStreamingChatModel.builder()
-                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .mistralAiClient(defaultMistralAiClient())
                 .modelName(MistralAiChatModelName.MISTRAL_SMALL_LATEST)
                 .temperature(0d)
                 .build();
@@ -508,4 +503,13 @@ class MistralAiStreamingChatModelIT {
         // results in: "In2020, Germany's inflation rate was0.5%."
         assertThat(responseHandler.get().content().text()).containsIgnoringCase("In 2020");
     }
+
+    private MistralAiClient defaultMistralAiClient() {
+        return MistralAiClient.builder()
+                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+    }
+
 }


### PR DESCRIPTION
## Change
The `MistralAiClient` provides a convenient way to provide a custom implementation of the underlying HTTP interaction. Using the `MistralAiClientBuilderFactory` SPI, it's possible to specify a custom static `Builder` for a `MistralAiClient`.

Since an instance of `MistralAiClient` is built internally from that static builder when building a `MistralChatClient` object, it's not possible to provide further customizations. For example, it's not possible to include additional configuration parameters to `MistralAiClient`, even though the Builder SPI would actually allow that. It's also not possible to initialise the `MistralAiClient` instance via dependency injection, resulting in not being able to manage it properly from a Spring application context.

This PR aims at solving that problem by making it possible to provide a `MistralAiClient` instance when building a  `MistralChatClient` object. The additional benefit is making it clearer what parameters are specific to the model integration (like model and temperature) and what are the ones specific to the HTTP client (like timeout and API key).

The change extends the current setup to avoid any breaking change. It also marks the previous way of configuring a Client deprecated.

## General checklist
- [x] There are no breaking changes
- [x] I have added unit and integration tests for my change
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)