### PR TITLE
Refactor equals methods to use pattern matching and eliminate raw typ…

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/classification/ClassificationResult.java
+++ b/langchain4j/src/main/java/dev/langchain4j/classification/ClassificationResult.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.classification;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import java.util.List;
 import java.util.Objects;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 /**
  * Represent the result of classification.
@@ -24,9 +24,8 @@ public class ClassificationResult<L> {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == this) return true;
-        if (obj == null || obj.getClass() != this.getClass()) return false;
-        var that = (ClassificationResult) obj;
+        if (this == obj) return true;
+        if (!(obj instanceof ClassificationResult<?> that)) return false;
         return Objects.equals(this.scoredLabels, that.scoredLabels);
     }
 
@@ -37,8 +36,6 @@ public class ClassificationResult<L> {
 
     @Override
     public String toString() {
-        return "ClassificationResult {" +
-                " scoredLabels = " + scoredLabels +
-                " }";
+        return "ClassificationResult {" + " scoredLabels = " + scoredLabels + " }";
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/classification/ScoredLabel.java
+++ b/langchain4j/src/main/java/dev/langchain4j/classification/ScoredLabel.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.classification;
 
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.quoted;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import java.util.Objects;
 
 /**
  * Represents a classification label with score.
@@ -30,11 +30,10 @@ public class ScoredLabel<L> {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == this) return true;
-        if (obj == null || obj.getClass() != this.getClass()) return false;
-        var that = (ScoredLabel) obj;
-        return Objects.equals(this.label, that.label) &&
-                Double.doubleToLongBits(this.score) == Double.doubleToLongBits(that.score);
+        if (this == obj) return true;
+        if (!(obj instanceof ScoredLabel<?> that)) return false;
+        return Objects.equals(this.label, that.label)
+                && Double.doubleToLongBits(this.score) == Double.doubleToLongBits(that.score);
     }
 
     @Override
@@ -44,9 +43,6 @@ public class ScoredLabel<L> {
 
     @Override
     public String toString() {
-        return "ScoredLabel {" +
-                " label = " + quoted(label) +
-                ", score = " + score +
-                " }";
+        return "ScoredLabel {" + " label = " + quoted(label) + ", score = " + score + " }";
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/classification/ClassificationResultTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/classification/ClassificationResultTest.java
@@ -1,0 +1,79 @@
+package dev.langchain4j.classification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ClassificationResultTest {
+
+    @Test
+    void equals_shouldReturnFalse_whenComparedWithNull() {
+        ClassificationResult<String> result = new ClassificationResult<>(List.of(new ScoredLabel<>("Label1", 0.9)));
+        assertNotEquals(null, result);
+    }
+
+    @Test
+    void equals_shouldReturnFalse_whenComparedWithDifferentClass() {
+        ClassificationResult<String> result = new ClassificationResult<>(List.of(new ScoredLabel<>("Label1", 0.9)));
+        assertNotEquals("some string", result);
+    }
+
+    @Test
+    void equals_shouldReturnTrue_whenComparedWithItself() {
+        ClassificationResult<String> result = new ClassificationResult<>(List.of(new ScoredLabel<>("Label1", 0.9)));
+        assertEquals(result, result);
+    }
+
+    @Test
+    void equals_shouldReturnTrue_whenScoredLabelsAreEqual() {
+        ClassificationResult<String> result1 =
+                new ClassificationResult<>(List.of(new ScoredLabel<>("Label1", 0.9), new ScoredLabel<>("Label2", 0.8)));
+        ClassificationResult<String> result2 =
+                new ClassificationResult<>(List.of(new ScoredLabel<>("Label1", 0.9), new ScoredLabel<>("Label2", 0.8)));
+        assertEquals(result1, result2);
+        assertEquals(result2, result1);
+    }
+
+    @Test
+    void equals_shouldReturnFalse_whenScoredLabelsDifferInSize() {
+        ClassificationResult<String> result1 = new ClassificationResult<>(List.of(new ScoredLabel<>("Label1", 0.9)));
+        ClassificationResult<String> result2 =
+                new ClassificationResult<>(List.of(new ScoredLabel<>("Label1", 0.9), new ScoredLabel<>("Label2", 0.8)));
+        assertNotEquals(result1, result2);
+    }
+
+    @Test
+    void equals_shouldReturnFalse_whenScoredLabelsHaveDifferentValues() {
+        ClassificationResult<String> result1 = new ClassificationResult<>(List.of(new ScoredLabel<>("Label1", 0.9)));
+        ClassificationResult<String> result2 = new ClassificationResult<>(
+                List.of(new ScoredLabel<>("Label1", 0.8)) // different score
+                );
+        assertNotEquals(result1, result2);
+    }
+
+    @Test
+    void equals_shouldReturnTrue_whenListInstancesAreDifferentButContentIsSame() {
+        List<ScoredLabel<String>> list1 =
+                Arrays.asList(new ScoredLabel<>("Label1", 0.9), new ScoredLabel<>("Label2", 0.8));
+
+        List<ScoredLabel<String>> list2 =
+                Arrays.asList(new ScoredLabel<>("Label1", 0.9), new ScoredLabel<>("Label2", 0.8));
+
+        ClassificationResult<String> result1 = new ClassificationResult<>(list1);
+        ClassificationResult<String> result2 = new ClassificationResult<>(list2);
+
+        assertEquals(result1, result2);
+    }
+
+    @Test
+    void equals_shouldReturnTrue_whenEmptyListsAreCompared() {
+        ClassificationResult<String> result1 = new ClassificationResult<>(Collections.emptyList());
+        ClassificationResult<String> result2 = new ClassificationResult<>(Collections.emptyList());
+
+        assertEquals(result1, result2);
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/classification/ScoredLabelTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/classification/ScoredLabelTest.java
@@ -1,0 +1,62 @@
+package dev.langchain4j.classification;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ScoredLabelTest {
+
+    @Test
+    void equals_shouldReturnFalse_whenComparedWithNull() {
+        ScoredLabel<String> label = new ScoredLabel<>("Label1", 0.9);
+        assertNotEquals(null, label);
+    }
+
+    @Test
+    void equals_shouldReturnFalse_whenComparedWithDifferentClass() {
+        ScoredLabel<String> label = new ScoredLabel<>("Label1", 0.9);
+        assertNotEquals("some string", label);
+    }
+
+    @Test
+    void equals_shouldReturnTrue_whenComparedWithItself() {
+        ScoredLabel<String> label = new ScoredLabel<>("Label1", 0.9);
+        assertEquals(label, label);
+    }
+
+    @Test
+    void equals_shouldReturnTrue_whenLabelAndScoreAreEqual() {
+        ScoredLabel<String> label1 = new ScoredLabel<>("Label1", 0.9);
+        ScoredLabel<String> label2 = new ScoredLabel<>("Label1", 0.9);
+        assertEquals(label1, label2);
+        assertEquals(label2, label1);
+    }
+
+    @Test
+    void equals_shouldReturnFalse_whenLabelsAreDifferent() {
+        ScoredLabel<String> label1 = new ScoredLabel<>("Label1", 0.9);
+        ScoredLabel<String> label2 = new ScoredLabel<>("Label2", 0.9);
+        assertNotEquals(label1, label2);
+    }
+
+    @Test
+    void equals_shouldReturnFalse_whenScoresAreDifferent() {
+        ScoredLabel<String> label1 = new ScoredLabel<>("Label1", 0.9);
+        ScoredLabel<String> label2 = new ScoredLabel<>("Label1", 0.8);
+        assertNotEquals(label1, label2);
+    }
+
+    @Test
+    void equals_shouldHandleDoubleNaNCorrectly() {
+        ScoredLabel<String> label1 = new ScoredLabel<>("Label1", Double.NaN);
+        ScoredLabel<String> label2 = new ScoredLabel<>("Label1", Double.NaN);
+        assertEquals(label1, label2); // because you use Double.doubleToLongBits
+    }
+
+    @Test
+    void equals_shouldDifferentiateNegativeZeroAndZero() {
+        ScoredLabel<String> label1 = new ScoredLabel<>("Label1", 0.0);
+        ScoredLabel<String> label2 = new ScoredLabel<>("Label1", -0.0);
+        assertFalse(label1.equals(label2)); // because 0.0 != -0.0 in long bits
+    }
+}


### PR DESCRIPTION
## Refactor `equals()` Methods to Use Pattern Matching and Remove Raw Type Warnings

### Summary

This PR refactors the `equals()` methods in the following generic classes to eliminate IDE warnings related to raw types:

- `ClassificationResult<L>`
- `ScoredLabel<L>`

### Changes Made

- Replaced old-style raw type checks and unsafe casting:

  ```java
  if (obj == null || obj.getClass() != this.getClass()) return false;
  var that = (ClassificationResult) obj;
  ```
with Java 16+ safe pattern matching:
```
if (!(obj instanceof ClassificationResult<?> that)) return false;
```

Applied the same pattern to ScoredLabel<L>.
Removed IDE warnings like:

```
ClassificationResult is a raw type. References to generic type ClassificationResult<L> should be parameterized
ScoredLabel is a raw type. References to generic type ScoredLabel<L> should be parameterized
```