### PR TITLE
DashScope: Bump dashscope-sdk-java version from 2.16.4 to 2.16.8

### DIFF
--- a/langchain4j-dashscope/pom.xml
+++ b/langchain4j-dashscope/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dashscope-sdk-java</artifactId>
-            <version>2.16.4</version>
+            <version>2.16.8</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Change
Bump dashscope-sdk-java version from 2.16.4 to 2.16.8

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
