### PR TITLE
AI Service: option to execute tools concurrently

### DIFF
--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -548,6 +548,29 @@ The value provided to the AI Service method will be automatically passed to the 
 This feature is useful if you have multiple users and/or multiple chats/memories per user
 and wish to distinguish between them inside the `@Tool` method.
 
+### Executing Tools Concurrently
+
+By default, when the LLM calls multiple tools, the AI Service executes them sequentially.
+If you want the tools to be executed concurrently, you can call
+`executeToolsConcurrently()` or `executeToolsConcurrently(Executor)` when building the AI Service.
+If you enable one of these options, the tools will be executed concurrently (with one exception - see below),
+using either the default or the specified `Executor`.
+
+#### When using `ChatModel`:
+- When the LLM calls multiple tools, they are executed concurrently in separate threads
+using the `Executor`.
+- When the LLM calls a single tool, it is executed in the same (caller) thread,
+the `Executor` is **_not_** used to avoid wasting resources.
+
+#### When using `StreamingChatModel`:
+- When the LLM calls multiple tools, they are executed concurrently in separate threads
+using the `Executor`.
+Each tool is executed as soon as `StreamingChatResponseHandler.onCompleteToolCall(CompleteToolCall)`
+is called, without waiting for other tools or for the response streaming to complete.
+- When the LLM calls a single tool, it is executed in a separate thread using the `Executor`.
+We cannot execute it in the same thread because, at that point,
+we do not yet know how many tools the LLM will call.
+
 ### Accessing Executed Tools
 If you wish to access tools executed during the invocation of an AI Service,
 you can easily do so by wrapping the return type in the `Result` class:

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -550,9 +550,9 @@ and wish to distinguish between them inside the `@Tool` method.
 
 ### Executing Tools Concurrently
 
-By default, when the LLM calls multiple tools, the AI Service executes them sequentially.
-If you want the tools to be executed concurrently, you can call
-`executeToolsConcurrently()` or `executeToolsConcurrently(Executor)` when building the AI Service.
+By default, when the LLM calls **_multiple_** tools at once (also known as parallel tool calling),
+the AI Service executes them sequentially. If you want the tools to be executed concurrently,
+you can call `executeToolsConcurrently()` or `executeToolsConcurrently(Executor)` when building the AI Service.
 If you enable one of these options, the tools will be executed concurrently (with one exception - see below),
 using either the default or the specified `Executor`.
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -166,8 +166,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             } else {
                 for (ToolExecutionRequest toolExecutionRequest : aiMessage.toolExecutionRequests()) {
                     handleBeforeTool(toolExecutionRequest);
-                    // TODO applyToolHallucinationStrategy
                     ToolExecutor toolExecutor = toolExecutors.get(toolExecutionRequest.name());
+                    // TODO applyToolHallucinationStrategy
                     String toolExecutionResult = toolExecutor.execute(toolExecutionRequest, memoryId);
                     handleAfterTool(toolExecutionRequest, toolExecutionResult);
                     addToMemory(ToolExecutionResultMessage.from(toolExecutionRequest, toolExecutionResult));

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -15,6 +15,7 @@ import dev.langchain4j.guardrail.OutputGuardrailRequest;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.TokenUsage;
@@ -24,6 +25,11 @@ import dev.langchain4j.service.tool.ToolExecutor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +63,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     private final List<ToolSpecification> toolSpecifications;
     private final Map<String, ToolExecutor> toolExecutors;
+    private final Executor toolExecutor;
+    private final Queue<CompletableFuture<ToolExecutionResultMessage>> toolResultFutures = new ConcurrentLinkedQueue<>();
+
     private final List<String> responseBuffer = new ArrayList<>();
     private final boolean hasOutputGuardrails;
 
@@ -75,6 +84,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             TokenUsage tokenUsage,
             List<ToolSpecification> toolSpecifications,
             Map<String, ToolExecutor> toolExecutors,
+            Executor toolExecutor,
             GuardrailRequestParams commonGuardrailParams,
             Object methodKey) {
         this.chatExecutor = ensureNotNull(chatExecutor, "chatExecutor");
@@ -96,6 +106,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
         this.toolSpecifications = copy(toolSpecifications);
         this.toolExecutors = copy(toolExecutors);
+        this.toolExecutor = toolExecutor;
+
         this.hasOutputGuardrails = context.guardrailService().hasOutputGuardrails(methodKey);
     }
 
@@ -117,6 +129,21 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     }
 
     @Override
+    public void onCompleteToolCall(CompleteToolCall completeToolCall) {
+        if (toolExecutor != null) {
+            CompletableFuture<ToolExecutionResultMessage> future = CompletableFuture.supplyAsync(() -> {
+                ToolExecutionRequest toolExecutionRequest = completeToolCall.toolExecutionRequest();
+                ToolExecutor toolExecutor = toolExecutors.get(toolExecutionRequest.name());
+                handleBeforeTool(toolExecutionRequest);
+                String toolExecutionResult = toolExecutor.execute(toolExecutionRequest, memoryId);
+                handleAfterTool(toolExecutionRequest, toolExecutionResult);
+                return ToolExecutionResultMessage.from(toolExecutionRequest, toolExecutionResult);
+            }, toolExecutor);
+            toolResultFutures.add(future);
+        }
+    }
+
+    @Override
     public void onCompleteResponse(ChatResponse chatResponse) {
         AiMessage aiMessage = chatResponse.aiMessage();
         addToMemory(aiMessage);
@@ -127,27 +154,25 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 intermediateResponseHandler.accept(chatResponse);
             }
 
