### PR TITLE
quarkus-mcp-server update for tests plus a minor test fix

### DIFF
--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpReconnectIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpReconnectIT.java
@@ -52,6 +52,9 @@ public class McpReconnectIT {
 
     @AfterAll
     static void tearDown() throws IOException, InterruptedException {
+        if (mcpClient != null) {
+            mcpClient.close();
+        }
         if (process != null) {
             process.destroyForcibly();
         }

--- a/langchain4j-mcp/src/test/resources/logging_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/logging_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.1
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.1.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.1.0
 //Q:CONFIG quarkus.mcp.server.client-logging.default-level=DEBUG
 
 import java.util.List;

--- a/langchain4j-mcp/src/test/resources/prompts_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/prompts_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.1
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.1.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.1.0
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +15,7 @@ import io.quarkiverse.mcp.server.Prompt;
 import io.quarkiverse.mcp.server.PromptArg;
 import io.quarkiverse.mcp.server.PromptMessage;
 import io.quarkiverse.mcp.server.ResourceContents;
+import io.quarkiverse.mcp.server.Role;
 import io.quarkiverse.mcp.server.TextContent;
 
 public class prompts_mcp_server {
@@ -46,7 +47,7 @@ public class prompts_mcp_server {
     PromptMessage embeddedBinaryResource() {
         ResourceContents blob = new BlobResourceContents("file:///embedded-blob", "aaaaa", "application/octet-stream");
         Content content = new EmbeddedResource(blob);
-        return new PromptMessage("user", content);
+        return new PromptMessage(Role.USER, content);
     }
 
 }

--- a/langchain4j-mcp/src/test/resources/resources_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/resources_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.1
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.1.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.1.0
 
 import java.util.ArrayList;
 import java.util.List;

--- a/langchain4j-mcp/src/test/resources/tool_list_updates_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/tool_list_updates_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.1
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.1.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.1.0
 
 import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.Tool;

--- a/langchain4j-mcp/src/test/resources/tools_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/tools_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.1
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.0.1
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.1.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.1.0
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Properly close the client in one of the tests to avoid spamming the log of subsequent tests with failed reconnect attempts