### PR TITLE
Add default method executeWithRetry() to HttpClient for retrying fail…

### DIFF
--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClient.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClient.java
@@ -23,6 +23,48 @@ public interface HttpClient {
     SuccessfulHttpResponse execute(HttpRequest request) throws HttpException, RuntimeException;
 
     /**
+     * Executes the given HTTP request synchronously with retry support.
+     * <p>
+     * This method wraps the {@link #execute(HttpRequest)} method and attempts to re-execute the request
+     * if it fails due to a {@link HttpException} (for 4XX/5XX responses) or other {@link RuntimeException}
+     * (such as network issues or timeouts).
+     * <p>
+     * Retries are performed immediately, with no delay between attempts. If all attempts fail, the last
+     * encountered exception is thrown.
+     * <p>
+     * Example usage:
+     * <pre>{@code
+     * HttpRequest request = ...;
+     * SuccessfulHttpResponse response = httpClient.executeWithRetry(request, 3);
+     * }</pre>
+     *
+     * @param request the HTTP request to be executed.
+     * @param maxRetries the maximum number of retry attempts (excluding the initial attempt).
+     *                   For example, maxRetries = 2 means up to 3 total attempts (1 original + 2 retries).
+     * @return a {@link SuccessfulHttpResponse} if the request eventually succeeds.
+     * @throws HttpException    if the request fails after all retry attempts due to a 4XX/5XX response.
+     * @throws RuntimeException if the request fails after all retry attempts due to unexpected runtime issues.
+     * @throws IllegalArgumentException if {@code maxRetries} is negative.
+     */
+    default SuccessfulHttpResponse executeWithRetry(HttpRequest request, int maxRetries)
+            throws HttpException, RuntimeException {
+        if (maxRetries < 0) {
+            throw new IllegalArgumentException("maxRetries must be >= 0");
+        }
+
+        int attempt = 0;
+        while (true) {
+            try {
+                return execute(request);
+            } catch (RuntimeException ex) {
+                if (attempt++ >= maxRetries) {
+                    throw ex; // rethrow last exception after all retries
+                }
+            }
+        }
+    }
+
+    /**
      * Executes a given HTTP request asynchronously with server-sent events (SSE) handling.
      * This method returns immediately while processing continues on a separate thread.
      * Events are processed through the provided {@link ServerSentEventListener}.


### PR DESCRIPTION
### Summary

This PR introduces a new default method `executeWithRetry(HttpRequest, int)` to the `HttpClient` interface. The method provides built-in retry logic for synchronous HTTP requests that fail due to transient errors or server-side issues.

### Changes Introduced

- Added `executeWithRetry(...)` as a `default` method to maintain backward compatibility.
- Supports retrying requests on any  `RuntimeException` (e.g., network issues).
- Retries are performed immediately without delay, up to the specified `maxRetries`.
- Throws `IllegalArgumentException` if the provided `maxRetries` is negative.
- Includes detailed Javadoc with usage examples and behavior explanation.


### Example

```java
HttpRequest request = ...;
SuccessfulHttpResponse response = httpClient.executeWithRetry(request, 2);
