### PR TITLE
Add unit tests for default map name handling and fix Javadoc in Coher…

### DIFF
--- a/langchain4j-coherence/src/main/java/dev/langchain4j/store/memory/chat/coherence/CoherenceChatMemoryStore.java
+++ b/langchain4j-coherence/src/main/java/dev/langchain4j/store/memory/chat/coherence/CoherenceChatMemoryStore.java
@@ -1,21 +1,18 @@
 package dev.langchain4j.store.memory.chat.coherence;
 
-import com.oracle.coherence.ai.DocumentChunk;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import com.tangosol.net.Coherence;
 import com.tangosol.net.NamedMap;
 import com.tangosol.net.Session;
-
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageDeserializer;
 import dev.langchain4j.data.message.ChatMessageSerializer;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
-
 import java.util.ArrayList;
 import java.util.List;
-
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 /**
  * A {@link ChatMemoryStore} backed by an Oracle Coherence named map.
@@ -86,7 +83,7 @@ public class CoherenceChatMemoryStore implements ChatMemoryStore {
      * Create a {@link CoherenceChatMemoryStore} that uses the
      * specified Coherence {@link NamedMap} name.
      *
-     * @param name  the name of the Coherence {@link NamedMap} used to store documents
+     * @param name  the name of the Coherence {@link NamedMap} used to store chat messages
      *
      * @return a {@link CoherenceChatMemoryStore}
      */
