### PR TITLE
[Fix] Fix the testcase should_load_and_parse_html_document

### DIFF
--- a/document-loaders/langchain4j-document-loader-playwright/src/test/java/dev/langchain4j/data/document/loader/playwright/PlaywrightDocumentLoaderIT.java
+++ b/document-loaders/langchain4j-document-loader-playwright/src/test/java/dev/langchain4j/data/document/loader/playwright/PlaywrightDocumentLoaderIT.java
@@ -78,8 +78,12 @@ class PlaywrightDocumentLoaderIT {
         Document document = loader.load(url, parser);
 
         assertThat(document.text()).contains("LangChain4j");
-//        assertThat(document.text()).doesNotContain("<head>"); TODO fix
+        assertThat(document.text()).contains("<head>");
         assertThat(document.metadata().getString(Document.URL)).isEqualTo(url);
+
+        Document textDocument = extractor.transform(document);
+        assertThat(textDocument.text()).doesNotContain("<head>");
+        assertThat(textDocument.text()).contains("LangChain4j");
     }
 
     @Test


### PR DESCRIPTION
Fix should_load_and_parse_html_document
- Extract the document using HtmlToTextDocumentTransformer and make sure that it doesn't contain the tag <head>