### PR TITLE
Draft: Add think support for Ollama

### DIFF
--- a/docs/docs/integrations/language-models/ollama.md
+++ b/docs/docs/integrations/language-models/ollama.md
@@ -195,6 +195,7 @@ public class OllamaStreamingChatExample {
             .temperature(0.0)
             .logRequests(true)
             .logResponses(true)
+            .think(false)
             .modelName(TINY_DOLPHIN_MODEL)
             .build();
 
@@ -206,6 +207,11 @@ public class OllamaStreamingChatExample {
         @Override
         public void onPartialResponse(String partialResponse) {
             System.out.print(partialResponse);
+        }
+
+        @Override
+        public void onPartialThinkingResponse(String partialThinkingResponse) {
+            System.err.print(partialThinkingResponse);
         }
 
         @Override
@@ -248,6 +254,11 @@ class OllamaStreamingChatLocalModelTest {
           }
 
           @Override
+          public void onPartialThinkingResponse(String partialThinkingResponse) {
+              System.err.print(partialThinkingResponse);
+          }
+
+          @Override
           public void onCompleteResponse(ChatResponse completeResponse) {
               futureResponse.complete(completeResponse);
           }
@@ -272,6 +283,7 @@ params with the builder pattern:
 |------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|------------------------|
 | `baseUrl`        | The base URL of Ollama server.                                                                                                                                                    | `String`         | http://localhost:11434 |
 | `modelName`      | The name of the model to use from Ollama server.                                                                                                                                  | `String`         |                        |
+| `think`          | Whether to enable or disable thinking capabilities of the model.                                                                                                                  | `Boolean`        |                        |
 | `temperature`    | Controls the randomness of the generated responses. Higher values (e.g., 1.0) result in more diverse output, while lower values (e.g., 0.2) produce more deterministic responses. | `Double`         |                        |
 | `topK`           | Specifies the number of highest probability tokens to consider for each step during generation.                                                                                   | `Integer`        |                        |
 | `topP`           | Controls the diversity of the generated responses by setting a threshold for the cumulative probability of top tokens.                                                            | `Double`         |                        |

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/AiMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/AiMessage.java
@@ -42,7 +42,7 @@ public class AiMessage implements ChatMessage {
      */
     public AiMessage(String text, String thinking) {
         this.text = ensureNotNull(text, "text");
-        this.thinking = ensureNotNull(thinking, "thinking");
+        this.thinking = thinking;
         this.toolExecutionRequests = List.of();
     }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/AiMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/AiMessage.java
@@ -21,6 +21,7 @@ import static java.util.Arrays.asList;
 public class AiMessage implements ChatMessage {
 
     private final String text;
+    private String thinking;
     private final List<ToolExecutionRequest> toolExecutionRequests;
 
     /**
@@ -34,6 +35,18 @@ public class AiMessage implements ChatMessage {
     }
 
     /**
+     * Create a new {@link AiMessage} with the given text and thinking content.
+     *
+     * @param text the text of the message.
+     * @param thinking the thinking text of the message.
+     */
+    public AiMessage(String text, String thinking) {
+        this.text = ensureNotNull(text, "text");
+        this.thinking = ensureNotNull(thinking, "thinking");
+        this.toolExecutionRequests = List.of();
+    }
+
+    /**
      * Create a new {@link AiMessage} with the given tool execution requests.
      *
      * @param toolExecutionRequests the tool execution requests of the message.
@@ -41,6 +54,19 @@ public class AiMessage implements ChatMessage {
     public AiMessage(List<ToolExecutionRequest> toolExecutionRequests) {
         this.text = null;
         this.toolExecutionRequests = ensureNotEmpty(toolExecutionRequests, "toolExecutionRequests");
+    }
+
+    /**
+     * Create a new {@link AiMessage} with the given text and tool execution requests.
+     *
+     * @param text                  the text of the message.
+     * @param thinking              the thinking text of the message.
+     * @param toolExecutionRequests the tool execution requests of the message.
+     */
+    public AiMessage(String text, String thinking, List<ToolExecutionRequest> toolExecutionRequests) {
+        this.text = text;
+        this.thinking = thinking;
+        this.toolExecutionRequests = copy(toolExecutionRequests);
     }
 
     /**
@@ -61,6 +87,15 @@ public class AiMessage implements ChatMessage {
      */
     public String text() {
         return text;
+    }
+
+    /**
+     * Get the thinking content of the message.
+     *
+     * @return the thinking content of the message.
+     */
+    public String thinking() {
+        return thinking;
     }
 
     /**
@@ -104,6 +139,7 @@ public class AiMessage implements ChatMessage {
     public String toString() {
         return "AiMessage {" +
                 " text = " + quoted(text) +
+                " thinking = " + quoted(thinking) +
                 " toolExecutionRequests = " + toolExecutionRequests +
                 " }";
     }
@@ -115,10 +151,16 @@ public class AiMessage implements ChatMessage {
     public static class Builder {
 
         private String text;
+        private String thinking;
         private List<ToolExecutionRequest> toolExecutionRequests;
 
         public Builder text(String text) {
             this.text = text;
+            return this;
+        }
+
+        public Builder thinking(String thinking) {
+            this.thinking = thinking;
             return this;
         }
 
@@ -128,7 +170,7 @@ public class AiMessage implements ChatMessage {
         }
 
         public AiMessage build() {
-            return new AiMessage(text, toolExecutionRequests);
+            return new AiMessage(text, thinking, toolExecutionRequests);
         }
     }
 
@@ -140,6 +182,17 @@ public class AiMessage implements ChatMessage {
      */
     public static AiMessage from(String text) {
         return new AiMessage(text);
+    }
+
+    /**
+     * Create a new {@link AiMessage} with the given text.
+     *
+     * @param text the text of the message.
+     * @param thinking the thinking content of the message.
+     * @return the new {@link AiMessage}.
+     */
+    public static AiMessage from(String text, String thinking) {
+        return new AiMessage(text, thinking);
     }
 
     /**
@@ -171,6 +224,18 @@ public class AiMessage implements ChatMessage {
      */
     public static AiMessage from(String text, List<ToolExecutionRequest> toolExecutionRequests) {
         return new AiMessage(text, toolExecutionRequests);
+    }
+
+    /**
+     * Create a new {@link AiMessage} with the given text and tool execution requests.
+     *
+     * @param text                  the text of the message.
+     * @param thinking              the thinking content of the message.
+     * @param toolExecutionRequests the tool execution requests of the message.
+     * @return the new {@link AiMessage}.
+     */
+    public static AiMessage from(String text, String thinking, List<ToolExecutionRequest> toolExecutionRequests) {
+        return new AiMessage(text, thinking, toolExecutionRequests);
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/LambdaStreamingResponseHandler.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/LambdaStreamingResponseHandler.java
@@ -44,6 +44,9 @@ public class LambdaStreamingResponseHandler {
             }
 
             @Override
+            public void onPartialThinkingResponse(String partialThinkingResponse) {}
+
+            @Override
             public void onCompleteResponse(ChatResponse completeResponse) {}
 
             @Override
@@ -61,6 +64,9 @@ public class LambdaStreamingResponseHandler {
             public void onPartialResponse(String partialResponse) {
                 onPartialResponseLambda.accept(partialResponse);
             }
+
+            @Override
+            public void onPartialThinkingResponse(String partialThinkingResponse) {}
 
             @Override
             public void onCompleteResponse(ChatResponse completeResponse) {}
@@ -84,7 +90,7 @@ public class LambdaStreamingResponseHandler {
     public static void onPartialResponseBlocking(
             StreamingChatModel model, String message, Consumer<String> onPartialResponse) throws InterruptedException {
 
-        onPartialResponseAndErrorBlocking(model, message, onPartialResponse, Throwable::printStackTrace);
+        onPartialResponseAndErrorBlocking(model, message, onPartialResponse, null, Throwable::printStackTrace);
     }
 
     /**
@@ -98,7 +104,7 @@ public class LambdaStreamingResponseHandler {
      * @throws InterruptedException if the thread is interrupted while waiting for completion
      */
     public static void onPartialResponseAndErrorBlocking(
-            StreamingChatModel model, String message, Consumer<String> onPartialResponse, Consumer<Throwable> onError)
+            StreamingChatModel model, String message, Consumer<String> onPartialResponse, Consumer<String> onPartialThinkingResponse, Consumer<Throwable> onError)
             throws InterruptedException {
 
         CountDownLatch completionLatch = new CountDownLatch(1);
@@ -107,6 +113,13 @@ public class LambdaStreamingResponseHandler {
             @Override
             public void onPartialResponse(String partialResponse) {
                 onPartialResponse.accept(partialResponse);
+            }
+
+            @Override
+            public void onPartialThinkingResponse(String partialThinkingResponse) {
+                if (onPartialThinkingResponse != null) {
+                  onPartialThinkingResponse.accept(partialThinkingResponse);
+                }
             }
 
             @Override

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/StreamingChatModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/StreamingChatModel.java
@@ -50,6 +50,11 @@ public interface StreamingChatModel {
             }
 
             @Override
+            public void onPartialThinkingResponse(String partialThinkingResponse) {
+                handler.onPartialThinkingResponse(partialThinkingResponse);
+            }
+
+            @Override
             public void onCompleteResponse(ChatResponse completeResponse) {
                 onResponse(completeResponse, finalChatRequest, provider(), attributes, listeners);
                 handler.onCompleteResponse(completeResponse);

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/response/StreamingChatResponseHandler.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/response/StreamingChatResponseHandler.java
@@ -41,5 +41,6 @@ public interface StreamingChatResponseHandler {
      * 
      * @param partialThinkingResponse
      */
-	void onPartialThinkingResponse(String partialThinkingResponse);
+    default void onPartialThinkingResponse(String partialThinkingResponse) {
+    }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/response/StreamingChatResponseHandler.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/response/StreamingChatResponseHandler.java
@@ -39,7 +39,7 @@ public interface StreamingChatResponseHandler {
     /**
      * Invoked each time the model generates a partial thinking response (thinking token) in a textual response.
      * 
-     * @param thinking
+     * @param partialThinkingResponse
      */
 	void onPartialThinkingResponse(String partialThinkingResponse);
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/response/StreamingChatResponseHandler.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/response/StreamingChatResponseHandler.java
@@ -35,4 +35,11 @@ public interface StreamingChatResponseHandler {
      * @param error The error that occurred
      */
     void onError(Throwable error);
+
+    /**
+     * Invoked each time the model generates a partial thinking response (thinking token) in a textual response.
+     * 
+     * @param thinking
+     */
+	void onPartialThinkingResponse(String partialThinkingResponse);
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/LambdaStreamingResponseHandlerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/LambdaStreamingResponseHandlerTest.java
@@ -114,6 +114,7 @@ class LambdaStreamingResponseHandlerTest implements WithAssertions {
                         completed.set(true);
                     }
                 },
+                null,
                 t -> thrown[0] = t);
 
         // then
@@ -166,7 +167,7 @@ class LambdaStreamingResponseHandlerTest implements WithAssertions {
         final Throwable[] thrown = {null};
         AtomicBoolean completed = new AtomicBoolean(false);
 
-        onPartialResponseAndErrorBlocking(model, "Test message", receivedTokens::add, t -> {
+        onPartialResponseAndErrorBlocking(model, "Test message", receivedTokens::add, null, t -> {
             thrown[0] = t;
             completed.set(true);
         });

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/StreamingChatModelTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/StreamingChatModelTest.java
@@ -41,6 +41,10 @@ class StreamingChatModelTest implements WithAssertions {
         }
 
         @Override
+        public void onPartialThinkingResponse(String partialThinkingResponse) {
+        }
+
+        @Override
         public void onCompleteResponse(ChatResponse completeResponse) {
             responses.add(completeResponse);
         }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/TestStreamingChatResponseHandler.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/TestStreamingChatResponseHandler.java
@@ -14,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestStreamingChatResponseHandler implements StreamingChatResponseHandler {
 
     private final StringBuffer responseBuilder = new StringBuffer();
+    private final StringBuffer thinkingResponseBuilder = new StringBuffer();
+
     private final CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
 
     @Override
@@ -27,7 +29,15 @@ public class TestStreamingChatResponseHandler implements StreamingChatResponseHa
         if (!aiMessage.hasToolExecutionRequests()) {
             assertThat(aiMessage.text()).isEqualTo(responseBuilder.toString());
         }
+        if (aiMessage.thinking()!=null) {
+            assertThat(aiMessage.thinking()).isEqualTo(thinkingResponseBuilder.toString());
+        }
         futureResponse.complete(completeResponse);
+    }
+
+    @Override
+    public void onPartialThinkingResponse(String partialThinkingResponse) {
+        thinkingResponseBuilder.append(partialThinkingResponse);
     }
 
     @Override

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/common/AbstractStreamingChatModelListenerIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/common/AbstractStreamingChatModelListenerIT.java
@@ -257,6 +257,11 @@ public abstract class AbstractStreamingChatModelListenerIT {
             }
 
             @Override
+            public void onPartialThinkingResponse(String partialThinkingResponse) {
+                fail("onPartialThinkingResponse() must not be called");
+            }
+
+            @Override
             public void onCompleteResponse(ChatResponse completeResponse) {
                 fail("onCompleteResponse() must not be called");
             }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/common/StreamingMetadata.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/common/StreamingMetadata.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 public record StreamingMetadata(String concatenatedPartialResponses,
                                 int timesOnPartialResponseWasCalled,
+                                int timesOnThinkingPartialResponseWasCalled,
                                 int timesOnCompleteResponseWasCalled,
                                 Set<Thread> threads
 ) {

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/CompletionRequest.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/CompletionRequest.java
@@ -22,16 +22,18 @@ class CompletionRequest {
     private String format;
 
     private Boolean stream;
+    private Boolean think;
 
     CompletionRequest() {}
 
-    CompletionRequest(String model, String system, String prompt, Options options, String format, Boolean stream) {
+    CompletionRequest(String model, String system, String prompt, Options options, String format, Boolean stream, Boolean think) {
         this.model = model;
         this.system = system;
         this.prompt = prompt;
         this.options = options;
         this.format = format;
         this.stream = stream;
+        this.think = think;
     }
 
     static Builder builder() {
@@ -82,6 +84,10 @@ class CompletionRequest {
         return stream;
     }
 
+    public Boolean getThink() {
+        return think;
+    }
+
     public void setStream(Boolean stream) {
         this.stream = stream;
     }
@@ -94,6 +100,7 @@ class CompletionRequest {
         private Options options;
         private String format;
         private Boolean stream;
+        private Boolean think;
 
         Builder model(String model) {
             this.model = model;
@@ -125,8 +132,13 @@ class CompletionRequest {
             return this;
         }
 
+        Builder think(Boolean think) {
+            this.think = think;
+            return this;
+        }
+
         CompletionRequest build() {
-            return new CompletionRequest(model, system, prompt, options, format, stream);
+            return new CompletionRequest(model, system, prompt, options, format, stream, think);
         }
     }
 }

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -139,7 +139,7 @@ class InternalOllamaHelper {
                 new TokenUsage(ollamaChatResponse.getPromptEvalCount(), ollamaChatResponse.getEvalCount()));
     }
 
-    static OllamaChatRequest toOllamaChatRequest(ChatRequest chatRequest, boolean stream, Boolean think) {
+    static OllamaChatRequest toOllamaChatRequest(ChatRequest chatRequest, boolean stream) {
         OllamaChatRequestParameters requestParameters = (OllamaChatRequestParameters) chatRequest.parameters();
         return OllamaChatRequest.builder()
                 .model(requestParameters.modelName())
@@ -162,7 +162,7 @@ class InternalOllamaHelper {
                         .build())
                 .format(toOllamaResponseFormat(requestParameters.responseFormat()))
                 .stream(stream)
-                .think(think)
+                .think(requestParameters.think())
                 .tools(toOllamaTools(chatRequest.toolSpecifications()))
                 .keepAlive(requestParameters.keepAlive())
                 .build();

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -139,7 +139,7 @@ class InternalOllamaHelper {
                 new TokenUsage(ollamaChatResponse.getPromptEvalCount(), ollamaChatResponse.getEvalCount()));
     }
 
-    static OllamaChatRequest toOllamaChatRequest(ChatRequest chatRequest, boolean stream) {
+    static OllamaChatRequest toOllamaChatRequest(ChatRequest chatRequest, boolean stream, Boolean think) {
         OllamaChatRequestParameters requestParameters = (OllamaChatRequestParameters) chatRequest.parameters();
         return OllamaChatRequest.builder()
                 .model(requestParameters.modelName())
@@ -162,6 +162,7 @@ class InternalOllamaHelper {
                         .build())
                 .format(toOllamaResponseFormat(requestParameters.responseFormat()))
                 .stream(stream)
+                .think(think)
                 .tools(toOllamaTools(chatRequest.toolSpecifications()))
                 .keepAlive(requestParameters.keepAlive())
                 .build();

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -129,7 +129,7 @@ class InternalOllamaHelper {
         return ollamaChatResponse.getMessage().getToolCalls() != null
                 ? AiMessage.from(
                         toToolExecutionRequests(ollamaChatResponse.getMessage().getToolCalls()))
-                : AiMessage.from(ollamaChatResponse.getMessage().getContent());
+                : AiMessage.from(ollamaChatResponse.getMessage().getContent(), ollamaChatResponse.getMessage().getThinking());
     }
 
     static ChatResponseMetadata chatResponseMetadataFrom(OllamaChatResponse ollamaChatResponse) {

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/Message.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/Message.java
@@ -19,6 +19,7 @@ class Message {
 
     private Role role;
     private String content;
+    private String thinking;
     private List<String> images;
     private List<ToolCall> toolCalls;
     private Map<String, Object> additionalFields;
@@ -26,9 +27,10 @@ class Message {
     Message() {
     }
 
-    public Message(Role role, String content, List<String> images, List<ToolCall> toolCalls, Map<String, Object> additionalFields) {
+    public Message(Role role, String content, String thinking, List<String> images, List<ToolCall> toolCalls, Map<String, Object> additionalFields) {
         this.role = role;
         this.content = content;
+        this.thinking = thinking;
         this.images = images;
         this.toolCalls = toolCalls;
         this.additionalFields = additionalFields;
@@ -52,6 +54,14 @@ class Message {
 
     public void setContent(String content) {
         this.content = content;
+    }
+
+    public String getThinking() {
+        return thinking;
+    }
+
+    public void setThinking(String thinking) {
+        this.thinking = thinking;
     }
 
     public List<String> getImages() {
@@ -84,6 +94,7 @@ class Message {
 
         private Role role;
         private String content;
+        private String thinking;
         private List<String> images;
         private List<ToolCall> toolCalls;
         private Map<String, Object> additionalFields;
@@ -95,6 +106,11 @@ class Message {
 
         Builder content(String content) {
             this.content = content;
+            return this;
+        }
+
+        Builder thinking(String thinking) {
+            this.thinking = thinking;
             return this;
         }
 
@@ -114,7 +130,7 @@ class Message {
         }
 
         Message build() {
-            return new Message(role, content, images, toolCalls, additionalFields);
+            return new Message(role, content, thinking, images, toolCalls, additionalFields);
         }
     }
 }

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaBaseChatModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaBaseChatModel.java
@@ -67,6 +67,7 @@ abstract class OllamaBaseChatModel {
                 .repeatPenalty(getOrDefault(builder.repeatPenalty, ollamaParameters.repeatPenalty()))
                 .seed(getOrDefault(builder.seed, ollamaParameters.seed()))
                 .minP(getOrDefault(builder.minP, ollamaParameters.minP()))
+                .think(getOrDefault(builder.think, ollamaParameters.think()))
                 .keepAlive(ollamaParameters.keepAlive())
                 .build();
 
@@ -101,6 +102,7 @@ abstract class OllamaBaseChatModel {
         protected Double minP;
         protected ResponseFormat responseFormat;
         protected Duration timeout;
+        protected Boolean think;
         protected Map<String, String> customHeaders;
         protected Boolean logRequests;
         protected Boolean logResponses;
@@ -209,6 +211,11 @@ abstract class OllamaBaseChatModel {
 
         public B timeout(Duration timeout) {
             this.timeout = timeout;
+            return self();
+        }
+
+        public B think(Boolean think) {
+            this.think = think;
             return self();
         }
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatModel.java
@@ -37,7 +37,7 @@ public class OllamaChatModel extends OllamaBaseChatModel implements ChatModel {
     public ChatResponse doChat(ChatRequest chatRequest) {
         validate(chatRequest.parameters());
 
-        OllamaChatRequest ollamaChatRequest = toOllamaChatRequest(chatRequest, false, null);
+        OllamaChatRequest ollamaChatRequest = toOllamaChatRequest(chatRequest, false);
         OllamaChatResponse ollamaChatResponse =
                 withRetryMappingExceptions(() -> client.chat(ollamaChatRequest), maxRetries);
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatModel.java
@@ -37,7 +37,7 @@ public class OllamaChatModel extends OllamaBaseChatModel implements ChatModel {
     public ChatResponse doChat(ChatRequest chatRequest) {
         validate(chatRequest.parameters());
 
-        OllamaChatRequest ollamaChatRequest = toOllamaChatRequest(chatRequest, false);
+        OllamaChatRequest ollamaChatRequest = toOllamaChatRequest(chatRequest, false, null);
         OllamaChatResponse ollamaChatResponse =
                 withRetryMappingExceptions(() -> client.chat(ollamaChatRequest), maxRetries);
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatRequest.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatRequest.java
@@ -22,6 +22,7 @@ class OllamaChatRequest {
     private String format;
 
     private Boolean stream;
+    private Boolean think;
     private List<Tool> tools;
     private Integer keepAlive;
 
@@ -32,6 +33,7 @@ class OllamaChatRequest {
         this.messages = builder.messages;
         this.options = builder.options;
         this.stream = builder.stream;
+        this.think  = builder.think;
         this.tools = builder.tools;
         this.format = builder.format;
         this.keepAlive = builder.keepAlive;
@@ -78,7 +80,15 @@ class OllamaChatRequest {
     }
 
     public void setStream(Boolean stream) {
-        this.stream = stream;
+    	this.stream = stream;
+    }
+
+    public Boolean getThink() {
+        return think;
+    }
+
+    public void setThink(Boolean think) {
+        this.think = think;
     }
 
     public List<Tool> getTools() {
@@ -104,6 +114,7 @@ class OllamaChatRequest {
         private Options options;
         private String format;
         private Boolean stream;
+        private Boolean think;
         private List<Tool> tools;
         private Integer keepAlive;
 
@@ -129,6 +140,11 @@ class OllamaChatRequest {
 
         Builder stream(Boolean stream) {
             this.stream = stream;
+            return this;
+        }
+
+        Builder think(Boolean think) {
+            this.think = think;
             return this;
         }
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatRequestParameters.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatRequestParameters.java
@@ -21,6 +21,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
     private final Integer seed;
     private final Double minP;
     private final Integer keepAlive;
+    private final Boolean think;
 
     private OllamaChatRequestParameters(Builder builder) {
         super(builder);
@@ -33,6 +34,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
         this.seed = builder.seed;
         this.minP = builder.minP;
         this.keepAlive = builder.keepAlive;
+        this.think = builder.think;
     }
 
     public Integer mirostat() {
@@ -71,6 +73,10 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
         return keepAlive;
     }
 
+    public Boolean think() {
+        return think;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (o == null || getClass() != o.getClass()) return false;
@@ -84,6 +90,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
                 && Objects.equals(repeatPenalty, that.repeatPenalty)
                 && Objects.equals(seed, that.seed)
                 && Objects.equals(minP, that.minP)
+                && Objects.equals(think, that.think)
                 && Objects.equals(keepAlive, that.keepAlive);
     }
 
@@ -99,6 +106,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
                 repeatPenalty,
                 seed,
                 minP,
+                think,
                 keepAlive);
     }
 
@@ -106,6 +114,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
     public String toString() {
         return "OllamaChatRequestParameters{"
                 + "modelName=" + quoted(modelName())
+                + ", think=" + think()
                 + ", temperature=" + temperature()
                 + ", topP=" + topP()
                 + ", topK=" + topK()
@@ -151,6 +160,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
         private Integer seed;
         private Double minP;
         private Integer keepAlive;
+        private Boolean think;
 
         @Override
         public Builder overrideWith(ChatRequestParameters parameters) {
@@ -165,6 +175,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
                 seed(getOrDefault(ollamaChatRequestParameters.seed, seed));
                 minP(getOrDefault(ollamaChatRequestParameters.minP, minP));
                 keepAlive(getOrDefault(ollamaChatRequestParameters.keepAlive, keepAlive));
+                think(getOrDefault(ollamaChatRequestParameters.think, think));
             }
             return this;
         }
@@ -248,6 +259,17 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
          */
         public Builder keepAlive(Integer keepAlive) {
             this.keepAlive = keepAlive;
+            return this;
+        }
+
+        /**
+         * Controls whether the model’s thinking process should be enabled.
+         * <p>Default: null</p>
+         *
+         * @return builder
+         */
+        public Builder think(Boolean think) {
+            this.think = think;
             return this;
         }
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
@@ -133,7 +133,7 @@ class OllamaClient {
     public void streamingChat(ChatRequest request, StreamingChatResponseHandler handler) {
         ensureNotEmpty(request.messages(), "messages");
 
-        OllamaChatRequest ollamaChatRequest = toOllamaChatRequest(request, true, true);
+        OllamaChatRequest ollamaChatRequest = toOllamaChatRequest(request, true);
 
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(POST)
@@ -156,6 +156,15 @@ class OllamaClient {
                 if (!isNullOrEmpty(content)) {
                     try {
                         handler.onPartialResponse(content);
+                    } catch (Exception e) {
+                        withLoggingExceptions(() -> handler.onError(e));
+                    }
+                }
+
+                String thinking = ollamaChatResponse.getMessage().getThinking();
+                if (!isNullOrEmpty(thinking)) {
+                    try {
+                        handler.onPartialThinkingResponse(thinking);
                     } catch (Exception e) {
                         withLoggingExceptions(() -> handler.onError(e));
                     }

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
@@ -133,7 +133,7 @@ class OllamaClient {
     public void streamingChat(ChatRequest request, StreamingChatResponseHandler handler) {
         ensureNotEmpty(request.messages(), "messages");
 
-        OllamaChatRequest ollamaChatRequest = toOllamaChatRequest(request, true);
+        OllamaChatRequest ollamaChatRequest = toOllamaChatRequest(request, true, true);
 
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(POST)

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaLanguageModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaLanguageModel.java
@@ -29,6 +29,7 @@ public class OllamaLanguageModel implements LanguageModel {
     private final Options options;
     private final ResponseFormat responseFormat;
     private final Integer maxRetries;
+    private final Boolean think;
 
     public OllamaLanguageModel(OllamaLanguageModelBuilder builder) {
         this.client = OllamaClient.builder()
@@ -52,6 +53,7 @@ public class OllamaLanguageModel implements LanguageModel {
                 .build();
         this.responseFormat = builder.responseFormat;
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
+        this.think = builder.think;
     }
 
     public static OllamaLanguageModelBuilder builder() {
@@ -69,6 +71,7 @@ public class OllamaLanguageModel implements LanguageModel {
                 .prompt(prompt)
                 .options(options)
                 .format(toOllamaResponseFormat(responseFormat))
+                .think(think)
                 .stream(false)
                 .build();
 
@@ -96,6 +99,7 @@ public class OllamaLanguageModel implements LanguageModel {
         private Integer maxRetries;
         private Boolean logRequests;
         private Boolean logResponses;
+        private Boolean think;
         private Map<String, String> customHeaders;
 
         public OllamaLanguageModelBuilder() {
@@ -186,6 +190,11 @@ public class OllamaLanguageModel implements LanguageModel {
 
         public OllamaLanguageModelBuilder logResponses(Boolean logResponses) {
             this.logResponses = logResponses;
+            return this;
+        }
+
+        public OllamaLanguageModelBuilder think(Boolean think) {
+            this.think = think;
             return this;
         }
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaStreamingResponseBuilder.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaStreamingResponseBuilder.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 class OllamaStreamingResponseBuilder {
 
     private final StringBuffer contentBuilder = new StringBuffer();
+    private final StringBuffer thinkingBuilder = new StringBuffer();
     private volatile String modelName;
     private volatile TokenUsage tokenUsage;
     private final List<ToolExecutionRequest> toolExecutionRequests = new CopyOnWriteArrayList<>();
@@ -51,6 +52,11 @@ class OllamaStreamingResponseBuilder {
         String content = message.getContent();
         if (content != null) {
             contentBuilder.append(content);
+        }
+
+        String thinking = message.getThinking();
+        if (thinking!= null) {
+            thinkingBuilder.append(thinking);
         }
     }
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaStreamingResponseBuilder.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaStreamingResponseBuilder.java
@@ -72,8 +72,9 @@ class OllamaStreamingResponseBuilder {
         if (text.isEmpty()) {
             return null;
         } else {
+            String thinking = thinkingBuilder.toString();
             return ChatResponse.builder()
-                    .aiMessage(AiMessage.from(text))
+                    .aiMessage(AiMessage.from(text, thinking))
                     .metadata(chatResponseMetadataFrom(modelName, toFinishReason(ollamaChatResponse), tokenUsage))
                     .build();
         }

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaImage.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaImage.java
@@ -23,6 +23,8 @@ public class OllamaImage {
 
     public static final String GRANITE_3_GUARDIAN = "granite3-guardian";
 
+    public static final String MAGISTRAL_24B = "magistral:24b";
+
     public static DockerImageName resolve(String baseImage, String localImageName) {
         DockerImageName dockerImageName = DockerImageName.parse(baseImage);
         DockerClient dockerClient = DockerClientFactory.instance().client();

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaStreamingChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaStreamingChatModelIT.java
@@ -214,6 +214,11 @@ class OllamaStreamingChatModelIT extends AbstractOllamaLanguageModelInfrastructu
             }
 
             @Override
+            public void onPartialThinkingResponse(String partialThinkingResponse) {
+                future.completeExceptionally(new Exception("onPartialThinkingResponse() should never be called"));
+            }
+
+            @Override
             public void onCompleteResponse(ChatResponse completeResponse) {
                 future.completeExceptionally(new Exception("onCompleteResponse() should never be called"));
             }
@@ -284,6 +289,9 @@ class OllamaStreamingChatModelIT extends AbstractOllamaLanguageModelInfrastructu
             public void onPartialResponse(String partialResponse) {
                 onPartialResponseCounter.incrementAndGet();
             }
+
+            @Override
+            public void onPartialThinkingResponse(String partialThinkingResponse) {}
 
             @Override
             public void onCompleteResponse(ChatResponse completeResponse) {

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaStructuredOutputIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaStructuredOutputIT.java
@@ -5,7 +5,11 @@ import static dev.langchain4j.model.ollama.AbstractOllamaLanguageModelInfrastruc
 import static dev.langchain4j.model.ollama.OllamaJsonUtils.fromJson;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
@@ -24,9 +28,6 @@ import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.language.LanguageModel;
 import dev.langchain4j.model.language.StreamingLanguageModel;
 import dev.langchain4j.model.output.Response;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import org.junit.jupiter.api.Test;
 
 class OllamaStructuredOutputIT extends AbstractOllamaStructuredOutputLanguageModelInfrastructure {
 
@@ -123,6 +124,9 @@ class OllamaStructuredOutputIT extends AbstractOllamaStructuredOutputLanguageMod
 
             @Override
             public void onPartialResponse(String partialResponse) {}
+
+            @Override
+            public void onPartialThinkingResponse(String partialThinkingResponse) {}
 
             @Override
             public void onCompleteResponse(ChatResponse completeResponse) {

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaThinkChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaThinkChatModelIT.java
@@ -1,0 +1,101 @@
+package dev.langchain4j.model.ollama;
+
+import static dev.langchain4j.model.ollama.OllamaImage.MAGISTRAL_24B;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.TokenUsage;
+
+class OllamaThinkChatModelIT extends AbstractOllamaLanguageModelInfrastructure {
+
+    static final String MODEL_NAME = MAGISTRAL_24B;
+
+    @Test
+    void should_think() {
+
+        StreamingChatModel model = OllamaStreamingChatModel.builder()
+            .baseUrl(ollamaBaseUrl(ollama))
+            .modelName(MODEL_NAME)
+            .temperature(0.0)
+            .think(true)
+            .logRequests(true)
+            .logResponses(true)
+            .build();
+
+        // given
+        String userMessage = "What is the capital of Germany?";
+
+        // when
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        model.chat(userMessage, handler);
+        ChatResponse response = handler.get();
+        String answer = response.aiMessage().text();
+
+        // then
+        assertThat(answer).contains("Berlin");
+
+        AiMessage aiMessage = response.aiMessage();
+        assertThat(aiMessage.text()).isEqualTo(answer);
+        assertThat(aiMessage.toolExecutionRequests()).isEmpty();
+
+        ChatResponseMetadata metadata = response.metadata();
+
+        assertThat(metadata.modelName()).isEqualTo(MODEL_NAME);
+
+        TokenUsage tokenUsage = metadata.tokenUsage();
+        assertThat(tokenUsage.inputTokenCount()).isGreaterThan(0);
+        assertThat(tokenUsage.outputTokenCount()).isGreaterThan(0);
+        assertThat(tokenUsage.totalTokenCount())
+                .isEqualTo(tokenUsage.inputTokenCount() + tokenUsage.outputTokenCount());
+
+        assertThat(metadata.finishReason()).isEqualTo(FinishReason.STOP);
+    }
+
+    @Test
+    void should_not_think() {
+
+        StreamingChatModel model = OllamaStreamingChatModel.builder()
+            .baseUrl(ollamaBaseUrl(ollama))
+            .modelName(MODEL_NAME)
+            .temperature(0.0)
+            .think(false)
+            .logRequests(true)
+            .logResponses(true)
+            .build();
+
+        // given
+        String userMessage = "What is the capital of Germany?";
+
+        // when
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        model.chat(userMessage, handler);
+        ChatResponse response = handler.get();
+        String answer = response.aiMessage().text();
+
+        // then
+        assertThat(answer).contains("Berlin");
+
+        AiMessage aiMessage = response.aiMessage();
+        assertThat(aiMessage.text()).isEqualTo(answer);
+        assertThat(aiMessage.toolExecutionRequests()).isEmpty();
+
+        ChatResponseMetadata metadata = response.metadata();
+
+        assertThat(metadata.modelName()).isEqualTo(MODEL_NAME);
+
+        TokenUsage tokenUsage = metadata.tokenUsage();
+        assertThat(tokenUsage.inputTokenCount()).isGreaterThan(0);
+        assertThat(tokenUsage.outputTokenCount()).isGreaterThan(0);
+        assertThat(tokenUsage.totalTokenCount())
+                .isEqualTo(tokenUsage.inputTokenCount() + tokenUsage.outputTokenCount());
+
+        assertThat(metadata.finishReason()).isEqualTo(FinishReason.STOP);
+    }
+}

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaThinkChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaThinkChatModelIT.java
@@ -42,9 +42,10 @@ class OllamaThinkChatModelIT extends AbstractOllamaLanguageModelInfrastructure {
         assertThat(answer).contains("Berlin");
 
         AiMessage aiMessage = response.aiMessage();
+        System.out.println(aiMessage.thinking());
         assertThat(aiMessage.text()).isEqualTo(answer);
+        assertThat(aiMessage.thinking()).contains("Berlin").containsAnyOf("think","recall", "remember");
         assertThat(aiMessage.toolExecutionRequests()).isEmpty();
-
         ChatResponseMetadata metadata = response.metadata();
 
         assertThat(metadata.modelName()).isEqualTo(MODEL_NAME);
@@ -84,6 +85,7 @@ class OllamaThinkChatModelIT extends AbstractOllamaLanguageModelInfrastructure {
 
         AiMessage aiMessage = response.aiMessage();
         assertThat(aiMessage.text()).isEqualTo(answer);
+        assertThat(aiMessage.thinking()).isEmpty();
         assertThat(aiMessage.toolExecutionRequests()).isEmpty();
 
         ChatResponseMetadata metadata = response.metadata();


### PR DESCRIPTION
## Issue

The current langchain4j-ollama API lacks the option to set enable/disable the `think` mode.
Details: https://ollama.com/blog/thinking

```json
{
  "model": "magistral:24b",
  "messages": [
    {
      "role": "user",
      "content": "How many r in the word strawberry?"
    }
  ],
  "think": true,
  "stream": false
}
```

## Change

This change introduces the `think` parameter in the `OllamaLanguageModel` class. This parameter gets propagated to the default `DefaultChatRequestParameters` and finally to the `OllamaChatRequest` that gets transformed to the actual JSON.

The default value for this parameter is null - it thus does not change the payload when the client does not call `OllamaChatModel#think(true/false)`.

Additionally I also added `StreamingChatResponseHandler#onPartialThinkingResponse` and `AiMessage#thinking()` to enable access to thinking content in either sync or async ways.

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Questions

* Ollama returns the thinking tokens in a dedicated format. Should a dedicated builder be used to aggregate this thinking text?
```json
{
  "model":"magistral:24b",
  "created_at":"2025-06-10T17:47:34.74016734Z",
  "message": {
    "role":"assistant",
    "content":"",
    "thinking":" the"
  },
  "done":false
}
```

* Is there already work in progress on this feature? I hate to implement something that has already been done.
* Should AiMessage be extended to also include the thinking content or should this info be placed in a new class?