### PR TITLE
Version upgrade for Milvus integration

### DIFF
--- a/langchain4j-milvus/README.MD
+++ b/langchain4j-milvus/README.MD
@@ -1,0 +1,15 @@
+# Milvus Embedding Store
+
+This module implements `EmbeddingStore` using Milvus Vector Database.
+
+## Requirements
+
+- Milvus 2.4.20 or newer
+
+## Running the Test Suite
+
+The test suites can run on [Docker Testcontainers](https://java.testcontainers.org/modules/milvus/) or a [Zilliz Cloud](https://zilliz.com/cloud) cluster. For the cloud target, make sure the following environment variables are configured:
+- MILVUS_URI
+- MILVUS_API_KEY
+- MILVUS_USERNAME
+- MILVUS_PASSWORD

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreIT.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreIT.java
@@ -29,7 +29,7 @@ class MilvusEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
     private static final String COLLECTION_NAME = "test_collection";
 
     @Container
-    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.3.16");
+    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.4.20");
 
     MilvusEmbeddingStore embeddingStore = MilvusEmbeddingStore.builder()
             .uri(milvus.getEndpoint())

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreRemovalIT.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreRemovalIT.java
@@ -16,7 +16,7 @@ import static io.milvus.common.clientenum.ConsistencyLevelEnum.STRONG;
 class MilvusEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {
 
     @Container
-    static MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.3.16");
+    static MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.4.20");
 
     MilvusEmbeddingStore embeddingStore = MilvusEmbeddingStore.builder()
             .uri(milvus.getEndpoint())

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -86,7 +86,7 @@
         <jedis.version>5.0.0</jedis.version>
         <aws.java.sdk.version>2.21.44</aws.java.sdk.version>
         <github-api.version>1.318</github-api.version>
-        <milvus-sdk-java.version>2.4.2</milvus-sdk-java.version>
+        <milvus-sdk-java.version>2.5.3</milvus-sdk-java.version>
         <netty.version>4.1.111.Final</netty.version>
         <awaitility.version>4.2.2</awaitility.version>
         <jsonpath.version>2.9.0</jsonpath.version>


### PR DESCRIPTION
## Issue
Closes #2332

## Change
Milvus-sdk dependency upgraded to 2.5.3 and test containers to 2.4.20. Added a simple README.md 

## General checklist
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for changing existing embedding store integration
- [X] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
