### PR TITLE
Ability to pass JSON schema as a String PR:

### DIFF
--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -36,6 +36,11 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -34,11 +34,11 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
-        <!-- Test dependencies -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <!-- Test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ResponseFormat.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ResponseFormat.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.chat.request;
 
 import dev.langchain4j.Experimental;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaParser;
 
 import java.util.Objects;
 
@@ -70,6 +71,11 @@ public class ResponseFormat {
 
         public Builder jsonSchema(JsonSchema jsonSchema) {
             this.jsonSchema = jsonSchema;
+            return this;
+        }
+
+        public Builder jsonSchemaString(String jsonSchemaString) {
+            this.jsonSchema = JsonSchemaParser.fromJsonString(jsonSchemaString);
             return this;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonSchemaParser.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonSchemaParser.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.Experimental;
-import dev.langchain4j.model.chat.request.ResponseFormat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,14 +13,11 @@ public class JsonSchemaParser {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    public static ResponseFormat fromJsonString(String jsonSchemaString) {
+    public static JsonSchema fromJsonString(String jsonSchemaString) {
         try {
-            return ResponseFormat.builder()
-                .type(ResponseFormat.JSON.type())
-                .jsonSchema(JsonSchema.builder()
+            return JsonSchema.builder()
                     .rootElement(parse(mapper.readTree(jsonSchemaString)))
-                    .build())
-                .build();
+                    .build();
         }catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -32,23 +28,18 @@ public class JsonSchemaParser {
         String type = jsonNode.has("type") ? jsonNode.get("type").asText() : null;
         String description = jsonNode.has("description") ? jsonNode.get("description").asText() : null;
 
-        if (type == null){
+        if (type == null) {
             throw new IllegalArgumentException("Type cannot be null");
         }
 
         return switch (type) {
-            case "string" ->
-                JsonStringSchema.builder().description(description).build();
-            case "integer" ->
-                JsonIntegerSchema.builder().description(description).build();
-            case "boolean" ->
-                JsonBooleanSchema.builder().description(description).build();
-            case "number" ->
-                JsonNumberSchema.builder().description(description).build();
-            case "object" ->
-                parseObject(jsonNode);
-            case "array" ->
-                parseArray(jsonNode);
+            case "string" -> JsonStringSchema.builder().description(description).build();
+            case "integer" -> JsonIntegerSchema.builder().description(description).build();
+            case "boolean" -> JsonBooleanSchema.builder().description(description).build();
+            case "number" -> JsonNumberSchema.builder().description(description).build();
+            case "enum" -> JsonEnumSchema.builder().description(description).build();
+            case "object" -> parseObject(jsonNode);
+            case "array" -> parseArray(jsonNode);
             default -> throw new IllegalArgumentException("Unsupported JSON schema type: " + type);
         };
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonSchemaParser.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonSchemaParser.java
@@ -1,0 +1,85 @@
+package dev.langchain4j.model.chat.request.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Experimental
+public class JsonSchemaParser {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public static ResponseFormat fromJsonString(String jsonSchemaString) {
+        try {
+            return ResponseFormat.builder()
+                .type(ResponseFormat.JSON.type())
+                .jsonSchema(JsonSchema.builder()
+                    .rootElement(parse(mapper.readTree(jsonSchemaString)))
+                    .build())
+                .build();
+        }catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    private static JsonSchemaElement parse(JsonNode jsonNode) {
+        String type = jsonNode.has("type") ? jsonNode.get("type").asText() : null;
+        String description = jsonNode.has("description") ? jsonNode.get("description").asText() : null;
+
+        if (type == null){
+            throw new IllegalArgumentException("Type cannot be null");
+        }
+
+        return switch (type) {
+            case "string" ->
+                JsonStringSchema.builder().description(description).build();
+            case "integer" ->
+                JsonIntegerSchema.builder().description(description).build();
+            case "boolean" ->
+                JsonBooleanSchema.builder().description(description).build();
+            case "number" ->
+                JsonNumberSchema.builder().description(description).build();
+            case "object" ->
+                parseObject(jsonNode);
+            case "array" ->
+                parseArray(jsonNode);
+            default -> throw new IllegalArgumentException("Unsupported JSON schema type: " + type);
+        };
+    }
+
+    private static JsonObjectSchema parseObject(JsonNode jsonNode) {
+        JsonObjectSchema.Builder builder = new JsonObjectSchema.Builder();
+
+        if (jsonNode.has("properties")) {
+            JsonNode propertiesNode = jsonNode.get("properties");
+            propertiesNode.fields().forEachRemaining(entry -> {
+                String key = entry.getKey();
+                JsonNode value = entry.getValue();
+                builder.addProperty(key, parse(value));
+            });
+        }
+
+        if (jsonNode.has("required")) {
+            List<String> required = new ArrayList<>();
+            jsonNode.get("required").forEach(reqNode -> required.add(reqNode.asText()));
+            builder.required(required);
+        }
+
+        return builder.build();
+    }
+
+    private static JsonArraySchema parseArray(JsonNode jsonNode) {
+        JsonArraySchema.Builder builder = new JsonArraySchema.Builder();
+        if (jsonNode.has("items")) {
+            builder.items(parse(jsonNode.get("items")));
+        }
+        return builder.build();
+    }
+
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/json/JsonSchemaParserTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/json/JsonSchemaParserTest.java
@@ -1,8 +1,6 @@
 package dev.langchain4j.model.chat.request.json;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import dev.langchain4j.model.chat.request.ResponseFormat;
-import dev.langchain4j.model.chat.request.ResponseFormatType;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,10 +47,9 @@ public class JsonSchemaParserTest {
             }
         """;
 
-        ResponseFormat responseFormat = JsonSchemaParser.fromJsonString(jsonSchema);
-        assertEquals(responseFormat.type(), ResponseFormatType.JSON);
-        assertInstanceOf(JsonStringSchema.class, responseFormat.jsonSchema().rootElement());
-        assertEquals(((JsonStringSchema) responseFormat.jsonSchema().rootElement()).description(), "A simple string");
+        JsonSchema schema = JsonSchemaParser.fromJsonString(jsonSchema);
+        assertInstanceOf(JsonStringSchema.class, schema.rootElement());
+        assertEquals(((JsonStringSchema) schema.rootElement()).description(), "A simple string");
     }
 
 
@@ -79,10 +76,9 @@ public class JsonSchemaParserTest {
         }
     """;
 
-        ResponseFormat responseFormat = JsonSchemaParser.fromJsonString(jsonSchema);
-        assertEquals(responseFormat.type(), ResponseFormatType.JSON);
-        assertInstanceOf(JsonObjectSchema.class, responseFormat.jsonSchema().rootElement());
-        JsonObjectSchema rootSchema = (JsonObjectSchema) responseFormat.jsonSchema().rootElement();
+        JsonSchema schema = JsonSchemaParser.fromJsonString(jsonSchema);
+        assertInstanceOf(JsonObjectSchema.class, schema.rootElement());
+        JsonObjectSchema rootSchema = (JsonObjectSchema) schema.rootElement();
 
         assertEquals(1, rootSchema.properties().size());
         assertInstanceOf(JsonObjectSchema.class, rootSchema.properties().get("person"));
@@ -130,14 +126,14 @@ public class JsonSchemaParserTest {
             }
         """;
 
-        ResponseFormat responseFormat = JsonSchemaParser.fromJsonString(jsonSchema);
-        assertEquals(responseFormat.type(), ResponseFormatType.JSON);
-        assertInstanceOf(JsonObjectSchema.class, responseFormat.jsonSchema().rootElement());
-        assertEquals(4, ((JsonObjectSchema)responseFormat.jsonSchema().rootElement()).properties().size());
-        assertEquals(3, ((JsonObjectSchema)responseFormat.jsonSchema().rootElement()).required().size());
-        assertInstanceOf(JsonStringSchema.class, ((JsonObjectSchema)responseFormat.jsonSchema().rootElement()).properties().get("title"));
-        assertInstanceOf(JsonIntegerSchema.class, ((JsonObjectSchema)responseFormat.jsonSchema().rootElement()).properties().get("preparationTimeMinutes"));
-        assertEquals("A preparation time minutes", ((JsonIntegerSchema)((JsonObjectSchema)responseFormat.jsonSchema().rootElement()).properties().get("preparationTimeMinutes")).description());
+        JsonSchema schema = JsonSchemaParser.fromJsonString(jsonSchema);
+
+        assertInstanceOf(JsonObjectSchema.class, schema.rootElement());
+        assertEquals(4, ((JsonObjectSchema)schema.rootElement()).properties().size());
+        assertEquals(3, ((JsonObjectSchema)schema.rootElement()).required().size());
+        assertInstanceOf(JsonStringSchema.class, ((JsonObjectSchema)schema.rootElement()).properties().get("title"));
+        assertInstanceOf(JsonIntegerSchema.class, ((JsonObjectSchema)schema.rootElement()).properties().get("preparationTimeMinutes"));
+        assertEquals("A preparation time minutes", ((JsonIntegerSchema)((JsonObjectSchema)schema.rootElement()).properties().get("preparationTimeMinutes")).description());
     }
 
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/json/JsonSchemaParserTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/json/JsonSchemaParserTest.java
@@ -1,0 +1,143 @@
+package dev.langchain4j.model.chat.request.json;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ResponseFormatType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class JsonSchemaParserTest {
+
+    @Test
+    public void testParseInvalidJsonSchema() {
+        String jsonSchema = """
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type": "integer"
+                }
+                // Missing comma here should trigger an error
+                "email": {
+                    "type": "string"
+                }
+            }
+        }
+    """;
+
+        try {
+            JsonSchemaParser.fromJsonString(jsonSchema);
+            fail("Expected a JsonParseException to be thrown");
+        } catch (RuntimeException e) {
+            assertInstanceOf(JsonParseException.class, e.getCause());
+        }
+    }
+
+
+    @Test
+    public void testParseSimpleJsonString() {
+        String jsonSchema = """
+            {
+                "type": "string",
+                "description": "A simple string"
+            }
+        """;
+
+        ResponseFormat responseFormat = JsonSchemaParser.fromJsonString(jsonSchema);
+        assertEquals(responseFormat.type(), ResponseFormatType.JSON);
+        assertInstanceOf(JsonStringSchema.class, responseFormat.jsonSchema().rootElement());
+        assertEquals(((JsonStringSchema) responseFormat.jsonSchema().rootElement()).description(), "A simple string");
+    }
+
+
+    @Test
+    public void testParseNestedJsonObject() {
+        String jsonSchema = """
+        {
+            "type": "object",
+            "properties": {
+                "person": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "age": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": ["name"]
+                }
+            },
+            "required": ["person"]
+        }
+    """;
+
+        ResponseFormat responseFormat = JsonSchemaParser.fromJsonString(jsonSchema);
+        assertEquals(responseFormat.type(), ResponseFormatType.JSON);
+        assertInstanceOf(JsonObjectSchema.class, responseFormat.jsonSchema().rootElement());
+        JsonObjectSchema rootSchema = (JsonObjectSchema) responseFormat.jsonSchema().rootElement();
+
+        assertEquals(1, rootSchema.properties().size());
+        assertInstanceOf(JsonObjectSchema.class, rootSchema.properties().get("person"));
+        JsonObjectSchema personSchema = (JsonObjectSchema) rootSchema.properties().get("person");
+        assertEquals(2, personSchema.properties().size());
+        assertEquals(1, personSchema.required().size());
+        assertInstanceOf(JsonStringSchema.class, personSchema.properties().get("name"));
+        assertInstanceOf(JsonIntegerSchema.class, personSchema.properties().get("age"));
+    }
+
+
+
+
+    @Test
+    public void testParseComplexJsonString() {
+        String jsonSchema = """
+            {
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string"
+                        },
+                        "preparationTimeMinutes": {
+                            "description": "A preparation time minutes",
+                            "type": "integer"
+                        },
+                        "ingredients": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "steps": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "title",
+                        "preparationTimeMinutes",
+                        "steps"
+                    ]
+            }
+        """;
+
+        ResponseFormat responseFormat = JsonSchemaParser.fromJsonString(jsonSchema);
+        assertEquals(responseFormat.type(), ResponseFormatType.JSON);
+        assertInstanceOf(JsonObjectSchema.class, responseFormat.jsonSchema().rootElement());
+        assertEquals(4, ((JsonObjectSchema)responseFormat.jsonSchema().rootElement()).properties().size());
+        assertEquals(3, ((JsonObjectSchema)responseFormat.jsonSchema().rootElement()).required().size());
+        assertInstanceOf(JsonStringSchema.class, ((JsonObjectSchema)responseFormat.jsonSchema().rootElement()).properties().get("title"));
+        assertInstanceOf(JsonIntegerSchema.class, ((JsonObjectSchema)responseFormat.jsonSchema().rootElement()).properties().get("preparationTimeMinutes"));
+        assertEquals("A preparation time minutes", ((JsonIntegerSchema)((JsonObjectSchema)responseFormat.jsonSchema().rootElement()).properties().get("preparationTimeMinutes")).description());
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!



Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #https://github.com/langchain4j/langchain4j/issues/2013

## Change

This pull request introduces the JsonSchemaParser class to convert JSON formatted strings into a structured JsonSchema representation. The JsonSchemaParser provides a convenient method for parsing JSON schema strings, enabling validation and representation of schema properties in a strongly typed manner.



The JSON schema strings should adhere to the JSON Schema specification. Below are examples of valid schemas that can be parsed by JsonSchemaParser:

Simple JSON Schema:

```json
{
    "type": "string",
    "description": "A simple string"
}
```
Simple nested JsonSchema

```json
{
    "type": "object",
    "properties": {
        "person": {
            "type": "object",
            "properties": {
                "name": {
                    "type": "string"
                },
                "age": {
                    "type": "integer"
                }
            },
            "required": ["name"]
        }
    },
    "required": ["person"]
}
```

So in case you need to write gemini chat model

### Option1:

```java
ChatLanguageModel gemini = GoogleAiGeminiChatModel.builder()
    .apiKey(System.getenv("GEMINI_AI_KEY"))
    .modelName("gemini-1.5-flash")
    .responseFormat(ResponseFormat.builder()
        .type(JSON)
        .jsonSchema(JsonSchema.builder()
            .rootElement(JsonObjectSchema.builder()
                .properties(Map.of(
                    "title", JSON_STRING_SCHEMA,
                    "preparationTimeMinutes", JSON_INTEGER_SCHEMA,
                    "ingredients", JsonArraySchema.builder()
                        .items(JSON_STRING_SCHEMA)
                        .build(),
                    "steps", JsonArraySchema.builder()
                        .items(JSON_STRING_SCHEMA)
                        .build()
                    ))
                .build())
            .build())
        .build())
    .build();

String recipeResponse = gemini.generate(
    "Suggest a dessert recipe with strawberries");

System.out.println(recipeResponse);
```

### Option2

```java
ChatLanguageModel gemini = GoogleAiGeminiChatModel.builder()
                                .apiKey(System.getenv("GEMINI_AI_KEY"))
                                .modelName("gemini-1.5-flash")
                                .responseFormat(ResponseFormat.builder()
                                    .type(JSON)
                                    .jsonSchemaString("""
                                        {
    "type": "object",
    "properties": {
        "title": {
            "type": "string"
        },
        "preparationTimeMinutes": {
            "description": "A preparation time in minutes",
            "type": "integer"
        },
        "ingredients": {
            "type": "array",
            "items": {
                "type": "string"
            }
        },
        "steps": {
            "type": "array",
            "items": {
                "type": "string"
            }
        }
    },
    "required": [
        "title",
        "preparationTimeMinutes",
        "steps"
    ]
}

                                        """)
                                    .build())
                                .build();
String recipeResponse = gemini.generate(
    "Suggest a dessert recipe with strawberries");

System.out.println(recipeResponse);

```



## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [x] I have added unit and integration tests for my change
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
