### PR TITLE
Simplify equals() method in TableDefinition using Objects.equals

### DIFF
--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/builder/sql/TableDefinition.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/builder/sql/TableDefinition.java
@@ -1,12 +1,12 @@
 package dev.langchain4j.store.embedding.filter.builder.sql;
 
-import dev.langchain4j.Experimental;
-
-import java.util.ArrayList;
-import java.util.Collection;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+
+import dev.langchain4j.Experimental;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
 
 @Experimental
 public class TableDefinition {
@@ -42,17 +42,9 @@ public class TableDefinition {
         if (!(o instanceof TableDefinition)) return false;
         final TableDefinition other = (TableDefinition) o;
         if (!other.canEqual((Object) this)) return false;
-        final Object this$name = this.name;
-        final Object other$name = other.name;
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$description = this.description;
-        final Object other$description = other.description;
-        if (this$description == null ? other$description != null : !this$description.equals(other$description))
-            return false;
-        final Object this$columns = this.columns;
-        final Object other$columns = other.columns;
-        if (this$columns == null ? other$columns != null : !this$columns.equals(other$columns)) return false;
-        return true;
+        return Objects.equals(name, other.name)
+                && Objects.equals(description, other.description)
+                && Objects.equals(columns, other.columns);
     }
 
     protected boolean canEqual(final Object other) {
@@ -72,7 +64,8 @@ public class TableDefinition {
     }
 
     public String toString() {
-        return "TableDefinition(name=" + this.name + ", description=" + this.description + ", columns=" + this.columns + ")";
+        return "TableDefinition(name=" + this.name + ", description=" + this.description + ", columns=" + this.columns
+                + ")";
     }
 
     public static class Builder {

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/builder/sql/TableDefinitionTest.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/builder/sql/TableDefinitionTest.java
@@ -1,0 +1,111 @@
+package dev.langchain4j.store.embedding.filter.builder.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TableDefinitionTest {
+
+    private static ColumnDefinition col(String name, String type) {
+        return new ColumnDefinition(name, type);
+    }
+
+    private static ColumnDefinition col(String name, String type, String desc) {
+        return new ColumnDefinition(name, type, desc);
+    }
+
+    static Stream<Arguments> should_consider_equals_when_values_are_equal() {
+        return Stream.of(
+                Arguments.of(
+                        new TableDefinition("table1", "desc1", List.of(col("id", "int"))),
+                        new TableDefinition("table1", "desc1", List.of(col("id", "int"))),
+                        true),
+                Arguments.of(
+                        new TableDefinition("table1", "desc1", List.of(col("id", "int", "primary key"))),
+                        new TableDefinition("table1", "desc1", List.of(col("id", "int", "primary key"))),
+                        true));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("should_consider_equals_when_values_are_equal")
+    void should_consider_equals_when_values_are_equal(TableDefinition a, TableDefinition b, boolean expected) {
+        assertEquals(expected, a.equals(b));
+        assertEquals(expected, b.equals(a));
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    static Stream<Arguments> should_not_consider_equals_when_values_are_different() {
+        return Stream.of(
+                Arguments.of(
+                        new TableDefinition("table1", "desc1", List.of(col("id", "int"))),
+                        new TableDefinition("table2", "desc1", List.of(col("id", "int"))),
+                        false),
+                Arguments.of(
+                        new TableDefinition("table1", "desc1", List.of(col("id", "int"))),
+                        new TableDefinition("table1", "desc2", List.of(col("id", "int"))),
+                        false),
+                Arguments.of(
+                        new TableDefinition("table1", "desc1", List.of(col("id", "int"))),
+                        new TableDefinition("table1", "desc1", List.of(col("id", "varchar"))),
+                        false));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("should_not_consider_equals_when_values_are_different")
+    void should_not_consider_equals_when_values_are_different(TableDefinition a, TableDefinition b, boolean expected) {
+        assertEquals(expected, a.equals(b));
+        assertEquals(expected, b.equals(a));
+        assertNotEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    @DisplayName("should_return_false_when_compared_with_null_or_different_class")
+    void should_return_false_when_compared_with_null_or_different_class() {
+        TableDefinition def = new TableDefinition("table", "desc", List.of(col("id", "int")));
+        assertNotEquals(def, null);
+        assertNotEquals(def, "some string");
+    }
+
+    @Test
+    @DisplayName("should_use_toString_format_correctly")
+    void should_use_toString_format_correctly() {
+        TableDefinition def = new TableDefinition("table", "desc", List.of(col("id", "int")));
+        String output = def.toString();
+        assertTrue(output.contains("table"));
+        assertTrue(output.contains("desc"));
+        assertTrue(output.contains("ColumnDefinition"));
+    }
+
+    @Test
+    @DisplayName("should_build_using_builder_with_columns")
+    void should_build_using_builder_with_columns() {
+        TableDefinition def = TableDefinition.builder()
+                .name("table")
+                .description("desc")
+                .addColumn("id", "int")
+                .addColumn("name", "string", "username")
+                .build();
+
+        assertEquals("table", def.name());
+        assertEquals("desc", def.description());
+        assertEquals(2, def.columns().size());
+    }
+
+    @Test
+    @DisplayName("should_throw_exception_when_name_is_blank_or_columns_is_empty")
+    void should_throw_exception_when_name_is_blank_or_columns_is_empty() {
+        assertThrows(IllegalArgumentException.class, () -> new TableDefinition("", "desc", List.of(col("id", "int"))));
+        assertThrows(IllegalArgumentException.class, () -> new TableDefinition("table", "desc", List.of()));
+    }
+}


### PR DESCRIPTION
### Summary

Refactored the `equals()` method in the `TableDefinition` class to improve readability and maintainability.

### Changes

- Replaced verbose null-safe comparisons with `Objects.equals(...)` for fields: `name`, `description`, and `columns`.
- The logic remains functionally equivalent to the previous implementation.
- `canEqual()` check is retained to preserve correctness in inheritance scenarios.