### PR TITLE
Allow using the MCP ToolExecutor outside of the McpToolProvider

### DIFF
--- a/docs/docs/tutorials/mcp.md
+++ b/docs/docs/tutorials/mcp.md
@@ -119,6 +119,24 @@ Bot bot = AiServices.builder(Bot.class)
     .build();
 ```
 
+Alternatively, you can provide tools using a `Map<ToolSpecification, ToolExecutor>`.
+
+```java
+Map<ToolSpecification, ToolExecutor> tools = mcpClient.listTools().stream().collect(Collectors.toMap(
+        tool -> tool, 
+        tool -> new McpToolExecutor(mcpClient)
+));
+```
+
+To bind tools to an AI service, simply use the `tools` method of an AI service builder:
+
+```java
+Bot bot = AiServices.builder(Bot.class)
+    .chatModel(model)
+    .tools(tools)
+    .build();
+```
+
 More information on tool support in LangChain4j can be found [here](/tutorials/tools).
 
 ## Logging

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolExecutor.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolExecutor.java
@@ -1,0 +1,20 @@
+package dev.langchain4j.mcp;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolExecutor;
+
+public class McpToolExecutor implements ToolExecutor {
+    private final McpClient mcpClient;
+
+    public McpToolExecutor(McpClient mcpClient) {
+        this.mcpClient = ensureNotNull(mcpClient, "mcpClient");
+    }
+
+    @Override
+    public String execute(ToolExecutionRequest executionRequest, Object memoryId) {
+        return mcpClient.executeTool(executionRequest);
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolProvider.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolProvider.java
@@ -1,6 +1,5 @@
 package dev.langchain4j.mcp;
 
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.internal.Utils;
 import dev.langchain4j.mcp.client.McpClient;
@@ -116,7 +115,7 @@ public class McpToolProvider implements ToolProvider {
             ToolProviderRequest request, BiPredicate<McpClient, ToolSpecification> mcpToolsFilter) {
         ToolProviderResult.Builder builder = ToolProviderResult.builder();
         for (McpClient mcpClient : mcpClients) {
-            var defaultToolExecutor = new DefaultToolExecutor(mcpClient);
+            var defaultToolExecutor = new McpToolExecutor(mcpClient);
             try {
                 mcpClient.listTools().stream()
                         .filter(tool -> mcpToolsFilter.test(mcpClient, tool))
@@ -238,16 +237,4 @@ public class McpToolProvider implements ToolProvider {
         }
     }
 
-    private static class DefaultToolExecutor implements ToolExecutor {
-        private final McpClient mcpClient;
-
-        public DefaultToolExecutor(McpClient mcpClient) {
-            this.mcpClient = mcpClient;
-        }
-
-        @Override
-        public String execute(ToolExecutionRequest executionRequest, Object memoryId) {
-            return mcpClient.executeTool(executionRequest);
-        }
-    }
 }


### PR DESCRIPTION
## Change
The `McpToolProvider` has an implementation of a `ToolExecutor` used internally.
This PR extracts it to a `McpToolExecutor` so it can be used outside the `McpToolProvider`.

**Why doing this?**
To register tools for an AI service, there are a lot of different ways:
- using `AiService.tools(Object...)`
- using `AiService.toolProvider(ToolProvider)`
- using `AiSerice.tools(Map<ToolSpecification, ToolExecutor>)`

We use the latter in our code as we handle dynamically multiple types of tools (WebSearch, MCP Client, custom tools, etc.). To be able to use it, we have our own copy of the currently private MCP ToolExecutor.

With the change of this PR, we would be able to use the newly extracted `McpToolExecutor` to register tools using  `AiSerice.tools(Map<ToolSpecification, ToolExecutor>)` instead of copying its code to a custom class.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
