### PR TITLE
Add varargs-based  method for creating metadata from multiple key-val…

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
@@ -442,6 +442,30 @@ public class Metadata {
     public static Metadata from(Map<String, ?> metadata) {
         return new Metadata(metadata);
     }
+    
+    /**
+     * Constructs a Metadata object from multiple key-value pairs.
+     *
+     * @param keyValuePairs alternating keys (String) and values (Object)
+     * @return a Metadata object
+     * @throws IllegalArgumentException if the number of arguments is not even
+     */
+    public static Metadata from(Object... keyValuePairs) {
+        if (keyValuePairs.length % 2 != 0) {
+            throw new IllegalArgumentException("Expected even number of arguments (key-value pairs).");
+        }
+
+        Map<String, Object> metadata = new HashMap<>();
+        for (int i = 0; i < keyValuePairs.length; i += 2) {
+            if (!(keyValuePairs[i] instanceof String)) {
+                throw new IllegalArgumentException("Key must be a String at index " + i);
+            }
+            String key = (String) keyValuePairs[i];
+            Object value = keyValuePairs[i + 1];
+            metadata.put(key, value);
+        }
+        return new Metadata(metadata);
+    }
 
     /**
      * Constructs a Metadata object from a single key-value pair.

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
@@ -442,7 +442,7 @@ public class Metadata {
     public static Metadata from(Map<String, ?> metadata) {
         return new Metadata(metadata);
     }
-    
+
     /**
      * Constructs a Metadata object from multiple key-value pairs.
      *

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/document/MetadataTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/document/MetadataTest.java
@@ -262,6 +262,55 @@ class MetadataTest implements WithAssertions {
                 .hasMessageEndingWith("which is of the unsupported type 'java.lang.Object'. "
                         + "Currently, the supported types are: [class java.lang.String, class java.util.UUID, int, class java.lang.Integer, "
                         + "long, class java.lang.Long, float, class java.lang.Float, double, class java.lang.Double]");
+        
+        assertThatThrownBy(() -> Metadata.from("key", new Object()))
+        .isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("The metadata key 'key' has the value")
+        .hasMessageEndingWith("which is of the unsupported type 'java.lang.Object'. "
+                + "Currently, the supported types are: [class java.lang.String, class java.util.UUID, int, class java.lang.Integer, "
+                + "long, class java.lang.Long, float, class java.lang.Float, double, class java.lang.Double]");
+    }
+    
+    @Test
+    void should_create_from_multiple_key_value_pairs() {
+        UUID uuid = UUID.randomUUID();
+
+        Metadata metadata = Metadata.from(
+                "string", "s",
+                "int", 1,
+                "float", 1.5f,
+                "uuid", uuid
+        );
+
+        assertThat(metadata.getString("string")).isEqualTo("s");
+        assertThat(metadata.getInteger("int")).isEqualTo(1);
+        assertThat(metadata.getFloat("float")).isEqualTo(1.5f);
+        assertThat(metadata.getUUID("uuid")).isEqualTo(uuid);
+    }
+    
+    @Test
+    void should_fail_when_odd_number_of_arguments_provided() {
+        assertThatThrownBy(() -> Metadata.from("key1", "value1", "key2"))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Expected even number of arguments (key-value pairs).");
+    }
+
+    @Test
+    void should_fail_when_key_is_null_or_blank() {
+        assertThatThrownBy(() -> Metadata.from(null, "value"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The metadata key with the value 'value' cannot be null or blank");
+
+        assertThatThrownBy(() -> Metadata.from("   ", "value"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The metadata key with the value 'value' cannot be null or blank");
+    }
+
+    @Test
+    void should_fail_when_value_is_null() {
+        assertThatThrownBy(() -> Metadata.from("key", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The metadata value for the key 'key' cannot be null");
     }
 
     @Test

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/document/MetadataTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/document/MetadataTest.java
@@ -262,32 +262,27 @@ class MetadataTest implements WithAssertions {
                 .hasMessageEndingWith("which is of the unsupported type 'java.lang.Object'. "
                         + "Currently, the supported types are: [class java.lang.String, class java.util.UUID, int, class java.lang.Integer, "
                         + "long, class java.lang.Long, float, class java.lang.Float, double, class java.lang.Double]");
-        
+
         assertThatThrownBy(() -> Metadata.from("key", new Object()))
-        .isExactlyInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("The metadata key 'key' has the value")
-        .hasMessageEndingWith("which is of the unsupported type 'java.lang.Object'. "
-                + "Currently, the supported types are: [class java.lang.String, class java.util.UUID, int, class java.lang.Integer, "
-                + "long, class java.lang.Long, float, class java.lang.Float, double, class java.lang.Double]");
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("The metadata key 'key' has the value")
+                .hasMessageEndingWith("which is of the unsupported type 'java.lang.Object'. "
+                        + "Currently, the supported types are: [class java.lang.String, class java.util.UUID, int, class java.lang.Integer, "
+                        + "long, class java.lang.Long, float, class java.lang.Float, double, class java.lang.Double]");
     }
-    
+
     @Test
     void should_create_from_multiple_key_value_pairs() {
         UUID uuid = UUID.randomUUID();
 
-        Metadata metadata = Metadata.from(
-                "string", "s",
-                "int", 1,
-                "float", 1.5f,
-                "uuid", uuid
-        );
+        Metadata metadata = Metadata.from("string", "s", "int", 1, "float", 1.5f, "uuid", uuid);
 
         assertThat(metadata.getString("string")).isEqualTo("s");
         assertThat(metadata.getInteger("int")).isEqualTo(1);
         assertThat(metadata.getFloat("float")).isEqualTo(1.5f);
         assertThat(metadata.getUUID("uuid")).isEqualTo(uuid);
     }
-    
+
     @Test
     void should_fail_when_odd_number_of_arguments_provided() {
         assertThatThrownBy(() -> Metadata.from("key1", "value1", "key2"))
@@ -425,7 +420,11 @@ class MetadataTest implements WithAssertions {
         assertThat(new Metadata().put("k1", "v1").putAll(Map.of("k1", "v2")).toMap())
                 .isEqualTo(Map.of("k1", "v2"));
 
-        assertThatThrownBy(() -> new Metadata().putAll(new HashMap<>() {{ put("k", null); }}))
+        assertThatThrownBy(() -> new Metadata().putAll(new HashMap<>() {
+                    {
+                        put("k", null);
+                    }
+                }))
                 .isExactlyInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new Metadata().putAll(Map.of("k", new Object())))

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/document/MetadataTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/document/MetadataTest.java
@@ -263,7 +263,7 @@ class MetadataTest implements WithAssertions {
                         + "Currently, the supported types are: [class java.lang.String, class java.util.UUID, int, class java.lang.Integer, "
                         + "long, class java.lang.Long, float, class java.lang.Float, double, class java.lang.Double]");
 
-        assertThatThrownBy(() -> Metadata.from("key", new Object()))
+        assertThatThrownBy(() -> Metadata.from("key1", "value1", "key", new Object()))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("The metadata key 'key' has the value")
                 .hasMessageEndingWith("which is of the unsupported type 'java.lang.Object'. "


### PR DESCRIPTION
### Summary

This PR introduces an overloaded `Metadata.from(Object... keyValuePairs)` method that allows constructing a `Metadata` instance using multiple key-value pairs in a more concise and readable manner.

### Motivation

Currently, `Metadata` supports construction using:
- A single key-value pair (`Metadata.from(String, String)`), or
- A `Map<String, ?>`

However, there's no convenient way to create metadata inline with multiple entries without building a `Map` or chaining multiple `.put()` calls.

### Example Usage After Change

```java
Metadata meta = Metadata.from("category", "finance", "source", "news", "relevance", 9);
```