### PR TITLE
Optimization of UUID Generation Using HexFormat

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -175,9 +176,8 @@ public class Utils {
    */
   public static String generateUUIDFrom(String input) {
       byte[] hashBytes = getSha256Instance().digest(input.getBytes(UTF_8));
-      StringBuilder sb = new StringBuilder();
-      for (byte b : hashBytes) sb.append("%02x".formatted(b));
-      return UUID.nameUUIDFromBytes(sb.toString().getBytes(UTF_8)).toString();
+      String hexFormat = HexFormat.of().formatHex(hashBytes);
+      return UUID.nameUUIDFromBytes(hexFormat.getBytes(UTF_8)).toString();
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->

This pull request introduces the HexFormat class (Java 17+) to optimize the hexadecimal encoding of SHA-256 hashes used for UUID generation in the generateUUIDFrom method. By replacing the manual byte-to-hex conversion with HexFormat, this update aims to improve code readability and potentially enhance performance.


I created JMH test to ensure that HexFormat is more efficient than format of String.

```java
package dev.langchain4j;




import org.openjdk.jmh.annotations.*;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.RunnerException;
import org.openjdk.jmh.runner.options.CommandLineOptionException;
import org.openjdk.jmh.runner.options.CommandLineOptions;
import org.openjdk.jmh.runner.options.Options;
import org.openjdk.jmh.runner.options.OptionsBuilder;

import java.security.MessageDigest;
import java.security.NoSuchAlgorithmException;
import java.util.HexFormat;
import java.util.UUID;
import java.util.concurrent.TimeUnit;

import static java.nio.charset.StandardCharsets.UTF_8;

@State(Scope.Benchmark)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(1)
@Warmup(iterations = 5)
@Measurement(iterations = 2)
public class BenchmarkHex {

    private static String largeString;

    @Setup(Level.Trial)
    public void setup() {
        largeString = generateLargeString(100000);
    }

    @Benchmark
    public void benchmarkOldBehavior(){
        boolean optimized = false;
        generateUUIDFrom(largeString, optimized);
    }


    @Benchmark
    public void benchmarkOptimizedBehavior(){
        boolean optimized = true;
        generateUUIDFrom(largeString, optimized);
    }

    private String generateUUIDFrom(String input, boolean optimized) {
        byte[] hashBytes = getSha256Instance().digest(input.getBytes(UTF_8));
        if (optimized) {
            return UUID.nameUUIDFromBytes(HexFormat.of().formatHex(hashBytes).getBytes(UTF_8)).toString();
        }
        StringBuilder sb = new StringBuilder();
        for (byte b : hashBytes) {
            sb.append("%02x".formatted(b));
        }
        return UUID.nameUUIDFromBytes(sb.toString().getBytes(UTF_8)).toString();
    }

    private MessageDigest getSha256Instance() {
        try {
            return MessageDigest.getInstance("SHA-256");
        } catch (NoSuchAlgorithmException e) {
            throw new IllegalArgumentException(e);
        }
    }

    private String generateLargeString(int length) {
        StringBuilder sb = new StringBuilder();
        for (int i = 0; i < length; i++) {
            sb.append(UUID.randomUUID());
        }
        return sb.toString();
    }

    public static void main(String[] args) throws RunnerException, CommandLineOptionException {
        Options opt = new OptionsBuilder()
                .parent(new CommandLineOptions(args))
                .timeUnit(TimeUnit.NANOSECONDS)
                .include(BenchmarkHex.class.getSimpleName())
                .build();

        new Runner(opt).run();
    }



}

``` 

Results:
```java
Benchmark                                Mode  Cnt  Score   Error  Units
BenchmarkHex.benchmarkOldBehavior        avgt       1.811          ms/op
BenchmarkHex.benchmarkOptimizedBehavior  avgt       1.625          ms/op
```


It's not a really big enhancement, but it's can be here for improving the code



## Change
<!-- Please describe the changes you made. -->


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [ ] I have added unit and integration tests for my change
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
