### PR TITLE
MCP: ping responses and simplification of McpTransport

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/protocol/ClientMethod.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/protocol/ClientMethod.java
@@ -12,5 +12,7 @@ public enum ClientMethod {
     @JsonProperty("notifications/cancelled")
     NOTIFICATION_CANCELLED,
     @JsonProperty("notifications/initialized")
-    NOTIFICATION_INITIALIZED
+    NOTIFICATION_INITIALIZED,
+    @JsonProperty("ping")
+    PING
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/protocol/PingResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/protocol/PingResponse.java
@@ -1,0 +1,16 @@
+package dev.langchain4j.mcp.client.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PingResponse extends McpClientMessage {
+
+    // has to be an empty object
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final Map<String, Object> result = new HashMap<>();
+
+    public PingResponse(final Long id) {
+        super(id);
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
@@ -1,9 +1,8 @@
 package dev.langchain4j.mcp.client.transport;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import dev.langchain4j.mcp.client.protocol.McpCallToolRequest;
+import dev.langchain4j.mcp.client.protocol.McpClientMessage;
 import dev.langchain4j.mcp.client.protocol.McpInitializeRequest;
-import dev.langchain4j.mcp.client.protocol.McpListToolsRequest;
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
@@ -24,20 +23,13 @@ public interface McpTransport extends Closeable {
     CompletableFuture<JsonNode> initialize(McpInitializeRequest request);
 
     /**
-     * Requests a list of available tools from the MCP server.
+     * Executes an operation that expects a response from the server.
      */
-    CompletableFuture<JsonNode> listTools(McpListToolsRequest request);
+    CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage request);
 
     /**
-     * Executes a tool on the MCP server.
-     * @param request the tool execution request
+     * Sends a message that does not expect a response from the server. The 'id' field
+     * of the message should be null.
      */
-    CompletableFuture<JsonNode> executeTool(McpCallToolRequest request);
-
-    /**
-     * Cancels a running operation on the server (sends a 'notifications/cancelled' message to the server).
-     * This does not expect any response from the server.
-     * @param operationId The ID of the operation to be cancelled.
-     */
-    void cancelOperation(long operationId);
+    void executeOperationWithoutResponse(McpClientMessage request);
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
@@ -6,12 +6,9 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.langchain4j.mcp.client.protocol.CancellationNotification;
 import dev.langchain4j.mcp.client.protocol.InitializationNotification;
-import dev.langchain4j.mcp.client.protocol.McpCallToolRequest;
 import dev.langchain4j.mcp.client.protocol.McpClientMessage;
 import dev.langchain4j.mcp.client.protocol.McpInitializeRequest;
-import dev.langchain4j.mcp.client.protocol.McpListToolsRequest;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import java.io.IOException;
@@ -83,7 +80,7 @@ public class HttpMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> listTools(McpListToolsRequest operation) {
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
         try {
             Request httpRequest = createRequest(operation);
             return execute(httpRequest, operation.getId());
@@ -93,22 +90,12 @@ public class HttpMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeTool(McpCallToolRequest operation) {
+    public void executeOperationWithoutResponse(McpClientMessage operation) {
         try {
             Request httpRequest = createRequest(operation);
-            return execute(httpRequest, operation.getId());
-        } catch (JsonProcessingException e) {
-            return CompletableFuture.failedFuture(e);
-        }
-    }
-
-    @Override
-    public void cancelOperation(long operationId) {
-        try {
-            Request httpRequest = createRequest(new CancellationNotification(operationId, "Timeout"));
             execute(httpRequest, null);
         } catch (JsonProcessingException e) {
-            log.warn("Failed to create a cancellation request", e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
@@ -3,11 +3,9 @@ package dev.langchain4j.mcp.client.transport.stdio;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.langchain4j.mcp.client.protocol.CancellationNotification;
 import dev.langchain4j.mcp.client.protocol.InitializationNotification;
-import dev.langchain4j.mcp.client.protocol.McpCallToolRequest;
+import dev.langchain4j.mcp.client.protocol.McpClientMessage;
 import dev.langchain4j.mcp.client.protocol.McpInitializeRequest;
-import dev.langchain4j.mcp.client.protocol.McpListToolsRequest;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import java.io.IOException;
@@ -69,34 +67,19 @@ public class StdioMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> listTools(McpListToolsRequest operation) {
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
         try {
             String requestString = OBJECT_MAPPER.writeValueAsString(operation);
             return execute(requestString, operation.getId());
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            return CompletableFuture.failedFuture(e);
         }
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeTool(McpCallToolRequest operation) {
+    public void executeOperationWithoutResponse(McpClientMessage operation) {
         try {
             String requestString = OBJECT_MAPPER.writeValueAsString(operation);
-            return execute(requestString, operation.getId());
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    public void cancelOperation(long operationId) {
-        try {
-            String requestString =
-                    OBJECT_MAPPER.writeValueAsString(new CancellationNotification(operationId, "Timeout"));
-            // Note: we're passing a null operationId here because this
-            // argument refers to the 'cancellation' notification, not the
-            // operation being cancelled. The cancellation is a notification
-            // so it does not have any ID and does not expect any response.
             execute(requestString, null);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
- Makes the `McpTransport` interface more generic by squashing most operations into `executeOperationWithResponse` and `executeOperationWithoutResponse` instead of having a separate method for each operation
- Implements responding to server-initiated pings

Test coverage for pings I currently only have for the Quarkus side https://github.com/jmartisk/quarkus-langchain4j/commit/5cdcf4298e0168b3e5ba42d5f8780710ac4d9c93 because only there I have a mock MCP server where I am able to hook into pings and confirm to the client that the server received a pong