### PR TITLE
DashScope: Support baseUrl in QwenEmbeddingModel

### DIFF
--- a/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenEmbeddingModel.java
+++ b/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenEmbeddingModel.java
@@ -35,13 +35,13 @@ public class QwenEmbeddingModel extends DimensionAwareEmbeddingModel {
     private final TextEmbedding embedding;
 
     @Builder
-    public QwenEmbeddingModel(String apiKey, String modelName) {
+    public QwenEmbeddingModel(String baseUrl, String apiKey, String modelName) {
         if (Utils.isNullOrBlank(apiKey)) {
             throw new IllegalArgumentException("DashScope api key must be defined. It can be generated here: https://dashscope.console.aliyun.com/apiKey");
         }
         this.modelName = Utils.isNullOrBlank(modelName) ? QwenModelName.TEXT_EMBEDDING_V2 : modelName;
         this.apiKey = apiKey;
-        this.embedding = new TextEmbedding();
+        this.embedding = Utils.isNullOrBlank(baseUrl) ? new TextEmbedding() : new TextEmbedding(baseUrl);
     }
 
     private boolean containsDocuments(List<TextSegment> textSegments) {

--- a/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenTokenizer.java
+++ b/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenTokenizer.java
@@ -9,6 +9,7 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.Tokenizer;
+import lombok.Builder;
 
 import java.util.Collections;
 
@@ -21,6 +22,7 @@ public class QwenTokenizer implements Tokenizer {
     private final String modelName;
     private final Tokenization tokenizer;
 
+    @Builder
     public QwenTokenizer(String apiKey, String modelName) {
         if (isNullOrBlank(apiKey)) {
             throw new IllegalArgumentException("DashScope api key must be defined. It can be generated here: https://dashscope.console.aliyun.com/apiKey");

--- a/langchain4j-dashscope/src/test/java/dev/langchain4j/model/dashscope/QwenTokenizerIT.java
+++ b/langchain4j-dashscope/src/test/java/dev/langchain4j/model/dashscope/QwenTokenizerIT.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -28,7 +27,10 @@ public class QwenTokenizerIT {
 
     @BeforeEach
     public void setUp() {
-        tokenizer = new QwenTokenizer(apiKey(), QwenModelName.QWEN_PLUS);
+        tokenizer = QwenTokenizer.builder()
+                .apiKey(apiKey())
+                .modelName(QwenModelName.QWEN_PLUS)
+                .build();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Support baseUrl in QwenEmbeddingModel.
And support builder for QwenTokenizer.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green

