### PR TITLE
Update Alibaba Tablestore to 5.17.6

### DIFF
--- a/langchain4j-tablestore/pom.xml
+++ b/langchain4j-tablestore/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.aliyun.openservices</groupId>
             <artifactId>tablestore</artifactId>
-            <version>5.17.4</version>
+            <version>5.17.6</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Update Alibaba Tablestore to 5.17.6 to prevent a DoS vulnerability:

Denial of Service (DoS) [High Severity] https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-2331703 in com.google.protobuf:protobuf-java@2.4.1 introduced by com.aliyun.openservices:tablestore@5.17.4 > com.google.protobuf:protobuf-java@2.4.1 This issue was fixed in versions: 3.16.1, 3.18.2, 3.19.2