### PR TITLE
feat: MMR reranker

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/MmrReranker.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/MmrReranker.java
@@ -69,7 +69,7 @@ public final class MmrReranker {
         List<EmbeddingMatch<Embedded>> unranked = new ArrayList<>(candidates);
 
         // MMR is an iterative selection process. It's best to start with the most relevant candidate.
-        // We sort the candidates by their initial score (relevance to the query) in descending order.
+        // Sort the candidates by their initial score (relevance to the query) in descending order.
         unranked.sort(comparingDouble((EmbeddingMatch<Embedded> match) -> match.score()).reversed());
 
         // Iterate until the desired number of results is reached or no more candidates are available
@@ -77,22 +77,18 @@ public final class MmrReranker {
             // Find the best candidate from the unranked list based on MMR score
             EmbeddingMatch<Embedded> bestCandidate = findBestCandidate(unranked, ranked, lambda);
 
-            // Add the best candidate to the ranked list and remove it from the unranked list
-            // The fallback logic is now handled more implicitly by the loop condition
-            // and the nature of `findBestCandidate` returning null if no suitable candidate is found
+            // If a best candidate is found, add it to the ranked list and remove it from the unranked pool.
             if (nonNull(bestCandidate)) {
                 ranked.add(bestCandidate);
-                // Remove the selected candidate from the unranked list
-                // Using remove(Object) is less efficient for large lists, but clear.
-                // If performance is critical for very large 'unranked' lists,
-                // consider using an alternative data structure or tracking indices.
+                // Remove the selected candidate. For large lists, consider alternative data structures
+                // or index-based removal if performance is critical.
                 unranked.remove(bestCandidate);
             } else {
-                // This else branch should ideally not be reached if the algorithm is working correctly
-                // and there are still candidates. It implies no candidate could improve the MMR score.
-                // As a robust fallback, if no best candidate is found but results are still needed,
-                // we can add the next most relevant item (which is at index 0 after initial sort).
-                // This prevents an infinite loop if MMR calculation somehow fails to find a positive score.
+                // Fallback: This branch should ideally not be reached if the algorithm is functioning
+                // as expected and there are still candidates. It might imply that no candidate
+                // can improve the MMR score. As a robust measure, if no best candidate is found
+                // but more results are needed, the next most relevant item (which is at index 0
+                // after the initial sort and subsequent removals) is added. This prevents infinite loops.
                 if (!unranked.isEmpty()) {
                     ranked.add(unranked.remove(0));
                 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/MmrReranker.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/MmrReranker.java
@@ -1,0 +1,117 @@
+package dev.langchain4j.store.embedding;
+
+import dev.langchain4j.data.embedding.Embedding;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static dev.langchain4j.store.embedding.CosineSimilarity.between;
+import static java.util.Comparator.comparingDouble;
+
+/**
+ * A utility class that implements the Maximum Marginal Relevance (MMR) algorithm.
+ * MMR reranks a list of candidate embeddings to balance relevance to the query with diversity among the results.
+ * <p>
+ * This class is designed to be a low-level, stateless utility that operates on embeddings,
+ * making it reusable across different modules and applications.
+ */
+public final class MmrReranker {
+
+    private static final double INITIAL_MMR_SCORE = -1.0;
+    private static final double INITIAL_DIVERSITY_SCORE = 0.0;
+
+    private MmrReranker() {}
+
+    /**
+     * Reranks a list of candidate embeddings using the MMR algorithm.
+     *
+     * @param queryEmbedding  The embedding of the query.
+     * @param candidates      The list of candidate matches to be reranked, typically sorted by relevance.
+     * @param maxResults      The maximum number of results to return.
+     * @param lambda          A value between 0 and 1 that balances relevance and diversity.
+     * A higher lambda (e.g., 0.7-0.8) prioritizes relevance, while a lower lambda (e.g., 0.3-0.4)
+     * prioritizes diversity. A value of 1.0 is equivalent to standard relevance-based ranking.
+     * @param <Embedded>      The type of the content that has been embedded.
+     * @return A new list of reranked embedding matches.
+     */
+    public static <Embedded> List<EmbeddingMatch<Embedded>> rerank(
+            Embedding queryEmbedding,
+            List<EmbeddingMatch<Embedded>> candidates,
+            int maxResults,
+            double lambda) {
+
+        // Validate lambda parameter
+        if (lambda < 0.0 || lambda > 1.0) {
+            throw new IllegalArgumentException("Lambda must be between 0.0 and 1.0 (inclusive).");
+        }
+
+        if (candidates == null || candidates.isEmpty() || maxResults <= 0) {
+            return new ArrayList<>();
+        }
+
+        // If the number of candidates is already less than or equal to the max results,
+        // no reranking is needed. Just return the existing list.
+        if (candidates.size() <= maxResults) {
+            return new ArrayList<>(candidates);
+        }
+
+        List<EmbeddingMatch<Embedded>> ranked = new ArrayList<>();
+        List<EmbeddingMatch<Embedded>> unranked = new ArrayList<>(candidates);
+
+        // MMR is an iterative selection process. It's best to start with the most relevant candidate.
+        // We sort the candidates by their initial score (relevance to the query).
+        unranked.sort(comparingDouble((EmbeddingMatch<Embedded> match) -> match.score()).reversed());
+
+        while (ranked.size() < maxResults && !unranked.isEmpty()) {
+            double maxMmrScore = INITIAL_MMR_SCORE;
+            EmbeddingMatch<Embedded> bestCandidate = null;
+            int bestCandidateIndex = -1;
+
+            for (int i = 0; i < unranked.size(); i++) {
+                EmbeddingMatch<Embedded> candidate = unranked.get(i);
+                double relevanceScore = candidate.score(); // Score from initial search
+
+                // Diversity score is the max similarity with any item already in the ranked list.
+                double diversityScore = INITIAL_DIVERSITY_SCORE;
+                if (!ranked.isEmpty()) {
+                    double maxSimilarityWithRanked = ranked.stream()
+                            .mapToDouble(rankedMatch -> between(candidate.embedding(), rankedMatch.embedding()))
+                            .max()
+                            .orElse(INITIAL_DIVERSITY_SCORE);
+                    diversityScore = maxSimilarityWithRanked;
+                }
+
+                // MMR formula
+                double mmrScore = calculateMmrScore(lambda, relevanceScore, diversityScore);
+
+                if (mmrScore > maxMmrScore) {
+                    maxMmrScore = mmrScore;
+                    bestCandidate = candidate;
+                    bestCandidateIndex = i;
+                }
+            }
+
+            if (bestCandidate != null) {
+                ranked.add(bestCandidate);
+                unranked.remove(bestCandidateIndex);
+            } else {
+                // Fallback: If for some reason a best candidate cannot be found,
+                // just add the next most relevant item to avoid an infinite loop.
+                ranked.add(unranked.remove(0));
+            }
+        }
+        return ranked;
+    }
+
+    /**
+     * Calculates the MMR score based on relevance, diversity, and lambda.
+     *
+     * @param lambda          A value between 0 and 1 that balances relevance and diversity.
+     * @param relevanceScore  The relevance score of the candidate to the query.
+     * @param diversityScore  The diversity score (max similarity with already ranked items).
+     * @return The calculated MMR score.
+     */
+    private static double calculateMmrScore(double lambda, double relevanceScore, double diversityScore) {
+        return lambda * relevanceScore - (1 - lambda) * diversityScore;
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/MmrRerankerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/MmrRerankerTest.java
@@ -1,0 +1,219 @@
+package dev.langchain4j.store.embedding;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link MmrReranker} class.
+ */
+class MmrRerankerTest {
+
+    // Helper method to create a dummy Embedding for testing
+    private Embedding createEmbedding(float... vector) {
+        return Embedding.from(vector);
+    }
+
+    // Helper method to create an EmbeddingMatch for testing
+    private EmbeddingMatch<TextSegment> createEmbeddingMatch(double score, float[] vector, String text) {
+        // embeddingId should ideally be unique, but for testing purposes, hashCode is sufficient.
+        return new EmbeddingMatch<>(score, String.valueOf(text.hashCode()), createEmbedding(vector), TextSegment.from(text));
+    }
+
+    @Test
+    void should_rerank_with_balanced_lambda() {
+        // Given: Query embedding and candidates with varying relevance/similarity
+        // Query: "apple" (Vector: [1.0, 0.0, 0.0])
+        Embedding queryEmbedding = createEmbedding(1.0f, 0.0f, 0.0f);
+
+        // Candidates: Scores indicate relevance to the query, vectors are used for diversity
+        // Candidates very similar to 'apple' (high scores)
+        EmbeddingMatch<TextSegment> candidate1 = createEmbeddingMatch(0.9, new float[]{0.9f, 0.1f, 0.0f}, "red apple"); // Most similar to query (score 0.9)
+        EmbeddingMatch<TextSegment> candidate2 = createEmbeddingMatch(0.8, new float[]{0.8f, 0.2f, 0.0f}, "green apple"); // Similar to query, also similar to candidate1 (score 0.8)
+        EmbeddingMatch<TextSegment> candidate3 = createEmbeddingMatch(0.7, new float[]{0.7f, 0.3f, 0.0f}, "apple pie recipe"); // Similar to query, also similar to candidate1,2 (score 0.7)
+
+        // Candidates less similar to 'apple', but high diversity from previous ones
+        EmbeddingMatch<TextSegment> candidate4 = createEmbeddingMatch(0.6, new float[]{0.0f, 0.8f, 0.1f}, "yellow banana"); // Less similar to query, but high diversity from previous (score 0.6)
+        EmbeddingMatch<TextSegment> candidate5 = createEmbeddingMatch(0.5, new float[]{0.1f, 0.7f, 0.1f}, "banana smoothie"); // Less similar to query, similar to candidate4 (score 0.5)
+
+        List<EmbeddingMatch<TextSegment>> candidates = Arrays.asList(
+                candidate1, candidate2, candidate3, candidate4, candidate5
+        );
+
+        int maxResults = 3;
+        double lambda = 0.7; // Balance between relevance (0.7) and diversity (0.3)
+
+        // When: Execute MMR reranking
+        List<EmbeddingMatch<TextSegment>> reranked = MmrReranker.rerank(queryEmbedding, candidates, maxResults, lambda);
+
+        // Then: Verify expected results
+        assertThat(reranked).hasSize(maxResults);
+        // 1. The most relevant "red apple" should come first (initial selection)
+        assertThat(reranked.get(0).embedded().text()).isEqualTo("red apple");
+        // 2. Following "red apple", "yellow banana" should come next due to its diversity, despite a lower score
+        //    (score 0.6, but vectorially distant from candidate1,2,3, leading to a high diversity score)
+        assertThat(reranked.get(1).embedded().text()).isEqualTo("yellow banana");
+        // 3. Following "red apple" and "yellow banana", "green apple" should come next, balancing relevance and diversity
+        //    (candidate2 has a high score of 0.8, but was initially less diverse than candidate4.
+        //     After candidate4 is selected, its MMR score might become higher, leading to its selection.)
+        assertThat(reranked.get(2).embedded().text()).isEqualTo("green apple");
+    }
+
+    @Test
+    void should_rerank_prioritizing_relevance_only() {
+        // Given: Lambda = 1.0 (100% relevance prioritization)
+        Embedding queryEmbedding = createEmbedding(1.0f, 0.0f, 0.0f);
+        EmbeddingMatch<TextSegment> candidate1 = createEmbeddingMatch(0.9, new float[]{0.9f, 0.1f, 0.0f}, "red apple");
+        EmbeddingMatch<TextSegment> candidate2 = createEmbeddingMatch(0.8, new float[]{0.8f, 0.2f, 0.0f}, "green apple");
+        EmbeddingMatch<TextSegment> candidate3 = createEmbeddingMatch(0.7, new float[]{0.7f, 0.3f, 0.0f}, "apple pie recipe");
+        EmbeddingMatch<TextSegment> candidate4 = createEmbeddingMatch(0.6, new float[]{0.0f, 0.8f, 0.1f}, "yellow banana");
+
+        List<EmbeddingMatch<TextSegment>> candidates = Arrays.asList(
+                candidate1, candidate2, candidate3, candidate4
+        );
+
+        int maxResults = 2;
+        double lambda = 1.0;
+
+        // When: Execute MMR reranking
+        List<EmbeddingMatch<TextSegment>> reranked = MmrReranker.rerank(queryEmbedding, candidates, maxResults, lambda);
+
+        // Then: Results should be sorted solely by initial score (relevanceScore)
+        assertThat(reranked).hasSize(maxResults);
+        assertThat(reranked.get(0).embedded().text()).isEqualTo("red apple");
+        assertThat(reranked.get(1).embedded().text()).isEqualTo("green apple");
+    }
+
+    @Test
+    void should_rerank_prioritizing_diversity_only() {
+        // Given: Lambda = 0.0 (100% diversity prioritization)
+        Embedding queryEmbedding = createEmbedding(1.0f, 0.0f, 0.0f);
+        EmbeddingMatch<TextSegment> candidate1 = createEmbeddingMatch(0.9, new float[]{0.9f, 0.1f, 0.0f}, "red apple");
+        EmbeddingMatch<TextSegment> candidate2 = createEmbeddingMatch(0.8, new float[]{0.8f, 0.2f, 0.0f}, "green apple");
+        EmbeddingMatch<TextSegment> candidate3 = createEmbeddingMatch(0.7, new float[]{0.7f, 0.3f, 0.0f}, "apple pie recipe");
+        EmbeddingMatch<TextSegment> candidate4 = createEmbeddingMatch(0.6, new float[]{0.0f, 0.8f, 0.1f}, "yellow banana");
+
+        List<EmbeddingMatch<TextSegment>> candidates = Arrays.asList(
+                candidate1, candidate2, candidate3, candidate4
+        );
+
+        int maxResults = 2;
+        double lambda = 0.0;
+
+        // When: Execute MMR reranking
+        List<EmbeddingMatch<TextSegment>> reranked = MmrReranker.rerank(queryEmbedding, candidates, maxResults, lambda);
+
+        // Then: Results should prioritize diversity
+        assertThat(reranked).hasSize(maxResults);
+        // 1. The most relevant "red apple" should come first (initial selection step of MMR algorithm)
+        assertThat(reranked.get(0).embedded().text()).isEqualTo("red apple");
+        // 2. "yellow banana" should come next as it's most diverse from "red apple"
+        assertThat(reranked.get(1).embedded().text()).isEqualTo("yellow banana");
+    }
+
+    @Test
+    void should_return_empty_list_if_candidates_are_null() {
+        // Given: Null candidate list
+        Embedding queryEmbedding = createEmbedding(1.0f, 0.0f, 0.0f);
+        List<EmbeddingMatch<TextSegment>> candidates = null;
+        int maxResults = 3;
+        double lambda = 0.7;
+
+        // When: Execute MMR reranking
+        List<EmbeddingMatch<TextSegment>> reranked = MmrReranker.rerank(queryEmbedding, candidates, maxResults, lambda);
+
+        // Then: An empty list should be returned
+        assertThat(reranked).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_list_if_candidates_are_empty() {
+        // Given: Empty candidate list
+        Embedding queryEmbedding = createEmbedding(1.0f, 0.0f, 0.0f);
+        List<EmbeddingMatch<TextSegment>> candidates = new ArrayList<>();
+        int maxResults = 3;
+        double lambda = 0.7;
+
+        // When: Execute MMR reranking
+        List<EmbeddingMatch<TextSegment>> reranked = MmrReranker.rerank(queryEmbedding, candidates, maxResults, lambda);
+
+        // Then: An empty list should be returned
+        assertThat(reranked).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_list_if_maxResults_is_zero() {
+        // Given: maxResults is 0
+        Embedding queryEmbedding = createEmbedding(1.0f, 0.0f, 0.0f);
+        List<EmbeddingMatch<TextSegment>> candidates = Arrays.asList(
+                createEmbeddingMatch(0.9, new float[]{0.9f, 0.1f, 0.0f}, "red apple")
+        );
+        int maxResults = 0;
+        double lambda = 0.7;
+
+        // When: Execute MMR reranking
+        List<EmbeddingMatch<TextSegment>> reranked = MmrReranker.rerank(queryEmbedding, candidates, maxResults, lambda);
+
+        // Then: An empty list should be returned
+        assertThat(reranked).isEmpty();
+    }
+
+    @Test
+    void should_return_all_candidates_if_maxResults_is_greater_than_candidates_size() {
+        // Given: maxResults is greater than the number of candidates
+        Embedding queryEmbedding = createEmbedding(1.0f, 0.0f, 0.0f);
+        EmbeddingMatch<TextSegment> candidate1 = createEmbeddingMatch(0.9, new float[]{0.9f, 0.1f, 0.0f}, "red apple");
+        EmbeddingMatch<TextSegment> candidate2 = createEmbeddingMatch(0.8, new float[]{0.8f, 0.2f, 0.0f}, "green apple");
+        List<EmbeddingMatch<TextSegment>> candidates = Arrays.asList(candidate1, candidate2);
+        int maxResults = 5; // More than candidates
+
+        double lambda = 0.7;
+
+        // When: Execute MMR reranking
+        List<EmbeddingMatch<TextSegment>> reranked = MmrReranker.rerank(queryEmbedding, candidates, maxResults, lambda);
+
+        // Then: All candidates should be returned (order will be based on initial sort)
+        assertThat(reranked).hasSize(2);
+        assertThat(reranked.get(0).embedded().text()).isEqualTo("red apple");
+        assertThat(reranked.get(1).embedded().text()).isEqualTo("green apple");
+    }
+
+    @Test
+    void should_throw_exception_for_invalid_lambda_less_than_zero() {
+        // Given: Lambda value less than 0
+        Embedding queryEmbedding = createEmbedding(1.0f, 0.0f, 0.0f);
+        List<EmbeddingMatch<TextSegment>> candidates = Arrays.asList(
+                createEmbeddingMatch(0.9, new float[]{0.9f, 0.1f, 0.0f}, "red apple")
+        );
+        int maxResults = 1;
+        double lambda = -0.1; // Invalid lambda
+
+        // When & Then: IllegalArgumentException should be thrown
+        assertThrows(IllegalArgumentException.class, () ->
+                MmrReranker.rerank(queryEmbedding, candidates, maxResults, lambda)
+        );
+    }
+
+    @Test
+    void should_throw_exception_for_invalid_lambda_greater_than_one() {
+        // Given: Lambda value greater than 1
+        Embedding queryEmbedding = createEmbedding(1.0f, 0.0f, 0.0f);
+        List<EmbeddingMatch<TextSegment>> candidates = Arrays.asList(
+                createEmbeddingMatch(0.9, new float[]{0.9f, 0.1f, 0.0f}, "red apple")
+        );
+        int maxResults = 1;
+        double lambda = 1.1; // Invalid lambda
+
+        // When & Then: IllegalArgumentException should be thrown
+        assertThrows(IllegalArgumentException.class, () ->
+                MmrReranker.rerank(queryEmbedding, candidates, maxResults, lambda)
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below. Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples. Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
\-->

## Issue

<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->

None

## Change

This PR introduces the `MmrReranker` utility class within the `dev.langchain4j.store.embedding` package, implementing the Maximum Marginal Relevance (MMR) reranking algorithm. This algorithm helps to reorder retrieved candidate results by balancing their relevance to the query and diversity among themselves, thereby improving the quality of content presented in RAG pipelines and other applications.

Key changes include:

* **`MmrReranker.java` Added**:

  * A stateless utility class that encapsulates the core logic of the MMR algorithm.

  * It takes a query embedding and a list of candidate matches as input, returning a reranked list.

  * Includes robust validation for the `lambda` parameter (which balances relevance and diversity).

  * Internally uses `CosineSimilarity` for calculating similarities between embeddings. While other similarity metrics (e.g., L2 distance) could be used, the current design focuses on `CosineSimilarity` due to the absence of a generic similarity interface within the current package structure.

  * Refactored for improved readability and modularity by extracting logic into helper methods like `findBestCandidate` and `calculateMmrScore`.

  * Enhanced null checks for input parameters, including `queryEmbedding`, to increase robustness. The `queryEmbedding` parameter is included for conceptual clarity and future extensibility, even though its direct use for `relevanceScore` calculation is handled by `EmbeddingMatch.score()`.

* **`MmrRerankerTest.java` Added**:

  * A comprehensive JUnit 5 test suite for the `MmrReranker` class.

  * Covers various scenarios, including balanced lambda, relevance-only prioritization, diversity-only prioritization, and edge cases such as null or empty candidate lists, zero `maxResults`, and invalid `lambda` values.

* **Design Considerations**:

  * This implementation focuses solely on the core MMR logic within the `core.embedding` module.

  * Integration with higher-level components like RAG pipelines (e.g., via a new `ContentAggregator` implementation) or other application-specific contexts is considered a separate concern, requiring distinct interface definitions and component designs outside the scope of this core utility. This approach ensures modularity and adherence to the single responsibility principle.

## General checklist

<!-- Please double-check the following points and mark them like this: \[X\] -->

* \[X\] There are no breaking changes (This is a new utility class, so no existing functionality is altered).

* \[X\] I have added unit and/or integration tests for my change (Unit tests are provided in `MmrRerankerTest.java`).

* \[X\] The tests cover both positive and negative cases (Covered scenarios like valid inputs, empty lists, nulls, and invalid lambda).

* \[ \] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green (Cannot be performed by me, but tests are designed to pass).

* \[ \] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green (Cannot be performed by me).

<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->

* \[ \] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)

* \[ \] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (This is a low-level utility, typically integrated into higher-level features like RAG, so a direct example in the examples repo might not be applicable at this stage. Documentation will cover usage.)

* \[ \] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (Not applicable for this change).

## Checklist for adding new maven module

<!-- Please double-check the following points and mark them like this: \[X\] -->

* \[ \] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml` (Not applicable, files are added to an existing module).

## Checklist for adding new embedding store integration

<!-- Please double-check the following points and mark them like this: \[X\] -->

* \[ \] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT` (Not applicable, this is a reranker, not an embedding store integration).

* \[ \] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT` (Not applicable).

## Checklist for changing existing embedding store integration

<!-- Please double-check the following points and mark them like this: \[X\] -->

* \[ \] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j (Not applicable, this is a new utility, not a change to an existing embedding store integration).