### PR TITLE
Add varargs overload for splitAll to DocumentSplitter

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/DocumentSplitter.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/DocumentSplitter.java
@@ -1,10 +1,12 @@
 package dev.langchain4j.data.document;
 
-import dev.langchain4j.data.segment.TextSegment;
-
-import java.util.List;
-
 import static java.util.stream.Collectors.toList;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.internal.Utils;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Defines the interface for splitting a document into text segments.
@@ -33,8 +35,36 @@ public interface DocumentSplitter {
      * @return A list of TextSegment objects derived from the input Documents.
      */
     default List<TextSegment> splitAll(List<Document> documents) {
-        return documents.stream()
-                .flatMap(document -> split(document).stream())
-                .collect(toList());
+        return documents.stream().flatMap(document -> split(document).stream()).collect(toList());
+    }
+
+    /**
+     * Splits multiple {@link Document} instances into a list of {@link TextSegment} objects.
+     * <p>
+     * This is a convenience method that allows callers to pass a variable number of Document arguments
+     * (using varargs) instead of explicitly creating a list. Internally, it delegates to the {@link #splitAll(List)}
+     * method by converting the varargs array into a {@link List}.
+     * <p>
+     * For example:
+     * <pre>{@code
+     * List<TextSegment> segments = documentSplitter.splitAll(doc1, doc2, doc3);
+     * }</pre>
+     * This is equivalent to:
+     * <pre>{@code
+     * List<TextSegment> segments = documentSplitter.splitAll(Arrays.asList(doc1, doc2, doc3));
+     * }</pre>
+     *
+     * @param documents One or more {@code Document} instances to be split.
+     *                  If no documents are provided, an empty list is returned.
+     * @return A list of {@code TextSegment} objects derived from the input documents.
+     *         The resulting list is a flat combination of all segments from all input documents.
+     * @see #split(Document)
+     * @see #splitAll(List)
+     */
+    default List<TextSegment> splitAll(Document... documents) {
+        if (Utils.isNullOrEmpty(documents)) {
+            return Collections.emptyList();
+        }
+        return splitAll(Arrays.asList(documents));
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -191,6 +191,16 @@ public class Utils {
     }
 
     /**
+     * Utility method to check if an array is null or has no elements.
+     *
+     * @param array the array to check
+     * @return {@code true} if the array is null or has no elements, otherwise {@code false}
+     */
+    public static boolean isNullOrEmpty(Object[] array) {
+        return array == null || array.length == 0;
+    }
+
+    /**
      * Is the map object {@code null} or empty?
      *
      * @param map The iterable object to check.

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/document/DocumentSplitterTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/document/DocumentSplitterTest.java
@@ -34,4 +34,31 @@ class DocumentSplitterTest implements WithAssertions {
                         new TextSegment("abc", Metadata.metadata("foo", "bar")),
                         new TextSegment("def", Metadata.metadata("foo", "bar")));
     }
+
+    @Test
+    void split_all_varargs() {
+        WhitespaceSplitter splitter = new WhitespaceSplitter();
+
+        // Case 1: null varargs
+        assertThat(splitter.splitAll((Document[]) null)).isEmpty();
+
+        // Case 2: empty varargs
+        assertThat(splitter.splitAll()).isEmpty();
+
+        // Case 3: single document with default metadata
+        Document doc1 = Document.document("hello world");
+        List<TextSegment> result1 = splitter.splitAll(doc1);
+        assertThat(result1)
+                .containsExactly(new TextSegment("hello", new Metadata()), new TextSegment("world", new Metadata()));
+
+        // Case 4: multiple documents with mixed metadata
+        Document doc2 = Document.document("foo bar", Metadata.metadata("x", "1"));
+        List<TextSegment> result2 = splitter.splitAll(doc1, doc2);
+        assertThat(result2)
+                .containsExactly(
+                        new TextSegment("hello", new Metadata()),
+                        new TextSegment("world", new Metadata()),
+                        new TextSegment("foo", Metadata.metadata("x", "1")),
+                        new TextSegment("bar", Metadata.metadata("x", "1")));
+    }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
@@ -147,6 +147,27 @@ class UtilsTest {
     }
 
     @Test
+    void array_is_null_or_empty() {
+        // Null array
+        assertThat(Utils.isNullOrEmpty((Object[]) null)).isTrue();
+
+        // Empty array
+        assertThat(Utils.isNullOrEmpty(new Object[0])).isTrue();
+
+        // Non-empty array with one element
+        assertThat(Utils.isNullOrEmpty(new Object[] {"abc"})).isFalse();
+
+        // Non-empty array with multiple elements
+        assertThat(Utils.isNullOrEmpty(new Object[] {"a", "b", "c"})).isFalse();
+
+        // Array with a null element (still non-empty)
+        assertThat(Utils.isNullOrEmpty(new Object[] {null})).isFalse();
+
+        // Mixed null and non-null elements
+        assertThat(Utils.isNullOrEmpty(new Object[] {null, "xyz"})).isFalse();
+    }
+
+    @Test
     void repeat() {
         assertThat(Utils.repeat("foo", 0)).isEmpty();
         assertThat(Utils.repeat("foo", 1)).isEqualTo("foo");


### PR DESCRIPTION
# Add varargs overload for splitAll to DocumentSplitter

## Summary

This pull request introduces a convenience overload for the `splitAll` method in the `DocumentSplitter` interface, allowing clients to pass a variable number of `Document` instances via varargs instead of creating a `List<Document>` manually.

---

## What’s Added

### New method:

```java
default List<TextSegment> splitAll(Document... documents) {
    if (Utils.isNullOrEmpty(documents)) {
        return Collections.emptyList();
    }
    return splitAll(Arrays.asList(documents));
}
