### PR TITLE
Add RegEx MetadataFilters

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/Filter.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/Filter.java
@@ -12,6 +12,8 @@ import dev.langchain4j.store.embedding.filter.comparison.IsNotIn;
 import dev.langchain4j.store.embedding.filter.logical.And;
 import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
+import dev.langchain4j.store.embedding.filter.regex.Find;
+import dev.langchain4j.store.embedding.filter.regex.Matches;
 
 /**
  * This class represents a filter that can be applied during search in an {@link EmbeddingStore}.
@@ -33,6 +35,8 @@ import dev.langchain4j.store.embedding.filter.logical.Or;
  * @see IsLessThanOrEqualTo
  * @see IsIn
  * @see IsNotIn
+ * @see Find
+ * @see Matches
  * @see And
  * @see Not
  * @see Or

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/MetadataFilterBuilder.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/MetadataFilterBuilder.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.store.embedding.filter;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
 import dev.langchain4j.store.embedding.filter.comparison.IsGreaterThan;
@@ -9,16 +14,12 @@ import dev.langchain4j.store.embedding.filter.comparison.IsLessThan;
 import dev.langchain4j.store.embedding.filter.comparison.IsLessThanOrEqualTo;
 import dev.langchain4j.store.embedding.filter.comparison.IsNotEqualTo;
 import dev.langchain4j.store.embedding.filter.comparison.IsNotIn;
-
+import dev.langchain4j.store.embedding.filter.regex.Find;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static java.util.Arrays.asList;
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.toList;
+import java.util.regex.Pattern;
 
 /**
  * A helper class for building a {@link Filter} for {@link Metadata} key.
@@ -34,7 +35,6 @@ public class MetadataFilterBuilder {
     public static MetadataFilterBuilder metadataKey(String key) {
         return new MetadataFilterBuilder(key);
     }
-
 
     // isEqualTo
 
@@ -62,7 +62,6 @@ public class MetadataFilterBuilder {
         return new IsEqualTo(key, value);
     }
 
-
     // isNotEqualTo
 
     public Filter isNotEqualTo(String value) {
@@ -89,7 +88,6 @@ public class MetadataFilterBuilder {
         return new IsNotEqualTo(key, value);
     }
 
-
     // isGreaterThan
 
     public Filter isGreaterThan(String value) {
@@ -111,7 +109,6 @@ public class MetadataFilterBuilder {
     public Filter isGreaterThan(double value) {
         return new IsGreaterThan(key, value);
     }
-
 
     // isGreaterThanOrEqualTo
 
@@ -135,7 +132,6 @@ public class MetadataFilterBuilder {
         return new IsGreaterThanOrEqualTo(key, value);
     }
 
-
     // isLessThan
 
     public Filter isLessThan(String value) {
@@ -157,7 +153,6 @@ public class MetadataFilterBuilder {
     public Filter isLessThan(double value) {
         return new IsLessThan(key, value);
     }
-
 
     // isLessThanOrEqualTo
 
@@ -181,7 +176,6 @@ public class MetadataFilterBuilder {
         return new IsLessThanOrEqualTo(key, value);
     }
 
-
     // isBetween
 
     public Filter isBetween(String fromValue, String toValue) {
@@ -203,7 +197,6 @@ public class MetadataFilterBuilder {
     public Filter isBetween(double fromValue, double toValue) {
         return isGreaterThanOrEqualTo(fromValue).and(isLessThanOrEqualTo(toValue));
     }
-
 
     // isIn
 
@@ -239,7 +232,6 @@ public class MetadataFilterBuilder {
         return new IsIn(key, values);
     }
 
-
     // isNotIn
 
     public Filter isNotIn(String... values) {
@@ -272,5 +264,25 @@ public class MetadataFilterBuilder {
 
     public Filter isNotIn(Collection<?> values) {
         return new IsNotIn(key, values);
+    }
+
+    // find
+
+    public Filter find(Pattern pattern) {
+        return new Find(key, pattern);
+    }
+
+    public Filter find(String pattern) {
+        return find(Pattern.compile(pattern));
+    }
+
+    // matches
+
+    public Filter matches(Pattern pattern) {
+        return new Find(key, pattern);
+    }
+
+    public Filter matches(String pattern) {
+        return matches(Pattern.compile(pattern));
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/regex/Find.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/regex/Find.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.store.embedding.filter.regex;
+
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * A filter that checks if a subsequence of or the entire value of a metadata key matches a regular expression {@link Pattern}.
+ * The value of the metadata key must be a string or a UUID.
+ * Uses {@link java.util.regex.Matcher#find}.
+ */
+public class Find implements Filter {
+
+    private final String key;
+    private final Pattern pattern;
+
+    public Find(String key, Pattern pattern) {
+        this.key = ensureNotBlank(key, "key");
+        this.pattern = ensureNotNull(pattern, "pattern with key '" + key + "'");
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public Pattern pattern() {
+        return pattern;
+    }
+
+    @Override
+    public boolean test(Object object) {
+        if (!(object instanceof Metadata metadata)) {
+            return false;
+        }
+
+        if (!metadata.containsKey(key)) {
+            return false;
+        }
+
+        Object actualValue = metadata.toMap().get(key);
+
+        if (actualValue == null) {
+            return false;
+        }
+
+        if (actualValue instanceof UUID uuid) {
+            return pattern.matcher(uuid.toString()).find();
+        }
+
+        if (actualValue instanceof String str) {
+            return pattern.matcher(str).find();
+        }
+
+        throw illegalArgument(
+                "Type mismatch: actual value of metadata key \"%s\" (%s) has type %s, "
+                        + "while it is expected to be a string or a UUID",
+                key, actualValue, actualValue.getClass().getName());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof Find other)) return false;
+
+        return Objects.equals(this.key, other.key) && Objects.equals(this.pattern, other.pattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, pattern);
+    }
+
+    @Override
+    public String toString() {
+        return "Find(key=" + this.key + ", pattern=" + this.pattern + ")";
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/regex/Matches.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/regex/Matches.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.store.embedding.filter.regex;
+
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * A filter that checks if the entire value of a metadata key matches a regular expression {@link Pattern}.
+ * The value of the metadata key must be a string or a UUID.
+ * Uses {@link java.util.regex.Matcher#matches}.
+ */
+public class Matches implements Filter {
+
+    private final String key;
+    private final Pattern pattern;
+
+    public Matches(String key, Pattern pattern) {
+        this.key = ensureNotBlank(key, "key");
+        this.pattern = ensureNotNull(pattern, "pattern with key '" + key + "'");
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public Pattern pattern() {
+        return pattern;
+    }
+
+    @Override
+    public boolean test(Object object) {
+        if (!(object instanceof Metadata metadata)) {
+            return false;
+        }
+
+        if (!metadata.containsKey(key)) {
+            return false;
+        }
+
+        Object actualValue = metadata.toMap().get(key);
+
+        if (actualValue == null) {
+            return false;
+        }
+
+        if (actualValue instanceof UUID uuid) {
+            return pattern.matcher(uuid.toString()).matches();
+        }
+
+        if (actualValue instanceof String str) {
+            return pattern.matcher(str).matches();
+        }
+
+        throw illegalArgument(
+                "Type mismatch: actual value of metadata key \"%s\" (%s) has type %s, "
+                        + "while it is expected to be a string or a UUID",
+                key, actualValue, actualValue.getClass().getName());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof Matches other)) return false;
+
+        return Objects.equals(this.key, other.key) && Objects.equals(this.pattern, other.pattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, pattern);
+    }
+
+    @Override
+    public String toString() {
+        return "Matches(key=" + this.key + ", pattern=" + this.pattern + ")";
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/regex/FindTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/regex/FindTest.java
@@ -1,0 +1,68 @@
+package dev.langchain4j.store.embedding.filter.regex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.document.Metadata;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class FindTest {
+
+    @Test
+    void testShouldReturnFalseWhenNotMetadata() {
+        Find find = new Find("key", Pattern.compile("regex"));
+        assertThat(find.test("notMetadata")).isFalse();
+    }
+
+    @Test
+    void testShouldReturnFalseWhenKeyNotFound() {
+        Find find = new Find("key", Pattern.compile("regex"));
+        Metadata metadata = new Metadata(Map.of());
+        assertThat(find.test(metadata)).isFalse();
+    }
+
+    @Test
+    void testShouldReturnTrueWhenUUIDSegmentFound() {
+        UUID uuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+
+        Find find = new Find("key", Pattern.compile("12d3-a456"));
+        Metadata metadata = new Metadata(Map.of("key", uuid));
+        assertThat(find.test(metadata)).isTrue();
+    }
+
+    @Test
+    void testShouldReturnFalseWhenUUIDSegmentNotFound() {
+        UUID uuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+
+        Find find = new Find("key", Pattern.compile("21e2-b365"));
+        Metadata metadata = new Metadata(Map.of("key", uuid));
+        assertThat(find.test(metadata)).isFalse();
+    }
+
+    @Test
+    void testShouldReturnTrueWhenFound() {
+        Find find = new Find("key", Pattern.compile("[A-Z]{5}"));
+        Metadata metadata = new Metadata(Map.of("key", "testREGEXtest"));
+        assertThat(find.test(metadata)).isTrue();
+    }
+
+    @Test
+    void testShouldReturnFalseWhenNotFound() {
+        Find find = new Find("key", Pattern.compile("[A-Z]{5}"));
+        Metadata metadata = new Metadata(Map.of("key", "testregextest"));
+        assertThat(find.test(metadata)).isFalse();
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenTypeMismatch() {
+        Find find = new Find("key", Pattern.compile("[A-Z]{5}"));
+        Metadata metadata = new Metadata(Map.of("key", 123));
+        assertThatThrownBy(() -> find.test(metadata))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Type mismatch: actual value of metadata key \"key\" (123) has type java.lang.Integer, while it is expected to be a string or a UUID");
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/regex/MatchesTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/regex/MatchesTest.java
@@ -1,0 +1,68 @@
+package dev.langchain4j.store.embedding.filter.regex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.document.Metadata;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class MatchesTest {
+
+    @Test
+    void testShouldReturnFalseWhenNotMetadata() {
+        Matches matches = new Matches("key", Pattern.compile("regex"));
+        assertThat(matches.test("notMetadata")).isFalse();
+    }
+
+    @Test
+    void testShouldReturnFalseWhenKeyNotFound() {
+        Matches matches = new Matches("key", Pattern.compile("regex"));
+        Metadata metadata = new Metadata(Map.of());
+        assertThat(matches.test(metadata)).isFalse();
+    }
+
+    @Test
+    void testShouldReturnTrueWhenUUIDMatches() {
+        UUID uuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+
+        Find matches = new Find("key", Pattern.compile(uuid.toString()));
+        Metadata metadata = new Metadata(Map.of("key", uuid));
+        assertThat(matches.test(metadata)).isTrue();
+    }
+
+    @Test
+    void testShouldReturnFalseWhenUUIDNotMatches() {
+        UUID uuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+
+        Find matches = new Find("key", Pattern.compile(uuid.toString().replace("2", "4")));
+        Metadata metadata = new Metadata(Map.of("key", uuid));
+        assertThat(matches.test(metadata)).isFalse();
+    }
+
+    @Test
+    void testShouldReturnTrueWhenMatch() {
+        Matches matches = new Matches("key", Pattern.compile("[A-Z]{5}"));
+        Metadata metadata = new Metadata(Map.of("key", "REGEX"));
+        assertThat(matches.test(metadata)).isTrue();
+    }
+
+    @Test
+    void testShouldReturnFalseWhenNoMatch() {
+        Matches matches = new Matches("key", Pattern.compile("[A-Z]{5}"));
+        Metadata metadata = new Metadata(Map.of("key", "testREGEXtest"));
+        assertThat(matches.test(metadata)).isFalse();
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenTypeMismatch() {
+        Matches matches = new Matches("key", Pattern.compile("regex"));
+        Metadata metadata = new Metadata(Map.of("key", 123));
+        assertThatThrownBy(() -> matches.test(metadata))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Type mismatch: actual value of metadata key \"key\" (123) has type java.lang.Integer, while it is expected to be a string or a UUID");
+    }
+}


### PR DESCRIPTION
## Change

This PR adds new MetadataFilters that allow filtering metadata values by RegEx, both with `Matcher::matches` and `Matcher::find`.
The ability to use RegEx is very powerful, though embedding stores might not be able to filter by RegEx internally.
## General checklist

- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)