### PR TITLE
minor fix findJsonEnd for json array

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
@@ -50,7 +50,7 @@ public class JsonParsingUtils {
 
     private static int findJsonEnd(String text, int fromIndex) {
         int jsonMapEnd = text.lastIndexOf('}', fromIndex);
-        int jsonListEnd = text.indexOf(']', fromIndex);
+        int jsonListEnd = text.lastIndexOf(']', fromIndex);
         return Math.max(jsonMapEnd, jsonListEnd);
     }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.internal;
 
 import dev.langchain4j.Internal;
-
 import java.util.Optional;
 
 @Internal
@@ -12,7 +11,7 @@ public class JsonParsingUtils {
         R apply(T t) throws Exception;
     }
 
-    public record ParsedJson<T>(T value, String json) { }
+    public record ParsedJson<T>(T value, String json) {}
 
     public static <T> Optional<ParsedJson<T>> extractAndParseJson(String text, Class<T> type) {
         return extractAndParseJson(text, s -> Json.fromJson(s, type));
@@ -63,7 +62,7 @@ public class JsonParsingUtils {
             if (c == openingBrace) {
                 braceCount++;
                 if (braceCount == 0) {
-                    return i == 0 || text.charAt(i-1) != openingBrace ? i : -1;
+                    return i == 0 || text.charAt(i - 1) != openingBrace ? i : -1;
                 }
             } else if (c == closingBrace) {
                 braceCount--;

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
@@ -1,16 +1,15 @@
 package dev.langchain4j.internal;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 /**
  * Comprehensive unit tests for JsonParsingUtils.extractAndParseJson method.
- * These tests cover various scenarios including nested JSON structures, 
+ * These tests cover various scenarios including nested JSON structures,
  * text with noise, multiple JSON blocks, and edge cases.
  */
 class JsonParsingUtilsTest {
@@ -24,14 +23,20 @@ class JsonParsingUtilsTest {
         public int age;
         public List<String> tags;
         public Map<String, Object> extra;
+
         public MyPojo() {}
-        public MyPojo(String name, int age) { this.name = name; this.age = age; }
-        @Override public boolean equals(Object o) {
+
+        public MyPojo(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        @Override
+        public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             MyPojo myPojo = (MyPojo) o;
-            return age == myPojo.age &&
-                    java.util.Objects.equals(name, myPojo.name);
+            return age == myPojo.age && java.util.Objects.equals(name, myPojo.name);
         }
     }
 
@@ -70,7 +75,8 @@ class JsonParsingUtilsTest {
     @Test
     void extract_array() {
         String json = "[{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}]";
-        Optional<JsonParsingUtils.ParsedJson<MyPojo[]>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        Optional<JsonParsingUtils.ParsedJson<MyPojo[]>> result =
+                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isPresent();
         assertThat(result.get().value().length).isEqualTo(2);
         assertThat(result.get().value()[0].name).isEqualTo("A");
@@ -85,7 +91,8 @@ class JsonParsingUtilsTest {
     @Test
     void extract_array_with_noise() {
         String json = "abc [{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}] xyz";
-        Optional<JsonParsingUtils.ParsedJson<MyPojo[]>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        Optional<JsonParsingUtils.ParsedJson<MyPojo[]>> result =
+                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isPresent();
         assertThat(result.get().value().length).isEqualTo(2);
     }
@@ -99,7 +106,8 @@ class JsonParsingUtilsTest {
     @Test
     void extract_nested_array() {
         String json = "[[{\"name\":\"A\",\"age\":1}],[{\"name\":\"B\",\"age\":2}]]";
-        Optional<JsonParsingUtils.ParsedJson<MyPojo[][]>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[][].class);
+        Optional<JsonParsingUtils.ParsedJson<MyPojo[][]>> result =
+                JsonParsingUtils.extractAndParseJson(json, MyPojo[][].class);
         assertThat(result).isPresent();
         assertThat(result.get().value().length).isEqualTo(2);
         assertThat(result.get().value()[0][0].name).isEqualTo("A");
@@ -181,9 +189,11 @@ class JsonParsingUtilsTest {
      */
     @Test
     void extract_json_array_with_nested_objects_and_arrays() {
-        String json = "[{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",\"b\"]},{\"name\":\"Jerry\",\"age\":20,\"tags\":[\"x\",\"y\"]}]";
-        Optional<JsonParsingUtils.ParsedJson<MyPojo[]>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        String json =
+                "[{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",\"b\"]},{\"name\":\"Jerry\",\"age\":20,\"tags\":[\"x\",\"y\"]}]";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo[]>> result =
+                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isPresent();
         assertThat(result.get().value()[1].tags).containsExactly("x", "y");
     }
-} 
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
@@ -8,8 +8,17 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Comprehensive unit tests for JsonParsingUtils.extractAndParseJson method.
+ * These tests cover various scenarios including nested JSON structures, 
+ * text with noise, multiple JSON blocks, and edge cases.
+ */
 class JsonParsingUtilsTest {
 
+    /**
+     * Test POJO class with various field types to test different JSON structures.
+     * Includes primitive types, collections, and nested objects.
+     */
     static class MyPojo {
         public String name;
         public int age;
@@ -26,6 +35,10 @@ class JsonParsingUtilsTest {
         }
     }
 
+    /**
+     * Test basic JSON object extraction without any surrounding text.
+     * This is the simplest case where the entire text is valid JSON.
+     */
     @Test
     void extract_simple_object() {
         String json = "{\"name\":\"Tom\",\"age\":18}";
@@ -35,6 +48,11 @@ class JsonParsingUtilsTest {
         assertThat(result.get().value().age).isEqualTo(18);
     }
 
+    /**
+     * Test JSON object extraction when surrounded by non-JSON text.
+     * This tests the ability to find and extract JSON from mixed content.
+     * The method should ignore the prefix and suffix text.
+     */
     @Test
     void extract_object_with_prefix_suffix() {
         String json = "prefix {\"name\":\"Jerry\",\"age\":20} suffix";
@@ -44,6 +62,11 @@ class JsonParsingUtilsTest {
         assertThat(result.get().value().age).isEqualTo(20);
     }
 
+    /**
+     * Test JSON array extraction containing multiple objects.
+     * This verifies that the method can handle array structures and
+     * properly parse each element in the array.
+     */
     @Test
     void extract_array() {
         String json = "[{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}]";
@@ -54,6 +77,11 @@ class JsonParsingUtilsTest {
         assertThat(result.get().value()[1].age).isEqualTo(2);
     }
 
+    /**
+     * Test JSON array extraction when surrounded by noise text.
+     * This tests the lastIndexOf logic - it should find the outermost ']'
+     * even when there are other characters before it.
+     */
     @Test
     void extract_array_with_noise() {
         String json = "abc [{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}] xyz";
@@ -62,6 +90,12 @@ class JsonParsingUtilsTest {
         assertThat(result.get().value().length).isEqualTo(2);
     }
 
+    /**
+     * Test nested array extraction with multiple levels of nesting.
+     * This is a critical test for the lastIndexOf logic - it must find
+     * the outermost closing bracket, not the inner ones.
+     * The structure is: [[object1], [object2]]
+     */
     @Test
     void extract_nested_array() {
         String json = "[[{\"name\":\"A\",\"age\":1}],[{\"name\":\"B\",\"age\":2}]]";
@@ -72,6 +106,11 @@ class JsonParsingUtilsTest {
         assertThat(result.get().value()[1][0].name).isEqualTo("B");
     }
 
+    /**
+     * Test JSON object with an array field.
+     * This verifies that the method can handle objects containing
+     * array properties and parse them correctly.
+     */
     @Test
     void extract_object_with_array_field() {
         String json = "{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",\"b\"]}";
@@ -80,6 +119,11 @@ class JsonParsingUtilsTest {
         assertThat(result.get().value().tags).containsExactly("a", "b");
     }
 
+    /**
+     * Test JSON object with a map/object field.
+     * This verifies that the method can handle nested object structures
+     * and parse complex JSON hierarchies.
+     */
     @Test
     void extract_object_with_map_field() {
         String json = "{\"name\":\"Tom\",\"age\":18,\"extra\":{\"k1\":123,\"k2\":\"v2\"}}";
@@ -88,15 +132,26 @@ class JsonParsingUtilsTest {
         assertThat(result.get().value().extra).containsEntry("k1", 123).containsEntry("k2", "v2");
     }
 
+    /**
+     * Test extraction when multiple JSON blocks are present in the text.
+     * This is a key test for the lastIndexOf logic - it should extract
+     * the last (rightmost) JSON block, not the first one.
+     * The method should find the outermost closing brace/bracket from the end.
+     */
     @Test
     void extract_multiple_json_blocks() {
         String json = "foo {\"name\":\"A\",\"age\":1} bar {\"name\":\"B\",\"age\":2}";
         Optional<JsonParsingUtils.ParsedJson<MyPojo>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo.class);
         assertThat(result).isPresent();
-        // 应该提取最后一个 JSON
+        // Should extract the last JSON block due to lastIndexOf logic
         assertThat(result.get().value().name).isEqualTo("B");
     }
 
+    /**
+     * Test behavior when no valid JSON is present in the text.
+     * The method should return an empty Optional when no parseable
+     * JSON structure can be found.
+     */
     @Test
     void extract_invalid_json() {
         String json = "not a json";
@@ -104,6 +159,12 @@ class JsonParsingUtilsTest {
         assertThat(result).isEmpty();
     }
 
+    /**
+     * Test JSON object with array elements containing bracket characters.
+     * This tests that the method correctly handles brackets that are
+     * part of string content rather than JSON structure.
+     * The lastIndexOf should not be confused by brackets in string values.
+     */
     @Test
     void extract_json_with_inner_brackets() {
         String json = "{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",\"b\",\"[c]\"]}";
@@ -112,15 +173,12 @@ class JsonParsingUtilsTest {
         assertThat(result.get().value().tags).contains("[c]");
     }
 
-    @Test
-    void extract_json_with_nested_arrays() {
-        String json = "{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",[\"b\",\"c\"]]}";
-        Optional<JsonParsingUtils.ParsedJson<MyPojo>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo.class);
-        assertThat(result).isPresent();
-        // tags 字段类型为 List<String>，嵌套数组会被解析为字符串
-        assertThat(result.get().value().tags).isNotEmpty();
-    }
-
+    /**
+     * Test complex JSON array with nested objects and arrays.
+     * This comprehensive test verifies that the method can handle
+     * complex nested structures and properly extract the entire array
+     * using the lastIndexOf logic to find the outermost closing bracket.
+     */
     @Test
     void extract_json_array_with_nested_objects_and_arrays() {
         String json = "[{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",\"b\"]},{\"name\":\"Jerry\",\"age\":20,\"tags\":[\"x\",\"y\"]}]";

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
@@ -1,0 +1,131 @@
+package dev.langchain4j.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonParsingUtilsTest {
+
+    static class MyPojo {
+        public String name;
+        public int age;
+        public List<String> tags;
+        public Map<String, Object> extra;
+        public MyPojo() {}
+        public MyPojo(String name, int age) { this.name = name; this.age = age; }
+        @Override public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MyPojo myPojo = (MyPojo) o;
+            return age == myPojo.age &&
+                    java.util.Objects.equals(name, myPojo.name);
+        }
+    }
+
+    @Test
+    void extract_simple_object() {
+        String json = "{\"name\":\"Tom\",\"age\":18}";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo.class);
+        assertThat(result).isPresent();
+        assertThat(result.get().value().name).isEqualTo("Tom");
+        assertThat(result.get().value().age).isEqualTo(18);
+    }
+
+    @Test
+    void extract_object_with_prefix_suffix() {
+        String json = "prefix {\"name\":\"Jerry\",\"age\":20} suffix";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo.class);
+        assertThat(result).isPresent();
+        assertThat(result.get().value().name).isEqualTo("Jerry");
+        assertThat(result.get().value().age).isEqualTo(20);
+    }
+
+    @Test
+    void extract_array() {
+        String json = "[{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}]";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo[]>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        assertThat(result).isPresent();
+        assertThat(result.get().value().length).isEqualTo(2);
+        assertThat(result.get().value()[0].name).isEqualTo("A");
+        assertThat(result.get().value()[1].age).isEqualTo(2);
+    }
+
+    @Test
+    void extract_array_with_noise() {
+        String json = "abc [{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}] xyz";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo[]>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        assertThat(result).isPresent();
+        assertThat(result.get().value().length).isEqualTo(2);
+    }
+
+    @Test
+    void extract_nested_array() {
+        String json = "[[{\"name\":\"A\",\"age\":1}],[{\"name\":\"B\",\"age\":2}]]";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo[][]>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[][].class);
+        assertThat(result).isPresent();
+        assertThat(result.get().value().length).isEqualTo(2);
+        assertThat(result.get().value()[0][0].name).isEqualTo("A");
+        assertThat(result.get().value()[1][0].name).isEqualTo("B");
+    }
+
+    @Test
+    void extract_object_with_array_field() {
+        String json = "{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",\"b\"]}";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo.class);
+        assertThat(result).isPresent();
+        assertThat(result.get().value().tags).containsExactly("a", "b");
+    }
+
+    @Test
+    void extract_object_with_map_field() {
+        String json = "{\"name\":\"Tom\",\"age\":18,\"extra\":{\"k1\":123,\"k2\":\"v2\"}}";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo.class);
+        assertThat(result).isPresent();
+        assertThat(result.get().value().extra).containsEntry("k1", 123).containsEntry("k2", "v2");
+    }
+
+    @Test
+    void extract_multiple_json_blocks() {
+        String json = "foo {\"name\":\"A\",\"age\":1} bar {\"name\":\"B\",\"age\":2}";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo.class);
+        assertThat(result).isPresent();
+        // 应该提取最后一个 JSON
+        assertThat(result.get().value().name).isEqualTo("B");
+    }
+
+    @Test
+    void extract_invalid_json() {
+        String json = "not a json";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo.class);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void extract_json_with_inner_brackets() {
+        String json = "{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",\"b\",\"[c]\"]}";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo.class);
+        assertThat(result).isPresent();
+        assertThat(result.get().value().tags).contains("[c]");
+    }
+
+    @Test
+    void extract_json_with_nested_arrays() {
+        String json = "{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",[\"b\",\"c\"]]}";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo.class);
+        assertThat(result).isPresent();
+        // tags 字段类型为 List<String>，嵌套数组会被解析为字符串
+        assertThat(result.get().value().tags).isNotEmpty();
+    }
+
+    @Test
+    void extract_json_array_with_nested_objects_and_arrays() {
+        String json = "[{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",\"b\"]},{\"name\":\"Jerry\",\"age\":20,\"tags\":[\"x\",\"y\"]}]";
+        Optional<JsonParsingUtils.ParsedJson<MyPojo[]>> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        assertThat(result).isPresent();
+        assertThat(result.get().value()[1].tags).containsExactly("x", "y");
+    }
+} 


### PR DESCRIPTION
## Change
This PR fixes an issue in the `findJsonEnd` method where the end index for JSON arrays was incorrectly determined using `text.indexOf(']', fromIndex)`. The method has been updated to use `text.lastIndexOf(']', fromIndex)` to correctly locate the last closing bracket for JSON arrays. This ensures proper parsing of JSON structures.

## General checklist
- [X] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [x] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [x] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [x] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [x] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [x] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [x] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j