### PR TITLE
Adds the possibility to encrypt vectors and text segments in the DB

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/embedding/EmbeddingTransformer.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/embedding/EmbeddingTransformer.java
@@ -1,0 +1,37 @@
+package dev.langchain4j.data.embedding;
+
+import dev.langchain4j.data.segment.TextSegment;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Defines the interface for transforming a {@link Embedding}.
+ * Implementations can perform a variety of tasks such as encrypting, salting, etc.
+ */
+public interface EmbeddingTransformer {
+
+    /**
+     * Transforms a provided embedding.
+     *
+     * @param embedding The embedding to be transformed.
+     * @return The transformed embedding, or null if the segment should be filtered out.
+     */
+    Embedding transform(Embedding embedding);
+
+    /**
+     * Transforms all the provided embeddings.
+     *
+     * @param embeddings A list of embeddings to be transformed.
+     * @return A list of transformed embeddings. The length of this list may be shorter or longer than the original list. Returns an empty list if all segments were filtered out.
+     */
+    default List<Embedding> transformAll(List<Embedding> embeddings) {
+        return embeddings.stream()
+                .map(this::transform)
+                .filter(Objects::nonNull)
+                .collect(toList());
+    }
+
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/segment/TextSegmentStorageTransformer.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/segment/TextSegmentStorageTransformer.java
@@ -1,0 +1,36 @@
+package dev.langchain4j.data.segment;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Defines the interface for transforming a {@link TextSegment} before it is inserted into the database.
+ * Implementations can perform a variety of tasks such as transforming, filtering, encrypting, signing, etc.
+ * This is executed after the vector is calculated and before data is inserted into the storage.
+ */
+public interface TextSegmentStorageTransformer {
+
+    /**
+     * Transforms a provided segment.
+     *
+     * @param segment The segment to be transformed.
+     * @return The transformed segment, or null if the segment should be filtered out.
+     */
+    TextSegment transform(TextSegment segment);
+
+    /**
+     * Transforms all the provided segments.
+     *
+     * @param segments A list of segments to be transformed.
+     * @return A list of transformed segments. The length of this list may be shorter or longer than the original list. Returns an empty list if all segments were filtered out.
+     */
+    default List<TextSegment> transformAll(List<TextSegment> segments) {
+        return segments.stream()
+                .map(this::transform)
+                .filter(Objects::nonNull)
+                .collect(toList());
+    }
+
+}


### PR DESCRIPTION
## Issue

Closes #2296 

## Change

Adds the possibility to encrypt vectors and text segments in the DB

## General checklist

- [ ~]  There are no breaking changes *If the user uses Builder in EmbeddingStoreIngestor* then no break as I only changed the constructor arguments. But in the constructor now you need to set two new optional parameters. To avoid this situation we can duplicate the constructor. In fact no test needed to be rewrittten.
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

No IT test required

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

NA

cc/ @mariofusco 
