### PR TITLE
Upgrade to OpenAI SDK Java 3.1.2

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -315,10 +315,11 @@ public class Utils {
                 HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
                 connection.setRequestMethod("GET");
                 // Add headers to appear as a legitimate browser request
-                connection.setRequestProperty("User-Agent",
+                connection.setRequestProperty(
+                        "User-Agent",
                         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36");
-                connection.setRequestProperty("Accept",
-                        "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
+                connection.setRequestProperty(
+                        "Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
                 connection.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
                 connection.setRequestProperty("Accept-Encoding", "gzip, deflate");
                 connection.setRequestProperty("Connection", "keep-alive");

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -314,6 +314,14 @@ public class Utils {
                 // Handle URLs
                 HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
                 connection.setRequestMethod("GET");
+                // Add headers to appear as a legitimate browser request
+                connection.setRequestProperty("User-Agent",
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36");
+                connection.setRequestProperty("Accept",
+                        "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
+                connection.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
+                connection.setRequestProperty("Accept-Encoding", "gzip, deflate");
+                connection.setRequestProperty("Connection", "keep-alive");
 
                 int responseCode = connection.getResponseCode();
 

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -58,8 +58,8 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
-import dev.langchain4j.model.chat.request.json.JsonRawSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonRawSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
@@ -102,7 +102,10 @@ class InternalOpenAiOfficialHelper {
             return ModelHost.GITHUB_MODELS; // Forced by the user
         }
         if (baseUrl != null) {
-            if (baseUrl.endsWith("openai.azure.com") || baseUrl.endsWith("openai.azure.com/") || baseUrl.endsWith("cognitiveservices.azure.com") || baseUrl.endsWith("cognitiveservices.azure.com/") ) {
+            if (baseUrl.endsWith("openai.azure.com")
+                    || baseUrl.endsWith("openai.azure.com/")
+                    || baseUrl.endsWith("cognitiveservices.azure.com")
+                    || baseUrl.endsWith("cognitiveservices.azure.com/")) {
                 return ModelHost.AZURE_OPENAI;
             } else if (baseUrl.startsWith(GITHUB_MODELS_URL)) {
                 return ModelHost.GITHUB_MODELS;
@@ -241,14 +244,13 @@ class InternalOpenAiOfficialHelper {
         } else if (modelHost == ModelHost.AZURE_OPENAI) {
             // Using Azure OpenAI
             String tmpUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
-            // If the Azure deployment name is not configured, the model name will be used by default by the OpenAI Java SDK
+            // If the Azure deployment name is not configured, the model name will be used by default by the OpenAI Java
+            // SDK
             if (azureDeploymentName != null && !azureDeploymentName.equals(modelName)) {
                 tmpUrl += "/openai/deployments/" + azureDeploymentName;
-
             }
             if (azureOpenAiServiceVersion != null) {
-                tmpUrl += "?api-version="
-                        + azureOpenAiServiceVersion.value();
+                tmpUrl += "?api-version=" + azureOpenAiServiceVersion.value();
             }
             return tmpUrl;
         } else {
@@ -319,12 +321,13 @@ class InternalOpenAiOfficialHelper {
             }
 
             List<ChatCompletionMessageToolCall> toolCalls = aiMessage.toolExecutionRequests().stream()
-                    .map(it -> ChatCompletionMessageToolCall.ofFunction(
-                            ChatCompletionMessageFunctionToolCall.builder()
-                                    .id(it.id())
-                                    .function(ChatCompletionMessageFunctionToolCall.Function.builder().name(it.name()).arguments(it.arguments()).build())
-                                    .build()
-                            ))
+                    .map(it -> ChatCompletionMessageToolCall.ofFunction(ChatCompletionMessageFunctionToolCall.builder()
+                            .id(it.id())
+                            .function(ChatCompletionMessageFunctionToolCall.Function.builder()
+                                    .name(it.name())
+                                    .arguments(it.arguments())
+                                    .build())
+                            .build()))
                     .collect(toList());
 
             return ChatCompletionMessageParam.ofAssistant(ChatCompletionAssistantMessageParam.builder()
@@ -472,7 +475,8 @@ class InternalOpenAiOfficialHelper {
         if (!toolCall.isFunction() || toolCall.function().isEmpty()) {
             return null;
         }
-        ChatCompletionMessageFunctionToolCall functionToolCall = toolCall.function().get();
+        ChatCompletionMessageFunctionToolCall functionToolCall =
+                toolCall.function().get();
         return ToolExecutionRequest.builder()
                 .id(functionToolCall.id())
                 .name(functionToolCall.function().name())

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -100,7 +100,7 @@ class InternalOpenAiOfficialHelper {
             return ModelHost.GITHUB_MODELS; // Forced by the user
         }
         if (baseUrl != null) {
-            if (baseUrl.endsWith("openai.azure.com") || baseUrl.endsWith("openai.azure.com/")) {
+            if (baseUrl.endsWith("openai.azure.com") || baseUrl.endsWith("openai.azure.com/") || baseUrl.endsWith("cognitiveservices.azure.com") || baseUrl.endsWith("cognitiveservices.azure.com/") ) {
                 return ModelHost.AZURE_OPENAI;
             } else if (baseUrl.startsWith(GITHUB_MODELS_URL)) {
                 return ModelHost.GITHUB_MODELS;

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -74,7 +74,7 @@
         <mockito-kotlin.version>5.4.0</mockito-kotlin.version>
         <mockito.version>5.14.2</mockito.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <openai-java.version>2.19.1</openai-java.version>
+        <openai-java.version>3.1.2</openai-java.version>
         <opensearch-containers.version>2.0.1</opensearch-containers.version>
         <opensearch-java.version>2.9.0</opensearch-java.version>
         <retrofit.version>2.9.0</retrofit.version>


### PR DESCRIPTION
Fixes #3592

- Updates the Utils.java class in the core module so that Wikipedia accepts our requests (otherwise we're getting 403 errors)
- Updates to the new OpenAI Java SDK and fixes the API