### PR TITLE
Remove deprecated TokenStream API

### DIFF
--- a/docs/docs/integrations/language-models/qianfan.md
+++ b/docs/docs/integrations/language-models/qianfan.md
@@ -293,7 +293,7 @@ LLMs generate text one token at a time, so many LLM providers offer a way to str
   IAiService assistant = AiServices.create(IAiService.class, qianfanStreamingChatModel);
   
   TokenStream tokenStream = assistant.chatInTokenStream("Tell me a story.");
-  tokenStream.onNext(System.out::println)
+  tokenStream.onPartialResponse(System.out::println)
           .onError(Throwable::printStackTrace)
           .start();
 ```

--- a/docs/docs/tutorials/ai-services.md
+++ b/docs/docs/tutorials/ai-services.md
@@ -524,10 +524,10 @@ Assistant assistant = AiServices.create(Assistant.class, model);
 
 TokenStream tokenStream = assistant.chat("Tell me a joke");
 
-tokenStream.onNext((String token) -> System.out.println(token))
+tokenStream.onPartialResponse((String partialResponse) -> System.out.println(partialResponse))
     .onRetrieved((List<Content> contents) -> System.out.println(contents))
     .onToolExecuted((ToolExecution toolExecution) -> System.out.println(toolExecution))
-    .onComplete((Response<AiMessage> response) -> System.out.println(response))
+    .onCompleteResponse((ChatResponse response) -> System.out.println(response))
     .onError((Throwable error) -> error.printStackTrace())
     .start();
 ```

--- a/docs/docs/tutorials/rag.md
+++ b/docs/docs/tutorials/rag.md
@@ -900,9 +900,10 @@ interface Assistant {
 }
 
 assistant.chat("How to do Easy RAG with LangChain4j?")
-    .onRetrieved(sources -> ...)
-    .onNext(token -> ...)
-    .onError(error -> ...)
+    .onRetrieved((List<Content> sources) -> ...)
+    .onPartialResponse(...)
+    .onCompleteResponse(...)
+    .onError(...)
     .start();
 ```
 

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -378,9 +378,9 @@ interface Assistant {
 TokenStream tokenStream = assistant.chat("Cancel my booking");
 
 tokenStream
-    .onNext(...)
     .onToolExecuted((ToolExecution toolExecution) -> System.out.println(toolExecution))
-    .onComplete(...)
+    .onPartialResponse(...)
+    .onCompleteResponse(...)
     .onError(...)
     .start();
 ```

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelIT.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelIT.java
@@ -6,7 +6,6 @@ import static dev.langchain4j.model.googleai.GeminiHarmBlockThreshold.BLOCK_LOW_
 import static dev.langchain4j.model.googleai.GeminiHarmCategory.HARM_CATEGORY_HARASSMENT;
 import static dev.langchain4j.model.googleai.GeminiHarmCategory.HARM_CATEGORY_HATE_SPEECH;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -27,7 +26,6 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
