### PR TITLE
Implementation of returnDirect in @Tool annotation

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.agent.tool;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 /**
  * Java methods annotated with {@code @Tool} are considered tools/functions that language model can execute/call.
@@ -36,4 +36,10 @@ public @interface Tool {
      * @return description of the tool.
      */
     String[] value() default "";
+
+    /**
+     * Whether to return directly from the tool rather than continuing the agent loop.
+     * Defaults to false.
+     */
+    boolean returnDirect() default false;
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecification.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecification.java
@@ -1,13 +1,12 @@
 package dev.langchain4j.agent.tool;
 
-import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import static dev.langchain4j.internal.Utils.quoted;
+import static java.util.Arrays.asList;
 
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
-import static dev.langchain4j.internal.Utils.quoted;
-import static java.util.Arrays.asList;
 
 /**
  * Describes a tool that language model can execute.
@@ -18,7 +17,9 @@ public class ToolSpecification {
 
     private final String name;
     private final String description;
+    private final boolean returnDirect;
     private final JsonObjectSchema parameters;
+
     @Deprecated(forRemoval = true)
     private final ToolParameters toolParameters;
 
@@ -31,9 +32,10 @@ public class ToolSpecification {
         this.name = builder.name;
         this.description = builder.description;
         if (builder.parameters != null && builder.toolParameters != null) {
-            throw new IllegalArgumentException("Both (new) JsonObjectSchema and (old) ToolParameters " +
-                    "are used to specify tool parameters. Please use only (new) JsonObjectSchema.");
+            throw new IllegalArgumentException("Both (new) JsonObjectSchema and (old) ToolParameters "
+                    + "are used to specify tool parameters. Please use only (new) JsonObjectSchema.");
         }
+        this.returnDirect = builder.returnDirect;
         this.parameters = builder.parameters;
         this.toolParameters = builder.toolParameters;
     }
@@ -45,6 +47,15 @@ public class ToolSpecification {
      */
     public String name() {
         return name;
+    }
+
+    /**
+     * Returns the value of returnDirect for the tool.
+     *
+     * @return the value of returnDirect for the tool.
+     */
+    public boolean returnDirect() {
+        return returnDirect;
     }
 
     /**
@@ -76,13 +87,13 @@ public class ToolSpecification {
     @Override
     public boolean equals(Object another) {
         if (this == another) return true;
-        return another instanceof ToolSpecification ts
-                && equalTo(ts);
+        return another instanceof ToolSpecification ts && equalTo(ts);
     }
 
     private boolean equalTo(ToolSpecification another) {
         return Objects.equals(name, another.name)
                 && Objects.equals(description, another.description)
+                && Objects.equals(returnDirect, another.returnDirect)
                 && Objects.equals(parameters, another.parameters)
                 && Objects.equals(toolParameters, another.toolParameters);
     }
@@ -92,6 +103,7 @@ public class ToolSpecification {
         int h = 5381;
         h += (h << 5) + Objects.hashCode(name);
         h += (h << 5) + Objects.hashCode(description);
+        h += (h << 5) + Objects.hashCode(returnDirect);
         h += (h << 5) + Objects.hashCode(parameters);
         h += (h << 5) + Objects.hashCode(toolParameters);
         return h;
@@ -102,6 +114,7 @@ public class ToolSpecification {
         return "ToolSpecification {"
                 + " name = " + quoted(name)
                 + ", description = " + quoted(description)
+                + ", returnDirect = " + returnDirect
                 + ", parameters = " + parameters
                 + ", toolParameters = " + toolParameters
                 + " }";
@@ -123,15 +136,16 @@ public class ToolSpecification {
 
         private String name;
         private String description;
+        private boolean returnDirect;
         private JsonObjectSchema parameters;
+
         @Deprecated(forRemoval = true)
         private ToolParameters toolParameters;
 
         /**
          * Creates a {@link Builder}.
          */
