### PR TITLE
Fix broken anchor link to 'Customizable RAG' section in RAG tutorial

### DIFF
--- a/docs/docs/tutorials/rag.md
+++ b/docs/docs/tutorials/rag.md
@@ -88,7 +88,7 @@ You don't have to learn about embeddings, choose a vector store, find the right 
 figure out how to parse and split documents, etc.
 Just point to your document(s), and LangChain4j will do its magic.
 
-If you need a customizable RAG, skip to the [next section](/tutorials/rag#rag-apis).
+If you need a customizable RAG, skip to the [next section](/tutorials/rag#core-rag-apis).
 
 If you are using Quarkus, there is an even easier way to do Easy RAG.
 Please read [Quarkus documentation](https://docs.quarkiverse.io/quarkus-langchain4j/dev/easy-rag.html).


### PR DESCRIPTION
Fix broken anchor link in RAG tutorial documentation

What’s changed: Updated the anchor link in the RAG tutorial from /tutorials/rag#rag-apis to /tutorials/rag#core-rag-apis to correctly point to the "Customizable RAG" section.