### PR TITLE
Feature/mcp sse add header

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
@@ -14,10 +14,12 @@ import dev.langchain4j.mcp.client.transport.McpTransport;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -36,7 +38,7 @@ public class HttpMcpTransport implements McpTransport {
 
     private static final Logger log = LoggerFactory.getLogger(HttpMcpTransport.class);
     private final String sseUrl;
-    private final Map<String, String> headers;
+    private final Map<String, String> userHeaders;
     private final OkHttpClient client;
     private final boolean logResponses;
     private final boolean logRequests;
@@ -63,7 +65,7 @@ public class HttpMcpTransport implements McpTransport {
         }
         this.logResponses = builder.logResponses;
         sseUrl = ensureNotNull(builder.sseUrl, "Missing SSE endpoint URL");
-        headers = getOrDefault(builder.headers, Map.of());
+        userHeaders = getOrDefault(builder.headers, Map.of());
         client = httpClientBuilder.build();
     }
 
@@ -183,15 +185,15 @@ public class HttpMcpTransport implements McpTransport {
 
     private Headers buildCommonHeaders() {
         Headers.Builder headerBuilder = new Headers.Builder();
-        headers.forEach(headerBuilder::add);
+        userHeaders.forEach(headerBuilder::add);
         return headerBuilder.build();
     }
 
     private Request createRequest(McpClientMessage message) throws JsonProcessingException {
-       Headers.Builder headerBuilder = new Headers.Builder()
+        Headers.Builder headerBuilder = new Headers.Builder()
                 .add(CONTENT_TYPE, CONTENT_TYPE_JSON);
-        headers.forEach(headerBuilder::add);
-        
+        userHeaders.forEach(headerBuilder::add);
+
         return new Request.Builder()
                 .url(postUrl)
                 .headers(headerBuilder.build())
@@ -225,7 +227,7 @@ public class HttpMcpTransport implements McpTransport {
             this.sseUrl = sseUrl;
             return this;
         }
-        
+
         public Builder headers(Map<String, String> headers) {
             this.headers = headers;
             return this;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -31,6 +31,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
 
     private static final Logger log = LoggerFactory.getLogger(HttpMcpTransport.class);
     private final String url;
+    private final Map<String, String> userHeaders;
     private final boolean logResponses;
     private final boolean logRequests;
     static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -44,6 +45,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
         logRequests = builder.logRequests;
         logResponses = builder.logResponses;
         Duration timeout = getOrDefault(builder.timeout, Duration.ofSeconds(60));
+        userHeaders = getOrDefault(builder.headers, Map.of());
         HttpClient.Builder clientBuilder = HttpClient.newBuilder();
         if (builder.executor != null) {
             clientBuilder.executor(builder.executor);
@@ -74,6 +76,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
         if (sessionId != null) {
             builder.header("Mcp-Session-Id", sessionId);
         }
+        userHeaders.forEach(builder::header);
         return builder.uri(URI.create(url))
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json,text/event-stream")
@@ -185,6 +188,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
 
         private Executor executor;
         private String url;
+        private Map<String, String> headers;
         private Duration timeout;
         private boolean logRequests = false;
         private boolean logResponses = false;
@@ -194,6 +198,14 @@ public class StreamableHttpMcpTransport implements McpTransport {
          */
         public StreamableHttpMcpTransport.Builder url(String url) {
             this.url = url;
+            return this;
+        }
+
+        /**
+         * The request headers of the MCP server.
+         */
+        public StreamableHttpMcpTransport.Builder headers(Map<String, String> headers) {
+            this.headers = headers;
             return this;
         }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -20,6 +20,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;


### PR DESCRIPTION
## Issue
Closes #3157

## Change

The addition of custom header capabilities to the HttpMcpTransport and StreamableHttpMcpTransport classes allows users to pass in their own headers, which is a common use case, such as including authentication information for MCP requests. The code has been self-tested and does not impact the existing logic.

## General checklist
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)