### PR TITLE
Amazon Bedrock: deprecate old models using invoke API

### DIFF
--- a/docs/docs/integrations/language-models/amazon-bedrock.md
+++ b/docs/docs/integrations/language-models/amazon-bedrock.md
@@ -55,11 +55,11 @@ ChatLanguageModel model = BedrockChatModel.builder()
 ## ChatLanguageModel using InvokeAPI
 
 ### AI21 Models
-- `BedrockAI21LabsChatModel`
+- `BedrockAI21LabsChatModel` (deprecated, please use `BedrockChatModel`)
 
 ### Anthropic Models
-- `BedrockAnthropicMessageChatModel`: supports new Messages API
-- `BedrockAnthropicCompletionChatModel`: supports old Text Completions API
+- `BedrockAnthropicMessageChatModel`: (deprecated, please use `BedrockChatModel`) supports new Messages API
+- `BedrockAnthropicCompletionChatModel`: (deprecated, please use `BedrockChatModel`) supports old Text Completions API
 - `BedrockAnthropicStreamingChatModel`
 
 Example:
@@ -70,19 +70,19 @@ ChatLanguageModel model = BedrockAnthropicMessageChatModel.builder()
 ```
 
 ### Cohere Models
-- `BedrockCohereChatModel`
+- `BedrockCohereChatModel` (deprecated, please use `BedrockChatModel`)
 
 ### Meta Llama Models
-- `BedrockLlamaChatModel`
+- `BedrockLlamaChatModel` (deprecated, please use `BedrockChatModel`)
 
 ### Mistral Models
-- `BedrockMistralAiChatModel`
+- `BedrockMistralAiChatModel` (deprecated, please use `BedrockChatModel`)
 
 ### Titan Models
-- `BedrockTitanChatModel`
+- `BedrockTitanChatModel` (deprecated, please use `BedrockChatModel`)
 - `BedrockTitanEmbeddingModel`
 
 ### Examples
 
-- [BedrockChatModelExample](https://github.com/langchain4j/langchain4j-examples/blob/main/bedrock-examples/src/main/java/invoke/BedrockChatModelExample.java)
+- [BedrockChatModelExample](https://github.com/langchain4j/langchain4j-examples/blob/main/bedrock-examples/src/main/java/converse/BedrockChatModelExample.java)
 - [BedrockStreamingChatModelExample](https://github.com/langchain4j/langchain4j-examples/blob/main/bedrock-examples/src/main/java/invoke/BedrockStreamingChatModelExample.java)

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAI21LabsChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAI21LabsChatModel.java
@@ -8,6 +8,10 @@ import lombok.experimental.SuperBuilder;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @deprecated please use {@link BedrockChatModel} instead
+ */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @SuperBuilder
 public class BedrockAI21LabsChatModel extends AbstractBedrockChatModel<BedrockAI21LabsChatModelResponse> {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAI21LabsChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAI21LabsChatModelResponse.java
@@ -9,8 +9,9 @@ import lombok.Setter;
 import java.util.List;
 
 /**
- * Bedrock AI21 Labs model invoke response
+ * @deprecated please use {@link BedrockChatModel}
  */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 public class BedrockAI21LabsChatModelResponse implements BedrockChatModelResponse {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicCompletionChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicCompletionChatModel.java
@@ -8,6 +8,10 @@ import lombok.experimental.SuperBuilder;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @deprecated please use {@link BedrockChatModel} instead
+ */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @SuperBuilder
 public class BedrockAnthropicCompletionChatModel extends AbstractBedrockChatModel<BedrockAnthropicCompletionChatModelResponse> {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicCompletionChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicCompletionChatModelResponse.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Bedrock Anthropic Text Completions API Invoke response
- * <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-text-completion.html">...</a>
+ * @deprecated please use {@link BedrockChatModel}
  */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 public class BedrockAnthropicCompletionChatModelResponse implements BedrockChatModelResponse {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicContent.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicContent.java
@@ -8,6 +8,10 @@ import lombok.Setter;
 
 import java.util.Map;
 
+/**
+ * @deprecated please use {@link BedrockChatModel}
+ */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 @Builder

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicImageSource.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicImageSource.java
@@ -4,6 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * @deprecated please use {@link BedrockChatModel}
+ */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 @AllArgsConstructor

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessage.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessage.java
@@ -5,6 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * @deprecated please use {@link BedrockChatModel}
+ */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 @AllArgsConstructor

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessageChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessageChatModel.java
@@ -64,6 +64,10 @@ import static java.util.Collections.singletonList;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.joining;
 
+/**
+ * @deprecated please use {@link BedrockChatModel} instead
+ */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @SuperBuilder
 public class BedrockAnthropicMessageChatModel

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessageChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicMessageChatModelResponse.java
@@ -9,9 +9,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Bedrock Anthropic Messages API Invoke response
- * <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html">...</a>
+ * @deprecated please use {@link BedrockChatModel}
  */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 public class BedrockAnthropicMessageChatModelResponse implements BedrockChatModelResponse {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicStreamingChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAnthropicStreamingChatModel.java
@@ -30,4 +30,6 @@ public class BedrockAnthropicStreamingChatModel extends AbstractBedrockStreaming
             this.value = modelID;
         }
     }
+
+    // TODO deprecate and remove after https://github.com/langchain4j/langchain4j/pull/2620 is completed
 }

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAntropicToolSpecification.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockAntropicToolSpecification.java
@@ -6,6 +6,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * @deprecated please use {@link BedrockChatModel}
+ */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 @Builder

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereChatModel.java
@@ -8,6 +8,10 @@ import lombok.experimental.SuperBuilder;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @deprecated please use {@link BedrockChatModel} instead
+ */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @SuperBuilder
 public class BedrockCohereChatModel extends AbstractBedrockChatModel<BedrockCohereChatModelResponse> {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereChatModelResponse.java
@@ -9,8 +9,9 @@ import lombok.Setter;
 import java.util.List;
 
 /**
- * Bedrock Cohere model invoke response
+ * @deprecated please use {@link BedrockChatModel}
  */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 public class BedrockCohereChatModelResponse implements BedrockChatModelResponse {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockLlamaChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockLlamaChatModel.java
@@ -8,6 +8,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
+/**
+ * @deprecated please use {@link BedrockChatModel} instead
+ */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @SuperBuilder
 public class BedrockLlamaChatModel extends AbstractBedrockChatModel<BedrockLlamaChatModelResponse> {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockLlamaChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockLlamaChatModelResponse.java
@@ -7,8 +7,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Bedrock Llama Invoke response
+ * @deprecated please use {@link BedrockChatModel}
  */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 public class BedrockLlamaChatModelResponse implements BedrockChatModelResponse {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAiChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAiChatModel.java
@@ -27,6 +27,10 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 
+/**
+ * @deprecated please use {@link BedrockChatModel} instead
+ */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Slf4j
 @Getter
 @SuperBuilder

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAiChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockMistralAiChatModelResponse.java
@@ -8,8 +8,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Bedrock Mistral AI Invoke response
+ * @deprecated please use {@link BedrockChatModel}
  */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 class BedrockMistralAiChatModelResponse implements BedrockChatModelResponse {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStabilityAIChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStabilityAIChatModel.java
@@ -10,12 +10,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Bedrock stability AI model
- * This is for image generation.
- * Might not make sense to make it a chat model.
- * <p>
- * <a href="https://docs.stability-ai.com/bedrock-runtime-api-reference/invoke-model">...</a>
+ * @deprecated Will be removed in the next release, this functionality will not be supported anymore.
+ * Please reach out (via GitHub issues) if you use it.
  */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @SuperBuilder
 public class BedrockStabilityAIChatModel extends AbstractBedrockChatModel<BedrockStabilityAIChatModelResponse> {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStabilityAIChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStabilityAIChatModelResponse.java
@@ -9,8 +9,10 @@ import lombok.Setter;
 import java.util.List;
 
 /**
- * Bedrock Anthropic Invoke response
+ * @deprecated Will be removed in the next release, this functionality will not be supported anymore.
+ * Please reach out (via GitHub issues) if you use it.
  */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 public class BedrockStabilityAIChatModelResponse implements BedrockChatModelResponse {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockTitanChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockTitanChatModel.java
@@ -9,8 +9,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Bedrock Amazon Titan chat model
+ * @deprecated please use {@link BedrockChatModel} instead
  */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @SuperBuilder
 public class BedrockTitanChatModel extends AbstractBedrockChatModel<BedrockTitanChatModelResponse> {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockTitanChatModelResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockTitanChatModelResponse.java
@@ -9,8 +9,9 @@ import lombok.Setter;
 import java.util.List;
 
 /**
- * Bedrock Titan Chat response
+ * @deprecated please use {@link BedrockChatModel}
  */
+@Deprecated(forRemoval = true, since = "1.0.0-beta2")
 @Getter
 @Setter
 public class BedrockTitanChatModelResponse implements BedrockChatModelResponse {


### PR DESCRIPTION
## Issue
Closes #2606

## Change
Deprecated old Amazon Bedrock models that used invoke API:
- `BedrockAI21LabsChatModel`
- `BedrockAnthropicCompletionChatModel`
- `BedrockAnthropicMessageChatModel`
- `BedrockCohereChatModel`
- `BedrockLlamaChatModel`
- `BedrockMistralAiChatModel`
- `BedrockStabilityAIChatModel`
- `BedrockTitanChatModel`

Please use `BedrockChatModel` instead.

## General checklist
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)