-        private Builder() {
-        }
+        private Builder() {}
 
         /**
          * Sets the {@code name}.
@@ -152,6 +166,17 @@ public class ToolSpecification {
          */
         public Builder description(String description) {
             this.description = description;
+            return this;
+        }
+
+        /**
+         * Sets {@code returnDirect}.
+         *
+         * @param returnDirect the {@code returnDirect} parameter
+         * @return {@code this}
+         */
+        public Builder returnDirect(boolean returnDirect) {
+            this.returnDirect = returnDirect;
             return this;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
@@ -1,9 +1,12 @@
 package dev.langchain4j.agent.tool;
 
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElementHelper;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
@@ -14,17 +17,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.toList;
-
 /**
  * Utility methods for {@link ToolSpecification}s.
  */
 public class ToolSpecifications {
 
-    private ToolSpecifications() {
-    }
+    private ToolSpecifications() {}
 
     /**
      * Returns {@link ToolSpecification}s for all methods annotated with @{@link Tool} within the specified class.
@@ -58,13 +56,15 @@ public class ToolSpecifications {
      *
      * @param toolSpecifications list of ToolSpecification to be validated.
      */
-    public static void validateSpecifications(List<ToolSpecification> toolSpecifications) throws IllegalArgumentException {
+    public static void validateSpecifications(List<ToolSpecification> toolSpecifications)
+            throws IllegalArgumentException {
 
         // Checks for duplicates methods
         Set<String> names = new HashSet<>();
         for (ToolSpecification toolSpecification : toolSpecifications) {
             if (!names.add(toolSpecification.name())) {
-                throw new IllegalArgumentException(String.format("Tool names must be unique. The tool '%s' appears several times", toolSpecification.name()));
+                throw new IllegalArgumentException(String.format(
+                        "Tool names must be unique. The tool '%s' appears several times", toolSpecification.name()));
             }
         }
     }
@@ -86,11 +86,14 @@ public class ToolSpecifications {
             description = null;
         }
 
+        boolean returnDirect = annotation.returnDirect();
+
         JsonObjectSchema parameters = parametersFrom(method.getParameters());
 
         return ToolSpecification.builder()
                 .name(name)
                 .description(description)
+                .returnDirect(returnDirect)
                 .parameters(parameters)
                 .build();
     }
@@ -135,15 +138,11 @@ public class ToolSpecifications {
                 .build();
     }
 
-    private static JsonSchemaElement jsonSchemaElementFrom(Parameter parameter,
-                                                           Map<Class<?>, JsonSchemaElementHelper.VisitedClassMetadata> visited) {
+    private static JsonSchemaElement jsonSchemaElementFrom(
+            Parameter parameter, Map<Class<?>, JsonSchemaElementHelper.VisitedClassMetadata> visited) {
         P annotation = parameter.getAnnotation(P.class);
         String description = annotation == null ? null : annotation.value();
         return JsonSchemaElementHelper.jsonSchemaElementFrom(
-                parameter.getType(),
-                parameter.getParameterizedType(),
-                description,
-                visited
-        );
+                parameter.getType(), parameter.getParameterizedType(), description, visited);
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationTest.java
@@ -1,12 +1,11 @@
 package dev.langchain4j.agent.tool;
 
+import static java.util.Collections.singletonMap;
+
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import java.util.Collections;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-
-import static java.util.Collections.singletonMap;
 
 class ToolSpecificationTest implements WithAssertions {
     @Test
@@ -39,13 +38,11 @@ class ToolSpecificationTest implements WithAssertions {
         assertThat(ts.name()).isEqualTo("name");
         assertThat(ts.description()).isEqualTo("description");
         assertThat(ts.toolParameters().type()).isEqualTo("object");
-        assertThat(ts.toolParameters().properties().get("req"))
-                .containsEntry("type", "boolean");
+        assertThat(ts.toolParameters().properties().get("req")).containsEntry("type", "boolean");
         assertThat(ts.toolParameters().properties().get("foo"))
                 .containsEntry("type", "string")
                 .containsEntry("description", "description");
-        assertThat(ts.toolParameters().properties().get("bar"))
-                .containsEntry("type", "integer");
+        assertThat(ts.toolParameters().properties().get("bar")).containsEntry("type", "integer");
         assertThat(ts.toolParameters().required()).containsOnly("req");
     }
 
@@ -79,38 +76,38 @@ class ToolSpecificationTest implements WithAssertions {
                 .hasSameHashCodeAs(sp2);
 
         assertThat(ToolSpecification.builder()
-                .name("changed")
-                .description("description")
-                .parameters(ToolParameters.builder()
-                        .type("type")
-                        .properties(singletonMap("foo", singletonMap("bar", "baz")))
-                        .required(Collections.singletonList("foo"))
+                        .name("changed")
+                        .description("description")
+                        .parameters(ToolParameters.builder()
+                                .type("type")
+                                .properties(singletonMap("foo", singletonMap("bar", "baz")))
+                                .required(Collections.singletonList("foo"))
+                                .build())
                         .build())
-                .build())
                 .isNotEqualTo(sp1)
                 .doesNotHaveSameHashCodeAs(sp1);
 
         assertThat(ToolSpecification.builder()
-                .name("name")
-                .description("changed")
-                .parameters(ToolParameters.builder()
-                        .type("type")
-                        .properties(singletonMap("foo", singletonMap("bar", "baz")))
-                        .required(Collections.singletonList("foo"))
+                        .name("name")
+                        .description("changed")
+                        .parameters(ToolParameters.builder()
+                                .type("type")
+                                .properties(singletonMap("foo", singletonMap("bar", "baz")))
+                                .required(Collections.singletonList("foo"))
+                                .build())
                         .build())
-                .build())
                 .isNotEqualTo(sp1)
                 .doesNotHaveSameHashCodeAs(sp1);
 
         assertThat(ToolSpecification.builder()
-                .name("name")
-                .description("description")
-                .parameters(ToolParameters.builder()
-                        .type("type")
-                        .properties(singletonMap("foo", singletonMap("bar", "baz")))
-                        .required(Collections.singletonList("changed"))
+                        .name("name")
+                        .description("description")
+                        .parameters(ToolParameters.builder()
+                                .type("type")
+                                .properties(singletonMap("foo", singletonMap("bar", "baz")))
+                                .required(Collections.singletonList("changed"))
+                                .build())
                         .build())
-                .build())
                 .isNotEqualTo(sp1)
                 .doesNotHaveSameHashCodeAs(sp1);
     }
@@ -120,18 +117,19 @@ class ToolSpecificationTest implements WithAssertions {
         ToolSpecification sp1 = ToolSpecification.builder()
                 .name("name")
                 .description("description")
+                .returnDirect(true)
                 .parameters(JsonObjectSchema.builder()
                         .addStringProperty("foo")
                         .required("foo")
                         .build())
                 .build();
 
-        assertThat(sp1.toString()).isEqualTo(
-                "ToolSpecification { " +
-                        "name = \"name\", " +
-                        "description = \"description\", " +
-                        "parameters = JsonObjectSchema {description = null, properties = {foo=JsonStringSchema {description = null }}, required = [foo], additionalProperties = null, definitions = null }, " +
-                        "toolParameters = null " +
-                        "}");
+        assertThat(sp1.toString())
+                .isEqualTo("ToolSpecification { " + "name = \"name\", "
+                        + "description = \"description\", "
+                        + "returnDirect = true, "
+                        + "parameters = JsonObjectSchema {description = null, properties = {foo=JsonStringSchema {description = null }}, required = [foo], additionalProperties = null, definitions = null }, "
+                        + "toolParameters = null "
+                        + "}");
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -162,6 +162,15 @@ public class ToolService {
                         .result(toolExecutionResultMessage.text())
                         .build());
 
+                ToolSpecification toolSpec = toolSpecifications.stream()
+                        .filter(spec -> spec.name().equals(toolExecutionRequest.name()))
+                        .findFirst()
+                        .orElse(null);
+
+                if (toolSpec != null && toolSpec.returnDirect()) {
+                    return new ToolExecutionResult(chatResponse, toolExecutions, tokenUsageAccumulator);
+                }
+
                 if (chatMemory != null) {
                     chatMemory.add(toolExecutionResultMessage);
                 } else {


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #2542 

## Change
<!-- Please describe the changes you made. -->
Implemented the returnDirect parameter for the @ Tool annotation in LangChain4j.

This allows tool methods to immediately return a result and halt the agent loop, improving efficiency in scenarios where a tool's response is conclusive.

The following changes were made:

    Added a returnDirect element (boolean type with default false) to the @ Tool annotation.
    Modified ToolSpecification to include the returnDirect property.
    Updated ToolService.java to read the returnDirect value from ToolSpecification within the executeInferenceAndToolsLoop method.
    Adjusted the agent loop logic in ToolService.java to terminate the loop and return the tool's result directly when returnDirect is true.
    Adjusted test_toString in ToolSpecificationTest.
    (Will) add unit tests to verify the returnDirect functionality, covering both true and false cases.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
