### PR TITLE
chore(selenium-loader): upgrade selenium-java to 4.33.0

### DIFF
--- a/document-loaders/langchain4j-document-loader-selenium/pom.xml
+++ b/document-loaders/langchain4j-document-loader-selenium/pom.xml
@@ -16,7 +16,7 @@
         https://www.selenium.dev/documentation/about/copyright</description>
 
     <properties>
-        <selenium.webdriver.version>4.13.0</selenium.webdriver.version>
+        <selenium.webdriver.version>4.33.0</selenium.webdriver.version>
         <!-- TODO: remove enforcer.skipRules -->
         <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>
     </properties>


### PR DESCRIPTION
## Issue
Closes #3148

## Change
Upgraded `org.seleniumhq.selenium:selenium-java` from version `4.13.0` to `4.33.0` in `langchain4j-document-loader-selenium/pom.xml`.

The previous version had a transitive dependency on a vulnerable version of `org.asynchttpclient`, flagged by Snyk:  
https://security.snyk.io/vuln/SNYK-JAVA-ORGASYNCHTTPCLIENT-8447519

The updated version resolves this CVE.

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change (existing tests reused)
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green

_No new docs or examples needed as this is an internal dependency upgrade only._