-import dev.langchain4j.model.chat.TestStreamingResponseHandler;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
@@ -38,7 +36,6 @@ import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.FinishReason;
-import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.TokenStream;
@@ -683,28 +680,28 @@ class GoogleAiGeminiStreamingChatModelIT {
                 .build();
 
         // then
-        CompletableFuture<Response<AiMessage>> future1 = new CompletableFuture<>();
+        CompletableFuture<ChatResponse> future1 = new CompletableFuture<>();
         assistant
                 .chat("What is the amount of transaction T001?")
-                .onNext(System.out::println)
-                .onComplete(future1::complete)
+                .onPartialResponse(System.out::println)
+                .onCompleteResponse(future1::complete)
                 .onError(future1::completeExceptionally)
                 .start();
-        Response<AiMessage> response1 = future1.get(30, TimeUnit.SECONDS);
+        ChatResponse response1 = future1.get(30, TimeUnit.SECONDS);
 
-        assertThat(response1.content().text()).containsIgnoringCase("11.1");
+        assertThat(response1.aiMessage().text()).containsIgnoringCase("11.1");
         verify(spyTransactions).getTransactionAmount("T001");
 
-        CompletableFuture<Response<AiMessage>> future2 = new CompletableFuture<>();
+        CompletableFuture<ChatResponse> future2 = new CompletableFuture<>();
         assistant
                 .chat("What is the amount of transaction T002?")
-                .onNext(System.out::println)
-                .onComplete(future2::complete)
+                .onPartialResponse(System.out::println)
+                .onCompleteResponse(future2::complete)
                 .onError(future2::completeExceptionally)
                 .start();
-        Response<AiMessage> response2 = future2.get(30, TimeUnit.SECONDS);
+        ChatResponse response2 = future2.get(30, TimeUnit.SECONDS);
 
-        assertThat(response2.content().text()).containsIgnoringCase("22.2");
+        assertThat(response2.aiMessage().text()).containsIgnoringCase("22.2");
         verify(spyTransactions).getTransactionAmount("T002");
 
         verifyNoMoreInteractions(spyTransactions);

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/VertexAiGeminiStreamingChatModelIT.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/VertexAiGeminiStreamingChatModelIT.java
@@ -36,7 +36,6 @@ import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.output.Response;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.TokenStream;
 import java.io.File;
@@ -401,17 +400,17 @@ class VertexAiGeminiStreamingChatModelIT {
                 .build();
 
         // when
-        CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
         assistant
                 .chat("Is there more stock of ABC or of XYZ?")
-                .onNext(System.out::println)
-                .onComplete(future::complete)
+                .onPartialResponse(System.out::println)
+                .onCompleteResponse(future::complete)
                 .onError(future::completeExceptionally)
                 .start();
-        Response<AiMessage> response = future.get(30, TimeUnit.SECONDS);
+        ChatResponse response = future.get(30, TimeUnit.SECONDS);
 
         // then
-        assertThat(response.content().toString()).contains("XYZ");
+        assertThat(response.aiMessage().toString()).contains("XYZ");
 
         chatMemory.messages().forEach(System.out::println);
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -9,7 +9,6 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
-import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutor;
@@ -38,7 +37,6 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final Consumer<String> partialResponseHandler;
     private final Consumer<ToolExecution> toolExecutionHandler;
     private final Consumer<ChatResponse> completeResponseHandler;
-    private final Consumer<Response<AiMessage>> completionHandler;
 
     private final Consumer<Throwable> errorHandler;
 
@@ -53,7 +51,6 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                                       Consumer<String> partialResponseHandler,
                                       Consumer<ToolExecution> toolExecutionHandler,
                                       Consumer<ChatResponse> completeResponseHandler,
-                                      Consumer<Response<AiMessage>> completionHandler,
                                       Consumer<Throwable> errorHandler,
                                       List<ChatMessage> temporaryMemory,
                                       TokenUsage tokenUsage,
@@ -64,7 +61,6 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
         this.partialResponseHandler = ensureNotNull(partialResponseHandler, "partialResponseHandler");
         this.completeResponseHandler = completeResponseHandler;
-        this.completionHandler = completionHandler;
         this.toolExecutionHandler = toolExecutionHandler;
         this.errorHandler = errorHandler;
 
@@ -117,7 +113,6 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     partialResponseHandler,
                     toolExecutionHandler,
                     completeResponseHandler,
-                    completionHandler,
                     errorHandler,
                     temporaryMemory,
                     TokenUsage.sum(tokenUsage, completeResponse.metadata().tokenUsage()),
@@ -140,13 +135,6 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                         .build();
                 // TODO should completeResponseHandler accept all ChatResponses that happened?
                 completeResponseHandler.accept(finalChatResponse);
-            } else if (completionHandler != null) {
-                Response<AiMessage> finalResponse = Response.from(
-                        aiMessage,
-                        TokenUsage.sum(tokenUsage, completeResponse.metadata().tokenUsage()),
-                        completeResponse.metadata().finishReason()
-                );
-                completionHandler.accept(finalResponse);
             }
         }
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -1,12 +1,10 @@
 package dev.langchain4j.service;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
