### PR TITLE
Add overload of  load method to SeleniumDocumentLoader for raw content loading

### DIFF
--- a/document-loaders/langchain4j-document-loader-selenium/src/main/java/dev/langchain4j/data/document/loader/selenium/SeleniumDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-selenium/src/main/java/dev/langchain4j/data/document/loader/selenium/SeleniumDocumentLoader.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentParser;
+import dev.langchain4j.data.document.Metadata;
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.util.Objects;
@@ -50,30 +51,74 @@ public class SeleniumDocumentLoader implements AutoCloseable {
     }
 
     /**
-     * Loads a document from the specified URL.
+     * Loads a document from the specified URL and parses its content using the given {@link DocumentParser}.
+     * <p>
+     * This method uses the configured {@link WebDriver} to navigate to the provided URL, and retrieves the raw page content.
+     * The content is then passed to the provided {@link DocumentParser} for parsing, and the resulting
+     * {@link Document} is returned with the URL added to its metadata.
+     * </p>
      *
-     * @param url            The URL of the file. Must not be null.
-     * @param documentParser The parser to be used for parsing text from the URL. Must not be null.
-     * @return document
+     * @param url             The URL of the web page to load. Must not be null.
+     * @param documentParser  The parser used to extract structured text from the loaded page content. Must not be null.
+     * @return A {@link Document} containing parsed content and the source URL as metadata.
+     * @throws NullPointerException if the {@code documentParser} is null.
+     * @throws RuntimeException     if an error occurs while loading or retrieving the content from the URL.
      */
     public Document load(String url, DocumentParser documentParser) {
-        requireNonNull(url, "url must not be null");
         requireNonNull(documentParser, "documentParser must not be null");
         logger.info("Loading document from URL: {}", url);
-        String pageContent;
+        String pageContent = pageContent(url);
+        Document parsedDocument = documentParser.parse(new ByteArrayInputStream(pageContent.getBytes()));
+        parsedDocument.metadata().put(Document.URL, url);
+        return parsedDocument;
+    }
+
+    /**
+     * Loads a document from the specified URL and wraps the raw page source as a {@link Document}.
+     * <p>
+     * This method fetches the content of the given URL using the configured {@link WebDriver},
+     * waits until the page is fully loaded and returns a {@link Document} containing the raw HTML
+     * or text content along with the source URL as metadata.
+     * </p>
+     *
+     * @param url The URL to load the document from. Must not be null.
+     * @return A {@link Document} containing the raw page source and the URL as metadata.
+     * @throws RuntimeException if the page fails to load or an error occurs during retrieval.
+     */
+    public Document load(String url) {
+        String pageContent = pageContent(url);
+        return Document.from(pageContent, Metadata.from(Document.URL, url));
+    }
+
+    /**
+     * Retrieves the full page source of the given URL using Selenium.
+     * <p>
+     * This method navigates the {@link WebDriver} to the specified URL, waits for the page
+     * to be fully loaded, and then returns the page content as a string.
+     * </p>
+     *
+     * @param url The URL to load. Must not be null.
+     * @return The full HTML or text content of the loaded page.
+     * @throws RuntimeException if an error occurs while loading the page or retrieving the content.
+     */
+    public String pageContent(String url) {
+        requireNonNull(url, "url must not be null");
+
         try {
+            logger.info("Navigating to URL: {}", url);
             webDriver.get(url);
+
+            logger.debug("Waiting for page to load: {}", url);
             WebDriverWait wait = new WebDriverWait(webDriver, timeout);
+
             logger.debug("Waiting webpage fully loaded: {}", url);
             wait.until(pageReadyCondition);
-            pageContent = webDriver.getPageSource();
+
+            return webDriver.getPageSource();
         } catch (Exception e) {
             logger.error("Failed to load document from URL: {}", url, e);
             throw new RuntimeException("Failed to load document from URL: " + url, e);
         }
-        Document parsedDocument = documentParser.parse(new ByteArrayInputStream(pageContent.getBytes()));
-        parsedDocument.metadata().put(Document.URL, url);
-        return parsedDocument;
     }
 
     /**
@@ -81,13 +126,16 @@ public class SeleniumDocumentLoader implements AutoCloseable {
      */
     @Override
     public void close() {
+        logger.debug("Attempting to close WebDriver...");
         if (webDriver != null) {
             try {
                 webDriver.quit();
                 logger.info("WebDriver closed successfully.");
             } catch (Exception e) {
-                logger.warn("Error closing WebDriver", e);
+                logger.warn("Failed to close WebDriver. Resources may not be fully released.", e);
             }
+        } else {
+            logger.debug("WebDriver was already null. No action taken.");
         }
     }
 

--- a/document-loaders/langchain4j-document-loader-selenium/src/test/java/dev/langchain4j/data/document/loader/selenium/SeleniumDocumentLoaderIT.java
+++ b/document-loaders/langchain4j-document-loader-selenium/src/test/java/dev/langchain4j/data/document/loader/selenium/SeleniumDocumentLoaderIT.java
@@ -96,4 +96,33 @@ class SeleniumDocumentLoaderIT {
         assertThat(document.text()).contains("test");
         customLoader.close();
     }
+
+    @Test
+    void should_load_raw_document_content() {
+        String url =
+                "https://raw.githubusercontent.com/langchain4j/langchain4j/main/langchain4j/src/test/resources/test-file-utf8.txt";
+
+        Document document = loader.load(url);
+
+        assertThat(document.text()).contains("test", "content"); // raw content
+        assertThat(document.metadata().getString(Document.URL)).isEqualTo(url);
+    }
+
+    @Test
+    void should_fail_to_load_from_unreachable_url_without_parser() {
+        String url = "https://nonexistent.domain.abc123";
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> loader.load(url))
+                .withMessageContaining("Failed to load document from URL");
+    }
+
+    @Test
+    void should_fail_to_load_from_malformed_url_without_parser() {
+        String url = "ht!tp://bad_url";
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> loader.load(url))
+                .withMessageContaining("Failed to load document from URL");
+    }
 }


### PR DESCRIPTION
### Summary

This PR adds an overloaded method `public Document load(String url)` to `SeleniumDocumentLoader` to support loading a web document without requiring a `DocumentParser`. The content is returned as-is (raw HTML or plain text) and wrapped in a `Document` object with the source URL added to its metadata.

### Changes

- Added `load(String url)` method that:
  - Loads the page using the existing Selenium WebDriver setup.
  - Captures the raw page content via `getPageSource()`.
  - Returns a `Document` using `Document.from(String, Metadata)`.
- Enhanced Javadoc for:
  - `load(String url)`
  - Supporting public method `pageContent(String url)`

### Use Case

This overload simplifies use cases where:
- Consumers want raw content without applying parsing logic.
- Parsing will be applied manually or deferred.
- Basic HTML/text capture is sufficient.
