### PR TITLE
#2471 Added explicit setting of socket timeout to bedrock http client…

### DIFF
--- a/langchain4j-bedrock/pom.xml
+++ b/langchain4j-bedrock/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>dev.langchain4j</groupId>
@@ -110,15 +108,10 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+        </dependency>
     </dependencies>
-
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
 
 </project>


### PR DESCRIPTION
… to override default 30 sec timeout

## Issue
Fixes  #2471 

## Change
Set socket timeout on Apache HTTP client to be either the same as the specified timeout on the Bedrock model, or the default suggested by AWS in https://repost.aws/articles/AR_A_6aqweQYOR5FCgvM2vdA/solving-read-timed-out-error-and-high-latencies-in-amazon-bedrock-with-aws-java-sdk-client


## General checklist
- [X ] There are no breaking changes
- The existing tests should suffice as there is no functional changes.
- [X ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- I tested this fix with my company product that uses langchain for both, Bedrock and OpenAI models.

There is no changes in the use of Bedrock model.
