### PR TITLE
Add varargs overload for splitAll to DocumentSplitter

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/DocumentSplitter.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/DocumentSplitter.java
@@ -1,10 +1,12 @@
 package dev.langchain4j.data.document;
 
-import dev.langchain4j.data.segment.TextSegment;
-
-import java.util.List;
-
 import static java.util.stream.Collectors.toList;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.internal.Utils;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Defines the interface for splitting a document into text segments.
@@ -33,8 +35,36 @@ public interface DocumentSplitter {
      * @return A list of TextSegment objects derived from the input Documents.
      */
     default List<TextSegment> splitAll(List<Document> documents) {
-        return documents.stream()
-                .flatMap(document -> split(document).stream())
-                .collect(toList());
+        return documents.stream().flatMap(document -> split(document).stream()).collect(toList());
+    }
+
+    /**
+     * Splits multiple {@link Document} instances into a list of {@link TextSegment} objects.
+     * <p>
+     * This is a convenience method that allows callers to pass a variable number of Document arguments
+     * (using varargs) instead of explicitly creating a list. Internally, it delegates to the {@link #splitAll(List)}
+     * method by converting the varargs array into a {@link List}.
+     * <p>
+     * For example:
+     * <pre>{@code
+     * List<TextSegment> segments = documentSplitter.splitAll(doc1, doc2, doc3);
+     * }</pre>
+     * This is equivalent to:
+     * <pre>{@code
+     * List<TextSegment> segments = documentSplitter.splitAll(Arrays.asList(doc1, doc2, doc3));
+     * }</pre>
+     *
+     * @param documents One or more {@code Document} instances to be split.
+     *                  If no documents are provided, an empty list is returned.
+     * @return A list of {@code TextSegment} objects derived from the input documents.
+     *         The resulting list is a flat combination of all segments from all input documents.
+     * @see #split(Document)
+     * @see #splitAll(List)
+     */
+    default List<TextSegment> splitAll(Document... documents) {
+        if (Utils.isNullOrEmpty(documents)) {
+            return Collections.emptyList();
+        }
+        return splitAll(Arrays.asList(documents));
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -1,7 +1,12 @@
 package dev.langchain4j.internal;
 
-import dev.langchain4j.Internal;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Collections.unmodifiableSet;
 
+import dev.langchain4j.Internal;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -25,30 +30,24 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-import static java.net.HttpURLConnection.HTTP_OK;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableMap;
-import static java.util.Collections.unmodifiableSet;
-
 /**
  * Utility methods.
  */
 @Internal
 public class Utils {
 
-  private Utils() {}
+    private Utils() {}
 
-  /**
-   * Returns the given value if it is not {@code null}, otherwise returns the given default value.
-   * @param value The value to return if it is not {@code null}.
-   * @param defaultValue The value to return if the value is {@code null}.
-   * @return the given value if it is not {@code null}, otherwise returns the given default value.
-   * @param <T> The type of the value.
-   */
-  public static <T> T getOrDefault(T value, T defaultValue) {
-    return value != null ? value : defaultValue;
-  }
+    /**
+     * Returns the given value if it is not {@code null}, otherwise returns the given default value.
+     * @param value The value to return if it is not {@code null}.
+     * @param defaultValue The value to return if the value is {@code null}.
+     * @return the given value if it is not {@code null}, otherwise returns the given default value.
+     * @param <T> The type of the value.
+     */
+    public static <T> T getOrDefault(T value, T defaultValue) {
+        return value != null ? value : defaultValue;
+    }
 
     /**
      * Returns the given list if it is not {@code null} and not empty, otherwise returns the given default list.
@@ -73,225 +72,235 @@ public class Utils {
         return isNullOrEmpty(map) ? defaultMap : map;
     }
 
-  /**
-   * Returns the given value if it is not {@code null}, otherwise returns the value returned by the given supplier.
-   * @param value The value to return if it is not {@code null}.
-   * @param defaultValueSupplier The supplier to call if the value is {@code null}.
-   * @return the given value if it is not {@code null}, otherwise returns the value returned by the given supplier.
-   * @param <T> The type of the value.
-   */
-  public static <T> T getOrDefault(T value, Supplier<T> defaultValueSupplier) {
-    return value != null ? value : defaultValueSupplier.get();
-  }
-
-  /**
-   * Is the given string {@code null} or blank?
-   * @param string The string to check.
-   * @return true if the string is {@code null} or blank.
-   */
-  public static boolean isNullOrBlank(String string) {
-    return string == null || string.trim().isEmpty();
-  }
-
-  /**
-   * Is the given string {@code null} or empty ("")?
-   * @param string The string to check.
-   * @return true if the string is {@code null} or empty.
-   */
-  public static boolean isNullOrEmpty(String string) {
-    return string == null || string.isEmpty();
-  }
-
-  /**
-   * Is the given string not {@code null} and not blank?
-   * @param string The string to check.
-   * @return true if there's something in the string.
-   */
-  public static boolean isNotNullOrBlank(String string) {
-    return !isNullOrBlank(string);
-  }
-
-  /**
-   * Is the given string not {@code null} and not empty ("")?
-   * @param string The string to check.
-   * @return true if the given string is not {@code null} and not empty ("")?
-   */
-  public static boolean isNotNullOrEmpty(String string) {
-    return !isNullOrEmpty(string);
-  }
-
-  /**
-   * Are all the given strings not {@code null} and not blank?
-   * @param strings The strings to check.
-   * @return {@code true} if every string is non-{@code null} and non-empty.
-   */
-  public static boolean areNotNullOrBlank(String... strings) {
-    if (strings == null || strings.length == 0) {
-      return false;
+    /**
+     * Returns the given value if it is not {@code null}, otherwise returns the value returned by the given supplier.
+     * @param value The value to return if it is not {@code null}.
+     * @param defaultValueSupplier The supplier to call if the value is {@code null}.
+     * @return the given value if it is not {@code null}, otherwise returns the value returned by the given supplier.
+     * @param <T> The type of the value.
+     */
+    public static <T> T getOrDefault(T value, Supplier<T> defaultValueSupplier) {
+        return value != null ? value : defaultValueSupplier.get();
     }
 
-    for (String string : strings) {
-      if (isNullOrBlank(string)) {
-        return false;
-      }
+    /**
+     * Is the given string {@code null} or blank?
+     * @param string The string to check.
+     * @return true if the string is {@code null} or blank.
+     */
+    public static boolean isNullOrBlank(String string) {
+        return string == null || string.trim().isEmpty();
     }
 
-    return true;
-  }
-
-  /**
-   * Is the collection {@code null} or empty?
-   * @param collection The collection to check.
-   * @return {@code true} if the collection is {@code null} or {@link Collection#isEmpty()}, otherwise {@code false}.
-   */
-  public static boolean isNullOrEmpty(Collection<?> collection) {
-    return collection == null || collection.isEmpty();
-  }
-
-  /**
-   * Is the iterable object {@code null} or empty?
-   * @param iterable The iterable object to check.
-   * @return {@code true} if the iterable object is {@code null} or there are no objects to iterate over, otherwise {@code false}.
-   */
-  public static boolean isNullOrEmpty(Iterable<?> iterable) {
-    return iterable == null || !iterable.iterator().hasNext();
-  }
-
-  /**
-   * Is the map object {@code null} or empty?
-   * @param map The iterable object to check.
-   * @return {@code true} if the map object is {@code null} or empty map, otherwise {@code false}.
-   * */
-  public static boolean isNullOrEmpty(Map<?, ?> map) {
-      return map == null || map.isEmpty();
-  }
-
-  /**
-   * Returns a string consisting of the given string repeated {@code times} times.
-   *
-   * @param string The string to repeat.
-   * @param times  The number of times to repeat the string.
-   * @return A string consisting of the given string repeated {@code times} times.
-   */
-  public static String repeat(String string, int times) {
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < times; i++) {
-      sb.append(string);
+    /**
+     * Is the given string {@code null} or empty ("")?
+     * @param string The string to check.
+     * @return true if the string is {@code null} or empty.
+     */
+    public static boolean isNullOrEmpty(String string) {
+        return string == null || string.isEmpty();
     }
-    return sb.toString();
-  }
 
-  /**
-   * Returns a random UUID.
-   * @return a UUID.
-   */
-  public static String randomUUID() {
-    return UUID.randomUUID().toString();
-  }
-
-  /**
-   * Internal method to get a SHA-256 instance of {@link MessageDigest}.
-   * @return a {@link MessageDigest}.
-   */
-  @JacocoIgnoreCoverageGenerated
-  private static MessageDigest getSha256Instance() {
-    try {
-      return MessageDigest.getInstance("SHA-256");
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalArgumentException(e);
+    /**
+     * Is the given string not {@code null} and not blank?
+     * @param string The string to check.
+     * @return true if there's something in the string.
+     */
+    public static boolean isNotNullOrBlank(String string) {
+        return !isNullOrBlank(string);
     }
-  }
 
-  /**
-   * Generates a UUID from a hash of the given input string.
-   * @param input The input string.
-   * @return A UUID.
-   */
-  public static String generateUUIDFrom(String input) {
-      byte[] hashBytes = getSha256Instance().digest(input.getBytes(UTF_8));
-      String hexFormat = HexFormat.of().formatHex(hashBytes);
-      return UUID.nameUUIDFromBytes(hexFormat.getBytes(UTF_8)).toString();
-  }
-
-  /**
-   * Appends a trailing '/' if the provided URL does not end with '/'
-   * 
-   * @param url URL to check for trailing '/'
-   * @return Same URL if it already ends with '/' or a new URL with '/' appended
-   */
-  public static String ensureTrailingForwardSlash(String url) {
-      return url.endsWith("/") ? url : url + "/";
-  }
-
-  /**
-   * Returns the given object's {@code toString()} surrounded by quotes.
-   *
-   * <p>If the given object is {@code null}, the string {@code "null"} is returned.
-   *
-   * @param object The object to quote.
-   * @return The given object surrounded by quotes.
-   */
-  public static String quoted(Object object) {
-    if (object == null) {
-      return "null";
+    /**
+     * Is the given string not {@code null} and not empty ("")?
+     * @param string The string to check.
+     * @return true if the given string is not {@code null} and not empty ("")?
+     */
+    public static boolean isNotNullOrEmpty(String string) {
+        return !isNullOrEmpty(string);
     }
-    return "\"" + object + "\"";
-  }
 
-  /**
-   * Returns the first {@code numberOfChars} characters of the given string.
-   * If the string is shorter than {@code numberOfChars}, the whole string is returned.
-   *
-   * @param string        The string to get the first characters from.
-   * @param numberOfChars The number of characters to return.
-   * @return The first {@code numberOfChars} characters of the given string.
-   */
-  public static String firstChars(String string, int numberOfChars) {
-    if (string == null) {
-      return null;
-    }
-    return string.length() > numberOfChars ? string.substring(0, numberOfChars) : string;
-  }
-
-  /**
-   * Reads the content as bytes from the given URL as a GET request for HTTP/HTTPS resources,
-   * and from files stored on the local filesystem.
-   *
-   * @param url The URL to read from.
-   * @return The content as bytes.
-   * @throws RuntimeException if the request fails.
-   */
-  public static byte[] readBytes(String url) {
-    try {
-      if (url.startsWith("http://") || url.startsWith("https://")) {
-        // Handle URLs
-        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
-        connection.setRequestMethod("GET");
-
-        int responseCode = connection.getResponseCode();
-
-        if (responseCode == HTTP_OK) {
-          InputStream inputStream = connection.getInputStream();
-          ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-          byte[] buffer = new byte[1024];
-          int bytesRead;
-          while ((bytesRead = inputStream.read(buffer)) != -1) {
-            outputStream.write(buffer, 0, bytesRead);
-          }
-
-          return outputStream.toByteArray();
-        } else {
-          throw new RuntimeException("Error while reading: " + responseCode);
+    /**
+     * Are all the given strings not {@code null} and not blank?
+     * @param strings The strings to check.
+     * @return {@code true} if every string is non-{@code null} and non-empty.
+     */
+    public static boolean areNotNullOrBlank(String... strings) {
+        if (strings == null || strings.length == 0) {
+            return false;
         }
-      } else {
-        // Handle files
-        return Files.readAllBytes(Path.of(new URI(url)));
-      }
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+
+        for (String string : strings) {
+            if (isNullOrBlank(string)) {
+                return false;
+            }
+        }
+
+        return true;
     }
-  }
+
+    /**
+     * Is the collection {@code null} or empty?
+     * @param collection The collection to check.
+     * @return {@code true} if the collection is {@code null} or {@link Collection#isEmpty()}, otherwise {@code false}.
+     */
+    public static boolean isNullOrEmpty(Collection<?> collection) {
+        return collection == null || collection.isEmpty();
+    }
+
+    /**
+     * Is the iterable object {@code null} or empty?
+     * @param iterable The iterable object to check.
+     * @return {@code true} if the iterable object is {@code null} or there are no objects to iterate over, otherwise {@code false}.
+     */
+    public static boolean isNullOrEmpty(Iterable<?> iterable) {
+        return iterable == null || !iterable.iterator().hasNext();
+    }
+
+    /**
+     * Is the map object {@code null} or empty?
+     * @param map The iterable object to check.
+     * @return {@code true} if the map object is {@code null} or empty map, otherwise {@code false}.
+     * */
+    public static boolean isNullOrEmpty(Map<?, ?> map) {
+        return map == null || map.isEmpty();
+    }
+
+    /**
+     * Utility method to check if an array is null or has no elements.
+     *
+     * @param array the array to check
+     * @return {@code true} if the array is null or has no elements, otherwise {@code false}
+     */
+    public static boolean isNullOrEmpty(Object[] array) {
+        return array == null || array.length == 0;
+    }
+
+    /**
+     * Returns a string consisting of the given string repeated {@code times} times.
+     *
+     * @param string The string to repeat.
+     * @param times  The number of times to repeat the string.
+     * @return A string consisting of the given string repeated {@code times} times.
+     */
+    public static String repeat(String string, int times) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < times; i++) {
+            sb.append(string);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Returns a random UUID.
+     * @return a UUID.
+     */
+    public static String randomUUID() {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Internal method to get a SHA-256 instance of {@link MessageDigest}.
+     * @return a {@link MessageDigest}.
+     */
+    @JacocoIgnoreCoverageGenerated
+    private static MessageDigest getSha256Instance() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Generates a UUID from a hash of the given input string.
+     * @param input The input string.
+     * @return A UUID.
+     */
+    public static String generateUUIDFrom(String input) {
+        byte[] hashBytes = getSha256Instance().digest(input.getBytes(UTF_8));
+        String hexFormat = HexFormat.of().formatHex(hashBytes);
+        return UUID.nameUUIDFromBytes(hexFormat.getBytes(UTF_8)).toString();
+    }
+
+    /**
+     * Appends a trailing '/' if the provided URL does not end with '/'
+     *
+     * @param url URL to check for trailing '/'
+     * @return Same URL if it already ends with '/' or a new URL with '/' appended
+     */
+    public static String ensureTrailingForwardSlash(String url) {
+        return url.endsWith("/") ? url : url + "/";
+    }
+
+    /**
+     * Returns the given object's {@code toString()} surrounded by quotes.
+     *
+     * <p>If the given object is {@code null}, the string {@code "null"} is returned.
+     *
+     * @param object The object to quote.
+     * @return The given object surrounded by quotes.
+     */
+    public static String quoted(Object object) {
+        if (object == null) {
+            return "null";
+        }
+        return "\"" + object + "\"";
+    }
+
+    /**
+     * Returns the first {@code numberOfChars} characters of the given string.
+     * If the string is shorter than {@code numberOfChars}, the whole string is returned.
+     *
+     * @param string        The string to get the first characters from.
+     * @param numberOfChars The number of characters to return.
+     * @return The first {@code numberOfChars} characters of the given string.
+     */
+    public static String firstChars(String string, int numberOfChars) {
+        if (string == null) {
+            return null;
+        }
+        return string.length() > numberOfChars ? string.substring(0, numberOfChars) : string;
+    }
+
+    /**
+     * Reads the content as bytes from the given URL as a GET request for HTTP/HTTPS resources,
+     * and from files stored on the local filesystem.
+     *
+     * @param url The URL to read from.
+     * @return The content as bytes.
+     * @throws RuntimeException if the request fails.
+     */
+    public static byte[] readBytes(String url) {
+        try {
+            if (url.startsWith("http://") || url.startsWith("https://")) {
+                // Handle URLs
+                HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+                connection.setRequestMethod("GET");
+
+                int responseCode = connection.getResponseCode();
+
+                if (responseCode == HTTP_OK) {
+                    InputStream inputStream = connection.getInputStream();
+                    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+                    byte[] buffer = new byte[1024];
+                    int bytesRead;
+                    while ((bytesRead = inputStream.read(buffer)) != -1) {
+                        outputStream.write(buffer, 0, bytesRead);
+                    }
+
+                    return outputStream.toByteArray();
+                } else {
+                    throw new RuntimeException("Error while reading: " + responseCode);
+                }
+            } else {
+                // Handle files
+                return Files.readAllBytes(Path.of(new URI(url)));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     /**
      * Returns an (unmodifiable) copy of the provided set.
@@ -325,21 +334,21 @@ public class Utils {
         return unmodifiableSet(set);
     }
 
-  /**
-   * Returns an (unmodifiable) copy of the provided list.
-   * Returns <code>null</code> if the provided list is <code>null</code>.
-   *
-   * @param list The list to copy.
-   * @param <T>  Generic type of the list.
-   * @return The copy of the provided list.
-   */
-  public static <T> List<T> copyIfNotNull(List<T> list) {
-    if (list == null) {
-      return null;
-    }
+    /**
+     * Returns an (unmodifiable) copy of the provided list.
+     * Returns <code>null</code> if the provided list is <code>null</code>.
+     *
+     * @param list The list to copy.
+     * @param <T>  Generic type of the list.
+     * @return The copy of the provided list.
+     */
+    public static <T> List<T> copyIfNotNull(List<T> list) {
+        if (list == null) {
+            return null;
+        }
 
-    return unmodifiableList(list);
-  }
+        return unmodifiableList(list);
+    }
 
     /**
      * Returns an (unmodifiable) copy of the provided list.
@@ -357,20 +366,20 @@ public class Utils {
         return unmodifiableList(list);
     }
 
-  /**
-   * Returns an (unmodifiable) copy of the provided map.
-   * Returns <code>null</code> if the provided map is <code>null</code>.
-   *
-   * @param map The map to copy.
-   * @return The copy of the provided map.
-   */
-  public static <K,V> Map<K,V> copyIfNotNull(Map<K,V> map) {
-    if (map == null) {
-      return null;
-    }
+    /**
+     * Returns an (unmodifiable) copy of the provided map.
+     * Returns <code>null</code> if the provided map is <code>null</code>.
+     *
+     * @param map The map to copy.
+     * @return The copy of the provided map.
+     */
+    public static <K, V> Map<K, V> copyIfNotNull(Map<K, V> map) {
+        if (map == null) {
+            return null;
+        }
 
-    return unmodifiableMap(map);
-  }
+        return unmodifiableMap(map);
+    }
 
     /**
      * Returns an (unmodifiable) copy of the provided map.
@@ -379,7 +388,7 @@ public class Utils {
      * @param map The map to copy.
      * @return The copy of the provided map or an empty map.
      */
-    public static <K,V> Map<K,V> copy(Map<K,V> map) {
+    public static <K, V> Map<K, V> copy(Map<K, V> map) {
         if (map == null) {
             return Map.of();
         }

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/document/DocumentSplitterTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/document/DocumentSplitterTest.java
@@ -34,4 +34,31 @@ class DocumentSplitterTest implements WithAssertions {
                         new TextSegment("abc", Metadata.metadata("foo", "bar")),
                         new TextSegment("def", Metadata.metadata("foo", "bar")));
     }
+
+    @Test
+    void split_all_varargs() {
+        WhitespaceSplitter splitter = new WhitespaceSplitter();
+
+        // Case 1: null varargs
+        assertThat(splitter.splitAll((Document[]) null)).isEmpty();
+
+        // Case 2: empty varargs
+        assertThat(splitter.splitAll()).isEmpty();
+
+        // Case 3: single document with default metadata
+        Document doc1 = Document.document("hello world");
+        List<TextSegment> result1 = splitter.splitAll(doc1);
+        assertThat(result1)
+                .containsExactly(new TextSegment("hello", new Metadata()), new TextSegment("world", new Metadata()));
+
+        // Case 4: multiple documents with mixed metadata
+        Document doc2 = Document.document("foo bar", Metadata.metadata("x", "1"));
+        List<TextSegment> result2 = splitter.splitAll(doc1, doc2);
+        assertThat(result2)
+                .containsExactly(
+                        new TextSegment("hello", new Metadata()),
+                        new TextSegment("world", new Metadata()),
+                        new TextSegment("foo", Metadata.metadata("x", "1")),
+                        new TextSegment("bar", Metadata.metadata("x", "1")));
+    }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.entry;
 
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.InvocationHandler;
@@ -136,6 +135,27 @@ class UtilsTest {
         assertThat(Utils.isNullOrEmpty((Collection<?>) null)).isTrue();
         assertThat(Utils.isNullOrEmpty(emptyList())).isTrue();
         assertThat(Utils.isNullOrEmpty(Collections.singletonList("abc"))).isFalse();
+    }
+
+    @Test
+    void array_is_null_or_empty() {
+        // Null array
+        assertThat(Utils.isNullOrEmpty((Object[]) null)).isTrue();
+
+        // Empty array
+        assertThat(Utils.isNullOrEmpty(new Object[0])).isTrue();
+
+        // Non-empty array with one element
+        assertThat(Utils.isNullOrEmpty(new Object[] {"abc"})).isFalse();
+
+        // Non-empty array with multiple elements
+        assertThat(Utils.isNullOrEmpty(new Object[] {"a", "b", "c"})).isFalse();
+
+        // Array with a null element (still non-empty)
+        assertThat(Utils.isNullOrEmpty(new Object[] {null})).isFalse();
+
+        // Mixed null and non-null elements
+        assertThat(Utils.isNullOrEmpty(new Object[] {null, "xyz"})).isFalse();
     }
 
     @Test
@@ -359,11 +379,11 @@ class UtilsTest {
 
     @Retention(RUNTIME)
     @Target({METHOD})
-    public @interface MyAnnotation { }
+    public @interface MyAnnotation {}
 
     @Retention(RUNTIME)
     @Target({METHOD})
-    public @interface AnotherAnnotation { }
+    public @interface AnotherAnnotation {}
 
     public interface MyInterface {
         @MyAnnotation
@@ -380,9 +400,7 @@ class UtilsTest {
     @Test
     void shouldRetrieveAnnotationOnProxyMethod() throws NoSuchMethodException {
         Object proxyInstance = Proxy.newProxyInstance(
-                MyInterface.class.getClassLoader(),
-                new Class<?>[] {MyInterface.class},
-                new InvocationHandler() {
+                MyInterface.class.getClassLoader(), new Class<?>[] {MyInterface.class}, new InvocationHandler() {
                     @Override
                     public Object invoke(Object proxy, Method method, Object[] args) throws Exception {
                         return null;


### PR DESCRIPTION
# Add varargs overload for splitAll to DocumentSplitter

## Summary

This pull request introduces a convenience overload for the `splitAll` method in the `DocumentSplitter` interface, allowing developers to pass a variable number of `Document` instances via varargs instead of creating a `List<Document>` manually.

---

## What’s Added

### New method:

```java
default List<TextSegment> splitAll(Document... documents) {
    if (Utils.isNullOrEmpty(documents)) {
        return Collections.emptyList();
    }
    return splitAll(Arrays.asList(documents));
}
```
