### PR TITLE
Add utility methods to find SystemMessage instances in chat messages

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/SystemMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/SystemMessage.java
@@ -1,6 +1,8 @@
 package dev.langchain4j.data.message;
 
 import java.util.Objects;
+import java.util.List;
+import java.util.Optional;
 
 import static dev.langchain4j.data.message.ChatMessageType.SYSTEM;
 import static dev.langchain4j.internal.Utils.quoted;
@@ -71,5 +73,26 @@ public class SystemMessage implements ChatMessage {
      */
     public static SystemMessage systemMessage(String text) {
         return from(text);
+    }
+
+    public static Optional<SystemMessage> findFirst(List<ChatMessage> messages) {
+        return messages.stream()
+                .filter(message -> message instanceof SystemMessage)
+                .map(message -> (SystemMessage) message)
+                .findFirst();
+    }
+
+    public static Optional<SystemMessage> findLast(List<ChatMessage> messages) {
+        return messages.stream()
+                .filter(message -> message instanceof SystemMessage)
+                .map(message -> (SystemMessage) message)
+                .reduce((first, second) -> second);
+    }
+
+    public static List<SystemMessage> findAll(List<ChatMessage> messages) {
+        return messages.stream()
+                .filter(message -> message instanceof SystemMessage)
+                .map(message -> (SystemMessage) message)
+                .toList();
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/SystemMessageTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/SystemMessageTest.java
@@ -3,6 +3,9 @@ package dev.langchain4j.data.message;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.List;
+
 class SystemMessageTest implements WithAssertions {
     @Test
     void builders() {
@@ -38,5 +41,80 @@ class SystemMessageTest implements WithAssertions {
                 .doesNotHaveSameHashCodeAs(s3);
 
         assertThat(s3).isEqualTo(s3).isEqualTo(s4).hasSameHashCodeAs(s4);
+    }
+
+    @Test
+    void find_with_null_list() {
+        assertThatThrownBy(() -> SystemMessage.findFirst(null))
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> SystemMessage.findLast(null))
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> SystemMessage.findAll(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void find_with_empty_list() {
+        List<ChatMessage> emptyList = Collections.emptyList();
+        assertThat(SystemMessage.findFirst(emptyList)).isEmpty();
+        assertThat(SystemMessage.findLast(emptyList)).isEmpty();
+        assertThat(SystemMessage.findAll(emptyList)).isEmpty();
+    }
+
+    @Test
+    void find_with_single_system_message() {
+        SystemMessage systemMessage = new SystemMessage("system text");
+        List<ChatMessage> messages = List.of(systemMessage);
+
+        assertThat(SystemMessage.findFirst(messages))
+                .isPresent()
+                .contains(systemMessage);
+
+        assertThat(SystemMessage.findLast(messages))
+                .isPresent()
+                .contains(systemMessage);
+
+        assertThat(SystemMessage.findAll(messages))
+                .hasSize(1)
+                .containsExactly(systemMessage);
+    }
+
+    @Test
+    void find_with_single_user_message() {
+        UserMessage userMessage = new UserMessage("user text");
+        List<ChatMessage> messages = List.of(userMessage);
+
+        assertThat(SystemMessage.findFirst(messages)).isEmpty();
+        assertThat(SystemMessage.findLast(messages)).isEmpty();
+        assertThat(SystemMessage.findAll(messages)).isEmpty();
+    }
+
+    @Test
+    void find_with_mixed_messages() {
+        SystemMessage system1 = new SystemMessage("system 1");
+        UserMessage user1 = new UserMessage("user 1");
+        AiMessage ai1 = new AiMessage("ai 1");
+        SystemMessage system2 = new SystemMessage("system 2");
+        UserMessage user2 = new UserMessage("user 2");
+        AiMessage ai2 = new AiMessage("ai 2");
+        SystemMessage system3 = new SystemMessage("system 3");
+
+        List<ChatMessage> messages = List.of(
+                user1, system1, ai1, system2, user2, ai2, system3
+        );
+
+        assertThat(SystemMessage.findFirst(messages))
+                .isPresent()
+                .contains(system1);
+
+        assertThat(SystemMessage.findLast(messages))
+                .isPresent()
+                .contains(system3);
+
+        assertThat(SystemMessage.findAll(messages))
+                .hasSize(3)
+                .containsExactly(system1, system2, system3);
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -1,5 +1,11 @@
 package dev.langchain4j.memory.chat;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
@@ -8,13 +14,6 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
-
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 /**
  * This chat memory operates as a sliding window of {@link #maxMessages} messages.
@@ -54,7 +53,7 @@ public class MessageWindowChatMemory implements ChatMemory {
     public void add(ChatMessage message) {
         List<ChatMessage> messages = messages();
         if (message instanceof SystemMessage) {
-            Optional<SystemMessage> systemMessage = findSystemMessage(messages);
+            Optional<SystemMessage> systemMessage = SystemMessage.findFirst(messages);
             if (systemMessage.isPresent()) {
                 if (systemMessage.get().equals(message)) {
                     return; // do not add the same system message
@@ -66,13 +65,6 @@ public class MessageWindowChatMemory implements ChatMemory {
         messages.add(message);
         ensureCapacity(messages, maxMessages);
         store.updateMessages(id, messages);
-    }
-
-    private static Optional<SystemMessage> findSystemMessage(List<ChatMessage> messages) {
-        return messages.stream()
-                .filter(message -> message instanceof SystemMessage)
-                .map(message -> (SystemMessage) message)
-                .findAny();
     }
 
     @Override

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
@@ -1,5 +1,11 @@
 package dev.langchain4j.memory.chat;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
@@ -9,13 +15,6 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
-
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 /**
  * This chat memory operates as a sliding window of {@link #maxTokens} tokens.
@@ -58,7 +57,7 @@ public class TokenWindowChatMemory implements ChatMemory {
     public void add(ChatMessage message) {
         List<ChatMessage> messages = messages();
         if (message instanceof SystemMessage) {
-            Optional<SystemMessage> maybeSystemMessage = findSystemMessage(messages);
+            Optional<SystemMessage> maybeSystemMessage = SystemMessage.findFirst(messages);
             if (maybeSystemMessage.isPresent()) {
                 if (maybeSystemMessage.get().equals(message)) {
                     return; // do not add the same system message
@@ -70,13 +69,6 @@ public class TokenWindowChatMemory implements ChatMemory {
         messages.add(message);
         ensureCapacity(messages, maxTokens, tokenCountEstimator);
         store.updateMessages(id, messages);
-    }
-
-    private static Optional<SystemMessage> findSystemMessage(List<ChatMessage> messages) {
-        return messages.stream()
-                .filter(message -> message instanceof SystemMessage)
-                .map(message -> (SystemMessage) message)
-                .findAny();
     }
 
     @Override


### PR DESCRIPTION
## Issue
Fixes #3562

## Change
 Add utility methods to find SystemMessage instances in chat message lists

  - Add `findFirst()` method to get the first SystemMessage from a list
  - Add `findLast()` method to get the last SystemMessage from a list
  - Add `findAll()` method to get all SystemMessage instances from a list
  - Add comprehensive tests covering null lists, empty lists, single messages, and mixed message scenarios
  - Refactor `MessageWindowChatMemory` and `TokenWindowChatMemory` to use these new methods

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
