### PR TITLE
test: Add comprehensive edge case tests for Content class

### DIFF
--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/ContentTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/ContentTest.java
@@ -120,5 +120,4 @@ class ContentTest {
         assertThatThrownBy(() -> content.metadata().put(ContentMetadata.EMBEDDING_ID, "test"))
                 .isInstanceOf(UnsupportedOperationException.class);
     }
-
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/ContentTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/ContentTest.java
@@ -2,8 +2,10 @@ package dev.langchain4j.rag.content;
 
 import static dev.langchain4j.rag.content.ContentMetadata.SCORE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.data.segment.TextSegment;
+import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -79,4 +81,44 @@ class ContentTest {
                 .hasToString(
                         "DefaultContent { textSegment = TextSegment { text = \"content\" metadata = {} }, metadata = {} }");
     }
+
+    @Test
+    void create_from_text_segment_with_null_metadata() {
+        // given
+        TextSegment segment = TextSegment.from("text");
+
+        // when
+        Content content = Content.from(segment, null);
+
+        // then
+        assertThat(content.textSegment()).isSameAs(segment);
+        assertThat(content.metadata()).isEmpty();
+    }
+
+    @Test
+    void create_from_text_segment_with_empty_metadata() {
+        // given
+        TextSegment segment = TextSegment.from("text");
+        Map<ContentMetadata, Object> emptyMetadata = Collections.emptyMap();
+
+        // when
+        Content content = Content.from(segment, emptyMetadata);
+
+        // then
+        assertThat(content.textSegment()).isSameAs(segment);
+        assertThat(content.metadata()).isEmpty();
+    }
+
+    @Test
+    void metadata_returned_is_defensive_copy() {
+        // given
+        TextSegment segment = TextSegment.from("text");
+        Map<ContentMetadata, Object> metadata = Map.of(SCORE, 0.5);
+        Content content = Content.from(segment, metadata);
+
+        // when/then - attempting to modify returned metadata should fail
+        assertThatThrownBy(() -> content.metadata().put(ContentMetadata.EMBEDDING_ID, "test"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
 }


### PR DESCRIPTION
Adds additional test coverage for Content class focusing on edge cases:

- **Null/empty metadata handling**: Tests for null and empty metadata maps
- **Immutability verification**: Ensures returned metadata map is defensive copy and cannot be modified
- **Edge case validation**: Covers boundary conditions that weren't previously tested

These tests improve robustness and ensure the Content class behaves correctly under various input conditions.