### PR TITLE
Refactor: Replace usage of jsoup's internal StringUtil.in() with safe…

### DIFF
--- a/document-transformers/langchain4j-document-transformer-jsoup/src/main/java/dev/langchain4j/data/document/transformer/jsoup/HtmlToTextDocumentTransformer.java
+++ b/document-transformers/langchain4j-document-transformer-jsoup/src/main/java/dev/langchain4j/data/document/transformer/jsoup/HtmlToTextDocumentTransformer.java
@@ -3,6 +3,8 @@ package dev.langchain4j.data.document.transformer.jsoup;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentTransformer;
 import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.internal.Utils;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
@@ -17,7 +19,6 @@ import static dev.langchain4j.data.document.Document.URL;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
-import static org.jsoup.internal.StringUtil.in;
 import static org.jsoup.select.NodeTraversor.traverse;
 
 /**
@@ -119,14 +120,14 @@ public class HtmlToTextDocumentTransformer implements DocumentTransformer {
                 textBuilder.append("\n * ");
             else if (name.equals("dt"))
                 textBuilder.append("  ");
-            else if (in(name, "p", "h1", "h2", "h3", "h4", "h5", "h6", "tr"))
+            else if (Utils.contains(name, "p", "h1", "h2", "h3", "h4", "h5", "h6", "tr"))
                 textBuilder.append("\n");
         }
 
         @Override
         public void tail(Node node, int depth) { // hit when all the node's children (if any) have been visited
             String name = node.nodeName();
-            if (in(name, "br", "dd", "dt", "p", "h1", "h2", "h3", "h4", "h5", "h6"))
+            if (Utils.contains(name, "br", "dd", "dt", "p", "h1", "h2", "h3", "h4", "h5", "h6"))
                 textBuilder.append("\n");
             else if (includeLinks && name.equals("a")) {
                 String link = node.absUrl("href");

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -477,4 +477,36 @@ public class Utils {
         }
         return Optional.empty();
     }
+
+    /**
+     * Determines whether a given {@code target} string is present within a list of {@code candidates}.
+     * <p>
+     * This method performs a null-safe equality check, meaning it returns {@code true} if both the
+     * {@code target} and any element in {@code candidates} are {@code null}.
+     * </p>
+     *
+     * <p>Examples:</p>
+     * <ul>
+     *   <li>{@code contains("a", "b", "a", "c")} returns {@code true}</li>
+     *   <li>{@code contains(null, "x", null, "y")} returns {@code true}</li>
+     *   <li>{@code contains("z", "x", "y", "z")} returns {@code true}</li>
+     *   <li>{@code contains("a")} returns {@code false}</li>
+     *   <li>{@code contains("a", (String[]) null)} returns {@code false}</li>
+     * </ul>
+     *
+     * @param target     the string to search for; may be {@code null}
+     * @param candidates the list of strings to search within; may be {@code null} or empty
+     * @return {@code true} if the {@code target} is found in {@code candidates}, {@code false} otherwise
+     */
+    public static boolean contains(String target, String... candidates) {
+        if (candidates == null || candidates.length == 0) {
+            return false;
+        }
+        for (String candidate : candidates) {
+            if (Objects.equals(candidate, target)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.internal;
 
+import static dev.langchain4j.internal.Utils.contains;
 import static dev.langchain4j.internal.Utils.getAnnotatedMethod;
 import static dev.langchain4j.internal.Utils.quoted;
 import static dev.langchain4j.internal.Utils.toStringValueMap;
@@ -442,5 +443,58 @@ class UtilsTest {
 
         assertThat(getAnnotatedMethod(proxyMethod, MyAnnotation.class)).contains(myMethod);
         assertThat(getAnnotatedMethod(proxyMethod, AnotherAnnotation.class)).isEmpty();
+    }
+
+    @Test
+    void contains_when_target_is_in_candidates_should_return_true() {
+        assertThat(contains("apple", "banana", "apple", "cherry")).isTrue();
+        assertThat(contains("banana", "banana")).isTrue();
+    }
+
+    @Test
+    void contains_when_target_is_not_in_candidates_should_return_false() {
+        assertThat(contains("grape", "banana", "apple", "cherry")).isFalse();
+        assertThat(contains("grape", "grapefruit", "grapes")).isFalse();
+    }
+
+    @Test
+    void contains_when_candidates_are_empty_should_return_false() {
+        assertThat(contains("apple")).isFalse();
+        assertThat(contains("apple", new String[] {})).isFalse();
+    }
+
+    @Test
+    void contains_when_candidates_is_null_should_return_false() {
+        assertThat(contains("apple", (String[]) null)).isFalse();
+    }
+
+    @Test
+    void contains_when_target_is_null_and_present_in_candidates_should_return_true() {
+        assertThat(contains(null, "a", null, "b")).isTrue();
+    }
+
+    @Test
+    void contains_when_target_is_null_and_not_present_should_return_false() {
+        assertThat(contains(null, "a", "b", "c")).isFalse();
+    }
+
+    @Test
+    void contains_when_candidates_have_only_nulls_and_target_is_null_should_return_true() {
+        assertThat(contains(null, null, null)).isTrue();
+    }
+
+    @Test
+    void contains_when_candidates_have_only_nulls_and_target_is_not_null_should_return_false() {
+        assertThat(contains("not-null", null, null)).isFalse();
+    }
+
+    @Test
+    void contains_when_case_does_not_match_should_return_false() {
+        assertThat(contains("Apple", "apple", "banana")).isFalse();
+    }
+
+    @Test
+    void contains_when_case_matches_should_return_true() {
+        assertThat(contains("Apple", "Apple", "Banana")).isTrue();
     }
 }


### PR DESCRIPTION
### Summary

This pull request refactors the usage of `org.jsoup.internal.StringUtil.in(...)` and replaces it with a custom utility method `Utils.contains(...)` to improve code safety and future compatibility.

### Why this change?

- `StringUtil.in(...)` is part of jsoup's internal API, not meant for public use.
- As documented by jsoup:
  > A minimal String utility class. Designed for internal jsoup use only — the API and outcome may change without notice.
- Relying on such internal APIs introduces upgrade risks and potential breakage without warning.

### What's changed?

- Introduced a new `Utils.contains(String target, String... candidates)` utility method.
  - Fully null-safe using `Objects.equals()`.
  - Handles empty and null candidate arrays gracefully.
  - Covered by a complete JUnit 5 test suite using AssertJ.
- Replaced all usages of `StringUtil.in(...)` in our codebase with `Utils.contains(...)`.

### Benefits

- Removes dependency on non-public jsoup internals.
- Unit tested for robust behavior across nulls, empty arrays, and case sensitivity.


---
Note: Ignored spotless fixes for the class HtmlToTextDocumentTransformer
