### PR TITLE
Docs: fix typo in pom type configuration tag

### DIFF
--- a/docs/docs/integrations/embedding-models/qianfan.md
+++ b/docs/docs/integrations/embedding-models/qianfan.md
@@ -75,7 +75,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>

--- a/docs/docs/integrations/embedding-models/xinference.md
+++ b/docs/docs/integrations/embedding-models/xinference.md
@@ -27,7 +27,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>

--- a/docs/docs/integrations/embedding-models/zhipu-ai.md
+++ b/docs/docs/integrations/embedding-models/zhipu-ai.md
@@ -51,7 +51,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>

--- a/docs/docs/integrations/embedding-stores/redis.md
+++ b/docs/docs/integrations/embedding-stores/redis.md
@@ -78,7 +78,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>

--- a/docs/docs/integrations/embedding-stores/vearch.md
+++ b/docs/docs/integrations/embedding-stores/vearch.md
@@ -41,7 +41,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>

--- a/docs/docs/integrations/image-models/xinference.md
+++ b/docs/docs/integrations/image-models/xinference.md
@@ -27,7 +27,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>

--- a/docs/docs/integrations/image-models/zhipu-ai.md
+++ b/docs/docs/integrations/image-models/zhipu-ai.md
@@ -51,7 +51,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>

--- a/docs/docs/integrations/language-models/chatglm.md
+++ b/docs/docs/integrations/language-models/chatglm.md
@@ -44,7 +44,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>

--- a/docs/docs/integrations/language-models/qianfan.md
+++ b/docs/docs/integrations/language-models/qianfan.md
@@ -76,7 +76,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>

--- a/docs/docs/integrations/language-models/xinference.md
+++ b/docs/docs/integrations/language-models/xinference.md
@@ -27,7 +27,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>

--- a/docs/docs/integrations/language-models/zhipu-ai.md
+++ b/docs/docs/integrations/language-models/zhipu-ai.md
@@ -51,7 +51,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>

--- a/docs/docs/integrations/scoring-reranking-models/xinference.md
+++ b/docs/docs/integrations/scoring-reranking-models/xinference.md
@@ -27,7 +27,7 @@ Or, you can use BOM to manage dependencies consistently:
         <groupId>dev.langchain4j</groupId>
         <artifactId>langchain4j-community-bom</artifactId>
         <version>${latest version here}</version>
-        <typ>pom</typ>
+        <type>pom</type>
         <scope>import</scope>
     </dependency>
 </dependencyManagement>


### PR DESCRIPTION
## Issue

Fixes #3596

## Change

Fix typo in pom type configuration tag

Corrects a typo in the documentation where the XML tag for pom type was incorrectly written as `<typ>pom</typ>` instead of the proper `<type>pom</type>`.

This change:
- Fixes invalid XML syntax in the configuration example
- Ensures consistency with standard Maven configuration conventions
- Prevents potential implementation issues when developers copy-paste the snippet

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
