### PR TITLE
Fix that Qwen does not allow tool description to be null (but allows blank string)

### DIFF
--- a/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenHelper.java
+++ b/langchain4j-dashscope/src/main/java/dev/langchain4j/model/dashscope/QwenHelper.java
@@ -380,7 +380,7 @@ class QwenHelper {
     static ToolBase toToolFunction(ToolSpecification toolSpecification) {
         FunctionDefinition functionDefinition = FunctionDefinition.builder()
                 .name(toolSpecification.name())
-                .description(toolSpecification.description())
+                .description(getOrDefault(toolSpecification.description(), ""))
                 .parameters(toParameters(toolSpecification))
                 .build();
         return ToolFunction.builder().function(functionDefinition).build();


### PR DESCRIPTION
## Change
Fix that Qwen does not allow tool description to be null (but allows blank string)

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green

