### PR TITLE
Fix the incorrect endpoint for ERNIE-Speed-128K.

### DIFF
--- a/langchain4j-qianfan/src/main/java/dev/langchain4j/model/qianfan/QianfanChatModelNameEnum.java
+++ b/langchain4j-qianfan/src/main/java/dev/langchain4j/model/qianfan/QianfanChatModelNameEnum.java
@@ -9,7 +9,7 @@ public enum QianfanChatModelNameEnum {
     ERNIE_BOT_4("ERNIE-Bot 4.0", "completions_pro"),
     ERNIE_BOT_8("ERNIE-Bot-8K", "ernie_bot_8k"),
     ERNIE_BOT_TURBO("ERNIE-Bot-turbo", "eb-instant"),
-    ERNIE_SPEED_128K("ERNIE-Speed-128K", "completions"),
+    ERNIE_SPEED_128K("ERNIE-Speed-128K", "ernie-speed-128k"),
     EB_TURBO_APPBUILDER("EB-turbo-AppBuilder", "ai_apaas"),
     YI_34B_CHAT("Yi-34B-Chat", "yi_34b_chat"),
     BLOOMZ_7B("BLOOMZ-7B","bloomz_7b1"),


### PR DESCRIPTION
https://cloud.baidu.com/doc/WENXINWORKSHOP/s/6ltgkzya5
https://cloud.baidu.com/doc/WENXINWORKSHOP/s/jlil56u11

According to the documentation, the only difference between the interfaces of ERNIE-Speed-128K and ERNIE-3.5-8K is the endpoint part.

https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/ernie-speed-128k
https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/completions
