### PR TITLE
Add splitter for Markdown, taking document hierarchy into account

### DIFF
--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -93,8 +93,7 @@
         <infinispan.version>15.0.0.Final</infinispan.version>
         <kotlin.version>1.9.25</kotlin.version>
         <kotlinx.version>1.9.0</kotlinx.version>
-        <!-- SNAPSHOT including https://github.com/commonmark/commonmark-java/pull/361 -->
-        <commonmark.version>0.24.1-SNAPSHOT</commonmark.version>
+        <commonmark.version>0.24.0</commonmark.version>
     </properties>
 
     <dependencyManagement>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -93,6 +93,8 @@
         <infinispan.version>15.0.0.Final</infinispan.version>
         <kotlin.version>1.9.25</kotlin.version>
         <kotlinx.version>1.9.0</kotlinx.version>
+        <!-- SNAPSHOT including https://github.com/commonmark/commonmark-java/pull/361 -->
+        <commonmark.version>0.24.1-SNAPSHOT</commonmark.version>
     </properties>
 
     <dependencyManagement>
@@ -205,6 +207,24 @@
                 <groupId>com.knuddels</groupId>
                 <artifactId>jtokkit</artifactId>
                 <version>${jtokkit.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.commonmark</groupId>
+                <artifactId>commonmark</artifactId>
+                <version>${commonmark.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.commonmark</groupId>
+                <artifactId>commonmark-ext-gfm-tables</artifactId>
+                <version>${commonmark.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.commonmark</groupId>
+                <artifactId>commonmark-ext-yaml-front-matter</artifactId>
+                <version>${commonmark.version}</version>
             </dependency>
 
             <dependency>

--- a/langchain4j/pom.xml
+++ b/langchain4j/pom.xml
@@ -37,6 +37,21 @@
         </dependency>
 
         <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark-ext-gfm-tables</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark-ext-yaml-front-matter</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/MarkdownSectionSplitter.java
+++ b/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/MarkdownSectionSplitter.java
@@ -1,0 +1,610 @@
+package dev.langchain4j.data.document.splitter;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.internal.ValidationUtils;
+import org.commonmark.Extension;
+import org.commonmark.ext.front.matter.YamlFrontMatterExtension;
+import org.commonmark.ext.front.matter.YamlFrontMatterVisitor;
+import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.node.FencedCodeBlock;
+import org.commonmark.node.Heading;
+import org.commonmark.node.Image;
+import org.commonmark.node.IndentedCodeBlock;
+import org.commonmark.node.Link;
+import org.commonmark.node.Node;
+import org.commonmark.node.Text;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.NodeRenderer;
+import org.commonmark.renderer.markdown.CoreMarkdownNodeRenderer;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererFactory;
+import org.commonmark.renderer.markdown.MarkdownRenderer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A {@link DocumentSplitter} that takes a Markdown as input.
+ *
+ * <p>The class is instantiated via the {@link Builder} returned from the {@link #builder()} method.</p>
+ *
+ * <p>Internally it splits the document into sections, with metadata entries to identify the location of each section
+ * in the document. It then optionally splits each section with the {@link DocumentSplitter} passed in to the Builder.
+ *
+ */
+public class MarkdownSectionSplitter implements DocumentSplitter {
+
+    private static final Header NO_HEADER = new Header(null, 1);
+    private static final Set<Extension> EXTENSIONS = Set.of(TablesExtension.create());
+
+
+    public static final String SECTION_LEVEL = "md_section_level";
+    public static final String SECTION_HEADER = "md_section_header";
+    public static final String SECTION_INDEX_WITHIN_PARENT = "md_section_index_in_parent";
+    public static final String SECTION_PARENT_HEADER = "md_parent_header";
+    public static final String SEGMENT_LINKS = "segmen_links";
+    private static final DocumentSplitter NO_SPLIT = document -> Collections.singletonList(document.toTextSegment());
+
+    private final DocumentSplitter sectionSplitter;
+
+    private final String documentTitle;
+
+    private final String emptySectionPlaceholderText;
+
+    private final LinkHandling linkHandling;
+
+    private final DocumentAdjuster documentAdjuster;
+    private final TextSegmentsAdjuster textSegmentsAdjuster;
+    private final YamlFrontMatterConsumer yamlFrontMatterConsumer;
+
+    protected MarkdownSectionSplitter(Builder builder) {
+        ValidationUtils.ensureNotNull(builder.getSectionSplitter(), "sectionSplitter");
+        ValidationUtils.ensureNotNull(builder.getLinkHandling(), "linkHandling");
+        ValidationUtils.ensureNotNull(builder.getSectionSplitter(), "sectionSplitter");
+        ValidationUtils.ensureNotNull(builder.getLinkHandling(), "linkHandling");
+        ValidationUtils.ensureNotNull(builder.getDocumentAdjuster(), "documentAdjuster");
+        ValidationUtils.ensureNotNull(builder.getTextSegmentAdjuster(), "textSegmentAdjuster");
+        this.sectionSplitter = builder.getSectionSplitter();
+        this.documentTitle = builder.getDocumentTitle();
+        this.emptySectionPlaceholderText = builder.getEmptySectionPlaceholderText();
+        this.linkHandling = builder.getLinkHandling();
+        this.documentAdjuster = builder.getDocumentAdjuster();
+        this.textSegmentsAdjuster = builder.getTextSegmentAdjuster();
+        this.yamlFrontMatterConsumer = builder.getYamlFrontMatterConsumer();
+    }
+
+    /**
+     * Creates a new Builder used to instantiate this class.
+     *
+     * @return the builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public List<TextSegment> split(Document document) {
+        Set<Extension> parserExtensions = new HashSet<>(EXTENSIONS);
+        if (yamlFrontMatterConsumer != null) {
+            parserExtensions.add(YamlFrontMatterExtension.create());
+        }
+        Node node = Parser.builder().extensions(parserExtensions).build().parse(document.text());
+        if (yamlFrontMatterConsumer != null) {
+            YamlFrontMatterVisitor visitor = new YamlFrontMatterVisitor();
+            node.accept(visitor);
+            yamlFrontMatterConsumer.consumeFrontMatter(visitor.getData());
+        }
+
+        MarkdownSplitterContext context = new MarkdownSplitterContext(document.metadata());
+        MarkdownRenderer renderer = MarkdownRenderer.builder()
+                .nodeRendererFactory(new MarkdownSectionSplitterNodeRendererFactory(context))
+                .extensions(EXTENSIONS)
+                .build();
+        // We use the Appendable allowed by the renderer as the hook in.
+        // I tried a few other approaches, but this is the only one I can find that works...
+        renderer.render(node, context.getBuffer());
+        context.endSection();
+
+        return context.getSegments();
+    }
+
+    public static class Builder {
+        private DocumentSplitter sectionSplitter = NO_SPLIT;
+        private String documentTitle;
+        private String emptySectionPlaceholderText;
+
+        private LinkHandling linkHandling = LinkHandling.STANDARD;
+
+        private DocumentAdjuster documentAdjuster = new DocumentAdjuster() {};
+        private TextSegmentsAdjuster textSegmentsAdjuster = new TextSegmentsAdjuster() {};
+        private YamlFrontMatterConsumer yamlFrontMatterConsumer;
+
+        /**
+         * <p>Sets the {@link DocumentSplitter} to further split each section.</p>
+         *
+         * <p>If not specified, the {@link MarkdownSectionSplitter} created by this builder will not
+         * attempt to split the sections further.</p>
+         *
+         * @param sectionSplitter the {@link DocumentSplitter} used to further split the sections.
+         * @return this Builder instance
+         */
+        public Builder setSectionSplitter(DocumentSplitter sectionSplitter) {
+            this.sectionSplitter = sectionSplitter;
+            return this;
+        }
+
+        /**
+         * <p>Sets the title of the source document</p>
+         *
+         * <p>This is for the corner case where a Markdown document does not start with a header. If the document title
+         * is set, it is used as the header for the first section.</p>
+         *
+         * @param title the document title
+         * @return this Builder instance
+         */
+        public Builder setDocumentTitle(String title) {
+            this.documentTitle = title;
+            return this;
+        }
+
+        /**
+         * <p>Set placeholder text to be used for empty sections, i.e. ones that just have a header.</p>
+         *
+         * <p>This is needed because the {@link Document} constructor throws an error if the constructor is empty.</p>
+         * @param text placeholder text
+         * @return this Builder instance
+         */
+        public Builder setEmptySectionPlaceholderText(String text) {
+            this.emptySectionPlaceholderText = text;
+            return this;
+        }
+
+        /**
+         * Sets the link handling for the splitter. The default is {@link LinkHandling#STRIP}.
+         *
+         * @param linkHandling the link handling
+         * @return this builder
+         */
+        public Builder setLinkHandling(LinkHandling linkHandling) {
+            this.linkHandling = linkHandling;
+            return this;
+        }
+
+        /**
+         * Sets an {@code DocumentAdjuster} to use to add/remove metadata in, or otherwise, adjust a {@link Document}
+         * from an extracted section before further splitting it into {@link TextSegment}s.
+         *
+         * @param documentAdjuster the adjuster
+         * @return this builder
+         */
+        public Builder setDocumentAdjuster(DocumentAdjuster documentAdjuster) {
+            this.documentAdjuster = documentAdjuster;
+            return this;
+        }
+
+        /**
+         * Sets an {@code TextSegmentsAdjuster} to use to add/remove metadata in, or otherwise, adjust {@link TextSegment}s
+         * split from a section
+         *
+         * @param textSegmentsAdjuster the adjuster
+         * @return this builder
+         */
+        public Builder setTextSegmentsAdjuster(TextSegmentsAdjuster textSegmentsAdjuster) {
+            this.textSegmentsAdjuster = textSegmentsAdjuster;
+            return this;
+        }
+
+        /**
+         * Sets a {@link YamlFrontMatterConsumer} to handle parsed YAML front matter
+         * @param yamlFrontMatterConsumer
+         * @return
+         */
+        public Builder setYamlFrontMatterConsumer(YamlFrontMatterConsumer yamlFrontMatterConsumer) {
+            this.yamlFrontMatterConsumer = yamlFrontMatterConsumer;
+            return this;
+        }
+
+
+        /**
+         * Constructs the {@link MarkdownSectionSplitter} instance
+         * @return the MarkdownSectionSplitter
+         */
+        public MarkdownSectionSplitter build() {
+            return new MarkdownSectionSplitter(this);
+        }
+
+        public DocumentSplitter getSectionSplitter() {
+            return sectionSplitter;
+        }
+
+        public String getDocumentTitle() {
+            return documentTitle;
+        }
+
+        public String getEmptySectionPlaceholderText() {
+            return emptySectionPlaceholderText;
+        }
+
+        public LinkHandling getLinkHandling() {
+            return linkHandling;
+        }
+
+        public DocumentAdjuster getDocumentAdjuster() {
+            return documentAdjuster;
+        }
+
+        public TextSegmentsAdjuster getTextSegmentAdjuster() {
+            return textSegmentsAdjuster;
+        }
+
+        public YamlFrontMatterConsumer getYamlFrontMatterConsumer() {
+            return yamlFrontMatterConsumer;
+        }
+    }
+
+    /**
+     * Callback to adjust a {@link  Document} representing a section before splitting it further.
+     */
+    public interface DocumentAdjuster {
+        /**
+         * Adjust a document representing a section.
+         * @param original the document
+         * @return the adjusted document
+         */
+        default Document adjust(Document original) {
+            return original;
+        }
+    }
+
+    public interface TextSegmentsAdjuster {
+        /**
+         * Adjust the TextSegments representing a section.
+         *
+         * @param originalSegments the TextSegments
+         * @return the adjusted TextSegments
+         */
+        default List<TextSegment> adjust(List<TextSegment> originalSegments) {
+            return originalSegments;
+        }
+    }
+
+    /**
+     * Sets a consumer to handle parsed YAML from the front-matter of a {@code Document}
+     */
+    public interface YamlFrontMatterConsumer {
+        void consumeFrontMatter(Map<String, List<String>> frontMatterYaml);
+    }
+
+    public enum LinkHandling {
+        /**
+         * Doesn't do anything to the links. The markdown for links in the resulting {@code TextSegment}s is the same
+         * as in the original.
+         */
+        STANDARD,
+        /**
+         * Strips any links out, just leaving the text. So {@code [A Link](https://z.com)} becomes just {@code A Link}.
+         */
+        STRIP,
+        /**
+         * The original link text is left in place, and the links are added to the metadata. So e.g. the following
+         * markdown is left in place in the markdown:
+         * <pre>
+         *     Click [here](https://a.com) and [here](https://b.com)
+         * </pre>
+         * <p>
+         * The above will result in the following Json string in the the metadata under the key "segment-links":
+         * <pre>
+         *     "{
+         *          "[here](https://a.com)":"https://a.com",
+         *          "[here](https://b.com)":"https://b.com"
+         *      }"
+         * </pre>
+         * </p>
+         */
+        METADATA
+    }
+
+    private class MarkdownSplitterContext {
+        private final MarkdownSplitterBuffer buffer = new MarkdownSplitterBuffer();
+
+        private final Metadata originalMetadata;
+        private final List<TextSegment> segments = new ArrayList<>();
+        private final List<Header> headers = new ArrayList<>();
+        private Header currentHeader;
+        private int nullHeaderIndex = 0;
+        private Map<String, String> currentSectionLinks = new HashMap<>();
+
+        MarkdownSplitterContext(Metadata metadata) {
+            originalMetadata = metadata;
+        }
+
+        MarkdownSplitterBuffer getBuffer() {
+            return buffer;
+        }
+
+        LinkHandling getLinkHandling() {
+            return linkHandling;
+        }
+
+        public void endSection() {
+            String currentSection = buffer.rollover();
+            // This should be the section
+            if (currentHeader == null && headers.isEmpty() && !currentSection.isEmpty() && documentTitle != null) {
+                currentHeader = new Header(documentTitle, 1);
+            }
+            if (currentHeader != null || !currentSection.isEmpty()) {
+                Header header = currentHeader != null ? currentHeader : NO_HEADER;
+                addHeaderToHierarchy(header);
+                addSectionSegments(header, currentSection);
+                currentSectionLinks.clear();
+            }
+        }
+
+        public void newSectionHeaderFound(Heading heading) {
+            // The buffer will contain the header, clean it out and read it directly from the Heading instead to
+            // remove any markup characters.
+            buffer.rollover();
+            currentHeader = new Header(heading);
+        }
+
+        private void addSectionSegments(Header header, String sectionText) {
+            // Set metadata about this particular section. Work on a copy
+            Metadata metadata = new Metadata(originalMetadata.toMap());
+            metadata.put(SECTION_LEVEL, header.level);
+            if (header.text != null) {
+                metadata.put(SECTION_HEADER, header.text);
+            }
+            metadata.put(SECTION_INDEX_WITHIN_PARENT, header.indexInParent);
+            if (header.parent != null && header.parent.text != null) {
+                metadata.put(SECTION_PARENT_HEADER, header.parent.text);
+            }
+
+            if (sectionText.isBlank() && emptySectionPlaceholderText != null) {
+                // Document constructor does not like blank text
+                sectionText = emptySectionPlaceholderText;
+            }
+            Document document = new Document(sectionText, metadata);
+            document = documentAdjuster.adjust(document);
+
+            List<TextSegment> segments = sectionSplitter.split(document);
+            if (!currentSectionLinks.isEmpty()) {
+
+                for (TextSegment segment : segments) {
+
+                    Map<String, String> segmentLinks = null;
+                    String segmentText = segment.text();
+
+                    for (Map.Entry<String, String> entry : currentSectionLinks.entrySet()) {
+                        if (segmentText.contains(entry.getKey())) {
+                            if (segmentLinks == null) {
+                                segmentLinks = new HashMap<>();
+                            }
+                            segmentLinks.put(entry.getKey(), entry.getValue());
+                        }
+                    }
+                    if (segmentLinks != null) {
+                        Gson gson = new GsonBuilder().create();
+                        String serializedLinks = gson.toJson(segmentLinks);
+                        segment.metadata().put(SEGMENT_LINKS, serializedLinks);
+                    }
+                }
+
+            }
+            segments = textSegmentsAdjuster.adjust(segments);
+            this.segments.addAll(segments);
+        }
+
+
+        private void addHeaderToHierarchy(Header header) {
+            if (!headers.isEmpty()) {
+                for (ListIterator<Header> it = headers.listIterator(headers.size()); it.hasPrevious() ; ) {
+                    Header curr = it.previous();
+                    if (curr.level < header.level) {
+                        curr.addChild(header);
+                        break;
+                    }
+                }
+            }
+
+            headers.add(header);
+            if (header.parent == null) {
+                header.indexInParent = nullHeaderIndex++;
+            }
+
+        }
+
+        public List<TextSegment> getSegments() {
+            return segments;
+        }
+
+        public void addLink(String markdownLink, String destination) {
+            currentSectionLinks.put(markdownLink, destination);
+        }
+    }
+
+    private static class MarkdownSplitterBuffer implements Appendable {
+        // Temporary for testing
+        private StringBuilder current = new StringBuilder();
+
+        @Override
+        public Appendable append(final CharSequence csq) {
+            current.append(csq);
+            return this;
+        }
+
+        @Override
+        public Appendable append(final CharSequence csq, final int start, final int end) {
+            current.append(csq, start, end);
+            return this;
+        }
+
+        @Override
+        public Appendable append(final char c) {
+            current.append(c);
+            return this;
+        }
+
+        public String rollover() {
+            String temp = current.toString();
+            current = new StringBuilder();
+            return temp;
+        }
+
+        public String current() {
+            return current.toString();
+        }
+
+        @Override
+        public String toString() {
+            return current.toString();
+        }
+
+        int length() {
+            return current.length();
+        }
+    }
+
+    private static class MarkdownSectionSplitterNodeRendererFactory implements MarkdownNodeRendererFactory {
+        private final MarkdownSplitterContext splitterContext;
+
+        public MarkdownSectionSplitterNodeRendererFactory(MarkdownSplitterContext splitterContext) {
+            this.splitterContext = splitterContext;
+        }
+
+        @Override
+        public NodeRenderer create(final MarkdownNodeRendererContext context) {
+            return new HeaderSplittingCoreNodeRenderer(context, splitterContext);
+        }
+
+        @Override
+        public Set<Character> getSpecialCharacters() {
+            return Set.of();
+        }
+
+    }
+
+    private static class HeaderSplittingCoreNodeRenderer extends CoreMarkdownNodeRenderer {
+        private final MarkdownSplitterContext context;
+
+        public HeaderSplittingCoreNodeRenderer(MarkdownNodeRendererContext context, MarkdownSplitterContext splitterContext) {
+            super(context);
+            this.context = splitterContext;
+        }
+
+        @Override
+        public void visit(Heading heading) {
+            boolean isSectionHeader = !isHeadingInBlock(heading);
+
+            if (isSectionHeader) {
+                context.endSection();
+            }
+
+            super.visit(heading);
+
+            if (isSectionHeader) {
+                context.newSectionHeaderFound(heading);
+            }
+        }
+
+        @Override
+        public void visit(final Image image) {
+            // Don't handle images
+        }
+
+        public void visit(final IndentedCodeBlock indentedCodeBlock) {
+            // Translate from indented to fenced code blocks for consistency
+            FencedCodeBlock fencedCodeBlock = new FencedCodeBlock();
+            String literal = indentedCodeBlock.getLiteral();
+            fencedCodeBlock.setLiteral(literal);
+            super.visit(fencedCodeBlock);
+        }
+
+        @Override
+        public void visit(final Link link) {
+            switch (context.getLinkHandling()) {
+                case STANDARD: {
+                    super.visit(link);
+                    break;
+                }
+                case STRIP: {
+                    visitChildren(link);
+                    return;
+                }
+                case METADATA: {
+                    int before = context.getBuffer().length();
+                    String destination = link.getDestination();
+                    super.visit(link);
+                    int after = context.getBuffer().length();
+
+                    String contents = context.getBuffer().current();
+                    String markdownLink = contents.substring(before, after);
+                    context.addLink(markdownLink, destination);
+                    break;
+                }
+                default:
+                    throw new IllegalStateException("Unknown: " + context.getLinkHandling());
+            }
+        }
+
+        private boolean isHeadingInBlock(Heading heading) {
+            Node parent = heading.getParent();
+            if (parent != null) {
+                if (!(parent instanceof org.commonmark.node.Document) && !(parent instanceof Heading)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private static class Header {
+        private final String text;
+        private final int level;
+        private Header parent;
+        private final List<Header> children = new ArrayList<>();
+        private int indexInParent;
+
+        Header(Heading heading) {
+            this(
+                    heading.getFirstChild() != null ? ((Text) heading.getFirstChild()).getLiteral() : null,
+                    heading.getLevel());
+        }
+
+        private Header(final String text, final int level) {
+            this.text = text;
+            this.level = level - 1;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Header header = (Header) o;
+            return level == header.level && Objects.equals(text, header.text);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(text, level);
+        }
+
+        private void addChild(Header child) {
+            children.add(child);
+            child.indexInParent = children.size() - 1;
+            child.parent = this;
+        }
+    }
+
+}

--- a/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/MarkdownSectionSplitter.java
+++ b/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/MarkdownSectionSplitter.java
@@ -2,6 +2,7 @@ package dev.langchain4j.data.document.splitter;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import dev.langchain4j.data.document.DefaultDocument;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentSplitter;
 import dev.langchain4j.data.document.Metadata;
@@ -23,7 +24,6 @@ import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.renderer.markdown.CoreMarkdownNodeRenderer;
 import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
 import org.commonmark.renderer.markdown.MarkdownNodeRendererFactory;
-import org.commonmark.renderer.markdown.MarkdownRenderer;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -108,10 +108,10 @@ public class MarkdownSectionSplitter implements DocumentSplitter {
         }
 
         MarkdownSplitterContext context = new MarkdownSplitterContext(document.metadata());
-        MarkdownRenderer renderer = MarkdownRenderer.builder()
+        TempMarkdownRenderer renderer = TempMarkdownRenderer.builder()
                 .nodeRendererFactory(new MarkdownSectionSplitterNodeRendererFactory(context))
                 .extensions(EXTENSIONS)
-                .build();
+                .tempBuild();
         // We use the Appendable allowed by the renderer as the hook in.
         // I tried a few other approaches, but this is the only one I can find that works...
         renderer.render(node, context.getBuffer());
@@ -375,7 +375,7 @@ public class MarkdownSectionSplitter implements DocumentSplitter {
                 // Document constructor does not like blank text
                 sectionText = emptySectionPlaceholderText;
             }
-            Document document = new Document(sectionText, metadata);
+            Document document = new DefaultDocument(sectionText, metadata);
             document = documentAdjuster.adjust(document);
 
             List<TextSegment> segments = sectionSplitter.split(document);

--- a/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/TempMarkdownRenderer.java
+++ b/langchain4j/src/main/java/dev/langchain4j/data/document/splitter/TempMarkdownRenderer.java
@@ -1,0 +1,126 @@
+package dev.langchain4j.data.document.splitter;
+
+import org.commonmark.Extension;
+import org.commonmark.internal.renderer.NodeRendererMap;
+import org.commonmark.node.Node;
+import org.commonmark.renderer.NodeRenderer;
+import org.commonmark.renderer.Renderer;
+import org.commonmark.renderer.markdown.CoreMarkdownNodeRenderer;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererContext;
+import org.commonmark.renderer.markdown.MarkdownNodeRendererFactory;
+import org.commonmark.renderer.markdown.MarkdownRenderer;
+import org.commonmark.renderer.markdown.MarkdownWriter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Temporary replacement for MarkdownRenderer, including the fix in
+ * https://github.com/commonmark/commonmark-java/pull/361.
+ *
+ * It contains that fix, and adjustments needed to be able to use this replacement.
+ */
+class TempMarkdownRenderer implements Renderer {
+
+    private final List<MarkdownNodeRendererFactory> nodeRendererFactories;
+
+    private TempMarkdownRenderer(Builder builder) {
+        this.nodeRendererFactories = new ArrayList<>(builder.nodeRendererFactories.size() + 1);
+        this.nodeRendererFactories.addAll(builder.nodeRendererFactories);
+        // Add as last. This means clients can override the rendering of core nodes if they want.
+        this.nodeRendererFactories.add(new MarkdownNodeRendererFactory() {
+            @Override
+            public NodeRenderer create(MarkdownNodeRendererContext context) {
+                return new CoreMarkdownNodeRenderer(context);
+            }
+
+            @Override
+            public Set<Character> getSpecialCharacters() {
+                return Set.of();
+            }
+        });
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public void render(Node node, Appendable output) {
+        RendererContext context = new RendererContext(new MarkdownWriter(output));
+        context.render(node);
+    }
+
+    @Override
+    public String render(Node node) {
+        StringBuilder sb = new StringBuilder();
+        render(node, sb);
+        return sb.toString();
+    }
+
+    static class Builder extends MarkdownRenderer.Builder {
+
+        private final List<MarkdownNodeRendererFactory> nodeRendererFactories = new ArrayList<>();
+
+        public TempMarkdownRenderer tempBuild() {
+            return new TempMarkdownRenderer(this);
+        }
+
+        public Builder nodeRendererFactory(MarkdownNodeRendererFactory nodeRendererFactory) {
+            this.nodeRendererFactories.add(nodeRendererFactory);
+            return this;
+        }
+
+        public Builder extensions(Iterable<? extends Extension> extensions) {
+            for (Extension extension : extensions) {
+                if (extension instanceof MarkdownRenderer.MarkdownRendererExtension) {
+                    MarkdownRenderer.MarkdownRendererExtension markdownRendererExtension = (MarkdownRenderer.MarkdownRendererExtension) extension;
+                    markdownRendererExtension.extend(this);
+                }
+            }
+            return this;
+        }
+    }
+
+    private class RendererContext implements MarkdownNodeRendererContext {
+        private final MarkdownWriter writer;
+        private final NodeRendererMap nodeRendererMap = new NodeRendererMap();
+        private final Set<Character> additionalTextEscapes;
+
+        private RendererContext(MarkdownWriter writer) {
+            // Set fields that are used by interface
+            this.writer = writer;
+            Set<Character> escapes = new HashSet<>();
+            for (MarkdownNodeRendererFactory factory : nodeRendererFactories) {
+                escapes.addAll(factory.getSpecialCharacters());
+            }
+            additionalTextEscapes = Collections.unmodifiableSet(escapes);
+
+            // The first node renderer for a node type "wins". The NodeRendererMap
+            // disallows overwriting.
+            for (MarkdownNodeRendererFactory nodeRendererFactory : nodeRendererFactories) {
+                // Pass in this as context here, which uses the fields set above
+                NodeRenderer nodeRenderer = nodeRendererFactory.create(this);
+                nodeRendererMap.add(nodeRenderer);
+            }
+        }
+
+        @Override
+        public MarkdownWriter getWriter() {
+            return writer;
+        }
+
+        @Override
+        public void render(Node node) {
+            nodeRendererMap.render(node);
+        }
+
+        @Override
+        public Set<Character> getSpecialCharacters() {
+            return additionalTextEscapes;
+        }
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/data/document/splitter/MarkdownRebuilder.java
+++ b/langchain4j/src/test/java/dev/langchain4j/data/document/splitter/MarkdownRebuilder.java
@@ -1,0 +1,148 @@
+package dev.langchain4j.data.document.splitter;
+import org.commonmark.node.*;
+import org.commonmark.parser.Parser;
+
+public class MarkdownRebuilder extends AbstractVisitor {
+    private final StringBuilder markdownBuilder = new StringBuilder();
+
+    public static void main(String[] args) {
+        String markdown = """
+                # Header 1
+                Some content under header 1.
+                
+                Another paragraph.
+                A new line
+
+                ## Header 1.1
+                Content under header 1.1.
+
+                - List item 1
+                  - Iten 2.1
+                  - Item 2.2
+                    - Item 2.2.1
+                  - Item 2.3
+                - List **item** 2
+
+                `Inline code`
+
+                > Blockquote
+
+                """;
+
+        Parser parser = Parser.builder().build();
+        Node document = parser.parse(markdown);
+
+        MarkdownOutputVisitor visitor = new MarkdownOutputVisitor();
+        document.accept(visitor);
+        System.out.println(visitor.getOutput());
+        System.out.println("----");
+    }
+
+    static class MarkdownOutputVisitor extends AbstractVisitor {
+        private StringBuilder output = new StringBuilder();
+
+        public String getOutput() {
+            return output.toString();
+        }
+
+        @Override
+        public void visit(Heading heading) {
+            output.append("#".repeat(heading.getLevel())).append(" ");
+            visitChildren(heading); // Visit children to get the text content
+            output.append("\n");
+        }
+
+        @Override
+        public void visit(Paragraph paragraph) {
+            visitChildren(paragraph); // Visit children to get the text content
+            if (!(paragraph.getParent() instanceof ListItem)) { // Don't add extra lines for paragraphs in lists
+               output.append("\n\n");
+            }
+        }
+
+        @Override
+        public void visit(Text text) {
+            output.append(text.getLiteral());
+        }
+
+        @Override
+        public void visit(StrongEmphasis strongEmphasis) {
+            output.append("**");
+            visitChildren(strongEmphasis); // Visit children to get the text content
+            output.append("**");
+        }
+
+        @Override
+        public void visit(Emphasis emphasis) {
+            output.append("*");
+            visitChildren(emphasis); // Visit children to get the text content
+            output.append("*");
+        }
+
+        @Override
+        public void visit(FencedCodeBlock fencedCodeBlock) {
+            output.append("```").append(fencedCodeBlock.getInfo()).append("\n")
+                  .append(fencedCodeBlock.getLiteral())
+                  .append("```\n\n");
+        }
+
+
+        @Override
+        public void visit(OrderedList orderedList) {
+//            if (orderedList.getParent() instanceof ListItem) {
+//                output.append("\n");
+//            }
+            visitChildren(orderedList); // Visit children (list items)
+            if (!(orderedList.getParent() instanceof ListItem)) {
+                output.append("\n");
+            }
+        }
+
+        @Override
+        public void visit(BulletList bulletList) {
+//            if (bulletList.getParent() instanceof ListItem) {
+//                output.append("\n");
+//            }
+            visitChildren(bulletList); // Visit children (list items)
+            if (!(bulletList.getParent() instanceof ListItem)) {
+                output.append("\n\n");
+            }
+        }
+
+        @Override
+        public void visit(ListItem listItem) {
+            if (output.length() == 0 || output.charAt(output.length() - 1) != '\n') {
+                output.append("\n");
+            }
+
+            output.append("- ");
+            visitChildren(listItem); // Visit children to get the text content
+
+        }
+
+        @Override
+        public void visit(final Code code) {
+            output.append("`");
+            output.append(code.getLiteral());
+            output.append("`");
+        }
+
+
+
+        @Override
+        public void visit(final HardLineBreak hardLineBreak) {
+            output.append("\n\n");
+            visitChildren(hardLineBreak);
+        }
+
+        @Override
+        public void visit(final SoftLineBreak softLineBreak) {
+            // Don't break softly
+            //output.append("\n")
+            if (!Character.isSpaceChar(output.charAt(output.length() - 1))) {
+                output.append(" ");
+            }
+            super.visit(softLineBreak);
+        }
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/data/document/splitter/MarkdownSectionSplitterTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/data/document/splitter/MarkdownSectionSplitterTest.java
@@ -1,0 +1,689 @@
+package dev.langchain4j.data.document.splitter;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentLoader;
+import dev.langchain4j.data.document.DocumentSource;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.document.parser.TextDocumentParser;
+import dev.langchain4j.data.segment.TextSegment;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static dev.langchain4j.data.document.splitter.MarkdownSectionSplitter.SECTION_HEADER;
+import static dev.langchain4j.data.document.splitter.MarkdownSectionSplitter.SECTION_INDEX_WITHIN_PARENT;
+import static dev.langchain4j.data.document.splitter.MarkdownSectionSplitter.SECTION_LEVEL;
+import static dev.langchain4j.data.document.splitter.MarkdownSectionSplitter.SECTION_PARENT_HEADER;
+import static dev.langchain4j.data.document.splitter.MarkdownSectionSplitter.SEGMENT_LINKS;
+import static org.junit.Assert.assertEquals;
+
+public class MarkdownSectionSplitterTest implements WithAssertions {
+
+    @Test
+    public void testNoSubSplitter() {
+        String text = "# Title\n"
+                + "## Section 1\n"
+                + "section 1\n"
+                + "## Section 2\n"
+                + "section 2\n"
+                + "### Section 2.1\n"
+                + "section 2.1\n"
+                + "#### Section 2.1.1\n"
+                + "section 2.1.1\n"
+                + "#### Section 2.1.2\n"
+                + "section 2.1.2\nmore\n"
+                + "### Section 2.2\n"
+                + "#### Section 2.2.1\n"
+                + "## Section 3\n"
+                + "section 3\n"
+                // Jump in section levels. There is no intermediate '###' on purpose
+                + "#### Section 3.1.1\n"
+                + "section 3.1.1\n"
+                + "## Section 4\n"
+                + "section 4 \n"
+                // Add another level 1 section to make sure we can support more than one
+                + "# Header 1\n"
+                + "header\n";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .setEmptySectionPlaceholderText(".")
+                .build();
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        assertThat(segments.size()).isEqualTo(12);
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0, ".");
+        checkTextSegment(source, segments.get(1), "Section 1", "Title", 1, 0, "section 1");
+        checkTextSegment(source, segments.get(2), "Section 2", "Title", 1, 1, "section 2");
+        checkTextSegment(source, segments.get(3), "Section 2.1", "Section 2", 2, 0, "section 2.1");
+        checkTextSegment(source, segments.get(4), "Section 2.1.1", "Section 2.1", 3, 0, "section 2.1.1");
+        checkTextSegment(source, segments.get(5), "Section 2.1.2", "Section 2.1", 3, 1, "section 2.1.2\nmore");
+        checkTextSegment(source, segments.get(6), "Section 2.2", "Section 2", 2, 1, ".");
+        checkTextSegment(source, segments.get(7), "Section 2.2.1", "Section 2.2", 3, 0, ".");
+        checkTextSegment(source, segments.get(8), "Section 3", "Title", 1, 2, "section 3");
+        checkTextSegment(source, segments.get(9), "Section 3.1.1", "Section 3", 3, 0, "section 3.1.1");
+        checkTextSegment(source, segments.get(10), "Section 4", "Title", 1, 3, "section 4");
+        checkTextSegment(source, segments.get(11), "Header 1", null, 0, 1, "header");
+    }
+
+    @Test
+    public void testIntroductoryTextNoHeaderNoDocumentTitle() {
+        String text = "Intro text\n" + "## Section 1\n" + "section 1\n";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder().build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        assertThat(segments.size()).isEqualTo(2);
+        checkTextSegment(source, segments.get(0), null, null, 0, 0, "Intro text");
+        checkTextSegment(source, segments.get(1), "Section 1", null, 1, 0, "section 1");
+    }
+
+    @Test
+    public void testIntroductoryTextNoHeaderWithDocumentTitle() {
+        String text = "Intro text\n" + "## Section 1\n" + "section 1\n";
+
+        DocumentSplitter splitter =
+                MarkdownSectionSplitter.builder().setDocumentTitle("Doc Title").build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        assertThat(segments.size()).isEqualTo(2);
+        checkTextSegment(source, segments.get(0), "Doc Title", null, 0, 0, "Intro text");
+        checkTextSegment(source, segments.get(1), "Section 1", "Doc Title", 1, 0, "section 1");
+    }
+
+    @Test
+    public void testSectionSplitter() {
+        String text = "# Title\n"
+                + "## Section 1\n"
+                + "section 1\n"
+                + "## Section 2\n"
+                + "section 2 split\n"
+                + "### Section 2.1\n"
+                + "section 2.1\n"
+                + "### Section 2.2\n"
+                + "section 2.2 split\n";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .setEmptySectionPlaceholderText(".")
+                .setDocumentTitle("Doc Title")
+                .setSectionSplitter(DocumentSplitters.recursive(11, 0))
+                .build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        assertThat(segments.size()).isEqualTo(7);
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0, ".");
+        assertThat(segments.get(0).metadata().getInteger("index")).isEqualTo(0);
+
+        checkTextSegment(source, segments.get(1), "Section 1", "Title", 1, 0, "section 1");
+        assertThat(segments.get(1).metadata().getInteger("index")).isEqualTo(0);
+
+        checkTextSegment(source, segments.get(2), "Section 2", "Title", 1, 1, "section 2");
+        assertThat(segments.get(2).metadata().getInteger("index")).isEqualTo(0);
+
+        checkTextSegment(source, segments.get(3), "Section 2", "Title", 1, 1, "split");
+        assertThat(segments.get(3).metadata().getInteger("index")).isEqualTo(1);
+
+        checkTextSegment(source, segments.get(4), "Section 2.1", "Section 2", 2, 0, "section 2.1");
+        assertThat(segments.get(4).metadata().getInteger("index")).isEqualTo(0);
+
+        checkTextSegment(source, segments.get(5), "Section 2.2", "Section 2", 2, 1, "section 2.2");
+        assertThat(segments.get(5).metadata().getInteger("index")).isEqualTo(0);
+
+        checkTextSegment(source, segments.get(6), "Section 2.2", "Section 2", 2, 1, "split");
+        assertThat(segments.get(6).metadata().getInteger("index")).isEqualTo(1);
+    }
+
+    @Test
+    public void testHeaderInFencedCodeBlock() {
+        // The parser adds a blank line between the previous paragraph and the code block.
+        // Test input with both cases
+        String text = "# Title\n"
+                + "## Section 1\n"
+                + "section 1\n"
+                + "```\n"
+                + "# In Code\n"
+                + "```\n"
+                + "## Section 2\n"
+                + "section 2\n"
+                + "\n"
+                + "```\n"
+                + "# In Code\n"
+                + "```\n";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .setEmptySectionPlaceholderText(".")
+                .build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        assertThat(segments.size()).isEqualTo(3);
+
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0, ".");
+        checkTextSegment(source, segments.get(1), "Section 1", "Title", 1, 0, "section 1\n\n```\n# In Code\n```");
+        checkTextSegment(source, segments.get(2), "Section 2", "Title", 1, 1, "section 2\n\n```\n# In Code\n```");
+    }
+
+    @Test
+    public void testCodeSpan() {
+        String text = "# Title\n"
+                + "## Section 1\n"
+                + "section 1 is `the best` ever\n"
+;
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .setEmptySectionPlaceholderText(".")
+                .build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        assertThat(segments.size()).isEqualTo(2);
+
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0, ".");
+        checkTextSegment(source, segments.get(1), "Section 1", "Title", 1, 0, "section 1 is `the best` ever");
+    }
+
+    @Test
+    public void testAdjusters() {
+        String text = "# Title\n" + "intro\n" + "## Section 1\n" + "section 1\n";
+
+        TestMarkdownAdjuster adjuster = new TestMarkdownAdjuster();
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .setDocumentAdjuster(adjuster)
+                .setTextSegmentsAdjuster(adjuster)
+                .build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(2, segments.size());
+
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0, "intro");
+        assertThat(segments.get(0).metadata().getInteger("test-doc-counter")).isEqualTo(0);
+        assertThat(segments.get(0).metadata().getInteger("test-segment-counter")).isEqualTo(0);
+
+        checkTextSegment(source, segments.get(1), "Section 1", "Title", 1, 0, "section 1");
+        assertThat(segments.get(1).metadata().getInteger("test-doc-counter")).isEqualTo(1);
+        assertThat(segments.get(1).metadata().getInteger("test-segment-counter")).isEqualTo(10);
+    }
+
+    @Test
+    public void testFencedCodeBlock() {
+        // The renderer adds empty lines around code blocks
+        // Test some variations of the input.
+        String text = "# Title\n" +
+                "Some text\n" +
+                "```\n" +
+                "    function(){\n" +
+                "       this.i++;\n" +
+                "\t}\n" +
+                "```\n" +
+                "More text\n\n" +
+                "```\n" +
+                "    print(x);\n" +
+                "```\n\n" +
+                "Final text";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder().build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "Some text\n\n```\n    function(){\n       this.i++;\n\t}\n```\n\n" +
+                        "More text\n\n```\n    print(x);\n```\n\nFinal text");
+
+    }
+
+    @Test
+    public void testIndentedCodeBlock() {
+        // The renderer adds empty lines around code blocks
+        // Test some variations of the input.
+        // In the output Markdown, we use the fenced style always for consistency.
+        String text = "# Title\n" +
+                "Some text\n\n" +
+                "        function(){\n" +
+                "           this.i++;\n" +
+                "\t    }\n" +
+                "More text\n\n" +
+                "        print(x);\n" +
+                "Final text";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder().build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "Some text\n\n```\n    function(){\n       this.i++;\n    }\n```\n\n" +
+                        "More text\n\n```\n    print(x);\n```\n\nFinal text");
+
+    }
+
+    @Test
+    public void testParagraphs() {
+        // More than two '\n\n' gets replaced with just one.
+        String text = "# Title\n" +
+                "Paragraph 1\n\nParagraph2\n\n\nParagraph3";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder().build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "Paragraph 1\n\nParagraph2\n\nParagraph3");
+    }
+
+    @Test
+    public void testEmphasis() {
+        //The renderer replaces '__' with '**'. They have the same meaning.
+        String text = "# Title\n" +
+                "The *quick* brown _fox_ jumped **over** the __lazy__ dog";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder().build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "The *quick* brown _fox_ jumped **over** the **lazy** dog");
+    }
+
+    @Test
+    public void testSetextHeaders() {
+        // We are testing ATX Headers elsewhere (they are of the format "# Header 1", "## Header 2" etc.)
+        // Setext uses equals under a line for H1, and hyphens for H2
+        String text = "Title\n" +
+                "=====\n" +
+                "intro\n\n" +
+                "Section 1\n" +
+                "----\n" +
+                "section 1\n";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(2, segments.size());
+
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0, "intro");
+        checkTextSegment(source, segments.get(1), "Section 1", "Title", 1, 0, "section 1");
+    }
+
+    @Test
+    public void testBulletList() {
+        // The renderer adds empty lines around the lists.
+        // Test some variations of the input.
+        String text = "# Title\n" +
+                "intro\n" +
+                "- One\n" +
+                "- Two `test` two\n" +
+                "\n" + // Double \n is needed here to end the list
+                "After text\n" +
+                "\n" +
+                "* First\n" +
+                "* Second";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "intro\n\n- One\n- Two `test` two\n\nAfter text\n\n* First\n* Second");
+    }
+
+    @Test
+    public void testOrderedList() {
+        // The renderer adds empty lines around the lists.
+        // Test some variations of the input.
+        String text = "# Title\n" +
+                "intro\n" +
+                "1. One\n" +
+                "2. Two `test` two\n" +
+                "\n" + // Double \n is needed here to end the list
+                "After text\n" +
+                "\n" +
+                "1. First\n" +
+                "2. Second";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "intro\n\n1. One\n2. Two `test` two\n\nAfter text\n\n1. First\n2. Second");
+    }
+
+    @Test
+    public void testNestedLists() {
+        // The renderer adds empty lines around the lists.
+        // Test some variations of the input.
+        // Note that nested lists of ordered lists need at least 3 spaces, while nested lists in
+        // bullet lists can do with 2.
+        String body = "intro\n\n" +
+                "* One\n" +
+                "* Two\n" +
+                "  * 2-1\n" +
+                "  * 2-2\n" +
+                "    1. 2-2-1\n" +
+                "       1. 2-2-1-1\n" +
+                "       2. 2-2-1-2\n" +
+                "    2. 2-2-2\n" +
+                "* Three\n" +
+                "  1. 3-1\n" +
+                "     * 3-1-1\n" +
+                "     * 3-1-2\n" +
+                "       * 3-1-2-1\n" +
+                "       * 3-1-2-2\n" +
+                "     * 3-1-3";
+
+
+        String text = "# Title\n" +
+                body;
+
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0, body.trim());
+    }
+
+    @Test
+    public void testBlockQuotes() {
+        // The renderer adds empty lines around the lists.
+        // Test some variations of the input.
+        String text = "# Title\n" +
+                "intro\n" +
+                "> line1\n" +
+                ">\n" +
+                ">line2\n" +
+                "line3\n" +
+                "\n" +
+                "Other text\n\n" +
+                "> # Ignored header\n\n" +
+                "Final text";
+
+        // The renderer massages the continuing 'line3' a bit, and adds a space after '>' but it is semantically the same.
+        String expected = "intro\n\n" +
+                "> line1\n" +
+                "> \n" +
+                "> line2\n" +
+                "> line3\n" +
+                "\n" +
+                "Other text\n\n" +
+                "> # Ignored header\n\n" +
+                "Final text";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder().build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0, expected);
+
+    }
+
+    @Test
+    public void testNestedBlockQuotes() {
+        String body = "> Test\n" +
+                "> \n" +
+                "> > # Ignored header\n" +
+                "> > \n" +
+                "> > 1. One\n" +
+                "> > 2. Two";
+
+        String text = "# Title\n\n" + body;
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder().build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0, body);
+
+    }
+
+    @Test
+    public void testImagesRemoved() {
+        // I don't think images are relevant at this stage so let's check they are removed
+        String text = "# Title\n\n" +
+                "intro\n" +
+                "![link](/uri)\n" +
+                "outro\n";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder().build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "intro\n\noutro");
+    }
+
+    @Test
+    public void testLinks_Standard() {
+        String text = "# Title\n\n" +
+                "intro [A Link](https://a.com \"testA\").";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "intro [A Link](https://a.com \"testA\").");
+    }
+
+    @Test
+    public void testLinks_Stripped() {
+        String text = "# Title\n\n" +
+                "intro [A Link](https://a.com \"real\").";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .setLinkHandling(MarkdownSectionSplitter.LinkHandling.STRIP)
+                .build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "intro A Link.");
+    }
+
+    @Test
+    public void testLinks_Metadata() {
+        String text = "# Title\n\n" +
+                "intro [Link A](https://a.com) [Link B](https://b.com).\n\n" +
+                "---\n\n" +
+                "outro [Link C](https://c.com)";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .setLinkHandling(MarkdownSectionSplitter.LinkHandling.METADATA)
+                .setSectionSplitter(document -> {
+                    String text1 = document.text();
+                    int index = text1.indexOf("---\n\n");
+                    TextSegment segmentA = TextSegment.textSegment(
+                            text1.substring(0, index), new Metadata(document.metadata().toMap()));
+                    TextSegment segmentB = TextSegment.textSegment(
+                            text1.substring(index + 4), new Metadata(document.metadata().toMap()));
+                    return List.of(segmentA, segmentB);
+                })
+                .build();
+
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(2, segments.size());
+
+        Gson gson = new GsonBuilder().create();
+        Type type = new TypeToken<HashMap<String, String>>(){}.getType();
+
+
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "intro [Link A](https://a.com) [Link B](https://b.com).");
+        Map<String, String> links = gson.fromJson(segments.get(0).metadata().getString(SEGMENT_LINKS), type);
+        Assertions.assertEquals(2, links.size());
+        Assertions.assertEquals("https://a.com", links.get("[Link A](https://a.com)"));
+        Assertions.assertEquals("https://b.com", links.get("[Link B](https://b.com)"));
+
+        checkTextSegment(source, segments.get(1), "Title", null, 0, 0,
+                "outro [Link C](https://c.com)");
+        links = gson.fromJson(segments.get(1).metadata().getString(SEGMENT_LINKS), type);
+        Assertions.assertEquals(1, links.size());
+        Assertions.assertEquals("https://c.com", links.get("[Link C](https://c.com)"));
+    }
+
+    @Test
+    public void testTables() {
+                String text = "# Title\n\n" +
+                "intro\n" +
+                "\n" +
+                "| H1 | H2 |\n" +
+                "|----|----|\n" +
+                "| 1  | 2  |\n" +
+                "| 3  | 4  |\n\n" +
+                "outro";
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .build();
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "intro\n\n|H1|H2|\n|---|---|\n|1|2|\n|3|4|\n\noutro");
+
+    }
+
+    @Test
+    public void testYamlFrontMatter() {
+                String text = "---\n" +
+                "hello: world\n" +
+                "empty:\n" +
+                "---\n" +
+                "# Title\n\n" +
+                "intro\n";
+
+        Map<String, List<String>> frontMatter = new HashMap<>();
+
+        DocumentSplitter splitter = MarkdownSectionSplitter.builder()
+                .setYamlFrontMatterConsumer(frontMatter::putAll)
+                .build();
+        Document source = createDocument(text);
+        List<TextSegment> segments = splitter.split(source);
+
+        Assertions.assertEquals(1, segments.size());
+
+        checkTextSegment(source, segments.get(0), "Title", null, 0, 0,
+                "intro");
+        Assertions.assertEquals(2, frontMatter.size());
+        Assertions.assertEquals(1, frontMatter.get("hello").size());
+        Assertions.assertEquals("world", frontMatter.get("hello").get(0));
+        Assertions.assertEquals(0, frontMatter.get("empty").size());
+    }
+
+
+    private Document createDocument(String text) {
+        DocumentSource loader = new StringDocumentSource(text);
+        Document doc = DocumentLoader.load(loader, new TextDocumentParser());
+        doc.metadata().put("doc-a", "DOC-A");
+        doc.metadata().put("doc-b", "DOC-B");
+
+        return doc;
+    }
+
+    private void checkTextSegment(
+            Document source,
+            TextSegment ts,
+            String header,
+            String parentHeader,
+            int level,
+            int indexInParent,
+            String text) {
+        assertThat(ts.metadata().getString(SECTION_HEADER)).isEqualTo(header);
+        assertThat(ts.metadata().getString(SECTION_PARENT_HEADER)).isEqualTo(parentHeader);
+        assertThat(ts.metadata().getInteger(SECTION_LEVEL).intValue()).isEqualTo(level);
+        assertThat(ts.metadata().getInteger(SECTION_INDEX_WITHIN_PARENT)).isEqualTo(indexInParent);
+        assertThat(ts.text().trim()).isEqualTo(text);
+
+        for (String key : source.metadata().toMap().keySet()) {
+            assertThat(ts.metadata().getString(key)).isEqualTo(source.metadata().getString(key));
+        }
+    }
+
+    private record StringDocumentSource(String text) implements DocumentSource {
+
+        @Override
+        public InputStream inputStream() throws IOException {
+            return new ByteArrayInputStream(text.getBytes("UTF-8"));
+        }
+
+        @Override
+        public Metadata metadata() {
+            return new Metadata();
+        }
+    }
+
+    private static class TestMarkdownAdjuster implements MarkdownSectionSplitter.DocumentAdjuster, MarkdownSectionSplitter.TextSegmentsAdjuster {
+        static int doc_counter = 0;
+        static int segment_counter = 0;
+        @Override
+        public Document adjust(final Document original) {
+            original.metadata().put("test-doc-counter", doc_counter++);
+            return original;
+        }
+
+        @Override
+        public List<TextSegment> adjust(final List<TextSegment> originalSegments) {
+            originalSegments.forEach(ts -> ts.metadata().put("test-segment-counter", segment_counter));
+            segment_counter += 10;
+            return originalSegments;
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #2417

## Change
<!-- Please describe the changes you made. -->
I added a MarkdownSectionSplitter to split Markdown documents by headers.

The header goes into the metadata of the resulting TextSegments, while the body of the section goes into the TextSegments.

The Markdown must be well-formed, we don't try to do any validation beyond what the user gives us.

The list of TextSegments list the sections in order, while the metadata of each segment allows us to find where in the document the segment came from.

Headers appearing in code blocks are ignored (some languages use '#' for comments). 

A user may optionally specify a splitter to further split the sections.

Finally, there is a hook to override the creation of the Document  used to further split each section. This allows the caller to add of more metadata for each section.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [C] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
