### PR TITLE
Introduce a way to provide a wrapper around the ToolExecutor for MCP tool calls

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolProvider.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolProvider.java
@@ -1,9 +1,11 @@
 package dev.langchain4j.mcp;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.internal.Utils;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.service.IllegalConfigurationException;
+import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
@@ -13,6 +15,8 @@ import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
+
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,16 +29,22 @@ public class McpToolProvider implements ToolProvider {
     private final CopyOnWriteArrayList<McpClient> mcpClients;
     private final boolean failIfOneServerFails;
     private final AtomicReference<BiPredicate<McpClient, ToolSpecification>> mcpToolsFilter;
+    private final Function<ToolExecutor, ToolExecutor> toolWrapper;
     private static final Logger log = LoggerFactory.getLogger(McpToolProvider.class);
 
     private McpToolProvider(Builder builder) {
-        this(builder.mcpClients, Utils.getOrDefault(builder.failIfOneServerFails, false), builder.mcpToolsFilter);
+        this(builder.mcpClients, Utils.getOrDefault(builder.failIfOneServerFails, false), builder.mcpToolsFilter, builder.toolWrapper);
     }
 
     protected McpToolProvider(List<McpClient> mcpClients, boolean failIfOneServerFails, BiPredicate<McpClient, ToolSpecification> mcpToolsFilter) {
+        this(Objects.requireNonNull(mcpClients), failIfOneServerFails, mcpToolsFilter, Function.identity());
+    }
+
+    protected McpToolProvider(List<McpClient> mcpClients, boolean failIfOneServerFails, BiPredicate<McpClient, ToolSpecification> mcpToolsFilter, Function<ToolExecutor, ToolExecutor> toolWrapper) {
         this.mcpClients = new CopyOnWriteArrayList<>(mcpClients);
         this.failIfOneServerFails = failIfOneServerFails;
         this.mcpToolsFilter = new AtomicReference<>(mcpToolsFilter);
+        this.toolWrapper = toolWrapper;
     }
 
     /**
@@ -97,10 +107,11 @@ public class McpToolProvider implements ToolProvider {
     protected ToolProviderResult provideTools(ToolProviderRequest request, BiPredicate<McpClient, ToolSpecification> mcpToolsFilter) {
         ToolProviderResult.Builder builder = ToolProviderResult.builder();
         for (McpClient mcpClient : mcpClients) {
+            var defaultToolExecutor = new DefaultToolExecutor(mcpClient);
             try {
                 mcpClient.listTools().stream().filter(tool -> mcpToolsFilter.test(mcpClient, tool))
                         .forEach(toolSpecification -> {
-                    builder.add(toolSpecification, (executionRequest, memoryId) -> mcpClient.executeTool(executionRequest));
+                    builder.add(toolSpecification, toolWrapper.apply(defaultToolExecutor));
                 });
             } catch (IllegalConfigurationException e) {
                 throw e;
@@ -124,6 +135,7 @@ public class McpToolProvider implements ToolProvider {
         private List<McpClient> mcpClients;
         private Boolean failIfOneServerFails;
         private BiPredicate<McpClient, ToolSpecification> mcpToolsFilter = (mcp, tool) -> true;
+        private Function<ToolExecutor, ToolExecutor> toolWrapper = Function.identity();
 
         /**
          * The list of MCP clients to use for retrieving tools.
@@ -164,6 +176,14 @@ public class McpToolProvider implements ToolProvider {
             return this;
         }
 
+        /**
+         * Provide a wrapper around the {@link ToolExecutor} that can be used to implement tracing for example.
+         */
+        public McpToolProvider.Builder toolWrapper(Function<ToolExecutor, ToolExecutor> toolWrapper) {
+            this.toolWrapper = toolWrapper;
+            return this;
+        }
+
         public McpToolProvider build() {
             return new McpToolProvider(this);
         }
@@ -183,6 +203,19 @@ public class McpToolProvider implements ToolProvider {
         @Override
         public boolean test(McpClient mcpClient, ToolSpecification tool) {
             return toolNames.stream().anyMatch(name -> name.equals(tool.name()));
+        }
+    }
+
+    private static class DefaultToolExecutor implements ToolExecutor {
+        private final McpClient mcpClient;
+
+        public DefaultToolExecutor(McpClient mcpClient) {
+            this.mcpClient = mcpClient;
+        }
+
+        @Override
+        public String execute(ToolExecutionRequest executionRequest, Object memoryId) {
+            return mcpClient.executeTool(executionRequest);
         }
     }
 }


### PR DESCRIPTION
This can be used to implement tracing for example.

The absence of tracing for MCP tool in Quarkus LangChain4j was originally mentioned at: https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/quarkus-micrometer-opentelemetry/near/519595776