### PR TITLE
Fix bug in output guardrails when maxRetries == 0

### DIFF
--- a/integration-tests/integration-tests-guardrails/src/test/java/dev/langchain4j/service/guardrail/MyChatModel.java
+++ b/integration-tests/integration-tests-guardrails/src/test/java/dev/langchain4j/service/guardrail/MyChatModel.java
@@ -5,8 +5,11 @@ import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class MyChatModel implements ChatModel {
+    private final AtomicInteger spy = new AtomicInteger(0);
+
     private static String getUserMessage(ChatRequest chatRequest) {
         return chatRequest.messages().stream()
                 .filter(message -> message.type() == ChatMessageType.USER)
@@ -17,8 +20,14 @@ public class MyChatModel implements ChatModel {
 
     @Override
     public ChatResponse doChat(ChatRequest chatRequest) {
+        spy.incrementAndGet();
+
         return ChatResponse.builder()
                 .aiMessage(AiMessage.from("Request: %s; Response: Hi!".formatted(getUserMessage(chatRequest))))
                 .build();
+    }
+
+    public int spy() {
+        return spy.get();
     }
 }


### PR DESCRIPTION
There's a bug in the output guardrail execution if maxRetries == 0. Currently it will always execute at least 1 retry if the guardrail says to retry or reprompt.