### PR TITLE
support pseduo sets in the tool schema

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -117,6 +117,8 @@ class ToolSpecificationHelper {
                 }
                 builder.items(jsonNodeToJsonSchemaElement(node.get("items")));
                 return builder.build();
+            } else if (nodeType.equals("null")) {
+                return new JsonNullSchema();
             } else {
                 throw new IllegalArgumentException("Unknown element type: " + nodeType);
             }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -18,7 +18,6 @@ import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import wiremock.net.javacrumbs.jsonunit.core.internal.Node.JsonMap;
 
 class ToolSpecificationHelperTest {
 
@@ -409,10 +408,10 @@ class ToolSpecificationHelperTest {
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(toolSpecifications.get(0).parameters().properties().get("fieldSelections"))
                 .isInstanceOf(JsonAnyOfSchema.class);
-        JsonAnyOfSchema jsAny = (JsonAnyOfSchema) toolSpecifications.get(0).parameters().properties().get("fieldSelections");
+        JsonAnyOfSchema jsAny = (JsonAnyOfSchema)
+                toolSpecifications.get(0).parameters().properties().get("fieldSelections");
         assertThat(jsAny.anyOf()).hasSize(2);
         assertThat(jsAny.anyOf().get(0)).isInstanceOf(JsonObjectSchema.class);
         assertThat(jsAny.anyOf().get(1)).isInstanceOf(JsonNullSchema.class);
-        
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -18,6 +18,7 @@ import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import wiremock.net.javacrumbs.jsonunit.core.internal.Node.JsonMap;
 
 class ToolSpecificationHelperTest {
 
@@ -362,5 +363,56 @@ class ToolSpecificationHelperTest {
         List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
         assertThat(toolSpecifications.get(0).parameters().properties().get("value"))
                 .isInstanceOf(JsonObjectSchema.class);
+    }
+
+    @Test
+    public void nullType() throws JsonProcessingException {
+        // the 'type' parameter is "null" and so most not be present
+        // trimmed version from Atalassian's MCP server
+        String text =
+                """
+                [{
+                  "name": "createCompassCustomFieldDefinition",
+                  "description": "Create a new Compass custom field definition",
+                  "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                      "cloudId": {
+                        "type": "string",
+                        "description": "Unique identifier for an Atlassian Cloud instance in the form of a UUID. Can also be a site URL. If not working, use the 'getAccessibleAtlassianResources' tool to find accessible Cloud IDs."
+                      },
+                      "fieldSelections": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "null"
+                            },
+                            "description": "An list of options for the custom field definition, expressed as maps. The keys should be the options, and the values should all be null. Only used for SingleSelect and MultiSelect custom field definitions."
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "description": "An list of options for the custom field definition, expressed as maps. The keys should be the options, and the values should all be null. Only used for SingleSelect and MultiSelect custom field definitions."
+                      }
+                    },
+                    "required": [
+                      "cloudId"
+                    ],
+                    "additionalProperties": false,
+                    "$schema": "http://json-schema.org/draft-07/schema#"
+                  }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+        assertThat(toolSpecifications.get(0).parameters().properties().get("fieldSelections"))
+                .isInstanceOf(JsonAnyOfSchema.class);
+        JsonAnyOfSchema jsAny = (JsonAnyOfSchema) toolSpecifications.get(0).parameters().properties().get("fieldSelections");
+        assertThat(jsAny.anyOf()).hasSize(2);
+        assertThat(jsAny.anyOf().get(0)).isInstanceOf(JsonObjectSchema.class);
+        assertThat(jsAny.anyOf().get(1)).isInstanceOf(JsonNullSchema.class);
+        
     }
 }


### PR DESCRIPTION
Atlassians MCP Server used a "set" in the schema which caused lang4j to blow up when parsing.

This adds support for the `"null"` type when parsing tool specifications.

I have tested a local build of this with the Atlassian MCP Server in a test app:
* The error is no longer observed and the app can continue.  It can successfully retrieve Jira data via the MCP server (using `npx -yes mcp-remote https://mcp.atlassian.com/v1/sse`)
* I have no access to Atlassian Compass in order to test this end-to-end to see if this is indeed the correct fix, or if there are further fixes needed to fully support Atlassian's MCP server.

Attempted to run the ITs but there are also numerous failures on `main`.  No attempt to correlate the failures was done, as the tests where eventually timing out and causing other tests to fail to be open sockets (as the port was still in use) :-( 


<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #3151

## Change
<!-- Please describe the changes you made. -->

Use `JsonNullSchema` for the "null" nodeType when parsing ToolSpecifications.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
