### PR TITLE
Tiny fix for `EmbeddingStoreWithFilteringIT`

### DIFF
--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithFilteringIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreWithFilteringIT.java
@@ -94,7 +94,7 @@ public abstract class EmbeddingStoreWithFilteringIT extends EmbeddingStoreIT {
                         metadataKey("key").isEqualTo(TEST_UUID),
                         asList(
                                 new Metadata().put("key", TEST_UUID),
-                                new Metadata().put("key", TEST_UUID).put("key2", "b")
+                                new Metadata().put("key", TEST_UUID).put("key2", UUID.randomUUID())
                         ),
                         asList(
                                 new Metadata().put("key", UUID.randomUUID()),

--- a/langchain4j-milvus/pom.xml
+++ b/langchain4j-milvus/pom.xml
@@ -88,6 +88,18 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreCloudIT.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreCloudIT.java
@@ -10,6 +10,7 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreWithFilteringIT;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.util.List;
 
@@ -17,6 +18,7 @@ import static io.milvus.common.clientenum.ConsistencyLevelEnum.STRONG;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@EnabledIfEnvironmentVariable(named = "MILVUS_API_KEY", matches = ".+")
 class MilvusEmbeddingStoreCloudIT extends EmbeddingStoreWithFilteringIT {
 
     private static final String COLLECTION_NAME = "test_collection";

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStoreIT.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStoreIT.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.AfterAll;
 
 import java.sql.SQLException;
 
-public class OracleEmbeddingStoreWithFilteringIT extends EmbeddingStoreWithFilteringIT {
+public class OracleEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
 
     private static final OracleEmbeddingStore EMBEDDING_STORE = CommonTestOperations.newEmbeddingStore();
 

--- a/langchain4j-pinecone/pom.xml
+++ b/langchain4j-pinecone/pom.xml
@@ -86,6 +86,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>

--- a/langchain4j-qdrant/pom.xml
+++ b/langchain4j-qdrant/pom.xml
@@ -103,6 +103,18 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStoreIT.java
+++ b/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStoreIT.java
@@ -36,8 +36,7 @@ import static dev.langchain4j.internal.Utils.randomUUID;
 
 @Testcontainers
 class QdrantEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
-    protected static final UUID TEST_UUID = UUID.randomUUID();
-    static final UUID TEST_UUID2 = UUID.randomUUID();
+
     private static String collectionName = "langchain4j-" + randomUUID();
     private static int dimension = 384;
     private static Distance distance = Distance.Cosine;


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #1924  

## Change
<!-- Please describe the changes you made. -->

> This PR is mainly for `ClickHosue` because a column can have only one type.

1. Change `key2` from `"b"` to `UUID.randomUUID()`.
2. Rename `OracleEmbeddingStoreWithFilteringIT` to `OracleEmbeddingStoreIT` to keep the consistence with other modules.
3. Add tinylog test dependencies in some modules which has no slf4j implementation.

For all subclass of `EmbeddingStoreWithFilteringIT`, I have verified them and they are all green. (except `AzureAiSearch` and `MilvusCloud`, which I have no api key)

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
