### PR TITLE
Fixes #2790: Add callback handler before the tool is executed

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -9,15 +9,16 @@ import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.guardrail.ChatExecutor;
 import dev.langchain4j.guardrail.GuardrailRequestParams;
 import dev.langchain4j.guardrail.OutputGuardrailRequest;
 import dev.langchain4j.memory.ChatMemory;
-import dev.langchain4j.guardrail.ChatExecutor;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.tool.BeforeToolExecutionContext;
 import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutor;
 import java.util.ArrayList;
@@ -44,6 +45,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     private final Consumer<String> partialResponseHandler;
     private final Consumer<PartialThinking> partialThinkingHandler;
+    private final Consumer<BeforeToolExecutionContext> beforeToolExecutionHandler;
     private final Consumer<ToolExecution> toolExecutionHandler;
     private final Consumer<ChatResponse> intermediateResponseHandler;
     private final Consumer<ChatResponse> completeResponseHandler;
@@ -64,6 +66,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             Object memoryId,
             Consumer<String> partialResponseHandler,
             Consumer<PartialThinking> partialThinkingHandler,
+            Consumer<BeforeToolExecutionContext> beforeToolExecutionHandler,
             Consumer<ToolExecution> toolExecutionHandler,
             Consumer<ChatResponse> intermediateResponseHandler,
             Consumer<ChatResponse> completeResponseHandler,
@@ -83,6 +86,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         this.partialThinkingHandler = partialThinkingHandler;
         this.intermediateResponseHandler = intermediateResponseHandler;
         this.completeResponseHandler = completeResponseHandler;
+        this.beforeToolExecutionHandler = beforeToolExecutionHandler;
         this.toolExecutionHandler = toolExecutionHandler;
         this.errorHandler = errorHandler;
 
