### PR TITLE
Dynamic updates and caching of the MCP tool list

### DIFF
--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolUpdatesHttpTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolUpdatesHttpTransportIT.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.skipTestsIfJbangNotAvailable;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.startServerHttp;
+
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class McpToolUpdatesHttpTransportIT extends McpToolUpdatesTestBase {
+
+    private static final Logger log = LoggerFactory.getLogger(McpToolUpdatesHttpTransportIT.class);
+    private static Process process;
+
+    @BeforeAll
+    static void setup() throws IOException, InterruptedException, TimeoutException {
+        skipTestsIfJbangNotAvailable();
+        process = startServerHttp("tool_list_updates_mcp_server.java");
+        McpTransport transport = new HttpMcpTransport.Builder()
+                .sseUrl("http://localhost:8080/mcp/sse")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+        mcpClient = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .toolExecutionTimeout(Duration.ofSeconds(4))
+                .build();
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (mcpClient != null) {
+            mcpClient.close();
+        }
+        if (process != null && process.isAlive()) {
+            process.destroyForcibly();
+        }
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolUpdatesStdioTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolUpdatesStdioTransportIT.java
@@ -1,0 +1,39 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getJBangCommand;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getPathToScript;
+
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+class McpToolUpdatesStdioTransportIT extends McpToolUpdatesTestBase {
+
+    @BeforeAll
+    static void setup() {
+        McpTransport transport = new StdioMcpTransport.Builder()
+                .command(List.of(
+                        getJBangCommand(),
+                        "--quiet",
+                        "--fresh",
+                        "run",
+                        getPathToScript("tool_list_updates_mcp_server.java")))
+                .logEvents(true)
+                .build();
+        mcpClient = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .toolExecutionTimeout(Duration.ofSeconds(4))
+                .build();
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (mcpClient != null) {
+            mcpClient.close();
+        }
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolUpdatesTestBase.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolUpdatesTestBase.java
@@ -1,0 +1,43 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.McpClient;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public abstract class McpToolUpdatesTestBase {
+
+    static McpClient mcpClient;
+
+    @Test
+    public void verifyToolSpecifications() throws InterruptedException {
+        List<ToolSpecification> tools = mcpClient.listTools();
+        assertThat(tools).hasSize(1);
+        assertThat(tools.get(0).name()).isEqualTo("registerNewTool");
+
+        // now trigger the registration of a new tool on the server
+        mcpClient.executeTool(ToolExecutionRequest.builder()
+                .name("registerNewTool")
+                .arguments("{}")
+                .build());
+
+        // check that the client has received a tool list notification and updated its tool list
+        List<ToolSpecification> toolsAfterAddingANewTool = mcpClient.listTools();
+        assertThat(toolsAfterAddingANewTool).hasSize(2);
+
+        assertThat(findToolSpecificationByName(toolsAfterAddingANewTool, "registerNewTool"))
+                .isNotNull();
+        assertThat(findToolSpecificationByName(toolsAfterAddingANewTool, "toLowerCase"))
+                .isNotNull();
+    }
+
+    ToolSpecification findToolSpecificationByName(List<ToolSpecification> toolSpecifications, String name) {
+        return toolSpecifications.stream()
+                .filter(t -> t.name().equals(name))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/langchain4j-mcp/src/test/resources/logging_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/logging_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.0.CR1
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.0.CR1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.1
 //Q:CONFIG quarkus.mcp.server.client-logging.default-level=DEBUG
 
 import java.util.List;

--- a/langchain4j-mcp/src/test/resources/prompts_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/prompts_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.0.CR1
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.0.CR1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.1
 
 import java.util.ArrayList;
 import java.util.List;

--- a/langchain4j-mcp/src/test/resources/resources_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/resources_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.0.CR1
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.0.CR1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.1
 
 import java.util.ArrayList;
 import java.util.List;

--- a/langchain4j-mcp/src/test/resources/tool_list_updates_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/tool_list_updates_mcp_server.java
@@ -1,0 +1,32 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.0
+
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
+
+import io.quarkiverse.mcp.server.ToolManager;
+import jakarta.inject.Inject;
+
+// Server used for testing dynamic changes to the tool list
+public class tool_list_updates_mcp_server {
+
+    @Inject
+    ToolManager toolManager;
+
+    // we use this just as a way to tell the server that it should register a new tool
+    @Tool
+    public String registerNewTool() {
+        toolManager.newTool("toLowerCase")
+                .setDescription("Converts input string to lower case.")
+                .addArgument("value", "Value to convert", true, String.class)
+                .setHandler(
+                        ta -> ToolResponse.success(ta.args().get("value").toString().toLowerCase()))
+                .register();
+        return "OK";
+    }
+
+}

--- a/langchain4j-mcp/src/test/resources/tool_list_updates_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/tool_list_updates_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.0
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.1
 
 import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.Tool;

--- a/langchain4j-mcp/src/test/resources/tools_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/tools_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.0.CR1
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.0.CR1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.1
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
## Issue
Closes #2263

## Change
Properly receiving the `notifications/tools/list_changed` notification from the MCP server and only requesting a new list of tools after that.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green

