### PR TITLE
Ollama: return `FinishReason.TOOL_EXECUTION` when tool calls are present in the response

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
@@ -156,7 +156,7 @@ class OllamaClient {
                 }
 
                 if (TRUE.equals(ollamaChatResponse.getDone())) {
-                    ChatResponse response = responseBuilder.build(ollamaChatResponse.getDoneReason());
+                    ChatResponse response = responseBuilder.build(ollamaChatResponse);
                     handler.onCompleteResponse(response);
                 }
             }

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaStreamingResponseBuilder.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaStreamingResponseBuilder.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.model.ollama.InternalOllamaHelper.chatResponseMetadataFrom;
 import static dev.langchain4j.model.ollama.InternalOllamaHelper.toFinishReason;
 import static dev.langchain4j.model.ollama.InternalOllamaHelper.toToolExecutionRequests;
+import static dev.langchain4j.model.output.FinishReason.TOOL_EXECUTION;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
@@ -53,11 +54,11 @@ class OllamaStreamingResponseBuilder {
         }
     }
 
-    ChatResponse build(String finishReason) {
+    ChatResponse build(OllamaChatResponse ollamaChatResponse) {
         if (!isNullOrEmpty(toolExecutionRequests)) {
             return ChatResponse.builder()
                     .aiMessage(AiMessage.from(toolExecutionRequests))
-                    .metadata(chatResponseMetadataFrom(modelName, toFinishReason(finishReason), tokenUsage))
+                    .metadata(chatResponseMetadataFrom(modelName, TOOL_EXECUTION, tokenUsage))
                     .build();
         }
 
@@ -67,7 +68,7 @@ class OllamaStreamingResponseBuilder {
         } else {
             return ChatResponse.builder()
                     .aiMessage(AiMessage.from(text))
-                    .metadata(chatResponseMetadataFrom(modelName, toFinishReason(finishReason), tokenUsage))
+                    .metadata(chatResponseMetadataFrom(modelName, toFinishReason(ollamaChatResponse), tokenUsage))
                     .build();
         }
     }

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaOpenAiChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaOpenAiChatModelIT.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 class OllamaOpenAiChatModelIT extends AbstractOllamaLanguageModelInfrastructure {
 
     ChatModel model = OpenAiChatModel.builder()
-            .baseUrl(ollamaBaseUrl(ollama) + "/v1") // TODO add "/v1" by default?
+            .baseUrl(ollamaBaseUrl(ollama) + "/v1")
             .modelName(TINY_DOLPHIN_MODEL)
             .temperature(0.0)
             .logRequests(true)

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaOpenAiStreamingChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaOpenAiStreamingChatModelIT.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 class OllamaOpenAiStreamingChatModelIT extends AbstractOllamaLanguageModelInfrastructure {
 
     StreamingChatModel model = OpenAiStreamingChatModel.builder()
-            .baseUrl(ollamaBaseUrl(ollama) + "/v1") // TODO add "/v1" by default?
+            .baseUrl(ollamaBaseUrl(ollama) + "/v1")
             .modelName(TINY_DOLPHIN_MODEL)
             .temperature(0.0)
             .logRequests(true)

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaAiServiceIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaAiServiceIT.java
@@ -20,11 +20,6 @@ class OllamaAiServiceIT extends AbstractAiServiceIT {
     }
 
     @Override
-    protected boolean assertToolInteractions() {
-        return false; // TODO fix
-    }
-
-    @Override
     protected Class<? extends TokenUsage> tokenUsageType(ChatModel chatModel) {
         if (chatModel instanceof OpenAiChatModel) {
             return OpenAiTokenUsage.class;

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaChatModelIT.java
@@ -80,7 +80,7 @@ class OllamaChatModelIT extends AbstractChatModelIT {
             .baseUrl(ollamaBaseUrl(ollamaWithVision))
             .modelName(MODEL_WITH_VISION)
             .temperature(0.0)
-            .logRequests(true)
+            .logRequests(false) // base64-encoded images are huge in logs
             .logResponses(true)
             .timeout(ofSeconds(180))
             .build();
@@ -98,7 +98,7 @@ class OllamaChatModelIT extends AbstractChatModelIT {
             .baseUrl(ollamaBaseUrl(ollamaWithVision) + "/v1")
             .modelName(MODEL_WITH_VISION)
             .temperature(0.0)
-            .logRequests(true)
+            .logRequests(false) // base64-encoded images are huge in logs
             .logResponses(true)
             .timeout(ofSeconds(180))
             .build();
@@ -198,7 +198,8 @@ class OllamaChatModelIT extends AbstractChatModelIT {
 
     @Override
     protected boolean supportsToolChoiceRequired() {
-        return false; // TODO check if Ollama supports this
+        return false; // Ollama does not support tool choice
+        // also for OpenAI-compatible API: https://github.com/ollama/ollama/blob/main/docs/openai.md
     }
 
     @Override
@@ -223,7 +224,7 @@ class OllamaChatModelIT extends AbstractChatModelIT {
 
     @Override
     protected boolean assertResponseId() {
-        return false; // TODO implement
+        return false; // Ollama does not return response ID
     }
 
     @Override

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaChatModelIT.java
@@ -192,11 +192,6 @@ class OllamaChatModelIT extends AbstractChatModelIT {
     }
 
     @Override
-    protected boolean assertFinishReason() {
-        return false; // TODO: Ollama does not support TOOL_EXECUTION finish reason.
-    }
-
-    @Override
     protected boolean supportsToolChoiceRequired() {
         return false; // Ollama does not support tool choice
         // also for OpenAI-compatible API: https://github.com/ollama/ollama/blob/main/docs/openai.md

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaStreamingChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaStreamingChatModelIT.java
@@ -79,7 +79,7 @@ class OllamaStreamingChatModelIT extends AbstractStreamingChatModelIT {
             .baseUrl(ollamaBaseUrl(ollamaWithVision))
             .modelName(MODEL_WITH_VISION)
             .temperature(0.0)
-            .logRequests(true)
+            .logRequests(false) // base64-encoded images are huge in logs
             .logResponses(true)
             .timeout(ofSeconds(180))
             .build();
@@ -97,7 +97,7 @@ class OllamaStreamingChatModelIT extends AbstractStreamingChatModelIT {
             .baseUrl(ollamaBaseUrl(ollamaWithVision) + "/v1")
             .modelName(MODEL_WITH_VISION)
             .temperature(0.0)
-            .logRequests(true)
+            .logRequests(false) // base64-encoded images are huge in logs
             .logResponses(true)
             .timeout(ofSeconds(180))
             .build();
@@ -222,12 +222,12 @@ class OllamaStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Override
     protected boolean assertResponseId() {
-        return false; // TODO implement
+        return false; // Ollama does not return response ID
     }
 
     @Override
     protected boolean assertTimesOnPartialResponseWasCalled() {
-        return false; // TODO
+        return false; // Ollama responds with a single SSE event for some reason (perhaps due to tools)
     }
 
     @Override

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaStreamingChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaStreamingChatModelIT.java
@@ -191,11 +191,6 @@ class OllamaStreamingChatModelIT extends AbstractStreamingChatModelIT {
     }
 
     @Override
-    protected boolean assertFinishReason() {
-        return false; // TODO: Ollama does not support TOOL_EXECUTION finish reason.
-    }
-
-    @Override
     protected boolean supportsToolChoiceRequired() {
         return false; // TODO check if Ollama supports this
     }


### PR DESCRIPTION
## Change
Return `FinishReason.TOOL_EXECUTION` when tool calls are present in the response

## General checklist
- [ ] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)