@@ -124,6 +128,12 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             }
 
             for (ToolExecutionRequest toolExecutionRequest : aiMessage.toolExecutionRequests()) {
+                if (beforeToolExecutionHandler != null) {
+                    BeforeToolExecutionContext beforeToolExecutionContext = BeforeToolExecutionContext.builder()
+                            .toolExecutionRequests(toolExecutionRequest)
+                            .build();
+                    beforeToolExecutionHandler.accept(beforeToolExecutionContext);
+                }
                 String toolName = toolExecutionRequest.name();
                 ToolExecutor toolExecutor = toolExecutors.get(toolName);
                 String toolExecutionResult = toolExecutor.execute(toolExecutionRequest, memoryId);
@@ -151,6 +161,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     memoryId,
                     partialResponseHandler,
                     partialThinkingHandler,
+                    beforeToolExecutionHandler,
                     toolExecutionHandler,
                     intermediateResponseHandler,
                     completeResponseHandler,
@@ -168,8 +179,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 ChatResponse finalChatResponse = ChatResponse.builder()
                         .aiMessage(aiMessage)
                         .metadata(chatResponse.metadata().toBuilder()
-                                .tokenUsage(tokenUsage.add(
-                                        chatResponse.metadata().tokenUsage()))
+                                .tokenUsage(
+                                        tokenUsage.add(chatResponse.metadata().tokenUsage()))
                                 .build())
                         .build();
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -7,15 +7,16 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.guardrail.ChatExecutor;
 import dev.langchain4j.guardrail.GuardrailRequestParams;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
-import dev.langchain4j.guardrail.ChatExecutor;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.service.tool.BeforeToolExecutionContext;
 import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutor;
 import java.util.List;
@@ -37,6 +38,7 @@ public class AiServiceTokenStream implements TokenStream {
     private Consumer<String> partialResponseHandler;
     private Consumer<PartialThinking> partialThinkingHandler;
     private Consumer<List<Content>> contentsHandler;
+    private Consumer<BeforeToolExecutionContext> beforeToolExecutionHandler;
     private Consumer<ToolExecution> toolExecutionHandler;
     private Consumer<ChatResponse> intermediateResponseHandler;
     private Consumer<ChatResponse> completeResponseHandler;
@@ -47,6 +49,7 @@ public class AiServiceTokenStream implements TokenStream {
     private int onIntermediateResponseInvoked;
     private int onCompleteResponseInvoked;
     private int onRetrievedInvoked;
+    private int beforeToolExecutionInvoked;
     private int onToolExecutedInvoked;
     private int onErrorInvoked;
     private int ignoreErrorsInvoked;
@@ -91,6 +94,13 @@ public class AiServiceTokenStream implements TokenStream {
     }
 
     @Override
+    public TokenStream beforeToolExecution(Consumer<BeforeToolExecutionContext> beforeToolExecutionHandler) {
+        this.beforeToolExecutionHandler = beforeToolExecutionHandler;
+        this.beforeToolExecutionInvoked++;
+        return this;
+    }
+
+    @Override
     public TokenStream onToolExecuted(Consumer<ToolExecution> toolExecutionHandler) {
         this.toolExecutionHandler = toolExecutionHandler;
         this.onToolExecutedInvoked++;
@@ -129,11 +139,12 @@ public class AiServiceTokenStream implements TokenStream {
     public void start() {
         validateConfiguration();
 
-        ChatRequest chatRequest = context.chatRequestTransformer
-                .apply(ChatRequest.builder()
+        ChatRequest chatRequest = context.chatRequestTransformer.apply(
+                ChatRequest.builder()
                         .messages(messages)
                         .toolSpecifications(toolSpecifications)
-                        .build(), memoryId);
+                        .build(),
+                memoryId);
 
         ChatExecutor chatExecutor = ChatExecutor.builder(context.streamingChatModel)
                 .errorHandler(errorHandler)
@@ -146,6 +157,7 @@ public class AiServiceTokenStream implements TokenStream {
                 memoryId,
                 partialResponseHandler,
                 partialThinkingHandler,
+                beforeToolExecutionHandler,
                 toolExecutionHandler,
                 intermediateResponseHandler,
                 completeResponseHandler,
@@ -172,13 +184,17 @@ public class AiServiceTokenStream implements TokenStream {
             throw new IllegalConfigurationException("onPartialThinking can be invoked on TokenStream at most 1 time");
         }
         if (onIntermediateResponseInvoked > 1) {
-            throw new IllegalConfigurationException("onIntermediateResponse can be invoked on TokenStream at most 1 time");
+            throw new IllegalConfigurationException(
+                    "onIntermediateResponse can be invoked on TokenStream at most 1 time");
         }
         if (onCompleteResponseInvoked > 1) {
             throw new IllegalConfigurationException("onCompleteResponse can be invoked on TokenStream at most 1 time");
         }
         if (onRetrievedInvoked > 1) {
             throw new IllegalConfigurationException("onRetrieved can be invoked on TokenStream at most 1 time");
+        }
+        if (beforeToolExecutionInvoked > 1) {
+            throw new IllegalConfigurationException("beforeToolExecution can be invoked on TokenStream at most 1 time");
         }
         if (onToolExecutedInvoked > 1) {
             throw new IllegalConfigurationException("onToolExecuted can be invoked on TokenStream at most 1 time");

--- a/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
@@ -6,6 +6,7 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.service.tool.BeforeToolExecutionContext;
 import dev.langchain4j.service.tool.ToolExecution;
 import java.util.List;
 import java.util.function.Consumer;
@@ -51,6 +52,16 @@ public interface TokenStream {
     TokenStream onRetrieved(Consumer<List<Content>> contentHandler);
 
     /**
+     * The provided consumer will be invoked once streaming is complete and the response contains one tool to be executed.
+     * <p>
+     * The invocation happens before the tool method is called.
+     *
+     * @param beforeToolExecutionHandler lambda that consumes {@link dev.langchain4j.service.tool.BeforeToolExecutionContext}
+     * @return token stream instance used to configure or start stream processing
+     */
+    TokenStream beforeToolExecution(Consumer<BeforeToolExecutionContext> beforeToolExecutionHandler);
+
+    /**
      * The provided consumer will be invoked when a language model finishes streaming the <i>intermediate</i> chat response,
      * as opposed to the final response (see {@link #onCompleteResponse(Consumer)}).
      * Intermediate chat responses contain {@link ToolExecutionRequest}s, AI service will execute them
@@ -62,8 +73,8 @@ public interface TokenStream {
      * @since 1.2.0
      */
     default TokenStream onIntermediateResponse(Consumer<ChatResponse> intermediateResponseHandler) {
-        throw new UnsupportedOperationException("Consuming intermediate responses is not supported " +
-                "by this implementation of TokenStream: " + this.getClass().getName());
+        throw new UnsupportedOperationException("Consuming intermediate responses is not supported "
+                + "by this implementation of TokenStream: " + this.getClass().getName());
     }
 
     /**

--- a/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
@@ -52,7 +52,7 @@ public interface TokenStream {
     TokenStream onRetrieved(Consumer<List<Content>> contentHandler);
 
     /**
-     * The provided consumer will be invoked once streaming is complete and the response contains one tool to be executed.
+     * The provided consumer will be invoked before executing a tool.
      * <p>
      * The invocation happens before the tool method is called.
      *

--- a/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
@@ -59,7 +59,7 @@ public interface TokenStream {
      * @param beforeToolExecutionHandler lambda that consumes {@link dev.langchain4j.service.tool.BeforeToolExecutionContext}
      * @return token stream instance used to configure or start stream processing
      */
-    TokenStream beforeToolExecution(Consumer<BeforeToolExecutionContext> beforeToolExecutionHandler);
+    default TokenStream beforeToolExecution(Consumer<BeforeToolExecutionContext> beforeToolExecutionHandler); { return this; }
 
     /**
      * The provided consumer will be invoked when a language model finishes streaming the <i>intermediate</i> chat response,

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/BeforeToolExecutionContext.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/BeforeToolExecutionContext.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.service.tool;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import java.util.Objects;
+
+/**
+ * Context for the BeforeToolExecutionHandler that is passed to the handler before executing one tool.
+ * It contains a tool execution request that is about to be executed.
+ */
+public class BeforeToolExecutionContext {
+    private final ToolExecutionRequest toolExecutionRequest;
+
+    private BeforeToolExecutionContext(Builder builder) {
+        this.toolExecutionRequest = builder.toolExecutionRequest;
+    }
+
+    /**
+     * Returns the tool execution request that is about to be executed.
+     *
+     * @return the tool execution request
+     */
+    public ToolExecutionRequest toolExecutionRequest() {
+        return toolExecutionRequest;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        BeforeToolExecutionContext that = (BeforeToolExecutionContext) obj;
+        return Objects.equals(toolExecutionRequest, that.toolExecutionRequest);
+    }
+
+    @Override
+    public String toString() {
+        return "BeforeToolExecutionContext {" + " toolExecutionRequest = " + toolExecutionRequest + " }";
+    }
+
+    @Override
+    public int hashCode() {
+        int h = 5381;
+        h += (h << 5) + Objects.hashCode(toolExecutionRequest);
+        return h;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private ToolExecutionRequest toolExecutionRequest;
+
+        private Builder() {}
+
+        public Builder toolExecutionRequests(ToolExecutionRequest toolExecutionRequest) {
+            this.toolExecutionRequest = toolExecutionRequest;
+            return this;
+        }
+
+        public BeforeToolExecutionContext build() {
+            return new BeforeToolExecutionContext(this);
+        }
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/BeforeToolExecutionContext.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/BeforeToolExecutionContext.java
@@ -11,7 +11,7 @@ public class BeforeToolExecutionContext {
     private final ToolExecutionRequest toolExecutionRequest;
 
     private BeforeToolExecutionContext(Builder builder) {
-        this.toolExecutionRequest = builder.toolExecutionRequest;
+        this.toolExecutionRequest = ensureNotNull(builder.toolExecutionRequest, "toolExecutionRequest");
     }
 
     /**

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/BeforeToolExecutionContext.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/BeforeToolExecutionContext.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 /**
  * Context for the BeforeToolExecutionHandler that is passed to the handler before executing one tool.
  * It contains a tool execution request that is about to be executed.
+ * @since 1.2.0 
  */
 public class BeforeToolExecutionContext {
     private final ToolExecutionRequest toolExecutionRequest;

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
@@ -11,6 +11,7 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.service.tool.BeforeToolExecutionContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,8 @@ class AiServiceTokenStreamTest {
     static Consumer<PartialThinking> DUMMY_PARTIAL_THINKING_HANDLER = (partialThinking) -> {};
     static Consumer<Throwable> DUMMY_ERROR_HANDLER = (error) -> {};
     static Consumer<ChatResponse> DUMMY_CHAT_RESPONSE_HANDLER = (chatResponse) -> {};
+    static Consumer<BeforeToolExecutionContext> DUMMY_BEFORE_TOOL_EXECUTION_HANDLER =
+            (beforeToolExecutionContext) -> {};
 
     List<ChatMessage> messages = new ArrayList<>();
 
@@ -71,6 +74,29 @@ class AiServiceTokenStreamTest {
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("onPartialResponse must be invoked on TokenStream exactly 1 time");
+    }
+
+    @Test
+    void start_beforeToolExecutionInvoked_shouldNotThrowException() {
+        tokenStream
+                .onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER)
+                .beforeToolExecution(DUMMY_BEFORE_TOOL_EXECUTION_HANDLER)
+                .ignoreErrors();
+
+        assertThatNoException().isThrownBy(() -> tokenStream.start());
+    }
+
+    @Test
+    void start_beforeToolExecutionInvokedMultipleTimes_shouldThrowException() {
+        tokenStream
+                .onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER)
+                .beforeToolExecution(DUMMY_BEFORE_TOOL_EXECUTION_HANDLER)
+                .beforeToolExecution(DUMMY_BEFORE_TOOL_EXECUTION_HANDLER)
+                .ignoreErrors();
+
+        assertThatThrownBy(() -> tokenStream.start())
+                .isExactlyInstanceOf(IllegalConfigurationException.class)
+                .hasMessage("beforeToolExecution can be invoked on TokenStream at most 1 time");
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
@@ -1,5 +1,18 @@
 package dev.langchain4j.service;
 
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+import static dev.langchain4j.service.StreamingAiServicesWithToolsIT.TemperatureUnit.CELSIUS;
+import static dev.langchain4j.service.StreamingAiServicesWithToolsIT.TransactionService.EXPECTED_SPECIFICATION;
+import static dev.langchain4j.service.StreamingAiServicesWithToolsIT.WeatherService.TEMPERATURE;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,45 +32,29 @@ import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderResult;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
-
-import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
-import static dev.langchain4j.service.StreamingAiServicesWithToolsIT.TemperatureUnit.CELSIUS;
-import static dev.langchain4j.service.StreamingAiServicesWithToolsIT.TransactionService.EXPECTED_SPECIFICATION;
-import static dev.langchain4j.service.StreamingAiServicesWithToolsIT.WeatherService.TEMPERATURE;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class StreamingAiServicesWithToolsIT {
 
     static Stream<StreamingChatModel> models() {
-        return Stream.of(
-                OpenAiStreamingChatModel.builder()
-                        .baseUrl(System.getenv("OPENAI_BASE_URL"))
-                        .apiKey(System.getenv("OPENAI_API_KEY"))
-                        .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
-                        .modelName(GPT_4_O_MINI)
-                        .temperature(0.0)
-                        .logRequests(true)
-                        .logResponses(true)
-                        .build()
-        );
+        return Stream.of(OpenAiStreamingChatModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName(GPT_4_O_MINI)
+                .temperature(0.0)
+                .logRequests(true)
+                .logResponses(true)
+                .build());
     }
 
     interface Assistant {
@@ -108,7 +105,8 @@ class StreamingAiServicesWithToolsIT {
 
         // when
         CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
-        assistant.chat(userMessage)
+        assistant
+                .chat(userMessage)
                 .onPartialResponse(ignored -> {})
                 .onCompleteResponse(futureResponse::complete)
                 .onError(futureResponse::completeExceptionally)
@@ -124,24 +122,20 @@ class StreamingAiServicesWithToolsIT {
 
         // then
         List<ChatMessage> messages = chatMemory.messages();
-        verify(spyModel).chat(
-                eq(
-                        ChatRequest.builder()
+        verify(spyModel)
+                .chat(
+                        eq(ChatRequest.builder()
                                 .messages(messages.get(0))
                                 .toolSpecifications(EXPECTED_SPECIFICATION)
-                                .build()
-                ),
-                any()
-        );
-        verify(spyModel).chat(
-                eq(
-                        ChatRequest.builder()
+                                .build()),
+                        any());
+        verify(spyModel)
+                .chat(
+                        eq(ChatRequest.builder()
                                 .messages(messages.get(0), messages.get(1), messages.get(2))
                                 .toolSpecifications(EXPECTED_SPECIFICATION)
-                                .build()
-                ),
-                any()
-        );
+                                .build()),
+                        any());
     }
 
     static class WeatherService {
@@ -165,7 +159,9 @@ class StreamingAiServicesWithToolsIT {
     }
 
     enum TemperatureUnit {
-        CELSIUS, fahrenheit, Kelvin
+        CELSIUS,
+        fahrenheit,
+        Kelvin
     }
 
     @ParameterizedTest
@@ -189,7 +185,8 @@ class StreamingAiServicesWithToolsIT {
 
         // when
         CompletableFuture<ChatResponse> future = new CompletableFuture<>();
-        assistant.chat(userMessage)
+        assistant
+                .chat(userMessage)
                 .onPartialResponse(ignored -> {})
                 .onCompleteResponse(future::complete)
                 .onError(future::completeExceptionally)
@@ -203,24 +200,20 @@ class StreamingAiServicesWithToolsIT {
         verifyNoMoreInteractions(weatherService);
 
         List<ChatMessage> messages = chatMemory.messages();
-        verify(spyModel).chat(
-                eq(
-                        ChatRequest.builder()
+        verify(spyModel)
+                .chat(
+                        eq(ChatRequest.builder()
                                 .messages(messages.get(0))
                                 .toolSpecifications(WeatherService.EXPECTED_SPECIFICATION)
-                                .build()
-                ),
-                any()
-        );
-        verify(spyModel).chat(
-                eq(
-                        ChatRequest.builder()
+                                .build()),
+                        any());
+        verify(spyModel)
+                .chat(
+                        eq(ChatRequest.builder()
                                 .messages(messages.get(0), messages.get(1), messages.get(2))
                                 .toolSpecifications(WeatherService.EXPECTED_SPECIFICATION)
-                                .build()
-                ),
-                any()
-        );
+                                .build()),
+                        any());
     }
 
     @Test
@@ -247,7 +240,8 @@ class StreamingAiServicesWithToolsIT {
 
         // when
         CompletableFuture<ChatResponse> future = new CompletableFuture<>();
-        assistant.chat(userMessage)
+        assistant
+                .chat(userMessage)
                 .onPartialResponse(ignored -> {})
                 .onCompleteResponse(future::complete)
                 .onError(future::completeExceptionally)
@@ -263,24 +257,20 @@ class StreamingAiServicesWithToolsIT {
 
         // then
         List<ChatMessage> messages = chatMemory.messages();
-        verify(spyModel).chat(
-                eq(
-                        ChatRequest.builder()
+        verify(spyModel)
+                .chat(
+                        eq(ChatRequest.builder()
                                 .messages(messages.get(0))
                                 .toolSpecifications(EXPECTED_SPECIFICATION)
-                                .build()
-                ),
-                any()
-        );
-        verify(spyModel).chat(
-                eq(
-                        ChatRequest.builder()
+                                .build()),
+                        any());
+        verify(spyModel)
+                .chat(
+                        eq(ChatRequest.builder()
                                 .messages(messages.get(0), messages.get(1), messages.get(2))
                                 .toolSpecifications(EXPECTED_SPECIFICATION)
-                                .build()
-                ),
-                any()
-        );
+                                .build()),
+                        any());
         verifyNoMoreInteractionsFor(spyModel);
     }
 
@@ -302,11 +292,60 @@ class StreamingAiServicesWithToolsIT {
 
     private static Map<String, Object> toMap(String arguments) {
         try {
-            return new ObjectMapper().readValue(arguments, new TypeReference<>() {
-            });
+            return new ObjectMapper().readValue(arguments, new TypeReference<>() {});
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    void should_invoke_tool_before_execution_handler() throws Exception {
+
+        // given
+        WeatherService weatherService = spy(new WeatherService());
+
+        StreamingChatModel spyModel = spy(models().findFirst().get());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .streamingChatModel(spyModel)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(weatherService)
+                .build();
+
+        String userMessage = "What is the temperature in Munich and London, in Celsius?";
+
+        List<ToolExecutionRequest> toolExecutionRequests = new ArrayList<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+
+        // when
+        assistant
+                .chat(userMessage)
+                .onPartialResponse(ignored -> {})
+                .beforeToolExecution(beforeToolsExecutionContext ->
+                        toolExecutionRequests.add(beforeToolsExecutionContext.toolExecutionRequest()))
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+        ChatResponse response = future.get(60, SECONDS);
+
+        // then
+        assertThat(response.aiMessage().text()).contains(String.valueOf(WeatherService.TEMPERATURE));
+
+        // then
+        verify(weatherService).currentTemperature("Munich", CELSIUS);
+        verify(weatherService).currentTemperature("London", CELSIUS);
+        verifyNoMoreInteractions(weatherService);
+
+        // then
+        assertThat(toolExecutionRequests).hasSize(2);
+
+        assertThat(toolExecutionRequests.get(0).name()).isEqualTo("currentTemperature");
+        assertThat(toolExecutionRequests.get(0).arguments())
+                .isEqualToIgnoringWhitespace("{\"arg0\":\"Munich\", \"arg1\": \"CELSIUS\"}");
+
+        assertThat(toolExecutionRequests.get(1).name()).isEqualTo("currentTemperature");
+        assertThat(toolExecutionRequests.get(1).arguments())
+                .isEqualToIgnoringWhitespace("{\"arg0\":\"London\", \"arg1\":\"CELSIUS\"}");
     }
 
     @Test
@@ -329,7 +368,8 @@ class StreamingAiServicesWithToolsIT {
         CompletableFuture<ChatResponse> future = new CompletableFuture<>();
 
         // when
-        assistant.chat(userMessage)
+        assistant
+                .chat(userMessage)
                 .onPartialResponse(ignored -> {})
                 .onToolExecuted(toolExecutions::add)
                 .onCompleteResponse(future::complete)
@@ -349,11 +389,13 @@ class StreamingAiServicesWithToolsIT {
         assertThat(toolExecutions).hasSize(2);
 
         assertThat(toolExecutions.get(0).request().name()).isEqualTo("currentTemperature");
-        assertThat(toolExecutions.get(0).request().arguments()).isEqualToIgnoringWhitespace("{\"arg0\":\"Munich\", \"arg1\": \"CELSIUS\"}");
+        assertThat(toolExecutions.get(0).request().arguments())
+                .isEqualToIgnoringWhitespace("{\"arg0\":\"Munich\", \"arg1\": \"CELSIUS\"}");
         assertThat(toolExecutions.get(0).result()).isEqualTo(String.valueOf(WeatherService.TEMPERATURE));
 
         assertThat(toolExecutions.get(1).request().name()).isEqualTo("currentTemperature");
-        assertThat(toolExecutions.get(1).request().arguments()).isEqualToIgnoringWhitespace("{\"arg0\":\"London\", \"arg1\":\"CELSIUS\"}");
+        assertThat(toolExecutions.get(1).request().arguments())
+                .isEqualToIgnoringWhitespace("{\"arg0\":\"London\", \"arg1\":\"CELSIUS\"}");
         assertThat(toolExecutions.get(1).result()).isEqualTo(String.valueOf(WeatherService.TEMPERATURE));
     }
 


### PR DESCRIPTION
## Change  
This PR adds a **pre-tool-execution handler** to the streaming pipeline. Users of  `TokenStream` can provide `beforeToolExecution` handler, enabling live UI feedback like:

> “AI is calling `myTool` with args: { … }”

### Summary of changes  
- Introduced `beforeToolExecution(Consumer<BeforeToolExecution> beforeToolExecutionHandler))` callback in:
  - `TokenStream`
- Tool invocation is intercepted, and the event fired **immediately before** dispatching to the tool


### Design notes  
- No breaking changes: existing `onPartialResponse` and `onToolExecuted` callbacks remain unaffected
- The new callback is optional, and does not trigger unless explicitly subscribed

## General checklist  
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)