### PR TITLE
Sanitize messages before sending to Qwen models

### DIFF
--- a/langchain4j-dashscope/pom.xml
+++ b/langchain4j-dashscope/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dashscope-sdk-java</artifactId>
-            <version>2.14.7</version>
+            <version>2.15.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" -->
Closes #1326 

## Change
Construct the message list according to the constraints of Qwen models. (Otherwise, the model provider will return an exception.)
1. If there is a system message, it should be the first message. Otherwise, the user message is the first message.
2. User/Tool-execution-result messages and AI messages should alternate. Use the newest one when duplicated.
3. The last message in the message list should be a user/tool-execution-result message. This serves as the model query/input for the current round.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [x] I have added unit and integration tests for my change
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green

