### PR TITLE
Use correct name in Eviction policy documentation

### DIFF
--- a/docs/docs/tutorials/2-chat-memory.md
+++ b/docs/docs/tutorials/2-chat-memory.md
@@ -46,7 +46,7 @@ Currently, LangChain4j offers 2 out-of-the-box implementations:
   which also operates as a sliding window but focuses on keeping the `N` most recent **tokens**,
   evicting older messages as needed.
   Messages are indivisible. If a message doesn't fit, it is evicted completely.
-  `MessageWindowChatMemory` requires a `Tokenizer` to count the tokens in each `ChatMessage`.
+  `TokenWindowChatMemory` requires a `Tokenizer` to count the tokens in each `ChatMessage`.
 
 ## Persistence
 


### PR DESCRIPTION
## Change
Replace "MessageWindowChatMemory" with "TokenWindowChatMemory" in Eviction policy documentation.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
