### PR TITLE
Fix NullPointerException if the response doesn't contain usage info

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiEmbeddingModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiEmbeddingModel.java
@@ -1,24 +1,5 @@
 package dev.langchain4j.model.openai;
 
-import dev.ai4j.openai4j.OpenAiClient;
-import dev.ai4j.openai4j.embedding.EmbeddingRequest;
-import dev.ai4j.openai4j.embedding.EmbeddingResponse;
-import dev.langchain4j.data.embedding.Embedding;
-import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.Tokenizer;
-import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
-import dev.langchain4j.model.embedding.TokenCountEstimator;
-import dev.langchain4j.model.openai.spi.OpenAiEmbeddingModelBuilderFactory;
-import dev.langchain4j.model.output.Response;
-import dev.langchain4j.model.output.TokenUsage;
-
-import java.net.Proxy;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.StringJoiner;
-
 import static dev.langchain4j.internal.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
@@ -30,6 +11,25 @@ import static dev.langchain4j.model.openai.InternalOpenAiHelper.tokenUsageFrom;
 import static dev.langchain4j.model.openai.OpenAiModelName.TEXT_EMBEDDING_ADA_002;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.time.Duration.ofSeconds;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.embedding.EmbeddingRequest;
+import dev.ai4j.openai4j.embedding.EmbeddingResponse;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.Tokenizer;
+import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
+import dev.langchain4j.model.embedding.TokenCountEstimator;
+import dev.langchain4j.model.openai.spi.OpenAiEmbeddingModelBuilderFactory;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+import java.net.Proxy;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Represents an OpenAI embedding model, such as text-embedding-ada-002.
@@ -44,20 +44,21 @@ public class OpenAiEmbeddingModel extends DimensionAwareEmbeddingModel implement
     private final Integer maxSegmentsPerBatch;
     private final Tokenizer tokenizer;
 
-    public OpenAiEmbeddingModel(String baseUrl,
-                                String apiKey,
-                                String organizationId,
-                                String modelName,
-                                Integer dimensions,
-                                String user,
-                                Duration timeout,
-                                Integer maxRetries,
-                                Integer maxSegmentsPerBatch,
-                                Proxy proxy,
-                                Boolean logRequests,
-                                Boolean logResponses,
-                                Tokenizer tokenizer,
-                                Map<String, String> customHeaders) {
+    public OpenAiEmbeddingModel(
+            String baseUrl,
+            String apiKey,
+            String organizationId,
+            String modelName,
+            Integer dimensions,
+            String user,
+            Duration timeout,
+            Integer maxRetries,
+            Integer maxSegmentsPerBatch,
+            Proxy proxy,
+            Boolean logRequests,
+            Boolean logResponses,
+            Tokenizer tokenizer,
+            Map<String, String> customHeaders) {
 
         baseUrl = getOrDefault(baseUrl, OPENAI_URL);
         if (OPENAI_DEMO_API_KEY.equals(apiKey)) {
@@ -105,9 +106,7 @@ public class OpenAiEmbeddingModel extends DimensionAwareEmbeddingModel implement
     @Override
     public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
 
-        List<String> texts = textSegments.stream()
-                .map(TextSegment::text)
-                .toList();
+        List<String> texts = textSegments.stream().map(TextSegment::text).toList();
 
         List<List<String>> textBatches = partition(texts, maxSegmentsPerBatch);
 
@@ -136,9 +135,9 @@ public class OpenAiEmbeddingModel extends DimensionAwareEmbeddingModel implement
                         .toList(),
                 responses.stream()
                         .map(Response::tokenUsage)
+                        .filter(Objects::nonNull)
                         .reduce(TokenUsage::add)
-                        .orElse(null)
-        );
+                        .orElse(null));
     }
 
     private Response<List<Embedding>> embedTexts(List<String> texts) {
@@ -156,10 +155,7 @@ public class OpenAiEmbeddingModel extends DimensionAwareEmbeddingModel implement
                 .map(openAiEmbedding -> Embedding.from(openAiEmbedding.embedding()))
                 .toList();
 
-        return Response.from(
-                embeddings,
-                tokenUsageFrom(response.usage())
-        );
+        return Response.from(embeddings, tokenUsageFrom(response.usage()));
     }
 
     @Override
@@ -294,8 +290,7 @@ public class OpenAiEmbeddingModel extends DimensionAwareEmbeddingModel implement
                     this.logRequests,
                     this.logResponses,
                     this.tokenizer,
