### PR TITLE
Fix typo in artifactId in spring-boot-integration.md

### DIFF
--- a/docs/docs/tutorials/spring-boot-integration.md
+++ b/docs/docs/tutorials/spring-boot-integration.md
@@ -13,7 +13,7 @@ To use one of the Spring Boot starters, first import the corresponding dependenc
 ```xml
 <dependency>
     <groupId>dev.langchain4j</groupId>
-    <artifactId>langchain4j-open-ai-spring-boot-starter</artifactId>
+    <artifactId>langchain4j-spring-boot-starter</artifactId>
     <version>0.32.0</version>
 </dependency>
 ```


### PR DESCRIPTION
## Change
I found a typo in the tutorial section of the LangChain4j official documentation.
When integrating with Spring Boot, the dependency for Spring Boot starters should be as follows:

```
<dependency>
    <groupId>dev.langchain4j</groupId>
    <artifactId>langchain4j-spring-boot-starter</artifactId>
    <version>0.32.0</version>
</dependency>
```




