### PR TITLE
Fix bedrock streaming model hangs, when using tools.

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
@@ -105,13 +105,13 @@ public class BedrockStreamingChatModel extends AbstractBedrockChatModel implemen
                         .onMessageStop(responseBuilder::append)
                         .build())
                 .build();
+            this.client.converseStream(converseStreamRequest, converseStreamResponseHandler)
+                    .exceptionally(ex->{
+                        RuntimeException mappedError = BedrockExceptionMapper.INSTANCE.mapException(ex);
+                        withLoggingExceptions(() -> handler.onError(mappedError));
+                        return null;
+                    });
 
-        try {
-            this.client.converseStream(converseStreamRequest, converseStreamResponseHandler).get();
-        } catch (Exception e) {
-            RuntimeException mappedError = BedrockExceptionMapper.INSTANCE.mapException(e);
-            withLoggingExceptions(() -> handler.onError(mappedError));
-        }
     }
 
     @Override


### PR DESCRIPTION
## Issue
Closes #3396

## Change
Removed the blocking .get call in the BedrockStreamingChatModel, which prevents nesting chat calls.


## General checklist
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)