### PR TITLE
Refactor equals method to use Objects.equals for improved readability

### DIFF
--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/builder/sql/ColumnDefinition.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/builder/sql/ColumnDefinition.java
@@ -1,8 +1,9 @@
 package dev.langchain4j.store.embedding.filter.builder.sql;
 
-import dev.langchain4j.Experimental;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+import dev.langchain4j.Experimental;
+import java.util.Objects;
 
 @Experimental
 public class ColumnDefinition {
@@ -38,17 +39,10 @@ public class ColumnDefinition {
         if (!(o instanceof ColumnDefinition)) return false;
         final ColumnDefinition other = (ColumnDefinition) o;
         if (!other.canEqual((Object) this)) return false;
-        final Object this$name = this.name;
-        final Object other$name = other.name;
-        if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-        final Object this$type = this.type;
-        final Object other$type = other.type;
-        if (this$type == null ? other$type != null : !this$type.equals(other$type)) return false;
-        final Object this$description = this.description;
-        final Object other$description = other.description;
-        if (this$description == null ? other$description != null : !this$description.equals(other$description))
-            return false;
-        return true;
+
+        return Objects.equals(name, other.name)
+                && Objects.equals(type, other.type)
+                && Objects.equals(description, other.description);
     }
 
     protected boolean canEqual(final Object other) {

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/builder/sql/ColumnDefinitionTest.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/builder/sql/ColumnDefinitionTest.java
@@ -1,0 +1,81 @@
+package dev.langchain4j.store.embedding.filter.builder.sql;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ColumnDefinitionTest {
+
+    private static ColumnDefinition col(String name, String type) {
+        return new ColumnDefinition(name, type);
+    }
+
+    private static ColumnDefinition col(String name, String type, String desc) {
+        return new ColumnDefinition(name, type, desc);
+    }
+
+    static Stream<Arguments> should_consider_equals_when_values_are_equal() {
+        return Stream.of(
+                Arguments.of(col("id", "int"), col("id", "int"), true),
+                Arguments.of(col("id", "int", "primary key"), col("id", "int", "primary key"), true),
+                Arguments.of(col("name", "string", null), col("name", "string", null), true));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("should_consider_equals_when_values_are_equal")
+    void should_consider_equals_when_values_are_equal(ColumnDefinition a, ColumnDefinition b, boolean expected) {
+        assertEquals(expected, a.equals(b));
+        assertEquals(expected, b.equals(a));
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    static Stream<Arguments> should_not_consider_equals_when_values_are_different() {
+        return Stream.of(
+                Arguments.of(col("id", "int"), col("ID", "int"), false),
+                Arguments.of(col("id", "int"), col("id", "varchar"), false),
+                Arguments.of(col("id", "int", "desc1"), col("id", "int", "desc2"), false),
+                Arguments.of(col("id", "int", null), col("id", "int", "desc"), false));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("should_not_consider_equals_when_values_are_different")
+    void should_not_consider_equals_when_values_are_different(
+            ColumnDefinition a, ColumnDefinition b, boolean expected) {
+        assertEquals(expected, a.equals(b));
+        assertEquals(expected, b.equals(a));
+        assertNotEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    @DisplayName("should_return_false_when_compared_with_null_or_different_class")
+    void should_return_false_when_compared_with_null_or_different_class() {
+        ColumnDefinition col = col("id", "int");
+        assertNotEquals(null, col);
+        assertNotEquals("not a column", col);
+    }
+
+    @Test
+    @DisplayName("should_use_toString_format_correctly")
+    void should_use_toString_format_correctly() {
+        ColumnDefinition col = col("id", "int", "primary key");
+        String output = col.toString();
+        assertTrue(output.contains("id"));
+        assertTrue(output.contains("int"));
+        assertTrue(output.contains("primary key"));
+        assertTrue(output.startsWith("ColumnDefinition("));
+    }
+
+    @Test
+    @DisplayName("should_throw_exception_when_name_or_type_is_blank")
+    void should_throw_exception_when_name_or_type_is_blank() {
+        assertThrows(IllegalArgumentException.class, () -> new ColumnDefinition("", "int"));
+        assertThrows(IllegalArgumentException.class, () -> new ColumnDefinition("id", ""));
+    }
+}


### PR DESCRIPTION
### Summary
Refactored the `equals` method in `ColumnDefinition` to use `Objects.equals(...)` instead of manual null-safe comparisons.

### Benefits
- Improves readability and maintainability
- Leverages standard library utility for null-safe equality
- Logic remains unchanged

### Notes
No behavioral changes. All comparisons are functionally equivalent.

