### PR TITLE
 Allow ChatRequestParameters in AiServices chat method (#2410)

### DIFF
--- a/docs/docs/tutorials/ai-services.md
+++ b/docs/docs/tutorials/ai-services.md
@@ -174,6 +174,47 @@ This annotation is necessary only when the `-parameters` option is *not* enabled
 `@UserMessage` can also load a prompt template from resources:
 `@UserMessage(fromResource = "my-prompt-template.txt")`
 
+## ChatRequestParameters
+
+In some cases, you may want to configure parameters (e.g., temperature, toolsChoice, maximum tokens, etc.) on a per-call basis. For example, you might want some requests to be more “creative” (higher temperature) and others to be more deterministic (lower temperature).
+
+To achieve this, you can create a second parameter in your AI Service method that accepts ChatRequestParams—marked with a custom annotation (@ChatRequestParams). This tells LangChain4j to accept and merge these parameters during each invocation.
+
+:::note
+Note that ChatRequestParameters toolsSpecification and responseFormat will override parameters set on AiContext. If not set by ChatRequestParameters, AiContext definition will be used.
+:::
+
+Define your interface with a second parameter:
+
+```java
+interface AssistantWithChatParams {
+
+    String chat(@UserMessage String userMessage, ChatRequestParameters params);
+}
+```
+
+Build the AI Service:
+
+java
+```java
+AssistantWithChatParams assistant = AiServices.builder(AssistantWithChatParams.class)
+.chatLanguageModel(openAiChatModel)  // or whichever model
+.build();
+```
+
+Call it with any per-call parameters:
+
+```java
+ChatRequestParameters customParams = ChatRequestParameters.builder()
+.temperature(0.85)
+.build();
+
+String answer = assistant.chat("Hi there!", customParams);
+```
+
+
+
+
 ## Examples of valid AI Service methods
 
 Below are some examples of valid AI service methods.
@@ -185,6 +226,8 @@ Below are some examples of valid AI service methods.
 String chat(String userMessage);
 
 String chat(@UserMessage String userMessage);
+
+String chat(@UserMessage String userMessage, ChatRequestParameters parameters);
 
 String chat(@UserMessage String userMessage, @V("country") String country); // userMessage contains "{{country}}" template variable
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesSystemAndUserMessageConfigsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesSystemAndUserMessageConfigsTest.java
@@ -1,14 +1,5 @@
 package dev.langchain4j.service;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.model.chat.mock.ChatModelMock;
-import dev.langchain4j.model.chat.request.ChatRequest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Spy;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import static dev.langchain4j.data.message.SystemMessage.systemMessage;
 import static dev.langchain4j.data.message.UserMessage.userMessage;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,6 +8,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class AiServicesSystemAndUserMessageConfigsTest {
@@ -144,9 +144,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_1() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatLanguageModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatLanguageModel(model).build();
 
         // when-then
         assertThat(aiService.chat1("Country: Germany")).containsIgnoringCase("Berlin");
@@ -162,9 +161,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_2() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatLanguageModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatLanguageModel(model).build();
 
         // when-then
         assertThat(aiService.chat2("Country: Germany")).containsIgnoringCase("Berlin");
@@ -180,9 +178,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_3() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatLanguageModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatLanguageModel(model).build();
 
         // when-then
         assertThat(aiService.chat3("a name of it's capital", "Country: Germany"))
@@ -199,9 +196,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_4() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatLanguageModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatLanguageModel(model).build();
 
         // when-then
         assertThat(aiService.chat4("Country: {{country}}", "Germany")).containsIgnoringCase("Berlin");
@@ -217,9 +213,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_5() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatLanguageModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatLanguageModel(model).build();
 
         // when-then
         assertThat(aiService.chat5("a name of it's capital", "Country: {{country}}", "Germany"))
@@ -236,9 +231,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_6() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatLanguageModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatLanguageModel(model).build();
 
         // when-then
         assertThat(aiService.chat6()).containsIgnoringCase("Berlin");
@@ -254,9 +248,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_7() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatLanguageModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatLanguageModel(model).build();
 
         // when-then
         assertThat(aiService.chat7("a name of it's capital")).containsIgnoringCase("Berlin");
@@ -272,9 +265,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_8() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatLanguageModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatLanguageModel(model).build();
 
         // when-then
         assertThat(aiService.chat8("Germany")).containsIgnoringCase("Berlin");
@@ -290,9 +282,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_9() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatLanguageModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatLanguageModel(model).build();
 
         // when-then
         assertThat(aiService.chat9("Germany")).containsIgnoringCase("Berlin");
@@ -308,9 +299,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_10() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatLanguageModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatLanguageModel(model).build();
 
         // when-then
         assertThat(aiService.chat10("a name of it's capital", "Germany")).containsIgnoringCase("Berlin");
@@ -538,15 +528,14 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void illegal_system_message_configuration_1() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatLanguageModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatLanguageModel(model).build();
 
         // when-then
         assertThatThrownBy(() -> aiService.illegalChat1("a name of it's capital", "Country: Germany"))
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("Parameter 'arg1' of method 'illegalChat1' should be annotated "
-                        + "with @V or @UserMessage or @UserName or @MemoryId");
+                        + "with @V or @UserMessage or @UserName or @MemoryId or be ChatRequestParameters");
     }
 
     @Test
@@ -562,6 +551,6 @@ class AiServicesSystemAndUserMessageConfigsTest {
         assertThatThrownBy(() -> aiService.illegalChat2("a name of it's capital", "Country: Germany"))
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("Parameter 'arg1' of method 'illegalChat2' should be annotated "
-                        + "with @V or @UserMessage or @UserName or @MemoryId");
+                        + "with @V or @UserMessage or @UserName or @MemoryId or be ChatRequestParameters");
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesUserMessageConfigTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesUserMessageConfigTest.java
@@ -230,7 +230,7 @@ class AiServicesUserMessageConfigTest {
         assertThatThrownBy(() -> aiService.illegalChat3("What is the capital of {{it}}?", "Germany"))
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("Parameter 'arg0' of method 'illegalChat3' should be annotated "
-                        + "with @V or @UserMessage or @UserName or @MemoryId");
+                        + "with @V or @UserMessage or @UserName or @MemoryId or be ChatRequestParameters");
     }
 
     @Test
@@ -245,7 +245,7 @@ class AiServicesUserMessageConfigTest {
         assertThatThrownBy(() -> aiService.illegalChat4("What is the capital of {{it}}?", "Germany"))
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("Parameter 'arg1' of method 'illegalChat4' should be annotated "
-                        + "with @V or @UserMessage or @UserName or @MemoryId");
+                        + "with @V or @UserMessage or @UserName or @MemoryId or be ChatRequestParameters");
     }
 
     @Test


### PR DESCRIPTION
## Issue
"Implements #2410"

## Change
Add option to set custom ChatRequestParameters when calling chat method on AiServices interface.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
X - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
X - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
