### PR TITLE
Judge0: migrate from Gson to Jackson

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
@@ -39,6 +39,11 @@
         <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/Json.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/Json.java
@@ -1,0 +1,41 @@
+package dev.langchain4j.code.judge0;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
+
+public class Json {
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .enable(INDENT_OUTPUT)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    ;
+
+    static String toJson(Object o) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(o);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static <T> T fromJson(String json, Class<T> type) {
+        try {
+            return OBJECT_MAPPER.readValue(json, type);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static <T> T fromJson(String json, TypeReference<T> type) {
+        try {
+            return OBJECT_MAPPER.readValue(json, type);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/Json.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/Json.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
 
-public class Json {
+class Json {
     static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .enable(INDENT_OUTPUT)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/Judge0JavaScriptEngine.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/Judge0JavaScriptEngine.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.code.judge0;
 
 import dev.langchain4j.code.CodeExecutionEngine;
-import dev.langchain4j.internal.Json;
 import okhttp3.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,6 +82,22 @@ class Judge0JavaScriptEngine implements CodeExecutionEngine {
             this.language_id = languageId;
             this.source_code = sourceCode;
         }
+
+        public int getLanguage_id() {
+            return language_id;
+        }
+
+        public void setLanguage_id(int language_id) {
+            this.language_id = language_id;
+        }
+
+        public String getSource_code() {
+            return source_code;
+        }
+
+        public void setSource_code(String source_code) {
+            this.source_code = source_code;
+        }
     }
 
     private static class SubmissionResult {
@@ -90,11 +105,51 @@ class Judge0JavaScriptEngine implements CodeExecutionEngine {
         String stdout;
         Status status;
         String compile_output;
+
+        public String getStdout() {
+            return stdout;
+        }
+
+        public void setStdout(String stdout) {
+            this.stdout = stdout;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public void setStatus(Status status) {
+            this.status = status;
+        }
+
+        public String getCompile_output() {
+            return compile_output;
+        }
+
+        public void setCompile_output(String compile_output) {
+            this.compile_output = compile_output;
+        }
     }
 
     private static class Status {
 
         int id;
         String description;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #
https://github.com/langchain4j/langchain4j/issues/1691
## Change
<!-- Please describe the changes you made. -->
Define a Json class in Judge0 which use Jackson and migrate all usages in Judge0 package to it.
Generate getter and setter for Beans in Judge0 package to adapt Jackson.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core]