### PR TITLE
Support hybrid search with Neo4J

### DIFF
--- a/langchain4j-neo4j/pom.xml
+++ b/langchain4j-neo4j/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/langchain4j-neo4j/pom.xml
+++ b/langchain4j-neo4j/pom.xml
@@ -113,6 +113,29 @@
             <artifactId>slf4j-tinylog</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>1.0.0-alpha2-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-document-loader-selenium</artifactId>
+            <version>1.0.0-alpha2-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>selenium</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-document-transformer-jsoup</artifactId>
+            <version>1.0.0-alpha2-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingStore.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingStore.java
@@ -1,33 +1,30 @@
 package dev.langchain4j.store.embedding.neo4j;
 
+import static dev.langchain4j.internal.Utils.*;
+import static dev.langchain4j.internal.ValidationUtils.*;
+import static dev.langchain4j.store.embedding.neo4j.Neo4jEmbeddingUtils.*;
+import static java.util.Collections.singletonList;
+
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import java.util.*;
+import java.util.stream.Stream;
 import lombok.Builder;
 import lombok.Getter;
 import org.neo4j.cypherdsl.support.schema_name.SchemaNames;
 import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.*;
-import java.util.stream.Stream;
-
-import static dev.langchain4j.internal.Utils.*;
-import static dev.langchain4j.internal.ValidationUtils.*;
-import static java.util.Collections.singletonList;
-
-import org.neo4j.driver.Driver;
-import org.neo4j.driver.SessionConfig;
-
-import static dev.langchain4j.store.embedding.neo4j.Neo4jEmbeddingUtils.*;
 
 /**
  * Represents a Vector index as an embedding store.
@@ -66,7 +63,7 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
     private final boolean fullTextAutocreate;
 
     /**
-     * Creates an instance of Neo4jEmbeddingStore defining a {@link Driver} 
+     * Creates an instance of Neo4jEmbeddingStore defining a {@link Driver}
      * starting from uri, user and password
      */
     public static class Neo4jEmbeddingStoreBuilder {
@@ -87,7 +84,7 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
      * @param textProperty: the optional textProperty property name (default: "text")
      * @param indexName: the optional index name (default: "vector")
      * @param databaseName: the optional database name (default: "neo4j")
-     * @param retrievalQuery: the optional retrieval query 
+     * @param retrievalQuery: the optional retrieval query
      *                        (default: "RETURN properties(node) AS metadata, node.`idProperty` AS `idProperty`, node.`textProperty` AS `textProperty`, node.`embeddingProperty` AS `embeddingProperty`, score")
      */
     @Builder
@@ -104,12 +101,11 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
             String databaseName,
             String retrievalQuery,
             long awaitIndexTimeout,
-
             String fullTextIndexName,
             String fullTextQuery,
             String fullTextRetrievalQuery,
             boolean fullTextAutocreate) {
-        
+
         /* required configs */
         this.driver = ensureNotNull(driver, "driver");
         this.dimension = ensureBetween(dimension, 0, 4096, "dimension");
@@ -140,10 +136,8 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
         */
         String defaultRetrievalQuery = String.format(
                 "RETURN properties(node) AS metadata, node.%1$s AS %1$s, node.%2$s AS %2$s, node.%3$s AS %3$s, score",
-                this.sanitizedIdProperty, this.sanitizedText, this.sanitizedEmbeddingProperty
-        );
+                this.sanitizedIdProperty, this.sanitizedText, this.sanitizedEmbeddingProperty);
         this.retrievalQuery = getOrDefault(retrievalQuery, defaultRetrievalQuery);
-
 
         this.notMetaKeys = new HashSet<>(Arrays.asList(this.idProperty, this.embeddingProperty, this.textProperty));
 
@@ -160,7 +154,7 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
     /*
     Methods with `@Override`
     */
