### PR TITLE
Exposing MCP resources automatically over synthetic tools

### DIFF
--- a/langchain4j-mcp/pom.xml
+++ b/langchain4j-mcp/pom.xml
@@ -34,12 +34,17 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-
         <!-- test dependencies -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolProvider.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolProvider.java
@@ -4,20 +4,20 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.internal.Utils;
 import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.resourcesastools.McpResourcesAsToolsPresenter;
 import dev.langchain4j.service.IllegalConfigurationException;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
-
 import java.util.function.Function;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,20 +31,28 @@ public class McpToolProvider implements ToolProvider {
     private final AtomicReference<BiPredicate<McpClient, ToolSpecification>> mcpToolsFilter;
     private final Function<ToolExecutor, ToolExecutor> toolWrapper;
     private static final Logger log = LoggerFactory.getLogger(McpToolProvider.class);
+    private final McpResourcesAsToolsPresenter resourcesAsToolsPresenter;
 
     private McpToolProvider(Builder builder) {
-        this(builder.mcpClients, Utils.getOrDefault(builder.failIfOneServerFails, false), builder.mcpToolsFilter, builder.toolWrapper);
+        this(
+                builder.mcpClients,
+                Utils.getOrDefault(builder.failIfOneServerFails, false),
+                builder.mcpToolsFilter,
+                builder.toolWrapper,
+                builder.resourcesAsToolsPresenter);
     }
 
-    protected McpToolProvider(List<McpClient> mcpClients, boolean failIfOneServerFails, BiPredicate<McpClient, ToolSpecification> mcpToolsFilter) {
-        this(Objects.requireNonNull(mcpClients), failIfOneServerFails, mcpToolsFilter, Function.identity());
-    }
-
-    protected McpToolProvider(List<McpClient> mcpClients, boolean failIfOneServerFails, BiPredicate<McpClient, ToolSpecification> mcpToolsFilter, Function<ToolExecutor, ToolExecutor> toolWrapper) {
+    protected McpToolProvider(
+            List<McpClient> mcpClients,
+            boolean failIfOneServerFails,
+            BiPredicate<McpClient, ToolSpecification> mcpToolsFilter,
+            Function<ToolExecutor, ToolExecutor> toolWrapper,
+            McpResourcesAsToolsPresenter resourcesAsToolsPresenter) {
         this.mcpClients = new CopyOnWriteArrayList<>(mcpClients);
         this.failIfOneServerFails = failIfOneServerFails;
         this.mcpToolsFilter = new AtomicReference<>(mcpToolsFilter);
         this.toolWrapper = toolWrapper;
+        this.resourcesAsToolsPresenter = resourcesAsToolsPresenter;
     }
 
     /**
@@ -104,15 +112,17 @@ public class McpToolProvider implements ToolProvider {
         return provideTools(request, mcpToolsFilter.get());
     }
 
-    protected ToolProviderResult provideTools(ToolProviderRequest request, BiPredicate<McpClient, ToolSpecification> mcpToolsFilter) {
+    protected ToolProviderResult provideTools(
+            ToolProviderRequest request, BiPredicate<McpClient, ToolSpecification> mcpToolsFilter) {
         ToolProviderResult.Builder builder = ToolProviderResult.builder();
         for (McpClient mcpClient : mcpClients) {
             var defaultToolExecutor = new DefaultToolExecutor(mcpClient);
             try {
-                mcpClient.listTools().stream().filter(tool -> mcpToolsFilter.test(mcpClient, tool))
+                mcpClient.listTools().stream()
+                        .filter(tool -> mcpToolsFilter.test(mcpClient, tool))
                         .forEach(toolSpecification -> {
-                    builder.add(toolSpecification, toolWrapper.apply(defaultToolExecutor));
-                });
+                            builder.add(toolSpecification, toolWrapper.apply(defaultToolExecutor));
+                        });
             } catch (IllegalConfigurationException e) {
                 throw e;
             } catch (Exception e) {
@@ -123,6 +133,17 @@ public class McpToolProvider implements ToolProvider {
                 }
             }
         }
+        if (resourcesAsToolsPresenter != null) {
+            List<McpClient> mcpClientsUnmodifiable = Collections.unmodifiableList(mcpClients);
+            ToolSpecification listResourcesToolSpec = resourcesAsToolsPresenter.createListResourcesSpecification();
+            builder.add(
+                    listResourcesToolSpec,
+                    toolWrapper.apply(resourcesAsToolsPresenter.createListResourcesExecutor(mcpClientsUnmodifiable)));
+            ToolSpecification getResourceToolSpec = resourcesAsToolsPresenter.createGetResourceSpecification();
+            builder.add(
+                    getResourceToolSpec,
+                    toolWrapper.apply(resourcesAsToolsPresenter.createGetResourceExecutor(mcpClientsUnmodifiable)));
+        }
         return builder.build();
     }
 
@@ -132,6 +153,7 @@ public class McpToolProvider implements ToolProvider {
 
     public static class Builder {
 
+        private McpResourcesAsToolsPresenter resourcesAsToolsPresenter;
         private List<McpClient> mcpClients;
         private Boolean failIfOneServerFails;
         private BiPredicate<McpClient, ToolSpecification> mcpToolsFilter = (mcp, tool) -> true;
@@ -181,6 +203,16 @@ public class McpToolProvider implements ToolProvider {
          */
         public McpToolProvider.Builder toolWrapper(Function<ToolExecutor, ToolExecutor> toolWrapper) {
             this.toolWrapper = toolWrapper;
+            return this;
+        }
+
+        /**
+         * Provides a presenter for presenting resources via synthetic tools. If none is provided, then
+         * resources won't automatically be exposed via tools.
+         */
+        public McpToolProvider.Builder resourcesAsToolsPresenter(
+                McpResourcesAsToolsPresenter resourcesAsToolsPresenter) {
+            this.resourcesAsToolsPresenter = resourcesAsToolsPresenter;
             return this;
         }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/resourcesastools/DefaultMcpResourcesAsToolsPresenter.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/resourcesastools/DefaultMcpResourcesAsToolsPresenter.java
@@ -1,0 +1,189 @@
+package dev.langchain4j.mcp.resourcesastools;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.internal.Utils;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.util.List;
+
+/**
+ * Default implementation of {@link McpResourcesAsToolsPresenter}.
+ * A presenter that presents MCP resources as tools. It provides two tools: {@code list_resources} and {@code get_resource}.
+ *
+ * The {@code list_resources} tool lists all available resources. It doesn't take any arguments and returns a JSON array where
+ * each object represents a single resource. For example:
+ *
+ * <pre>
+ * [ {
+ *   "mcpServer" : "alice",
+ *   "uri" : "file:///info",
+ *   "uriTemplate" : null,
+ *   "name" : "basicInfo",
+ *   "description" : "Basic information about Alice",
+ *   "mimeType" : "text/plain"
+ * }, {
+ *   "mcpServer" : "bob",
+ *   "uri" : "file:///info",
+ *   "uriTemplate" : null,
+ *   "name" : "basicInfo",
+ *   "description" : "Basic information about Bob",
+ *   "mimeType" : "text/plain"
+ * } ]
+ * </pre>
+ *
+ * The {@code get_resource} tool retrieves a specific resource based on its MCP server name and URI. It takes two arguments:
+ * {@code mcpServer} and {@code uri}. Both arguments are mandatory. For example:
+ *
+ * The DefaultMcpResourcesAsToolsPresenter provides default names and descriptions of these two tools and their arguments. These
+ * descriptions should generally work, but if it's necessary to override them, this can be done in the builder.
+ *
+ */
+public class DefaultMcpResourcesAsToolsPresenter implements McpResourcesAsToolsPresenter {
+
+    private final String nameOfGetResourceTool;
+    private final String descriptionOfGetResourceTool;
+    private final String descriptionOfMcpServerParameterOfGetResourceTool;
+    private final String descriptionOfUriParameterOfGetResourceTool;
+    private final String nameOfListResourcesTool;
+    private final String descriptionOfListResourcesTool;
+
+    public static final String DEFAULT_NAME_OF_GET_RESOURCE_TOOL = "get_resource";
+    public static final String DEFAULT_DESCRIPTION_OF_GET_RESOURCE_TOOL =
+            "Retrieves a resource identified by the MCP server name and the resource URI."
+                    + "The 'list_resources' tool should be called before this one to obtain the list.";
+    public static final String DEFAULT_DESCRIPTION_OF_MCP_SERVER_PARAMETER_OF_GET_RESOURCE_TOOL =
+            "The name of the MCP server to get the resource from.";
+    public static final String DEFAULT_DESCRIPTION_OF_URI_PARAMETER_OF_GET_RESOURCE_TOOL =
+            "The URI of the resource to get.";
+
+    public static final String DEFAULT_NAME_OF_LIST_RESOURCES_TOOL = "list_resources";
+    public static final String DEFAULT_DESCRIPTION_OF_LIST_RESOURCES_TOOL = "Lists all available resources.";
+
+    private DefaultMcpResourcesAsToolsPresenter(Builder builder) {
+        this(
+                Utils.getOrDefault(builder.nameOfGetResourceTool, DEFAULT_NAME_OF_GET_RESOURCE_TOOL),
+                Utils.getOrDefault(builder.descriptionOfGetResourceTool, DEFAULT_DESCRIPTION_OF_GET_RESOURCE_TOOL),
+                Utils.getOrDefault(
+                        builder.descriptionOfMcpServerParameterOfGetResourceTool,
+                        DEFAULT_DESCRIPTION_OF_MCP_SERVER_PARAMETER_OF_GET_RESOURCE_TOOL),
+                Utils.getOrDefault(
+                        builder.descriptionOfUriParameterOfGetResourceTool,
+                        DEFAULT_DESCRIPTION_OF_URI_PARAMETER_OF_GET_RESOURCE_TOOL),
+                Utils.getOrDefault(builder.nameOfListResourcesTool, DEFAULT_NAME_OF_LIST_RESOURCES_TOOL),
+                Utils.getOrDefault(builder.descriptionOfListResourcesTool, DEFAULT_DESCRIPTION_OF_LIST_RESOURCES_TOOL));
+    }
+
+    protected DefaultMcpResourcesAsToolsPresenter(
+            String nameOfGetResourceTool,
+            String descriptionOfGetResourceTool,
+            String descriptionOfMcpServerParameterOfGetResourceTool,
+            String descriptionOfUriParameterOfGetResourceTool,
+            String nameOfListResourcesTool,
+            String descriptionOfListResourcesTool) {
+        this.nameOfGetResourceTool = nameOfGetResourceTool;
+        this.descriptionOfGetResourceTool = descriptionOfGetResourceTool;
+        this.descriptionOfMcpServerParameterOfGetResourceTool = descriptionOfMcpServerParameterOfGetResourceTool;
+        this.descriptionOfUriParameterOfGetResourceTool = descriptionOfUriParameterOfGetResourceTool;
+        this.nameOfListResourcesTool = nameOfListResourcesTool;
+        this.descriptionOfListResourcesTool = descriptionOfListResourcesTool;
+    }
+
+    @Override
+    public ToolSpecification createListResourcesSpecification() {
+        return ToolSpecification.builder()
+                .name(nameOfListResourcesTool)
+                .description(descriptionOfListResourcesTool)
+                .parameters(JsonObjectSchema.builder().build())
+                .build();
+    }
+
+    @Override
+    public ToolExecutor createListResourcesExecutor(List<McpClient> mcpClients) {
+        return new ListResourcesToolExecutor(mcpClients);
+    }
+
+    @Override
+    public ToolSpecification createGetResourceSpecification() {
+        return ToolSpecification.builder()
+                .name(nameOfGetResourceTool)
+                .description(descriptionOfGetResourceTool)
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("mcpServer", descriptionOfMcpServerParameterOfGetResourceTool)
+                        .addStringProperty("uri", descriptionOfUriParameterOfGetResourceTool)
+                        .build())
+                .build();
+    }
+
+    @Override
+    public ToolExecutor createGetResourceExecutor(List<McpClient> mcpClients) {
+        return new GetResourceToolExecutor(mcpClients);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String nameOfGetResourceTool;
+        private String descriptionOfGetResourceTool;
+        private String descriptionOfMcpServerParameterOfGetResourceTool;
+        private String descriptionOfUriParameterOfGetResourceTool;
+        private String nameOfListResourcesTool;
+        private String descriptionOfListResourcesTool;
+
+        /**
+         * Overrides the name of the `get_resource` tool.
+         */
+        public Builder nameOfGetResourceTool(String nameOfGetResourceTool) {
+            this.nameOfGetResourceTool = nameOfGetResourceTool;
+            return this;
+        }
+
+        /**
+         * Overrides the description of the `get_resource` tool.
+         */
+        public Builder descriptionOfGetResourceTool(String descriptionOfGetResourceTool) {
+            this.descriptionOfGetResourceTool = descriptionOfGetResourceTool;
+            return this;
+        }
+
+        /**
+         * Overrides the description of the `mcp_server` parameter of the `get_resource` tool.
+         */
+        public Builder descriptionOfMcpServerParameterOfGetResourceTool(
+                String descriptionOfMcpServerParameterOfGetResourceTool) {
+            this.descriptionOfMcpServerParameterOfGetResourceTool = descriptionOfMcpServerParameterOfGetResourceTool;
+            return this;
+        }
+
+        /**
+         * Overrides the description of the `uri` parameter of the `get_resource` tool.
+         */
+        public Builder descriptionOfUriParameterOfGetResourceTool(String descriptionOfUriParameterOfGetResourceTool) {
+            this.descriptionOfUriParameterOfGetResourceTool = descriptionOfUriParameterOfGetResourceTool;
+            return this;
+        }
+
+        /**
+         * Overrides the name of the `list_resources` tool.
+         */
+        public Builder nameOfListResourcesTool(String nameOfListResourcesTool) {
+            this.nameOfListResourcesTool = nameOfListResourcesTool;
+            return this;
+        }
+
+        /**
+         * Overrides the description of the `list_resources` tool.
+         */
+        public Builder descriptionOfListResourcesTool(String descriptionOfListResourcesTool) {
+            this.descriptionOfListResourcesTool = descriptionOfListResourcesTool;
+            return this;
+        }
+
+        public DefaultMcpResourcesAsToolsPresenter build() {
+            return new DefaultMcpResourcesAsToolsPresenter(this);
+        }
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/resourcesastools/GetResourceToolExecutor.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/resourcesastools/GetResourceToolExecutor.java
@@ -1,0 +1,60 @@
+package dev.langchain4j.mcp.resourcesastools;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.internal.Json;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpResourceContents;
+import dev.langchain4j.mcp.client.McpTextResourceContents;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Default executor for the 'get_resource' synthetic tool that can retrieve a resource from an MCP server.
+ * It expects two arguments: mcpServer and uri.
+ */
+class GetResourceToolExecutor implements ToolExecutor {
+
+    private final List<McpClient> mcpClients;
+
+    GetResourceToolExecutor(List<McpClient> mcpClients) {
+        this.mcpClients = mcpClients;
+    }
+
+    @Override
+    public String execute(ToolExecutionRequest toolExecutionRequest, Object memoryId) {
+        ObjectNode arguments = Json.fromJson(toolExecutionRequest.arguments(), ObjectNode.class);
+        if (!arguments.has("mcpServer")) {
+            return "ERROR: missing argument 'mcpServer'";
+        }
+        String mcpServerKey = arguments.get("mcpServer").asText();
+        if (!arguments.has("uri")) {
+            return "ERROR: missing argument 'uri'";
+        }
+        String uri = arguments.get("uri").asText();
+        Optional<McpClient> client = mcpClients.stream()
+                .filter(mcpClient -> mcpClient.key().equals(mcpServerKey))
+                .findFirst();
+        if (client.isEmpty()) {
+            return "ERROR: unknown MCP server: " + mcpServerKey;
+        } else {
+            StringBuilder result = new StringBuilder();
+            List<McpResourceContents> contents = client.get().readResource(uri).contents();
+            for (McpResourceContents content : contents) {
+                if (content instanceof McpTextResourceContents) {
+                    result.append(((McpTextResourceContents) content).text());
+                } else {
+                    return "ERROR: binary content was requested, this is not supported yet";
+                }
+            }
+            return result.toString();
+        }
+    }
+
+    private Optional<McpClient> findMcpClientByKey(String key) {
+        return mcpClients.stream()
+                .filter(mcpClient -> mcpClient.key().equals(key))
+                .findFirst();
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/resourcesastools/ListResourcesToolExecutor.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/resourcesastools/ListResourcesToolExecutor.java
@@ -1,0 +1,69 @@
+package dev.langchain4j.mcp.resourcesastools;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.internal.Json;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpResource;
+import dev.langchain4j.mcp.client.McpResourceTemplate;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Default Executor for the 'list_resources' synthetic tool that can retrieve a list of resources from one or more MCP servers
+ * and returns a JSON representation of the available resources.
+ */
+class ListResourcesToolExecutor implements ToolExecutor {
+
+    private final List<McpClient> mcpClients;
+
+    ListResourcesToolExecutor(List<McpClient> mcpClients) {
+        this.mcpClients = mcpClients;
+    }
+
+    @Override
+    public String execute(ToolExecutionRequest toolExecutionRequest, Object memoryId) {
+        List<ResourceDescription> descriptions = new ArrayList<>();
+        for (McpClient client : mcpClients) {
+            for (McpResource resource : client.listResources()) {
+                descriptions.add(new ResourceDescription(
+                        client.key(),
+                        resource.uri(),
+                        null,
+                        resource.name(),
+                        resource.description(),
+                        resource.mimeType()));
+            }
+            for (McpResourceTemplate template : client.listResourceTemplates()) {
+                descriptions.add(new ResourceDescription(
+                        client.key(),
+                        null,
+                        template.uriTemplate(),
+                        template.name(),
+                        template.description(),
+                        template.mimeType()));
+            }
+        }
+        return Json.toJson(descriptions);
+    }
+
+    private static class ResourceDescription {
+
+        ResourceDescription(
+                String mcpServer, String uri, String uriTemplate, String name, String description, String mimeType) {
+            this.mcpServer = mcpServer;
+            this.uri = uri;
+            this.uriTemplate = uriTemplate;
+            this.name = name;
+            this.description = description;
+            this.mimeType = mimeType;
+        }
+
+        String mcpServer;
+        String uri;
+        String uriTemplate;
+        String name;
+        String description;
+        String mimeType;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/resourcesastools/McpResourcesAsToolsPresenter.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/resourcesastools/McpResourcesAsToolsPresenter.java
@@ -1,0 +1,35 @@
+package dev.langchain4j.mcp.resourcesastools;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolExecutor;
+import java.util.List;
+
+/**
+ * A presenter that presents MCP resources (from one or more MCP clients) as tools to a chat model, allowing the
+ * chat model to discover and interact with resources. An implementation has to provide two tools,
+ * one for obtaining a list of resources, one for obtaining a particular resource. See {@link DefaultMcpResourcesAsToolsPresenter}
+ * for the default implementation.
+ */
+public interface McpResourcesAsToolsPresenter {
+
+    /**
+     * Create a specification for the tool that lists available resources.
+     */
+    ToolSpecification createListResourcesSpecification();
+
+    /**
+     * Create an executor for the tool that lists available resources.
+     */
+    ToolExecutor createListResourcesExecutor(List<McpClient> mcpClients);
+
+    /**
+     * Create a specification for the tool that gets a particular resource.
+     */
+    ToolSpecification createGetResourceSpecification();
+
+    /**
+     * Create an executor for the tool that gets a particular resource.
+     */
+    ToolExecutor createGetResourceExecutor(List<McpClient> mcpClients);
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpResourcesAsToolsHttpTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpResourcesAsToolsHttpTransportIT.java
@@ -1,0 +1,55 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.*;
+
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class McpResourcesAsToolsHttpTransportIT extends McpResourcesAsToolsTestBase {
+
+    private static Process processAlice;
+    private static Process processBob;
+
+    @BeforeAll
+    static void setup() throws IOException, InterruptedException, TimeoutException {
+        skipTestsIfJbangNotAvailable();
+        processAlice = startServerHttp("resources_alice_mcp_server.java", 8180);
+        processBob = startServerHttp("resources_bob_mcp_server.java", 8181);
+        HttpMcpTransport transportAlice = new HttpMcpTransport.Builder()
+                .sseUrl("http://localhost:8180/mcp/sse")
+                .build();
+        mcpClientAlice = new DefaultMcpClient.Builder()
+                .transport(transportAlice)
+                .key("alice")
+                .build();
+        HttpMcpTransport transportBob = new HttpMcpTransport.Builder()
+                .sseUrl("http://localhost:8181/mcp/sse")
+                .build();
+        mcpClientBob = new DefaultMcpClient.Builder()
+                .transport(transportBob)
+                .key("bob")
+                .build();
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (mcpClientAlice != null) {
+            mcpClientAlice.close();
+        }
+        if (mcpClientBob != null) {
+            mcpClientBob.close();
+        }
+        if (processAlice != null && processAlice.isAlive()) {
+            processAlice.destroyForcibly();
+        }
+        if (processBob != null && processBob.isAlive()) {
+            processBob.destroyForcibly();
+        }
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpResourcesAsToolsStdioTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpResourcesAsToolsStdioTransportIT.java
@@ -1,0 +1,58 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.*;
+
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class McpResourcesAsToolsStdioTransportIT extends McpResourcesAsToolsTestBase {
+
+    @BeforeAll
+    static void setup() {
+        skipTestsIfJbangNotAvailable();
+        McpTransport transportAlice = new StdioMcpTransport.Builder()
+                .command(List.of(
+                        getJBangCommand(),
+                        "--quiet",
+                        "--fresh",
+                        "run",
+                        "-Dquarkus.http.port=8180",
+                        getPathToScript("resources_alice_mcp_server.java")))
+                .logEvents(true)
+                .build();
+        mcpClientAlice = new DefaultMcpClient.Builder()
+                .transport(transportAlice)
+                .key("alice")
+                .build();
+        McpTransport transportBob = new StdioMcpTransport.Builder()
+                .command(List.of(
+                        getJBangCommand(),
+                        "--quiet",
+                        "--fresh",
+                        "run",
+                        "-Dquarkus.http.port=8181",
+                        getPathToScript("resources_bob_mcp_server.java")))
+                .logEvents(true)
+                .build();
+        mcpClientBob = new DefaultMcpClient.Builder()
+                .transport(transportBob)
+                .key("bob")
+                .build();
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (mcpClientAlice != null) {
+            mcpClientAlice.close();
+        }
+        if (mcpClientBob != null) {
+            mcpClientBob.close();
+        }
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpResourcesAsToolsTestBase.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpResourcesAsToolsTestBase.java
@@ -1,0 +1,109 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+import static org.assertj.core.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.internal.Json;
+import dev.langchain4j.mcp.McpToolProvider;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.resourcesastools.DefaultMcpResourcesAsToolsPresenter;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public abstract class McpResourcesAsToolsTestBase {
+
+    static McpClient mcpClientAlice;
+    static McpClient mcpClientBob;
+
+    OpenAiChatModel chatModel = OpenAiChatModel.builder()
+            .baseUrl(System.getenv("OPENAI_BASE_URL"))
+            .apiKey(System.getenv("OPENAI_API_KEY"))
+            .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+            .modelName(GPT_4_O_MINI)
+            .temperature(0.0)
+            .logRequests(true)
+            .logResponses(true)
+            .build();
+
+    @Test
+    public void listResourcesAndThenGet() {
+        ToolProvider toolProvider = McpToolProvider.builder()
+                .mcpClients(mcpClientAlice)
+                .resourcesAsToolsPresenter(
+                        DefaultMcpResourcesAsToolsPresenter.builder().build())
+                .build();
+
+        // check that the tool provider has two tools: list_resources and get_resource
+        ToolProviderResult toolProviderResult = toolProvider.provideTools(null);
+        assertThat(toolProviderResult.tools().size()).isEqualTo(2);
+        List<String> toolNames = toolProviderResult.tools().keySet().stream()
+                .map(ToolSpecification::name)
+                .collect(Collectors.toList());
+        assertThat(toolNames).containsExactlyInAnyOrder("list_resources", "get_resource");
+
+        // call the list_resources tool and verify the output
+        String listResourcesResult =
+                toolProviderResult.toolExecutorByName("list_resources").execute(null, null);
+        ArrayNode resources = Json.fromJson(listResourcesResult, ArrayNode.class);
+        assertThat(resources.size()).isEqualTo(1);
+        assertThat(resources.get(0).get("mcpServer").asText()).isEqualTo("alice");
+        assertThat(resources.get(0).get("uri").asText()).isEqualTo("file:///info");
+        assertThat(resources.get(0).get("uriTemplate").isNull()).isTrue();
+        assertThat(resources.get(0).get("name").asText()).isEqualTo("basicInfo");
+        assertThat(resources.get(0).get("description").asText()).isEqualTo("Basic information about Alice");
+        assertThat(resources.get(0).get("mimeType").asText()).isEqualTo("text/plain");
+
+        // call the get_resource tool
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .name("get_resource")
+                .arguments("{\"mcpServer\": \"alice\", \"uri\": \"file:///info\"}")
+                .build();
+        String getBasicInfoResult =
+                toolProviderResult.toolExecutorByName("get_resource").execute(request, null);
+        assertThat(getBasicInfoResult).isEqualTo("Alice was born in 1962 and lives in Manchester.");
+    }
+
+    @Test
+    public void integrationTestWithAiService() {
+        ToolProvider toolProvider = McpToolProvider.builder()
+                .mcpClients(mcpClientAlice, mcpClientBob)
+                .resourcesAsToolsPresenter(
+                        DefaultMcpResourcesAsToolsPresenter.builder().build())
+                .build();
+        ChatService service = AiServices.builder(ChatService.class)
+                .toolProvider(toolProvider)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .chatModel(chatModel)
+                .build();
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .name("list_resources")
+                .arguments("{}")
+                .build();
+        String out = toolProvider
+                .provideTools(null)
+                .toolExecutorByName("list_resources")
+                .execute(request, null);
+        System.out.println(out);
+
+        String aliceResponse = service.chat("When was Alice born?");
+        assertThat(aliceResponse).contains("1962");
+
+        String bobResponse = service.chat("When was Bob born?");
+        assertThat(bobResponse).contains("1956");
+    }
+
+    interface ChatService {
+        @SystemMessage("Use list_resources and get_resource tools to answer user's questions")
+        String chat(String prompt);
+    }
+}

--- a/langchain4j-mcp/src/test/resources/resources_alice_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/resources_alice_mcp_server.java
@@ -1,0 +1,23 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.1.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.1.0
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import io.quarkiverse.mcp.server.BlobResourceContents;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceTemplate;
+import io.quarkiverse.mcp.server.TextResourceContents;
+
+public class resources_alice_mcp_server {
+
+    @Resource(uri = "file:///info", description = "Basic information about Alice", mimeType = "text/plain")
+    TextResourceContents basicInfo() {
+        return TextResourceContents.create("file:///info", "Alice was born in 1962 and lives in Manchester.");
+    }
+
+}

--- a/langchain4j-mcp/src/test/resources/resources_bob_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/resources_bob_mcp_server.java
@@ -1,0 +1,23 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS io.quarkus:quarkus-bom:${quarkus.version:3.20.0}@pom
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.1.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.1.0
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import io.quarkiverse.mcp.server.BlobResourceContents;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceTemplate;
+import io.quarkiverse.mcp.server.TextResourceContents;
+
+public class resources_bob_mcp_server {
+
+    @Resource(uri = "file:///info", description = "Basic information about Bob", mimeType = "text/plain")
+    TextResourceContents basicInfo() {
+        return TextResourceContents.create("file:///info", "Bob was born in 1956 and lives in London.");
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/langchain4j/langchain4j/issues/2767

Wanted to get some early feedback before I proceed to creating more tests and documentation (and probably extend it to prompts too).

The idea is that the user can now, when creating a `McpToolProvider`, enable the `exposeResourcesAsTools` option. If this is enabled, then the tool provider will expose two extra 'synthetic' tools:

- `list_resources` to obtain a list of all resources available for all MCP clients that are wrapped into this tool provider
- `get_resource` to render a specific resource - it takes two arguments:
  - resource URI (I chose URI instead of the name to be able to retrieve [resource templates](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#resource-templates) too in the same way)
  - name (`key`) of the MCP client that this resource belongs to

The result of `list_resources` is JSON and looks something like this:

```
[ {
  "mcpServer" : "alice",
  "uri" : "file:///info",
  "uriTemplate" : null,
  "name" : "basicInfo",
  "description" : "Basic information about Alice",
  "mimeType" : "text/plain"
}, {
  "mcpServer" : "bob",
  "uri" : "file:///info",
  "uriTemplate" : null,
  "name" : "basicInfo",
  "description" : "Basic information about Bob",
  "mimeType" : "text/plain"
} ]
```

I tested this with `gpt-4o-mini` and it understood how to find and retrieve a relevant resource (see `McpResourcesAsToolsTestBase#integrationTestWithAiService` for demonstration)

So a resource is identified by uri AND the name of the mcp connection, because it may happen that two servers will have resources on the same URI.
When it's a resource, then `uri` is specified here, if it's a template, then  `uriTemplate` is specified instead.

Note: another way would be to expose a separate synthetic tool for each resource instead of having `get_resource` over all of them. That would render it unnecessary to invent a new JSON schema for the `list_resources`, but I'm afraid that there will, in the real world, be too many resources, and exposing a tool for each separately would explode the context size.

