### PR TITLE
Promote logging of messages received over SSE to INFO

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseEventListener.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseEventListener.java
@@ -36,7 +36,7 @@ public class SseEventListener extends EventSourceListener {
     public void onEvent(EventSource eventSource, String id, String type, String data) {
         if (type.equals("message")) {
             if (logEvents) {
-                log.debug("< {}", data);
+                log.info("< {}", data);
             }
             try {
                 JsonNode jsonNode = OBJECT_MAPPER.readTree(data);


### PR DESCRIPTION
As this is something that needs to be explicitly enabled anyway, I think the log messages can be promoted to INFO. I find it confusing and annoying that even if you set `logEvents=true`, you don't actually see the received messages until you also set the log level for the `dev.langchain4j` package to `DEBUG`.