### PR TITLE
[BUG] Azure OpenAI: IllegalArgumentException is thrown when content has been filtered

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/ContentFilteredException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/ContentFilteredException.java
@@ -1,0 +1,25 @@
+package dev.langchain4j.exception;
+
+public class ContentFilteredException extends InvalidRequestException {
+
+    private String contentFilterResults = "";
+    private Throwable cause;
+
+    public ContentFilteredException(final String message, final String contentFilterResults) {
+        super(message);
+        this.contentFilterResults = contentFilterResults;
+    }
+
+    public ContentFilteredException(final String message, final Throwable cause) {
+        super(message);
+        this.cause = cause;
+    }
+
+    public String getContentFilterResults() {
+        return this.contentFilterResults;
+    }
+
+    public Throwable getCause() {
+        return this.cause;
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/ExceptionMapper.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/ExceptionMapper.java
@@ -2,6 +2,7 @@ package dev.langchain4j.internal;
 
 import dev.langchain4j.Internal;
 import dev.langchain4j.exception.AuthenticationException;
+import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.InternalServerException;
 import dev.langchain4j.exception.InvalidRequestException;
@@ -68,6 +69,9 @@ public interface ExceptionMapper {
                 return new RateLimitException(cause);
             }
             if (httpStatusCode >= 400 && httpStatusCode < 500) {
+                if(cause.getMessage().contains("\"code\":\"content_filter\"")) {
+                    return new ContentFilteredException("Content has been filtered", cause);
+                }
                 return new InvalidRequestException(cause);
             }
             return cause instanceof RuntimeException re ? re : new LangChain4jException(cause);


### PR DESCRIPTION
**Describe the bug**
1. Configure custom content filter (e.g. "doFilterThis") in azure portal and assign it to your llm deployment
2. Send request to llm with "doFilterThis"

**Log and Stack trace**
Caused by: java.lang.IllegalArgumentException: text cannot be null
	at dev.langchain4j.internal.Exceptions.illegalArgument(Exceptions.java:23) ~[langchain4j-core-1.1.0.jar:?]
	at dev.langchain4j.internal.ValidationUtils.ensureNotNull(ValidationUtils.java:54) ~[langchain4j-core-1.1.0.jar:?]
	at dev.langchain4j.internal.ValidationUtils.ensureNotNull(ValidationUtils.java:41) ~[langchain4j-core-1.1.0.jar:?]
	at dev.langchain4j.data.message.AiMessage.<init>(AiMessage.java:32) ~[langchain4j-core-1.1.0.jar:?]
	at dev.langchain4j.data.message.AiMessage.from(AiMessage.java:142) ~[langchain4j-core-1.1.0.jar:?]
	at dev.langchain4j.data.message.AiMessage.aiMessage(AiMessage.java:183) ~[langchain4j-core-1.1.0.jar:?]
	at dev.langchain4j.model.azure.InternalAzureOpenAiHelper.aiMessageFrom(InternalAzureOpenAiHelper.java:368) ~[langchain4j-azure-open-ai-1.1.0-rc1.jar:?]
	at dev.langchain4j.model.azure.AzureOpenAiChatModel.doChat(AzureOpenAiChatModel.java:204) ~[langchain4j-azure-open-ai-1.1.0-rc1.jar:?]
	at dev.langchain4j.model.chat.ChatModel.chat(ChatModel.java:46) ~[langchain4j-core-1.1.0.jar:?]

**Expected behavior**
- Throw a ContentFilteredException

**Please complete the following information:**
- LangChain4j version: 1.1.0
- LLM(s) used: chatGPT 4o / 4o-mini azure
- Java version: 17

**Additional context**
This does not refer to the IllegalArgumentException but the OpenAiStreamingChatModel produces a httpResponseException without finish reason. It just has "code": "content_filter" in the message text. This is hard to handle.

## Issue #3260

## Change
Added ContentFilterException

## General checklist
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
