### PR TITLE
Upgrade Milvus SDK to 2.5.9

### DIFF
--- a/langchain4j-milvus/pom.xml
+++ b/langchain4j-milvus/pom.xml
@@ -85,7 +85,7 @@
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
-                <version>2.20.0</version>
+                <version>2.38.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/langchain4j-milvus/pom.xml
+++ b/langchain4j-milvus/pom.xml
@@ -80,6 +80,16 @@
         </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>2.20.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>

--- a/langchain4j-milvus/pom.xml
+++ b/langchain4j-milvus/pom.xml
@@ -18,6 +18,16 @@
         <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>2.38.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>
@@ -79,16 +89,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_annotations</artifactId>
-                <version>2.38.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreIT.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreIT.java
@@ -24,10 +24,12 @@ import org.testcontainers.milvus.MilvusContainer;
 @Testcontainers
 class MilvusEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
 
+    static final String MILVUS_DOCKER_IMAGE = "milvusdb/milvus:v2.5.10";
+
     private static final String COLLECTION_NAME = "test_collection";
 
     @Container
-    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.5.8");
+    private static final MilvusContainer milvus = new MilvusContainer(MILVUS_DOCKER_IMAGE);
 
     MilvusEmbeddingStore embeddingStore = MilvusEmbeddingStore.builder()
             .uri(milvus.getEndpoint())

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreRemovalIT.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreRemovalIT.java
@@ -10,13 +10,14 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.milvus.MilvusContainer;
 
 import static dev.langchain4j.internal.Utils.randomUUID;
+import static dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStoreIT.MILVUS_DOCKER_IMAGE;
 import static io.milvus.common.clientenum.ConsistencyLevelEnum.STRONG;
 
 @Testcontainers
 class MilvusEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {
 
     @Container
-    static MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.5.8");
+    static MilvusContainer milvus = new MilvusContainer(MILVUS_DOCKER_IMAGE);
 
     MilvusEmbeddingStore embeddingStore = MilvusEmbeddingStore.builder()
             .uri(milvus.getEndpoint())

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreRemovalIT.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStoreRemovalIT.java
@@ -1,17 +1,17 @@
 package dev.langchain4j.store.embedding.milvus;
 
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStoreIT.MILVUS_DOCKER_IMAGE;
+import static io.milvus.common.clientenum.ConsistencyLevelEnum.STRONG;
+
 import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.milvus.MilvusContainer;
-
-import static dev.langchain4j.internal.Utils.randomUUID;
-import static dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStoreIT.MILVUS_DOCKER_IMAGE;
-import static io.milvus.common.clientenum.ConsistencyLevelEnum.STRONG;
 
 @Testcontainers
 class MilvusEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -70,7 +70,7 @@
         <log4j.version>2.24.3</log4j.version>
         <logback.version>1.3.14</logback.version>
         <lombok.version>1.18.38</lombok.version>
-        <milvus-sdk-java.version>2.5.7</milvus-sdk-java.version>
+        <milvus-sdk-java.version>2.5.9</milvus-sdk-java.version>
         <mockito-kotlin.version>5.4.0</mockito-kotlin.version>
         <mockito.version>5.14.2</mockito.version>
         <okhttp.version>4.12.0</okhttp.version>


### PR DESCRIPTION
Fixes #3141 

Main reason for this PR is to fix the security issue detailed in #3141 

This also:

- Updates the Docker image used for tests to the latest version (2.5.10)
- Fixes a Spotless formatting issue

I have run the full test suite, both with TestContainers and using the Milvus Cloud, and this is all green.