-                    this.customHeaders
-            );
+                    this.customHeaders);
         }
 
         @Override


### PR DESCRIPTION
Currently when using the OpenAI embedding model, if there is no `usage` element in the response it fails with a `NullPointerException`.

There are some model serving runtimes (like SBERT) which do not provide the `usage` element on embedding responses.

For example...

`curl -X POST http://localhost:11434/v1/embeddings -H "Accept: application/json" -H "Content-Type: application/json" -d @input.json > output.json`

input.json:
```json
{
  "model": "nomic-embed-text:v1.5",
  "input": [
    "Parasol Insurance Company\nPolicy Document\n\n1. Coverage\n1.1. This policy provides coverage for the insured vehicle as specified in the declarations page.\n1.2. Coverage types may include:\n\n1.2.1. Liability (Bodily Injury and Property Damage)\n1.2.2. Collision\n1.2.3. Comprehensive\n1.2.4. Personal Injury Protection (PIP)\n1.2.5. Uninsured / Underinsured Motorist\n\n1.3. Specific coverage limits and deductibles are listed on the declarations page.\n\n2. Policy Term\n2.1. The policy term is six months from the date of inception, unless otherwise specified.\n2.2. Renewal is not automatic and must be initiated by the policyholder.\n\n3. Exclusions\n3.1. Damage caused by intential acts or gross negligence is not covered.\n3.2. Normal wear and tear is excluded from coverage.\n3.3. Damage resulting from racing is excluded\n3.4. Damage resulting from using the vehicle for commercial purposes without proper endorsement\n\nis excluded.\n3.5. Driving under the influence of alcohol or drugs voids coverage for that incident.\n\n4. Claim Process\n4.1. Claims should be filed as soon as possible after an incident.\n4.2. Policyholders must provide all relevant information, including police reports when applicable.\n4.3. An adjuster may be assigned to inspect the vehicle and assess damages.",
    "4.3.\n\nAn adjuster may be assigned to inspect the vehicle and assess damages.\n\n5. Premiums and Deductibles\n5.1. Premiums are calculated based on factors including driver history, vehicle type, and coverage\n\nselected.\n5.2. Deductibles apply to collision and comprehensive coverage as specified on the declarations\n\npage.\n\n6. Cancellation\n6.1. The policyholder may cancel at any time with pro-rata refund of premiums.\n6.2. The insurer reserves the right to cancel within 30 days notice, or immediately in cases of\n\nnon-payment or fraud.\n\n7. Definitions\n7.1. "Insured vehicle" refers to the automobile listed on the declarations page.\n\n7.2. "Accident" means a sudden, unexpected event resulting in damage or injury.\n\n8. Additional Provisions\n8.1. Coverage extends to other drivers listed on the policy.\n8.2. Rental car coverage may be included if specified on the declarations page.\n8.3. Roadside assistance may be available if specified on the declarations page.\n\n9. Contact Information\nFor claims or inquiries:\nPhone: 800-CAR-SAFE\nEmail: claims@parasol.com"
  ]
}
```

output.json:
```json
{
  "object": "list",
  "data": [
    {
      "object": "embedding",
      "embedding": [
        0.061953582,
        0.023107821,
        -0.18001755
      ],
      "index": 0
    },
    {
      "object": "embedding",
      "embedding": [
        0.030326294,
        0.0034915505,
        -0.15638898,
        -0.013955873,
        0.06822011,
        -0.01184705,
        0.024880989
      ],
      "index": 1
    }
  ],
  "model": "nomic-embed-text:v1.5"
}
```

You end up with

```
java.lang.NullPointerException
        at java.base/java.util.Objects.requireNonNull(Objects.java:233)
        at java.base/java.util.Optional.of(Optional.java:113)
        at java.base/java.util.stream.ReduceOps$2ReducingSink.get(ReduceOps.java:129)
        at java.base/java.util.stream.ReduceOps$2ReducingSink.get(ReduceOps.java:107)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:662)
        at dev.langchain4j.model.openai.OpenAiEmbeddingModel.embedBatchedTexts(OpenAiEmbeddingModel.java:139)
        at dev.langchain4j.model.openai.OpenAiEmbeddingModel.embedAll(OpenAiEmbeddingModel.java:114)
```

The fix here is to filter out all results that are `null` before trying to reduce to a `TokenUsage`.