-    
+
     @Override
     public String add(Embedding embedding) {
         String id = randomUUID();
@@ -191,36 +185,42 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
         var embeddingValue = Values.value(request.queryEmbedding().vector());
 
         try (var session = session()) {
-            Map<String, Object> params = new HashMap<>(Map.of("indexName", indexName,
-                    "embeddingValue", embeddingValue,
-                    "minScore", request.minScore(),
-                    "maxResults", request.maxResults()));
+            Map<String, Object> params = new HashMap<>(Map.of(
+                    "indexName",
+                    indexName,
+                    "embeddingValue",
+                    embeddingValue,
+                    "minScore",
+                    request.minScore(),
+                    "maxResults",
+                    request.maxResults()));
 
-            String query = """
+            String query =
+                    """
                     CALL db.index.vector.queryNodes($indexName, $maxResults, $embeddingValue)
                     YIELD node, score
                     WHERE score >= $minScore
                     """
-                    + retrievalQuery;
+                            + retrievalQuery;
 
             if (fullTextQuery != null) {
 
-                query += """
+                query +=
+                        """
                    \nUNION
                    CALL db.index.fulltext.queryNodes($fullTextIndexName, $question, {limit: $maxResults})
                    YIELD node, score
                    WHERE score >= $minScore
-                   """ + fullTextRetrievalQuery;
+                   """
+                                + fullTextRetrievalQuery;
 
                 params.putAll(Map.of(
                         "fullTextIndexName", fullTextIndexName,
-                        "question", fullTextQuery
-                ));
+                        "question", fullTextQuery));
             }
 
-            List<EmbeddingMatch<TextSegment>> matches = session
-                    .run(query, params)
-                    .list(item -> toEmbeddingMatch(this, item));
+            List<EmbeddingMatch<TextSegment>> matches =
+                    session.run(query, params).list(item -> toEmbeddingMatch(this, item));
 
             return new EmbeddingSearchResult<>(matches);
         }
@@ -241,7 +241,9 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
             return;
         }
         ensureTrue(ids.size() == embeddings.size(), "ids size is not equal to embeddings size");
-        ensureTrue(embedded == null || embeddings.size() == embedded.size(), "embeddings size is not equal to embedded size");
+        ensureTrue(
+                embedded == null || embeddings.size() == embedded.size(),
+                "embeddings size is not equal to embedded size");
 
         bulk(ids, embeddings, embedded);
     }
@@ -251,24 +253,19 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
 
         try (var session = session()) {
             rowsBatched.forEach(rows -> {
-                    String statement = """
+                String statement =
+                        """
                                 UNWIND $rows AS row
                                 MERGE (u:%1$s {%2$s: row.%2$s})
                                 SET u += row.%3$s
                                 WITH row, u
                                 CALL db.create.setNodeVectorProperty(u, $embeddingProperty, row.%4$s)
-                                RETURN count(*)""".formatted(
-                            this.sanitizedLabel,
-                            this.sanitizedIdProperty,
-                            PROPS,
-                            EMBEDDINGS_ROW_KEY);
-                    
-                    Map<String, Object> params = Map.of(
-                            "rows", rows,
-                            "embeddingProperty", this.embeddingProperty
-                    );
-    
-                    session.executeWrite(tx -> tx.run(statement, params).consume());
+                                RETURN count(*)"""
+                                .formatted(this.sanitizedLabel, this.sanitizedIdProperty, PROPS, EMBEDDINGS_ROW_KEY);
+
+                Map<String, Object> params = Map.of("rows", rows, "embeddingProperty", this.embeddingProperty);
+
+                session.executeWrite(tx -> tx.run(statement, params).consume());
             });
         }
     }
@@ -285,9 +282,7 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
         try (var session = session()) {
             String query = String.format(
                     "CREATE CONSTRAINT IF NOT EXISTS FOR (n:%s) REQUIRE n.%s IS UNIQUE",
-                    this.sanitizedLabel,
-                    this.sanitizedIdProperty
-            );
+                    this.sanitizedLabel, this.sanitizedIdProperty);
             session.run(query);
         }
     }
@@ -300,23 +295,18 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
                 return false;
             }
             var record = resIndex.single();
-            List<String> idxLabels = record
-                    .get("labelsOrTypes")
-                    .asList(Value::asString);
+            List<String> idxLabels = record.get("labelsOrTypes").asList(Value::asString);
             List<Object> idxProps = record.get("properties").asList();
-            
-            boolean isIndexDifferent = !idxLabels.equals(singletonList(this.label)) 
-                                       || !idxProps.equals(singletonList(this.embeddingProperty));
+
+            boolean isIndexDifferent = !idxLabels.equals(singletonList(this.label))
+                    || !idxProps.equals(singletonList(this.embeddingProperty));
             if (isIndexDifferent) {
-                String errMessage = String.format("""
+                String errMessage = String.format(
+                        """
                                 It's not possible to create an index for the label `%s` and the property `%s`,
                                 as there is another index with name `%s` with different labels: `%s` and properties `%s`.
                                 Please provide another indexName to create the vector index, or delete the existing one""",
-                        this.label,
-                        this.embeddingProperty,
-                        this.indexName,
-                        idxLabels,
-                        idxProps);
+                        this.label, this.embeddingProperty, this.indexName, idxLabels, idxProps);
                 throw new RuntimeException(errMessage);
             }
             return true;
