### PR TITLE
Expose invoke on ToolExecutor

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -85,6 +85,19 @@ public class DefaultToolExecutor implements ToolExecutor {
         }
     }
 
+    public Object invoke(ToolExecutionRequest toolExecutionRequest, Object memoryId) throws Throwable {
+        Map<String, Object> argumentsMap = argumentsAsMap(toolExecutionRequest.arguments());
+        Object[] arguments = prepareArguments(originalMethod, argumentsMap, memoryId);
+        try {
+            methodToInvoke.setAccessible(true);
+            return methodToInvoke.invoke(object, arguments);
+        } catch (IllegalAccessException e) {
+            throw e;
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
     private String execute(Object[] arguments) throws IllegalAccessException, InvocationTargetException {
         Object result = methodToInvoke.invoke(object, arguments);
         Class<?> returnType = methodToInvoke.getReturnType();

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutor.java
@@ -16,4 +16,19 @@ public interface ToolExecutor {
      * @return The result of the tool execution.
      */
     String execute(ToolExecutionRequest toolExecutionRequest, Object memoryId);
+
+
+    /**
+     * Invokes a tool request, but does not marshal the result to a string.
+     *
+     * @param toolExecutionRequest The tool execution request. Contains tool name and arguments.
+     * @param memoryId              The ID of the chat memory. See {@link MemoryId} for more details.
+     * @throws Throwable Propagated exception from the reflection call on the tool method
+     * @return The tool execution result.
+     */
+    default Object invoke(ToolExecutionRequest toolExecutionRequest, Object memoryId) throws Throwable {
+        // Default implementation is for backward compatibility with the old ToolExecutor interface.
+        throw new UnsupportedOperationException("invoke is not supported by this tool executor");
+    }
+
 }


### PR DESCRIPTION

## Issue
Closes #3328 

## Change
* Added an invoke() method to ToolExecutor that returns result of raw method invocation
* Implemented invoke() invocation in DefaultToolExecutor

In my current use case, I don't want to marshal the result into json as I want to do some local processing on the tool execution.
If the methods in DefaultToolExecutor were protected instead of private, I could have extended DefaultToolExecutor.  I think adding an invoke method to ToolExecutor would be better and useful.



