### PR TITLE
re #1506 Enabling Maven (version) enforcer plugin in `LangChain4j :: Integration :: OpenAI` module.

### DIFF
--- a/langchain4j-open-ai/pom.xml
+++ b/langchain4j-open-ai/pom.xml
@@ -21,10 +21,34 @@
             <artifactId>langchain4j-core</artifactId>
         </dependency>
 
+        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OPENAI4J (START) -->
+
+        <!-- To resolve version conflicts inside the 'openai4j' library, we are excluding the transitive -->
+        <!-- dependencies causing version divergence errors and including them explicitly. This ensures a consistent -->
+        <!-- version to be used in the project and satisfies Maven Enforcer requirements to avoid version divergence -->
+        <!-- in the project. -->
+
+        <!-- Please check whether version conflicts are gone after upgrading  this library as this will make it -->
+        <!-- possible to remove these exclusions and explicit inclusions below. -->
+
         <dependency>
             <groupId>dev.ai4j</groupId>
             <artifactId>openai4j</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib-jdk8</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>1.9.10</version>
+        </dependency>
+
+        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OPENAI4J (END)  -->
 
         <dependency>
             <groupId>com.knuddels</groupId>
@@ -75,6 +99,29 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence/>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <licenses>
         <license>


### PR DESCRIPTION
## Issue

#1506

## Change

Enabled Maven version enforcer plugin in `LangChain4j :: Integration :: OpenAI` module.

To do this I first had to resolve version conflict:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (enforce) on project langchain4j-open-ai:
[ERROR] Rule 0: org.apache.maven.enforcer.rules.dependency.DependencyConvergence failed with message:
[ERROR] Failed while enforcing releasability.
[ERROR]
[ERROR] Dependency convergence error for org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.9.10 paths to dependency are:
[ERROR] +-dev.langchain4j:langchain4j-open-ai:jar:0.33.0-SNAPSHOT
[ERROR]   +-dev.ai4j:openai4j:jar:0.17.0:compile
[ERROR]     +-com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[ERROR]       +-com.squareup.okio:okio:jar:3.6.0:compile
[ERROR]         +-com.squareup.okio:okio-jvm:jar:3.6.0:compile
[ERROR]           +-org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.9.10:compile
[ERROR] and
[ERROR] +-dev.langchain4j:langchain4j-open-ai:jar:0.33.0-SNAPSHOT
[ERROR]   +-dev.ai4j:openai4j:jar:0.17.0:compile
[ERROR]     +-com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[ERROR]       +-org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.8.21:compile
[ERROR] and
[ERROR] +-dev.langchain4j:langchain4j-open-ai:jar:0.33.0-SNAPSHOT
[ERROR]   +-dev.ai4j:openai4j:jar:0.17.0:compile
[ERROR]     +-com.squareup.okhttp3:okhttp-sse:jar:4.12.0:compile
[ERROR]       +-org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.8.21:compile
[ERROR]
```
... originating from:

```
<dependency>
    <groupId>dev.ai4j</groupId>
    <artifactId>openai4j</artifactId>
</dependency>
```

I've decided to solve it like this:
```
<!-- DEPENDENCY CONFLICT RESOLUTION FOR OPENAI4J (START) -->

<!-- To resolve version conflicts inside the 'openai4j' library, we are excluding the transitive -->
<!-- dependencies causing version divergence errors and including them explicitly. This ensures a consistent -->
<!-- version to be used in the project and satisfies Maven Enforcer requirements to avoid version divergence -->
<!-- in the project. -->

<!-- Please check whether version conflicts are gone after upgrading  this library as this will make it -->
<!-- possible to remove these exclusions and explicit inclusions below. -->

<dependency>
    <groupId>dev.ai4j</groupId>
    <artifactId>openai4j</artifactId>
    <exclusions>
        <exclusion>
            <groupId>org.jetbrains.kotlin</groupId>
            <artifactId>kotlin-stdlib-jdk8</artifactId>
        </exclusion>
    </exclusions>
</dependency>

<dependency>
    <groupId>org.jetbrains.kotlin</groupId>
    <artifactId>kotlin-stdlib-jdk8</artifactId>
    <version>1.9.10</version>
</dependency>

<!-- DEPENDENCY CONFLICT RESOLUTION FOR OPENAI4J (END)  -->
```

So this solution:
- uses start and end comment to mark the lines where verions resolutions spans through 
- excluded the conflicting dependency and includes it explicitly below - that way we have everything in single place


## Tests

`mvn clean test` passed