### PR TITLE
Fix ITs : Aws Nova models now support requiring a tool execution

### DIFF
--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatModelNovaWithVisionIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatModelNovaWithVisionIT.java
@@ -44,13 +44,6 @@ class BedrockChatModelNovaWithVisionIT extends AbstractChatModelIT {
                 .build();
     }
 
-    // ToolChoice "only supported by Anthropic Claude 3 models and by Mistral AI Mistral Large" from
-    // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
-    @Override
-    protected boolean supportsToolChoiceRequired() {
-        return false;
-    }
-
     // output format not supported
     @Override
     protected boolean supportsJsonResponseFormat() {

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatModelWithoutVisionIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatModelWithoutVisionIT.java
@@ -105,7 +105,7 @@ class BedrockChatModelWithoutVisionIT extends AbstractChatModelIT {
     @MethodSource("modelsSupportingTools")
     @DisabledIf("supportsToolChoiceRequired")
     protected void should_fail_if_tool_choice_REQUIRED_is_not_supported(ChatLanguageModel model) {
-        if (model.equals(MISTRAL_LARGE)) {
+        if (List.of(MISTRAL_LARGE, AWS_NOVA_MICRO).contains(model)) {
             super.should_force_LLM_to_execute_any_tool(model);
         } else {
             super.should_fail_if_tool_choice_REQUIRED_is_not_supported(model);


### PR DESCRIPTION
Amazon Nova models now support requiring a tool execution : https://aws.amazon.com/about-aws/whats-new/2025/03/amazon-nova-expands-tool-converse-api/

## Issue
Closes #

## Change
BedrockChatModelNovaWithVisionIT.java and BedrockChatModelWithoutVisionIT.java now has supportsToolChoiceRequired() returning true


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
