### PR TITLE
Introduce pluggable invocation policy

### DIFF
--- a/document-loaders/langchain4j-document-loader-github/src/main/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-github/src/main/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoader.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 
 public class GitHubDocumentLoader {
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_3_HAIKU_20240307;
 import static dev.langchain4j.model.anthropic.InternalAnthropicHelper.createErrorContext;

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessageChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessageChatModel.java
@@ -47,7 +47,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.bedrock.internal.sanitizer.BedrockAnthropicMessageSanitizer.sanitizeMessages;

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatModel.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.bedrock;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.Utils.readBytes;

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModel.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.bedrock.internal.Json.fromJson;

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAiChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAiChatModel.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.bedrock;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/internal/AbstractBedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/internal/AbstractBedrockChatModel.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.bedrock.internal;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/internal/AbstractBedrockEmbeddingModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/internal/AbstractBedrockEmbeddingModel.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.bedrock.internal;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;

--- a/langchain4j-cohere/src/main/java/dev/langchain4j/model/cohere/CohereScoringModel.java
+++ b/langchain4j-cohere/src/main/java/dev/langchain4j/model/cohere/CohereScoringModel.java
@@ -10,7 +10,7 @@ import java.net.Proxy;
 import java.time.Duration;
 import java.util.List;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static java.time.Duration.ofSeconds;

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/policy/ExceptionMapper.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/policy/ExceptionMapper.java
@@ -1,0 +1,29 @@
+package dev.langchain4j.model.chat.policy;
+
+import java.util.concurrent.Callable;
+
+public interface ExceptionMapper extends InvocationPolicy {
+
+    ExceptionMapper DEFAULT = new DefaultExceptionMapper();
+
+    @Override
+    default Callable<?> apply(final Callable<?> action) {
+        return () -> {
+            try {
+                return action.call();
+            } catch (Exception e) {
+                throw mapException(e);
+            }
+        };
+    }
+
+    RuntimeException mapException(Exception e);
+
+    class DefaultExceptionMapper implements ExceptionMapper {
+        @Override
+        public RuntimeException mapException(Exception e) {
+            System.out.println(e.getMessage());
+            return e instanceof RuntimeException re ? re : new RuntimeException(e);
+        }
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/policy/InvocationPolicy.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/policy/InvocationPolicy.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.model.chat.policy;
+
+import java.util.concurrent.Callable;
+
+import static dev.langchain4j.model.chat.policy.RetryUtils.DEFAULT_RETRY_POLICY;
+
+@FunctionalInterface
+public interface InvocationPolicy {
+
+    InvocationPolicy DEFAULT = ExceptionMapper.DEFAULT.andThen(RetryUtils.DEFAULT_RETRY_POLICY);
+
+    Callable<?> apply(Callable<?> action);
+
+    default InvocationPolicy andThen(InvocationPolicy invocationPolicy) {
+        return action -> invocationPolicy.apply(this.apply(action));
+    }
+
+    static InvocationPolicyBuilder builder() {
+        return new InvocationPolicyBuilder();
+    }
+
+    class InvocationPolicyBuilder {
+        private RetryUtils.RetryPolicy retryPolicy = DEFAULT_RETRY_POLICY;
+        private ExceptionMapper exceptionMapper = ExceptionMapper.DEFAULT;
+
+        public InvocationPolicyBuilder withRetryPolicy(RetryUtils.RetryPolicy retryPolicy) {
+            this.retryPolicy = retryPolicy;
+            return this;
+        }
+
+        public InvocationPolicyBuilder withExceptionMapper(ExceptionMapper exceptionMapper) {
+            this.exceptionMapper = exceptionMapper;
+            return this;
+        }
+
+        public InvocationPolicy build() {
+            return exceptionMapper.andThen(retryPolicy);
+        }
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/policy/PolicyUtil.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/policy/PolicyUtil.java
@@ -1,0 +1,13 @@
+package dev.langchain4j.model.chat.policy;
+
+import java.util.concurrent.Callable;
+
+public class PolicyUtil {
+    public static <T> T invokePolicy(InvocationPolicy policy, Callable<T> callable) {
+        try {
+            return (T) policy.apply(callable).call();
+        } catch (Exception e) {
+            throw e instanceof RuntimeException re ? re : new RuntimeException(e);
+        }
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/RetryUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/RetryUtilsTest.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.internal;
 
+import dev.langchain4j.model.chat.policy.RetryUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Callable;

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiEmbeddingModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiEmbeddingModel.java
@@ -1,6 +1,5 @@
 package dev.langchain4j.model.googleai;
 
-import com.google.gson.Gson;
 import dev.langchain4j.Experimental;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
@@ -15,7 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModel.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
 import static dev.langchain4j.model.googleai.FinishReasonMapper.fromGFinishReasonToFinishReason;

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModel.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 
 @Experimental
 @Slf4j

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiTokenizer.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiTokenizer.java
@@ -13,7 +13,7 @@ import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.googleai.PartsAndContentsMapper.fromMessageToGContent;

--- a/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaEmbeddingModel.java
+++ b/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaEmbeddingModel.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.jina;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static java.time.Duration.ofSeconds;
 import static java.util.stream.Collectors.toList;

--- a/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaScoringModel.java
+++ b/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaScoringModel.java
@@ -12,7 +12,7 @@ import lombok.Builder;
 import java.time.Duration;
 import java.util.List;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static java.time.Duration.ofSeconds;

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaChatModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaChatModel.java
@@ -9,7 +9,7 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.*;
 import dev.langchain4j.internal.Json;
-import dev.langchain4j.internal.RetryUtils;
+import dev.langchain4j.model.chat.policy.RetryUtils;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.jlama.spi.JlamaChatModelBuilderFactory;
 import dev.langchain4j.model.output.Response;

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaEmbeddingModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaEmbeddingModel.java
@@ -6,7 +6,7 @@ import com.github.tjake.jlama.model.bert.BertModel;
 import com.github.tjake.jlama.model.functions.Generator;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.internal.RetryUtils;
+import dev.langchain4j.model.chat.policy.RetryUtils;
 import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
 import dev.langchain4j.model.jlama.spi.JlamaEmbeddingModelBuilderFactory;
 import dev.langchain4j.model.output.Response;

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaLanguageModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaLanguageModel.java
@@ -4,7 +4,7 @@ import com.github.tjake.jlama.model.AbstractModel;
 import com.github.tjake.jlama.model.functions.Generator;
 import com.github.tjake.jlama.safetensors.DType;
 import com.github.tjake.jlama.safetensors.prompt.PromptContext;
-import dev.langchain4j.internal.RetryUtils;
+import dev.langchain4j.model.chat.policy.RetryUtils;
 import dev.langchain4j.model.jlama.spi.JlamaLanguageModelBuilderFactory;
 import dev.langchain4j.model.language.LanguageModel;
 import dev.langchain4j.model.output.FinishReason;

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingChatModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingChatModel.java
@@ -20,7 +20,7 @@ import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.internal.Json;
-import dev.langchain4j.internal.RetryUtils;
+import dev.langchain4j.model.chat.policy.RetryUtils;
 import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.jlama.spi.JlamaStreamingChatModelBuilderFactory;

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingLanguageModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingLanguageModel.java
@@ -4,7 +4,7 @@ import com.github.tjake.jlama.model.AbstractModel;
 import com.github.tjake.jlama.model.functions.Generator;
 import com.github.tjake.jlama.safetensors.DType;
 import com.github.tjake.jlama.safetensors.prompt.PromptContext;
-import dev.langchain4j.internal.RetryUtils;
+import dev.langchain4j.model.chat.policy.RetryUtils;
 import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.jlama.spi.JlamaStreamingLanguageModelBuilderFactory;
 import dev.langchain4j.model.language.StreamingLanguageModel;

--- a/langchain4j-local-ai/src/main/java/dev/langchain4j/model/localai/LocalAiChatModel.java
+++ b/langchain4j-local-ai/src/main/java/dev/langchain4j/model/localai/LocalAiChatModel.java
@@ -14,7 +14,7 @@ import lombok.Builder;
 import java.time.Duration;
 import java.util.List;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.aiMessageFrom;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.finishReasonFrom;

--- a/langchain4j-local-ai/src/main/java/dev/langchain4j/model/localai/LocalAiEmbeddingModel.java
+++ b/langchain4j-local-ai/src/main/java/dev/langchain4j/model/localai/LocalAiEmbeddingModel.java
@@ -13,7 +13,7 @@ import lombok.Builder;
 import java.time.Duration;
 import java.util.List;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.time.Duration.ofSeconds;

--- a/langchain4j-local-ai/src/main/java/dev/langchain4j/model/localai/LocalAiLanguageModel.java
+++ b/langchain4j-local-ai/src/main/java/dev/langchain4j/model/localai/LocalAiLanguageModel.java
@@ -10,7 +10,7 @@ import lombok.Builder;
 
 import java.time.Duration;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.finishReasonFrom;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatModel.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.mistralai;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiEmbeddingModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiEmbeddingModel.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.mistralai;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.mistralai.internal.mapper.MistralAiMapper.tokenUsageFrom;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModels.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModels.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.mistralai;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
@@ -14,7 +14,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static java.util.Collections.singletonList;

--- a/langchain4j-nomic/src/main/java/dev/langchain4j/model/nomic/NomicEmbeddingModel.java
+++ b/langchain4j-nomic/src/main/java/dev/langchain4j/model/nomic/NomicEmbeddingModel.java
@@ -11,7 +11,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static java.time.Duration.ofSeconds;

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatModel.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaEmbeddingModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaEmbeddingModel.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaLanguageModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaLanguageModel.java
@@ -11,7 +11,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.ollama.OllamaMessagesUtils.toOllamaResponseFormat;

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModels.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModels.java
@@ -6,7 +6,7 @@ import dev.langchain4j.model.output.Response;
 import java.time.Duration;
 import java.util.List;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 
 public class OllamaModels {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiEmbeddingModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiEmbeddingModel.java
@@ -1,5 +1,13 @@
 package dev.langchain4j.model.openai;
 
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
+import static dev.langchain4j.model.openai.InternalOpenAiHelper.DEFAULT_USER_AGENT;
+import static dev.langchain4j.model.openai.InternalOpenAiHelper.tokenUsageFrom;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+import static java.time.Duration.ofSeconds;
+
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.http.client.HttpClientBuilder;
@@ -19,14 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.DEFAULT_OPENAI_URL;
-import static dev.langchain4j.model.openai.InternalOpenAiHelper.DEFAULT_USER_AGENT;
-import static dev.langchain4j.model.openai.InternalOpenAiHelper.tokenUsageFrom;
-import static dev.langchain4j.spi.ServiceHelper.loadFactories;
-import static java.time.Duration.ofSeconds;
 
 /**
  * Represents an OpenAI embedding model, such as text-embedding-ada-002.

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiExceptionMapper.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiExceptionMapper.java
@@ -1,0 +1,20 @@
+package dev.langchain4j.model.openai;
+
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.model.chat.policy.ExceptionMapper;
+
+class OpenAiExceptionMapper implements ExceptionMapper {
+
+    static final OpenAiExceptionMapper INSTANCE = new OpenAiExceptionMapper();
+
+    @Override
+    public RuntimeException mapException(Exception e) {
+        if (e instanceof HttpException openAiHttpException) {
+            return openAiHttpException;
+        }
+        if (e.getCause() instanceof HttpException openAiHttpException) {
+            return openAiHttpException;
+        }
+        return e instanceof RuntimeException re ? re : new RuntimeException(e);
+    }
+}

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.DEFAULT_OPENAI_URL;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.DEFAULT_USER_AGENT;

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiLanguageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiLanguageModel.java
@@ -14,7 +14,7 @@ import dev.langchain4j.model.output.Response;
 import java.time.Duration;
 import java.util.Map;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.DEFAULT_OPENAI_URL;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.DEFAULT_USER_AGENT;

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
@@ -15,7 +15,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.DEFAULT_OPENAI_URL;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.DEFAULT_USER_AGENT;

--- a/langchain4j-ovh-ai/src/main/java/dev/langchain4j/model/ovhai/OvhAiEmbeddingModel.java
+++ b/langchain4j-ovh-ai/src/main/java/dev/langchain4j/model/ovhai/OvhAiEmbeddingModel.java
@@ -12,7 +12,7 @@ import lombok.Builder;
 import java.time.Duration;
 import java.util.List;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static java.util.stream.Collectors.toList;
 

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/VertexAiGeminiChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/VertexAiGeminiChatModel.java
@@ -9,7 +9,6 @@ import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.model.chat.TokenCountEstimator;
 import dev.langchain4j.model.chat.listener.*;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.vertexai.spi.VertexAiGeminiChatModelBuilderFactory;
@@ -27,7 +26,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;

--- a/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiChatModel.java
+++ b/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiChatModel.java
@@ -19,7 +19,7 @@ import java.util.List;
 import static com.google.protobuf.Value.newBuilder;
 import static dev.langchain4j.data.message.ChatMessageType.*;
 import static dev.langchain4j.internal.Json.toJson;
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.util.Collections.singletonList;

--- a/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModel.java
+++ b/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiEmbeddingModel.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static dev.langchain4j.internal.Json.toJson;
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;

--- a/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiImageModel.java
+++ b/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiImageModel.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 
 import static com.google.protobuf.Value.newBuilder;
 import static dev.langchain4j.internal.Json.toJson;
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.ValidationUtils.ensureBetween;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;

--- a/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiLanguageModel.java
+++ b/langchain4j-vertex-ai/src/main/java/dev/langchain4j/model/vertexai/VertexAiLanguageModel.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static com.google.protobuf.Value.newBuilder;
 import static dev.langchain4j.internal.Json.toJson;
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.vertexai.VertexAiChatModel.extractTokenCount;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;

--- a/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiEmbeddingModel.java
+++ b/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiEmbeddingModel.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.voyageai.VoyageAiApi.DEFAULT_BASE_URL;

--- a/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiScoringModel.java
+++ b/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiScoringModel.java
@@ -8,7 +8,7 @@ import dev.langchain4j.model.scoring.ScoringModel;
 import java.time.Duration;
 import java.util.List;
 
-import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.model.chat.policy.RetryUtils.withRetry;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.voyageai.VoyageAiApi.DEFAULT_BASE_URL;

--- a/langchain4j/src/test/java/dev/langchain4j/internal/EchoChatLanguageModel.java
+++ b/langchain4j/src/test/java/dev/langchain4j/internal/EchoChatLanguageModel.java
@@ -1,0 +1,18 @@
+package dev.langchain4j.internal;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class EchoChatLanguageModel implements ChatLanguageModel {
+
+    @Override
+    public Response<AiMessage> generate(final List<ChatMessage> messages) {
+        String response = messages.stream().map(ChatMessage::text).collect(Collectors.joining("; "));
+        System.out.println(response);
+        return Response.from(AiMessage.from(response));
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceThrowingExceptionIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceThrowingExceptionIT.java
@@ -57,7 +57,9 @@ class AiServiceThrowingExceptionIT {
                 .chatMemory(chatMemory)
                 .build();
 
-        assertThrows(RuntimeException.class, () -> assistant.chat("hi"));
+        assertThatThrownBy(() -> assistant.chat("hi"))
+                .isExactlyInstanceOf(HttpException.class)
+                .hasMessage("Insufficient quota");
         assertThat(invocationCount.get()).isEqualTo(3);
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceThrowingExceptionIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceThrowingExceptionIT.java
@@ -1,0 +1,63 @@
+package dev.langchain4j.service;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.model.chat.policy.InvocationPolicy;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AiServiceThrowingExceptionIT {
+    interface ThrowingService {
+        Result<AiMessage> chat(String userMessage);
+    }
+
+    @Test
+    void with_no_policy() {
+
+        AtomicInteger invocationCount = new AtomicInteger(0);
+
+        ChatLanguageModel chatLanguageModel = new ChatModelMock(chatRequest -> {
+            invocationCount.incrementAndGet();
+            throw new HttpException(429, "Insufficient quota");
+        });
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+
+        ThrowingService assistant = AiServices.builder(ThrowingService.class)
+                .chatLanguageModel(chatLanguageModel)
+                .chatMemory(chatMemory)
+                .build();
+
+        assertThrows(RuntimeException.class, () -> assistant.chat("hi"));
+        assertThat(invocationCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    void with_default_policy() {
+
+        AtomicInteger invocationCount = new AtomicInteger(0);
+
+        ChatLanguageModel chatLanguageModel = new ChatModelMock(chatRequest -> {
+            invocationCount.incrementAndGet();
+            throw new HttpException(429, "Insufficient quota");
+        }).withInvocationPolicy(InvocationPolicy.DEFAULT);
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+
+        ThrowingService assistant = AiServices.builder(ThrowingService.class)
+                .chatLanguageModel(chatLanguageModel)
+                .chatMemory(chatMemory)
+                .build();
+
+        assertThrows(RuntimeException.class, () -> assistant.chat("hi"));
+        assertThat(invocationCount.get()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
This pull request allows to optionally configure a `ChatLanguageModel` with an `InvocationPolicy`. Both the `RetryPolicy` and the `ExceptionMapper` (used to map HttpException to specific exeception based on the http code, still to be implemented) are  `InvocationPolicy`. `InvocationPolicy` are composable, through decoration, so an `InvocationPolicy` can define both the retry policy and the exception mapping, plus other strategies that we may want to add in future.

@dliubars Please give a look and let me know if the idea makes sense for you. If so I will also implement a proper execption mapping based on http error codes as discussed.