### PR TITLE
Add Javadoc link to DefaultContentAggregator documentation

### DIFF
--- a/docs/docs/tutorials/rag.md
+++ b/docs/docs/tutorials/rag.md
@@ -818,7 +818,7 @@ Please see [`DefaultContentAggregator` Javadoc](https://javadoc.io/doc/dev.langc
 The `ReRankingContentAggregator` uses a `ScoringModel`, like Cohere, to perform re-ranking.
 The complete list of supported scoring (re-ranking) models can be found
 [here](https://docs.langchain4j.dev/category/scoring-reranking-models).
-Please see `ReRankingContentAggregator` Javadoc for more details.
+Please see [`ReRankingContentAggregator` Javadoc](https://javadoc.io/doc/dev.langchain4j/langchain4j-core/latest/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregator.html) for more details.
 
 ### Content Injector
 

--- a/docs/docs/tutorials/rag.md
+++ b/docs/docs/tutorials/rag.md
@@ -812,7 +812,7 @@ The `ContentAggregator` is responsible for aggregating multiple ranked lists of 
 #### Default Content Aggregator
 The `DefaultContentAggregator` is the default implementation of `ContentAggregator`,
 which performs two-stage Reciprocal Rank Fusion (RRF).
-Please see `DefaultContentAggregator` Javadoc for more details.
+Please see [`DefaultContentAggregator` Javadoc](https://javadoc.io/doc/dev.langchain4j/langchain4j-core/latest/dev/langchain4j/rag/content/aggregator/DefaultContentAggregator.html) for more details.
 
 #### Re-Ranking Content Aggregator
 The `ReRankingContentAggregator` uses a `ScoringModel`, like Cohere, to perform re-ranking.


### PR DESCRIPTION
### Summary

This PR adds a direct Javadoc link to the `DefaultContentAggregator` class in the documentation, which improves the developer experience by providing quick access to detailed API information.

### Changes

- Added Javadoc reference link:  
  [DefaultContentAggregator Javadoc](https://javadoc.io/doc/dev.langchain4j/langchain4j-core/latest/dev/langchain4j/rag/content/aggregator/DefaultContentAggregator.html)

### Impact

- Documentation only
- No code logic changes
