### PR TITLE
Google Vertex AI Gemini: use GoogleSearch instead of GoogleSearchRetrieval

### DIFF
--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/ResponseGrounding.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/ResponseGrounding.java
@@ -1,6 +1,5 @@
 package dev.langchain4j.model.vertexai.gemini;
 
-import com.google.cloud.vertexai.api.GoogleSearchRetrieval;
 import com.google.cloud.vertexai.api.Retrieval;
 import com.google.cloud.vertexai.api.Tool;
 import com.google.cloud.vertexai.api.VertexAISearch;
@@ -13,11 +12,8 @@ class ResponseGrounding {
 
     static Tool googleSearchTool() {
         return Tool.newBuilder()
-            .setGoogleSearchRetrieval(
-                GoogleSearchRetrieval.newBuilder()
-//                    .setDisableAttribution(false)
-                    .build())
-            .build();
+                .setGoogleSearch(Tool.GoogleSearch.newBuilder().build())
+                .build();
     }
 
     /**

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/ResponseGrounding.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/ResponseGrounding.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.vertexai.gemini;
 
+import com.google.cloud.vertexai.api.GoogleSearchRetrieval;
 import com.google.cloud.vertexai.api.Retrieval;
 import com.google.cloud.vertexai.api.Tool;
 import com.google.cloud.vertexai.api.VertexAISearch;
@@ -10,10 +11,16 @@ import com.google.cloud.vertexai.api.VertexAISearch;
  */
 class ResponseGrounding {
 
-    static Tool googleSearchTool() {
-        return Tool.newBuilder()
-                .setGoogleSearch(Tool.GoogleSearch.newBuilder().build())
-                .build();
+    static Tool googleSearchTool(String modelName) {
+        if (modelName.startsWith("gemini-1")) {
+            return Tool.newBuilder()
+                    .setGoogleSearchRetrieval(GoogleSearchRetrieval.newBuilder().build())
+                    .build();
+        } else {
+            return Tool.newBuilder()
+                    .setGoogleSearch(Tool.GoogleSearch.newBuilder().build())
+                    .build();
+        }
     }
 
     /**

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -110,6 +110,8 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
                                    Boolean logRequests,
                                    Boolean logResponses,
                                    List<ChatModelListener> listeners) {
+        ensureNotBlank(modelName, "modelName");
+
         GenerationConfig.Builder generationConfigBuilder = GenerationConfig.newBuilder();
         if (temperature != null) {
             generationConfigBuilder.setTemperature(temperature);
@@ -146,7 +148,7 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         }
 
         if (useGoogleSearch != null && useGoogleSearch) {
-            googleSearch = ResponseGrounding.googleSearchTool();
+            googleSearch = ResponseGrounding.googleSearchTool(modelName);
         } else {
             googleSearch = null;
         }
@@ -198,8 +200,7 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
                 .setCustomHeaders(Collections.singletonMap("user-agent", "LangChain4j"))
                 .build();
 
-        this.generativeModel = new GenerativeModel(
-                ensureNotBlank(modelName, "modelName"), vertexAI)
+        this.generativeModel = new GenerativeModel(modelName, vertexAI)
                 .withGenerationConfig(generationConfig);
 
         this.maxRetries = getOrDefault(maxRetries, 2);

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModel.java
@@ -88,6 +88,8 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
             Boolean logResponses,
             List<ChatModelListener> listeners,
             final Map<String, String> customHeaders) {
+        ensureNotBlank(modelName, "modelName");
+
         GenerationConfig.Builder generationConfigBuilder = GenerationConfig.newBuilder();
         if (temperature != null) {
             generationConfigBuilder.setTemperature(temperature);
@@ -121,7 +123,7 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         }
 
         if (useGoogleSearch != null && useGoogleSearch) {
-            googleSearch = ResponseGrounding.googleSearchTool();
+            googleSearch = ResponseGrounding.googleSearchTool(modelName);
         } else {
             googleSearch = null;
         }
@@ -181,7 +183,7 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
                 .setCustomHeaders(headers)
                 .build();
 
-        this.generativeModel = new GenerativeModel(ensureNotBlank(modelName, "modelName"), vertexAI)
+        this.generativeModel = new GenerativeModel(modelName, vertexAI)
                 .withGenerationConfig(generationConfig);
 
         if (logRequests != null) {

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelIT.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelIT.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.RetryingTest;
 
 class VertexAiGeminiChatModelIT {
@@ -584,14 +585,15 @@ class VertexAiGeminiChatModelIT {
         assertThat(response).contains("rejected");
     }
 
-    @Test
-    void should_use_google_search() {
+    @ParameterizedTest
+    @ValueSource(strings = {"gemini-1.5-flash", "gemini-2.0-flash-lite"})
+    void should_use_google_search(String modelName) {
 
         // given
         VertexAiGeminiChatModel modelWithSearch = VertexAiGeminiChatModel.builder()
                 .project(System.getenv("GCP_PROJECT_ID"))
                 .location(System.getenv("GCP_LOCATION"))
-                .modelName("gemini-2.0-flash-lite")
+                .modelName(modelName)
                 .useGoogleSearch(true)
                 .build();
 

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModelIT.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModelIT.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.RetryingTest;
 
 class VertexAiGeminiStreamingChatModelIT {
@@ -437,14 +438,15 @@ class VertexAiGeminiStreamingChatModelIT {
         assertThat(aiMsg.toolExecutionRequests().get(1).arguments()).isEqualTo("{\"product\":\"XYZ\"}");
     }
 
-    @Test
-    void should_use_google_search() {
+    @ParameterizedTest
+    @ValueSource(strings = {"gemini-1.5-flash", "gemini-2.0-flash-lite"})
+    void should_use_google_search(String modelName) {
 
         // given
         VertexAiGeminiStreamingChatModel modelWithSearch = VertexAiGeminiStreamingChatModel.builder()
                 .project(System.getenv("GCP_PROJECT_ID"))
                 .location(System.getenv("GCP_LOCATION"))
-                .modelName("gemini-2.0-flash-lite")
+                .modelName(modelName)
                 .useGoogleSearch(true)
                 .build();
 


### PR DESCRIPTION
## Issue
Started getting this errors when switched from `gemini-1.5-flash-001` to `gemini-2.0-flash-lite`:

```
2025-06-03T01:47:08.9610274Z [ERROR] Errors: 
2025-06-03T01:47:08.9613382Z [ERROR]   VertexAiGeminiChatModelIT.should_use_google_search:599 » Runtime com.google.api.gax.rpc.InvalidArgumentException: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Unable to submit request because google_search_retrieval is not supported; please use google_search field instead. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini
2025-06-03T01:47:08.9618337Z [ERROR]   VertexAiGeminiStreamingChatModelIT.should_use_google_search:457 » Runtime java.util.concurrent.ExecutionException: com.google.api.gax.rpc.InvalidArgumentException: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Unable to submit request because google_search_retrieval is not supported; please use google_search field instead. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini
```

## Change
Use `GoogleSearch` instead of `GoogleSearchRetrieval`

## General checklist
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)