### PR TITLE
Azure OpenAI - add support for token usage reporting on streaming chat model

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiStreamingResponseBuilder.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiStreamingResponseBuilder.java
@@ -89,7 +89,7 @@ class InternalAzureOpenAiStreamingResponseBuilder {
         }
     }
 
-    Response<AiMessage> build(TokenCountEstimator tokenCountEstimator) {
+    Response<AiMessage> build(TokenCountEstimator tokenCountEstimator, TokenUsage tokenUsage) {
 
         String content = contentBuilder.toString();
 
@@ -103,7 +103,7 @@ class InternalAzureOpenAiStreamingResponseBuilder {
                 .toolExecutionRequests(toolExecutionRequests)
                 .build();
 
-        TokenUsage tokenUsage = null;
+        // for backward compatibility, if token count estimator is provided, compute token usage based on it
         if (tokenCountEstimator != null) {
             int outputTokenCount = tokenCountEstimator.estimateTokenCountInMessage(aiMessage);
             tokenUsage = new TokenUsage(inputTokenCount, outputTokenCount);

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelIT.java
@@ -43,6 +43,56 @@ class AzureOpenAiStreamingChatModelIT {
 
     @ParameterizedTest(name = "Deployment name {0} using {1} with async client set to {2}")
     @CsvSource({"gpt-4o, gpt-4o"})
+    void should_stream_answer_with_token_usage(String deploymentName, String gptVersion) throws Exception {
+
+        CompletableFuture<String> futureAnswer = new CompletableFuture<>();
+        CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
+
+        //no token count estimator used, information retrieved from the azure openai service response
+        StreamingChatModel model = AzureOpenAiStreamingChatModel.builder()
+                .deploymentName(deploymentName)
+                .logRequestsAndResponses(true)
+                .build();
+
+        model.chat("What is the capital of France?", new StreamingChatResponseHandler() {
+
+            private final StringBuilder answerBuilder = new StringBuilder();
+
+            @Override
+            public void onPartialResponse(String partialResponse) {
+                answerBuilder.append(partialResponse);
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                futureAnswer.complete(answerBuilder.toString());
+                futureResponse.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                futureAnswer.completeExceptionally(error);
+                futureResponse.completeExceptionally(error);
+            }
+        });
+
+        String answer = futureAnswer.get(STREAMING_TIMEOUT, SECONDS);
+        ChatResponse response = futureResponse.get(STREAMING_TIMEOUT, SECONDS);
+
+        assertThat(answer).contains("Paris");
+        assertThat(response.aiMessage().text()).isEqualTo(answer);
+
+        assertThat(response.tokenUsage().inputTokenCount()).isGreaterThan(0);
+        assertThat(response.tokenUsage().outputTokenCount()).isGreaterThan(0);
+        assertThat(response.tokenUsage().totalTokenCount())
+                .isEqualTo(response.tokenUsage().inputTokenCount()
+                        + response.tokenUsage().outputTokenCount());
+
+        assertThat(response.finishReason()).isEqualTo(STOP);
+    }
+
+    @ParameterizedTest(name = "Deployment name {0} using {1} with async client set to {2}")
+    @CsvSource({"gpt-4o, gpt-4o"})
     void should_stream_answer(String deploymentName, String gptVersion) throws Exception {
 
         CompletableFuture<String> futureAnswer = new CompletableFuture<>();

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingLanguageModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingLanguageModelIT.java
@@ -56,7 +56,12 @@ class AzureOpenAiStreamingLanguageModelIT {
         assertThat(answer).containsIgnoringCase("Paris");
         assertThat(response.content()).isEqualTo(answer);
 
-        assertThat(response.tokenUsage()).isNull();
+        assertThat(response.tokenUsage()).isNotNull();
+        assertThat(response.tokenUsage().inputTokenCount()).isGreaterThan(0);
+        assertThat(response.tokenUsage().outputTokenCount()).isGreaterThan(0);
+        assertThat(response.tokenUsage().totalTokenCount()).isEqualTo(
+                response.tokenUsage().inputTokenCount()
+                        + response.tokenUsage().outputTokenCount());
 
         assertThat(response.finishReason()).isEqualTo(STOP);
     }


### PR DESCRIPTION
## Issue
Closes #1068
Azure AI Chat client did not have support to report token usage.

## Change
Azure chat completions api supports requesting token usage reporting by setting:

`"stream_options": {"include_usage":true}`

https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2025-04-01-preview/inference.json


Impl includes:
If a token estimator is set on the chat completion options, then do not request token usage.
Updated sse responses to set token usage if present in the response.
Updated integration tests to validate that token usage is set if no token count estimator is set.

