### PR TITLE
Update to Elasticsearch client 8.15.2

### DIFF
--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationScript.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationScript.java
@@ -2,7 +2,6 @@ package dev.langchain4j.store.embedding.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
-import co.elastic.clients.elasticsearch._types.InlineScript;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.ScriptScoreQuery;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
@@ -67,11 +66,9 @@ public class ElasticsearchConfigurationScript extends ElasticsearchConfiguration
         return ScriptScoreQuery.of(q -> q
                 .minScore(minScore)
                 .query(query)
-                .script(s -> s.inline(InlineScript.of(i -> i
-                        // The script adds 1.0 to the cosine similarity to prevent the score from being negative.
-                        // divided by 2 to keep score in the range [0, 1]
+                .script(s -> s
                         .source("(cosineSimilarity(params.query_vector, 'vector') + 1.0) / 2")
-                        .params("query_vector", queryVector)))));
+                        .params("query_vector", queryVector)));
     }
 
     private <T> JsonData toJsonData(T rawData) throws JsonProcessingException {

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapper.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapper.java
@@ -11,6 +11,7 @@ import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -61,31 +62,143 @@ class ElasticsearchMetadataFilterMapper {
     }
 
     private static Query mapGreaterThan(IsGreaterThan isGreaterThan) {
-        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                r.field("metadata." + isGreaterThan.key())
-                        .gt(JsonData.of(isGreaterThan.comparisonValue()))
-        ))).build();
+        if (isGreaterThan.comparisonValue() instanceof Integer) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isGreaterThan.key())
+                            .gt(((Integer) isGreaterThan.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isGreaterThan.comparisonValue() instanceof Long) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isGreaterThan.key())
+                            .gt(((Long) isGreaterThan.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isGreaterThan.comparisonValue() instanceof Float) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isGreaterThan.key())
+                            .gt(((Float) isGreaterThan.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isGreaterThan.comparisonValue() instanceof Double) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isGreaterThan.key())
+                            .gt((Double) isGreaterThan.comparisonValue()))
+            ))).build();
+        } else if (isGreaterThan.comparisonValue() instanceof Date) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.date(df -> df.field("metadata." + isGreaterThan.key())
+                            .gt((String) isGreaterThan.comparisonValue()))
+            ))).build();
+        } else if (isGreaterThan.comparisonValue() instanceof String) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.date(df -> df.field("metadata." + isGreaterThan.key())
+                            .gt((String) isGreaterThan.comparisonValue()))
+            ))).build();
+        }
+        throw new UnsupportedOperationException("Unsupported type for comparison value: " + isGreaterThan.comparisonValue().getClass().getSimpleName());
     }
 
     private static Query mapGreaterThanOrEqual(IsGreaterThanOrEqualTo isGreaterThanOrEqualTo) {
-        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                r.field("metadata." + isGreaterThanOrEqualTo.key())
-                        .gte(JsonData.of(isGreaterThanOrEqualTo.comparisonValue()))
-        ))).build();
+        if (isGreaterThanOrEqualTo.comparisonValue() instanceof Integer) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isGreaterThanOrEqualTo.key())
+                            .gte(((Integer) isGreaterThanOrEqualTo.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isGreaterThanOrEqualTo.comparisonValue() instanceof Long) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isGreaterThanOrEqualTo.key())
+                            .gte(((Long) isGreaterThanOrEqualTo.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isGreaterThanOrEqualTo.comparisonValue() instanceof Float) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isGreaterThanOrEqualTo.key())
+                            .gte(((Float) isGreaterThanOrEqualTo.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isGreaterThanOrEqualTo.comparisonValue() instanceof Double) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isGreaterThanOrEqualTo.key())
+                            .gte((Double) isGreaterThanOrEqualTo.comparisonValue()))
+            ))).build();
+        } else if (isGreaterThanOrEqualTo.comparisonValue() instanceof Date) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.date(df -> df.field("metadata." + isGreaterThanOrEqualTo.key())
+                            .gte((String) isGreaterThanOrEqualTo.comparisonValue()))
+            ))).build();
+        } else if (isGreaterThanOrEqualTo.comparisonValue() instanceof String) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.date(df -> df.field("metadata." + isGreaterThanOrEqualTo.key())
+                            .gte((String) isGreaterThanOrEqualTo.comparisonValue()))
+            ))).build();
+        }
+        throw new UnsupportedOperationException("Unsupported type for comparison value: " + isGreaterThanOrEqualTo.comparisonValue().getClass().getSimpleName());
     }
 
     private static Query mapLessThan(IsLessThan isLessThan) {
-        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                r.field("metadata." + isLessThan.key())
-                        .lt(JsonData.of(isLessThan.comparisonValue()))
-        ))).build();
+        if (isLessThan.comparisonValue() instanceof Integer) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isLessThan.key())
+                            .lt(((Integer) isLessThan.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isLessThan.comparisonValue() instanceof Long) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isLessThan.key())
+                            .lt(((Long) isLessThan.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isLessThan.comparisonValue() instanceof Float) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isLessThan.key())
+                            .lt(((Float) isLessThan.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isLessThan.comparisonValue() instanceof Double) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isLessThan.key())
+                            .lt((Double) isLessThan.comparisonValue()))
+            ))).build();
+        } else if (isLessThan.comparisonValue() instanceof Date) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.date(df -> df.field("metadata." + isLessThan.key())
+                            .lt((String) isLessThan.comparisonValue()))
+            ))).build();
+        } else if (isLessThan.comparisonValue() instanceof String) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.date(df -> df.field("metadata." + isLessThan.key())
+                            .lt((String) isLessThan.comparisonValue()))
+            ))).build();
+        }
+        throw new UnsupportedOperationException("Unsupported type for comparison value: " + isLessThan.comparisonValue().getClass().getSimpleName());
     }
 
     private static Query mapLessThanOrEqual(IsLessThanOrEqualTo isLessThanOrEqualTo) {
-        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                r.field("metadata." + isLessThanOrEqualTo.key())
-                        .lte(JsonData.of(isLessThanOrEqualTo.comparisonValue()))
-        ))).build();
+        if (isLessThanOrEqualTo.comparisonValue() instanceof Integer) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isLessThanOrEqualTo.key())
+                            .lte(((Integer) isLessThanOrEqualTo.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isLessThanOrEqualTo.comparisonValue() instanceof Long) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isLessThanOrEqualTo.key())
+                            .lte(((Long) isLessThanOrEqualTo.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isLessThanOrEqualTo.comparisonValue() instanceof Float) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isLessThanOrEqualTo.key())
+                            .lte(((Float) isLessThanOrEqualTo.comparisonValue()).doubleValue()))
+            ))).build();
+        } else if (isLessThanOrEqualTo.comparisonValue() instanceof Double) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.number(nf -> nf.field("metadata." + isLessThanOrEqualTo.key())
+                            .lte((Double) isLessThanOrEqualTo.comparisonValue()))
+            ))).build();
+        } else if (isLessThanOrEqualTo.comparisonValue() instanceof Date) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.date(df -> df.field("metadata." + isLessThanOrEqualTo.key())
+                            .lte((String) isLessThanOrEqualTo.comparisonValue()))
+            ))).build();
+        } else if (isLessThanOrEqualTo.comparisonValue() instanceof String) {
+            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                    r.date(df -> df.field("metadata." + isLessThanOrEqualTo.key())
+                            .lte((String) isLessThanOrEqualTo.comparisonValue()))
+            ))).build();
+        }
+        throw new UnsupportedOperationException("Unsupported type for comparison value: " + isLessThanOrEqualTo.comparisonValue().getClass().getSimpleName());
     }
 
     public static Query mapIn(IsIn isIn) {

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapper.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapper.java
@@ -11,7 +11,6 @@ import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
 
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -62,143 +61,35 @@ class ElasticsearchMetadataFilterMapper {
     }
 
     private static Query mapGreaterThan(IsGreaterThan isGreaterThan) {
-        if (isGreaterThan.comparisonValue() instanceof Integer) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isGreaterThan.key())
-                            .gt(((Integer) isGreaterThan.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isGreaterThan.comparisonValue() instanceof Long) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isGreaterThan.key())
-                            .gt(((Long) isGreaterThan.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isGreaterThan.comparisonValue() instanceof Float) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isGreaterThan.key())
-                            .gt(((Float) isGreaterThan.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isGreaterThan.comparisonValue() instanceof Double) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isGreaterThan.key())
-                            .gt((Double) isGreaterThan.comparisonValue()))
-            ))).build();
-        } else if (isGreaterThan.comparisonValue() instanceof Date) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.date(df -> df.field("metadata." + isGreaterThan.key())
-                            .gt((String) isGreaterThan.comparisonValue()))
-            ))).build();
-        } else if (isGreaterThan.comparisonValue() instanceof String) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.date(df -> df.field("metadata." + isGreaterThan.key())
-                            .gt((String) isGreaterThan.comparisonValue()))
-            ))).build();
-        }
-        throw new UnsupportedOperationException("Unsupported type for comparison value: " + isGreaterThan.comparisonValue().getClass().getSimpleName());
+        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                r.untyped(nf -> nf
+                        .field("metadata." + isGreaterThan.key())
+                        .gt(JsonData.of(isGreaterThan.comparisonValue()))
+                )))).build();
     }
 
     private static Query mapGreaterThanOrEqual(IsGreaterThanOrEqualTo isGreaterThanOrEqualTo) {
-        if (isGreaterThanOrEqualTo.comparisonValue() instanceof Integer) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isGreaterThanOrEqualTo.key())
-                            .gte(((Integer) isGreaterThanOrEqualTo.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isGreaterThanOrEqualTo.comparisonValue() instanceof Long) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isGreaterThanOrEqualTo.key())
-                            .gte(((Long) isGreaterThanOrEqualTo.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isGreaterThanOrEqualTo.comparisonValue() instanceof Float) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isGreaterThanOrEqualTo.key())
-                            .gte(((Float) isGreaterThanOrEqualTo.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isGreaterThanOrEqualTo.comparisonValue() instanceof Double) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isGreaterThanOrEqualTo.key())
-                            .gte((Double) isGreaterThanOrEqualTo.comparisonValue()))
-            ))).build();
-        } else if (isGreaterThanOrEqualTo.comparisonValue() instanceof Date) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.date(df -> df.field("metadata." + isGreaterThanOrEqualTo.key())
-                            .gte((String) isGreaterThanOrEqualTo.comparisonValue()))
-            ))).build();
-        } else if (isGreaterThanOrEqualTo.comparisonValue() instanceof String) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.date(df -> df.field("metadata." + isGreaterThanOrEqualTo.key())
-                            .gte((String) isGreaterThanOrEqualTo.comparisonValue()))
-            ))).build();
-        }
-        throw new UnsupportedOperationException("Unsupported type for comparison value: " + isGreaterThanOrEqualTo.comparisonValue().getClass().getSimpleName());
+        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                r.untyped(nf -> nf
+                        .field("metadata." + isGreaterThanOrEqualTo.key())
+                        .gte(JsonData.of(isGreaterThanOrEqualTo.comparisonValue()))
+                )))).build();
     }
 
     private static Query mapLessThan(IsLessThan isLessThan) {
-        if (isLessThan.comparisonValue() instanceof Integer) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isLessThan.key())
-                            .lt(((Integer) isLessThan.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isLessThan.comparisonValue() instanceof Long) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isLessThan.key())
-                            .lt(((Long) isLessThan.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isLessThan.comparisonValue() instanceof Float) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isLessThan.key())
-                            .lt(((Float) isLessThan.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isLessThan.comparisonValue() instanceof Double) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isLessThan.key())
-                            .lt((Double) isLessThan.comparisonValue()))
-            ))).build();
-        } else if (isLessThan.comparisonValue() instanceof Date) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.date(df -> df.field("metadata." + isLessThan.key())
-                            .lt((String) isLessThan.comparisonValue()))
-            ))).build();
-        } else if (isLessThan.comparisonValue() instanceof String) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.date(df -> df.field("metadata." + isLessThan.key())
-                            .lt((String) isLessThan.comparisonValue()))
-            ))).build();
-        }
-        throw new UnsupportedOperationException("Unsupported type for comparison value: " + isLessThan.comparisonValue().getClass().getSimpleName());
+        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                r.untyped(nf -> nf
+                        .field("metadata." + isLessThan.key())
+                        .lt(JsonData.of(isLessThan.comparisonValue()))
+                )))).build();
     }
 
     private static Query mapLessThanOrEqual(IsLessThanOrEqualTo isLessThanOrEqualTo) {
-        if (isLessThanOrEqualTo.comparisonValue() instanceof Integer) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isLessThanOrEqualTo.key())
-                            .lte(((Integer) isLessThanOrEqualTo.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isLessThanOrEqualTo.comparisonValue() instanceof Long) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isLessThanOrEqualTo.key())
-                            .lte(((Long) isLessThanOrEqualTo.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isLessThanOrEqualTo.comparisonValue() instanceof Float) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isLessThanOrEqualTo.key())
-                            .lte(((Float) isLessThanOrEqualTo.comparisonValue()).doubleValue()))
-            ))).build();
-        } else if (isLessThanOrEqualTo.comparisonValue() instanceof Double) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.number(nf -> nf.field("metadata." + isLessThanOrEqualTo.key())
-                            .lte((Double) isLessThanOrEqualTo.comparisonValue()))
-            ))).build();
-        } else if (isLessThanOrEqualTo.comparisonValue() instanceof Date) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.date(df -> df.field("metadata." + isLessThanOrEqualTo.key())
-                            .lte((String) isLessThanOrEqualTo.comparisonValue()))
-            ))).build();
-        } else if (isLessThanOrEqualTo.comparisonValue() instanceof String) {
-            return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                    r.date(df -> df.field("metadata." + isLessThanOrEqualTo.key())
-                            .lte((String) isLessThanOrEqualTo.comparisonValue()))
-            ))).build();
-        }
-        throw new UnsupportedOperationException("Unsupported type for comparison value: " + isLessThanOrEqualTo.comparisonValue().getClass().getSimpleName());
+        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
+                r.untyped(nf -> nf
+                        .field("metadata." + isLessThanOrEqualTo.key())
+                        .lte(JsonData.of(isLessThanOrEqualTo.comparisonValue()))
+                )))).build();
     }
 
     public static Query mapIn(IsIn isIn) {

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -41,7 +41,7 @@
         <aws-java-sdk-core.version>1.12.564</aws-java-sdk-core.version>
         <aws-opensearch.version>2.20.161</aws-opensearch.version>
         <opensearch-containers.version>2.0.1</opensearch-containers.version>
-        <elastic.version>8.14.3</elastic.version>
+        <elastic.version>8.15.2</elastic.version>
         <jackson.version>2.16.1</jackson.version>
         <jedis.version>5.0.0</jedis.version>
         <aws.java.sdk.version>2.21.44</aws.java.sdk.version>


### PR DESCRIPTION
## Issue

Relates to #1885

## Change

The Java client changed few APIs:

* script query is now easier to use without the need of `InlineScript`
* Range queries needs now to specifiy if you are using a `Double`, a `String` or a `Date`

## General checklist

- [X] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for changing existing embedding store integration

- [ ] I have manually verified that the `ElasticsearchEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
