### PR TITLE
Add OpenAI Official module to the BOM

### DIFF
--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -141,6 +141,12 @@
 
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-open-ai-official</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-ovh-ai</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
I totally missed that the new langchain4j-openai-official module needed to be added to the BOM.