-            for (ToolExecutionRequest toolExecutionRequest : aiMessage.toolExecutionRequests()) {
-                if (beforeToolExecutionHandler != null) {
-                    BeforeToolExecution beforeToolExecution = BeforeToolExecution.builder()
-                            .request(toolExecutionRequest)
-                            .build();
-                    beforeToolExecutionHandler.accept(beforeToolExecution);
+            if (toolExecutor == null) {
+                for (ToolExecutionRequest toolExecutionRequest : aiMessage.toolExecutionRequests()) {
+                    handleBeforeTool(toolExecutionRequest);
+                    // TODO applyToolHallucinationStrategy
+                    ToolExecutor toolExecutor = toolExecutors.get(toolExecutionRequest.name());
+                    String toolExecutionResult = toolExecutor.execute(toolExecutionRequest, memoryId);
+                    handleAfterTool(toolExecutionRequest, toolExecutionResult);
+                    ToolExecutionResultMessage toolExecutionResultMessage =
+                            ToolExecutionResultMessage.from(toolExecutionRequest, toolExecutionResult);
+                    addToMemory(toolExecutionResultMessage);
                 }
-
-                String toolName = toolExecutionRequest.name();
-                ToolExecutor toolExecutor = toolExecutors.get(toolName);
-                String toolExecutionResult = toolExecutor.execute(toolExecutionRequest, memoryId);
-                ToolExecutionResultMessage toolExecutionResultMessage =
-                        ToolExecutionResultMessage.from(toolExecutionRequest, toolExecutionResult);
-                addToMemory(toolExecutionResultMessage);
-
-                if (toolExecutionHandler != null) {
-                    ToolExecution toolExecution = ToolExecution.builder()
-                            .request(toolExecutionRequest)
-                            .result(toolExecutionResult)
-                            .build();
-                    toolExecutionHandler.accept(toolExecution);
+            } else {
+                for (CompletableFuture<ToolExecutionResultMessage> toolResultFuture : toolResultFutures) {
+                    try {
+                        ToolExecutionResultMessage toolExecutionResultMessage = toolResultFuture.get();
+                        addToMemory(toolExecutionResultMessage);
+                    } catch (InterruptedException | ExecutionException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
             }
 
@@ -171,6 +196,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     TokenUsage.sum(tokenUsage, chatResponse.metadata().tokenUsage()),
                     toolSpecifications,
                     toolExecutors,
+                    toolExecutor,
                     commonGuardrailParams,
                     methodKey);
 
@@ -213,6 +239,25 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
                 completeResponseHandler.accept(finalChatResponse);
             }
+        }
+    }
+
+    private void handleBeforeTool(ToolExecutionRequest toolExecutionRequest) {
+        if (beforeToolExecutionHandler != null) {
+            BeforeToolExecution beforeToolExecution = BeforeToolExecution.builder()
+                    .request(toolExecutionRequest)
+                    .build();
+            beforeToolExecutionHandler.accept(beforeToolExecution);
+        }
+    }
+
+    private void handleAfterTool(ToolExecutionRequest toolExecutionRequest, String toolExecutionResult) {
+        if (toolExecutionHandler != null) {
+            ToolExecution toolExecution = ToolExecution.builder()
+                    .request(toolExecutionRequest)
+                    .result(toolExecutionResult)
+                    .build();
+            toolExecutionHandler.accept(toolExecution);
         }
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -21,6 +21,7 @@ import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutor;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
 @Internal
@@ -29,6 +30,7 @@ public class AiServiceTokenStream implements TokenStream {
     private final List<ChatMessage> messages;
     private final List<ToolSpecification> toolSpecifications;
     private final Map<String, ToolExecutor> toolExecutors;
+    private final Executor toolExecutor;
     private final List<Content> retrievedContents;
     private final AiServiceContext context;
     private final Object memoryId;
@@ -64,6 +66,7 @@ public class AiServiceTokenStream implements TokenStream {
         this.messages = copy(ensureNotEmpty(parameters.messages(), "messages"));
         this.toolSpecifications = copy(parameters.toolSpecifications());
         this.toolExecutors = copy(parameters.toolExecutors());
+        this.toolExecutor = parameters.toolExecutor();
         this.retrievedContents = copy(parameters.gretrievedContents());
         this.context = ensureNotNull(parameters.context(), "context");
         ensureNotNull(this.context.streamingChatModel, "streamingChatModel");
@@ -166,6 +169,7 @@ public class AiServiceTokenStream implements TokenStream {
                 new TokenUsage(),
                 toolSpecifications,
                 toolExecutors,
+                toolExecutor,
                 commonGuardrailParams,
                 methodKey);
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStreamParameters.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStreamParameters.java
@@ -8,6 +8,7 @@ import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.service.tool.ToolExecutor;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 /**
  * Parameters for creating an {@link AiServiceTokenStream}.
@@ -18,6 +19,7 @@ public class AiServiceTokenStreamParameters {
     private final List<ChatMessage> messages;
     private final List<ToolSpecification> toolSpecifications;
     private final Map<String, ToolExecutor> toolExecutors;
+    private final Executor toolExecutor;
     private final List<Content> retrievedContents;
     private final AiServiceContext context;
     private final Object memoryId;
@@ -28,6 +30,7 @@ public class AiServiceTokenStreamParameters {
         this.messages = builder.messages;
         this.toolSpecifications = builder.toolSpecifications;
         this.toolExecutors = builder.toolExecutors;
+        this.toolExecutor = builder.toolExecutor;
         this.retrievedContents = builder.retrievedContents;
         this.context = builder.context;
         this.memoryId = builder.memoryId;
@@ -54,6 +57,13 @@ public class AiServiceTokenStreamParameters {
      */
     public Map<String, ToolExecutor> toolExecutors() {
         return toolExecutors;
+    }
+
+    /**
+     * @since 1.4.0
+     */
+    public Executor toolExecutor() {
+        return toolExecutor;
     }
 
     /**
@@ -114,6 +124,7 @@ public class AiServiceTokenStreamParameters {
         private List<ChatMessage> messages;
         private List<ToolSpecification> toolSpecifications;
         private Map<String, ToolExecutor> toolExecutors;
+        private Executor toolExecutor;
         private List<Content> retrievedContents;
         private AiServiceContext context;
         private Object memoryId;
@@ -152,6 +163,14 @@ public class AiServiceTokenStreamParameters {
          */
         public Builder toolExecutors(Map<String, ToolExecutor> toolExecutors) {
             this.toolExecutors = toolExecutors;
+            return this;
+        }
+
+        /**
+         * @since 1.4.0
+         */
+        public Builder toolExecutor(Executor toolExecutor) {
+            this.toolExecutor = toolExecutor;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -386,7 +386,7 @@ public abstract class AiServices<T> {
 
     /**
      * By default, when the LLM calls multiple tools, the AI Service executes them sequentially.
-     * If you enable this option, tools will be executed concurrently (with one exception, see below),
+     * If you enable this option, tools will be executed concurrently (with one exception - see below),
      * using the default {@link Executor}.
      * You can also specify your own {@link Executor}, see {@link #executeToolsConcurrently(Executor)}.
      * <ul>

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -22,6 +22,8 @@ import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.input.structured.StructuredPrompt;
 import dev.langchain4j.model.moderation.Moderation;
 import dev.langchain4j.model.moderation.ModerationModel;
@@ -39,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -378,6 +381,55 @@ public abstract class AiServices<T> {
      */
     public AiServices<T> tools(Map<ToolSpecification, ToolExecutor> tools) {
         context.toolService.tools(tools);
+        return this;
+    }
+
+    /**
+     * By default, when the LLM calls multiple tools, the AI Service executes them sequentially.
+     * If you enable this option, tools will be executed concurrently (with one exception, see below),
+     * using the default {@link Executor}. TODO
+     * You can also specify your own {@link Executor}, see {@link #executeToolsConcurrently(Executor)}.
+     * <ul>
+     *     <li>When using {@link ChatModel}:</li>
+     *     <ul>
+     *         <li>When the LLM calls multiple tools, they are executed concurrently in separate threads
+     *             using the {@link Executor}.</li>
+     *         <li>When the LLM calls a single tool, it is executed in the same (caller) thread,
+     *             the {@link Executor} is not used to avoid wasting resources.</li>
+     *     </ul>
+     *     <li>When using {@link StreamingChatModel}:</li>
+     *     <ul>
+     *         <li>When the LLM calls multiple tools, they are executed concurrently in separate threads
+     *             using the {@link Executor}.
+     *             Each tool is executed as soon as {@link StreamingChatResponseHandler#onCompleteToolCall(CompleteToolCall)}
+     *             is called, without waiting for other tools or for the response streaming to complete.</li>
+     *         <li>When the LLM calls a single tool, it is executed in a separate thread using the {@link Executor}.
+     *             We cannot execute it in the same thread because, at that point,
+     *             we do not yet know how many tools the LLM will call.</li>
+     *     </ul>
+     * </ul>
+     *
+     * @return builder
+     * @see #executeToolsConcurrently(Executor)
+     * @since 1.4.0
+     */
+    public AiServices<T> executeToolsConcurrently() {
+        context.toolService.executeToolsConcurrently();
+        return this;
+    }
+
+    /**
+     * See {@link #executeToolsConcurrently()}'s Javadoc for more info.
+     * <p>
+     * If {@code null} is specified, the default {@link Executor} will be used. TODO
+     *
+     * @param executor The {@link Executor} to be used to execute tools.
+     * @return builder
+     * @see #executeToolsConcurrently()
+     * @since 1.4.0
+     */
+    public AiServices<T> executeToolsConcurrently(Executor executor) {
+        context.toolService.executeToolsConcurrently(executor);
         return this;
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -387,7 +387,7 @@ public abstract class AiServices<T> {
     /**
      * By default, when the LLM calls multiple tools, the AI Service executes them sequentially.
      * If you enable this option, tools will be executed concurrently (with one exception, see below),
-     * using the default {@link Executor}. TODO
+     * using the default {@link Executor}.
      * You can also specify your own {@link Executor}, see {@link #executeToolsConcurrently(Executor)}.
      * <ul>
      *     <li>When using {@link ChatModel}:</li>
@@ -421,7 +421,7 @@ public abstract class AiServices<T> {
     /**
      * See {@link #executeToolsConcurrently()}'s Javadoc for more info.
      * <p>
-     * If {@code null} is specified, the default {@link Executor} will be used. TODO
+     * If {@code null} is specified, the default {@link Executor} will be used.
      *
      * @param executor The {@link Executor} to be used to execute tools.
      * @return builder

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -192,12 +192,11 @@ class DefaultAiServices<T> extends AiServices<T> {
                         userMessage = invokeInputGuardrails(
                                 context.guardrailService(), method, userMessage, commonGuardrailParam);
 
-                        // TODO give user ability to provide custom OutputParser
                         Type returnType = method.getGenericReturnType();
                         boolean streaming = returnType == TokenStream.class || canAdaptTokenStreamTo(returnType);
 
-                        boolean supportsJsonSchema = supportsJsonSchema(); // TODO should it be called for
-                        // returnType==String?
+                        // TODO should it be called when returnType==String?
+                        boolean supportsJsonSchema = supportsJsonSchema();
 
                         Optional<JsonSchema> jsonSchema = Optional.empty();
                         if (supportsJsonSchema && !streaming) {
@@ -228,6 +227,7 @@ class DefaultAiServices<T> extends AiServices<T> {
                                     .messages(messages)
                                     .toolSpecifications(toolServiceContext.toolSpecifications())
                                     .toolExecutors(toolServiceContext.toolExecutors())
+                                    .toolExecutor(context.toolService.executor())
                                     .retrievedContents(
                                             augmentationResult != null ? augmentationResult.contents() : null)
                                     .context(context)

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Function;
@@ -91,17 +90,25 @@ public class ToolService {
      * @since 1.4.0
      */
     public void executeToolsConcurrently() {
-        this.executor = createDefaultExecutor();
+        this.executor = defaultExecutor();
     }
 
     /**
      * @since 1.4.0
      */
     public void executeToolsConcurrently(Executor executor) {
-        this.executor = getOrDefault(executor, ToolService::createDefaultExecutor);
+        this.executor = getOrDefault(executor, ToolService::defaultExecutor);
     }
 
-    private static ExecutorService createDefaultExecutor() {
+    private static Executor defaultExecutor() {
+        return DefaultExecutorHolder.INSTANCE;
+    }
+
+    private static class DefaultExecutorHolder {
+        private static final Executor INSTANCE = createDefaultExecutor();
+    }
+
+    private static Executor createDefaultExecutor() {
         return new ThreadPoolExecutor(
                 0, Integer.MAX_VALUE,
                 1, SECONDS,

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -233,7 +233,7 @@ public class ToolService {
         }
     }
 
-    private Map<ToolExecutionRequest, ToolExecutionResultMessage> executeConcurrently( // TODO name
+    private Map<ToolExecutionRequest, ToolExecutionResultMessage> executeConcurrently(
             List<ToolExecutionRequest> toolExecutionRequests,
             Map<String, ToolExecutor> toolExecutors,
             Object memoryId) {
@@ -256,17 +256,17 @@ public class ToolService {
             try {
                 results.put(entry.getKey(), entry.getValue().get());
             } catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e); // TODO
+                throw new RuntimeException(e);
             }
         }
 
         return results;
     }
 
-    private Map<ToolExecutionRequest, ToolExecutionResultMessage> executeSequentially( // TODO name
-                                                                                       List<ToolExecutionRequest> toolExecutionRequests,
-                                                                                       Map<String, ToolExecutor> toolExecutors,
-                                                                                       Object memoryId) {
+    private Map<ToolExecutionRequest, ToolExecutionResultMessage> executeSequentially(
+            List<ToolExecutionRequest> toolExecutionRequests,
+            Map<String, ToolExecutor> toolExecutors,
+            Object memoryId) {
         Map<ToolExecutionRequest, ToolExecutionResultMessage> toolResults = new LinkedHashMap<>();
         for (ToolExecutionRequest toolExecutionRequest : toolExecutionRequests) {
             ToolExecutor toolExecutor = toolExecutors.get(toolExecutionRequest.name());

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -3,7 +3,9 @@ package dev.langchain4j.service.tool;
 import static dev.langchain4j.agent.tool.ToolSpecifications.toolSpecificationFrom;
 import static dev.langchain4j.internal.Exceptions.runtime;
 import static dev.langchain4j.internal.Utils.getAnnotatedMethod;
+import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.Tool;
@@ -24,9 +26,15 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Function;
 
 @Internal
@@ -35,6 +43,8 @@ public class ToolService {
     private final List<ToolSpecification> toolSpecifications = new ArrayList<>();
     private final Map<String, ToolExecutor> toolExecutors = new HashMap<>();
     private ToolProvider toolProvider;
+    private boolean executeToolsConcurrently;
+    private Executor executor;
     private int maxSequentialToolsInvocations = 100;
 
     private Function<ToolExecutionRequest, ToolExecutionResultMessage> toolHallucinationStrategy =
@@ -76,6 +86,30 @@ public class ToolService {
         }
         toolExecutors.put(toolSpecification.name(), new DefaultToolExecutor(objectWithTool, method));
         toolSpecifications.add(toolSpecificationFrom(method));
+    }
+
+    /**
+     * @since 1.4.0
+     */
+    public void executeToolsConcurrently() {
+        this.executeToolsConcurrently = true;
+        this.executor = createDefaultExecutor();
+    }
+
+    /**
+     * @since 1.4.0
+     */
+    public void executeToolsConcurrently(Executor executor) {
+        this.executeToolsConcurrently = true;
+        this.executor = getOrDefault(executor, ToolService::createDefaultExecutor);
+    }
+
+    private static ExecutorService createDefaultExecutor() { // TODO rethink params
+        return new ThreadPoolExecutor(
+                0, Integer.MAX_VALUE,
+                1, SECONDS,
+                new SynchronousQueue<>()
+        );
     }
 
     public void maxSequentialToolsInvocations(int maxSequentialToolsInvocations) {
@@ -143,23 +177,22 @@ public class ToolService {
 
             intermediateResponses.add(chatResponse);
 
-            for (ToolExecutionRequest toolExecutionRequest : aiMessage.toolExecutionRequests()) {
-                ToolExecutor toolExecutor = toolExecutors.get(toolExecutionRequest.name());
+            Map<ToolExecutionRequest, ToolExecutionResultMessage> toolResults =
+                    execute(aiMessage.toolExecutionRequests(), toolExecutors, memoryId);
 
-                ToolExecutionResultMessage toolExecutionResultMessage = toolExecutor == null
-                        ? applyToolHallucinationStrategy(toolExecutionRequest)
-                        : ToolExecutionResultMessage.from(
-                                toolExecutionRequest, toolExecutor.execute(toolExecutionRequest, memoryId));
+            for (Map.Entry<ToolExecutionRequest, ToolExecutionResultMessage> entry : toolResults.entrySet()) {
+                ToolExecutionResultMessage result = entry.getValue();
 
-                toolExecutions.add(ToolExecution.builder()
-                        .request(toolExecutionRequest)
-                        .result(toolExecutionResultMessage.text())
-                        .build());
+                ToolExecution toolExecution = ToolExecution.builder()
+                        .request(entry.getKey())
+                        .result(result.text())
+                        .build();
+                toolExecutions.add(toolExecution);
 
                 if (chatMemory != null) {
-                    chatMemory.add(toolExecutionResultMessage);
+                    chatMemory.add(result);
                 } else {
-                    messages.add(toolExecutionResultMessage);
+                    messages.add(result);
                 }
             }
 
@@ -184,6 +217,68 @@ public class ToolService {
                 .build();
     }
 
+    private Map<ToolExecutionRequest, ToolExecutionResultMessage> execute(
+            List<ToolExecutionRequest> toolExecutionRequests,
+            Map<String, ToolExecutor> toolExecutors,
+            Object memoryId) {
+        if (executeToolsConcurrently) {
+            if (toolExecutionRequests.size() > 1) {
+                return executeConcurrently(toolExecutionRequests, toolExecutors, memoryId);
+            } else {
+                // when there is only one tool to execute, it doesn't make sense to do it in a separate thread
+                return executeSequentially(toolExecutionRequests, toolExecutors, memoryId);
+            }
+        } else {
+            return executeSequentially(toolExecutionRequests, toolExecutors, memoryId);
+        }
+    }
+
+    private Map<ToolExecutionRequest, ToolExecutionResultMessage> executeConcurrently( // TODO name
+            List<ToolExecutionRequest> toolExecutionRequests,
+            Map<String, ToolExecutor> toolExecutors,
+            Object memoryId) {
+        Map<ToolExecutionRequest, CompletableFuture<ToolExecutionResultMessage>> futures = new LinkedHashMap<>();
+
+        for (ToolExecutionRequest toolExecutionRequest : toolExecutionRequests) {
+            CompletableFuture<ToolExecutionResultMessage> future = CompletableFuture.supplyAsync(() -> {
+                ToolExecutor toolExecutor = toolExecutors.get(toolExecutionRequest.name());
+                return toolExecutor == null
+                        ? applyToolHallucinationStrategy(toolExecutionRequest)
+                        : ToolExecutionResultMessage.from(
+                        toolExecutionRequest,
+                        toolExecutor.execute(toolExecutionRequest, memoryId));
+            }, executor);
+            futures.put(toolExecutionRequest, future);
+        }
+
+        Map<ToolExecutionRequest, ToolExecutionResultMessage> results = new LinkedHashMap<>();
+        for (Map.Entry<ToolExecutionRequest, CompletableFuture<ToolExecutionResultMessage>> entry : futures.entrySet()) {
+            try {
+                results.put(entry.getKey(), entry.getValue().get());
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e); // TODO
+            }
+        }
+
+        return results;
+    }
+
+    private Map<ToolExecutionRequest, ToolExecutionResultMessage> executeSequentially( // TODO name
+                                                                                       List<ToolExecutionRequest> toolExecutionRequests,
+                                                                                       Map<String, ToolExecutor> toolExecutors,
+                                                                                       Object memoryId) {
+        Map<ToolExecutionRequest, ToolExecutionResultMessage> toolResults = new LinkedHashMap<>();
+        for (ToolExecutionRequest toolExecutionRequest : toolExecutionRequests) {
+            ToolExecutor toolExecutor = toolExecutors.get(toolExecutionRequest.name());
+            ToolExecutionResultMessage toolExecutionResultMessage = toolExecutor == null
+                    ? applyToolHallucinationStrategy(toolExecutionRequest)
+                    : ToolExecutionResultMessage.from(
+                    toolExecutionRequest, toolExecutor.execute(toolExecutionRequest, memoryId));
+            toolResults.put(toolExecutionRequest, toolExecutionResultMessage);
+        }
+        return toolResults;
+    }
+
     public ToolExecutionResultMessage applyToolHallucinationStrategy(ToolExecutionRequest toolExecutionRequest) {
         return toolHallucinationStrategy.apply(toolExecutionRequest);
     }
@@ -194,6 +289,13 @@ public class ToolService {
 
     public Map<String, ToolExecutor> toolExecutors() {
         return toolExecutors;
+    }
+
+    /**
+     * @since 1.4.0
+     */
+    public Executor executor() {
+        return executor;
     }
 
     public ToolProvider toolProvider() {

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
@@ -455,34 +455,6 @@ class AiServicesWithToolsIT {
         assertThat(getCurrentTemperatureThread).isNotEqualTo(Thread.currentThread());
 
         assertThat(getCurrentTimeThread).isNotEqualTo(getCurrentTemperatureThread);
-
-        List<ChatMessage> messages = chatMemory.messages();
-        assertThat(messages).hasSize(5);
-
-        assertThat(messages.get(0)).isInstanceOf(dev.langchain4j.data.message.UserMessage.class);
-        assertThat(((UserMessage) messages.get(0)).singleText()).isEqualTo(userMessage);
-
-        AiMessage aiMessage = (AiMessage) messages.get(1);
-        assertThat(aiMessage.text()).isNull();
-        assertThat(aiMessage.toolExecutionRequests()).hasSize(2);
-
-        ToolExecutionRequest firstToolExecutionRequest = aiMessage.toolExecutionRequests().get(0);
-        assertThat(firstToolExecutionRequest.name()).isEqualTo("getCurrentTime");
-        assertThat(firstToolExecutionRequest.arguments()).isEqualToIgnoringWhitespace("{\"arg0\": \"Munich\"}");
-
-        ToolExecutionRequest secondToolExecutionRequest = aiMessage.toolExecutionRequests().get(1);
-        assertThat(secondToolExecutionRequest.name()).isEqualTo("getCurrentTemperature");
-        assertThat(secondToolExecutionRequest.arguments()).isEqualToIgnoringWhitespace("{\"arg0\": \"Munich\"}");
-
-        ToolExecutionResultMessage firstToolExecutionResultMessage = (ToolExecutionResultMessage) messages.get(2);
-        assertThat(firstToolExecutionResultMessage.id()).isEqualTo(firstToolExecutionRequest.id());
-        assertThat(firstToolExecutionResultMessage.toolName()).isEqualTo("getCurrentTime");
-        assertThat(firstToolExecutionResultMessage.text()).isEqualTo(Tools.CURRENT_TIME);
-
-        ToolExecutionResultMessage secondToolExecutionResultMessage = (ToolExecutionResultMessage) messages.get(3);
-        assertThat(secondToolExecutionResultMessage.id()).isEqualTo(secondToolExecutionRequest.id());
-        assertThat(secondToolExecutionResultMessage.toolName()).isEqualTo("getCurrentTemperature");
-        assertThat(secondToolExecutionResultMessage.text()).isEqualTo(Tools.CURRENT_TEMPERATURE);
     }
 
     static List<Executor> executors() {
@@ -532,25 +504,6 @@ class AiServicesWithToolsIT {
 
         assertThat(spyTools.getCurrentTemperatureThreads).hasSize(1);
         assertThat(spyTools.getCurrentTemperatureThreads.poll()).isEqualTo(Thread.currentThread());
-
-        List<ChatMessage> messages = chatMemory.messages();
-        assertThat(messages).hasSize(4);
-
-        assertThat(messages.get(0)).isInstanceOf(dev.langchain4j.data.message.UserMessage.class);
-        assertThat(((UserMessage) messages.get(0)).singleText()).isEqualTo(userMessage);
-
-        AiMessage aiMessage = (AiMessage) messages.get(1);
-        assertThat(aiMessage.text()).isNull();
-        assertThat(aiMessage.toolExecutionRequests()).hasSize(1);
-
-        ToolExecutionRequest toolExecutionRequest = aiMessage.toolExecutionRequests().get(0);
-        assertThat(toolExecutionRequest.name()).isEqualTo("getCurrentTemperature");
-        assertThat(toolExecutionRequest.arguments()).isEqualToIgnoringWhitespace("{\"arg0\": \"Munich\"}");
-
-        ToolExecutionResultMessage toolExecutionResultMessage = (ToolExecutionResultMessage) messages.get(2);
-        assertThat(toolExecutionResultMessage.id()).isEqualTo(toolExecutionRequest.id());
-        assertThat(toolExecutionResultMessage.toolName()).isEqualTo("getCurrentTemperature");
-        assertThat(toolExecutionResultMessage.text()).isEqualTo(Tools.CURRENT_TEMPERATURE);
     }
 
     static class IntegerListProcessor {

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
@@ -48,12 +48,17 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -103,6 +108,8 @@ class AiServicesWithToolsIT {
 
     static class TransactionService {
 
+        final Queue<Thread> threads = new ConcurrentLinkedQueue<>();
+
         static ToolSpecification EXPECTED_SPECIFICATION = ToolSpecification.builder()
                 .name("getTransactionAmount")
                 .description("returns amount of a given transaction")
@@ -114,6 +121,7 @@ class AiServicesWithToolsIT {
 
         @Tool("returns amount of a given transaction")
         double getTransactionAmount(@P("ID of a transaction") String id) {
+            threads.add(Thread.currentThread());
             System.out.printf("called getTransactionAmount(%s)%n", id);
             switch (id) {
                 case "T001":
@@ -152,6 +160,9 @@ class AiServicesWithToolsIT {
 
         verify(transactionService).getTransactionAmount("T001");
         verifyNoMoreInteractions(transactionService);
+
+        assertThat(transactionService.threads).hasSize(1);
+        assertThat(transactionService.threads.poll()).isEqualTo(Thread.currentThread());
 
         List<ChatMessage> messages = chatMemory.messages();
         assertThat(messages).hasSize(4);
@@ -243,6 +254,10 @@ class AiServicesWithToolsIT {
         verify(transactionService).getTransactionAmount("T002");
         verifyNoMoreInteractions(transactionService);
 
+        assertThat(transactionService.threads).hasSize(2);
+        assertThat(transactionService.threads.poll()).isEqualTo(Thread.currentThread());
+        assertThat(transactionService.threads.poll()).isEqualTo(Thread.currentThread());
+
         List<ChatMessage> messages = chatMemory.messages();
         assertThat(messages).hasSize(6);
 
@@ -331,6 +346,10 @@ class AiServicesWithToolsIT {
         verify(transactionService).getTransactionAmount("T002");
         verifyNoMoreInteractions(transactionService);
 
+        assertThat(transactionService.threads).hasSize(2);
+        assertThat(transactionService.threads.poll()).isEqualTo(Thread.currentThread());
+        assertThat(transactionService.threads.poll()).isEqualTo(Thread.currentThread());
+
         List<ChatMessage> messages = chatMemory.messages();
         assertThat(messages).hasSize(5);
 
@@ -375,6 +394,163 @@ class AiServicesWithToolsIT {
                         .messages(messages.get(0), messages.get(1), messages.get(2), messages.get(3))
                         .toolSpecifications(EXPECTED_SPECIFICATION)
                         .build());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @MethodSource("executors")
+    void should_execute_multiple_tools_in_parallel_concurrently_then_answer(Executor executor) {
+
+        // given
+        class Tools {
+
+            static final String CURRENT_TIME = "16:28";
+            static final String CURRENT_TEMPERATURE = "17";
+
+            final Queue<Thread> getCurrentTimeThreads = new ConcurrentLinkedQueue<>();
+            final Queue<Thread> getCurrentTemperatureThreads = new ConcurrentLinkedQueue<>();
+
+            @Tool
+            String getCurrentTime(String city) {
+                getCurrentTimeThreads.add(Thread.currentThread());
+                return CURRENT_TIME;
+            }
+
+            @Tool
+            String getCurrentTemperature(String city) {
+                getCurrentTemperatureThreads.add(Thread.currentThread());
+                return CURRENT_TEMPERATURE;
+            }
+        }
+
+        Tools spyTools = spy(new Tools());
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(models().findFirst().get())
+                .chatMemory(chatMemory)
+                .tools(spyTools)
+                .executeToolsConcurrently(executor)
+                .build();
+
+        String userMessage = "What is the current time and temperature in Munich?";
+
+        // when
+        Result<String> result = assistant.chat(userMessage);
+
+        // then
+        assertThat(result.content()).contains(Tools.CURRENT_TIME, Tools.CURRENT_TEMPERATURE);
+
+        verify(spyTools).getCurrentTime("Munich");
+        verify(spyTools).getCurrentTemperature("Munich");
+        verifyNoMoreInteractions(spyTools);
+
+        assertThat(spyTools.getCurrentTimeThreads).hasSize(1);
+        Thread getCurrentTimeThread = spyTools.getCurrentTimeThreads.poll();
+        assertThat(getCurrentTimeThread).isNotEqualTo(Thread.currentThread());
+
+        assertThat(spyTools.getCurrentTemperatureThreads).hasSize(1);
+        Thread getCurrentTemperatureThread = spyTools.getCurrentTemperatureThreads.poll();
+        assertThat(getCurrentTemperatureThread).isNotEqualTo(Thread.currentThread());
+
+        assertThat(getCurrentTimeThread).isNotEqualTo(getCurrentTemperatureThread);
+
+        List<ChatMessage> messages = chatMemory.messages();
+        assertThat(messages).hasSize(5);
+
+        assertThat(messages.get(0)).isInstanceOf(dev.langchain4j.data.message.UserMessage.class);
+        assertThat(((UserMessage) messages.get(0)).singleText()).isEqualTo(userMessage);
+
+        AiMessage aiMessage = (AiMessage) messages.get(1);
+        assertThat(aiMessage.text()).isNull();
+        assertThat(aiMessage.toolExecutionRequests()).hasSize(2);
+
+        ToolExecutionRequest firstToolExecutionRequest = aiMessage.toolExecutionRequests().get(0);
+        assertThat(firstToolExecutionRequest.name()).isEqualTo("getCurrentTime");
+        assertThat(firstToolExecutionRequest.arguments()).isEqualToIgnoringWhitespace("{\"arg0\": \"Munich\"}");
+
+        ToolExecutionRequest secondToolExecutionRequest = aiMessage.toolExecutionRequests().get(1);
+        assertThat(secondToolExecutionRequest.name()).isEqualTo("getCurrentTemperature");
+        assertThat(secondToolExecutionRequest.arguments()).isEqualToIgnoringWhitespace("{\"arg0\": \"Munich\"}");
+
+        ToolExecutionResultMessage firstToolExecutionResultMessage = (ToolExecutionResultMessage) messages.get(2);
+        assertThat(firstToolExecutionResultMessage.id()).isEqualTo(firstToolExecutionRequest.id());
+        assertThat(firstToolExecutionResultMessage.toolName()).isEqualTo("getCurrentTime");
+        assertThat(firstToolExecutionResultMessage.text()).isEqualTo(Tools.CURRENT_TIME);
+
+        ToolExecutionResultMessage secondToolExecutionResultMessage = (ToolExecutionResultMessage) messages.get(3);
+        assertThat(secondToolExecutionResultMessage.id()).isEqualTo(secondToolExecutionRequest.id());
+        assertThat(secondToolExecutionResultMessage.toolName()).isEqualTo("getCurrentTemperature");
+        assertThat(secondToolExecutionResultMessage.text()).isEqualTo(Tools.CURRENT_TEMPERATURE);
+    }
+
+    static List<Executor> executors() {
+        return List.of(Executors.newFixedThreadPool(2));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @MethodSource("executors")
+    void should_execute_single_tool_in_the_same_thread(Executor executor) {
+
+        // given
+        class Tools {
+
+            static final String CURRENT_TEMPERATURE = "17";
+
+            final Queue<Thread> getCurrentTemperatureThreads = new ConcurrentLinkedQueue<>();
+
+            @Tool
+            String getCurrentTemperature(String city) {
+                getCurrentTemperatureThreads.add(Thread.currentThread());
+                return CURRENT_TEMPERATURE;
+            }
+        }
+
+        Tools spyTools = spy(new Tools());
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(models().findFirst().get())
+                .chatMemory(chatMemory)
+                .tools(spyTools)
+                .executeToolsConcurrently(executor)
+                .build();
+
+        String userMessage = "What is the current temperature in Munich?";
+
+        // when
+        Result<String> result = assistant.chat(userMessage);
+
+        // then
+        assertThat(result.content()).contains(Tools.CURRENT_TEMPERATURE);
+
+        verify(spyTools).getCurrentTemperature("Munich");
+        verifyNoMoreInteractions(spyTools);
+
+        assertThat(spyTools.getCurrentTemperatureThreads).hasSize(1);
+        assertThat(spyTools.getCurrentTemperatureThreads.poll()).isEqualTo(Thread.currentThread());
+
+        List<ChatMessage> messages = chatMemory.messages();
+        assertThat(messages).hasSize(4);
+
+        assertThat(messages.get(0)).isInstanceOf(dev.langchain4j.data.message.UserMessage.class);
+        assertThat(((UserMessage) messages.get(0)).singleText()).isEqualTo(userMessage);
+
+        AiMessage aiMessage = (AiMessage) messages.get(1);
+        assertThat(aiMessage.text()).isNull();
+        assertThat(aiMessage.toolExecutionRequests()).hasSize(1);
+
+        ToolExecutionRequest toolExecutionRequest = aiMessage.toolExecutionRequests().get(0);
+        assertThat(toolExecutionRequest.name()).isEqualTo("getCurrentTemperature");
+        assertThat(toolExecutionRequest.arguments()).isEqualToIgnoringWhitespace("{\"arg0\": \"Munich\"}");
+
+        ToolExecutionResultMessage toolExecutionResultMessage = (ToolExecutionResultMessage) messages.get(2);
+        assertThat(toolExecutionResultMessage.id()).isEqualTo(toolExecutionRequest.id());
+        assertThat(toolExecutionResultMessage.toolName()).isEqualTo("getCurrentTemperature");
+        assertThat(toolExecutionResultMessage.text()).isEqualTo(Tools.CURRENT_TEMPERATURE);
     }
 
     static class IntegerListProcessor {

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -23,16 +22,17 @@ import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
-import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
@@ -40,12 +40,17 @@ import dev.langchain4j.service.tool.ToolProviderResult;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.InOrder;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
@@ -70,6 +75,8 @@ class StreamingAiServicesWithToolsIT {
 
     static class TransactionService {
 
+        final Queue<Thread> threads = new ConcurrentLinkedQueue<>();
+
         static ToolSpecification EXPECTED_SPECIFICATION = ToolSpecification.builder()
                 .name("getTransactionAmount")
                 .description("returns amount of a given transaction")
@@ -81,6 +88,7 @@ class StreamingAiServicesWithToolsIT {
 
         @Tool("returns amount of a given transaction")
         Double getTransactionAmount(@P("ID of a transaction") String id) {
+            threads.add(Thread.currentThread());
             System.out.printf("called getTransactionAmount(%s)%n", id);
             return switch (id) {
                 case "T001" -> 11.1;
@@ -109,13 +117,24 @@ class StreamingAiServicesWithToolsIT {
 
         String userMessage = "What is the amounts of transaction T001?";
 
-        // when
+        TestTokenStreamHandler handler = spy(new TestTokenStreamHandler());
         CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
-        assistant
-                .chat(userMessage)
-                .onPartialResponse(ignored -> {})
-                .onCompleteResponse(futureResponse::complete)
-                .onError(futureResponse::completeExceptionally)
+
+        // when
+        assistant.chat(userMessage)
+                .onPartialResponse(handler::onPartialResponse)
+                .onPartialThinking(handler::onPartialThinking)
+                .onIntermediateResponse(handler::onIntermediateResponse)
+                .beforeToolExecution(handler::beforeToolExecution)
+                .onToolExecuted(handler::onToolExecuted)
+                .onCompleteResponse(completeResponse -> {
+                    handler.onCompleteResponse(completeResponse);
+                    futureResponse.complete(completeResponse);
+                })
+                .onError(error -> {
+                    handler.onError(error);
+                    futureResponse.completeExceptionally(error);
+                })
                 .start();
         ChatResponse response = futureResponse.get(60, SECONDS);
 
@@ -125,6 +144,12 @@ class StreamingAiServicesWithToolsIT {
         // then
         verify(transactionService).getTransactionAmount("T001");
         verifyNoMoreInteractions(transactionService);
+
+        // then
+        assertThat(handler.allThreads).hasSize(1);
+        assertThat(handler.allThreads.iterator().next()).isNotEqualTo(Thread.currentThread());
+        assertThat(transactionService.threads).hasSize(1);
+        assertThat(transactionService.threads.poll()).isEqualTo(handler.allThreads.iterator().next());
 
         // then
         List<ChatMessage> messages = chatMemory.messages();
@@ -142,6 +167,233 @@ class StreamingAiServicesWithToolsIT {
                                 .toolSpecifications(EXPECTED_SPECIFICATION)
                                 .build()),
                         any());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @MethodSource("executors")
+    void should_execute_multiple_tools_in_parallel_concurrently_then_answer(Executor executor) throws Exception {
+
+        // given
+        class Tools {
+
+            static final String CURRENT_TIME = "16:28";
+            static final String CURRENT_TEMPERATURE = "17";
+
+            final Queue<Thread> getCurrentTimeThreads = new ConcurrentLinkedQueue<>();
+            final Queue<Thread> getCurrentTemperatureThreads = new ConcurrentLinkedQueue<>();
+
+            @Tool
+            String getCurrentTime(String city) {
+                getCurrentTimeThreads.add(Thread.currentThread());
+                return CURRENT_TIME;
+            }
+
+            @Tool
+            String getCurrentTemperature(String city) {
+                getCurrentTemperatureThreads.add(Thread.currentThread());
+                return CURRENT_TEMPERATURE;
+            }
+        }
+
+        Tools spyTools = spy(new Tools());
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .streamingChatModel(models().findFirst().get())
+                .chatMemory(chatMemory)
+                .tools(spyTools)
+                .executeToolsConcurrently(executor)
+                .build();
+
+        String userMessage = "What is the current time and temperature in Munich?";
+
+        TestTokenStreamHandler handler = spy(new TestTokenStreamHandler());
+        CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
+
+        // when
+        assistant.chat(userMessage)
+                .onPartialResponse(handler::onPartialResponse)
+                .onPartialThinking(handler::onPartialThinking)
+                .onIntermediateResponse(handler::onIntermediateResponse)
+                .beforeToolExecution(handler::beforeToolExecution)
+                .onToolExecuted(handler::onToolExecuted)
+                .onCompleteResponse(completeResponse -> {
+                    handler.onCompleteResponse(completeResponse);
+                    futureResponse.complete(completeResponse);
+                })
+                .onError(error -> {
+                    handler.onError(error);
+                    futureResponse.completeExceptionally(error);
+                })
+                .start();
+        ChatResponse response = futureResponse.get(60, SECONDS);
+
+        // then
+        assertThat(response.aiMessage().text()).contains(Tools.CURRENT_TIME, Tools.CURRENT_TEMPERATURE);
+
+        // then
+        InOrder inOrder = inOrder(handler, spyTools);
+        inOrder.verify(handler).beforeToolExecution(argThat(bte -> bte.request().name().equals("getCurrentTime")));
+        inOrder.verify(spyTools).getCurrentTime("Munich");
+        inOrder.verify(handler).onToolExecuted(argThat(te -> te.request().name().equals("getCurrentTime")));
+
+        InOrder inOrder2 = inOrder(handler, spyTools);
+        inOrder2.verify(handler).beforeToolExecution(argThat(bte -> bte.request().name().equals("getCurrentTemperature")));
+        inOrder2.verify(spyTools).getCurrentTemperature("Munich");
+        inOrder2.verify(handler).onToolExecuted(argThat(te -> te.request().name().equals("getCurrentTemperature")));
+
+        // then
+        assertThat(handler.allThreads).hasSize(3); // 1 for handler, 2 for tools
+
+        assertThat(handler.beforeToolExecutionThreads).hasSize(2);
+        assertThat(handler.beforeToolExecutionThreads.get("getCurrentTime")).hasSize(1);
+        assertThat(handler.beforeToolExecutionThreads.get("getCurrentTemperature")).hasSize(1);
+
+        assertThat(handler.onToolExecutedThreads).hasSize(2);
+        assertThat(handler.onToolExecutedThreads.get("getCurrentTime")).hasSize(1);
+        assertThat(handler.onToolExecutedThreads.get("getCurrentTemperature")).hasSize(1);
+
+        assertThat(spyTools.getCurrentTimeThreads).hasSize(1);
+        Thread getCurrentTimeThread = spyTools.getCurrentTimeThreads.poll();
+        assertThat(getCurrentTimeThread).isEqualTo(handler.beforeToolExecutionThreads.get("getCurrentTime").iterator().next());
+        assertThat(getCurrentTimeThread).isEqualTo(handler.onToolExecutedThreads.get("getCurrentTime").iterator().next());
+
+        assertThat(spyTools.getCurrentTemperatureThreads).hasSize(1);
+        Thread getCurrentTemperatureThread = spyTools.getCurrentTemperatureThreads.poll();
+        assertThat(getCurrentTemperatureThread).isEqualTo(handler.beforeToolExecutionThreads.get("getCurrentTemperature").iterator().next());
+        assertThat(getCurrentTemperatureThread).isEqualTo(handler.onToolExecutedThreads.get("getCurrentTemperature").iterator().next());
+
+        assertThat(getCurrentTimeThread).isNotEqualTo(getCurrentTemperatureThread);
+
+        // then
+        List<ChatMessage> messages = chatMemory.messages();
+        assertThat(messages).hasSize(5);
+
+        assertThat(messages.get(0)).isInstanceOf(dev.langchain4j.data.message.UserMessage.class);
+        assertThat(((dev.langchain4j.data.message.UserMessage) messages.get(0)).singleText()).isEqualTo(userMessage);
+
+        AiMessage aiMessage = (AiMessage) messages.get(1);
+        assertThat(aiMessage.text()).isNull();
+        assertThat(aiMessage.toolExecutionRequests()).hasSize(2);
+
+        ToolExecutionRequest firstToolExecutionRequest = aiMessage.toolExecutionRequests().get(0);
+        assertThat(firstToolExecutionRequest.name()).isEqualTo("getCurrentTime");
+        assertThat(firstToolExecutionRequest.arguments()).isEqualToIgnoringWhitespace("{\"arg0\": \"Munich\"}");
+
+        ToolExecutionRequest secondToolExecutionRequest = aiMessage.toolExecutionRequests().get(1);
+        assertThat(secondToolExecutionRequest.name()).isEqualTo("getCurrentTemperature");
+        assertThat(secondToolExecutionRequest.arguments()).isEqualToIgnoringWhitespace("{\"arg0\": \"Munich\"}");
+
+        ToolExecutionResultMessage firstToolExecutionResultMessage = (ToolExecutionResultMessage) messages.get(2);
+        assertThat(firstToolExecutionResultMessage.id()).isEqualTo(firstToolExecutionRequest.id());
+        assertThat(firstToolExecutionResultMessage.toolName()).isEqualTo("getCurrentTime");
+        assertThat(firstToolExecutionResultMessage.text()).isEqualTo(Tools.CURRENT_TIME);
+
+        ToolExecutionResultMessage secondToolExecutionResultMessage = (ToolExecutionResultMessage) messages.get(3);
+        assertThat(secondToolExecutionResultMessage.id()).isEqualTo(secondToolExecutionRequest.id());
+        assertThat(secondToolExecutionResultMessage.toolName()).isEqualTo("getCurrentTemperature");
+        assertThat(secondToolExecutionResultMessage.text()).isEqualTo(Tools.CURRENT_TEMPERATURE);
+    }
+
+    static List<Executor> executors() {
+        return List.of(Executors.newFixedThreadPool(2));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @MethodSource("executors")
+    void should_execute_single_tool_concurrently(Executor executor) throws Exception {
+
+        // given
+        class Tools {
+
+            static final String CURRENT_TEMPERATURE = "17";
+
+            final Queue<Thread> getCurrentTemperatureThreads = new ConcurrentLinkedQueue<>();
+
+            @Tool
+            String getCurrentTemperature(String city) {
+                getCurrentTemperatureThreads.add(Thread.currentThread());
+                return CURRENT_TEMPERATURE;
+            }
+        }
+
+        Tools spyTools = spy(new Tools());
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .streamingChatModel(models().findFirst().get())
+                .chatMemory(chatMemory)
+                .tools(spyTools)
+                .executeToolsConcurrently(executor)
+                .build();
+
+        String userMessage = "What is the current temperature in Munich?";
+
+        TestTokenStreamHandler handler = spy(new TestTokenStreamHandler());
+        CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
+
+        // when
+        assistant.chat(userMessage)
+                .onPartialResponse(handler::onPartialResponse)
+                .onPartialThinking(handler::onPartialThinking)
+                .onIntermediateResponse(handler::onIntermediateResponse)
+                .beforeToolExecution(handler::beforeToolExecution)
+                .onToolExecuted(handler::onToolExecuted)
+                .onCompleteResponse(completeResponse -> {
+                    handler.onCompleteResponse(completeResponse);
+                    futureResponse.complete(completeResponse);
+                })
+                .onError(error -> {
+                    handler.onError(error);
+                    futureResponse.completeExceptionally(error);
+                })
+                .start();
+        ChatResponse response = futureResponse.get(60, SECONDS);
+
+        // then
+        assertThat(response.aiMessage().text()).contains(Tools.CURRENT_TEMPERATURE);
+
+        // then
+        verify(spyTools).getCurrentTemperature("Munich");
+        verifyNoMoreInteractions(spyTools);
+
+        // then
+        assertThat(handler.allThreads).hasSize(2); // 1 for handler, 1 for tool
+
+        assertThat(handler.beforeToolExecutionThreads).hasSize(1);
+        assertThat(handler.beforeToolExecutionThreads.get("getCurrentTemperature")).hasSize(1);
+
+        assertThat(handler.onToolExecutedThreads).hasSize(1);
+        assertThat(handler.onToolExecutedThreads.get("getCurrentTemperature")).hasSize(1);
+
+        assertThat(spyTools.getCurrentTemperatureThreads).hasSize(1);
+        Thread getCurrentTemperatureThread = spyTools.getCurrentTemperatureThreads.poll();
+        assertThat(getCurrentTemperatureThread).isEqualTo(handler.beforeToolExecutionThreads.get("getCurrentTemperature").iterator().next());
+        assertThat(getCurrentTemperatureThread).isEqualTo(handler.onToolExecutedThreads.get("getCurrentTemperature").iterator().next());
+
+        // then
+        List<ChatMessage> messages = chatMemory.messages();
+        assertThat(messages).hasSize(4);
+
+        assertThat(messages.get(0)).isInstanceOf(dev.langchain4j.data.message.UserMessage.class);
+        assertThat(((UserMessage) messages.get(0)).singleText()).isEqualTo(userMessage);
+
+        AiMessage aiMessage = (AiMessage) messages.get(1);
+        assertThat(aiMessage.text()).isNull();
+        assertThat(aiMessage.toolExecutionRequests()).hasSize(1);
+
+        ToolExecutionRequest toolExecutionRequest = aiMessage.toolExecutionRequests().get(0);
+        assertThat(toolExecutionRequest.name()).isEqualTo("getCurrentTemperature");
+        assertThat(toolExecutionRequest.arguments()).isEqualToIgnoringWhitespace("{\"arg0\": \"Munich\"}");
+
+        ToolExecutionResultMessage toolExecutionResultMessage = (ToolExecutionResultMessage) messages.get(2);
+        assertThat(toolExecutionResultMessage.id()).isEqualTo(toolExecutionRequest.id());
+        assertThat(toolExecutionResultMessage.toolName()).isEqualTo("getCurrentTemperature");
+        assertThat(toolExecutionResultMessage.text()).isEqualTo(Tools.CURRENT_TEMPERATURE);
     }
 
     static class WeatherService {
@@ -320,28 +572,20 @@ class StreamingAiServicesWithToolsIT {
 
         String userMessage = "What is the temperature in Munich and London, in Celsius?";
 
-        interface TokenStreamHandler {
-            void onPartialResponse(String partialResponse);
-            void beforeToolExecution(BeforeToolExecution beforeToolExecution);
-            void onToolExecuted(ToolExecution toolExecution);
-            void onError(Throwable error);
-            void onCompleteResponse(ChatResponse completeResponse);
-        }
-
-        TokenStreamHandler tokenStreamHandler = mock(TokenStreamHandler.class);
+        TestTokenStreamHandler handler = spy(TestTokenStreamHandler.class);
         CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
 
         // when
         assistant.chat(userMessage)
-                .onPartialResponse(partialResponse -> tokenStreamHandler.onPartialResponse(partialResponse))
-                .beforeToolExecution(beforeToolExecution -> tokenStreamHandler.beforeToolExecution(beforeToolExecution))
-                .onToolExecuted(toolExecution -> tokenStreamHandler.onToolExecuted(toolExecution))
+                .onPartialResponse(handler::onPartialResponse)
+                .beforeToolExecution(handler::beforeToolExecution)
+                .onToolExecuted(handler::onToolExecuted)
                 .onError(error -> {
-                    tokenStreamHandler.onError(error);
+                    handler.onError(error);
                     futureResponse.completeExceptionally(error);
                 })
                 .onCompleteResponse(completeResponse -> {
-                    tokenStreamHandler.onCompleteResponse(completeResponse);
+                    handler.onCompleteResponse(completeResponse);
                     futureResponse.complete(completeResponse);
                 })
                 .start();
@@ -358,18 +602,18 @@ class StreamingAiServicesWithToolsIT {
         verifyNoMoreInteractions(weatherService);
 
         // then
-        InOrder inOrder = inOrder(tokenStreamHandler);
+        InOrder inOrder = inOrder(handler);
 
-        inOrder.verify(tokenStreamHandler).beforeToolExecution(argThat(bfe -> bfe.request().arguments().contains("Munich")));
-        inOrder.verify(tokenStreamHandler).onToolExecuted(argThat(toolExecution -> toolExecution.request().arguments().contains("Munich")));
-        inOrder.verify(tokenStreamHandler).beforeToolExecution(argThat(bfe -> bfe.request().arguments().contains("London")));
-        inOrder.verify(tokenStreamHandler).onToolExecuted(argThat(toolExecution -> toolExecution.request().arguments().contains("London")));
+        inOrder.verify(handler).beforeToolExecution(argThat(bfe -> bfe.request().arguments().contains("Munich")));
+        inOrder.verify(handler).onToolExecuted(argThat(toolExecution -> toolExecution.request().arguments().contains("Munich")));
+        inOrder.verify(handler).beforeToolExecution(argThat(bfe -> bfe.request().arguments().contains("London")));
+        inOrder.verify(handler).onToolExecuted(argThat(toolExecution -> toolExecution.request().arguments().contains("London")));
 
-        inOrder.verify(tokenStreamHandler, atLeastOnce()).onPartialResponse(any());
-        inOrder.verify(tokenStreamHandler).onCompleteResponse(any());
+        inOrder.verify(handler, atLeastOnce()).onPartialResponse(any());
+        inOrder.verify(handler).onCompleteResponse(any());
 
         inOrder.verifyNoMoreInteractions();
-        verifyNoMoreInteractions(tokenStreamHandler);
+        verifyNoMoreInteractions(handler);
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/TestTokenStreamHandler.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/TestTokenStreamHandler.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.service;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialThinking;
+import dev.langchain4j.service.tool.BeforeToolExecution;
+import dev.langchain4j.service.tool.ToolExecution;
+
+public class TestTokenStreamHandler {
+
+    Set<Thread> allThreads = ConcurrentHashMap.newKeySet();
+
+    Map<String, Set<Thread>> beforeToolExecutionThreads = new ConcurrentHashMap<>();
+    Map<String, Set<Thread>> onToolExecutedThreads = new ConcurrentHashMap<>();
+
+    void onPartialResponse(String partialResponse) {
+        allThreads.add(Thread.currentThread());
+    }
+
+    void onPartialThinking(PartialThinking partialThinking) {
+        allThreads.add(Thread.currentThread());
+    }
+
+    void onIntermediateResponse(ChatResponse intermediateResponse) {
+        allThreads.add(Thread.currentThread());
+    }
+
+    void beforeToolExecution(BeforeToolExecution beforeToolExecution) {
+        allThreads.add(Thread.currentThread());
+
+        Set<Thread> threads = beforeToolExecutionThreads.computeIfAbsent(beforeToolExecution.request().name(),
+                ignored -> ConcurrentHashMap.newKeySet());
+        threads.add(Thread.currentThread());
+    }
+
+    void onToolExecuted(ToolExecution toolExecution) {
+        allThreads.add(Thread.currentThread());
+
+        Set<Thread> threads = onToolExecutedThreads.computeIfAbsent(toolExecution.request().name(),
+                ignored -> ConcurrentHashMap.newKeySet());
+        threads.add(Thread.currentThread());
+    }
+
+    void onError(Throwable error) {
+        allThreads.add(Thread.currentThread());
+    }
+
+    void onCompleteResponse(ChatResponse completeResponse) {
+        allThreads.add(Thread.currentThread());
+    }
+}


### PR DESCRIPTION
## Issue
Closes #3290

## Change
Added an option to execute tools concurrently:

```java
    /**
     * By default, when the LLM calls multiple tools, the AI Service executes them sequentially.
     * If you enable this option, tools will be executed concurrently (with one exception - see below),
     * using the default {@link Executor}.
     * You can also specify your own {@link Executor}, see {@link #executeToolsConcurrently(Executor)}.
     * <ul>
     *     <li>When using {@link ChatModel}:</li>
     *     <ul>
     *         <li>When the LLM calls multiple tools, they are executed concurrently in separate threads
     *             using the {@link Executor}.</li>
     *         <li>When the LLM calls a single tool, it is executed in the same (caller) thread,
     *             the {@link Executor} is not used to avoid wasting resources.</li>
     *     </ul>
     *     <li>When using {@link StreamingChatModel}:</li>
     *     <ul>
     *         <li>When the LLM calls multiple tools, they are executed concurrently in separate threads
     *             using the {@link Executor}.
     *             Each tool is executed as soon as {@link StreamingChatResponseHandler#onCompleteToolCall(CompleteToolCall)}
     *             is called, without waiting for other tools or for the response streaming to complete.</li>
     *         <li>When the LLM calls a single tool, it is executed in a separate thread using the {@link Executor}.
     *             We cannot execute it in the same thread because, at that point,
     *             we do not yet know how many tools the LLM will call.</li>
     *     </ul>
     * </ul>
     *
     * @return builder
     * @see #executeToolsConcurrently(Executor)
     * @since 1.4.0
     */
    public AiServices<T> executeToolsConcurrently() {
        context.toolService.executeToolsConcurrently();
        return this;
    }

    /**
     * See {@link #executeToolsConcurrently()}'s Javadoc for more info.
     * <p>
     * If {@code null} is specified, the default {@link Executor} will be used.
     *
     * @param executor The {@link Executor} to be used to execute tools.
     * @return builder
     * @see #executeToolsConcurrently()
     * @since 1.4.0
     */
    public AiServices<T> executeToolsConcurrently(Executor executor) {
        context.toolService.executeToolsConcurrently(executor);
        return this;
    }
```

## General checklist
- [x] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)