### PR TITLE
fix(bom): add  langchain4j-reactor dependency

### DIFF
--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -33,6 +33,12 @@
 
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-reactor</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-easy-rag</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
## Change:

Added `langchain4j-reactor` to the `langchain4j-bom` module to avoid needing to specify the version manually when importing `langchain4j-reactor`, allowing it to be managed by the BOM.


<img width="1090" alt="image" src="https://github.com/user-attachments/assets/06d5a67f-bcea-49b2-a116-939a842d9454">
