### PR TITLE
Kotlin extensions for DocumentLoader and DocumentParser

### DIFF
--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -155,7 +155,8 @@
                         </goals>
                         <configuration>
                             <sourceDirs>
-                                <sourceDir>src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
                             </sourceDirs>
                         </configuration>
                     </execution>
@@ -166,9 +167,40 @@
                         </goals>
                         <configuration>
                             <sourceDirs>
-                                <sourceDir>src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
                             </sourceDirs>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by Maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by Maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <phase>test-compile</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -97,7 +97,7 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
-            <artifactId>kotlinx-coroutines-test</artifactId>
+            <artifactId>kotlinx-coroutines-test-jvm</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
@@ -529,7 +529,7 @@ public class Metadata {
      * The two Metadata objects must not have any common keys.
      *
      * @param another The Metadata object to be merged with the current Metadata object.
-     * @return A new Metadata object that contains all key-value pairs from both Metadata objects, or null.
+     * @return A new Metadata object that contains all key-value pairs from both Metadata objects.
      * @throws IllegalArgumentException if there are common keys between the two Metadata objects.
      */
     @NonNull

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents metadata of a {@link Document} or a {@link TextSegment}.
@@ -527,10 +529,14 @@ public class Metadata {
      * The two Metadata objects must not have any common keys.
      *
      * @param another The Metadata object to be merged with the current Metadata object.
-     * @return A new Metadata object that contains all key-value pairs from both Metadata objects.
+     * @return A new Metadata object that contains all key-value pairs from both Metadata objects, or null.
      * @throws IllegalArgumentException if there are common keys between the two Metadata objects.
      */
-    public Metadata merge(Metadata another) {
+    @NonNull
+    public Metadata merge(@Nullable Metadata another) {
+        if (another == null || another.metadata.isEmpty()) {
+            return this.copy();
+        }
         final var thisMap = this.toMap();
         final var anotherMap = another.toMap();
         final var commonKeys = new HashSet<>(thisMap.keySet());

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
@@ -1,9 +1,7 @@
 package dev.langchain4j.data.document;
 
-import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.store.embedding.EmbeddingStore;
-
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -14,6 +12,9 @@ import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.Exceptions.runtime;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 
 /**
  * Represents metadata of a {@link Document} or a {@link TextSegment}.
@@ -72,8 +73,8 @@ public class Metadata {
             validate(key, value);
             if (!SUPPORTED_VALUE_TYPES.contains(value.getClass())) {
                 throw illegalArgument("The metadata key '%s' has the value '%s', which is of the unsupported type '%s'. " +
-                        "Currently, the supported types are: %s",
-                    key, value, value.getClass().getName(), SUPPORTED_VALUE_TYPES
+                                "Currently, the supported types are: %s",
+                        key, value, value.getClass().getName(), SUPPORTED_VALUE_TYPES
                 );
             }
         });
@@ -121,7 +122,7 @@ public class Metadata {
         }
 
         throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-            "It cannot be returned as a String.", key, value, value.getClass().getName());
+                "It cannot be returned as a String.", key, value, value.getClass().getName());
     }
 
     /**
@@ -145,7 +146,7 @@ public class Metadata {
         }
 
         throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-            "It cannot be returned as a UUID.", key, value, value.getClass().getName());
+                "It cannot be returned as a UUID.", key, value, value.getClass().getName());
     }
 
     /**
@@ -177,7 +178,7 @@ public class Metadata {
         }
 
         throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-            "It cannot be returned as an Integer.", key, value, value.getClass().getName());
+                "It cannot be returned as an Integer.", key, value, value.getClass().getName());
     }
 
     /**
@@ -209,7 +210,7 @@ public class Metadata {
         }
 
         throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-            "It cannot be returned as a Long.", key, value, value.getClass().getName());
+                "It cannot be returned as a Long.", key, value, value.getClass().getName());
     }
 
     /**
@@ -241,7 +242,7 @@ public class Metadata {
         }
 
         throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-            "It cannot be returned as a Float.", key, value, value.getClass().getName());
+                "It cannot be returned as a Float.", key, value, value.getClass().getName());
     }
 
     /**
@@ -273,7 +274,7 @@ public class Metadata {
         }
 
         throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-            "It cannot be returned as a Double.", key, value, value.getClass().getName());
+                "It cannot be returned as a Double.", key, value, value.getClass().getName());
     }
 
     /**
@@ -454,8 +455,8 @@ public class Metadata {
     @Override
     public String toString() {
         return "Metadata {" +
-            " metadata = " + metadata +
-            " }";
+                " metadata = " + metadata +
+                " }";
     }
 
     /**
@@ -510,5 +511,26 @@ public class Metadata {
     @Deprecated(forRemoval = true)
     public static Metadata metadata(String key, Object value) {
         return from(key, value);
+    }
+
+    /**
+     * Merges the current Metadata object with another Metadata object.
+     * The two Metadata objects must not have any common keys.
+     *
+     * @param another The Metadata object to be merged with the current Metadata object.
+     * @return A new Metadata object that contains all key-value pairs from both Metadata objects.
+     * @throws IllegalArgumentException if there are common keys between the two Metadata objects.
+     */
+    public Metadata merge(Metadata another) {
+        final var thisMap = this.toMap();
+        final var anotherMap = another.toMap();
+        final var commonKeys = new HashSet<>(thisMap.keySet());
+        commonKeys.retainAll(anotherMap.keySet());
+        if (!commonKeys.isEmpty()) {
+            throw new IllegalArgumentException("Metadata keys are not unique. Common keys: " + commonKeys);
+        }
+        final var mergedMap = new HashMap<>(thisMap);
+        mergedMap.putAll(anotherMap);
+        return Metadata.from(mergedMap);
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -96,6 +95,7 @@ public class Metadata {
      * {@link #getFloat(String)}, {@link #getDouble(String)} instead.
      */
     @Deprecated(forRemoval = true)
+    @Nullable
     public String get(String key) {
         Object value = metadata.get(key);
         if (value != null) {
@@ -112,6 +112,7 @@ public class Metadata {
      * @return the {@code String} value associated with the given key, or {@code null} if the key is not present.
      * @throws RuntimeException if the value is not of type String
      */
+    @Nullable
     public String getString(String key) {
         if (!containsKey(key)) {
             return null;
@@ -135,6 +136,7 @@ public class Metadata {
      * @return the {@code UUID} value associated with the given key, or {@code null} if the key is not present.
      * @throws RuntimeException if the value is not of type String
      */
+    @Nullable
     public UUID getUUID(String key) {
         if (!containsKey(key)) {
             return null;
@@ -170,6 +172,7 @@ public class Metadata {
      * @return the {@link Integer} value associated with the given key, or {@code null} if the key is not present.
      * @throws RuntimeException if the value is not {@link Number}
      */
+    @Nullable
     public Integer getInteger(String key) {
         if (!containsKey(key)) {
             return null;
@@ -204,6 +207,7 @@ public class Metadata {
      * @return the {@code Long} value associated with the given key, or {@code null} if the key is not present.
      * @throws RuntimeException if the value is not {@link Number}
      */
+    @Nullable
     public Long getLong(String key) {
         if (!containsKey(key)) {
             return null;
@@ -238,14 +242,15 @@ public class Metadata {
      * @return the {@code Float} value associated with the given key, or {@code null} if the key is not present.
      * @throws RuntimeException if the value is not {@link Number}
      */
+    @Nullable
     public Float getFloat(String key) {
         if (!containsKey(key)) {
             return null;
         }
 
-        Object value = metadata.get(key);
-        if (value instanceof String) {
-            return Float.parseFloat(value.toString());
+        final var value = metadata.get(key);
+        if (value instanceof String str) {
+            return Float.parseFloat(str);
         } else if (value instanceof Number number) {
             return number.floatValue();
         }
@@ -272,6 +277,7 @@ public class Metadata {
      * @return the {@code Double} value associated with the given key, or {@code null} if the key is not present.
      * @throws RuntimeException if the value is not {@link Number}
      */
+    @Nullable
     public Double getDouble(String key) {
         if (!containsKey(key)) {
             return null;
@@ -532,7 +538,6 @@ public class Metadata {
      * @return A new Metadata object that contains all key-value pairs from both Metadata objects.
      * @throws IllegalArgumentException if there are common keys between the two Metadata objects.
      */
-    @NonNull
     public Metadata merge(@Nullable Metadata another) {
         if (another == null || another.metadata.isEmpty()) {
             return this.copy();

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
@@ -1,13 +1,5 @@
 package dev.langchain4j.data.document;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.Exceptions.runtime;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
@@ -15,6 +7,13 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * Represents metadata of a {@link Document} or a {@link TextSegment}.
@@ -72,10 +71,10 @@ public class Metadata {
         ensureNotNull(metadata, "metadata").forEach((key, value) -> {
             validate(key, value);
             if (!SUPPORTED_VALUE_TYPES.contains(value.getClass())) {
-                throw illegalArgument("The metadata key '%s' has the value '%s', which is of the unsupported type '%s'. " +
-                                "Currently, the supported types are: %s",
-                        key, value, value.getClass().getName(), SUPPORTED_VALUE_TYPES
-                );
+                throw illegalArgument(
+                        "The metadata key '%s' has the value '%s', which is of the unsupported type '%s'. "
+                                + "Currently, the supported types are: %s",
+                        key, value, value.getClass().getName(), SUPPORTED_VALUE_TYPES);
             }
         });
         this.metadata = new HashMap<>(metadata);
@@ -121,8 +120,10 @@ public class Metadata {
             return string;
         }
 
-        throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-                "It cannot be returned as a String.", key, value, value.getClass().getName());
+        throw runtime(
+                "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
+                        + "It cannot be returned as a String.",
+                key, value, value.getClass().getName());
     }
 
     /**
@@ -145,8 +146,10 @@ public class Metadata {
             return UUID.fromString(string);
         }
 
-        throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-                "It cannot be returned as a UUID.", key, value, value.getClass().getName());
+        throw runtime(
+                "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
+                        + "It cannot be returned as a UUID.",
+                key, value, value.getClass().getName());
     }
 
     /**
@@ -177,8 +180,10 @@ public class Metadata {
             return number.intValue();
         }
 
-        throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-                "It cannot be returned as an Integer.", key, value, value.getClass().getName());
+        throw runtime(
+                "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
+                        + "It cannot be returned as an Integer.",
+                key, value, value.getClass().getName());
     }
 
     /**
@@ -209,8 +214,10 @@ public class Metadata {
             return number.longValue();
         }
 
-        throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-                "It cannot be returned as a Long.", key, value, value.getClass().getName());
+        throw runtime(
+                "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
+                        + "It cannot be returned as a Long.",
+                key, value, value.getClass().getName());
     }
 
     /**
@@ -241,8 +248,10 @@ public class Metadata {
             return number.floatValue();
         }
 
-        throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-                "It cannot be returned as a Float.", key, value, value.getClass().getName());
+        throw runtime(
+                "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
+                        + "It cannot be returned as a Float.",
+                key, value, value.getClass().getName());
     }
 
     /**
@@ -273,8 +282,10 @@ public class Metadata {
             return number.doubleValue();
         }
 
-        throw runtime("Metadata entry with the key '%s' has a value of '%s' and type '%s'. " +
-                "It cannot be returned as a Double.", key, value, value.getClass().getName());
+        throw runtime(
+                "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
+                        + "It cannot be returned as a Double.",
+                key, value, value.getClass().getName());
     }
 
     /**
@@ -454,9 +465,7 @@ public class Metadata {
 
     @Override
     public String toString() {
-        return "Metadata {" +
-                " metadata = " + metadata +
-                " }";
+        return "Metadata {" + " metadata = " + metadata + " }";
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
@@ -542,7 +542,7 @@ public class Metadata {
         final var commonKeys = new HashSet<>(thisMap.keySet());
         commonKeys.retainAll(anotherMap.keySet());
         if (!commonKeys.isEmpty()) {
-            throw new IllegalArgumentException("Metadata keys are not unique. Common keys: " + commonKeys);
+            throw illegalArgument("Metadata keys are not unique. Common keys: %s", commonKeys);
         }
         final var mergedMap = new HashMap<>(thisMap);
         mergedMap.putAll(anotherMap);

--- a/langchain4j-core/src/main/kotlin/dev/langchain4j/data/document/DocumentLoaderExtensions.kt
+++ b/langchain4j-core/src/main/kotlin/dev/langchain4j/data/document/DocumentLoaderExtensions.kt
@@ -1,0 +1,23 @@
+package dev.langchain4j.data.document
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Asynchronously loads a document from the specified source using a given parser.
+ *
+ * @param source The [DocumentSource] from which the document will be loaded.
+ * @param parser The [DocumentParser] to parse the loaded document.
+ * @param context The [CoroutineContext] to use for asynchronous execution,
+ *                  defaults to `Dispatchers.IO`.
+ * @return The loaded and parsed Document.
+ */
+public suspend fun loadAsync(
+    source: DocumentSource,
+    parser: DocumentParser,
+    context: CoroutineContext = Dispatchers.IO
+): Document =
+    withContext(context) {
+        DocumentLoader.load(source, parser)
+    }

--- a/langchain4j-core/src/main/kotlin/dev/langchain4j/data/document/DocumentParserExtensions.kt
+++ b/langchain4j-core/src/main/kotlin/dev/langchain4j/data/document/DocumentParserExtensions.kt
@@ -1,0 +1,47 @@
+package dev.langchain4j.data.document
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.InputStream
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Asynchronously parses a document from the specified document source
+ * using the given coroutine context.
+ *
+ * @param source The [DocumentSource] from which the document will be parsed.
+ * @param context The [CoroutineContext] to use for asynchronous execution,
+ * defaults to [Dispatchers.IO].
+ * @return The parsed [Document], potentially with merged metadata from the document source.
+ */
+public suspend fun DocumentParser.parseAsync(
+    source: DocumentSource,
+    context: CoroutineContext = Dispatchers.IO
+): Document {
+    val document =
+        source.inputStream().use { inputStream ->
+            return@use parseAsync(inputStream, context)
+        }
+    val documentSourceMetadata = source.metadata()
+    return if (documentSourceMetadata.toMap().isNotEmpty()) {
+        Document.from(document.text(), documentSourceMetadata.merge(document.metadata()))
+    } else {
+        document
+    }
+}
+
+/**
+ * Asynchronously parses a document from the provided input stream using the specified dispatcher.
+ *
+ * @param input The [InputStream] from which the document will be parsed.
+ * @param context The CoroutineContext to use for asynchronous execution,
+ *                  defaults to `[Dispatchers.IO]`.
+ * @return The parsed Document.
+ */
+public suspend fun DocumentParser.parseAsync(
+    input: InputStream,
+    context: CoroutineContext = Dispatchers.IO
+): Document =
+    withContext(context) {
+        parse(input)
+    }

--- a/langchain4j-core/src/test/kotlin/dev/langchain4j/data/document/DocumentParserExtensionsKtTest.kt
+++ b/langchain4j-core/src/test/kotlin/dev/langchain4j/data/document/DocumentParserExtensionsKtTest.kt
@@ -1,0 +1,74 @@
+package dev.langchain4j.data.document
+
+import assertk.assertThat
+import assertk.assertions.containsOnly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isSameInstanceAs
+import dev.langchain4j.data.document.Document.ABSOLUTE_DIRECTORY_PATH
+import dev.langchain4j.data.document.Document.FILE_NAME
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+internal class DocumentParserExtensionsKtTest {
+    @Mock
+    private lateinit var documentParser: DocumentParser
+
+    @Mock
+    private lateinit var documentSource: DocumentSource
+
+    @Test
+    fun `parseAsync should parse document and return it combined metadata`() {
+        val documentContent = "parsed document content"
+        runTest {
+            val inputStream = documentContent.byteInputStream()
+            val documentMetadata = Metadata.from(mapOf<String, Any?>("title" to "Bar"))
+            val fileMetadata =
+                Metadata.from(
+                    mapOf(
+                        ABSOLUTE_DIRECTORY_PATH to "foo",
+                        FILE_NAME to "bar.txt"
+                    )
+                )
+            val document = Document.from(documentContent, documentMetadata)
+
+            whenever(documentSource.inputStream()).thenReturn(inputStream)
+            whenever(documentParser.parse(inputStream)).thenReturn(document)
+            whenever(documentSource.metadata()).thenReturn(fileMetadata)
+
+            val result = documentParser.parseAsync(documentSource, Dispatchers.IO)
+
+            assertThat(result.text()).isEqualTo(documentContent)
+            assertThat(result.metadata().toMap())
+                .containsOnly(
+                    ABSOLUTE_DIRECTORY_PATH to "foo",
+                    FILE_NAME to "bar.txt",
+                    "title" to "Bar"
+                )
+        }
+    }
+
+    @Test
+    fun `parseAsync should return parser document when no source metadata is present`() {
+        val documentContent = "parsed document content"
+        runTest {
+            val inputStream = documentContent.byteInputStream()
+            val documentMetadata = Metadata.from(mapOf<String, Any?>("title" to "Bar"))
+            val fileMetadata = Metadata.from(mapOf<String, Any?>())
+            val document = Document.from(documentContent, documentMetadata)
+
+            whenever(documentSource.inputStream()).thenReturn(inputStream)
+            whenever(documentParser.parse(inputStream)).thenReturn(document)
+            whenever(documentSource.metadata()).thenReturn(fileMetadata)
+
+            val result = documentParser.parseAsync(documentSource, Dispatchers.IO)
+
+            assertThat(result).isSameInstanceAs(document)
+        }
+    }
+}

--- a/langchain4j-core/src/test/kotlin/dev/langchain4j/data/document/MergeMetadataTest.kt
+++ b/langchain4j-core/src/test/kotlin/dev/langchain4j/data/document/MergeMetadataTest.kt
@@ -2,6 +2,7 @@ package dev.langchain4j.data.document
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotSameInstanceAs
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -26,6 +27,42 @@ class MergeMetadataTest {
                 "key2" to "value2",
                 "key3" to "value3",
                 "key4" to "value4"
+            )
+        )
+    }
+
+    @Test
+    fun `merge should combine with null object`() {
+        val metadata =
+            Metadata.from(
+                mapOf("key1" to "value1", "key2" to "value2")
+            )
+
+        val result = metadata.merge(null)
+
+        assertThat(result).isNotSameInstanceAs(metadata)
+        assertThat(result.toMap()).isEqualTo(
+            mapOf(
+                "key1" to "value1",
+                "key2" to "value2"
+            )
+        )
+    }
+
+    @Test
+    fun `merge should combine with empty metadata`() {
+        val metadata =
+            Metadata.from(
+                mapOf("key1" to "value1", "key2" to "value2")
+            )
+
+        val result = metadata.merge(Metadata())
+
+        assertThat(result).isNotSameInstanceAs(metadata)
+        assertThat(result.toMap()).isEqualTo(
+            mapOf(
+                "key1" to "value1",
+                "key2" to "value2"
             )
         )
     }

--- a/langchain4j-core/src/test/kotlin/dev/langchain4j/data/document/MergeMetadataTest.kt
+++ b/langchain4j-core/src/test/kotlin/dev/langchain4j/data/document/MergeMetadataTest.kt
@@ -1,0 +1,52 @@
+package dev.langchain4j.data.document
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MergeMetadataTest {
+    @Test
+    fun `merge should combine unique metadata from both objects`() {
+        val metadata1 =
+            Metadata.from(
+                mapOf("key1" to "value1", "key2" to "value2")
+            )
+
+        val metadata2 =
+            Metadata.from(
+                mapOf("key3" to "value3", "key4" to "value4")
+            )
+
+        val result = metadata1.merge(metadata2)
+
+        assertThat(result.toMap()).isEqualTo(
+            mapOf(
+                "key1" to "value1",
+                "key2" to "value2",
+                "key3" to "value3",
+                "key4" to "value4"
+            )
+        )
+    }
+
+    @Test
+    fun `merge should throw an exception when there are common keys`() {
+        val metadata1 =
+            Metadata.from(
+                mapOf("key1" to "value1", "key2" to "value2")
+            )
+        val metadata2 =
+            Metadata.from(
+                mapOf("key2" to "value3", "key3" to "value4")
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                metadata1.merge(metadata2)
+            }
+
+        assertThat(exception.message)
+            .isEqualTo("Metadata keys are not unique. Common keys: [key2]")
+    }
+}

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -175,7 +175,7 @@
 
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
-                <artifactId>kotlinx-coroutines-test</artifactId>
+                <artifactId>kotlinx-coroutines-test-jvm</artifactId>
                 <version>${kotlinx.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -465,7 +465,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.14.0</version>
-                    <extensions>true</extensions>
                     <configuration>
                         <annotationProcessorPaths>
                             <path>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -464,7 +464,8 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.0</version>
+                    <extensions>true</extensions>
                     <configuration>
                         <annotationProcessorPaths>
                             <path>
@@ -539,7 +540,8 @@
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-maven-plugin</artifactId>
                     <version>${kotlin.version}</version>
-                    <configuration>
+                    <extensions>true</extensions>
+                    <configuration combine.self="append">
                         <jvmTarget>${java.version}</jvmTarget>
                         <javaParameters>true</javaParameters>
                         <args>
@@ -561,7 +563,7 @@
                 <plugin>
                     <groupId>com.github.ozsie</groupId>
                     <artifactId>detekt-maven-plugin</artifactId>
-                    <version>1.23.7</version>
+                    <version>1.23.8</version>
                 </plugin>
                 <plugin>
                     <groupId>com.simpligility.maven.plugins</groupId>

--- a/langchain4j/pom.xml
+++ b/langchain4j/pom.xml
@@ -36,6 +36,18 @@
             <artifactId>opennlp-tools</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- test dependencies -->
 
         <dependency>
@@ -153,7 +165,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -162,6 +173,67 @@
                             <!-- For getting test source -->
                             <goal>test-jar-no-fork</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                            <!-- You can skip the <goals> element
+                        if you enable extensions for the plugin -->
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by Maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by Maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <phase>test-compile</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/langchain4j/pom.xml
+++ b/langchain4j/pom.xml
@@ -132,6 +132,18 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.willowtreeapps.assertk</groupId>
+            <artifactId>assertk-coroutines-jvm</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-test-jvm</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <!--  Contains references to a jar file created specifically for the ClasspathFileSystemDocumentLoaderTest tests  -->
@@ -186,8 +198,6 @@
                         <id>compile</id>
                         <goals>
                             <goal>compile</goal>
-                            <!-- You can skip the <goals> element
-                        if you enable extensions for the plugin -->
                         </goals>
                         <configuration>
                             <sourceDirs>
@@ -198,6 +208,9 @@
                     </execution>
                     <execution>
                         <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
                         <configuration>
                             <sourceDirs>
                                 <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>

--- a/langchain4j/src/main/kotlin/dev/langchain4j/data/document/loader/FileSystemDocumentLoaderExtensions.kt
+++ b/langchain4j/src/main/kotlin/dev/langchain4j/data/document/loader/FileSystemDocumentLoaderExtensions.kt
@@ -1,0 +1,84 @@
+package dev.langchain4j.data.document.loader
+
+import dev.langchain4j.data.document.Document
+import dev.langchain4j.data.document.DocumentParser
+import dev.langchain4j.data.document.parseAsync
+import dev.langchain4j.data.document.source.FileSystemSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.PathMatcher
+import kotlin.coroutines.CoroutineContext
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+
+private val logger = LoggerFactory.getLogger(FileSystemDocumentLoader::class.java)
+
+/**
+ * Asynchronously loads documents from the specified directories.
+ *
+ * @param directoryPaths A list of directories from which documents should be loaded.
+ * @param documentParser The parser to convert files into [Document] objects.
+ * @param recursive Determines whether subdirectories should also be searched for documents. Defaults to `false`.
+ * @param pathMatcher An optional filter to match file paths against specific patterns.
+ * @param context The CoroutineContext to be used for asynchronous operations. Defaults to [Dispatchers.IO].
+ * @return A list of Document objects representing the loaded documents.
+ */
+public suspend fun loadDocuments(
+    directoryPaths: List<Path>,
+    documentParser: DocumentParser,
+    recursive: Boolean = false,
+    pathMatcher: PathMatcher? = null,
+    context: CoroutineContext = Dispatchers.IO
+): List<Document> =
+    coroutineScope {
+        // Validate all paths before processing
+        directoryPaths.forEach { path ->
+            require(path.exists()) { "Path doesn't exist: $path" }
+            require(path.isDirectory()) { "Path is not a directory: $path" }
+        }
+        // Collect all files from the directory paths matching the pathMatcher
+        val matchedFiles =
+            directoryPaths.flatMap { path ->
+                val files = mutableListOf<Path>()
+                // Matches all if no pathMatcher is provided
+                val matcher: PathMatcher = pathMatcher ?: PathMatcher { true }
+
+                // Traverse directories conditionally based on the recursive flag
+                val fileStream = if (recursive) Files.walk(path) else Files.walk(path, 1)
+
+                fileStream.use { stream ->
+                    stream
+                        .filter { file ->
+                            Files.isRegularFile(file) && matcher.matches(file)
+                        }.forEach { file ->
+                            files.add(file)
+                        }
+                }
+                files
+            }
+
+        // Process each file in parallel
+        matchedFiles
+            .map { file ->
+                async(context) {
+                    documentParser.parseAsync(
+                        FileSystemSource(file),
+                        context
+                    )
+                }
+            }.awaitAll()
+            .map { document ->
+                val metadata = document.metadata()
+                logger.info(
+                    "Loaded document: {}/{}",
+                    metadata.getString(Document.ABSOLUTE_DIRECTORY_PATH),
+                    metadata.getString(Document.FILE_NAME)
+                )
+                document
+            }
+    }

--- a/langchain4j/src/test/kotlin/dev/langchain4j/data/document/loader/AsyncDocumentLoaderTest.kt
+++ b/langchain4j/src/test/kotlin/dev/langchain4j/data/document/loader/AsyncDocumentLoaderTest.kt
@@ -1,0 +1,73 @@
+package dev.langchain4j.data.document.loader
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.hasSize
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import dev.langchain4j.data.document.DocumentSource
+import dev.langchain4j.data.document.loadAsync
+import dev.langchain4j.data.document.parser.TextDocumentParser
+import dev.langchain4j.data.document.source.FileSystemSource
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+import java.nio.file.Paths
+
+internal class AsyncDocumentLoaderTest {
+    private lateinit var documentSource: DocumentSource
+    private val parser = TextDocumentParser()
+
+    @BeforeEach
+    fun beforeEach() {
+        documentSource =
+            FileSystemSource(
+                Paths.get("./src/test/resources/miles-of-smiles-terms-of-use.txt")
+            )
+    }
+
+    @Test
+    fun `Should load documents asynchronously`() =
+        runTest {
+            val document = loadAsync(documentSource, parser)
+            assertThat(document.text()).contains("Miles of Smiles Car Rental Services")
+            assertThat(document.metadata()).isNotNull()
+        }
+
+    @Test
+    fun `Should parse documents asynchronously`() =
+        runTest {
+            val document = parser.parse(documentSource.inputStream())
+            assertThat(document.text()).contains("Miles of Smiles Car Rental Services")
+            assertThat(document.metadata()).isNotNull()
+        }
+
+    @Test
+    fun `Should loadDocuments`() =
+        runTest {
+            val documents =
+                loadDocuments(
+                    recursive = true,
+                    documentParser = parser,
+                    directoryPaths = listOf(Path.of("./src/test/resources/classPathSourceTests"))
+                )
+            assertThat(documents)
+                .hasSize(4)
+
+            documents.forEach {
+                assertThat(it.text()).isNotEmpty()
+                assertThat(it.metadata()).isNotNull()
+            }
+
+            val documentNames = documents.map { it.metadata().getString("file_name") }
+            assertThat(documentNames)
+                .containsExactlyInAnyOrder(
+                    "file1.txt",
+                    "file2.txt",
+                    "test-file-3.banana",
+                    "test-file-4.banana"
+                )
+        }
+}


### PR DESCRIPTION
## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change

Introduced extensions for asynchronous document parsing and loading, enabling better handling of metadata merging and directory traversal.

### Updates to `pom.xml` files:

* [`langchain4j-core/pom.xml`](diffhunk://#diff-d5e14cd3ea595d104a7e9567cc90e030bef59c3f463944dc919e507767c2b20eL100-R100): Updated the `kotlinx-coroutines-test` dependency to `kotlinx-coroutines-test-jvm` and added new source directories for Kotlin and Java files. Additionally, added the `maven-compiler-plugin` with custom executions to replace default compile phases. [[1]](diffhunk://#diff-d5e14cd3ea595d104a7e9567cc90e030bef59c3f463944dc919e507767c2b20eL100-R100) [[2]](diffhunk://#diff-d5e14cd3ea595d104a7e9567cc90e030bef59c3f463944dc919e507767c2b20eL158-R159) [[3]](diffhunk://#diff-d5e14cd3ea595d104a7e9567cc90e030bef59c3f463944dc919e507767c2b20eL169-R206)
* [`langchain4j-parent/pom.xml`](diffhunk://#diff-db1dfc1ccffac6c8f8ae2414e6aad535940aaf08a488d30941157dc53ec573b0L178-R178): Updated the `kotlinx-coroutines-test` dependency to `kotlinx-coroutines-test-jvm`, upgraded the `maven-compiler-plugin` version to 3.14.0, and added extensions to the `kotlin-maven-plugin`. [[1]](diffhunk://#diff-db1dfc1ccffac6c8f8ae2414e6aad535940aaf08a488d30941157dc53ec573b0L178-R178) [[2]](diffhunk://#diff-db1dfc1ccffac6c8f8ae2414e6aad535940aaf08a488d30941157dc53ec573b0L467-R468) [[3]](diffhunk://#diff-db1dfc1ccffac6c8f8ae2414e6aad535940aaf08a488d30941157dc53ec573b0L542-R544) [[4]](diffhunk://#diff-db1dfc1ccffac6c8f8ae2414e6aad535940aaf08a488d30941157dc53ec573b0L564-R566)
* [`langchain4j/pom.xml`](diffhunk://#diff-6a11da747d472969478daaaac9adb40486c2f6c7a24eeef789f7bc3b0bfe4ee9R39-R50): Added Kotlin dependencies and updated the `maven-source-plugin` configuration. Also added the `kotlin-maven-plugin` and `maven-compiler-plugin` with custom executions. [[1]](diffhunk://#diff-6a11da747d472969478daaaac9adb40486c2f6c7a24eeef789f7bc3b0bfe4ee9R39-R50) [[2]](diffhunk://#diff-6a11da747d472969478daaaac9adb40486c2f6c7a24eeef789f7bc3b0bfe4ee9R135-R146) [[3]](diffhunk://#diff-6a11da747d472969478daaaac9adb40486c2f6c7a24eeef789f7bc3b0bfe4ee9L156) [[4]](diffhunk://#diff-6a11da747d472969478daaaac9adb40486c2f6c7a24eeef789f7bc3b0bfe4ee9R192-R253)

### New methods for asynchronous document loading and parsing:

* [`langchain4j-core/src/main/kotlin/dev/langchain4j/data/document/DocumentLoaderExtensions.kt`](diffhunk://#diff-47fde5ad400fcec2c2ee0038b643d8df51b1628d932aa66f8daae87c3c3ba1a6R1-R23): Added a new method `loadAsync` to asynchronously load documents using a given parser and coroutine context.
* [`langchain4j-core/src/main/kotlin/dev/langchain4j/data/document/DocumentParserExtensions.kt`](diffhunk://#diff-a51206b5cd9c96039502a2fe37c574e5428b5900fd90bb8ce54c07fcd18b35dfR1-R47): Added new methods `parseAsync` to asynchronously parse documents from a source or input stream using the specified coroutine context.

### New tests for asynchronous document parsing and metadata merging:

* [`langchain4j-core/src/test/kotlin/dev/langchain4j/data/document/DocumentParserExtensionsKtTest.kt`](diffhunk://#diff-fea6bb5abf476ff4767b94445f964822ae59726bb018cf5476400be37081f21eR1-R74): Added tests to verify the functionality of the `parseAsync` method, including scenarios with and without source metadata.
* [`langchain4j-core/src/test/kotlin/dev/langchain4j/data/document/MergeMetadataTest.kt`](diffhunk://#diff-e7769b7e3a88cc7a840b107320e765d30f5056d84a14f1bc319cb28dac0a9ba8R1-R52): Added tests to verify the `merge` method in the `Metadata` class, ensuring it correctly combines unique metadata and throws an exception for common keys.

### Refactoring and code improvements:

* [`langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java`](diffhunk://#diff-d0ab9b0541e87ff4f8b0803cb1d20c660444f0dd86cca88a21a59323bc9e968fL3-R4): Refactored imports and added a new method `merge` to combine metadata objects, ensuring no common keys exist between them. [[1]](diffhunk://#diff-d0ab9b0541e87ff4f8b0803cb1d20c660444f0dd86cca88a21a59323bc9e968fL3-R4) [[2]](diffhunk://#diff-d0ab9b0541e87ff4f8b0803cb1d20c660444f0dd86cca88a21a59323bc9e968fR16-R18) [[3]](diffhunk://#diff-d0ab9b0541e87ff4f8b0803cb1d20c660444f0dd86cca88a21a59323bc9e968fR515-R535)


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
