### PR TITLE
Fix incorrect @P annotation usage in tool method example

### DIFF
--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -268,7 +268,7 @@ This means that the LLM will have to produce a value for such a parameter.
 A parameter can be made optional by annotating it with `@P(required = false)`:
 ```java
 @Tool
-void getTemperature(String location, @P(required = false) Unit unit) {
+void getTemperature(String location, @P(value = "Unit of temperature (e.g., Celsius or Fahrenheit)", required = false) Unit unit) {
     ...
 }
 ```

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -268,7 +268,7 @@ This means that the LLM will have to produce a value for such a parameter.
 A parameter can be made optional by annotating it with `@P(required = false)`:
 ```java
 @Tool
-void getTemperature(String location, @P(value = "Unit of temperature (e.g., Celsius or Fahrenheit)", required = false) Unit unit) {
+void getTemperature(String location, @P(value = "Unit of temperature", required = false) Unit unit) {
     ...
 }
 ```


### PR DESCRIPTION
This PR corrects an incomplete usage of the @P annotation in the documentation.

## Issue
In the example:
```
@Tool
void getTemperature(String location, @P(required = false) Unit unit) {
    ...
}
```
The @P annotation omits the required value() element, which leads to a compilation error because value() is a mandatory parameter in the @P annotation definition.

## Fix
Updated the annotation usage to:

```
@Tool
void getTemperature(
    String location,
    @P(value = "Unit of temperature (e.g., Celsius or Fahrenheit)", required = false) Unit unit
) {
    ...
}
```

