### PR TITLE
Added maven-flatten-plugin, cleaned up POMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+**/.flattened-pom.xml
 
 ### IntelliJ IDEA ###
 .idea/*

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/pom.xml
@@ -14,7 +14,6 @@
     <description>Implementation of JavaScript and Python code execution engines and tools using GraalVM Polyglot/Truffle</description>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <graalvm.version>24.1.1</graalvm.version>
     </properties>
 

--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
@@ -26,6 +26,21 @@
             <artifactId>okhttp</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
 
         <!-- test dependencies -->
 

--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
@@ -13,10 +13,6 @@
     <name>LangChain4j :: Integration :: Judge0</name>
     <description>Implementation of JavaScript code execution engine and tool using Judge0</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
 
         <dependency>

--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
@@ -28,11 +28,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>

--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
@@ -28,8 +28,10 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/document-loaders/langchain4j-document-loader-amazon-s3/pom.xml
+++ b/document-loaders/langchain4j-document-loader-amazon-s3/pom.xml
@@ -31,6 +31,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
+
+        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
             <version>${project.version}</version>

--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
@@ -27,6 +27,11 @@
 
         <dependency>
             <groupId>com.azure</groupId>
+            <artifactId>azure-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
         </dependency>
 
@@ -44,6 +49,14 @@
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
@@ -38,6 +38,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>

--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>

--- a/document-loaders/langchain4j-document-loader-github/pom.xml
+++ b/document-loaders/langchain4j-document-loader-github/pom.xml
@@ -27,6 +27,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
+
+        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
             <version>${project.version}</version>

--- a/document-loaders/langchain4j-document-loader-github/pom.xml
+++ b/document-loaders/langchain4j-document-loader-github/pom.xml
@@ -24,12 +24,6 @@
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
             <version>${github-api.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/document-loaders/langchain4j-document-loader-github/pom.xml
+++ b/document-loaders/langchain4j-document-loader-github/pom.xml
@@ -23,6 +23,13 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
+            <version>${github-api.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/document-loaders/langchain4j-document-loader-google-cloud-storage/pom.xml
+++ b/document-loaders/langchain4j-document-loader-google-cloud-storage/pom.xml
@@ -35,16 +35,6 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/document-loaders/langchain4j-document-loader-google-cloud-storage/pom.xml
+++ b/document-loaders/langchain4j-document-loader-google-cloud-storage/pom.xml
@@ -26,22 +26,29 @@
 
     <dependencies>
 
-        <!-- Google Cloud Storage -->
-
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-storage</artifactId>
-        </dependency>
-
-        <!-- LangChain4j -->
-
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
             <version>${project.version}</version>
         </dependency>
 
-        <!--- Test dependencies -->
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/document-loaders/langchain4j-document-loader-selenium/pom.xml
+++ b/document-loaders/langchain4j-document-loader-selenium/pom.xml
@@ -22,6 +22,7 @@
     </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -33,6 +34,14 @@
             <artifactId>selenium-java</artifactId>
             <version>${selenium.webdriver.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/document-loaders/langchain4j-document-loader-tencent-cos/pom.xml
+++ b/document-loaders/langchain4j-document-loader-tencent-cos/pom.xml
@@ -17,6 +17,7 @@
     </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -28,6 +29,14 @@
             <artifactId>cos_api</artifactId>
             <version>5.6.240</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/document-parsers/langchain4j-document-parser-apache-tika/pom.xml
+++ b/document-parsers/langchain4j-document-parser-apache-tika/pom.xml
@@ -31,12 +31,32 @@
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
             <version>${apache-tika.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers-standard-package</artifactId>
             <version>${apache-tika.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/document-parsers/langchain4j-document-parser-apache-tika/pom.xml
+++ b/document-parsers/langchain4j-document-parser-apache-tika/pom.xml
@@ -31,32 +31,12 @@
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
             <version>${apache-tika.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers-standard-package</artifactId>
             <version>${apache-tika.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/document-transformers/langchain4j-document-transformer-jsoup/pom.xml
+++ b/document-transformers/langchain4j-document-transformer-jsoup/pom.xml
@@ -27,6 +27,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
+
+        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
             <version>${project.version}</version>

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/pom.xml
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/pom.xml
@@ -26,6 +26,12 @@
             <version>4.8</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
         <!-- test dependencies -->
 
         <dependency>

--- a/http-clients/langchain4j-http-client-jdk/pom.xml
+++ b/http-clients/langchain4j-http-client-jdk/pom.xml
@@ -16,6 +16,12 @@
 
         <dependency>
             <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-http-client</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/langchain4j-anthropic/pom.xml
+++ b/langchain4j-anthropic/pom.xml
@@ -61,12 +61,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-anthropic/pom.xml
+++ b/langchain4j-anthropic/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-anthropic</artifactId>
     <name>LangChain4j :: Integration :: Anthropic</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <properties>
         <skipAnthropicITs>false</skipAnthropicITs>
     </properties>
@@ -78,6 +69,7 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>

--- a/langchain4j-anthropic/pom.xml
+++ b/langchain4j-anthropic/pom.xml
@@ -36,31 +36,16 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/langchain4j-anthropic/pom.xml
+++ b/langchain4j-anthropic/pom.xml
@@ -31,12 +31,37 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
 

--- a/langchain4j-anthropic/pom.xml
+++ b/langchain4j-anthropic/pom.xml
@@ -36,34 +36,41 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-jackson</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-azure-ai-search/pom.xml
+++ b/langchain4j-azure-ai-search/pom.xml
@@ -27,14 +27,26 @@
 
         <dependency>
             <groupId>com.azure</groupId>
-            <artifactId>azure-search-documents</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.azure</groupId>
-                    <artifactId>azure-core-serializer-json-jackson</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>azure-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-search-documents</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/langchain4j-azure-cosmos-mongo-vcore/pom.xml
+++ b/langchain4j-azure-cosmos-mongo-vcore/pom.xml
@@ -12,6 +12,7 @@
     <name>LangChain4j :: Integration :: Azure CosmosDB Mongo vCore</name>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -23,6 +24,14 @@
             <artifactId>mongodb-driver-sync</artifactId>
             <version>4.11.5</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/langchain4j-azure-cosmos-mongo-vcore/pom.xml
+++ b/langchain4j-azure-cosmos-mongo-vcore/pom.xml
@@ -25,11 +25,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
             <version>${project.version}</version>

--- a/langchain4j-azure-cosmos-nosql/pom.xml
+++ b/langchain4j-azure-cosmos-nosql/pom.xml
@@ -46,6 +46,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
+
+        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
             <version>${project.version}</version>

--- a/langchain4j-azure-cosmos-nosql/pom.xml
+++ b/langchain4j-azure-cosmos-nosql/pom.xml
@@ -46,11 +46,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
             <version>${project.version}</version>

--- a/langchain4j-azure-open-ai/pom.xml
+++ b/langchain4j-azure-open-ai/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-azure-open-ai</artifactId>
     <name>LangChain4j :: Integration :: Azure OpenAI</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <properties>
         <!-- TODO: remove enforcer.skipRules -->
         <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>

--- a/langchain4j-azure-open-ai/pom.xml
+++ b/langchain4j-azure-open-ai/pom.xml
@@ -43,6 +43,21 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
 
         <!-- test dependencies -->
 

--- a/langchain4j-azure-open-ai/pom.xml
+++ b/langchain4j-azure-open-ai/pom.xml
@@ -34,28 +34,26 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR AZURE-AI-OPENAI (START) -->
-
-        <!-- To resolve version conflicts inside the 'azure-ai-openai' library, we are excluding the transitive -->
-        <!-- dependencies causing version divergence errors and including them explicitly. This ensures a consistent -->
-        <!-- version to be used in the project and satisfies Maven Enforcer requirements to avoid version divergence -->
-        <!-- in the project. -->
-
-        <!-- Please check whether version conflicts are gone after upgrading  this library as this will make it -->
-        <!-- possible to remove these exclusions and explicit inclusions below. -->
-
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-ai-openai</artifactId>
+            <version>${azure-ai-openai.version}</version>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR AZURE-AI-OPENAI (END) -->
+        <dependency>
+            <groupId>com.knuddels</groupId>
+            <artifactId>jtokkit</artifactId>
+            <version>${jtokkit.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
             <optional>true</optional>
         </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>
@@ -80,11 +78,6 @@
             <classifier>tests</classifier>
             <type>test-jar</type>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.knuddels</groupId>
-            <artifactId>jtokkit</artifactId>
         </dependency>
 
         <dependency>

--- a/langchain4j-bedrock/pom.xml
+++ b/langchain4j-bedrock/pom.xml
@@ -17,6 +17,7 @@
     </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -34,11 +35,29 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-bedrock/pom.xml
+++ b/langchain4j-bedrock/pom.xml
@@ -11,15 +11,6 @@
     <artifactId>langchain4j-bedrock</artifactId>
     <name>LangChain4j :: Integration :: Amazon Bedrock</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <properties>
         <!-- TODO: remove enforcer.skipRules -->
         <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>

--- a/langchain4j-bedrock/pom.xml
+++ b/langchain4j-bedrock/pom.xml
@@ -45,12 +45,8 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <dependency>

--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -9,6 +9,30 @@
 
     <name>LangChain4j :: BOM</name>
     <description>Bill of Materials POM for getting full, complete set of compatible versions of LangChain4j modules</description>
+    <url>https://github.com/langchain4j/langchain4j/tree/main</url>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>dliubarskyi</id>
+            <name>Dmytro Liubarskyi</name>
+            <email>info@langchain4j.dev</email>
+            <url>https://github.com/dliubarskyi</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/langchain4j/langchain4j.git</connection>
+        <developerConnection>scm:git:git@github.com:langchain4j/langchain4j.git</developerConnection>
+        <url>https://github.com/langchain4j/langchain4j/tree/main</url>
+    </scm>
 
     <dependencyManagement>
         <dependencies>

--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -556,6 +556,7 @@
                 <configuration>
                     <flattenMode>bom</flattenMode>
                     <pomElements>
+                        <properties>remove</properties>
                         <distributionManagement>remove</distributionManagement>
                     </pomElements>
                 </configuration>

--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -555,6 +555,9 @@
                 <artifactId>flatten-maven-plugin</artifactId>
                 <configuration>
                     <flattenMode>bom</flattenMode>
+                    <pomElements>
+                        <distributionManagement>remove</distributionManagement>
+                    </pomElements>
                 </configuration>
                 <executions>
                     <execution>

--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>dev.langchain4j</groupId>
-        <artifactId>langchain4j-parent</artifactId>
-        <version>1.0.0-beta4-SNAPSHOT</version>
-        <relativePath>../langchain4j-parent/pom.xml</relativePath>
-    </parent>
 
+    <groupId>dev.langchain4j</groupId>
     <artifactId>langchain4j-bom</artifactId>
+    <version>1.0.0-beta4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>LangChain4j :: BOM</name>

--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -2,37 +2,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>dev.langchain4j</groupId>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-parent</artifactId>
+        <version>1.0.0-beta4-SNAPSHOT</version>
+        <relativePath>../langchain4j-parent/pom.xml</relativePath>
+    </parent>
+
     <artifactId>langchain4j-bom</artifactId>
-    <version>1.0.0-beta4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>LangChain4j :: BOM</name>
     <description>Bill of Materials POM for getting full, complete set of compatible versions of LangChain4j modules</description>
-    <url>https://github.com/langchain4j/langchain4j/tree/main</url>
-
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>dliubarskyi</id>
-            <name>Dmytro Liubarskyi</name>
-            <email>info@langchain4j.dev</email>
-            <url>https://github.com/dliubarskyi</url>
-        </developer>
-    </developers>
-
-    <scm>
-        <connection>scm:git:git://github.com/langchain4j/langchain4j.git</connection>
-        <developerConnection>scm:git:git@github.com:langchain4j/langchain4j.git</developerConnection>
-        <url>https://github.com/langchain4j/langchain4j/tree/main</url>
-    </scm>
 
     <dependencyManagement>
         <dependencies>
@@ -566,5 +547,32 @@
 
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <flattenMode>bom</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/langchain4j-cassandra/pom.xml
+++ b/langchain4j-cassandra/pom.xml
@@ -10,7 +10,6 @@
     </parent>
     <artifactId>langchain4j-cassandra</artifactId>
     <name>LangChain4j :: Integration :: Cassandra and AstraDb</name>
-    <description>Some dependencies have a "Public Domain" license</description>
 
     <properties>
         <astra-db-client.version>1.2.4</astra-db-client.version>

--- a/langchain4j-cassandra/pom.xml
+++ b/langchain4j-cassandra/pom.xml
@@ -32,6 +32,16 @@
             <version>${astra-db-client.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
 
         <!-- test dependencies -->
 

--- a/langchain4j-cassandra/pom.xml
+++ b/langchain4j-cassandra/pom.xml
@@ -28,22 +28,13 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.datastax.astra</groupId>
             <artifactId>astra-db-client</artifactId>
             <version>${astra-db-client.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
 
-        <!-- TESTS -->
+        <!-- test dependencies -->
 
         <!-- Visibility for EmbeddingStoreIT -->
         <dependency>

--- a/langchain4j-cassandra/pom.xml
+++ b/langchain4j-cassandra/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <astra-db-client.version>1.2.4</astra-db-client.version>
-        <maven.compiler.release>11</maven.compiler.release>
         <!-- TODO: remove enforcer.skipRules -->
         <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>
     </properties>

--- a/langchain4j-cassandra/pom.xml
+++ b/langchain4j-cassandra/pom.xml
@@ -8,6 +8,7 @@
         <version>1.0.0-beta4-SNAPSHOT</version>
         <relativePath>../langchain4j-parent/pom.xml</relativePath>
     </parent>
+
     <artifactId>langchain4j-cassandra</artifactId>
     <name>LangChain4j :: Integration :: Cassandra and AstraDb</name>
 

--- a/langchain4j-chroma/pom.xml
+++ b/langchain4j-chroma/pom.xml
@@ -51,12 +51,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-chroma/pom.xml
+++ b/langchain4j-chroma/pom.xml
@@ -26,8 +26,23 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
 

--- a/langchain4j-chroma/pom.xml
+++ b/langchain4j-chroma/pom.xml
@@ -32,25 +32,11 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/langchain4j-chroma/pom.xml
+++ b/langchain4j-chroma/pom.xml
@@ -32,22 +32,35 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-jackson</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/langchain4j-chroma/pom.xml
+++ b/langchain4j-chroma/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-chroma</artifactId>
     <name>LangChain4j :: Integration :: Chroma</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencies>
 
         <dependency>

--- a/langchain4j-cohere/pom.xml
+++ b/langchain4j-cohere/pom.xml
@@ -12,6 +12,7 @@
     <name>LangChain4j :: Integration :: Cohere</name>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -40,12 +41,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-cohere/pom.xml
+++ b/langchain4j-cohere/pom.xml
@@ -22,25 +22,11 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/langchain4j-cohere/pom.xml
+++ b/langchain4j-cohere/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
         </dependency>

--- a/langchain4j-cohere/pom.xml
+++ b/langchain4j-cohere/pom.xml
@@ -21,17 +21,35 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -17,6 +17,16 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -33,13 +33,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
@@ -54,7 +52,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
-            <version>${jackson.version}</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -13,21 +13,6 @@
     <name>LangChain4j :: Core</name>
     <description>Core classes and interfaces of LangChain4j</description>
 
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <properties>
-        <!-- Tell the compiler to stop warning us about Java8 -->
-        <Xlint>-options</Xlint>
-        <!-- TODO: remove enforcer.skipRules -->
-        <enforcer.skipRules>requireUpperBoundDeps</enforcer.skipRules>
-    </properties>
-
     <dependencies>
 
         <dependency>
@@ -81,6 +66,7 @@
         </dependency>
 
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -33,26 +33,31 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
+            <version>${jspecify.version}</version>
         </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
+            <version>${jackson.version}</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
-
-        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-couchbase/pom.xml
+++ b/langchain4j-couchbase/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-couchbase</artifactId>
     <name>LangChain4j :: Integration :: Couchbase</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencies>
 
         <dependency>

--- a/langchain4j-couchbase/pom.xml
+++ b/langchain4j-couchbase/pom.xml
@@ -33,6 +33,12 @@
             <groupId>com.couchbase.client</groupId>
             <artifactId>java-client</artifactId>
             <version>3.7.6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/langchain4j-couchbase/pom.xml
+++ b/langchain4j-couchbase/pom.xml
@@ -33,12 +33,6 @@
             <groupId>com.couchbase.client</groupId>
             <artifactId>java-client</artifactId>
             <version>3.7.6</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/langchain4j-elasticsearch/pom.xml
+++ b/langchain4j-elasticsearch/pom.xml
@@ -55,6 +55,16 @@
             <version>2.0.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
 
         <!-- test dependencies -->
 

--- a/langchain4j-elasticsearch/pom.xml
+++ b/langchain4j-elasticsearch/pom.xml
@@ -40,6 +40,7 @@
     </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -62,6 +63,9 @@
             <artifactId>jakarta.json-api</artifactId>
             <version>2.0.2</version>
         </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/langchain4j-elasticsearch/pom.xml
+++ b/langchain4j-elasticsearch/pom.xml
@@ -49,6 +49,7 @@
         <dependency>
             <groupId>co.elastic.clients</groupId>
             <artifactId>elasticsearch-java</artifactId>
+            <version>${elastic.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>jakarta.json</groupId>
@@ -60,16 +61,6 @@
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
             <version>2.0.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
         </dependency>
 
         <dependency>

--- a/langchain4j-elasticsearch/pom.xml
+++ b/langchain4j-elasticsearch/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-elasticsearch</artifactId>
     <name>LangChain4j :: Integration :: Elasticsearch</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <properties>
         <!-- For tests only -->
         <!-- You can run the tests using

--- a/langchain4j-github-models/pom.xml
+++ b/langchain4j-github-models/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-github-models</artifactId>
     <name>LangChain4j :: Integration :: GitHub Models</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/langchain4j-github-models/pom.xml
+++ b/langchain4j-github-models/pom.xml
@@ -53,6 +53,24 @@
             <groupId>com.azure</groupId>
             <artifactId>azure-ai-inference</artifactId>
             <version>1.0.0-beta.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/langchain4j-github-models/pom.xml
+++ b/langchain4j-github-models/pom.xml
@@ -53,24 +53,6 @@
             <groupId>com.azure</groupId>
             <artifactId>azure-ai-inference</artifactId>
             <version>1.0.0-beta.4</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/langchain4j-google-ai-gemini/pom.xml
+++ b/langchain4j-google-ai-gemini/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-google-ai-gemini</artifactId>
     <name>LangChain4j :: Integration :: Google AI Gemini</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <properties>
         <skipGeminiITs>false</skipGeminiITs>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/langchain4j-google-ai-gemini/pom.xml
+++ b/langchain4j-google-ai-gemini/pom.xml
@@ -34,24 +34,21 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
 
-        <!-- JUnit 5 -->
+        <!-- test dependencies -->
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
 
-        <!-- LangChain4j for tests -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -67,6 +64,7 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
@@ -76,7 +74,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Retry flaky tests -->
         <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>

--- a/langchain4j-google-ai-gemini/pom.xml
+++ b/langchain4j-google-ai-gemini/pom.xml
@@ -25,6 +25,21 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
 
         <!-- test dependencies -->
 

--- a/langchain4j-http-client/pom.xml
+++ b/langchain4j-http-client/pom.xml
@@ -19,6 +19,11 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
         <!-- test dependencies -->
 
         <dependency>

--- a/langchain4j-hugging-face/pom.xml
+++ b/langchain4j-hugging-face/pom.xml
@@ -51,12 +51,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-hugging-face/pom.xml
+++ b/langchain4j-hugging-face/pom.xml
@@ -26,8 +26,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
 

--- a/langchain4j-hugging-face/pom.xml
+++ b/langchain4j-hugging-face/pom.xml
@@ -32,25 +32,11 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/langchain4j-hugging-face/pom.xml
+++ b/langchain4j-hugging-face/pom.xml
@@ -32,22 +32,35 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-jackson</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -60,6 +73,7 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/langchain4j-hugging-face/pom.xml
+++ b/langchain4j-hugging-face/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-hugging-face</artifactId>
     <name>LangChain4j :: Integration :: Hugging Face</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencies>
 
         <dependency>

--- a/langchain4j-infinispan/pom.xml
+++ b/langchain4j-infinispan/pom.xml
@@ -36,11 +36,13 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-api</artifactId>
+            <version>${infinispan.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
+            <version>${infinispan.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.logging</groupId>
@@ -52,16 +54,19 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-remote-query-client</artifactId>
+            <version>${infinispan.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-query-dsl</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <version>${infinispan.version}</version>
         </dependency>
 
         <dependency>
@@ -96,6 +101,7 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-server-testdriver-core</artifactId>
+            <version>${infinispan.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-infinispan/pom.xml
+++ b/langchain4j-infinispan/pom.xml
@@ -21,9 +21,17 @@
         </license>
     </licenses>
 
-    <properties>
-        <maven.compiler.release>17</maven.compiler.release>
-    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-bom</artifactId>
+                <version>${infinispan.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
 
@@ -36,13 +44,11 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-api</artifactId>
-            <version>${infinispan.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
-            <version>${infinispan.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.logging</groupId>
@@ -54,14 +60,15 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-remote-query-client</artifactId>
-            <version>${infinispan.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-query-dsl</artifactId>
-            <version>${infinispan.version}</version>
         </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>
@@ -95,7 +102,6 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-server-testdriver-core</artifactId>
-            <version>${infinispan.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-infinispan/pom.xml
+++ b/langchain4j-infinispan/pom.xml
@@ -55,12 +55,6 @@
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-remote-query-client</artifactId>
             <version>${infinispan.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/langchain4j-infinispan/pom.xml
+++ b/langchain4j-infinispan/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-infinispan</artifactId>
     <name>LangChain4j :: Integration :: Infinispan</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/langchain4j-infinispan/pom.xml
+++ b/langchain4j-infinispan/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>infinispan-query-dsl</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
 
         <!-- test dependencies -->
 

--- a/langchain4j-jina/pom.xml
+++ b/langchain4j-jina/pom.xml
@@ -41,12 +41,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-jina/pom.xml
+++ b/langchain4j-jina/pom.xml
@@ -22,25 +22,11 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/langchain4j-jina/pom.xml
+++ b/langchain4j-jina/pom.xml
@@ -19,17 +19,38 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-jlama/pom.xml
+++ b/langchain4j-jlama/pom.xml
@@ -39,14 +39,29 @@
             <groupId>com.github.tjake</groupId>
             <artifactId>jlama-core</artifactId>
             <version>${jlama.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
 
-        <!-- TESTS -->
+        <!-- test dependencies -->
+
         <dependency>
             <groupId>com.github.tjake</groupId>
             <artifactId>jlama-native</artifactId>
@@ -55,11 +70,13 @@
             <classifier>${os.detected.classifier}</classifier>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>

--- a/langchain4j-jlama/pom.xml
+++ b/langchain4j-jlama/pom.xml
@@ -19,6 +19,7 @@
     </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -29,6 +30,11 @@
             <groupId>com.github.tjake</groupId>
             <artifactId>jlama-core</artifactId>
             <version>${jlama.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
 

--- a/langchain4j-jlama/pom.xml
+++ b/langchain4j-jlama/pom.xml
@@ -39,24 +39,6 @@
             <groupId>com.github.tjake</groupId>
             <artifactId>jlama-core</artifactId>
             <version>${jlama.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-jlama/pom.xml
+++ b/langchain4j-jlama/pom.xml
@@ -12,18 +12,8 @@
     <name>LangChain4j :: Integration :: Jlama</name>
     <description>Jlama: LLM Inference Engine for Java - Requires Java 20+</description>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <properties>
         <jlama.version>0.8.3</jlama.version>
-        <spotless.version>2.40.0</spotless.version>
         <java.version>21</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
     </properties>

--- a/langchain4j-kotlin/pom.xml
+++ b/langchain4j-kotlin/pom.xml
@@ -12,14 +12,6 @@
     <name>LangChain4j :: Kotlin</name>
     <description>LangChain4j Kotlin extensions</description>
 
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
     <developers>
         <developer>
             <id>kpavlov</id>

--- a/langchain4j-local-ai/pom.xml
+++ b/langchain4j-local-ai/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-local-ai</artifactId>
     <name>LangChain4j :: Integration :: LocalAI</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <properties>
         <skipLocalAiITs>false</skipLocalAiITs>
     </properties>

--- a/langchain4j-mariadb/pom.xml
+++ b/langchain4j-mariadb/pom.xml
@@ -32,6 +32,18 @@
             <version>${mariadb-client.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>${jspecify.version}</version>
+        </dependency>
+
+
         <!-- test dependencies -->
 
         <dependency>

--- a/langchain4j-mariadb/pom.xml
+++ b/langchain4j-mariadb/pom.xml
@@ -15,7 +15,6 @@
 
     <properties>
         <mariadb-client.version>3.5.1</mariadb-client.version>
-        <jspecify.version>1.0.0</jspecify.version>
         <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>
     </properties>
 

--- a/langchain4j-mariadb/pom.xml
+++ b/langchain4j-mariadb/pom.xml
@@ -28,21 +28,12 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <version>${mariadb-client.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.jspecify</groupId>
-            <artifactId>jspecify</artifactId>
-            <version>${jspecify.version}</version>
-        </dependency>
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/langchain4j-mcp/pom.xml
+++ b/langchain4j-mcp/pom.xml
@@ -12,6 +12,7 @@
     <name>LangChain4j :: Integration :: Model Context Protocol</name>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
@@ -20,8 +21,21 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-mcp/pom.xml
+++ b/langchain4j-mcp/pom.xml
@@ -20,14 +20,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-mcp/pom.xml
+++ b/langchain4j-mcp/pom.xml
@@ -19,17 +19,15 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-milvus/pom.xml
+++ b/langchain4j-milvus/pom.xml
@@ -29,6 +29,7 @@
         <dependency>
             <groupId>io.milvus</groupId>
             <artifactId>milvus-sdk-java</artifactId>
+            <version>${milvus-sdk-java.version}</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-mistral-ai/pom.xml
+++ b/langchain4j-mistral-ai/pom.xml
@@ -35,12 +35,27 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
 

--- a/langchain4j-mistral-ai/pom.xml
+++ b/langchain4j-mistral-ai/pom.xml
@@ -40,32 +40,41 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-jackson</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-mistral-ai/pom.xml
+++ b/langchain4j-mistral-ai/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-mistral-ai</artifactId>
     <name>LangChain4j :: Integration :: MistralAI</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <developers>
         <developer>
             <id>czelabueno</id>

--- a/langchain4j-mistral-ai/pom.xml
+++ b/langchain4j-mistral-ai/pom.xml
@@ -65,12 +65,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-mistral-ai/pom.xml
+++ b/langchain4j-mistral-ai/pom.xml
@@ -40,31 +40,16 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/langchain4j-mongodb-atlas/pom.xml
+++ b/langchain4j-mongodb-atlas/pom.xml
@@ -16,6 +16,7 @@
     </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -27,6 +28,14 @@
             <artifactId>mongodb-driver-sync</artifactId>
             <version>5.2.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/langchain4j-mongodb-atlas/pom.xml
+++ b/langchain4j-mongodb-atlas/pom.xml
@@ -29,11 +29,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
             <version>${project.version}</version>

--- a/langchain4j-nomic/pom.xml
+++ b/langchain4j-nomic/pom.xml
@@ -21,22 +21,35 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-jackson</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-nomic/pom.xml
+++ b/langchain4j-nomic/pom.xml
@@ -12,6 +12,7 @@
     <name>LangChain4j :: Integration :: Nomic</name>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -24,8 +25,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
 

--- a/langchain4j-nomic/pom.xml
+++ b/langchain4j-nomic/pom.xml
@@ -21,25 +21,11 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/langchain4j-nomic/pom.xml
+++ b/langchain4j-nomic/pom.xml
@@ -40,12 +40,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-ollama/pom.xml
+++ b/langchain4j-ollama/pom.xml
@@ -19,20 +19,10 @@
 
         <dependency>
             <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-http-client-jdk</artifactId>
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
 
         <!-- test dependencies -->
 
@@ -88,6 +78,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
+            <version>${okhttp.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/langchain4j-ollama/pom.xml
+++ b/langchain4j-ollama/pom.xml
@@ -78,7 +78,6 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>${okhttp.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/langchain4j-ollama/pom.xml
+++ b/langchain4j-ollama/pom.xml
@@ -19,8 +19,35 @@
 
         <dependency>
             <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-http-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-http-client-jdk</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
 

--- a/langchain4j-onnx-scoring/pom.xml
+++ b/langchain4j-onnx-scoring/pom.xml
@@ -43,13 +43,6 @@
             <groupId>ai.djl</groupId>
             <artifactId>api</artifactId>
             <version>${ai.djl.version}</version>
-            <exclusions>
-                <exclusion>
-                    <!-- due to version conflict between dev.langchain4j:langchain4j-core and ai.djl:api -->
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/langchain4j-onnx-scoring/pom.xml
+++ b/langchain4j-onnx-scoring/pom.xml
@@ -11,15 +11,6 @@
     <artifactId>langchain4j-onnx-scoring</artifactId>
     <name>langchain4j-onnx-scoring</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <properties>
         <ai.djl.version>0.31.1</ai.djl.version>
         <onnxruntime.version>1.20.0</onnxruntime.version>

--- a/langchain4j-open-ai-official/pom.xml
+++ b/langchain4j-open-ai-official/pom.xml
@@ -42,6 +42,25 @@
         <dependency>
             <groupId>com.openai</groupId>
             <artifactId>openai-java</artifactId>
+            <version>${openai-java.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/langchain4j-open-ai-official/pom.xml
+++ b/langchain4j-open-ai-official/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-open-ai-official</artifactId>
     <name>LangChain4j :: Integration :: OpenAI Official</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/langchain4j-open-ai-official/pom.xml
+++ b/langchain4j-open-ai-official/pom.xml
@@ -43,24 +43,6 @@
             <groupId>com.openai</groupId>
             <artifactId>openai-java</artifactId>
             <version>${openai-java.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/langchain4j-open-ai/pom.xml
+++ b/langchain4j-open-ai/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-open-ai</artifactId>
     <name>LangChain4j :: Integration :: OpenAI</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencies>
 
         <dependency>

--- a/langchain4j-open-ai/pom.xml
+++ b/langchain4j-open-ai/pom.xml
@@ -32,7 +32,9 @@
         <dependency>
             <groupId>com.knuddels</groupId>
             <artifactId>jtokkit</artifactId>
+            <version>${jtokkit.version}</version>
         </dependency>
+
 
         <!-- test dependencies -->
 

--- a/langchain4j-open-ai/pom.xml
+++ b/langchain4j-open-ai/pom.xml
@@ -16,8 +16,35 @@
 
         <dependency>
             <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-http-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-http-client-jdk</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
 
         <dependency>

--- a/langchain4j-open-ai/pom.xml
+++ b/langchain4j-open-ai/pom.xml
@@ -34,17 +34,17 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
         </dependency>
 
         <dependency>

--- a/langchain4j-opensearch/pom.xml
+++ b/langchain4j-opensearch/pom.xml
@@ -24,7 +24,6 @@
     <properties>
         <!-- TODO: remove enforcer.skipRules -->
         <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>
-        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/langchain4j-opensearch/pom.xml
+++ b/langchain4j-opensearch/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-opensearch</artifactId>
     <name>LangChain4j :: Integration :: OpenSearch</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <properties>
         <!-- TODO: remove enforcer.skipRules -->
         <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>

--- a/langchain4j-opensearch/pom.xml
+++ b/langchain4j-opensearch/pom.xml
@@ -102,6 +102,7 @@
         <dependency>
             <groupId>org.opensearch</groupId>
             <artifactId>opensearch-testcontainers</artifactId>
+            <version>${opensearch-containers.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -114,6 +115,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
+            <version>${jsonpath.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-opensearch/pom.xml
+++ b/langchain4j-opensearch/pom.xml
@@ -37,11 +37,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
+            <version>${httpclient5.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.opensearch.client</groupId>
             <artifactId>opensearch-java</artifactId>
+            <version>${opensearch-java.version}</version>
         </dependency>
 
         <dependency>
@@ -54,15 +56,8 @@
             <artifactId>apache-client</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/langchain4j-opensearch/pom.xml
+++ b/langchain4j-opensearch/pom.xml
@@ -18,6 +18,7 @@
     </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -44,6 +45,16 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
 

--- a/langchain4j-ovh-ai/pom.xml
+++ b/langchain4j-ovh-ai/pom.xml
@@ -36,25 +36,11 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/langchain4j-ovh-ai/pom.xml
+++ b/langchain4j-ovh-ai/pom.xml
@@ -33,27 +33,38 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-ovh-ai/pom.xml
+++ b/langchain4j-ovh-ai/pom.xml
@@ -55,12 +55,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-ovh-ai/pom.xml
+++ b/langchain4j-ovh-ai/pom.xml
@@ -34,6 +34,16 @@
             <artifactId>converter-jackson</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
 
         <!-- test dependencies -->
 

--- a/langchain4j-ovh-ai/pom.xml
+++ b/langchain4j-ovh-ai/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-ovh-ai</artifactId>
     <name>LangChain4j :: Integration :: OVHcloud AI</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <properties>
         <skipOvhAIITs>false</skipOvhAIITs>
     </properties>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -98,6 +98,22 @@
         <dependencies>
 
             <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-bom</artifactId>
+                <version>${slf4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
 
     <name>LangChain4j :: Parent POM</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <url>https://github.com/langchain4j/langchain4j/tree/main</url>
 
     <licenses>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -209,8 +209,6 @@
                 <scope>test</scope>
             </dependency>
 
-
-
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
@@ -228,18 +226,13 @@
             </dependency>
 
             <dependency>
-                <groupId>org.opensearch</groupId>
-                <artifactId>opensearch-testcontainers</artifactId>
-                <version>${opensearch-containers.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-bom</artifactId>
                 <version>${mockito.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
             <dependency>
                 <groupId>org.mockito.kotlin</groupId>
                 <artifactId>mockito-kotlin</artifactId>
@@ -297,12 +290,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.jayway.jsonpath</groupId>
-                <artifactId>json-path</artifactId>
-                <version>${jsonpath.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>
@@ -319,14 +306,6 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
                 <version>${log4j.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>io.projectreactor</groupId>
-                <artifactId>reactor-bom</artifactId>
-                <version>${reactor-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -114,6 +114,26 @@
             </dependency>
 
             <dependency>
+                <groupId>com.squareup.retrofit2</groupId>
+                <artifactId>retrofit</artifactId>
+                <version>${retrofit.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.squareup.retrofit2</groupId>
+                <artifactId>converter-jackson</artifactId>
+                <version>${retrofit.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-bom</artifactId>
+                <version>${okhttp.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -8,15 +8,14 @@
     <packaging>pom</packaging>
 
     <name>LangChain4j :: Parent POM</name>
-    <description>Parent POM for LangChain4j submodules</description>
-    <url>https://github.com/langchain4j/langchain4j</url>
+    <description>${name}</description>
+    <url>https://github.com/langchain4j/langchain4j/tree/main</url>
 
     <licenses>
         <license>
-            <name>Apache-2.0</name>
+            <name>The Apache Software License, Version 2.0</name>
             <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
 
@@ -32,7 +31,7 @@
     <scm>
         <connection>scm:git:git://github.com/langchain4j/langchain4j.git</connection>
         <developerConnection>scm:git:git@github.com:langchain4j/langchain4j.git</developerConnection>
-        <url>https://github.com/langchain4j/langchain4j</url>
+        <url>https://github.com/langchain4j/langchain4j/tree/main</url>
     </scm>
 
     <distributionManagement>
@@ -525,6 +524,11 @@
                     <version>4.6.0</version>
                     <extensions>true</extensions>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.7.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -746,6 +750,33 @@
                                 <!-- TODO: Add requireUpperBoundDeps -->
                             </rules>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <flattenMode>ossrh</flattenMode>
+                    <pomElements>
+                        <build>remove</build>
+                        <repositories>remove</repositories>
+                    </pomElements>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -79,12 +79,10 @@
         <milvus-sdk-java.version>2.5.7</milvus-sdk-java.version>
         <mockito-kotlin.version>5.4.0</mockito-kotlin.version>
         <mockito.version>5.14.2</mockito.version>
-        <netty.version>4.1.119.Final</netty.version>
         <okhttp.version>4.12.0</okhttp.version>
         <openai-java.version>1.4.1</openai-java.version>
         <opensearch-containers.version>2.0.1</opensearch-containers.version>
         <opensearch-java.version>2.9.0</opensearch-java.version>
-        <reactor-bom.version>2024.0.3</reactor-bom.version>
         <retrofit.version>2.9.0</retrofit.version>
         <slf4j.version>2.0.17</slf4j.version>
         <testcontainers.version>1.20.4</testcontainers.version>
@@ -128,14 +126,6 @@
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp-bom</artifactId>
                 <version>${okhttp.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -265,13 +255,6 @@
                 <version>${aws.java.sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-                <exclusions>
-                    <!-- Exclusion due to CWE-295 vulnerability -->
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-handler</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -87,10 +87,11 @@
         <opensearch-java.version>2.9.0</opensearch-java.version>
         <reactor-bom.version>2024.0.3</reactor-bom.version>
         <retrofit.version>2.9.0</retrofit.version>
-        <slf4j-api.version>2.0.17</slf4j-api.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <testcontainers.version>1.20.4</testcontainers.version>
         <tinylog.version>2.6.2</tinylog.version>
         <wiremock.version>3.12.1</wiremock.version>
+        <opennlp-tools.version>2.5.4</opennlp-tools.version>
     </properties>
 
     <dependencyManagement>
@@ -105,12 +106,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-ai-openai</artifactId>
-                <version>${azure-ai-openai.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
                 <version>${langchain4j-embeddings.version}</version>
@@ -120,18 +115,6 @@
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-embedding-store-filter-parser-sql</artifactId>
                 <version>${langchain4j-embeddings.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.squareup.retrofit2</groupId>
-                <artifactId>retrofit</artifactId>
-                <version>${retrofit.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.squareup.retrofit2</groupId>
-                <artifactId>converter-jackson</artifactId>
-                <version>${retrofit.version}</version>
             </dependency>
 
             <dependency>
@@ -190,47 +173,7 @@
                 <scope>test</scope>
             </dependency>
 
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp-bom</artifactId>
-                <version>${okhttp.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
 
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>mockwebserver</artifactId>
-                <version>${okhttp.version}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.knuddels</groupId>
-                <artifactId>jtokkit</artifactId>
-                <version>${jtokkit.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>${lombok.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-bom</artifactId>
-                <version>${slf4j-api.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jspecify</groupId>
-                <artifactId>jspecify</artifactId>
-                <version>${jspecify.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>org.junit</groupId>
@@ -289,44 +232,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5</artifactId>
-                <version>${httpclient5.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.openai</groupId>
-                <artifactId>openai-java</artifactId>
-                <version>${openai-java.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.opensearch.client</groupId>
-                <artifactId>opensearch-java</artifactId>
-                <version>${opensearch-java.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>co.elastic.clients</groupId>
-                <artifactId>elasticsearch-java</artifactId>
-                <version>${elastic.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.opennlp</groupId>
-                <artifactId>opennlp-tools</artifactId>
-                <version>2.5.4</version>
-            </dependency>
-
-            <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
                 <version>${aws.java.sdk.version}</version>
@@ -359,26 +264,6 @@
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
                 <version>${jsonpath.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.kohsuke</groupId>
-                <artifactId>github-api</artifactId>
-                <version>${github-api.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.milvus</groupId>
-                <artifactId>milvus-sdk-java</artifactId>
-                <version>${milvus-sdk-java.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-bom</artifactId>
-                <version>${infinispan.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
             <dependency>

--- a/langchain4j-pgvector/pom.xml
+++ b/langchain4j-pgvector/pom.xml
@@ -40,6 +40,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/langchain4j-pgvector/pom.xml
+++ b/langchain4j-pgvector/pom.xml
@@ -14,7 +14,7 @@
     <description>It uses the pgvector-java library</description>
 
     <properties>
-        <pgvector-java.version>0.1.6</pgvector-java.version>
+        <pgvector.version>0.1.6</pgvector.version>
         <postgresql.version>42.7.4</postgresql.version>
         <!-- TODO: remove enforcer.skipRules -->
         <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>
@@ -31,12 +31,7 @@
         <dependency>
             <groupId>com.pgvector</groupId>
             <artifactId>pgvector</artifactId>
-            <version>${pgvector-java.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <version>${pgvector.version}</version>
         </dependency>
 
         <dependency>
@@ -48,8 +43,12 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/langchain4j-pgvector/pom.xml
+++ b/langchain4j-pgvector/pom.xml
@@ -11,7 +11,6 @@
 
     <artifactId>langchain4j-pgvector</artifactId>
     <name>LangChain4j :: Integration :: PGVector</name>
-    <description>It uses the pgvector-java library</description>
 
     <properties>
         <pgvector.version>0.1.6</pgvector.version>

--- a/langchain4j-qdrant/pom.xml
+++ b/langchain4j-qdrant/pom.xml
@@ -26,9 +26,24 @@
         </dependency>
 
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
+            <groupId>io.qdrant</groupId>
+            <artifactId>client</artifactId>
+            <version>1.13.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>1.65.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>32.0.0-jre</version>
+        </dependency>
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>
@@ -69,24 +84,6 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-protobuf</artifactId>
-            <version>1.65.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.qdrant</groupId>
-            <artifactId>client</artifactId>
-            <version>1.13.0</version>
         </dependency>
 
     </dependencies>

--- a/langchain4j-tablestore/pom.xml
+++ b/langchain4j-tablestore/pom.xml
@@ -18,6 +18,12 @@
             <groupId>com.aliyun.openservices</groupId>
             <artifactId>tablestore</artifactId>
             <version>5.17.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/langchain4j-tablestore/pom.xml
+++ b/langchain4j-tablestore/pom.xml
@@ -18,12 +18,6 @@
             <groupId>com.aliyun.openservices</groupId>
             <artifactId>tablestore</artifactId>
             <version>5.17.4</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/langchain4j-vertex-ai-gemini/pom.xml
+++ b/langchain4j-vertex-ai-gemini/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-vertex-ai-gemini</artifactId>
     <name>LangChain4j :: Integration :: Google Vertex AI Gemini</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <properties>
         <skipVertexAiGeminiITs>false</skipVertexAiGeminiITs>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/langchain4j-vertex-ai/pom.xml
+++ b/langchain4j-vertex-ai/pom.xml
@@ -105,7 +105,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-vertex-ai/pom.xml
+++ b/langchain4j-vertex-ai/pom.xml
@@ -62,7 +62,8 @@
             <artifactId>google-cloud-discoveryengine</artifactId>
         </dependency>
 
-        <!-- testing dependencies -->
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>
@@ -79,6 +80,7 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
@@ -103,9 +105,10 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.16</version>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/langchain4j-vertex-ai/pom.xml
+++ b/langchain4j-vertex-ai/pom.xml
@@ -12,15 +12,6 @@
     <artifactId>langchain4j-vertex-ai</artifactId>
     <name>LangChain4j :: Integration :: Google Vertex AI</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/langchain4j-vespa/pom.xml
+++ b/langchain4j-vespa/pom.xml
@@ -11,21 +11,7 @@
 
     <artifactId>langchain4j-vespa</artifactId>
     <name>LangChain4j :: Integration :: Vespa</name>
-    <description>Vespa is a fully featured search engine and vector database.
-        Integration with LangChain4j uses:
-        - Vespa's client &amp; vespa-feed-client libraries which have Apache License 2.0:
-        https://github.com/vespa-engine/vespa/blob/master/LICENSE
-        - org.apache.httpcomponents.client5.httpclient5-fluent library which has Apache License 2.0:
-        https://github.com/apache/httpcomponents-client/blob/master/LICENSE.txt</description>
-
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
+    <description>Vespa is a fully featured search engine and vector database</description>
 
     <properties>
         <vespa.version>8.458.13</vespa.version>

--- a/langchain4j-vespa/pom.xml
+++ b/langchain4j-vespa/pom.xml
@@ -54,25 +54,11 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/langchain4j-vespa/pom.xml
+++ b/langchain4j-vespa/pom.xml
@@ -43,8 +43,23 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
 

--- a/langchain4j-vespa/pom.xml
+++ b/langchain4j-vespa/pom.xml
@@ -43,32 +43,12 @@
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>client</artifactId>
             <version>${vespa.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>vespa-feed-client</artifactId>
             <version>${vespa.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -93,12 +73,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-vespa/pom.xml
+++ b/langchain4j-vespa/pom.xml
@@ -43,38 +43,66 @@
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>client</artifactId>
             <version>${vespa.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>vespa-feed-client</artifactId>
             <version>${vespa.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-jackson</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/langchain4j-voyage-ai/pom.xml
+++ b/langchain4j-voyage-ai/pom.xml
@@ -12,6 +12,7 @@
     <name>LangChain4j :: Integration :: Voyage AI</name>
 
     <dependencies>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -24,8 +25,28 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
 

--- a/langchain4j-voyage-ai/pom.xml
+++ b/langchain4j-voyage-ai/pom.xml
@@ -21,25 +21,11 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/langchain4j-voyage-ai/pom.xml
+++ b/langchain4j-voyage-ai/pom.xml
@@ -21,17 +21,35 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-voyage-ai/pom.xml
+++ b/langchain4j-voyage-ai/pom.xml
@@ -40,12 +40,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-weaviate/pom.xml
+++ b/langchain4j-weaviate/pom.xml
@@ -11,8 +11,6 @@
 
     <artifactId>langchain4j-weaviate</artifactId>
     <name>LangChain4j :: Integration :: Weaviate</name>
-    <description>Uses io.weaviate.client library which has a BSD 3-Clause license:
-        https://github.com/weaviate/java-client/blob/main/LICENSE</description>
 
     <properties>
         <!-- TODO: remove enforcer.skipRules -->

--- a/langchain4j-workers-ai/pom.xml
+++ b/langchain4j-workers-ai/pom.xml
@@ -53,12 +53,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/langchain4j-workers-ai/pom.xml
+++ b/langchain4j-workers-ai/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
         </dependency>

--- a/langchain4j-workers-ai/pom.xml
+++ b/langchain4j-workers-ai/pom.xml
@@ -34,25 +34,11 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/langchain4j-workers-ai/pom.xml
+++ b/langchain4j-workers-ai/pom.xml
@@ -34,17 +34,35 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-workers-ai/pom.xml
+++ b/langchain4j-workers-ai/pom.xml
@@ -14,15 +14,6 @@
 
     <name>LangChain4j :: Integration :: CloudFlare Workers AI</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencies>
 
         <dependency>

--- a/langchain4j/pom.xml
+++ b/langchain4j/pom.xml
@@ -22,9 +22,29 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.opennlp</groupId>
             <artifactId>opennlp-tools</artifactId>
             <version>${opennlp-tools.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
         <!-- test dependencies -->

--- a/langchain4j/pom.xml
+++ b/langchain4j/pom.xml
@@ -34,12 +34,6 @@
             <groupId>org.apache.opennlp</groupId>
             <artifactId>opennlp-tools</artifactId>
             <version>${opennlp-tools.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- test dependencies -->

--- a/langchain4j/pom.xml
+++ b/langchain4j/pom.xml
@@ -33,6 +33,13 @@
         <dependency>
             <groupId>org.apache.opennlp</groupId>
             <artifactId>opennlp-tools</artifactId>
+            <version>${opennlp-tools.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- test dependencies -->

--- a/langchain4j/pom.xml
+++ b/langchain4j/pom.xml
@@ -13,15 +13,6 @@
     <name>LangChain4j</name>
     <description>Build LLM-powered applications in Java: chatbots, agents, RAG, and much more</description>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencies>
 
         <dependency>

--- a/web-search-engines/langchain4j-web-search-engine-google-custom/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-google-custom/pom.xml
@@ -28,12 +28,19 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Custom Search API Client Library for Java -->
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-customsearch</artifactId>
             <version>v1-rev20240821-2.0.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/web-search-engines/langchain4j-web-search-engine-google-custom/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-google-custom/pom.xml
@@ -36,11 +36,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
@@ -53,12 +53,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
@@ -34,21 +34,35 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
@@ -34,25 +34,11 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
@@ -28,8 +28,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
 

--- a/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
@@ -14,15 +14,6 @@
 
     <name>LangChain4j :: Web Search Engine :: SearchApi</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencies>
 
         <dependency>

--- a/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
@@ -53,12 +53,6 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
             <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 

--- a/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
@@ -34,25 +34,11 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>${retrofit.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${retrofit.version}</version>
         </dependency>
 
 

--- a/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
@@ -34,22 +34,35 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-jackson</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>${retrofit.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
@@ -28,8 +28,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
 

--- a/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
@@ -14,15 +14,6 @@
 
     <name>LangChain4j :: Web Search Engine :: Tavily</name>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-
     <dependencies>
 
         <dependency>


### PR DESCRIPTION
## Change
- Added `maven-flatten-plugin` to `langchain4j-parent` and `langchain4j-bom`
- Removed integration-specific dependencies from `langchain4j-parent`'s `dependencyManagement` section and moved them to the modules where these dependencies are used
- Explicitly added missing implicit dependencies
- Removed redundant `<maven.compiler.release>` for cassandra, infinispan and opensearch modules
- Removed redundant license declarations and outdated properties


## General checklist
- [ ] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