@@ -98,7 +95,7 @@ public class CoherenceChatMemoryStore implements ChatMemoryStore {
      * Create a {@link CoherenceChatMemoryStore} that uses the
      * specified Coherence {@link NamedMap} name.
      *
-     * @param map  the {@link NamedMap} used to store documents
+     * @param map  the {@link NamedMap} used to store chat messages
      *
      * @return a {@link CoherenceChatMemoryStore}
      */
@@ -120,7 +117,7 @@ public class CoherenceChatMemoryStore implements ChatMemoryStore {
      */
     public static class Builder {
         /**
-         * The name of the {@link NamedMap} to contain the {@link DocumentChunk document chunks}.
+         * The name of the {@link NamedMap} to contain the serialized {@link ChatMessage chat messages}.
          */
         private String name = DEFAULT_MAP_NAME;
 
@@ -137,20 +134,17 @@ public class CoherenceChatMemoryStore implements ChatMemoryStore {
         /**
          * Create a {@link Builder}.
          */
-        protected Builder() {
-        }
+        protected Builder() {}
 
         /**
          * Set the name of the {@link NamedMap} that will hold the
-         * {@link DocumentChunk document chunks}.
+         * serialized {@link ChatMessage chat messages}.
          *
-         * @param name  the name of the {@link NamedMap} that will hold
-         *              the {@link DocumentChunk document chunks}
-         *
+         * @param name the name of the {@link NamedMap} to store serialized {@link ChatMessage chat messages}
          * @return this builder for fluent method calls
          */
-        public Builder name(String name) {
-            this.name = isNullOrEmpty(name) ? DEFAULT_MAP_NAME : name;
+        Builder name(String name) {
+            this.name = isNullOrBlank(name) ? DEFAULT_MAP_NAME : name;
             return this;
         }
 
@@ -183,17 +177,26 @@ public class CoherenceChatMemoryStore implements ChatMemoryStore {
         }
 
         /**
-         * Build a {@link CoherenceChatMemoryStore} from the state in this builder.
+         * Creates a new instance of {@link CoherenceChatMemoryStore} using the current
+         * configuration of this {@code Builder}.
+         * <p>
+         * If a {@link Session} has not been explicitly set via the builder, this method
+         * will attempt to resolve it by {@code sessionName} using {@link Coherence#getSession(String)}.
+         * If no {@code sessionName} is provided, the default session will be used via
+         * {@link Coherence#getSession()}.
+         * <p>
+         * Once a {@link Session} is resolved, the configured {@link NamedMap} (or the default
+         * {@link #DEFAULT_MAP_NAME} if none was set) is retrieved and used to create a new
+         * {@link CoherenceChatMemoryStore} instance.
          *
-         * @return a new instance of a {@link CoherenceChatMemoryStore}
+         * @return a new instance of {@link CoherenceChatMemoryStore}
          */
         public CoherenceChatMemoryStore build() {
             Session session = this.session;
             if (session == null) {
                 if (sessionName != null) {
                     session = Coherence.getInstance().getSession(sessionName);
-                }
-                else {
+                } else {
                     session = Coherence.getInstance().getSession();
                 }
             }

--- a/langchain4j-coherence/src/main/java/dev/langchain4j/store/memory/chat/coherence/CoherenceChatMemoryStore.java
+++ b/langchain4j-coherence/src/main/java/dev/langchain4j/store/memory/chat/coherence/CoherenceChatMemoryStore.java
@@ -143,7 +143,7 @@ public class CoherenceChatMemoryStore implements ChatMemoryStore {
          * @param name the name of the {@link NamedMap} to store serialized {@link ChatMessage chat messages}
          * @return this builder for fluent method calls
          */
-        Builder name(String name) {
+        public Builder name(String name) {
             this.name = isNullOrBlank(name) ? DEFAULT_MAP_NAME : name;
             return this;
         }

--- a/langchain4j-coherence/src/test/java/dev/langchain4j/store/memory/chat/coherence/CoherenceChatMemoryStoreIT.java
+++ b/langchain4j-coherence/src/test/java/dev/langchain4j/store/memory/chat/coherence/CoherenceChatMemoryStoreIT.java
@@ -149,4 +149,43 @@ class CoherenceChatMemoryStoreIT {
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("memoryId cannot be null");
     }
+
+    @Test
+    void should_use_default_map_name_when_name_is_blank() {
+        CoherenceChatMemoryStore store = CoherenceChatMemoryStore.builder()
+                .session(session)
+                .name(null) // null
+                .build();
+
+        assertThat(store.chatMemory.getName()).isEqualTo(CoherenceChatMemoryStore.DEFAULT_MAP_NAME);
+
+        store = CoherenceChatMemoryStore.builder()
+                .session(session)
+                .name("") // Empty string
+                .build();
+        assertThat(store.chatMemory.getName()).isEqualTo(CoherenceChatMemoryStore.DEFAULT_MAP_NAME);
+
+        store = CoherenceChatMemoryStore.builder()
+                .session(session)
+                .name("  ") // Empty Spaces
+                .build();
+        assertThat(store.chatMemory.getName()).isEqualTo(CoherenceChatMemoryStore.DEFAULT_MAP_NAME);
+
+        store = CoherenceChatMemoryStore.builder()
+                .session(session)
+                .name("  \t\n ")
+                .build();
+        assertThat(store.chatMemory.getName()).isEqualTo(CoherenceChatMemoryStore.DEFAULT_MAP_NAME);
+    }
+
+    @Test
+    void should_use_custom_name_when_set() {
+        String name = "custom-chat-memory";
+        CoherenceChatMemoryStore store = CoherenceChatMemoryStore.builder()
+                .session(session)
+                .name(name) // Custom Name
+                .build();
+
+        assertThat(store.chatMemory.getName()).isEqualTo(name);
+    }
 }

--- a/langchain4j-coherence/src/test/java/dev/langchain4j/store/memory/chat/coherence/CoherenceChatMemoryStoreIT.java
+++ b/langchain4j-coherence/src/test/java/dev/langchain4j/store/memory/chat/coherence/CoherenceChatMemoryStoreIT.java
@@ -28,6 +28,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class CoherenceChatMemoryStoreIT {
 
@@ -150,31 +153,13 @@ class CoherenceChatMemoryStoreIT {
                 .hasMessage("memoryId cannot be null");
     }
 
-    @Test
-    void should_use_default_map_name_when_name_is_blank() {
-        CoherenceChatMemoryStore store = CoherenceChatMemoryStore.builder()
-                .session(session)
-                .name(null) // null
-                .build();
+    @ParameterizedTest
+    @NullAndEmptySource // covers null and empty string ""
+    @ValueSource(strings = {"  ", "  \t\n "}) // strings with spaces, tabs, newlines
+    void should_use_default_map_name_when_name_is_blank(String name) {
+        CoherenceChatMemoryStore store =
+                CoherenceChatMemoryStore.builder().session(session).name(name).build();
 
-        assertThat(store.chatMemory.getName()).isEqualTo(CoherenceChatMemoryStore.DEFAULT_MAP_NAME);
-
-        store = CoherenceChatMemoryStore.builder()
-                .session(session)
-                .name("") // Empty string
-                .build();
-        assertThat(store.chatMemory.getName()).isEqualTo(CoherenceChatMemoryStore.DEFAULT_MAP_NAME);
-
-        store = CoherenceChatMemoryStore.builder()
-                .session(session)
-                .name("  ") // Empty Spaces
-                .build();
-        assertThat(store.chatMemory.getName()).isEqualTo(CoherenceChatMemoryStore.DEFAULT_MAP_NAME);
-
-        store = CoherenceChatMemoryStore.builder()
-                .session(session)
-                .name("  \t\n ")
-                .build();
         assertThat(store.chatMemory.getName()).isEqualTo(CoherenceChatMemoryStore.DEFAULT_MAP_NAME);
     }
 


### PR DESCRIPTION
- Added unit tests to verify default map name behavior when `name` is null, empty, or contains only whitespace in `CoherenceChatMemoryStore`.
- Added test case to confirm that a valid custom name is retained.
- Corrected/improved Javadoc comments for better clarity and consistency.
