### PR TITLE
Use info as the HTTP logging level

### DIFF
--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClientBuilderLoader.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClientBuilderLoader.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.http.client;
 
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+
 import java.util.Collection;
 import java.util.List;
-
-import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 
 public class HttpClientBuilderLoader {
 
@@ -14,8 +14,10 @@ public class HttpClientBuilderLoader {
             List<String> factoryNames = factories.stream()
                     .map(factory -> factory.getClass().getName())
                     .toList();
-            throw new IllegalStateException(String.format("Conflict: multiple HTTP clients have been found " +
-                    "in the classpath: %s. Please explicitly specify the one you wish to use.", factoryNames));
+            throw new IllegalStateException(String.format(
+                    "Conflict: multiple HTTP clients have been found "
+                            + "in the classpath: %s. Please explicitly specify the one you wish to use.",
+                    factoryNames));
         }
 
         for (HttpClientBuilderFactory factory : factories) {

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpMethod.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpMethod.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.http.client;
 
 public enum HttpMethod {
-
     GET,
     POST,
     DELETE

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
@@ -1,15 +1,15 @@
 package dev.langchain4j.http.client;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static java.util.Arrays.asList;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class HttpRequest {
 
@@ -52,8 +52,7 @@ public class HttpRequest {
         private Map<String, List<String>> headers;
         private String body;
 
-        private Builder() {
-        }
+        private Builder() {}
 
         public Builder method(HttpMethod method) {
             this.method = method;

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/SuccessfulHttpResponse.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/SuccessfulHttpResponse.java
@@ -1,11 +1,10 @@
 package dev.langchain4j.http.client;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.ValidationUtils.ensureBetween;
+
+import java.util.List;
+import java.util.Map;
 
 public class SuccessfulHttpResponse {
 
@@ -41,8 +40,7 @@ public class SuccessfulHttpResponse {
         private Map<String, List<String>> headers;
         private String body;
 
-        private Builder() {
-        }
+        private Builder() {}
 
         public Builder statusCode(int statusCode) {
             this.statusCode = statusCode;

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
@@ -1,18 +1,17 @@
 package dev.langchain4j.http.client.log;
 
-import dev.langchain4j.Internal;
-import dev.langchain4j.http.client.HttpRequest;
-import org.slf4j.Logger;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+
+import dev.langchain4j.Internal;
+import dev.langchain4j.http.client.HttpRequest;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
 
 @Internal
 class HttpRequestLogger {
@@ -22,14 +21,18 @@ class HttpRequestLogger {
 
     static void log(Logger log, HttpRequest httpRequest) {
         try {
-            log.info("""
+            log.info(
+                    """
                             HTTP request:
                             - method: {}
                             - url: {}
                             - headers: {}
                             - body: {}
                             """,
-                    httpRequest.method(), httpRequest.url(), format(httpRequest.headers()), httpRequest.body());
+                    httpRequest.method(),
+                    httpRequest.url(),
+                    format(httpRequest.headers()),
+                    httpRequest.body());
         } catch (Exception e) {
             log.warn("Exception occurred while logging HTTP request: {}", e.getMessage());
         }
@@ -43,9 +46,8 @@ class HttpRequestLogger {
 
     static String format(String headerKey, List<String> headerValues) {
         if (COMMON_SECRET_HEADERS.contains(headerKey.toLowerCase())) {
-            headerValues = headerValues.stream()
-                    .map(HttpRequestLogger::maskSecretKey)
-                    .collect(toList());
+            headerValues =
+                    headerValues.stream().map(HttpRequestLogger::maskSecretKey).collect(toList());
         }
 
         if (headerValues.size() == 1) {

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
@@ -22,7 +22,7 @@ class HttpRequestLogger {
 
     static void log(Logger log, HttpRequest httpRequest) {
         try {
-            log.debug("""
+            log.info("""
                             HTTP request:
                             - method: {}
                             - url: {}

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpResponseLogger.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpResponseLogger.java
@@ -1,23 +1,26 @@
 package dev.langchain4j.http.client.log;
 
+import static dev.langchain4j.http.client.log.HttpRequestLogger.format;
+
 import dev.langchain4j.Internal;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import org.slf4j.Logger;
-
-import static dev.langchain4j.http.client.log.HttpRequestLogger.format;
 
 @Internal
 class HttpResponseLogger {
 
     static void log(Logger log, SuccessfulHttpResponse response) {
         try {
-            log.info("""
+            log.info(
+                    """
                             HTTP response:
                             - status code: {}
                             - headers: {}
                             - body: {}
                             """,
-                    response.statusCode(), format(response.headers()), response.body());
+                    response.statusCode(),
+                    format(response.headers()),
+                    response.body());
         } catch (Exception e) {
             log.warn("Exception occurred while logging HTTP response: {}", e.getMessage());
         }

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpResponseLogger.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpResponseLogger.java
@@ -11,7 +11,7 @@ class HttpResponseLogger {
 
     static void log(Logger log, SuccessfulHttpResponse response) {
         try {
-            log.debug("""
+            log.info("""
                             HTTP response:
                             - status code: {}
                             - headers: {}

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/LoggingHttpClient.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/LoggingHttpClient.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.http.client.log;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import dev.langchain4j.Internal;
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.http.client.HttpClient;
@@ -10,9 +13,6 @@ import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 @Internal
 public class LoggingHttpClient implements HttpClient {

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/DefaultServerSentEventParser.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/DefaultServerSentEventParser.java
@@ -1,11 +1,11 @@
 package dev.langchain4j.http.client.sse;
 
+import static dev.langchain4j.http.client.sse.ServerSentEventListenerUtils.ignoringExceptions;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
-import static dev.langchain4j.http.client.sse.ServerSentEventListenerUtils.ignoringExceptions;
 
 public class DefaultServerSentEventParser implements ServerSentEventParser {
 

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/ServerSentEvent.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/ServerSentEvent.java
@@ -1,8 +1,8 @@
 package dev.langchain4j.http.client.sse;
 
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.quoted;
+
+import java.util.Objects;
 
 public class ServerSentEvent {
 
@@ -27,8 +27,7 @@ public class ServerSentEvent {
         if (obj == this) return true;
         if (obj == null || obj.getClass() != this.getClass()) return false;
         var that = (ServerSentEvent) obj;
-        return Objects.equals(this.event, that.event) &&
-                Objects.equals(this.data, that.data);
+        return Objects.equals(this.event, that.event) && Objects.equals(this.data, that.data);
     }
 
     @Override
@@ -38,9 +37,6 @@ public class ServerSentEvent {
 
     @Override
     public String toString() {
-        return "ServerSentEvent {" +
-                " event = " + quoted(event) +
-                ", data = " + quoted(data) +
-                " }";
+        return "ServerSentEvent {" + " event = " + quoted(event) + ", data = " + quoted(data) + " }";
     }
 }

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/ServerSentEventListener.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/ServerSentEventListener.java
@@ -4,15 +4,11 @@ import dev.langchain4j.http.client.SuccessfulHttpResponse;
 
 public interface ServerSentEventListener {
 
-    default void onOpen(SuccessfulHttpResponse response) {
-
-    }
+    default void onOpen(SuccessfulHttpResponse response) {}
 
     void onEvent(ServerSentEvent event);
 
     void onError(Throwable throwable);
 
-    default void onClose() {
-
-    }
+    default void onClose() {}
 }

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/ServerSentEventListenerUtils.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/ServerSentEventListenerUtils.java
@@ -13,8 +13,10 @@ public class ServerSentEventListenerUtils {
         try {
             runnable.run();
         } catch (Exception e) {
-            log.warn("An exception occurred during the invocation of the SSE listener. " +
-                    "This exception has been ignored.", e);
+            log.warn(
+                    "An exception occurred during the invocation of the SSE listener. "
+                            + "This exception has been ignored.",
+                    e);
         }
     }
 }

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientIT.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientIT.java
@@ -1,21 +1,5 @@
 package dev.langchain4j.http.client;
 
-import dev.langchain4j.exception.HttpException;
-import dev.langchain4j.http.client.sse.DefaultServerSentEventParser;
-import dev.langchain4j.http.client.sse.ServerSentEvent;
-import dev.langchain4j.http.client.sse.ServerSentEventListener;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.mockito.InOrder;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
 import static dev.langchain4j.http.client.HttpMethod.POST;
 import static java.util.Collections.synchronizedList;
 import static java.util.Collections.synchronizedSet;
@@ -27,6 +11,21 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
+
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.sse.DefaultServerSentEventParser;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.mockito.InOrder;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 public abstract class HttpClientIT {

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientTimeoutIT.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientTimeoutIT.java
@@ -1,22 +1,5 @@
 package dev.langchain4j.http.client;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import dev.langchain4j.exception.TimeoutException;
-import dev.langchain4j.http.client.sse.DefaultServerSentEventParser;
-import dev.langchain4j.http.client.sse.ServerSentEvent;
-import dev.langchain4j.http.client.sse.ServerSentEventListener;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.time.Duration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-
 import static dev.langchain4j.http.client.HttpMethod.GET;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,6 +9,22 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import dev.langchain4j.exception.TimeoutException;
+import dev.langchain4j.http.client.sse.DefaultServerSentEventParser;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class HttpClientTimeoutIT {
 
@@ -61,9 +60,8 @@ public abstract class HttpClientTimeoutIT {
 
         for (HttpClient client : clients(Duration.ofMillis(readTimeoutMillis))) {
 
-            wireMockServer.stubFor(WireMock.get("/endpoint")
-                    .willReturn(WireMock.aResponse()
-                            .withFixedDelay(readTimeoutMillis * 2)));
+            wireMockServer.stubFor(
+                    WireMock.get("/endpoint").willReturn(WireMock.aResponse().withFixedDelay(readTimeoutMillis * 2)));
 
             HttpRequest request = HttpRequest.builder()
                     .method(GET)
@@ -86,9 +84,8 @@ public abstract class HttpClientTimeoutIT {
 
         for (HttpClient client : clients(Duration.ofMillis(readTimeoutMillis))) {
 
-            wireMockServer.stubFor(WireMock.get("/endpoint")
-                    .willReturn(WireMock.aResponse()
-                            .withFixedDelay(readTimeoutMillis * 2)));
+            wireMockServer.stubFor(
+                    WireMock.get("/endpoint").willReturn(WireMock.aResponse().withFixedDelay(readTimeoutMillis * 2)));
 
             HttpRequest request = HttpRequest.builder()
                     .method(GET)
@@ -96,8 +93,7 @@ public abstract class HttpClientTimeoutIT {
                     .build();
 
             // when
-            record StreamingResult(Throwable throwable, Set<Thread> threads) {
-            }
+            record StreamingResult(Throwable throwable, Set<Thread> threads) {}
 
             CompletableFuture<StreamingResult> completableFuture = new CompletableFuture<>();
 
@@ -112,7 +108,8 @@ public abstract class HttpClientTimeoutIT {
 
                 @Override
                 public void onEvent(ServerSentEvent event) {
-                    completableFuture.completeExceptionally(new IllegalStateException("onEvent() should not be called"));
+                    completableFuture.completeExceptionally(
+                            new IllegalStateException("onEvent() should not be called"));
                 }
 
                 @Override
@@ -123,7 +120,8 @@ public abstract class HttpClientTimeoutIT {
 
                 @Override
                 public void onClose() {
-                    completableFuture.completeExceptionally(new IllegalStateException("onClose() should not be called"));
+                    completableFuture.completeExceptionally(
+                            new IllegalStateException("onClose() should not be called"));
                 }
             };
             ServerSentEventListener spyListener = spy(listener);

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpRequestTest.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpRequestTest.java
@@ -1,17 +1,16 @@
 package dev.langchain4j.http.client;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import static dev.langchain4j.http.client.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import static dev.langchain4j.http.client.HttpMethod.GET;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class HttpRequestTest {
 
@@ -20,7 +19,8 @@ class HttpRequestTest {
     void should_correctly_concatenate_baseUrl_and_path(String baseUrl, String path, String expectedUrl) {
 
         // when
-        String result = HttpRequest.builder().method(GET).url(baseUrl, path).build().url();
+        String result =
+                HttpRequest.builder().method(GET).url(baseUrl, path).build().url();
 
         // then
         assertThat(result).isEqualTo(expectedUrl);
@@ -33,8 +33,7 @@ class HttpRequestTest {
                 Arguments.of("http://example.com", "api", "http://example.com/api"),
                 Arguments.of("http://example.com/", "api", "http://example.com/api"),
                 Arguments.of("http://example.com/v1", "/api", "http://example.com/v1/api"),
-                Arguments.of("http://example.com/v1/", "/api", "http://example.com/v1/api")
-        );
+                Arguments.of("http://example.com/v1/", "/api", "http://example.com/v1/api"));
     }
 
     @Test
@@ -75,8 +74,7 @@ class HttpRequestTest {
         builder.addHeader("Content-Type", "application/json");
 
         // then
-        assertThat(builder.build().headers())
-                .containsEntry("Content-Type", List.of("application/json"));
+        assertThat(builder.build().headers()).containsEntry("Content-Type", List.of("application/json"));
     }
 
     @Test
@@ -89,8 +87,7 @@ class HttpRequestTest {
         builder.addHeader("Accept", "application/json", "application/xml");
 
         // then
-        assertThat(builder.build().headers())
-                .containsEntry("Accept", List.of("application/json", "application/xml"));
+        assertThat(builder.build().headers()).containsEntry("Accept", List.of("application/json", "application/xml"));
     }
 
     @Test
@@ -118,8 +115,7 @@ class HttpRequestTest {
         HttpRequest.Builder builder = HttpRequest.builder().method(GET).url("http://example.com");
         Map<String, String> headers = Map.of(
                 "Content-Type", "application/json",
-                "Accept", "text/plain"
-        );
+                "Accept", "text/plain");
 
         // when
         builder.addHeaders(headers);
@@ -170,8 +166,7 @@ class HttpRequestTest {
         HttpRequest.Builder builder = HttpRequest.builder().method(GET).url("http://example.com");
 
         // when
-        builder.addHeader(singleHeaderName, singleHeaderValues)
-                .addHeaders(mapHeaders);
+        builder.addHeader(singleHeaderName, singleHeaderValues).addHeaders(mapHeaders);
 
         // then
         assertThat(builder.build().headers()).containsExactlyInAnyOrderEntriesOf(expectedHeaders);
@@ -181,35 +176,27 @@ class HttpRequestTest {
         return Stream.of(
                 Arguments.of(
                         "Content-Type",
-                        new String[]{"application/json"},
+                        new String[] {"application/json"},
                         Map.of("Accept", "text/plain"),
                         Map.of(
                                 "Content-Type", List.of("application/json"),
-                                "Accept", List.of("text/plain")
-                        )
-                ),
+                                "Accept", List.of("text/plain"))),
                 Arguments.of(
                         "Accept",
-                        new String[]{"application/json", "application/xml"},
+                        new String[] {"application/json", "application/xml"},
                         Map.of("Content-Type", "application/json"),
                         Map.of(
                                 "Accept", List.of("application/json", "application/xml"),
-                                "Content-Type", List.of("application/json")
-                        )
-                ),
+                                "Content-Type", List.of("application/json"))),
                 Arguments.of(
                         "X-Custom-Header",
-                        new String[]{"value1"},
+                        new String[] {"value1"},
                         Map.of(
                                 "X-Custom-Header", "value2",
-                                "Accept", "application/json"
-                        ),
+                                "Accept", "application/json"),
                         Map.of(
                                 "X-Custom-Header", List.of("value2"),
-                                "Accept", List.of("application/json")
-                        )
-                )
-        );
+                                "Accept", List.of("application/json"))));
     }
 
     @Test
@@ -219,11 +206,9 @@ class HttpRequestTest {
         HttpRequest.Builder builder = HttpRequest.builder().method(GET).url("http://example.com");
 
         // when
-        builder.addHeader("Accept", "application/json")
-                .addHeaders(Map.of("Accept", "text/plain"));
+        builder.addHeader("Accept", "application/json").addHeaders(Map.of("Accept", "text/plain"));
 
         // then
-        assertThat(builder.build().headers())
-                .containsEntry("Accept", List.of("text/plain"));
+        assertThat(builder.build().headers()).containsEntry("Accept", List.of("text/plain"));
     }
 }


### PR DESCRIPTION
Otherwise, users you have configured to log
requests and/or responses see nothing by default