### PR TITLE
Allow to evict or completely disable the tool list cache in DefaultMcpClient

### DIFF
--- a/docs/docs/tutorials/mcp.md
+++ b/docs/docs/tutorials/mcp.md
@@ -411,3 +411,19 @@ ToolExecutionRequest request = ToolExecutionRequest.builder()
                 .build();
 String toolResult = mcpClient.executeTool(request);
 ```
+
+## Notes about Tool Caching
+
+`DefaultMcpClient` maintains an internal cache of MCP tools. Once retrieved, the
+tool list won't be requested again from the MCP server unless the server sends a
+notification that the list has been updated. You can manually clear this cache
+by calling `DefaultMcpClient.evictToolListCache()`. If you prefer to disable
+caching entirely, configure the client as follows:
+
+```java
+McpClient mcpClient = new DefaultMcpClient.Builder()
+    .key("MyMCPClient")
+    .transport(transport)
+    .cacheToolList(false)
+    .build();
+```

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -186,6 +186,79 @@ public class DefaultMcpClientTest {
         verify(transport, times(1)).executeOperationWithResponse(any());
     }
 
+    @Test
+    public void should_evict_tool_list_cache() throws Exception {
+        // given
+        final McpTransport transport = getMinimalMcpTransportMock();
+        final DefaultMcpClient client =
+                new DefaultMcpClient.Builder().transport(transport).build();
+        final ObjectNode toolsJsonResult = getToolResultJson(
+                new ToolDefinition("testTool", "A test tool", new ToolArg("argument1", "string", "An argument")));
+        when(transport.executeOperationWithResponse(any()))
+                .thenReturn(CompletableFuture.completedFuture(toolsJsonResult));
+
+        // and: the tools are cached
+        final List<ToolSpecification> tools = client.listTools();
+        // and: the tool list is changed
+        final ObjectNode newToolsJsonResult = getToolResultJson(new ToolDefinition(
+                "testToolAnother",
+                "Another test tool",
+                new ToolArg("argumentAnother1", "integer", "Another argument")));
+        when(transport.executeOperationWithResponse(any()))
+                .thenReturn(CompletableFuture.completedFuture(newToolsJsonResult));
+
+        // when
+        client.evictToolListCache();
+        final List<ToolSpecification> toolsAfterEviction = client.listTools();
+
+        // then: the tools were retrieved again
+        assertThat(tools).isNotNull().isNotEmpty();
+        assertThat(toolsAfterEviction).isNotNull().isNotEmpty();
+        assertThat(toolsAfterEviction).isNotSameAs(tools);
+        // and: the tool lists are different
+        assertThat(tools.get(0).name()).isEqualTo("testTool");
+        assertThat(toolsAfterEviction.get(0).name()).isEqualTo("testToolAnother");
+        // and: the transport operation was executed once more after the eviction
+        verify(transport, times(2)).executeOperationWithResponse(any());
+    }
+
+    @Test
+    public void should_allow_to_disable_tool_list_caching() {
+        // given: a client built with caching disabled
+        final McpTransport transport = getMinimalMcpTransportMock();
+        final DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .cacheToolList(false)
+                .build();
+        final ObjectNode toolsJsonResult = getToolResultJson(
+                new ToolDefinition("testTool", "A test tool", new ToolArg("argument1", "string", "An argument")));
+        when(transport.executeOperationWithResponse(any()))
+                .thenReturn(CompletableFuture.completedFuture(toolsJsonResult));
+
+        // and: an initial tool list is retrieved
+        final List<ToolSpecification> initialTools = client.listTools();
+        // and: the tool list is changed
+        final ObjectNode newToolsJsonResult = getToolResultJson(new ToolDefinition(
+                "testToolAnother",
+                "Another test tool",
+                new ToolArg("argumentAnother1", "integer", "Another argument")));
+        when(transport.executeOperationWithResponse(any()))
+                .thenReturn(CompletableFuture.completedFuture(newToolsJsonResult));
+
+        // when
+        final List<ToolSpecification> subsequentTools = client.listTools();
+
+        // then: the tools were retrieved again
+        assertThat(initialTools).isNotNull().isNotEmpty();
+        assertThat(subsequentTools).isNotNull().isNotEmpty();
+        assertThat(subsequentTools).isNotSameAs(initialTools);
+        // and: the tool lists are different
+        assertThat(initialTools.get(0).name()).isEqualTo("testTool");
+        assertThat(subsequentTools.get(0).name()).isEqualTo("testToolAnother");
+        // and: the transport operation was executed as many times as tools were retrieved
+        verify(transport, times(2)).executeOperationWithResponse(any());
+    }
+
     private static McpTransport getMinimalMcpTransportMock() {
         McpTransport transport = mock(McpTransport.class);
         ObjectNode emptyJsonNode = JsonNodeFactory.instance.objectNode();


### PR DESCRIPTION
## Issue
Closes #3573 

## Change

- Add `DefaultMcpClient.evictToolListCache()`
- Add `DefaultMcpClient.Builder.cacheToolList()`
- Add tests for all of that, plus tests for `DefaultMcpClient.listTools()`

## General checklist
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)