### PR TITLE
Health checks for MCP clients

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClient.java
@@ -47,4 +47,11 @@ public interface McpClient extends AutoCloseable {
      * Render the contents of a prompt.
      */
     McpGetPromptResult getPrompt(String name, Map<String, Object> arguments);
+
+    /**
+     * Performs a health check that returns normally if the MCP server is reachable and
+     * properly responding to ping requests. If this method throws an exception,
+     * the health of this MCP client is considered degraded.
+     */
+    void checkHealth();
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/protocol/McpPingRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/protocol/McpPingRequest.java
@@ -1,0 +1,13 @@
+package dev.langchain4j.mcp.client.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public class McpPingRequest extends McpClientMessage {
+
+    @JsonInclude
+    public final ClientMethod method = ClientMethod.PING;
+
+    public McpPingRequest(Long id) {
+        super(id);
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/protocol/McpPingResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/protocol/McpPingResponse.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.HashMap;
 import java.util.Map;
 
-public class PingResponse extends McpClientMessage {
+public class McpPingResponse extends McpClientMessage {
 
     // has to be an empty object
     @JsonInclude(JsonInclude.Include.ALWAYS)
     private final Map<String, Object> result = new HashMap<>();
 
-    public PingResponse(final Long id) {
+    public McpPingResponse(final Long id) {
         super(id);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
@@ -2,7 +2,7 @@ package dev.langchain4j.mcp.client.transport;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.mcp.client.logging.McpLogMessage;
-import dev.langchain4j.mcp.client.protocol.PingResponse;
+import dev.langchain4j.mcp.client.protocol.McpPingResponse;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -41,7 +41,7 @@ public class McpOperationHandler {
                 if (message.has("method")) {
                     String method = message.get("method").asText();
                     if (method.equals("ping")) {
-                        transport.executeOperationWithoutResponse(new PingResponse(messageId));
+                        transport.executeOperationWithoutResponse(new McpPingResponse(messageId));
                         return;
                     }
                 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
@@ -32,4 +32,14 @@ public interface McpTransport extends Closeable {
      * of the message should be null.
      */
     void executeOperationWithoutResponse(McpClientMessage request);
+
+    /**
+     * Performs transport-specific health checks, if applicable. This is called
+     * by `McpClient.checkHealth()` as the first check before performing a check
+     * by sending a 'ping' over the MCP protocol. The purpose is that the
+     * transport may have some specific and faster ways to detect that it is broken,
+     * like for example, the STDIO transport can fail the check if it detects
+     * that the server subprocess isn't alive anymore.
+     */
+    void checkHealth();
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
@@ -99,6 +99,11 @@ public class HttpMcpTransport implements McpTransport {
         }
     }
 
+    @Override
+    public void checkHealth() {
+        // no transport-specific checks right now
+    }
+
     private CompletableFuture<JsonNode> execute(Request request, Long id) {
         CompletableFuture<JsonNode> future = new CompletableFuture<>();
         if (id != null) {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
@@ -87,6 +87,13 @@ public class StdioMcpTransport implements McpTransport {
     }
 
     @Override
+    public void checkHealth() {
+        if (!process.isAlive()) {
+            throw new IllegalStateException("Process is not alive");
+        }
+    }
+
+    @Override
     public void close() throws IOException {
         process.destroy();
     }
@@ -106,6 +113,10 @@ public class StdioMcpTransport implements McpTransport {
             future.completeExceptionally(e);
         }
         return future;
+    }
+
+    public Process getProcess() {
+        return process;
     }
 
     public static class Builder {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHealthHttpTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHealthHttpTransportIT.java
@@ -1,0 +1,58 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.skipTestsIfJbangNotAvailable;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.startServerHttp;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class McpHealthHttpTransportIT {
+
+    static McpClient mcpClient;
+    static McpTransport transport;
+    static Process process;
+
+    @BeforeAll
+    static void setup() throws IOException, InterruptedException, TimeoutException {
+        skipTestsIfJbangNotAvailable();
+        process = startServerHttp("logging_mcp_server.java");
+        McpTransport transport = new HttpMcpTransport.Builder()
+                .sseUrl("http://localhost:8080/mcp/sse")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+        mcpClient = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .toolExecutionTimeout(Duration.ofSeconds(4))
+                .build();
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (mcpClient != null) {
+            mcpClient.close();
+        }
+    }
+
+    @Test
+    public void testHealth() throws ExecutionException, InterruptedException {
+        mcpClient.checkHealth();
+        process.destroy();
+        process.onExit().get();
+        assertThatThrownBy(() -> mcpClient.checkHealth())
+                .rootCause()
+                .isInstanceOf(ConnectException.class)
+                .hasMessageContaining("Connection refused");
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHealthStdioTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHealthStdioTransportIT.java
@@ -1,0 +1,55 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getJBangCommand;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getPathToScript;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class McpHealthStdioTransportIT {
+
+    static McpClient mcpClient;
+    static McpTransport transport;
+    static Process process;
+
+    @BeforeAll
+    static void setup() {
+        StdioMcpTransport transport = new StdioMcpTransport.Builder()
+                .command(List.of(
+                        getJBangCommand(), "--quiet", "--fresh", "run", getPathToScript("logging_mcp_server.java")))
+                .logEvents(true)
+                .build();
+        McpHealthStdioTransportIT.transport = transport;
+        mcpClient = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .toolExecutionTimeout(Duration.ofSeconds(4))
+                .build();
+        process = transport.getProcess();
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (mcpClient != null) {
+            mcpClient.close();
+        }
+    }
+
+    @Test
+    public void testHealth() throws ExecutionException, InterruptedException {
+        mcpClient.checkHealth();
+        process.destroy();
+        process.onExit().get();
+        assertThatThrownBy(() -> mcpClient.checkHealth())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Process is not alive");
+    }
+}


### PR DESCRIPTION
## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes https://github.com/langchain4j/langchain4j/issues/2766

## Change
Adds the `McpClient.checkHealth()` method that throws an exception if the server isn't reachable or isn't responding to pings within a reasonable timeout. I didn't include a dependency on MicroProfile Health as this probably isn't suitable here, but any runtime that integrates it (Quarkus) may want to wrap an invocation of this method into a built-in MicroProfile Health check.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green