-import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.service.tool.ToolExecution;
@@ -32,19 +30,13 @@ public class AiServiceTokenStream implements TokenStream {
     private final Object memoryId;
 
     private Consumer<String> partialResponseHandler;
-
     private Consumer<List<Content>> contentsHandler;
     private Consumer<ToolExecution> toolExecutionHandler;
-
     private Consumer<ChatResponse> completeResponseHandler;
-    private Consumer<Response<AiMessage>> completionHandler;
-
     private Consumer<Throwable> errorHandler;
 
     private int onPartialResponseInvoked;
-    private int onNextInvoked;
     private int onCompleteResponseInvoked;
-    private int onCompleteInvoked;
     private int onRetrievedInvoked;
     private int onToolExecutedInvoked;
     private int onErrorInvoked;
@@ -73,13 +65,6 @@ public class AiServiceTokenStream implements TokenStream {
     }
 
     @Override
-    public TokenStream onNext(Consumer<String> tokenHandler) {
-        this.partialResponseHandler = tokenHandler;
-        this.onNextInvoked++;
-        return this;
-    }
-
-    @Override
     public TokenStream onRetrieved(Consumer<List<Content>> contentsHandler) {
         this.contentsHandler = contentsHandler;
         this.onRetrievedInvoked++;
@@ -97,13 +82,6 @@ public class AiServiceTokenStream implements TokenStream {
     public TokenStream onCompleteResponse(Consumer<ChatResponse> completionHandler) {
         this.completeResponseHandler = completionHandler;
         this.onCompleteResponseInvoked++;
-        return this;
-    }
-
-    @Override
-    public TokenStream onComplete(Consumer<Response<AiMessage>> completionHandler) {
-        this.completionHandler = completionHandler;
-        this.onCompleteInvoked++;
         return this;
     }
 
@@ -136,7 +114,6 @@ public class AiServiceTokenStream implements TokenStream {
                 partialResponseHandler,
                 toolExecutionHandler,
                 completeResponseHandler,
-                completionHandler,
                 errorHandler,
                 initTemporaryMemory(context, messages),
                 new TokenUsage(),
@@ -152,13 +129,11 @@ public class AiServiceTokenStream implements TokenStream {
     }
 
     private void validateConfiguration() {
-        if (onPartialResponseInvoked + onNextInvoked != 1) {
-            throw new IllegalConfigurationException("One of [onPartialResponse, onNext] " +
-                    "must be invoked on TokenStream exactly 1 time");
+        if (onPartialResponseInvoked != 1) {
+            throw new IllegalConfigurationException("onPartialResponse must be invoked on TokenStream exactly 1 time");
         }
-        if (onCompleteResponseInvoked + onCompleteInvoked > 1) {
-            throw new IllegalConfigurationException("One of [onCompleteResponse, onComplete] " +
-                    "can be invoked on TokenStream at most 1 time");
+        if (onCompleteResponseInvoked > 1) {
+            throw new IllegalConfigurationException("onCompleteResponse can be invoked on TokenStream at most 1 time");
         }
         if (onRetrievedInvoked > 1) {
             throw new IllegalConfigurationException("onRetrieved can be invoked on TokenStream at most 1 time");

--- a/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
@@ -1,8 +1,6 @@
 package dev.langchain4j.service;
 
-import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.output.Response;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.service.tool.ToolExecution;
@@ -26,16 +24,6 @@ public interface TokenStream {
      * @return token stream instance used to configure or start stream processing
      */
     TokenStream onPartialResponse(Consumer<String> partialResponseHandler);
-
-    /**
-     * The provided consumer will be invoked every time a new token from a language model is available.
-     *
-     * @param tokenHandler lambda that consumes tokens of the response
-     * @return token stream instance used to configure or start stream processing
-     * @deprecated please use {@link #onPartialResponse(Consumer)} instead
-     */
-    @Deprecated(forRemoval = true)
-    TokenStream onNext(Consumer<String> tokenHandler);
 
     /**
      * The provided consumer will be invoked if any {@link Content}s are retrieved using {@link RetrievalAugmentor}.
@@ -64,16 +52,6 @@ public interface TokenStream {
      * @return token stream instance used to configure or start stream processing
      */
     TokenStream onCompleteResponse(Consumer<ChatResponse> completeResponseHandler);
-
-    /**
-     * The provided consumer will be invoked when a language model finishes streaming a response.
-     *
-     * @param completionHandler lambda that will be invoked when language model finishes streaming
-     * @return token stream instance used to configure or start stream processing
-     * @deprecated please use {@link #onCompleteResponse(Consumer)} instead
-     */
-    @Deprecated(forRemoval = true)
-    TokenStream onComplete(Consumer<Response<AiMessage>> completionHandler);
 
     /**
      * The provided consumer will be invoked when an error occurs during streaming.

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
@@ -1,10 +1,8 @@
 package dev.langchain4j.service;
 
-import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.output.Response;
 import dev.langchain4j.rag.content.Content;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,9 +28,6 @@ class AiServiceTokenStreamTest {
     };
 
     static Consumer<ChatResponse> DUMMY_CHAT_RESPONSE_HANDLER = (chatResponse) -> {
-    };
-
-    static Consumer<Response<AiMessage>> DUMMY_RESPONSE_HANDLER = (response) -> {
     };
 
     List<ChatMessage> messages = new ArrayList<>();
@@ -61,22 +56,13 @@ class AiServiceTokenStreamTest {
     }
 
     @Test
-    void start_withOnNext_shouldNotThrowException() {
-        tokenStream
-                .onNext(DUMMY_PARTIAL_RESPONSE_HANDLER)
-                .ignoreErrors();
-
-        assertThatNoException().isThrownBy(() -> tokenStream.start());
-    }
-
-    @Test
     void start_onPartialResponseNotInvoked_shouldThrowException() {
         tokenStream
                 .ignoreErrors();
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("One of [onPartialResponse, onNext] must be invoked on TokenStream exactly 1 time");
+                .hasMessage("onPartialResponse must be invoked on TokenStream exactly 1 time");
     }
 
     @Test
@@ -88,31 +74,7 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("One of [onPartialResponse, onNext] must be invoked on TokenStream exactly 1 time");
-    }
-
-    @Test
-    void start_onNextInvokedMultipleTimes_shouldThrowException() {
-        tokenStream
-                .onNext(DUMMY_PARTIAL_RESPONSE_HANDLER)
-                .onNext(DUMMY_PARTIAL_RESPONSE_HANDLER)
-                .ignoreErrors();
-
-        assertThatThrownBy(() -> tokenStream.start())
-                .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("One of [onPartialResponse, onNext] must be invoked on TokenStream exactly 1 time");
-    }
-
-    @Test
-    void start_onPartialResponseAndOnNextInvoked_shouldThrowException() {
-        tokenStream
-                .onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER)
-                .onNext(DUMMY_PARTIAL_RESPONSE_HANDLER)
-                .ignoreErrors();
-
-        assertThatThrownBy(() -> tokenStream.start())
-                .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("One of [onPartialResponse, onNext] must be invoked on TokenStream exactly 1 time");
+                .hasMessage("onPartialResponse must be invoked on TokenStream exactly 1 time");
     }
 
     @Test
@@ -138,16 +100,6 @@ class AiServiceTokenStreamTest {
     }
 
     @Test
-    void start_onCompleteInvokedOneTime_shouldNotThrowException() {
-        tokenStream
-                .onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER)
-                .ignoreErrors()
-                .onComplete(DUMMY_RESPONSE_HANDLER);
-
-        assertThatNoException().isThrownBy(() -> tokenStream.start());
-    }
-
-    @Test
     void start_onCompleteResponseInvokedMultipleTimes_shouldThrowException() {
         tokenStream
                 .onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER)
@@ -157,33 +109,7 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("One of [onCompleteResponse, onComplete] can be invoked on TokenStream at most 1 time");
-    }
-
-    @Test
-    void start_onCompleteInvokedMultipleTimes_shouldThrowException() {
-        tokenStream
-                .onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER)
-                .ignoreErrors()
-                .onComplete(DUMMY_RESPONSE_HANDLER)
-                .onComplete(DUMMY_RESPONSE_HANDLER);
-
-        assertThatThrownBy(() -> tokenStream.start())
-                .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("One of [onCompleteResponse, onComplete] can be invoked on TokenStream at most 1 time");
-    }
-
-    @Test
-    void start_onCompleteResponseAndOnCompleteInvoked_shouldThrowException() {
-        tokenStream
-                .onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER)
-                .ignoreErrors()
-                .onCompleteResponse(DUMMY_CHAT_RESPONSE_HANDLER)
-                .onComplete(DUMMY_RESPONSE_HANDLER);
-
-        assertThatThrownBy(() -> tokenStream.start())
-                .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("One of [onCompleteResponse, onComplete] can be invoked on TokenStream at most 1 time");
+                .hasMessage("onCompleteResponse can be invoked on TokenStream at most 1 time");
     }
 
     private AiServiceTokenStream setupAiServiceTokenStream() {

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
@@ -7,15 +7,14 @@ import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
-import dev.langchain4j.model.output.Response;
 import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
@@ -108,17 +107,16 @@ class StreamingAiServicesWithToolsIT {
         String userMessage = "What is the amounts of transaction T001?";
 
         // when
-        CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+        CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
         assistant.chat(userMessage)
-                .onNext(token -> {
-                })
-                .onComplete(future::complete)
-                .onError(future::completeExceptionally)
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(futureResponse::complete)
+                .onError(futureResponse::completeExceptionally)
                 .start();
-        Response<AiMessage> response = future.get(60, SECONDS);
+        ChatResponse response = futureResponse.get(60, SECONDS);
 
         // then
-        assertThat(response.content().text()).contains("11.1");
+        assertThat(response.aiMessage().text()).contains("11.1");
 
         // then
         verify(transactionService).getTransactionAmount("T001");
@@ -190,17 +188,16 @@ class StreamingAiServicesWithToolsIT {
         String userMessage = "What is the temperature in Munich now, in Celsius?";
 
         // when
-        CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
         assistant.chat(userMessage)
-                .onNext(token -> {
-                })
-                .onComplete(future::complete)
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
                 .onError(future::completeExceptionally)
                 .start();
-        Response<AiMessage> response = future.get(60, SECONDS);
+        ChatResponse response = future.get(60, SECONDS);
 
         // then
-        assertThat(response.content().text()).contains(String.valueOf(TEMPERATURE));
+        assertThat(response.aiMessage().text()).contains(String.valueOf(TEMPERATURE));
 
         verify(weatherService).currentTemperature("Munich", CELSIUS);
         verifyNoMoreInteractions(weatherService);
@@ -249,17 +246,16 @@ class StreamingAiServicesWithToolsIT {
         String userMessage = "What is the amounts of transactions T001?";
 
         // when
-        CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
         assistant.chat(userMessage)
-                .onNext(token -> {
-                })
-                .onComplete(future::complete)
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
                 .onError(future::completeExceptionally)
                 .start();
-        Response<AiMessage> response = future.get(60, SECONDS);
+        ChatResponse response = future.get(60, SECONDS);
 
         // then
-        assertThat(response.content().text()).contains("11.1");
+        assertThat(response.aiMessage().text()).contains("11.1");
 
         // then
         verify(toolExecutor).execute(any(), any());
@@ -330,20 +326,19 @@ class StreamingAiServicesWithToolsIT {
         String userMessage = "What is the temperature in Munich and London, in Celsius?";
 
         List<ToolExecution> toolExecutions = new ArrayList<>();
-        CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
 
         // when
         assistant.chat(userMessage)
-                .onNext(token -> {
-                })
+                .onPartialResponse(ignored -> {})
                 .onToolExecuted(toolExecutions::add)
-                .onComplete(future::complete)
+                .onCompleteResponse(future::complete)
                 .onError(future::completeExceptionally)
                 .start();
-        Response<AiMessage> response = future.get(60, SECONDS);
+        ChatResponse response = future.get(60, SECONDS);
 
         // then
-        assertThat(response.content().text()).contains(String.valueOf(WeatherService.TEMPERATURE));
+        assertThat(response.aiMessage().text()).contains(String.valueOf(WeatherService.TEMPERATURE));
 
         // then
         verify(weatherService).currentTemperature("Munich", CELSIUS);

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsWithoutMemoryIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsWithoutMemoryIT.java
@@ -2,14 +2,13 @@ package dev.langchain4j.service;
 
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
-import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
-import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -79,17 +78,16 @@ class StreamingAiServicesWithToolsWithoutMemoryIT {
         String userMessage = "What is the square root of 485906798473894056 in scientific notation?";
 
         // when
-        CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
         assistant.chat(userMessage)
-                .onNext(token -> {
-                })
-                .onComplete(future::complete)
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
                 .onError(future::completeExceptionally)
                 .start();
-        Response<AiMessage> response = future.get(60, TimeUnit.SECONDS);
+        ChatResponse response = future.get(60, TimeUnit.SECONDS);
 
         // then
-        assertThat(response.content().text()).contains("6.97");
+        assertThat(response.aiMessage().text()).contains("6.97");
         assertThat(response.finishReason()).isEqualTo(STOP);
 
         TokenUsage tokenUsage = response.tokenUsage();
@@ -146,17 +144,16 @@ class StreamingAiServicesWithToolsWithoutMemoryIT {
         String userMessage = "What is the square root of 485906798473894056 and 97866249624785 in scientific notation?";
 
         // when
-        CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
         assistant.chat(userMessage)
-                .onNext(token -> {
-                })
-                .onComplete(future::complete)
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
                 .onError(future::completeExceptionally)
                 .start();
-        Response<AiMessage> response = future.get(60, TimeUnit.SECONDS);
+        ChatResponse response = future.get(60, TimeUnit.SECONDS);
 
         // then
-        assertThat(response.content().text()).contains("6.97", "9.89");
+        assertThat(response.aiMessage().text()).contains("6.97", "9.89");
         assertThat(response.finishReason()).isEqualTo(STOP);
 
         TokenUsage tokenUsage = response.tokenUsage();
@@ -209,17 +206,16 @@ class StreamingAiServicesWithToolsWithoutMemoryIT {
         String userMessage = "What is the square root of 485906798473894056 and 97866249624785 in scientific notation?";
 
         // when
-        CompletableFuture<Response<AiMessage>> future = new CompletableFuture<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
         assistant.chat(userMessage)
-                .onNext(token -> {
-                })
-                .onComplete(future::complete)
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
                 .onError(future::completeExceptionally)
                 .start();
-        Response<AiMessage> response = future.get(60, TimeUnit.SECONDS);
+        ChatResponse response = future.get(60, TimeUnit.SECONDS);
 
         // then
-        assertThat(response.content().text()).contains("6.97", "9.89");
+        assertThat(response.aiMessage().text()).contains("6.97", "9.89");
         assertThat(response.finishReason()).isEqualTo(STOP);
 
         TokenUsage tokenUsage = response.tokenUsage();


### PR DESCRIPTION
## Change
`TokenStream.onNext` and `onComplete` were deprecated in previous releases, now we remove them completely.

## General checklist
- [ ] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [x] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)