### PR TITLE
Remove the need for Azure dependencies at compile time

### DIFF
--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/AzureInternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/AzureInternalOpenAiOfficialHelper.java
@@ -1,0 +1,14 @@
+package dev.langchain4j.model.openaiofficial;
+
+import com.azure.identity.AuthenticationUtil;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.openai.credential.BearerTokenCredential;
+import com.openai.credential.Credential;
+
+public class AzureInternalOpenAiOfficialHelper {
+
+    static Credential getAzureCredential() {
+        return BearerTokenCredential.create(AuthenticationUtil.getBearerTokenSupplier(
+                new DefaultAzureCredentialBuilder().build(), "https://cognitiveservices.azure.com/.default"));
+    }
+}

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/AzureInternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/AzureInternalOpenAiOfficialHelper.java
@@ -5,7 +5,7 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.openai.credential.BearerTokenCredential;
 import com.openai.credential.Credential;
 
-public class AzureInternalOpenAiOfficialHelper {
+class AzureInternalOpenAiOfficialHelper {
 
     static Credential getAzureCredential() {
         return BearerTokenCredential.create(AuthenticationUtil.getBearerTokenSupplier(

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -1,16 +1,14 @@
 package dev.langchain4j.model.openaiofficial;
 
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.chat.request.ResponseFormat.JSON;
 import static dev.langchain4j.model.chat.request.ResponseFormatType.TEXT;
-import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
 import static java.time.Duration.ofSeconds;
 import static java.util.stream.Collectors.toList;
 
-import com.azure.identity.AuthenticationUtil;
-import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.openai.azure.AzureOpenAIServiceVersion;
 import com.openai.azure.credential.AzureApiKeyCredential;
 import com.openai.client.OpenAIClient;
@@ -18,7 +16,6 @@ import com.openai.client.OpenAIClientAsync;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.client.okhttp.OpenAIOkHttpClientAsync;
 import com.openai.core.JsonValue;
-import com.openai.credential.BearerTokenCredential;
 import com.openai.credential.Credential;
 import com.openai.models.FunctionDefinition;
 import com.openai.models.FunctionParameters;
@@ -266,9 +263,7 @@ class InternalOpenAiOfficialHelper {
             return credential;
         } else if (modelHost == ModelHost.AZURE_OPENAI) {
             try {
-                return BearerTokenCredential.create(AuthenticationUtil.getBearerTokenSupplier(
-                        new DefaultAzureCredentialBuilder().build(), "https://cognitiveservices.azure.com/.default"));
-
+                return AzureInternalOpenAiOfficialHelper.getAzureCredential();
             } catch (NoClassDefFoundError e) {
                 throw new IllegalArgumentException(
                         "Azure OpenAI was detected, but no credential was provided. "
@@ -504,7 +499,8 @@ class InternalOpenAiOfficialHelper {
         if (completionTokensDetails.isPresent()
                 && completionTokensDetails.get().reasoningTokens().isPresent()) {
             outputTokensDetails = OpenAiOfficialTokenUsage.OutputTokensDetails.builder()
-                    .reasoningTokens(completionTokensDetails.get().reasoningTokens().get())
+                    .reasoningTokens(
+                            completionTokensDetails.get().reasoningTokens().get())
                     .build();
         }
 


### PR DESCRIPTION
Moving the imports to the Azure Identity library to another class removes the need to add this library as a dependency at compile time (it wasn't required at build time, but requiring at compile time is annoying for people not using Azure).