### PR TITLE
Bump com.knuddels:jtokkit from 1.0.0 to 1.1.0

### DIFF
--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -26,7 +26,7 @@
         <azure.identity.version>1.13.1</azure.identity.version>
         <retrofit.version>2.9.0</retrofit.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <jtokkit.version>1.0.0</jtokkit.version>
+        <jtokkit.version>1.1.0</jtokkit.version>
         <lombok.version>1.18.30</lombok.version>
         <jsoup.veresion>1.16.1</jsoup.veresion>
         <slf4j-api.version>2.0.7</slf4j-api.version>


### PR DESCRIPTION
Adds o200k_base encoding used by GPT4o and GPT4o-mini
