### PR TITLE
Add support for loading documents with custom DocumentParser

### DIFF
--- a/document-loaders/langchain4j-document-loader-playwright/src/main/java/dev/langchain4j/data/document/loader/playwright/PlaywrightDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-playwright/src/main/java/dev/langchain4j/data/document/loader/playwright/PlaywrightDocumentLoader.java
@@ -6,7 +6,9 @@ import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.LoadState;
 import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentParser;
 import dev.langchain4j.data.document.Metadata;
+import java.io.ByteArrayInputStream;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,32 +28,77 @@ public class PlaywrightDocumentLoader implements AutoCloseable {
     }
 
     /**
-     * Loads a document from the specified URL.
+     * Loads a {@link Document} from the specified URL by fetching its HTML content.
+     * <p>
+     * This method fetches the page content using {@code pageContent(url)}, and then wraps
+     * it into a {@link Document} with metadata indicating the source URL.
+     * </p>
      *
-     * @param url            The URL of the file. Must not be null.
-     * @return document
+     * @param url the URL of the web page to load; must not be {@code null}
+     * @return a {@link Document} instance containing the HTML content and metadata
+     * @throws NullPointerException if the provided {@code url} is {@code null}
+     * @throws RuntimeException if the document fails to load due to an underlying content fetch issue
      */
     public Document load(String url) {
-        requireNonNull(url, "url must not be null");
-        logger.info("Loading document from URL: {}", url);
-        String pageContent;
-        try {
-            try (Page page = browser.newPage()) {
-                page.navigate(url);
-
-                // Most of the time, this method is not needed because Playwright auto-waits before every action.
-                // https://playwright.dev/java/docs/actionability
-                page.waitForLoadState(LoadState.DOMCONTENTLOADED);
-
-                logger.debug("Waiting webpage fully loaded: {}", url);
-                pageContent = page.content();
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to load document from URL: " + url, e);
-        }
+        String pageContent = pageContent(url);
         return Document.from(pageContent, Metadata.from(Document.URL, url));
     }
 
+    /**
+     * Loads a {@link Document} from the specified URL by fetching its HTML content
+     * and parsing it using the provided {@link DocumentParser}.
+     * <p>
+     * This method delegates content parsing to the given parser and adds the source URL
+     * to the document's metadata.
+     * </p>
+     *
+     * @param url the URL of the web page to load; must not be {@code null}
+     * @param documentParser the parser used to convert raw HTML content into a {@link Document}; must not be {@code null}
+     * @return a {@link Document} parsed from the web page content, with metadata including the URL
+     * @throws NullPointerException if {@code url} or {@code documentParser} is {@code null}
+     * @throws RuntimeException if the document content cannot be loaded or parsed
+     */
+    public Document load(String url, DocumentParser documentParser) {
+        requireNonNull(documentParser, "documentParser must not be null");
+
+        String pageContent = pageContent(url);
+
+        Document parsedDocument = documentParser.parse(new ByteArrayInputStream(pageContent.getBytes()));
+
+        parsedDocument.metadata().put(Document.URL, url);
+        return parsedDocument;
+    }
+
+    /**
+     * Loads the HTML content of a web page from the specified URL using Playwright.
+     * <p>
+     * This method opens a new page in the browser, navigates to the given URL,
+     * waits for the DOM content to be fully loaded, and returns the full HTML content of the page.
+     * </p>
+     *
+     * @param url the URL of the web page to load; must not be {@code null}
+     * @return the full HTML content of the page as a {@code String}
+     * @throws NullPointerException if the provided {@code url} is {@code null}
+     * @throws RuntimeException if the page fails to load or an unexpected error occurs during navigation
+     */
+    public String pageContent(String url) {
+        requireNonNull(url, "url must not be null");
+        logger.info("Loading document from URL: {}", url);
+
+        try (Page page = browser.newPage()) {
+            logger.info("Navigating to URL: {}", url);
+            page.navigate(url);
+
+            // Explicit wait to ensure DOM is loaded (optional in most Playwright actions)
+            page.waitForLoadState(LoadState.DOMCONTENTLOADED);
+
+            logger.debug("Web page fully loaded: {}", url);
+            return page.content();
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load document from URL: " + url, e);
+        }
+    }
     /**
      * Closes the underlying Browser instance.
      */

--- a/document-loaders/langchain4j-document-loader-playwright/src/test/java/dev/langchain4j/data/document/loader/playwright/PlaywrightDocumentLoaderIT.java
+++ b/document-loaders/langchain4j-document-loader-playwright/src/test/java/dev/langchain4j/data/document/loader/playwright/PlaywrightDocumentLoaderIT.java
@@ -2,9 +2,12 @@ package dev.langchain4j.data.document.loader.playwright;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import com.microsoft.playwright.Browser;
 import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentParser;
+import dev.langchain4j.data.document.parser.TextDocumentParser;
 import dev.langchain4j.data.document.transformer.jsoup.HtmlToTextDocumentTransformer;
 import io.orangebuffalo.testcontainers.playwright.PlaywrightContainer;
 import org.junit.jupiter.api.AfterAll;
@@ -18,6 +21,7 @@ class PlaywrightDocumentLoaderIT {
     static Browser browser;
 
     HtmlToTextDocumentTransformer extractor = new HtmlToTextDocumentTransformer();
+    private DocumentParser parser = new TextDocumentParser();
 
     @BeforeAll
     static void beforeAll() {
@@ -65,5 +69,50 @@ class PlaywrightDocumentLoaderIT {
         assertThatExceptionOfType(RuntimeException.class)
                 .isThrownBy(() -> loader.load(url))
                 .withMessageContaining("Failed to load document from URL");
+    }
+
+    @Test
+    void should_load_and_parse_html_document() {
+        String url = "https://docs.langchain4j.dev/apidocs/index.html";
+
+        Document document = loader.load(url, parser);
+
+        assertThat(document.text()).contains("LangChain4j");
+        assertThat(document.text()).doesNotContain("<head>");
+        assertThat(document.metadata().getString(Document.URL)).isEqualTo(url);
+    }
+
+    @Test
+    void should_fail_for_unresolvable_url_with_parser() {
+        String url = "https://a.a";
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> loader.load(url, parser))
+                .withMessageContaining("Failed to load document from URL");
+    }
+
+    @Test
+    void should_fail_for_bad_url_with_parser() {
+        String url = "bad_url";
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> loader.load(url, parser))
+                .withMessageContaining("Failed to load document from URL");
+    }
+
+    @Test
+    void should_throw_null_pointer_exception_when_url_is_null() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> loader.load(null, parser))
+                .withMessage("url must not be null");
+    }
+
+    @Test
+    void should_throw_null_pointer_exception_when_parser_is_null() {
+        String url = "https://docs.langchain4j.dev/apidocs/index.html";
+
+        assertThatNullPointerException()
+                .isThrownBy(() -> loader.load(url, null))
+                .withMessage("documentParser must not be null");
     }
 }


### PR DESCRIPTION
### Summary

This PR introduces an overloaded `load(String url, DocumentParser parser)` method to allow parsing HTML content using a custom `DocumentParser` implementation. This enhancement improves flexibility and decouples the document loading from a fixed parsing strategy.

### Changes Made

- Added new method: `Document load(String url, DocumentParser documentParser)`
  - Ensures `url` and `documentParser` are non-null
  - Parses the page content using the provided parser
  - Attaches the source URL to the document metadata

- Added test cases for the new method:
  - Loads and parses a real HTML document using `TextDocumentParser`

### Backward Compatibility

- Existing method `load(String url)` remains unchanged.
- No breaking changes.
