### PR TITLE
Automatic reconnect for MCP over HTTP

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -64,6 +64,7 @@ public class DefaultMcpClient implements McpClient {
     private final AtomicReference<List<ToolSpecification>> toolListRefs = new AtomicReference<>();
     private final AtomicBoolean toolListOutOfDate = new AtomicBoolean(true);
     private final AtomicReference<CompletableFuture<Void>> toolListUpdateInProgress = new AtomicReference<>(null);
+    private final Duration reconnectInterval;
 
     public DefaultMcpClient(Builder builder) {
         transport = ensureNotNull(builder.transport, "transport");
@@ -75,6 +76,7 @@ public class DefaultMcpClient implements McpClient {
         promptsTimeout = getOrDefault(builder.promptsTimeout, Duration.ofSeconds(60));
         logHandler = getOrDefault(builder.logHandler, new DefaultMcpLogMessageHandler());
         pingTimeout = getOrDefault(builder.pingTimeout, Duration.ofSeconds(10));
+        reconnectInterval = getOrDefault(builder.reconnectInterval, Duration.ofSeconds(5));
         toolExecutionTimeoutErrorMessage =
                 getOrDefault(builder.toolExecutionTimeoutErrorMessage, "There was a timeout executing the tool");
         RESULT_TIMEOUT = JsonNodeFactory.instance.objectNode();
@@ -86,6 +88,15 @@ public class DefaultMcpClient implements McpClient {
                 .addObject()
                 .put("type", "text")
                 .put("text", toolExecutionTimeoutErrorMessage);
+        transport.onFailure(() -> {
+            try {
+                TimeUnit.MILLISECONDS.sleep(reconnectInterval.toMillis());
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            log.info("Trying to reconnect...");
+            initialize();
+        });
         initialize();
     }
 
@@ -346,6 +357,7 @@ public class DefaultMcpClient implements McpClient {
         private Duration pingTimeout;
         private Duration promptsTimeout;
         private McpLogMessageHandler logHandler;
+        private Duration reconnectInterval;
 
         public Builder transport(McpTransport transport) {
             this.transport = transport;
@@ -439,6 +451,15 @@ public class DefaultMcpClient implements McpClient {
          */
         public Builder pingTimeout(Duration pingTimeout) {
             this.pingTimeout = pingTimeout;
+            return this;
+        }
+
+        /**
+         * The delay before attempting to reconnect after a failed connection.
+         * The default is 5 seconds.
+         */
+        public Builder reconnectInterval(Duration reconnectInterval) {
+            this.reconnectInterval = reconnectInterval;
             return this;
         }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
@@ -42,4 +42,6 @@ public interface McpTransport extends Closeable {
      * that the server subprocess isn't alive anymore.
      */
     void checkHealth();
+
+    void onFailure(Runnable actionOnFailure);
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
@@ -36,6 +36,7 @@ public class HttpMcpTransport implements McpTransport {
     private final boolean logRequests;
     private EventSource mcpSseEventListener;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private volatile Runnable onFailure;
 
     // this is obtained from the server after initializing the SSE channel
     private volatile String postUrl;
@@ -104,6 +105,11 @@ public class HttpMcpTransport implements McpTransport {
         // no transport-specific checks right now
     }
 
+    @Override
+    public void onFailure(Runnable actionOnFailure) {
+        this.onFailure = actionOnFailure;
+    }
+
     private CompletableFuture<JsonNode> execute(Request request, Long id) {
         CompletableFuture<JsonNode> future = new CompletableFuture<>();
         if (id != null) {
@@ -137,7 +143,8 @@ public class HttpMcpTransport implements McpTransport {
     private EventSource startSseChannel(boolean logResponses) {
         Request request = new Request.Builder().url(sseUrl).build();
         CompletableFuture<String> initializationFinished = new CompletableFuture<>();
-        SseEventListener listener = new SseEventListener(messageHandler, logResponses, initializationFinished);
+        SseEventListener listener =
+                new SseEventListener(messageHandler, logResponses, initializationFinished, onFailure);
         EventSource eventSource = EventSources.createFactory(client).newEventSource(request, listener);
         // wait for the SSE channel to be created, receive the POST url from the server, throw an exception if that
         // failed

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseEventListener.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseEventListener.java
@@ -19,12 +19,17 @@ public class SseEventListener extends EventSourceListener {
     // this will contain the POST url for sending commands to the server
     private final CompletableFuture<String> initializationFinished;
     private final McpOperationHandler messageHandler;
+    private final Runnable onFailure;
 
     public SseEventListener(
-            McpOperationHandler messageHandler, boolean logEvents, CompletableFuture initializationFinished) {
+            McpOperationHandler messageHandler,
+            boolean logEvents,
+            CompletableFuture initializationFinished,
+            Runnable onFailure) {
         this.messageHandler = messageHandler;
         this.logEvents = logEvents;
         this.initializationFinished = initializationFinished;
+        this.onFailure = onFailure;
     }
 
     @Override
@@ -65,6 +70,9 @@ public class SseEventListener extends EventSourceListener {
         }
         if (t != null && (t.getMessage() == null || !t.getMessage().contains("Socket closed"))) {
             log.warn("SSE channel failure", t);
+            if (onFailure != null) {
+                onFailure.run();
+            }
         }
     }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
@@ -94,6 +94,11 @@ public class StdioMcpTransport implements McpTransport {
     }
 
     @Override
+    public void onFailure(Runnable actionOnFailure) {
+        // ignore, for stdio transport, we currently don't do reconnection attempts
+    }
+
+    @Override
     public void close() throws IOException {
         process.destroy();
     }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpReconnectIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpReconnectIT.java
@@ -1,0 +1,68 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.skipTestsIfJbangNotAvailable;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.startServerHttp;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class McpReconnectIT {
+
+    private static Process process;
+    private static DefaultMcpClient mcpClient;
+
+    @BeforeAll
+    static void setup() throws IOException, InterruptedException, TimeoutException {
+        skipTestsIfJbangNotAvailable();
+        process = startServerHttp("tools_mcp_server.java");
+        McpTransport transport = new HttpMcpTransport.Builder()
+                .sseUrl("http://localhost:8080/mcp/sse")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+        mcpClient = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .toolExecutionTimeout(Duration.ofSeconds(4))
+                .reconnectInterval(Duration.ofSeconds(1))
+                .build();
+    }
+
+    @Test
+    public void testReconnect() throws IOException, TimeoutException, InterruptedException {
+        executeAToolAndAssertSuccess();
+
+        // kill the server and restart it
+        process.destroy();
+        process = startServerHttp("tools_mcp_server.java");
+
+        // give the MCP client some time to reconnect
+        Thread.sleep(5_000);
+
+        executeAToolAndAssertSuccess();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException, InterruptedException {
+        if (process != null) {
+            process.destroyForcibly();
+        }
+    }
+
+    private void executeAToolAndAssertSuccess() {
+        ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
+                .name("echoString")
+                .arguments("{\"input\": \"abc\"}")
+                .build();
+        String result = mcpClient.executeTool(toolExecutionRequest);
+        assertThat(result).isEqualTo("abc");
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/langchain4j/langchain4j/issues/2644
Fixes https://github.com/langchain4j/langchain4j/issues/2858

Probably not super reliable (and requests will fail until the new connection is successfully established), but this is a relatively quick solution to reconnects with the old transport before we implement the new streamable HTTP transport where reconnects will be more straightforward and reliable (because executing operations won't require having an active SSE connection)