### PR TITLE
Update Metadata Documentation to Include UUID Support

### DIFF
--- a/docs/docs/tutorials/rag.md
+++ b/docs/docs/tutorials/rag.md
@@ -233,7 +233,7 @@ It stores meta information about the `Document`, such as its name, source, last 
 or any other relevant details.
 
 The `Metadata` is stored as a key-value map, where the key is of the `String` type,
-and the value can be one of the following types: `String`, `Integer`, `Long`, `Float`, `Double`.
+and the value can be one of the following types: `String`, `Integer`, `Long`, `Float`, `Double`, `UUID`.
 
 `Metadata` is useful for several reasons:
 - When including the content of the `Document` in a prompt to the LLM,


### PR DESCRIPTION
### Summary

This PR updates the documentation for the `Metadata` key-value map to include `UUID` as one of the supported value types.

### Details

The current documentation lists the supported value types as:
- String
- Integer
- Long
- Float
- Double

However, `UUID` is already supported in the implementation but missing from the docs.

This update adds `UUID` to the list of supported types in the documentation to improve clarity and accuracy.

This PR does not change any code logic, only updates the documentation.