@@ -337,19 +327,24 @@ public class Neo4jEmbeddingStore implements EmbeddingStore<TextSegment> {
     }
 
     private void createIndex() {
-        Map<String, Object> params = Map.of("indexName", this.indexName,
-                "label", this.label,
-                "embeddingProperty", this.embeddingProperty,
-                "dimension", this.dimension);
+        Map<String, Object> params = Map.of(
+                "indexName",
+                this.indexName,
+                "label",
+                this.label,
+                "embeddingProperty",
+                this.embeddingProperty,
+                "dimension",
+                this.dimension);
 
         // create vector index
         try (var session = session()) {
-            session.run("CALL db.index.vector.createNodeIndex($indexName, $label, $embeddingProperty, $dimension, 'cosine')",
+            session.run(
+                    "CALL db.index.vector.createNodeIndex($indexName, $label, $embeddingProperty, $dimension, 'cosine')",
                     params);
 
-            session.run("CALL db.awaitIndexes($timeout)", 
-                    Map.of("timeout", awaitIndexTimeout)
-            ).consume();
+            session.run("CALL db.awaitIndexes($timeout)", Map.of("timeout", awaitIndexTimeout))
+                    .consume();
         }
     }
 

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingUtils.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingUtils.java
@@ -28,6 +28,7 @@ class Neo4jEmbeddingUtils {
     public static final String DEFAULT_EMBEDDING_PROP = "embedding";
     public static final String PROPS = "props";
     public static final String DEFAULT_IDX_NAME = "vector";
+    public static final String DEFAULT_FULLTEXT_IDX_NAME = "fulltext";
     public static final String DEFAULT_LABEL = "Document";
     public static final String DEFAULT_TEXT_PROP = "text";
     public static final long DEFAULT_AWAIT_INDEX_TIMEOUT = 60L;

--- a/langchain4j-neo4j/src/main/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingUtils.java
+++ b/langchain4j-neo4j/src/main/java/dev/langchain4j/store/embedding/neo4j/Neo4jEmbeddingUtils.java
@@ -1,27 +1,26 @@
 package dev.langchain4j.store.embedding.neo4j;
 
+import static org.neo4j.cypherdsl.support.schema_name.SchemaNames.sanitize;
+
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
-import org.neo4j.driver.Record;
-import org.neo4j.driver.Value;
-import org.neo4j.driver.Values;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import static org.neo4j.cypherdsl.support.schema_name.SchemaNames.sanitize;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
 
 class Neo4jEmbeddingUtils {
-    
+
     /* not-configurable strings, just used under-the-hood in `UNWIND $rows ...` statement */
     public static final String EMBEDDINGS_ROW_KEY = "embeddingRow";
-    
+
     /* default configs */
     public static final String DEFAULT_ID_PROP = "id";
     public static final String DEFAULT_DATABASE_NAME = "neo4j";
@@ -45,22 +44,26 @@ class Neo4jEmbeddingUtils {
         Metadata metadata = new Metadata(metaData);
 
         Value text = neo4jRecord.get(store.getTextProperty());
-        TextSegment textSegment = text.isNull()
-                ? null
-                : TextSegment.from(text.asString(), metadata);
+        TextSegment textSegment = text.isNull() ? null : TextSegment.from(text.asString(), metadata);
 
-        List<Float> embeddingList = neo4jRecord.get(store.getEmbeddingProperty())
-                .asList(Value::asFloat);
+        List<Float> embeddingList =
+                neo4jRecord.get(store.getEmbeddingProperty()).asList(Value::asFloat);
 
         Embedding embedding = Embedding.from(embeddingList);
 
-        return new EmbeddingMatch<>(neo4jRecord.get("score").asDouble(),
+        return new EmbeddingMatch<>(
+                neo4jRecord.get("score").asDouble(),
                 neo4jRecord.get(store.getIdProperty()).asString(),
                 embedding,
                 textSegment);
     }
 
-    public static Map<String, Object> toRecord(Neo4jEmbeddingStore store, int idx, List<String> ids, List<Embedding> embeddings, List<TextSegment> embedded) {
+    public static Map<String, Object> toRecord(
+            Neo4jEmbeddingStore store,
+            int idx,
+            List<String> ids,
+            List<Embedding> embeddings,
+            List<TextSegment> embedded) {
         String id = ids.get(idx);
         Embedding embedding = embeddings.get(idx);
 
@@ -80,29 +83,26 @@ class Neo4jEmbeddingUtils {
         return row;
     }
 
-    public static Stream<List<Map<String, Object>>> getRowsBatched(Neo4jEmbeddingStore store, List<String> ids, List<Embedding> embeddings, List<TextSegment> embedded) {
+    public static Stream<List<Map<String, Object>>> getRowsBatched(
+            Neo4jEmbeddingStore store, List<String> ids, List<Embedding> embeddings, List<TextSegment> embedded) {
         int batchSize = 10_000;
         AtomicInteger batchCounter = new AtomicInteger();
         int total = ids.size();
-        int batchNumber = (int) Math.ceil( (double) total / batchSize );
-        return IntStream.range(0, batchNumber)
-                .mapToObj(part -> {
-                    List<Map<String, Object>> maps = ids.subList(Math.min(part * batchSize, total), Math.min((part + 1) * batchSize, total))
-                                    .stream()
-                                    .map(i -> toRecord(store, batchCounter.getAndIncrement(), ids, embeddings, embedded))
-                                    .toList();
-                            return maps;
-                        }
-                );
+        int batchNumber = (int) Math.ceil((double) total / batchSize);
+        return IntStream.range(0, batchNumber).mapToObj(part -> {
+            List<Map<String, Object>> maps =
+                    ids.subList(Math.min(part * batchSize, total), Math.min((part + 1) * batchSize, total)).stream()
+                            .map(i -> toRecord(store, batchCounter.getAndIncrement(), ids, embeddings, embedded))
+                            .toList();
+            return maps;
+        });
     }
 
     public static String sanitizeOrThrows(String value, String config) {
-        return sanitize(value)
-                .orElseThrow(() -> {
-                    String invalidSanitizeValue = String.format("The value %s, to assign to configuration %s, cannot be safely quoted",
-                            value,
-                            config);
-                    return new RuntimeException(invalidSanitizeValue);
-                });
+        return sanitize(value).orElseThrow(() -> {
+            String invalidSanitizeValue = String.format(
+                    "The value %s, to assign to configuration %s, cannot be safely quoted", value, config);
+            return new RuntimeException(invalidSanitizeValue);
+        });
     }
 }


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #1306

## Change
<!-- Please describe the changes you made. -->

- If we have [these configs](https://github.com/langchain4j/langchain4j/pull/2575/files#diff-89b713731c6e14e29b6208dc8c14a92aff1a1baad94b44b8a9b388db8be97eb9R64) we can execute an hybrid search with both vector and fullText index

- Created a test replicating as far as possible [the provided langchaing-ai example](https://neo4j.com/developer-blog/enhance-rag-knowledge-graph/).
  - Difficult something more meaningful since several things are missing compared to langchain python::
  - `Neo4jVector.from_existing_graph`
  - `TokenTextSplitter`
  - `ChatPromptTemplate.from_template`
  - `llm_transformer.convert_to_graph_documents`


- Created tests with different configs and invalid ones

#### TO EVALUATE

- Maybe we can use ChatMemoryStore to store the FullTextIndexes
- The issue says `WITH collect({node:node, score:score})` to retrieve both vector.queryNodes and fullText.queryNodes results, 
but we currently have `YIELD node, score WHERE score >= $minScore` to retrieve  vector.queryNodes  instead. 
So, used this method also for fullText.
Alternatively, we can change vector.queryNodes as well, but it would probably have to be done in another separate issue, where we should test `max` result as well, [as done here](https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/vectorstores/neo4j_vector.py#L115)

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
