### PR TITLE
Update HuggingFaceApi.java

### DIFF
--- a/langchain4j-hugging-face/src/main/java/dev/langchain4j/model/huggingface/HuggingFaceApi.java
+++ b/langchain4j-hugging-face/src/main/java/dev/langchain4j/model/huggingface/HuggingFaceApi.java
@@ -16,7 +16,7 @@ interface HuggingFaceApi {
     @Headers({"Content-Type: application/json"})
     Call<List<TextGenerationResponse>> generate(@Body TextGenerationRequest request, @Path("modelId") String modelId);
 
-    @POST("models/{modelId}/pipeline/feature-extraction")
+    @POST("models/{modelId}")
     @Headers({"Content-Type: application/json"})
     Call<List<float[]>> embed(@Body EmbeddingRequest request, @Path("modelId") String modelId);
 }


### PR DESCRIPTION
No sure where the Url  models/{modelId}/pipeline/feature-extraction comes from, shouldn't it be just models/modelId? At least the HuggingFace-models I am using do run on this Url


