### PR TITLE
Add numCandidates setting to ElasticsearchConfigurationKnn

### DIFF
--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationKnn.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationKnn.java
@@ -17,7 +17,7 @@ import java.io.IOException;
  */
 public class ElasticsearchConfigurationKnn extends ElasticsearchConfiguration {
     private static final Logger log = LoggerFactory.getLogger(ElasticsearchConfigurationKnn.class);
-    private final int numCandidates;
+    private final Integer numCandidates;
 
     public static class Builder {
         private Integer numCandidates;
@@ -45,7 +45,7 @@ public class ElasticsearchConfigurationKnn extends ElasticsearchConfiguration {
     }
 
 
-    private ElasticsearchConfigurationKnn(int numCandidates) {
+    private ElasticsearchConfigurationKnn(Integer numCandidates) {
         this.numCandidates = numCandidates;
     }
 
@@ -61,7 +61,7 @@ public class ElasticsearchConfigurationKnn extends ElasticsearchConfiguration {
             krb.filter(ElasticsearchMetadataFilterMapper.map(embeddingSearchRequest.filter()));
         }
 
-        if (numCandidates > 0) {
+        if (numCandidates != null) {
             krb.numCandidates(numCandidates);
         }
 

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationKnn.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationKnn.java
@@ -20,7 +20,7 @@ public class ElasticsearchConfigurationKnn extends ElasticsearchConfiguration {
     private final int numCandidates;
 
     public static class Builder {
-        private int numCandidates = 0;
+        private Integer numCandidates;
 
         public ElasticsearchConfigurationKnn build() {
             return new ElasticsearchConfigurationKnn(numCandidates);
@@ -34,7 +34,7 @@ public class ElasticsearchConfigurationKnn extends ElasticsearchConfiguration {
          * @param numCandidates The number of nearest neighbor candidates to consider per shard
          * @return the builder instance
          */
-        public Builder withNumCandidates(int numCandidates) {
+        public Builder numCandidates(Integer numCandidates) {
             this.numCandidates = numCandidates;
             return this;
         }

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationKnn.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationKnn.java
@@ -12,14 +12,31 @@ import java.io.IOException;
 
 /**
  * Represents an <a href="https://www.elastic.co/">Elasticsearch</a> index as an embedding store
- * using the Knn implementation.
+ * using the approximate kNN query implementation.
+ * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-knn-query.html#knn-query-top-level-parameters">kNN query</a>
  */
 public class ElasticsearchConfigurationKnn extends ElasticsearchConfiguration {
     private static final Logger log = LoggerFactory.getLogger(ElasticsearchConfigurationKnn.class);
+    private final int numCandidates;
 
     public static class Builder {
+        private int numCandidates = 0;
+
         public ElasticsearchConfigurationKnn build() {
-            return new ElasticsearchConfigurationKnn();
+            return new ElasticsearchConfigurationKnn(numCandidates);
+        }
+
+        /**
+         * The number of nearest neighbor candidates to consider per shard while doing knn search.
+         * Cannot exceed 10,000. Increasing num_candidates tends to improve the accuracy of the final
+         * results.
+         *
+         * @param numCandidates The number of nearest neighbor candidates to consider per shard
+         * @return the builder instance
+         */
+        public Builder withNumCandidates(int numCandidates) {
+            this.numCandidates = numCandidates;
+            return this;
         }
     }
 
@@ -27,8 +44,9 @@ public class ElasticsearchConfigurationKnn extends ElasticsearchConfiguration {
         return new Builder();
     }
 
-    private ElasticsearchConfigurationKnn() {
 
+    private ElasticsearchConfigurationKnn(int numCandidates) {
+        this.numCandidates = numCandidates;
     }
 
     @Override
@@ -42,6 +60,11 @@ public class ElasticsearchConfigurationKnn extends ElasticsearchConfiguration {
         if (embeddingSearchRequest.filter() != null) {
             krb.filter(ElasticsearchMetadataFilterMapper.map(embeddingSearchRequest.filter()));
         }
+
+        if (numCandidates > 0) {
+            krb.numCandidates(numCandidates);
+        }
+
         KnnQuery knn = krb.build();
 
         log.trace("Searching for embeddings in index [{}] with query [{}].", indexName, knn);

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchClientHelper.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchClientHelper.java
@@ -13,6 +13,7 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.message.BasicHeader;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.slf4j.Logger;
@@ -87,6 +88,10 @@ class ElasticsearchClientHelper {
         // We remove the indices in case we were running with a local test instance
         // we don't keep dirty things around
         client.indices().delete(dir -> dir.index(indexName).ignoreUnavailable(true));
+    }
+
+    void refreshIndex(String indexName) throws IOException {
+        restClient.performRequest(new Request("POST", "/" + indexName + "/_refresh"));
     }
 
     /**

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreKnnWithConfigurationIT.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreKnnWithConfigurationIT.java
@@ -33,9 +33,8 @@ class ElasticsearchEmbeddingStoreKnnWithConfigurationIT {
     }
 
     @BeforeEach
-    void createEmbeddingStore() throws IOException {
+    void createEmbeddingStore() {
         indexName = randomUUID();
-        elasticsearchClientHelper.removeDataStore(indexName);
     }
 
     @AfterEach
@@ -59,7 +58,7 @@ class ElasticsearchEmbeddingStoreKnnWithConfigurationIT {
         {
             EmbeddingStore<TextSegment> embeddingStore = ElasticsearchEmbeddingStore.builder()
                     .configuration(ElasticsearchConfigurationKnn.builder()
-                            .withNumCandidates(10)
+                            .numCandidates(10)
                             .build())
                     .restClient(elasticsearchClientHelper.restClient)
                     .indexName(indexName)
@@ -84,7 +83,7 @@ class ElasticsearchEmbeddingStoreKnnWithConfigurationIT {
         {
             EmbeddingStore<TextSegment> embeddingStore = ElasticsearchEmbeddingStore.builder()
                     .configuration(ElasticsearchConfigurationKnn.builder()
-                            .withNumCandidates(1)
+                            .numCandidates(1)
                             .build())
                     .restClient(elasticsearchClientHelper.restClient)
                     .indexName(indexName)

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreKnnWithConfigurationIT.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreKnnWithConfigurationIT.java
@@ -1,0 +1,106 @@
+package dev.langchain4j.store.embedding.elasticsearch;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ElasticsearchEmbeddingStoreKnnWithConfigurationIT {
+
+    static ElasticsearchClientHelper elasticsearchClientHelper = new ElasticsearchClientHelper();
+    String indexName;
+
+    @BeforeAll
+    static void startServices() throws IOException {
+        elasticsearchClientHelper.startServices();
+        assertThat(elasticsearchClientHelper.restClient).isNotNull();
+        assertThat(elasticsearchClientHelper.client).isNotNull();
+    }
+
+    @AfterAll
+    static void stopServices() throws IOException {
+        elasticsearchClientHelper.stopServices();
+    }
+
+    @BeforeEach
+    void createEmbeddingStore() throws IOException {
+        indexName = randomUUID();
+        elasticsearchClientHelper.removeDataStore(indexName);
+    }
+
+    @AfterEach
+    void removeDataStore() throws IOException {
+        // We remove the indices in case we were running with a local test instance
+        // we don't keep dirty things around
+        elasticsearchClientHelper.removeDataStore(indexName);
+    }
+
+    private final EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+    @Test
+    void withNumCandidates() throws IOException {
+        // Our dataset
+        Embedding embedding1 = embeddingModel.embed("hello").content();
+        Embedding embedding2 = embeddingModel.embed("bonjour").content();
+        Embedding embedding3 = embeddingModel.embed("buen día").content();
+        List<Embedding> embeddings = Arrays.asList(embedding1, embedding2, embedding3);
+
+        // Test with a high numCandidates
+        {
+            EmbeddingStore<TextSegment> embeddingStore = ElasticsearchEmbeddingStore.builder()
+                    .configuration(ElasticsearchConfigurationKnn.builder()
+                            .withNumCandidates(10)
+                            .build())
+                    .restClient(elasticsearchClientHelper.restClient)
+                    .indexName(indexName)
+                    .build();
+
+            // given
+            embeddingStore.addAll(embeddings);
+
+            // refresh the index
+            elasticsearchClientHelper.refreshIndex(indexName);
+
+            // then
+            assertThat(embeddingStore.search(EmbeddingSearchRequest.builder()
+                    .queryEmbedding(embedding1)
+                    .maxResults(10)
+                    .build()).matches()).hasSize(3);
+        }
+
+        // Remove the datastore between tests
+        elasticsearchClientHelper.removeDataStore(indexName);
+
+        {
+            EmbeddingStore<TextSegment> embeddingStore = ElasticsearchEmbeddingStore.builder()
+                    .configuration(ElasticsearchConfigurationKnn.builder()
+                            .withNumCandidates(1)
+                            .build())
+                    .restClient(elasticsearchClientHelper.restClient)
+                    .indexName(indexName)
+                    .build();
+
+            // given
+            embeddingStore.addAll(embeddings);
+
+            // refresh the index
+            elasticsearchClientHelper.refreshIndex(indexName);
+
+            // then
+            assertThat(embeddingStore.search(EmbeddingSearchRequest.builder()
+                    .queryEmbedding(embedding1)
+                    .maxResults(10)
+                    .build()).matches()).hasSize(1);
+        }
+    }
+}


### PR DESCRIPTION
## Issue

Related to #1640

## Change

We can now support a new setting for the `ElasticsearchConfigurationKnn`. It allows to define how many nearest neighbor candidates to consider per shard while doing knn search.

```java
EmbeddingStore<TextSegment> embeddingStore = ElasticsearchEmbeddingStore.builder()
        .configuration(ElasticsearchConfigurationKnn.builder()
                .withNumCandidates(10)
                .build())
        .restClient(restClient)
        .build();
```

## General checklist

- [X] There are no breaking changes
- [X] I have added unit and integration tests for my change
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for changing existing embedding store integration

- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
