### PR TITLE
Add varargs overload for transformAll in TextSegmentTransformer

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/segment/TextSegmentTransformer.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/segment/TextSegmentTransformer.java
@@ -45,7 +45,7 @@ public interface TextSegmentTransformer {
      */
     default List<TextSegment> transformAll(TextSegment... textSegments) {
         if (Utils.isNullOrEmpty(textSegments)) {
-            return List.of(); // Return empty immutable list
+            return List.of();
         }
         return transformAll(Arrays.asList(textSegments));
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/segment/TextSegmentTransformer.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/segment/TextSegmentTransformer.java
@@ -1,9 +1,11 @@
 package dev.langchain4j.data.segment;
 
+import static java.util.stream.Collectors.toList;
+
+import dev.langchain4j.internal.Utils;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * Defines the interface for transforming a {@link TextSegment}.
@@ -26,9 +28,25 @@ public interface TextSegmentTransformer {
      * @return A list of transformed segments. The length of this list may be shorter or longer than the original list. Returns an empty list if all segments were filtered out.
      */
     default List<TextSegment> transformAll(List<TextSegment> segments) {
-        return segments.stream()
-                .map(this::transform)
-                .filter(Objects::nonNull)
-                .collect(toList());
+        return segments.stream().map(this::transform).filter(Objects::nonNull).collect(toList());
+    }
+
+    /**
+     * Transforms all the provided {@link TextSegment}s using varargs input.
+     * <p>
+     * This is a convenience method that allows calling code to pass an arbitrary number of {@link TextSegment}
+     * instances without needing to explicitly construct a {@link List}. Internally, this method delegates to
+     * the {@link #transformAll(List)} method to perform the actual transformation logic, ensuring consistent behavior.
+     * </p>
+     *
+     * @param textSegments Varargs array of {@link TextSegment}s to be transformed. May be {@code null} or empty.
+     * @return A list of transformed segments. Returns an empty list if all segments were filtered out,
+     *         or if the input is {@code null} or empty.
+     */
+    default List<TextSegment> transformAll(TextSegment... textSegments) {
+        if (Utils.isNullOrEmpty(textSegments)) {
+            return List.of(); // Return empty immutable list
+        }
+        return transformAll(Arrays.asList(textSegments));
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/segment/TextSegmentTransformerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/segment/TextSegmentTransformerTest.java
@@ -39,4 +39,42 @@ class TextSegmentTransformerTest implements WithAssertions {
                         TextSegment.from("segment"),
                         TextSegment.from("transformer"));
     }
+
+    @Test
+    void transform_all_varargs() {
+        TextSegmentTransformer transformer = new LowercaseFnordTransformer();
+
+        TextSegment ts1 = TextSegment.from("Text");
+        ts1.metadata().put("abc", "123"); // metadata is copied over (not transformed)
+
+        TextSegment ts2 = TextSegment.from("Segment");
+        TextSegment ts3 = TextSegment.from("Fnord will be filtered out");
+        TextSegment ts4 = TextSegment.from("Transformer");
+
+        List<TextSegment> result = transformer.transformAll(ts1, ts2, ts3, ts4);
+
+        assertThat(result)
+                .containsExactly(
+                        TextSegment.from("text", ts1.metadata()),
+                        TextSegment.from("segment"),
+                        TextSegment.from("transformer"));
+    }
+
+    @Test
+    void transform_all_varargs_empty_input_returns_empty_list() {
+        TextSegmentTransformer transformer = new LowercaseFnordTransformer();
+
+        List<TextSegment> result = transformer.transformAll();
+
+        assertThat(result).isNotNull().isEmpty();
+    }
+
+    @Test
+    void transform_all_varargs_null_input_returns_empty_list() {
+        TextSegmentTransformer transformer = new LowercaseFnordTransformer();
+
+        List<TextSegment> result = transformer.transformAll((TextSegment[]) null);
+
+        assertThat(result).isNotNull().isEmpty();
+    }
 }


### PR DESCRIPTION
### Summary
Added a varargs-based overload for the `transformAll` method in the `TextSegmentTransformer` interface to improve usability and developer ergonomics.

### Changes
- Introduced `transformAll(TextSegment... textSegments)` default method.
- Internally delegates to the existing `transformAll(List<TextSegment>)` method for consistent transformation and filtering behavior.
- Handles `null` and empty inputs gracefully by returning an immutable empty list using `List.of()`.

### Additional Notes
- Utility method `Utils.isNullOrEmpty(...)` is used for concise null/empty handling.
- Considered adding test cases for edge conditions (empty, null) to ensure robustness.
