### PR TITLE
Replaced usage of `DefaultCredentialsProvider.create()` with `DefaultCredentialsProvider.builder().build()`

### DIFF
--- a/document-loaders/langchain4j-document-loader-amazon-s3/src/main/java/dev/langchain4j/data/document/loader/amazon/s3/AmazonS3DocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-amazon-s3/src/main/java/dev/langchain4j/data/document/loader/amazon/s3/AmazonS3DocumentLoader.java
@@ -1,9 +1,19 @@
 package dev.langchain4j.data.document.loader.amazon.s3;
 
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.util.stream.Collectors.toList;
+import static software.amazon.awssdk.regions.Region.US_EAST_1;
+
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentLoader;
 import dev.langchain4j.data.document.DocumentParser;
 import dev.langchain4j.data.document.source.amazon.s3.AmazonS3Source;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -14,17 +24,6 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.*;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
-
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static java.util.stream.Collectors.toList;
-import static software.amazon.awssdk.regions.Region.US_EAST_1;
 
 public class AmazonS3DocumentLoader {
 
@@ -202,7 +201,7 @@ public class AmazonS3DocumentLoader {
                 return awsCredentials.toCredentialsProvider();
             }
 
-            return DefaultCredentialsProvider.create();
+            return DefaultCredentialsProvider.builder().build();
         }
 
         private S3Client createS3Client(AwsCredentialsProvider credentialsProvider) {


### PR DESCRIPTION
### Summary

Replaced usage of `DefaultCredentialsProvider.create()` with `DefaultCredentialsProvider.builder().build()` as the former is deprecated in the AWS SDK v2.

### Rationale

The `create()` method returns a singleton instance, which can lead to lifecycle issues if one client closes the provider while others are still using it. Using `builder().build()` ensures that each component gets its own isolated instance of the credentials provider, which is safer and aligns with AWS SDK recommendations.

### Changes Made
- Replaced the instances of `DefaultCredentialsProvider.create()` with `DefaultCredentialsProvider.builder().build()`

### Reference
- [AWS SDK Java v2 Documentation](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html#create())
