### PR TITLE
Azure OpenAI: removed TokenCountEstimator from streaming models

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiStreamingResponseBuilder.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiStreamingResponseBuilder.java
@@ -5,7 +5,6 @@ import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.internal.ToolCallBuilder;
-import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 
@@ -20,21 +19,29 @@ import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.finishReason
  * in fact it almost certainly won't be.
  */
 @Internal
-class InternalAzureOpenAiStreamingResponseBuilder {
+class AzureOpenAiStreamingResponseBuilder {
 
-    private final Integer inputTokenCount;
     private final StringBuffer contentBuilder = new StringBuffer();
     private final ToolCallBuilder toolCallBuilder;
+    private volatile TokenUsage tokenUsage;
     private volatile CompletionsFinishReason finishReason;
 
-    InternalAzureOpenAiStreamingResponseBuilder(Integer inputTokenCount, ToolCallBuilder toolCallBuilder) {
-        this.inputTokenCount = inputTokenCount;
+    AzureOpenAiStreamingResponseBuilder() {
+        this(null);
+    }
+
+    AzureOpenAiStreamingResponseBuilder(ToolCallBuilder toolCallBuilder) {
         this.toolCallBuilder = toolCallBuilder;
     }
 
     void append(ChatCompletions completions) {
         if (completions == null) {
             return;
+        }
+
+        CompletionsUsage usage = completions.getUsage();
+        if (usage != null) {
+            tokenUsage = new TokenUsage(usage.getPromptTokens(), usage.getCompletionTokens());
         }
 
         List<ChatChoice> choices = completions.getChoices();
@@ -68,6 +75,11 @@ class InternalAzureOpenAiStreamingResponseBuilder {
             return;
         }
 
+        CompletionsUsage usage = completions.getUsage();
+        if (usage != null) {
+            tokenUsage = new TokenUsage(usage.getPromptTokens(), usage.getCompletionTokens());
+        }
+
         List<Choice> choices = completions.getChoices();
         if (isNullOrEmpty(choices)) {
             return;
@@ -89,7 +101,7 @@ class InternalAzureOpenAiStreamingResponseBuilder {
         }
     }
 
-    Response<AiMessage> build(TokenCountEstimator tokenCountEstimator, TokenUsage tokenUsage) {
+    Response<AiMessage> build() {
 
         String content = contentBuilder.toString();
 
@@ -102,12 +114,6 @@ class InternalAzureOpenAiStreamingResponseBuilder {
                 .text(content.isEmpty() ? null : content)
                 .toolExecutionRequests(toolExecutionRequests)
                 .build();
-
-        // for backward compatibility, if token count estimator is provided, compute token usage based on it
-        if (tokenCountEstimator != null) {
-            int outputTokenCount = tokenCountEstimator.estimateTokenCountInMessage(aiMessage);
-            tokenUsage = new TokenUsage(inputTokenCount, outputTokenCount);
-        }
 
         return Response.from(aiMessage, tokenUsage, finishReasonFrom(finishReason));
     }

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelIT.java
@@ -17,7 +17,6 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
 import dev.langchain4j.model.chat.request.ChatRequest;
@@ -30,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -91,16 +89,15 @@ class AzureOpenAiStreamingChatModelIT {
         assertThat(response.finishReason()).isEqualTo(STOP);
     }
 
-    @ParameterizedTest(name = "Deployment name {0} using {1} with async client set to {2}")
-    @CsvSource({"gpt-4o, gpt-4o"})
-    void should_stream_answer(String deploymentName, String gptVersion) throws Exception {
+    @ParameterizedTest(name = "Deployment name {0}")
+    @ValueSource(strings = {"gpt-4o"})
+    void should_stream_answer(String deploymentName) throws Exception {
 
         CompletableFuture<String> futureAnswer = new CompletableFuture<>();
         CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
 
         StreamingChatModel model = AzureModelBuilders.streamingChatModelBuilder()
                 .deploymentName(deploymentName)
-                .tokenCountEstimator(new AzureOpenAiTokenCountEstimator(gptVersion))
                 .logRequestsAndResponses(true)
                 .build();
 
@@ -163,7 +160,6 @@ class AzureOpenAiStreamingChatModelIT {
         StreamingChatModel model = AzureModelBuilders.streamingChatModelBuilder()
                 .openAIAsyncClient(asyncClient)
                 .deploymentName(deploymentName)
-                .tokenCountEstimator(new AzureOpenAiTokenCountEstimator(gptVersion))
                 .logRequestsAndResponses(true)
                 .build();
 
@@ -209,9 +205,9 @@ class AzureOpenAiStreamingChatModelIT {
         assertThat(response.aiMessage().text()).isEqualToIgnoringWhitespace(expectedJson);
     }
 
-    @ParameterizedTest(name = "Deployment name {0} using {1}")
-    @CsvSource({"gpt-4o,        gpt-4o"})
-    void should_execute_tool_forcefully_then_stream_answer(String deploymentName, String gptVersion) throws Exception {
+    @ParameterizedTest(name = "Deployment name {0}")
+    @ValueSource(strings = {"gpt-4o"})
+    void should_execute_tool_forcefully_then_stream_answer(String deploymentName) throws Exception {
 
         CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
 
@@ -219,7 +215,6 @@ class AzureOpenAiStreamingChatModelIT {
                 .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
                 .apiKey(System.getenv("AZURE_OPENAI_KEY"))
                 .deploymentName(deploymentName)
-                .tokenCountEstimator(new AzureOpenAiTokenCountEstimator(gptVersion))
                 .logRequestsAndResponses(true)
                 .build();
 
@@ -319,9 +314,9 @@ class AzureOpenAiStreamingChatModelIT {
         assertThat(response2.finishReason()).isEqualTo(STOP);
     }
 
-    @ParameterizedTest(name = "Deployment name {0} using {1}")
-    @CsvSource({"gpt-4o,        gpt-4o"})
-    void should_call_three_functions_in_parallel(String deploymentName, String gptVersion) throws Exception {
+    @ParameterizedTest(name = "Deployment name {0}")
+    @ValueSource(strings = {"gpt-4o"})
+    void should_call_three_functions_in_parallel(String deploymentName) throws Exception {
 
         CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
 
@@ -329,7 +324,6 @@ class AzureOpenAiStreamingChatModelIT {
                 .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
                 .apiKey(System.getenv("AZURE_OPENAI_KEY"))
                 .deploymentName(deploymentName)
-                .tokenCountEstimator(new AzureOpenAiTokenCountEstimator(gptVersion))
                 .logRequestsAndResponses(true)
                 .build();
 
@@ -446,47 +440,6 @@ class AzureOpenAiStreamingChatModelIT {
                 .isEqualTo(tokenUsage2.inputTokenCount() + tokenUsage2.outputTokenCount());
 
         assertThat(response2.finishReason()).isEqualTo(STOP);
-    }
-
-    @Test
-    void tools_should_work_without_tokenCountEstimator() {
-
-        // given
-        TokenCountEstimator tokenCountEstimator = null;
-
-        StreamingChatModel model = AzureOpenAiStreamingChatModel.builder()
-                .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
-                .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-                .deploymentName("gpt-4o")
-                .logRequestsAndResponses(true)
-                .tokenCountEstimator(tokenCountEstimator)
-                .build();
-
-        UserMessage userMessage = UserMessage.from("What is 2+2?");
-
-        ToolSpecification toolSpecification = ToolSpecification.builder()
-                .name("calculator")
-                .description("returns a sum of two numbers")
-                .parameters(JsonObjectSchema.builder()
-                        .addIntegerProperty("first")
-                        .addIntegerProperty("second")
-                        .required("first", "second")
-                        .build())
-                .build();
-
-        ChatRequest chatRequest = ChatRequest.builder()
-                .messages(userMessage)
-                .toolSpecifications(toolSpecification)
-                .toolChoice(REQUIRED)
-                .build();
-
-        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
-        model.chat(chatRequest, handler);
-
-        ChatResponse response = handler.get();
-
-        assertThat(response.aiMessage().hasToolExecutionRequests()).isTrue();
-        assertThat(response.tokenUsage()).isNull();
     }
 
     @ParameterizedTest

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelListenerIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelListenerIT.java
@@ -18,7 +18,6 @@ class AzureOpenAiStreamingChatModelListenerIT extends AbstractStreamingChatModel
                 .temperature(temperature())
                 .topP(topP())
                 .maxTokens(maxTokens())
-                .tokenCountEstimator(new AzureOpenAiTokenCountEstimator(modelName()))
                 .logRequestsAndResponses(true)
                 .listeners(singletonList(listener))
                 .build();

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/common/AzureOpenAiStreamingAiServiceIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/common/AzureOpenAiStreamingAiServiceIT.java
@@ -17,9 +17,4 @@ class AzureOpenAiStreamingAiServiceIT extends AbstractStreamingAiServiceIT {
                 // TODO add more model configs
                 );
     }
-
-    @Override
-    protected boolean assertTokenUsage() {
-        return false; // testing AzureOpenAiStreamingChatModel without TokenCountEstimator
-    }
 }

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/common/AzureOpenAiStreamingChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/common/AzureOpenAiStreamingChatModelIT.java
@@ -82,11 +82,6 @@ class AzureOpenAiStreamingChatModelIT extends AbstractStreamingChatModelIT {
     }
 
     @Override
-    protected boolean assertTokenUsage() {
-        return false; // testing AzureOpenAiStreamingChatModel without TokenCountEstimator
-    }
-
-    @Override
     public StreamingChatModel createModelWith(ChatModelListener listener) {
         return AzureOpenAiStreamingChatModel.builder()
                 .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))


### PR DESCRIPTION
## Issue
Continues https://github.com/langchain4j/langchain4j/pull/3412

## Change
Removed `tokenCountEstimator` parameter from `AzureOpenAiStreamingChatModel` and `AzureOpenAiStreamingLanguageModel` builders.
Thanks to https://github.com/langchain4j/langchain4j/pull/3412, both models can now return **_actual_** token usage from Azure OpenAI API instead of an _**estimated**_ token usage estimated by the `TokenCountEstimator` (which can be way off).

## General checklist
- [ ] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)