### PR TITLE
Add possibility to shutdown

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
@@ -116,6 +116,13 @@ public class OpenAiChatModel implements ChatLanguageModel, TokenCountEstimator {
         this.listeners = listeners == null ? emptyList() : new ArrayList<>(listeners);
     }
 
+    /**
+     * Shuts down the used client
+     */
+    public void shutdown() {
+        client.shutdown();
+    }
+
     public String modelName() {
         return modelName;
     }


### PR DESCRIPTION
When our app quits, we have following thing in [VisualVM](https://visualvm.github.io/):

![image](https://github.com/user-attachments/assets/52f22b86-c038-4874-ba00-88f5d16751ce)

I searched for ways to shutdown the task runner.

There seem to be discussions in OKHttp for shutdown "support" (https://github.com/square/okhttp/issues/6702, https://github.com/square/okhttp/issues/6173). When checking the code, there is something like `shutdown()` already existing: `dev.ai4j.openai4j.DefaultOpenAiClient#shutdown` 

The client is generated in `dev.langchain4j.model.openai.OpenAiChatModel#OpenAiChatModel` "automagically". On the one hand, this is cool, because a user does not need to take care about the client. On the other hand, the client's `shtudown()` method cannot be called.

I needed to decied between:

1. Change the constructor to accept an ´OpenAiClient` so that the caller has full control on the client.
2. Add a `shutdown` to the model to enable the model to shutdown all used services.

I opted for the latter to have more "lightweight" interface.

I additionally needed to decide to switch to [AutoClosable](https://docs.oracle.com/javase/8/docs/api/java/lang/AutoCloseable.html), because `close()` is IMHO the "modern" Java way for shutting down things. -- However, I kept `shutdown ` to focus at one issue at a time.

Curious, what you think.