### PR TITLE
Fix npe in DefaultToolExecutor

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -111,8 +111,8 @@ public class DefaultToolExecutor implements ToolExecutor {
             }
 
             String parameterName = parameter.getName();
-            if (argumentsMap.containsKey(parameterName)) {
-                Object argument = argumentsMap.get(parameterName);
+            Object argument = argumentsMap.get(parameterName);
+            if (argument != null) {
                 Class<?> parameterClass = parameter.getType();
                 Type parameterType = parameter.getParameterizedType();
 


### PR DESCRIPTION
## Issue
Closes #3384

## Change
Fix DefaultToolExecutor NPE in prepareArguments function
In the example of tool_calls arguments like:
```json
{
  "arg0": "xxx",
  "arg1": null
}
```

before
```java
if (argumentsMap.containsKey(parameterName)) {
   ...
}
```

after
```java
Object argument = argumentsMap.get(parameterName);
if (argument != null) {
   ...
}
```