### PR TITLE
Refactor AiServiceTokenStream constructor with pilot way for encapsulating parameters

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStreamParameters.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStreamParameters.java
@@ -1,0 +1,174 @@
+package dev.langchain4j.service;
+
+import static dev.langchain4j.internal.Utils.copyIfNotNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parameters for creating an {@link AiServiceTokenStream}.
+ */
+public class AiServiceTokenStreamParameters {
+    private final List<ChatMessage> messages;
+    private final List<ToolSpecification> toolSpecifications;
+    private final Map<String, ToolExecutor> toolExecutors;
+    private final List<Content> retrievedContents;
+    private final AiServiceContext context;
+    private final Object memoryId;
+
+    protected AiServiceTokenStreamParameters(Builder builder) {
+        this.messages = ensureNotEmpty(builder.messages, "messages");
+        this.toolSpecifications = copyIfNotNull(builder.toolSpecifications);
+        this.toolExecutors = copyIfNotNull(builder.toolExecutors);
+        this.retrievedContents = builder.retrievedContents;
+        this.context = ensureNotNull(builder.context, "context");
+        this.memoryId = ensureNotNull(builder.memoryId, "memoryId");
+        ensureNotNull(context.streamingChatModel, "streamingChatModel");
+    }
+
+    /**
+     * @return the messages
+     */
+    public List<ChatMessage> getMessages() {
+        return messages;
+    }
+
+    /**
+     * @return the tool specifications
+     */
+    public List<ToolSpecification> getToolSpecifications() {
+        return toolSpecifications;
+    }
+
+    /**
+     * @return the tool executors
+     */
+    public Map<String, ToolExecutor> getToolExecutors() {
+        return toolExecutors;
+    }
+
+    /**
+     * @return the retrieved contents
+     */
+    public List<Content> getRetrievedContents() {
+        return retrievedContents;
+    }
+
+    /**
+     * @return the AI service context
+     */
+    public AiServiceContext getContext() {
+        return context;
+    }
+
+    /**
+     * @return the memory ID
+     */
+    public Object getMemoryId() {
+        return memoryId;
+    }
+
+    /**
+     * Creates a new builder for {@link AiServiceTokenStreamParameters}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link AiServiceTokenStreamParameters}.
+     */
+    public static class Builder {
+        private List<ChatMessage> messages;
+        private List<ToolSpecification> toolSpecifications;
+        private Map<String, ToolExecutor> toolExecutors;
+        private List<Content> retrievedContents;
+        private AiServiceContext context;
+        private Object memoryId;
+
+        protected Builder() {}
+
+        /**
+         * Sets the messages.
+         *
+         * @param messages the messages
+         * @return this builder
+         */
+        public Builder messages(List<ChatMessage> messages) {
+            this.messages = messages;
+            return this;
+        }
+
+        /**
+         * Sets the tool specifications.
+         *
+         * @param toolSpecifications the tool specifications
+         * @return this builder
+         */
+        public Builder toolSpecifications(List<ToolSpecification> toolSpecifications) {
+            this.toolSpecifications = toolSpecifications;
+            return this;
+        }
+
+        /**
+         * Sets the tool executors.
+         *
+         * @param toolExecutors the tool executors
+         * @return this builder
+         */
+        public Builder toolExecutors(Map<String, ToolExecutor> toolExecutors) {
+            this.toolExecutors = toolExecutors;
+            return this;
+        }
+
+        /**
+         * Sets the retrieved contents.
+         *
+         * @param retrievedContents the retrieved contents
+         * @return this builder
+         */
+        public Builder retrievedContents(List<Content> retrievedContents) {
+            this.retrievedContents = retrievedContents;
+            return this;
+        }
+
+        /**
+         * Sets the AI service context.
+         *
+         * @param context the AI service context
+         * @return this builder
+         */
+        public Builder context(AiServiceContext context) {
+            this.context = context;
+            return this;
+        }
+
+        /**
+         * Sets the memory ID.
+         *
+         * @param memoryId the memory ID
+         * @return this builder
+         */
+        public Builder memoryId(Object memoryId) {
+            this.memoryId = memoryId;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link AiServiceTokenStreamParameters}.
+         *
+         * @return a new {@link AiServiceTokenStreamParameters}
+         */
+        public AiServiceTokenStreamParameters build() {
+            return new AiServiceTokenStreamParameters(this);
+        }
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
@@ -1,34 +1,30 @@
 package dev.langchain4j.service;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.rag.content.Content;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-
 @ExtendWith(MockitoExtension.class)
 class AiServiceTokenStreamTest {
 
-    static Consumer<String> DUMMY_PARTIAL_RESPONSE_HANDLER = (partialResponse) -> {
-    };
+    static Consumer<String> DUMMY_PARTIAL_RESPONSE_HANDLER = (partialResponse) -> {};
 
-    static Consumer<Throwable> DUMMY_ERROR_HANDLER = (error) -> {
-    };
+    static Consumer<Throwable> DUMMY_ERROR_HANDLER = (error) -> {};
 
-    static Consumer<ChatResponse> DUMMY_CHAT_RESPONSE_HANDLER = (chatResponse) -> {
-    };
+    static Consumer<ChatResponse> DUMMY_CHAT_RESPONSE_HANDLER = (chatResponse) -> {};
 
     List<ChatMessage> messages = new ArrayList<>();
 
@@ -48,17 +44,14 @@ class AiServiceTokenStreamTest {
 
     @Test
     void start_with_onPartialResponse_shouldNotThrowException() {
-        tokenStream
-                .onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER)
-                .ignoreErrors();
+        tokenStream.onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER).ignoreErrors();
 
         assertThatNoException().isThrownBy(() -> tokenStream.start());
     }
 
     @Test
     void start_onPartialResponseNotInvoked_shouldThrowException() {
-        tokenStream
-                .ignoreErrors();
+        tokenStream.ignoreErrors();
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
@@ -79,8 +72,7 @@ class AiServiceTokenStreamTest {
 
     @Test
     void start_onErrorNorIgnoreErrorsInvoked_shouldThrowException() {
-        tokenStream
-                .onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER);
+        tokenStream.onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER);
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
@@ -116,6 +108,11 @@ class AiServiceTokenStreamTest {
         StreamingChatLanguageModel model = mock(StreamingChatLanguageModel.class);
         AiServiceContext context = new AiServiceContext(getClass());
         context.streamingChatModel = model;
-        return new AiServiceTokenStream(messages, null, null, content, context, memoryId);
+        return new AiServiceTokenStream(AiServiceTokenStreamParameters.builder()
+                .messages(messages)
+                .retrievedContents(content)
+                .context(context)
+                .memoryId(memoryId)
+                .build());
     }
 }


### PR DESCRIPTION
This is somewhat of a POC for how we may in the future encapsulate classes with large numbers of parameters in their constructors.

This would allow it to be backwards-compatible and non-breaking whenever parameters to a constructor on public-facing objects are created.