### PR TITLE
Imorovized the doc and testcases for loadDocument to Support Branch, …

### DIFF
--- a/document-loaders/langchain4j-document-loader-github/src/main/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-github/src/main/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoader.java
@@ -64,7 +64,7 @@ public class GitHubDocumentLoader {
      * parses it using the provided {@link DocumentParser}, and returns the resulting {@link Document} object.
      * </p>
      *
-     * <h3>Parameters</h3>
+     * <p><b>Parameters:</b></p>
      * <ul>
      *     <li><b>owner</b> - The GitHub username or organization name that owns the repository. Must not be blank.</li>
      *     <li><b>repo</b> - The name of the GitHub repository. Must not be blank.</li>
@@ -80,16 +80,16 @@ public class GitHubDocumentLoader {
      *     <li><b>parser</b> - An implementation of {@link DocumentParser} used to parse the retrieved file content into a {@link Document} object.</li>
      * </ul>
      *
-     * <h3>Returns</h3>
+     * <p><b>Returns:</b></p>
      * A {@link Document} parsed from the contents of the file at the specified location and ref in the GitHub repository.
      *
-     * <h3>Throws</h3>
+     * <p><b>Throws:</b></p>
      * <ul>
      *     <li>{@link IllegalArgumentException} if the {@code owner} or {@code repo} is blank or null.</li>
      *     <li>{@link RuntimeException} if the GitHub API call fails or the content cannot be retrieved (wraps {@link IOException}).</li>
      * </ul>
      *
-     * <h3>Usage Example:</h3>
+     * <p><b>Usage Example:</b></p>
      * <pre>{@code
      * Document doc = loader.loadDocument("langchain4j", "langchain4j", "main", "pom.xml", new TextDocumentParser());
      * }</pre>
@@ -121,7 +121,7 @@ public class GitHubDocumentLoader {
      * {@link DocumentParser}, and returns a list of {@link Document} objects.
      * </p>
      *
-     * <h3>Parameters</h3>
+     * <p><b>Parameters:</b></p>
      * <ul>
      *     <li><b>owner</b> - The GitHub username or organization name that owns the repository. Must not be blank.</li>
      *     <li><b>repo</b> - The name of the GitHub repository. Must not be blank.</li>
@@ -130,16 +130,16 @@ public class GitHubDocumentLoader {
      *     <li><b>parser</b> - An implementation of {@link DocumentParser} used to convert file contents into {@link Document} objects.</li>
      * </ul>
      *
-     * <h3>Returns</h3>
+     * <p><b>Returns:</b></p>
      * A list of {@link Document} objects parsed from the files found in the specified directory and its subdirectories.
      *
-     * <h3>Throws</h3>
+     * <p><b>Throws:</b></p>
      * <ul>
      *     <li>{@link IllegalArgumentException} if {@code owner} or {@code repo} is blank or null.</li>
      *     <li>{@link RuntimeException} if an {@link IOException} occurs while accessing the GitHub repository content.</li>
      * </ul>
      *
-     * <h3>Usage Example:</h3>
+     * <p><b>Usage Example:</b></p>
      * <pre>{@code
      * List<Document> docs = loader.loadDocuments(
      *     "langchain4j",

--- a/document-loaders/langchain4j-document-loader-github/src/main/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-github/src/main/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoader.java
@@ -1,20 +1,20 @@
 package dev.langchain4j.data.document.loader.github;
 
+import static dev.langchain4j.internal.RetryUtils.withRetry;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentLoader;
 import dev.langchain4j.data.document.DocumentParser;
 import dev.langchain4j.data.document.source.github.GitHubSource;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import static dev.langchain4j.internal.RetryUtils.withRetry;
 
 public class GitHubDocumentLoader {
 
@@ -57,25 +57,115 @@ public class GitHubDocumentLoader {
         this.gitHub = gitHub;
     }
 
-    public Document loadDocument(String owner, String repo, String branch, String path, DocumentParser parser) {
+    /**
+     * Loads a document from a specific file in a GitHub repository using the provided reference (commit ID, branch name, or tag).
+     * <p>
+     * This method retrieves the contents of a file from a GitHub repository at a specific version (ref),
+     * parses it using the provided {@link DocumentParser}, and returns the resulting {@link Document} object.
+     * </p>
+     *
+     * <h3>Parameters</h3>
+     * <ul>
+     *     <li><b>owner</b> - The GitHub username or organization name that owns the repository. Must not be blank.</li>
+     *     <li><b>repo</b> - The name of the GitHub repository. Must not be blank.</li>
+     *     <li><b>ref</b> - The Git reference which can be one of the following:
+     *         <ul>
+     *             <li>A branch name (e.g., {@code main}, {@code develop})</li>
+     *             <li>A tag name (e.g., {@code v1.0.0})</li>
+     *             <li>A commit SHA (e.g., {@code a3c6e1b...})</li>
+     *         </ul>
+     *         If {@code null} or blank, GitHub will use the repository’s default branch (usually {@code main} or {@code master}).
+     *     </li>
+     *     <li><b>path</b> - The relative file path within the repository to the content to be loaded (e.g., {@code docs/README.md}).</li>
+     *     <li><b>parser</b> - An implementation of {@link DocumentParser} used to parse the retrieved file content into a {@link Document} object.</li>
+     * </ul>
+     *
+     * <h3>Returns</h3>
+     * A {@link Document} parsed from the contents of the file at the specified location and ref in the GitHub repository.
+     *
+     * <h3>Throws</h3>
+     * <ul>
+     *     <li>{@link IllegalArgumentException} if the {@code owner} or {@code repo} is blank or null.</li>
+     *     <li>{@link RuntimeException} if the GitHub API call fails or the content cannot be retrieved (wraps {@link IOException}).</li>
+     * </ul>
+     *
+     * <h3>Usage Example:</h3>
+     * <pre>{@code
+     * Document doc = loader.loadDocument("langchain4j", "langchain4j", "main", "pom.xml", new TextDocumentParser());
+     * }</pre>
+     *
+     * @param owner the GitHub repository owner (user or organization)
+     * @param repo the name of the GitHub repository
+     * @param ref the name of the commit SHA, branch, or tag. If {@code null}, the repository’s default branch is used
+     * @param path the relative path to the file in the repository
+     * @param parser the parser used to convert the GitHub content into a Document
+     * @return the parsed Document object representing the content of the file
+     */
+    public Document loadDocument(String owner, String repo, String ref, String path, DocumentParser parser) {
+        ensureNotBlank(owner, "owner");
+        ensureNotBlank(repo, "repo");
         GHContent content = null;
         try {
-            content = gitHub
-                    .getRepository(owner + "/" + repo)
-                    .getFileContent(path, branch);
+            content = gitHub.getRepository(owner + "/" + repo).getFileContent(path, ref);
         } catch (IOException ioException) {
             throw new RuntimeException(ioException);
         }
         return fromGitHub(parser, content);
     }
 
+    /**
+     * Loads and parses multiple documents from a directory in a GitHub repository at a specific branch.
+     * <p>
+     * This method recursively scans the specified directory in a GitHub repository at a given branch,
+     * retrieves all files contained within (including nested directories), parses each file using the provided
+     * {@link DocumentParser}, and returns a list of {@link Document} objects.
+     * </p>
+     *
+     * <h3>Parameters</h3>
+     * <ul>
+     *     <li><b>owner</b> - The GitHub username or organization name that owns the repository. Must not be blank.</li>
+     *     <li><b>repo</b> - The name of the GitHub repository. Must not be blank.</li>
+     *     <li><b>branch</b> - The name of the Git branch from which to read the directory contents (e.g., {@code main}, {@code develop}).</li>
+     *     <li><b>path</b> - The relative path to the directory within the repository to scan (e.g., {@code docs/} or {@code src/resources/}).</li>
+     *     <li><b>parser</b> - An implementation of {@link DocumentParser} used to convert file contents into {@link Document} objects.</li>
+     * </ul>
+     *
+     * <h3>Returns</h3>
+     * A list of {@link Document} objects parsed from the files found in the specified directory and its subdirectories.
+     *
+     * <h3>Throws</h3>
+     * <ul>
+     *     <li>{@link IllegalArgumentException} if {@code owner} or {@code repo} is blank or null.</li>
+     *     <li>{@link RuntimeException} if an {@link IOException} occurs while accessing the GitHub repository content.</li>
+     * </ul>
+     *
+     * <h3>Usage Example:</h3>
+     * <pre>{@code
+     * List<Document> docs = loader.loadDocuments(
+     *     "langchain4j",
+     *     "langchain4j",
+     *     "main",
+     *     "docs/",
+     *     new MarkdownParser()
+     * );
+     * }</pre>
+     *
+     * @param owner the GitHub repository owner (user or organization)
+     * @param repo the name of the GitHub repository
+     * @param branch the name of the Git branch to fetch the directory contents from
+     * @param path the relative path to the directory in the repository
+     * @param parser the parser used to convert each file into a Document
+     * @return a list of parsed Document objects from the specified directory
+     */
     public List<Document> loadDocuments(String owner, String repo, String branch, String path, DocumentParser parser) {
+        ensureNotBlank(owner, "owner");
+        ensureNotBlank(repo, "repo");
         List<Document> documents = new ArrayList<>();
         try {
-            gitHub
-                    .getRepository(owner + "/" + repo)
+            gitHub.getRepository(owner + "/" + repo)
                     .getDirectoryContent(path, branch)
-                    .forEach(ghDirectoryContent -> GitHubDocumentLoader.scanDirectory(ghDirectoryContent, documents, parser));
+                    .forEach(ghDirectoryContent ->
+                            GitHubDocumentLoader.scanDirectory(ghDirectoryContent, documents, parser));
         } catch (IOException ioException) {
             throw new RuntimeException(ioException);
         }
@@ -89,7 +179,10 @@ public class GitHubDocumentLoader {
     private static void scanDirectory(GHContent ghContent, List<Document> documents, DocumentParser parser) {
         if (ghContent.isDirectory()) {
             try {
-                ghContent.listDirectoryContent().forEach(ghDirectoryContent -> GitHubDocumentLoader.scanDirectory(ghDirectoryContent, documents, parser));
+                ghContent
+                        .listDirectoryContent()
+                        .forEach(ghDirectoryContent ->
+                                GitHubDocumentLoader.scanDirectory(ghDirectoryContent, documents, parser));
             } catch (IOException ioException) {
                 logger.error("Failed to read directory from GitHub: {}", ghContent.getHtmlUrl(), ioException);
             }
@@ -113,7 +206,8 @@ public class GitHubDocumentLoader {
                 GitHubSource source = new GitHubSource(content);
                 return DocumentLoader.load(source, parser);
             } else {
-                throw new IllegalArgumentException("Content must be a file, and not a directory: " + content.getHtmlUrl());
+                throw new IllegalArgumentException(
+                        "Content must be a file, and not a directory: " + content.getHtmlUrl());
             }
         } catch (IOException ioException) {
             throw new RuntimeException("Failed to load document from GitHub: {}", ioException);

--- a/document-loaders/langchain4j-document-loader-github/src/test/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoaderIT.java
+++ b/document-loaders/langchain4j-document-loader-github/src/test/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoaderIT.java
@@ -17,6 +17,8 @@ class GitHubDocumentLoaderIT {
 
     private static final String TEST_OWNER = "langchain4j";
     private static final String TEST_REPO = "langchain4j";
+    private static final String TAG_ID = "1.0.0";
+    private static final String COMMIT_ID = "734d56e1cbf714a93a2dc1a8d3d7f4f23a4d7cee";
 
     GitHubDocumentLoader loader;
 
@@ -62,8 +64,95 @@ class GitHubDocumentLoaderIT {
     }
 
     @Test
+    void should_load_file_from_tag() {
+        Document document = loader.loadDocument(TEST_OWNER, TEST_REPO, TAG_ID, "pom.xml", parser);
+
+        assertThat(document.text()).contains("<groupId>dev.langchain4j</groupId>");
+        assertThat(document.metadata().toMap()).hasSize(9);
+        assertThat(document.metadata().getString("github_git_url"))
+                .startsWith("https://api.github.com/repos/langchain4j/langchain4j");
+    }
+
+    @Test
+    void manage_exception_on_wrong_repository_from_tag() {
+        try {
+            loader.loadDocument(TEST_OWNER, "repository_that_do_not_exist", TAG_ID, "pom.xml", parser);
+            fail("Should throw an exception");
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(RuntimeException.class);
+            assertThat(e.getCause()).isInstanceOf(GHFileNotFoundException.class);
+        }
+    }
+
+    @Test
+    void manage_exception_on_wrong_file_from_tag() {
+        try {
+            loader.loadDocument(TEST_OWNER, TEST_REPO, TAG_ID, "file_that_do_not_exist.txt", parser);
+            fail("Should throw an exception");
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(RuntimeException.class);
+            assertThat(e.getCause()).isInstanceOf(GHFileNotFoundException.class);
+        }
+    }
+
+    @Test
+    void should_load_file_from_commit_id() {
+        Document document = loader.loadDocument(TEST_OWNER, TEST_REPO, COMMIT_ID, "pom.xml", parser);
+
+        assertThat(document.text()).contains("<groupId>dev.langchain4j</groupId>");
+        assertThat(document.metadata().toMap()).hasSize(9);
+        assertThat(document.metadata().getString("github_git_url"))
+                .startsWith("https://api.github.com/repos/langchain4j/langchain4j");
+    }
+
+    @Test
+    void manage_exception_on_wrong_repository_from_commit_id() {
+        try {
+            loader.loadDocument(TEST_OWNER, "repository_that_do_not_exist", COMMIT_ID, "pom.xml", parser);
+            fail("Should throw an exception");
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(RuntimeException.class);
+            assertThat(e.getCause()).isInstanceOf(GHFileNotFoundException.class);
+        }
+    }
+
+    @Test
+    void manage_exception_on_wrong_file_from_commit_id() {
+        try {
+            loader.loadDocument(TEST_OWNER, TEST_REPO, COMMIT_ID, "file_that_do_not_exist.txt", parser);
+            fail("Should throw an exception");
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(RuntimeException.class);
+            assertThat(e.getCause()).isInstanceOf(GHFileNotFoundException.class);
+        }
+    }
+
+    /*
+     * If the ref is null or blank, loadDocuments will fetch the documents from the repository's default branch (e.g., main).
+     */
+    @Test
+    void should_load_file_from_null_reference() {
+        Document document = loader.loadDocument(TEST_OWNER, TEST_REPO, null, "pom.xml", parser);
+
+        assertThat(document.text()).contains("<groupId>dev.langchain4j</groupId>");
+        assertThat(document.metadata().toMap()).hasSize(9);
+        assertThat(document.metadata().getString("github_git_url"))
+                .startsWith("https://api.github.com/repos/langchain4j/langchain4j");
+    }
+
+    @Test
     void should_load_repository() {
         List<Document> documents = loader.loadDocuments(TEST_OWNER, "awesome-langchain4j", "main", parser);
+
+        assertThat(documents.size()).isGreaterThan(1);
+    }
+
+    /*
+     * If the branch is null or blank, loadDocuments will fetch the documents from the repository's default branch (e.g., main).
+     */
+    @Test
+    void should_load_repository_null_branch() {
+        List<Document> documents = loader.loadDocuments(TEST_OWNER, "awesome-langchain4j", null, parser);
 
         assertThat(documents.size()).isGreaterThan(1);
     }


### PR DESCRIPTION
### Summary
This PR enhances the `loadDocument` method documentation and test cases to support loading a file from GitHub using a Git reference that can be a **branch name**, **tag**, or **commit SHA**.

### Changes

- Renamed parameter `branch` to `ref` for better clarity and flexibility.
- Tested support for tags and commit SHAs in addition to branch names.
- Improved parameter validation (`owner`, `repo`).
- Enhanced Javadoc with detailed usage instructions, supported ref types, and error handling.
- Added/updated unit tests to cover:
  - Valid branch
  - Valid tag
  - Valid commit SHA
  - Invalid refs and paths
  - Null or blank `ref` (defaults to repository’s default branch)

### Motivation

GitHub's API supports fetching file contents using any valid Git ref. Updating this method to leverage that capability makes it more robust and applicable in broader version control scenarios.

### Impact

- No breaking changes; behavior is backward compatible as `branch` usage still works when passed via `ref`.
- Improves the flexibility and reusability of the `loadDocument` method.

### Example Usage

```java
Document doc = loader.loadDocument("langchain4j", "langchain4j", "v1.0.0", "README.md", new TextDocumentParser());
