### PR TITLE
Allow tools to directly return the raw result

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
@@ -46,5 +46,5 @@ public @interface Tool {
      *
      * @return whether to return the result directly
      */
-    boolean returnDirectly() default false;
+    boolean directReturn() default false;
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.agent.tool;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Java methods annotated with {@code @Tool} are considered tools/functions that language model can execute/call.

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.agent.tool;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 /**
  * Java methods annotated with {@code @Tool} are considered tools/functions that language model can execute/call.
@@ -36,4 +36,15 @@ public @interface Tool {
      * @return description of the tool.
      */
     String[] value() default "";
+
+    /**
+     * Indicates whether the tool's String return value should be returned directly to the user.
+     * Only applicable if used within an AiService and if the return type is 'Result<String>'
+     * If true, the result will be returned directly without further LLM processing.
+     * If false or if return type is not Result<String>, normal processing continues.
+     * If true, the tool cannot be chained with other tools as the result will not be returned to the llm.
+     *
+     * @return whether to return the result directly
+     */
+    boolean returnDirectly() default false;
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
@@ -46,5 +46,5 @@ public @interface Tool {
      *
      * @return whether to return the result directly
      */
-    boolean directReturn() default false;
+    boolean rawReturn() default false;
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
@@ -38,13 +38,13 @@ public @interface Tool {
     String[] value() default "";
 
     /**
-     * Indicates whether the tool's String return value should be returned directly to the user.
-     * Only applicable if used within an AiService and if the return type is 'Result<String>'
+     * Indicates whether the tool's return value should be returned directly to the user.
+     * Only applicable if used within an AiService and if the return type is 'Result<String>'.
      * If true, the result will be returned directly without further LLM processing.
      * If false or if return type is not Result<String>, normal processing continues.
      * If true, the tool cannot be chained with other tools as the result will not be returned to the llm.
      *
      * @return whether to return the result directly
      */
-    boolean rawReturn() default false;
+    boolean returnRaw() default false;
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -40,11 +40,9 @@ import java.lang.reflect.Array;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -56,7 +54,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import static dev.langchain4j.internal.Exceptions.runtime;
 import static dev.langchain4j.service.TypeUtils.isResultRawString;
 
 class DefaultAiServices<T> extends AiServices<T> {
@@ -152,7 +149,7 @@ class DefaultAiServices<T> extends AiServices<T> {
                         Type returnType = method.getGenericReturnType();
                         boolean isReturnTypeRaw = typeHasRawClass(returnType, Result.class);
                         boolean isResultRawString = isReturnTypeRaw && isResultRawString(returnType);
-                        boolean directReturnFromTool = isResultRawString;
+                        boolean rawReturnFromTool = isResultRawString;
 
                         boolean streaming = returnType == TokenStream.class || canAdaptTokenStreamTo(returnType);
 
@@ -254,8 +251,8 @@ class DefaultAiServices<T> extends AiServices<T> {
                         }
                     }
 
-                    private boolean allToolsReturnDirectly(List<ToolExecutionRequest> requests, Map<String, ToolExecutor> toolExecutors) {
-                        return requests.stream().map(r -> toolExecutors.get(r.name())).allMatch(tExec -> tExec != null && tExec.isDirectReturn());
+                    private boolean allToolsReturnRaw(List<ToolExecutionRequest> requests, Map<String, ToolExecutor> toolExecutors) {
+                        return requests.stream().map(r -> toolExecutors.get(r.name())).allMatch(tExec -> tExec != null && tExec.isRawReturn());
                     }
 
                     private boolean canAdaptTokenStreamTo(Type returnType) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -54,20 +54,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-<<<<<<< HEAD
-import static dev.langchain4j.service.TypeUtils.isResultRawString;
-=======
-import static dev.langchain4j.exception.IllegalConfigurationException.illegalConfiguration;
-import static dev.langchain4j.internal.Exceptions.illegalArgument;
-import static dev.langchain4j.internal.Exceptions.runtime;
-import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
-import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
-import static dev.langchain4j.model.chat.request.ResponseFormatType.JSON;
 import static dev.langchain4j.service.TypeUtils.resolveFirstGenericParameterClass;
-import static dev.langchain4j.service.TypeUtils.typeHasRawClass;
-import static dev.langchain4j.service.output.JsonSchemas.jsonSchemaFrom;
-import static dev.langchain4j.spi.ServiceHelper.loadFactories;
->>>>>>> e1782916 (refactoring)
 
 class DefaultAiServices<T> extends AiServices<T> {
 
@@ -160,9 +147,6 @@ class DefaultAiServices<T> extends AiServices<T> {
 
                         // TODO give user ability to provide custom OutputParser
                         Type returnType = method.getGenericReturnType();
-                        boolean returnsResult = typeHasRawClass(returnType, Result.class);
-                        boolean returnsResultOfString =
-                                returnsResult && resolveFirstGenericParameterClass(returnType) == String.class;
 
                         boolean streaming = returnType == TokenStream.class || canAdaptTokenStreamTo(returnType);
 
@@ -251,7 +235,7 @@ class DefaultAiServices<T> extends AiServices<T> {
                                 chatResponse.aiMessage(), toolExecutionResult.tokenUsageAccumulator(), finishReason);
 
                         Object parsedResponse = serviceOutputParser.parse(response, returnType);
-                        if (returnsResult) {
+                        if (typeHasRawClass(returnType, Result.class)) {
                             return Result.builder()
                                     .content(parsedResponse)
                                     .tokenUsage(toolExecutionResult.tokenUsageAccumulator())
@@ -262,11 +246,6 @@ class DefaultAiServices<T> extends AiServices<T> {
                         } else {
                             return parsedResponse;
                         }
-                    }
-
-                    private boolean allToolsReturnRaw(AiMessage aiMessage, Map<String, ToolExecutor> toolExecutors) {
-                        return aiMessage.toolExecutionRequests().stream()
-                                .map(r -> toolExecutors.get(r.name())).allMatch(tExec -> tExec != null && tExec.returnRaw());
                     }
 
                     private boolean canAdaptTokenStreamTo(Type returnType) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -54,7 +54,20 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+<<<<<<< HEAD
 import static dev.langchain4j.service.TypeUtils.isResultRawString;
+=======
+import static dev.langchain4j.exception.IllegalConfigurationException.illegalConfiguration;
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+import static dev.langchain4j.internal.Exceptions.runtime;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
+import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
+import static dev.langchain4j.model.chat.request.ResponseFormatType.JSON;
+import static dev.langchain4j.service.TypeUtils.resolveFirstGenericParameterClass;
+import static dev.langchain4j.service.TypeUtils.typeHasRawClass;
+import static dev.langchain4j.service.output.JsonSchemas.jsonSchemaFrom;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+>>>>>>> e1782916 (refactoring)
 
 class DefaultAiServices<T> extends AiServices<T> {
 
@@ -147,9 +160,9 @@ class DefaultAiServices<T> extends AiServices<T> {
 
                         // TODO give user ability to provide custom OutputParser
                         Type returnType = method.getGenericReturnType();
-                        boolean isReturnTypeRaw = typeHasRawClass(returnType, Result.class);
-                        boolean isResultRawString = isReturnTypeRaw && isResultRawString(returnType);
-                        boolean rawReturnFromTool = isResultRawString;
+                        boolean returnsResult = typeHasRawClass(returnType, Result.class);
+                        boolean returnsResultOfString =
+                                returnsResult && resolveFirstGenericParameterClass(returnType) == String.class;
 
                         boolean streaming = returnType == TokenStream.class || canAdaptTokenStreamTo(returnType);
 
@@ -238,7 +251,7 @@ class DefaultAiServices<T> extends AiServices<T> {
                                 chatResponse.aiMessage(), toolExecutionResult.tokenUsageAccumulator(), finishReason);
 
                         Object parsedResponse = serviceOutputParser.parse(response, returnType);
-                        if (isReturnTypeRaw) {
+                        if (returnsResult) {
                             return Result.builder()
                                     .content(parsedResponse)
                                     .tokenUsage(toolExecutionResult.tokenUsageAccumulator())
@@ -251,8 +264,9 @@ class DefaultAiServices<T> extends AiServices<T> {
                         }
                     }
 
-                    private boolean allToolsReturnRaw(List<ToolExecutionRequest> requests, Map<String, ToolExecutor> toolExecutors) {
-                        return requests.stream().map(r -> toolExecutors.get(r.name())).allMatch(tExec -> tExec != null && tExec.isRawReturn());
+                    private boolean allToolsReturnRaw(AiMessage aiMessage, Map<String, ToolExecutor> toolExecutors) {
+                        return aiMessage.toolExecutionRequests().stream()
+                                .map(r -> toolExecutors.get(r.name())).allMatch(tExec -> tExec != null && tExec.returnRaw());
                     }
 
                     private boolean canAdaptTokenStreamTo(Type returnType) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/Result.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/Result.java
@@ -33,6 +33,18 @@ public class Result<T> {
         this.toolExecutions = copyIfNotNull(toolExecutions);
     }
 
+    /**
+     *
+     * For use only with result from Tools where returnDirectly=true and the content is nullable
+     */
+    public Result(TokenUsage tokenUsage, List<Content> sources, FinishReason finishReason, List<ToolExecution> toolExecutions) {
+        this.content = null;
+        this.tokenUsage = tokenUsage;
+        this.sources = copyIfNotNull(sources);
+        this.finishReason = finishReason;
+        this.toolExecutions = copyIfNotNull(toolExecutions);
+    }
+
     public static <T> ResultBuilder<T> builder() {
         return new ResultBuilder<T>();
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/Result.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/Result.java
@@ -4,10 +4,11 @@ import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.service.tool.ToolExecution;
+
 import java.util.List;
 
 import static dev.langchain4j.internal.Utils.copyIfNotNull;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 
 /**
  * Represents the result of an AI Service invocation.
@@ -26,19 +27,10 @@ public class Result<T> {
     private final List<ToolExecution> toolExecutions;
 
     public Result(T content, TokenUsage tokenUsage, List<Content> sources, FinishReason finishReason, List<ToolExecution> toolExecutions) {
-        this.content = ensureNotNull(content, "content");
-        this.tokenUsage = tokenUsage;
-        this.sources = copyIfNotNull(sources);
-        this.finishReason = finishReason;
-        this.toolExecutions = copyIfNotNull(toolExecutions);
-    }
-
-    /**
-     *
-     * For use only with result from Tools where returnDirectly=true and the content is nullable
-     */
-    public Result(TokenUsage tokenUsage, List<Content> sources, FinishReason finishReason, List<ToolExecution> toolExecutions) {
-        this.content = null;
+        if (content == null && isNullOrEmpty(toolExecutions)) {
+            throw new IllegalArgumentException("either 'content' or 'toolExecutions' must be specified");
+        }
+        this.content = content;
         this.tokenUsage = tokenUsage;
         this.sources = copyIfNotNull(sources);
         this.finishReason = finishReason;

--- a/langchain4j/src/main/java/dev/langchain4j/service/TypeUtils.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TypeUtils.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,6 +34,16 @@ public class TypeUtils {
         }
 
         return rawClass.equals(getRawClass(type));
+    }
+
+    public static boolean isResultRawString(Type returnType) {
+        if (!(returnType instanceof ParameterizedType paramType)) {
+            return false;
+        }
+        return Arrays.stream(paramType.getActualTypeArguments())
+                .findFirst()
+                .map(String.class::equals)
+                .orElse(false);
     }
 
     public static Class<?> resolveFirstGenericParameterClass(Type returnType) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/TypeUtils.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TypeUtils.java
@@ -36,16 +36,6 @@ public class TypeUtils {
         return rawClass.equals(getRawClass(type));
     }
 
-    public static boolean isResultRawString(Type returnType) {
-        if (!(returnType instanceof ParameterizedType paramType)) {
-            return false;
-        }
-        return Arrays.stream(paramType.getActualTypeArguments())
-                .findFirst()
-                .map(String.class::equals)
-                .orElse(false);
-    }
-
     public static Class<?> resolveFirstGenericParameterClass(Type returnType) {
         Type[] typeArguments = getTypeArguments(returnType);
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -42,9 +42,9 @@ public class DefaultToolExecutor implements ToolExecutor {
     }
 
     @Override
-    public boolean isRawReturn() {
+    public boolean returnRaw() {
         Tool toolAnnotation = originalMethod.getAnnotation(Tool.class);
-        return toolAnnotation != null && toolAnnotation.rawReturn();
+        return toolAnnotation != null && toolAnnotation.returnRaw();
     }
 
     private Method findMethod(Object object, ToolExecutionRequest toolExecutionRequest) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.service.tool;
 
+import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolMemoryId;
 import dev.langchain4j.internal.Json;
@@ -38,6 +39,11 @@ public class DefaultToolExecutor implements ToolExecutor {
         Objects.requireNonNull(toolExecutionRequest, "toolExecutionRequest");
         this.originalMethod = findMethod(object, toolExecutionRequest);
         this.methodToInvoke = this.originalMethod;
+    }
+
+    public boolean isReturnDirectly() {
+        Tool toolAnnotation = originalMethod.getAnnotation(Tool.class);
+        return toolAnnotation != null && toolAnnotation.returnDirectly();
     }
 
     private Method findMethod(Object object, ToolExecutionRequest toolExecutionRequest) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -41,9 +41,10 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = this.originalMethod;
     }
 
-    public boolean isReturnDirectly() {
+    @Override
+    public boolean isDirectReturn() {
         Tool toolAnnotation = originalMethod.getAnnotation(Tool.class);
-        return toolAnnotation != null && toolAnnotation.returnDirectly();
+        return toolAnnotation != null && toolAnnotation.directReturn();
     }
 
     private Method findMethod(Object object, ToolExecutionRequest toolExecutionRequest) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -42,9 +42,9 @@ public class DefaultToolExecutor implements ToolExecutor {
     }
 
     @Override
-    public boolean isDirectReturn() {
+    public boolean isRawReturn() {
         Tool toolAnnotation = originalMethod.getAnnotation(Tool.class);
-        return toolAnnotation != null && toolAnnotation.directReturn();
+        return toolAnnotation != null && toolAnnotation.rawReturn();
     }
 
     private Method findMethod(Object object, ToolExecutionRequest toolExecutionRequest) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutor.java
@@ -16,4 +16,14 @@ public interface ToolExecutor {
      * @return The result of the tool execution.
      */
     String execute(ToolExecutionRequest toolExecutionRequest, Object memoryId);
+
+    /**
+     * Returns true if the result of the tool invocation can be returned directly as it is,
+     * without any further processing from the LLM.
+     *
+     * @return True if the tool invocation result can be directly returned as it is.
+     */
+    default boolean isDirectReturn() {
+        return false;
+    }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutor.java
@@ -23,7 +23,7 @@ public interface ToolExecutor {
      *
      * @return True if the tool invocation result can be directly returned as it is.
      */
-    default boolean isDirectReturn() {
+    default boolean isRawReturn() {
         return false;
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutor.java
@@ -18,12 +18,10 @@ public interface ToolExecutor {
     String execute(ToolExecutionRequest toolExecutionRequest, Object memoryId);
 
     /**
-     * Returns true if the result of the tool invocation can be returned directly as it is,
+     * @return true if the raw result of the tool invocation should be returned directly as it is,
      * without any further processing from the LLM.
-     *
-     * @return True if the tool invocation result can be directly returned as it is.
      */
-    default boolean isRawReturn() {
+    default boolean returnRaw() {
         return false;
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -133,7 +133,7 @@ public class ToolService {
         int executionsLeft = MAX_SEQUENTIAL_TOOL_EXECUTIONS;
         List<ToolExecution> toolExecutions = new ArrayList<>();
 
-        boolean shouldReturnDirectly  = true;
+        boolean shouldReturnDirectly = true;
         while (true) {
 
             if (executionsLeft-- == 0) {
@@ -171,7 +171,7 @@ public class ToolService {
                     tokenUsageAccumulator, chatResponse.metadata().tokenUsage());
         }
 
-        return shouldReturnDirectly ?
+        return shouldReturnDirectly && !toolExecutions.isEmpty() ?
                 rawToolExecutionResult(chatResponse, toolExecutions, tokenUsageAccumulator) :
                 new ToolExecutionResult(chatResponse, toolExecutions, tokenUsageAccumulator);
     }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
@@ -782,7 +782,7 @@ public abstract class AiServicesWithNewToolsIT {
 
             if (verifyModelInteractions()) {
                 verify(model).supportedCapabilities();
-                verify(model, times(1)).chat(chatRequestCaptor.capture());  // only 1 time, to call the tool
+                verify(model, times(2)).chat(chatRequestCaptor.capture());  // 2 times, the model is always called regardless of the tool raw return
 
                 var toolSpecifications = chatRequestCaptor.getValue().toolSpecifications();
                 assertThat(toolSpecifications).hasSize(1);

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
@@ -739,9 +739,9 @@ public abstract class AiServicesWithNewToolsIT {
     }
 
 
-    static class ToolWithPrimitiveParametersReturnDirectly {
+    static class ToolWithPrimitiveParametersReturnRaw {
 
-        @Tool(directReturn = true)
+        @Tool(rawReturn = true)
         int add(int a, int b) {
             return a + b;
         }
@@ -754,14 +754,14 @@ public abstract class AiServicesWithNewToolsIT {
     }
 
     @Test
-    protected void should_execute_tool_with_primitive_parameters_return_directly() {
+    protected void should_execute_tool_with_primitive_parameters_return_raw() {
 
         for (var model : models()) {
 
             // given
             model = spy(model);
 
-            var tool = spy(new ToolWithPrimitiveParametersReturnDirectly());
+            var tool = spy(new ToolWithPrimitiveParametersReturnRaw());
 
             var assistant = AiServices.builder(AssistantResultString.class)
                     .chatLanguageModel(model)
@@ -791,20 +791,20 @@ public abstract class AiServicesWithNewToolsIT {
                 var toolSpecification = toolSpecifications.get(0);
                 assertThat(toolSpecification.name()).isEqualTo("add");
                 assertThat(toolSpecification.description()).isNull();
-                assertThat(toolSpecification.parameters()).isEqualTo(ToolWithPrimitiveParametersReturnDirectly.EXPECTED_SCHEMA);
+                assertThat(toolSpecification.parameters()).isEqualTo(ToolWithPrimitiveParametersReturnRaw.EXPECTED_SCHEMA);
             }
         }
     }
 
     @Test
-    protected void should_execute_tools_some_return_direct_false() {
+    protected void should_execute_tools_some_return_raw_false() {
 
         for (var model : models()) {
             // given
             model = spy(model);
 
-            var firstTool = spy(new FirstToolReturnDirectFalse());
-            var secondTool = spy(new SecondToolReturnDirectTrue());
+            var firstTool = spy(new FirstToolReturnRawFalse());
+            var secondTool = spy(new SecondToolReturnRawTrue());
 
             var assistant = AiServices.builder(AssistantResultString.class)
                     .chatLanguageModel(model)
@@ -817,7 +817,7 @@ public abstract class AiServicesWithNewToolsIT {
             var response = assistant.chat(text);
 
             // then
-            assertThat(response.content()).contains("20");  // since multiple tools are called without return directly set, content is returned
+            assertThat(response.content()).contains("20");  // since multiple tools are called without return raw set, content is returned
             assertThat(response.toolExecutions()).hasSize(2);
 
             assertThat(response.toolExecutions().get(0).result()).isEqualTo("5");
@@ -843,14 +843,14 @@ public abstract class AiServicesWithNewToolsIT {
     }
 
     @Test
-    protected void should_execute_tools_all_return_direct_true_single_called_at_a_time() {
+    protected void should_execute_tools_all_return_raw_true_single_called_at_a_time() {
 
         for (var model : models()) {
             // given
             model = spy(model);
 
-            var firstTool = spy(new FirstToolReturnDirectTrue());
-            var secondTool = spy(new SecondToolReturnDirectTrue());
+            var firstTool = spy(new FirstToolReturnRawTrue());
+            var secondTool = spy(new SecondToolReturnRawTrue());
 
             var assistant = AiServices.builder(AssistantResultString.class)
                     .chatLanguageModel(model)
@@ -863,8 +863,8 @@ public abstract class AiServicesWithNewToolsIT {
             var response = assistant.chat(text);
 
             // then
-            assertThat(response.content()).isNull();  // all tools have return direct set
-            assertThat(response.toolExecutions()).hasSize(1);  // second tool couldn't be called, first returned direct
+            assertThat(response.content()).isNull();  // all tools have return raw set
+            assertThat(response.toolExecutions()).hasSize(1);  // second tool couldn't be called, first returned raw
 
             assertThat(response.toolExecutions().get(0).result()).isEqualTo("5");
             assertThat(response.toolExecutions().get(0).request().name()).isEqualTo("add");
@@ -875,7 +875,7 @@ public abstract class AiServicesWithNewToolsIT {
 
             if (verifyModelInteractions()) {
                 verify(model).supportedCapabilities();
-                verify(model, times(1)).generate(anyList(), toolSpecificationCaptor.capture());  // 1 times = 1 tool requests return direct
+                verify(model, times(1)).generate(anyList(), toolSpecificationCaptor.capture());  // 1 times = 1 tool requests return raw
                 verifyNoMoreInteractions(model);
 
                 var toolSpecifications = toolSpecificationCaptor.getValue();
@@ -885,14 +885,14 @@ public abstract class AiServicesWithNewToolsIT {
     }
 
     @Test
-    protected void should_execute_tools_all_return_direct_true_multiple_called_at_a_time() {
+    protected void should_execute_tools_all_return_raw_true_multiple_called_at_a_time() {
 
         for (var model : models()) {
             // given
             model = spy(model);
 
-            var firstTool = spy(new FirstToolReturnDirectTrue());
-            var secondTool = spy(new SecondToolReturnDirectTrue());
+            var firstTool = spy(new FirstToolReturnRawTrue());
+            var secondTool = spy(new SecondToolReturnRawTrue());
 
             var assistant = AiServices.builder(AssistantResultString.class)
                     .chatLanguageModel(model)
@@ -905,7 +905,7 @@ public abstract class AiServicesWithNewToolsIT {
             var response = assistant.chat(text);
 
             // then
-            assertThat(response.content()).isNull();  // all tools have return direct set
+            assertThat(response.content()).isNull();  // all tools have return raw set
             assertThat(response.toolExecutions()).hasSize(2);  // both tools called simultaneously
 
             assertThat(response.toolExecutions().get(0).result()).isEqualTo("5");
@@ -921,7 +921,7 @@ public abstract class AiServicesWithNewToolsIT {
 
             if (verifyModelInteractions()) {
                 verify(model).supportedCapabilities();
-                verify(model, times(1)).generate(anyList(), toolSpecificationCaptor.capture());  // 1 times = 1 tool requests return direct
+                verify(model, times(1)).generate(anyList(), toolSpecificationCaptor.capture());  // 1 times = 1 tool requests return raw
                 verifyNoMoreInteractions(model);
 
                 var toolSpecifications = toolSpecificationCaptor.getValue();
@@ -933,8 +933,8 @@ public abstract class AiServicesWithNewToolsIT {
 
 
 
-    static class FirstToolReturnDirectFalse {
-        @Tool(directReturn = false)
+    static class FirstToolReturnRawFalse {
+        @Tool(rawReturn = false)
         int add(int a, int b) {
             return a + b;
         }
@@ -946,8 +946,8 @@ public abstract class AiServicesWithNewToolsIT {
                 .build();
     }
 
-    static class FirstToolReturnDirectTrue {
-        @Tool(directReturn = true)
+    static class FirstToolReturnRawTrue {
+        @Tool(rawReturn = true)
         int add(int a, int b) {
             return a + b;
         }
@@ -959,8 +959,8 @@ public abstract class AiServicesWithNewToolsIT {
                 .build();
     }
 
-    static class SecondToolReturnDirectTrue {
-        @Tool(directReturn = true)
+    static class SecondToolReturnRawTrue {
+        @Tool(rawReturn = true)
         int multiply(int a, int b) {
             return a * b;
         }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
@@ -741,7 +741,7 @@ public abstract class AiServicesWithNewToolsIT {
 
     static class ToolWithPrimitiveParametersReturnDirectly {
 
-        @Tool(returnDirectly = true)
+        @Tool(directReturn = true)
         int add(int a, int b) {
             return a + b;
         }
@@ -934,7 +934,7 @@ public abstract class AiServicesWithNewToolsIT {
 
 
     static class FirstToolReturnDirectFalse {
-        @Tool(returnDirectly = false)
+        @Tool(directReturn = false)
         int add(int a, int b) {
             return a + b;
         }
@@ -947,7 +947,7 @@ public abstract class AiServicesWithNewToolsIT {
     }
 
     static class FirstToolReturnDirectTrue {
-        @Tool(returnDirectly = true)
+        @Tool(directReturn = true)
         int add(int a, int b) {
             return a + b;
         }
@@ -960,7 +960,7 @@ public abstract class AiServicesWithNewToolsIT {
     }
 
     static class SecondToolReturnDirectTrue {
-        @Tool(returnDirectly = true)
+        @Tool(directReturn = true)
         int multiply(int a, int b) {
             return a * b;
         }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
@@ -740,7 +740,7 @@ public abstract class AiServicesWithNewToolsIT {
 
     static class ToolWithPrimitiveParametersReturnRaw {
 
-        @Tool(rawReturn = true)
+        @Tool(returnRaw = true)
         int add(int a, int b) {
             return a + b;
         }
@@ -933,7 +933,7 @@ public abstract class AiServicesWithNewToolsIT {
 
 
     static class FirstToolReturnRawFalse {
-        @Tool(rawReturn = false)
+        @Tool(returnRaw = false)
         int add(int a, int b) {
             return a + b;
         }
@@ -946,7 +946,7 @@ public abstract class AiServicesWithNewToolsIT {
     }
 
     static class FirstToolReturnRawTrue {
-        @Tool(rawReturn = true)
+        @Tool(returnRaw = true)
         int add(int a, int b) {
             return a + b;
         }
@@ -959,7 +959,7 @@ public abstract class AiServicesWithNewToolsIT {
     }
 
     static class SecondToolReturnRawTrue {
-        @Tool(rawReturn = true)
+        @Tool(returnRaw = true)
         int multiply(int a, int b) {
             return a * b;
         }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
@@ -732,6 +732,246 @@ public abstract class AiServicesWithNewToolsIT {
         }
     }
 
+    interface AssistantResultString {
+
+        Result<String> chat(String userMessage);
+
+    }
+
+
+    static class ToolWithPrimitiveParametersReturnDirectly {
+
+        @Tool(returnDirectly = true)
+        int add(int a, int b) {
+            return a + b;
+        }
+
+        static JsonSchemaElement EXPECTED_SCHEMA = JsonObjectSchema.builder()
+                .addIntegerProperty("arg0")
+                .addIntegerProperty("arg1")
+                .required("arg0", "arg1")
+                .build();
+    }
+
+    @Test
+    protected void should_execute_tool_with_primitive_parameters_return_directly() {
+
+        for (var model : models()) {
+
+            // given
+            model = spy(model);
+
+            var tool = spy(new ToolWithPrimitiveParametersReturnDirectly());
+
+            var assistant = AiServices.builder(AssistantResultString.class)
+                    .chatLanguageModel(model)
+                    .tools(tool)
+                    .build();
+
+            var text = "How much is 37 plus 87?";
+
+            // when
+            var response = assistant.chat(text);
+
+            // then
+            assertThat(response.content()).isNull();  // should only contain tool executions
+            assertThat(response.toolExecutions().size()).isEqualTo(1);
+            assertThat(response.toolExecutions().get(0).result()).isEqualTo("124");
+
+            verify(tool).add(37, 87);
+            verifyNoMoreInteractions(tool);
+
+            if (verifyModelInteractions()) {
+                verify(model).supportedCapabilities();
+                verify(model, times(1)).generate(anyList(), toolSpecificationCaptor.capture());  // only 1 time, to call the tool
+                verifyNoMoreInteractions(model);
+
+                var toolSpecifications = toolSpecificationCaptor.getValue();
+                assertThat(toolSpecifications).hasSize(1);
+                var toolSpecification = toolSpecifications.get(0);
+                assertThat(toolSpecification.name()).isEqualTo("add");
+                assertThat(toolSpecification.description()).isNull();
+                assertThat(toolSpecification.parameters()).isEqualTo(ToolWithPrimitiveParametersReturnDirectly.EXPECTED_SCHEMA);
+            }
+        }
+    }
+
+    @Test
+    protected void should_execute_tools_some_return_direct_false() {
+
+        for (var model : models()) {
+            // given
+            model = spy(model);
+
+            var firstTool = spy(new FirstToolReturnDirectFalse());
+            var secondTool = spy(new SecondToolReturnDirectTrue());
+
+            var assistant = AiServices.builder(AssistantResultString.class)
+                    .chatLanguageModel(model)
+                    .tools(firstTool, secondTool)
+                    .build();
+
+            var text = "First add 2 and 3, then multiply the result by 4";
+
+            // when
+            var response = assistant.chat(text);
+
+            // then
+            assertThat(response.content()).contains("20");  // since multiple tools are called without return directly set, content is returned
+            assertThat(response.toolExecutions()).hasSize(2);
+
+            assertThat(response.toolExecutions().get(0).result()).isEqualTo("5");
+            assertThat(response.toolExecutions().get(1).result()).isEqualTo("20");
+
+            assertThat(response.toolExecutions().get(0).request().name()).isEqualTo("add");
+            assertThat(response.toolExecutions().get(1).request().name()).isEqualTo("multiply");
+
+            // verify tool executions
+            verify(firstTool).add(2, 3);
+            verify(secondTool).multiply(5, 4);
+            verifyNoMoreInteractions(firstTool, secondTool);
+
+            if (verifyModelInteractions()) {
+                verify(model).supportedCapabilities();
+                verify(model, times(3)).generate(anyList(), toolSpecificationCaptor.capture());  // 3 times = 2 tool requests + summary
+                verifyNoMoreInteractions(model);
+
+                var toolSpecifications = toolSpecificationCaptor.getValue();
+                assertThat(toolSpecifications).hasSize(2);
+            }
+        }
+    }
+
+    @Test
+    protected void should_execute_tools_all_return_direct_true_single_called_at_a_time() {
+
+        for (var model : models()) {
+            // given
+            model = spy(model);
+
+            var firstTool = spy(new FirstToolReturnDirectTrue());
+            var secondTool = spy(new SecondToolReturnDirectTrue());
+
+            var assistant = AiServices.builder(AssistantResultString.class)
+                    .chatLanguageModel(model)
+                    .tools(firstTool, secondTool)
+                    .build();
+
+            var text = "First add 2 and 3, then multiply the result by 4";
+
+            // when
+            var response = assistant.chat(text);
+
+            // then
+            assertThat(response.content()).isNull();  // all tools have return direct set
+            assertThat(response.toolExecutions()).hasSize(1);  // second tool couldn't be called, first returned direct
+
+            assertThat(response.toolExecutions().get(0).result()).isEqualTo("5");
+            assertThat(response.toolExecutions().get(0).request().name()).isEqualTo("add");
+
+            // verify tool executions
+            verify(firstTool).add(2, 3);
+            verifyNoMoreInteractions(firstTool);
+
+            if (verifyModelInteractions()) {
+                verify(model).supportedCapabilities();
+                verify(model, times(1)).generate(anyList(), toolSpecificationCaptor.capture());  // 1 times = 1 tool requests return direct
+                verifyNoMoreInteractions(model);
+
+                var toolSpecifications = toolSpecificationCaptor.getValue();
+                assertThat(toolSpecifications).hasSize(2);
+            }
+        }
+    }
+
+    @Test
+    protected void should_execute_tools_all_return_direct_true_multiple_called_at_a_time() {
+
+        for (var model : models()) {
+            // given
+            model = spy(model);
+
+            var firstTool = spy(new FirstToolReturnDirectTrue());
+            var secondTool = spy(new SecondToolReturnDirectTrue());
+
+            var assistant = AiServices.builder(AssistantResultString.class)
+                    .chatLanguageModel(model)
+                    .tools(firstTool, secondTool)
+                    .build();
+
+            var text = "first add 2 and 3, then multiple 6 by 7.";
+
+            // when
+            var response = assistant.chat(text);
+
+            // then
+            assertThat(response.content()).isNull();  // all tools have return direct set
+            assertThat(response.toolExecutions()).hasSize(2);  // both tools called simultaneously
+
+            assertThat(response.toolExecutions().get(0).result()).isEqualTo("5");
+            assertThat(response.toolExecutions().get(0).request().name()).isEqualTo("add");
+
+            assertThat(response.toolExecutions().get(1).result()).isEqualTo("42");
+            assertThat(response.toolExecutions().get(1).request().name()).isEqualTo("multiply");
+
+            // verify tool executions
+            verify(firstTool).add(2, 3);
+            verify(secondTool).multiply(6, 7);
+            verifyNoMoreInteractions(firstTool, secondTool);
+
+            if (verifyModelInteractions()) {
+                verify(model).supportedCapabilities();
+                verify(model, times(1)).generate(anyList(), toolSpecificationCaptor.capture());  // 1 times = 1 tool requests return direct
+                verifyNoMoreInteractions(model);
+
+                var toolSpecifications = toolSpecificationCaptor.getValue();
+                assertThat(toolSpecifications).hasSize(2);
+            }
+        }
+    }
+
+
+
+
+    static class FirstToolReturnDirectFalse {
+        @Tool(returnDirectly = false)
+        int add(int a, int b) {
+            return a + b;
+        }
+
+        static JsonSchemaElement EXPECTED_SCHEMA = JsonObjectSchema.builder()
+                .addIntegerProperty("arg0")
+                .addIntegerProperty("arg1")
+                .required("arg0", "arg1")
+                .build();
+    }
+
+    static class FirstToolReturnDirectTrue {
+        @Tool(returnDirectly = true)
+        int add(int a, int b) {
+            return a + b;
+        }
+
+        static JsonSchemaElement EXPECTED_SCHEMA = JsonObjectSchema.builder()
+                .addIntegerProperty("arg0")
+                .addIntegerProperty("arg1")
+                .required("arg0", "arg1")
+                .build();
+    }
+
+    static class SecondToolReturnDirectTrue {
+        @Tool(returnDirectly = true)
+        int multiply(int a, int b) {
+            return a * b;
+        }
+
+        static JsonSchemaElement EXPECTED_SCHEMA = JsonObjectSchema.builder()
+                .addIntegerProperty("arg0")
+                .addIntegerProperty("arg1")
+                .required("arg0", "arg1")
+                .build();
+    }
+
     protected boolean verifyModelInteractions() {
         return false;
     }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
@@ -773,7 +773,7 @@ public abstract class AiServicesWithNewToolsIT {
             var response = assistant.chat(text);
 
             // then
-            assertThat(response.content()).isNull();  // should only contain tool executions
+            assertThat(response.content()).isEqualTo("124");
             assertThat(response.toolExecutions().size()).isEqualTo(1);
             assertThat(response.toolExecutions().get(0).result()).isEqualTo("124");
 
@@ -783,7 +783,6 @@ public abstract class AiServicesWithNewToolsIT {
             if (verifyModelInteractions()) {
                 verify(model).supportedCapabilities();
                 verify(model, times(1)).chat(chatRequestCaptor.capture());  // only 1 time, to call the tool
-                verifyNoMoreInteractions(model);
 
                 var toolSpecifications = chatRequestCaptor.getValue().toolSpecifications();
                 assertThat(toolSpecifications).hasSize(1);
@@ -816,7 +815,9 @@ public abstract class AiServicesWithNewToolsIT {
             var response = assistant.chat(text);
 
             // then
-            assertThat(response.content()).contains("20");  // since multiple tools are called without return raw set, content is returned
+            assertThat(response.content()).contains("20");
+            // the result is not only "20" but is manipulated by the LLM since one of the 2 tools doesn't have raw return
+            assertThat(response.content()).isNotEqualTo("20");
             assertThat(response.toolExecutions()).hasSize(2);
 
             assertThat(response.toolExecutions().get(0).result()).isEqualTo("5");
@@ -833,7 +834,6 @@ public abstract class AiServicesWithNewToolsIT {
             if (verifyModelInteractions()) {
                 verify(model).supportedCapabilities();
                 verify(model, times(3)).chat(chatRequestCaptor.capture());  // 3 times = 2 tool requests + summary
-                verifyNoMoreInteractions(model);
 
                 var toolSpecifications = chatRequestCaptor.getValue().toolSpecifications();
                 assertThat(toolSpecifications).hasSize(2);
@@ -862,8 +862,8 @@ public abstract class AiServicesWithNewToolsIT {
             var response = assistant.chat(text);
 
             // then
-            assertThat(response.content()).isNull();  // all tools have return raw set
-            assertThat(response.toolExecutions()).hasSize(1);  // second tool couldn't be called, first returned raw
+            assertThat(response.content()).isEqualTo("20");
+            assertThat(response.toolExecutions()).hasSize(2);  // both tools are return raw and get called
 
             assertThat(response.toolExecutions().get(0).result()).isEqualTo("5");
             assertThat(response.toolExecutions().get(0).request().name()).isEqualTo("add");
@@ -874,8 +874,7 @@ public abstract class AiServicesWithNewToolsIT {
 
             if (verifyModelInteractions()) {
                 verify(model).supportedCapabilities();
-                verify(model, times(1)).chat(chatRequestCaptor.capture());  // 1 times = 1 tool requests return raw
-                verifyNoMoreInteractions(model);
+                verify(model, times(3)).chat(chatRequestCaptor.capture());
 
                 var toolSpecifications = chatRequestCaptor.getValue().toolSpecifications();
                 assertThat(toolSpecifications).hasSize(2);
@@ -904,7 +903,7 @@ public abstract class AiServicesWithNewToolsIT {
             var response = assistant.chat(text);
 
             // then
-            assertThat(response.content()).isNull();  // all tools have return raw set
+            assertThat(response.content()).isEqualTo("42");
             assertThat(response.toolExecutions()).hasSize(2);  // both tools called simultaneously
 
             assertThat(response.toolExecutions().get(0).result()).isEqualTo("5");
@@ -920,8 +919,7 @@ public abstract class AiServicesWithNewToolsIT {
 
             if (verifyModelInteractions()) {
                 verify(model).supportedCapabilities();
-                verify(model, times(1)).chat(chatRequestCaptor.capture());  // 1 times = 1 tool requests return raw
-                verifyNoMoreInteractions(model);
+                verify(model, times(2)).chat(chatRequestCaptor.capture());
 
                 var toolSpecifications = chatRequestCaptor.getValue().toolSpecifications();
                 assertThat(toolSpecifications).hasSize(2);

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithNewToolsIT.java
@@ -30,7 +30,6 @@ import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.model.output.Response;
 import java.time.LocalTime;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -783,10 +782,10 @@ public abstract class AiServicesWithNewToolsIT {
 
             if (verifyModelInteractions()) {
                 verify(model).supportedCapabilities();
-                verify(model, times(1)).generate(anyList(), toolSpecificationCaptor.capture());  // only 1 time, to call the tool
+                verify(model, times(1)).chat(chatRequestCaptor.capture());  // only 1 time, to call the tool
                 verifyNoMoreInteractions(model);
 
-                var toolSpecifications = toolSpecificationCaptor.getValue();
+                var toolSpecifications = chatRequestCaptor.getValue().toolSpecifications();
                 assertThat(toolSpecifications).hasSize(1);
                 var toolSpecification = toolSpecifications.get(0);
                 assertThat(toolSpecification.name()).isEqualTo("add");
@@ -833,10 +832,10 @@ public abstract class AiServicesWithNewToolsIT {
 
             if (verifyModelInteractions()) {
                 verify(model).supportedCapabilities();
-                verify(model, times(3)).generate(anyList(), toolSpecificationCaptor.capture());  // 3 times = 2 tool requests + summary
+                verify(model, times(3)).chat(chatRequestCaptor.capture());  // 3 times = 2 tool requests + summary
                 verifyNoMoreInteractions(model);
 
-                var toolSpecifications = toolSpecificationCaptor.getValue();
+                var toolSpecifications = chatRequestCaptor.getValue().toolSpecifications();
                 assertThat(toolSpecifications).hasSize(2);
             }
         }
@@ -875,10 +874,10 @@ public abstract class AiServicesWithNewToolsIT {
 
             if (verifyModelInteractions()) {
                 verify(model).supportedCapabilities();
-                verify(model, times(1)).generate(anyList(), toolSpecificationCaptor.capture());  // 1 times = 1 tool requests return raw
+                verify(model, times(1)).chat(chatRequestCaptor.capture());  // 1 times = 1 tool requests return raw
                 verifyNoMoreInteractions(model);
 
-                var toolSpecifications = toolSpecificationCaptor.getValue();
+                var toolSpecifications = chatRequestCaptor.getValue().toolSpecifications();
                 assertThat(toolSpecifications).hasSize(2);
             }
         }
@@ -921,10 +920,10 @@ public abstract class AiServicesWithNewToolsIT {
 
             if (verifyModelInteractions()) {
                 verify(model).supportedCapabilities();
-                verify(model, times(1)).generate(anyList(), toolSpecificationCaptor.capture());  // 1 times = 1 tool requests return raw
+                verify(model, times(1)).chat(chatRequestCaptor.capture());  // 1 times = 1 tool requests return raw
                 verifyNoMoreInteractions(model);
 
-                var toolSpecifications = toolSpecificationCaptor.getValue();
+                var toolSpecifications = chatRequestCaptor.getValue().toolSpecifications();
                 assertThat(toolSpecifications).hasSize(2);
             }
         }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
@@ -749,6 +749,7 @@ class AiServicesWithToolsIT {
         Response<AiMessage> response = assistant.chat("When does my booking 123-456 starts?");
         assertThat(response.content().text()).contains("2027");
         verify(toolExecutor).execute(any(), any());
+        verify(toolExecutor).returnRaw();
         verifyNoMoreInteractions(toolExecutor);
     }
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -286,7 +286,7 @@ class DefaultToolExecutorTest implements WithAssertions {
 
     private static class TestToolReturnDirectly {
 
-        @Tool(returnDirectly = true)
+        @Tool(directReturn = true)
         public int addOne(int num) {
             return num + 1;
         }
@@ -333,7 +333,7 @@ class DefaultToolExecutorTest implements WithAssertions {
 
         DefaultToolExecutor toolExecutor = new DefaultToolExecutor(new TestToolReturnDirectly(), request);
 
-        assertThat(toolExecutor.isReturnDirectly()).isTrue();
+        assertThat(toolExecutor.isDirectReturn()).isTrue();
     }
 
     @Test
@@ -346,7 +346,7 @@ class DefaultToolExecutorTest implements WithAssertions {
 
         DefaultToolExecutor toolExecutor = new DefaultToolExecutor(new TestTool(), request);
 
-        assertThat(toolExecutor.isReturnDirectly()).isFalse();
+        assertThat(toolExecutor.isDirectReturn()).isFalse();
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -284,9 +284,9 @@ class DefaultToolExecutorTest implements WithAssertions {
         }
     }
 
-    private static class TestToolReturnDirectly {
+    private static class TestToolReturnRaw {
 
-        @Tool(directReturn = true)
+        @Tool(rawReturn = true)
         public int addOne(int num) {
             return num + 1;
         }
@@ -324,20 +324,20 @@ class DefaultToolExecutorTest implements WithAssertions {
     }
 
     @Test
-    public void test_get_return_directly_true() {
+    public void test_get_return_raw_true() {
         ToolExecutionRequest request = ToolExecutionRequest.builder()
                 .id("1")
                 .name("addOne")
                 .arguments("{ \"arg0\": 2 }")
                 .build();
 
-        DefaultToolExecutor toolExecutor = new DefaultToolExecutor(new TestToolReturnDirectly(), request);
+        DefaultToolExecutor toolExecutor = new DefaultToolExecutor(new TestToolReturnRaw(), request);
 
-        assertThat(toolExecutor.isDirectReturn()).isTrue();
+        assertThat(toolExecutor.isRawReturn()).isTrue();
     }
 
     @Test
-    public void test_get_return_directly_false() {
+    public void test_get_return_raw_false() {
         ToolExecutionRequest request = ToolExecutionRequest.builder()
                 .id("1")
                 .name("addOne")
@@ -346,7 +346,7 @@ class DefaultToolExecutorTest implements WithAssertions {
 
         DefaultToolExecutor toolExecutor = new DefaultToolExecutor(new TestTool(), request);
 
-        assertThat(toolExecutor.isDirectReturn()).isFalse();
+        assertThat(toolExecutor.isRawReturn()).isFalse();
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -284,6 +284,14 @@ class DefaultToolExecutorTest implements WithAssertions {
         }
     }
 
+    private static class TestToolReturnDirectly {
+
+        @Tool(returnDirectly = true)
+        public int addOne(int num) {
+            return num + 1;
+        }
+    }
+
     @Test
     void should_execute_tool_by_method_name() throws NoSuchMethodException {
         ToolExecutionRequest request = ToolExecutionRequest.builder()
@@ -316,7 +324,33 @@ class DefaultToolExecutorTest implements WithAssertions {
     }
 
     @Test
-    void should_not_execute_tool_with_wrong_execution_request() throws NoSuchMethodException {
+    public void test_get_return_directly_true() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("1")
+                .name("addOne")
+                .arguments("{ \"arg0\": 2 }")
+                .build();
+
+        DefaultToolExecutor toolExecutor = new DefaultToolExecutor(new TestToolReturnDirectly(), request);
+
+        assertThat(toolExecutor.isReturnDirectly()).isTrue();
+    }
+
+    @Test
+    public void test_get_return_directly_false() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("1")
+                .name("addOne")
+                .arguments("{ \"arg0\": 2 }")
+                .build();
+
+        DefaultToolExecutor toolExecutor = new DefaultToolExecutor(new TestTool(), request);
+
+        assertThat(toolExecutor.isReturnDirectly()).isFalse();
+    }
+
+    @Test
+    public void should_not_execute_tool_with_wrong_execution_request() throws NoSuchMethodException {
         ToolExecutionRequest request = ToolExecutionRequest.builder()
                 .id("1")
                 .name("unknownMethod")

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -286,7 +286,7 @@ class DefaultToolExecutorTest implements WithAssertions {
 
     private static class TestToolReturnRaw {
 
-        @Tool(rawReturn = true)
+        @Tool(returnRaw = true)
         public int addOne(int num) {
             return num + 1;
         }
@@ -333,7 +333,7 @@ class DefaultToolExecutorTest implements WithAssertions {
 
         DefaultToolExecutor toolExecutor = new DefaultToolExecutor(new TestToolReturnRaw(), request);
 
-        assertThat(toolExecutor.isRawReturn()).isTrue();
+        assertThat(toolExecutor.returnRaw()).isTrue();
     }
 
     @Test
@@ -346,7 +346,7 @@ class DefaultToolExecutorTest implements WithAssertions {
 
         DefaultToolExecutor toolExecutor = new DefaultToolExecutor(new TestTool(), request);
 
-        assertThat(toolExecutor.isRawReturn()).isFalse();
+        assertThat(toolExecutor.returnRaw()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
This is a review, rebase and reimplementation of https://github.com/langchain4j/langchain4j/pull/2291

I'm putting it here, in a different pull request because it changes a bit the logic of the original implementation, but in my opinion this is more correct. In fact it executes all the tools needed by the AI service and returns the tool result instead of the LLM one if and only if all those tools executions used tools annotated with raw return.

