### PR TITLE
Fixing issue #2585: NullPointerException when using Groq streaming.

### DIFF
--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/StreamingRequestExecutorTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/StreamingRequestExecutorTest.java
@@ -1,0 +1,51 @@
+package dev.langchain4j.model.openai.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class StreamingRequestExecutorTest {
+    private static final String ERROR_MESSAGE =
+            "{\"error\":{\"message\":\"Failed to call a function. Please adjust your prompt. See 'failed_generation' for more details.\",\"type\":\"invalid_request_error\",\"code\":\"tool_use_failed\",\"failed_generation\":\"Tool use failed: no tool can be called with name getCarsList\",\"status_code\":400}}";
+
+    @Test
+    void should_process_streaming_error() {
+        HttpClient httpClient = new HttpClient() {
+            @Override
+            public SuccessfulHttpResponse execute(HttpRequest request) throws HttpException, RuntimeException {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
+
+            @Override
+            public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+                listener.onEvent(new ServerSentEvent("error", ERROR_MESSAGE));
+            }
+        };
+        Consumer<ChatCompletionResponse> partialResponseHandler = new Consumer<ChatCompletionResponse>() {
+            @Override
+            public void accept(ChatCompletionResponse t) {}
+        };
+        HttpRequest streamingHttpRequest = HttpRequest.builder()
+                .url("http://localhost:8080/sse")
+                .method(HttpMethod.GET)
+                .build();
+        StreamingRequestExecutor executor =
+                new StreamingRequestExecutor(httpClient, streamingHttpRequest, ChatCompletionResponse.class);
+        executor.onPartialResponse(partialResponseHandler)
+                .onError(error -> {
+                    assertThat(error instanceof RuntimeException);
+                    assertThat(ERROR_MESSAGE.equals(error.getMessage()));
+                })
+                .execute();
+    }
+}


### PR DESCRIPTION
When the SSE event is of type "error", processing it as an error instead of a simple event.

Issue: https://github.com/langchain4j/langchain4j/issues/2585

## Issue
Closes #2585

## Change
When the event is of type "error" the errorHandler is called with a RuntimeException using the event data as the message.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

