### PR TITLE
support api key authentication for Bedrock API 

### DIFF
--- a/docs/docs/integrations/language-models/amazon-bedrock.md
+++ b/docs/docs/integrations/language-models/amazon-bedrock.md
@@ -16,8 +16,7 @@ sidebar_position: 1
 
 ## AWS credentials
 In order to use Amazon Bedrock models, you need to configure AWS credentials.
-One of the options is to set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-More information can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html).
+One of the options is to set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. More information can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html). Alternatively, set the `AWS_BEARER_TOKEN_BEDROCK` environment variable locally for API Key authentication. For additional API key details, refer to [docs](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html).
 
 ## BedrockChatModel
 :::note

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -51,7 +51,7 @@
         <assertj.version>3.27.3</assertj.version>
         <assertk.version>0.28.1</assertk.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <aws.java.sdk.version>2.31.62</aws.java.sdk.version>
+        <aws.java.sdk.version>2.31.74</aws.java.sdk.version>
         <azure-ai-openai.version>1.0.0-beta.16</azure-ai-openai.version>
         <azure-sdk.version>1.2.34</azure-sdk.version>
         <elastic.version>8.15.3</elastic.version>


### PR DESCRIPTION
## Issue
Feature #3331 

## Change
AWS Bedrock has introduced API key support on 7/7, simplifying authentication for the Amazon Bedrock API. To enable this new feature in langchain4j, this update bumps the required aws sdk version to "2.31.74". It has been tested and worked as expected with new `AWS_BEARER_TOKEN_BEDROCK` environment variable.