### PR TITLE
Support for the OpenAI gpt-image-1 image generation model

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
@@ -23,7 +23,7 @@ import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.time.Duration.ofSeconds;
 
 /**
- * Represents an OpenAI DALL·E models to generate artistic images. Versions 2 and 3 (default) are supported.
+ * Represents an OpenAI Image models to generate artistic images. DALL·E Versions 2 and 3 (default), gpt-image-1 are supported.
  * Find the parameters description <a href="https://platform.openai.com/docs/api-reference/images/create">here</a>.
  */
 public class OpenAiImageModel implements ImageModel {
@@ -34,6 +34,10 @@ public class OpenAiImageModel implements ImageModel {
     private final String style;
     private final String user;
     private final String responseFormat;
+    private final String background;
+    private final String moderation;
+    private final Integer outputCompression;
+    private final String outputFormat;
 
     private final OpenAiClient client;
 
@@ -62,6 +66,10 @@ public class OpenAiImageModel implements ImageModel {
         this.style = builder.style;
         this.user = builder.user;
         this.responseFormat = builder.responseFormat;
+        this.background = builder.background;
+        this.moderation = builder.moderation;
+        this.outputCompression = builder.outputCompression;
+        this.outputFormat = builder.outputFormat;
     }
 
     public String modelName() {
@@ -109,6 +117,10 @@ public class OpenAiImageModel implements ImageModel {
         private String style;
         private String user;
         private String responseFormat;
+        private String background;
+        private String moderation;
+        private Integer outputCompression;
+        private String outputFormat;
         private Duration timeout;
         private Integer maxRetries;
         private Boolean logRequests;
@@ -179,6 +191,26 @@ public class OpenAiImageModel implements ImageModel {
             return this;
         }
 
+        public OpenAiImageModelBuilder background(String background) {
+            this.background = background;
+            return this;
+        }
+
+        public OpenAiImageModelBuilder moderation(String moderation) {
+            this.moderation = moderation;
+            return this;
+        }
+
+        public OpenAiImageModelBuilder outputCompression(Integer outputCompression) {
+            this.outputCompression = outputCompression;
+            return this;
+        }
+
+        public OpenAiImageModelBuilder outputFormat(String outputFormat) {
+            this.outputFormat = outputFormat;
+            return this;
+        }
+
         public OpenAiImageModelBuilder timeout(Duration timeout) {
             this.timeout = timeout;
             return this;
@@ -221,6 +253,10 @@ public class OpenAiImageModel implements ImageModel {
                 .quality(quality)
                 .style(style)
                 .user(user)
-                .responseFormat(responseFormat);
+                .responseFormat(responseFormat)
+                .background(background)
+                .moderation(moderation)
+                .outputCompression(outputCompression)
+                .outputFormat(outputFormat);
     }
 }

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModelName.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModelName.java
@@ -3,7 +3,8 @@ package dev.langchain4j.model.openai;
 public enum OpenAiImageModelName {
 
     DALL_E_2("dall-e-2"),
-    DALL_E_3("dall-e-3");
+    DALL_E_3("dall-e-3"),
+    GPT_IMAGE_1("gpt-image-1");
 
     private final String stringValue;
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/GenerateImagesRequest.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/GenerateImagesRequest.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.util.Objects;
 
 /**
- * Represents the request from the OpenAI DALL·E API when generating images.
+ * Represents the request from the OpenAI Image API when generating images.
  * Find description of parameters <a href="https://platform.openai.com/docs/api-reference/images/create">here</a>.
  */
 @JsonDeserialize(builder = GenerateImagesRequest.Builder.class)
@@ -35,6 +35,14 @@ public class GenerateImagesRequest {
     private final String user;
     @JsonProperty
     private final String responseFormat;
+    @JsonProperty
+    private final String background;
+    @JsonProperty
+    private final String moderation;
+    @JsonProperty
+    private final Integer outputCompression;
+    @JsonProperty
+    private final String outputFormat;
 
     public GenerateImagesRequest(Builder builder) {
         this.model = builder.model;
@@ -45,6 +53,10 @@ public class GenerateImagesRequest {
         this.style = builder.style;
         this.user = builder.user;
         this.responseFormat = builder.responseFormat;
+        this.background = builder.background;
+        this.moderation = builder.moderation;
+        this.outputCompression = builder.outputCompression;
+        this.outputFormat = builder.outputFormat;
     }
 
     public int hashCode() {
@@ -57,6 +69,10 @@ public class GenerateImagesRequest {
         h += (h << 5) + Objects.hashCode(style);
         h += (h << 5) + Objects.hashCode(user);
         h += (h << 5) + Objects.hashCode(responseFormat);
+        h += (h << 5) + Objects.hashCode(background);
+        h += (h << 5) + Objects.hashCode(moderation);
+        h += (h << 5) + Objects.hashCode(outputCompression);
+        h += (h << 5) + Objects.hashCode(outputFormat);
         return h;
     }
 
@@ -79,6 +95,14 @@ public class GenerateImagesRequest {
                         user +
                         ", responseFormat=" +
                         responseFormat +
+                        ", background=" +
+                        background +
+                        ", moderation=" +
+                        moderation +
+                        ", outputCompression=" +
+                        outputCompression +
+                        ", outputFormat=" +
+                        outputFormat +
                         '}'
         );
     }
@@ -100,6 +124,10 @@ public class GenerateImagesRequest {
         private String style;
         private String user;
         private String responseFormat;
+        private String background;
+        private String moderation;
+        private Integer outputCompression;
+        private String outputFormat;
 
         public Builder model(String model) {
             this.model = model;
@@ -138,6 +166,26 @@ public class GenerateImagesRequest {
 
         public Builder responseFormat(String responseFormat) {
             this.responseFormat = responseFormat;
+            return this;
+        }
+
+        public Builder background(String background) {
+            this.background = background;
+            return this;
+        }
+
+        public Builder moderation(String moderation) {
+            this.moderation = moderation;
+            return this;
+        }
+
+        public Builder outputCompression(Integer outputCompression) {
+            this.outputCompression = outputCompression;
+            return this;
+        }
+
+        public Builder outputFormat(String outputFormat) {
+            this.outputFormat = outputFormat;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/GenerateImagesResponse.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/GenerateImagesResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Represents the response from the OpenAI DALL·E API when generating images.
+ * Represents the response from the OpenAI Image API when generating images.
  * Find description of parameters <a href="https://platform.openai.com/docs/api-reference/images/object">here</a>.
  */
 @JsonDeserialize(builder = GenerateImagesResponse.Builder.class)
@@ -22,9 +22,12 @@ public class GenerateImagesResponse {
 
     @JsonProperty
     private final List<ImageData> data;
+    @JsonProperty
+    private final Usage usage;
 
     public GenerateImagesResponse(Builder builder) {
         this.data = builder.data;
+        this.usage = builder.usage;
     }
 
     public static Builder builder() {
@@ -35,9 +38,20 @@ public class GenerateImagesResponse {
         return data;
     }
 
+    public Usage usage() {
+        return usage;
+    }
+
     @Override
     public String toString() {
-        return "GenerateImagesResponse{" + "data=" + data + '}';
+        return (
+                "GenerateImagesResponse{" +
+                        "data=" +
+                        data +
+                        ", usage=" +
+                        usage +
+                        '}'
+        );
     }
 
     @Override
@@ -45,12 +59,15 @@ public class GenerateImagesResponse {
         if (this == another) return true;
         if (another == null || getClass() != another.getClass()) return false;
         GenerateImagesResponse anotherGenerateImagesResponse = (GenerateImagesResponse) another;
-        return Objects.equals(data, anotherGenerateImagesResponse.data);
+        return (
+                Objects.equals(data, anotherGenerateImagesResponse.data) &&
+                        Objects.equals(usage, anotherGenerateImagesResponse.usage)
+        );
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(data);
+        return Objects.hash(data, usage);
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -59,9 +76,15 @@ public class GenerateImagesResponse {
     public static class Builder {
 
         private List<ImageData> data;
+        private Usage usage;
 
         public Builder data(List<ImageData> data) {
             this.data = data;
+            return this;
+        }
+
+        public Builder usage(Usage usage) {
+            this.usage = usage;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/InputTokenDetails.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/InputTokenDetails.java
@@ -1,0 +1,88 @@
+package dev.langchain4j.model.openai.internal.image;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class InputTokenDetails {
+
+    @JsonProperty
+    private final Integer textTokens;
+    @JsonProperty
+    private final Integer imageTokens;
+
+    public InputTokenDetails(Builder builder) {
+        this.textTokens = builder.textTokens;
+        this.imageTokens = builder.imageTokens;
+    }
+
+    public Integer textTokens() {
+        return textTokens;
+    }
+
+    public Integer imageTokens() {
+        return imageTokens;
+    }
+
+    @Override
+    public boolean equals(Object another) {
+        if (this == another) return true;
+        if (another == null || getClass() != another.getClass()) return false;
+        InputTokenDetails that = (InputTokenDetails) another;
+        return (
+                Objects.equals(textTokens, that.textTokens) &&
+                        Objects.equals(imageTokens, that.imageTokens)
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(textTokens, imageTokens);
+    }
+
+    @Override
+    public String toString() {
+        return (
+                "InputTokenDetails{" +
+                        "textTokens=" +
+                        textTokens +
+                        ", imageTokens=" +
+                        imageTokens +
+                        '}'
+        );
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Builder {
+
+        private Integer textTokens;
+        private Integer imageTokens;
+
+        public Builder textTokens(Integer textTokens) {
+            this.textTokens = textTokens;
+            return this;
+        }
+
+        public Builder imageTokens(Integer imageTokens) {
+            this.imageTokens = imageTokens;
+            return this;
+        }
+
+        public InputTokenDetails build() {
+            return new InputTokenDetails(this);
+        }
+    }
+}

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/Usage.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/Usage.java
@@ -1,0 +1,120 @@
+package dev.langchain4j.model.openai.internal.image;
+
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Usage {
+
+    @JsonProperty
+    private final Integer totalTokens;
+    @JsonProperty
+    private final Integer inputTokens;
+    @JsonProperty
+    private final Integer outputTokens;
+    @JsonProperty
+    private final InputTokenDetails inputTokenDetails;
+
+    public Usage(Builder builder) {
+        this.totalTokens = builder.totalTokens;
+        this.inputTokens = builder.inputTokens;
+        this.outputTokens = builder.outputTokens;
+        this.inputTokenDetails = builder.inputTokenDetails;
+    }
+
+    public Integer totalTokens() {
+        return totalTokens;
+    }
+
+    public Integer inputTokens() {
+        return inputTokens;
+    }
+
+    public Integer outputTokens() {
+        return outputTokens;
+    }
+
+    public InputTokenDetails inputTokenDetails() {
+        return inputTokenDetails;
+    }
+
+    @Override
+    public boolean equals(Object another) {
+        if (this == another) return true;
+        if (another == null || getClass() != another.getClass()) return false;
+        Usage usage = (Usage) another;
+        return (
+                Objects.equals(totalTokens, usage.totalTokens) &&
+                        Objects.equals(inputTokens, usage.inputTokens) &&
+                        Objects.equals(outputTokens, usage.outputTokens) &&
+                        Objects.equals(inputTokenDetails, usage.inputTokenDetails)
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(totalTokens, inputTokens, outputTokens, inputTokenDetails);
+    }
+
+    @Override
+    public String toString() {
+        return (
+                "Usage{" +
+                        "totalTokens=" +
+                        totalTokens +
+                        ", inputTokens=" +
+                        inputTokens +
+                        ", outputTokens=" +
+                        outputTokens +
+                        ", inputTokenDetails=" +
+                        inputTokenDetails +
+                        '}'
+        );
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Builder {
+
+        private Integer totalTokens;
+        private Integer inputTokens;
+        private Integer outputTokens;
+        private InputTokenDetails inputTokenDetails;
+
+        public Builder totalTokens(Integer totalTokens) {
+            this.totalTokens = totalTokens;
+            return this;
+        }
+
+        public Builder inputTokens(Integer inputTokens) {
+            this.inputTokens = inputTokens;
+            return this;
+        }
+
+        public Builder outputTokens(Integer outputTokens) {
+            this.outputTokens = outputTokens;
+            return this;
+        }
+
+        public Builder inputTokenDetails(InputTokenDetails inputTokenDetails) {
+            this.inputTokenDetails = inputTokenDetails;
+            return this;
+        }
+
+        public Usage build() {
+            return new Usage(this);
+        }
+    }
+}

--- a/langchain4j-open-ai/src/main/resources/META-INF/native-image/dev.langchain4j/langchain4j-open-ai/reflect-config.json
+++ b/langchain4j-open-ai/src/main/resources/META-INF/native-image/dev.langchain4j/langchain4j-open-ai/reflect-config.json
@@ -333,6 +333,24 @@
     "allPublicFields": true
   },
   {
+    "name": "dev.langchain4j.model.openai.internal.image.InputTokenDetails",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "dev.langchain4j.model.openai.internal.image.Usage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
     "name": "dev.langchain4j.model.openai.internal.moderation.Categories",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiImageModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiImageModelIT.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static dev.langchain4j.model.openai.OpenAiImageModelName.DALL_E_2;
 import static dev.langchain4j.model.openai.OpenAiImageModelName.DALL_E_3;
+import static dev.langchain4j.model.openai.OpenAiImageModelName.GPT_IMAGE_1;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Disabled("Run manually before release. Expensive to run very often.")
@@ -77,6 +78,29 @@ class OpenAiImageModelIT {
         String revisedPrompt = response.content().revisedPrompt();
         log.info("Your revised prompt: {}", revisedPrompt);
         assertThat(revisedPrompt).hasSizeGreaterThan(50);
+    }
+
+    @Test
+    void image_generation_with_gpt_image_1_works() {
+        OpenAiImageModel model = OpenAiImageModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName(GPT_IMAGE_1)
+                .size("1024x1024")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        Response<Image> response = model.generate("A cute capybara");
+
+        assertThat(response.content().url()).isNull();
+        assertThat(response.content().base64Data()).isNotNull().isBase64();
+        log.info("The remote image is a base64 encoded string.");
+
+        assertThat(response.tokenUsage()).isNotNull();
+        assertThat(response.tokenUsage().inputTokenCount()).isGreaterThan(0);
+        log.info("Token usage: {}", response.tokenUsage());
     }
 
     @Test


### PR DESCRIPTION
## Issue
Closes #2921

## Change
Added `gpt-image-1` support for OpenAI Image API


## General checklist
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green

- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
