### PR TITLE
Removing amazon.titan-text-express-v1 and ai21.jamba-instruct-v1:0 in ITS

### DIFF
--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatModelWithoutVisionIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatModelWithoutVisionIT.java
@@ -1,8 +1,7 @@
 package dev.langchain4j.model.bedrock;
 
-import static dev.langchain4j.model.bedrock.TestedModelsWithConverseAPI.AI_JAMBA_INSTRUCT;
+import static dev.langchain4j.model.bedrock.TestedModelsWithConverseAPI.AI_JAMBA_1_5_MINI;
 import static dev.langchain4j.model.bedrock.TestedModelsWithConverseAPI.AWS_NOVA_MICRO;
-import static dev.langchain4j.model.bedrock.TestedModelsWithConverseAPI.AWS_TITAN_TEXT_EXPRESS;
 import static dev.langchain4j.model.bedrock.TestedModelsWithConverseAPI.COHERE_COMMAND_R_PLUS;
 import static dev.langchain4j.model.bedrock.TestedModelsWithConverseAPI.MISTRAL_LARGE;
 
@@ -21,12 +20,12 @@ public class BedrockChatModelWithoutVisionIT extends AbstractChatModelIT {
 
     @Override
     protected List<ChatLanguageModel> models() {
-        return List.of(AWS_NOVA_MICRO, COHERE_COMMAND_R_PLUS, AI_JAMBA_INSTRUCT, MISTRAL_LARGE, AWS_TITAN_TEXT_EXPRESS);
+        return List.of(AWS_NOVA_MICRO, COHERE_COMMAND_R_PLUS, AI_JAMBA_1_5_MINI, MISTRAL_LARGE);
     }
 
     @Override
     protected List<ChatLanguageModel> modelsSupportingTools() {
-        return List.of(AWS_NOVA_MICRO, COHERE_COMMAND_R_PLUS, MISTRAL_LARGE);
+        return List.of(AWS_NOVA_MICRO, COHERE_COMMAND_R_PLUS, MISTRAL_LARGE, AI_JAMBA_1_5_MINI);
     }
 
     @Override
@@ -86,17 +85,6 @@ public class BedrockChatModelWithoutVisionIT extends AbstractChatModelIT {
 
     // OVERRIDED TESTS
 
-    // TITAN_EXPRESS doesn't support system prompt
-    // https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
-    @Override
-    @ParameterizedTest
-    @MethodSource("models")
-    protected void should_respect_system_message(ChatLanguageModel model) {
-        if (!model.equals(AWS_TITAN_TEXT_EXPRESS)) {
-            super.should_respect_system_message(model);
-        }
-    }
-
     // Nova models include support StopSequence but have an incoherrent behavior, it includes the stopSequence in the
     // response
     // TODO Titan express error : "Malformed input request: 3 schema violations found"
@@ -105,7 +93,7 @@ public class BedrockChatModelWithoutVisionIT extends AbstractChatModelIT {
     @MethodSource("models")
     @EnabledIf("supportsStopSequencesParameter")
     protected void should_respect_stopSequences_in_chat_request(ChatLanguageModel model) {
-        if (!model.equals(AWS_TITAN_TEXT_EXPRESS) && !model.equals(AWS_NOVA_MICRO)) {
+        if (!model.equals(AWS_NOVA_MICRO)) {
             super.should_respect_system_message(model);
         }
     }

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/TestedModelsWithConverseAPI.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/TestedModelsWithConverseAPI.java
@@ -13,9 +13,6 @@ public final class TestedModelsWithConverseAPI {
     public static final ChatLanguageModel AWS_NOVA_PRO =
             BedrockChatModel.builder().modelId("us.amazon.nova-pro-v1:0").build();
 
-    public static final ChatLanguageModel AWS_TITAN_TEXT_EXPRESS =
-            BedrockChatModel.builder().modelId("amazon.titan-text-express-v1").build();
-
     public static final ChatLanguageModel CLAUDE_3_HAIKU = BedrockChatModel.builder()
             .modelId("anthropic.claude-3-haiku-20240307-v1:0")
             .build();
@@ -31,6 +28,6 @@ public final class TestedModelsWithConverseAPI {
     public static final ChatLanguageModel COHERE_COMMAND_R_PLUS =
             BedrockChatModel.builder().modelId("cohere.command-r-plus-v1:0").build();
 
-    public static final ChatLanguageModel AI_JAMBA_INSTRUCT =
-            BedrockChatModel.builder().modelId("ai21.jamba-instruct-v1:0").build();
+    public static final ChatLanguageModel AI_JAMBA_1_5_MINI =
+            BedrockChatModel.builder().modelId("ai21.jamba-1-5-mini-v1:0").build();
 }


### PR DESCRIPTION
these models are considered legacy and have an end of life notice for august


## Issue

## Change
Removing amazon.titan-text-express-v1 and replacing ai21.jamba-instruct-v1:0 with ai21.jamba-1-5-mini-v1:0 in ITs as these models are considered legacy and have an end of life notice for august https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x ] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
