### PR TITLE
#3628: Use received description for visited json object schema

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -24,14 +24,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Internal
@@ -107,6 +100,19 @@ public class JsonSchemaElementUtils {
             if (jsonSchemaElement instanceof JsonReferenceSchema) {
                 visitedClassMetadata.recursionDetected = true;
             }
+            if (jsonSchemaElement instanceof JsonObjectSchema obj) {
+                if (Objects.equals(description, obj.description())) {
+                    return obj;
+                }
+                return JsonObjectSchema.builder()
+                        .description(description)
+                        .addProperties(obj.properties())
+                        .required(obj.required())
+                        .additionalProperties(obj.additionalProperties())
+                        .definitions(obj.definitions())
+                        .build();
+            }
+
             return jsonSchemaElement;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -104,13 +104,7 @@ public class JsonSchemaElementUtils {
                 if (Objects.equals(description, obj.description())) {
                     return obj;
                 }
-                return JsonObjectSchema.builder()
-                        .description(description)
-                        .addProperties(obj.properties())
-                        .required(obj.required())
-                        .additionalProperties(obj.additionalProperties())
-                        .definitions(obj.definitions())
-                        .build();
+                return obj.toBuilder().description(description).build();
             }
 
             return jsonSchemaElement;

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonObjectSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonObjectSchema.java
@@ -4,10 +4,7 @@ import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.quoted;
 import static java.util.Arrays.asList;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 public class JsonObjectSchema implements JsonSchemaElement {
 
@@ -51,6 +48,15 @@ public class JsonObjectSchema implements JsonSchemaElement {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return builder()
+                .description(this.description)
+                .addProperties(this.properties)
+                .required(this.required != null ? new ArrayList<>(this.required) : null)
+                .additionalProperties(this.additionalProperties)
+                .definitions(this.definitions != null ? new LinkedHashMap<>(this.definitions) : null);
     }
 
     public static class Builder {

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
@@ -1,9 +1,6 @@
 package dev.langchain4j.internal;
 
-import static dev.langchain4j.internal.JsonSchemaElementUtils.isJsonArray;
-import static dev.langchain4j.internal.JsonSchemaElementUtils.isJsonString;
-import static dev.langchain4j.internal.JsonSchemaElementUtils.jsonSchemaElementFrom;
-import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -134,6 +131,37 @@ class JsonSchemaElementUtilsTest {
                         .addStringProperty("uuid", "My UUID")
                         .required("uuid")
                         .build());
+    }
+
+    @Test
+    void givenVisitedJsonObjectSchema_whenDescriptionIsDifferent_thenReturnsNewSchemaWithUpdatedDescription() {
+        JsonObjectSchema jsonObjectSchema = JsonObjectSchema.builder()
+                .description("old")
+                .addStringProperty("a")
+                .build();
+        Map<Class<?>, VisitedClassMetadata> visited =
+                Map.of(CustomClass.class, new VisitedClassMetadata(jsonObjectSchema, "ref-object", false));
+
+        JsonSchemaElement result = jsonObjectOrReferenceSchemaFrom(CustomClass.class, "new", false, visited, false);
+
+        assertThat(result).isNotSameAs(jsonObjectSchema);
+        assertThat(result.description()).isEqualTo("new");
+    }
+
+    @Test
+    void givenVisitedJsonObjectSchema_whenDescriptionIsSame_thenReturnsSameInstance() {
+        JsonObjectSchema jsonObjectSchema = JsonObjectSchema.builder()
+                .description("same-desc")
+                .addStringProperty("a")
+                .build();
+        Map<Class<?>, VisitedClassMetadata> visited =
+                Map.of(CustomClass.class, new VisitedClassMetadata(jsonObjectSchema, "ref-object", false));
+
+        JsonSchemaElement result =
+                jsonObjectOrReferenceSchemaFrom(CustomClass.class, "same-desc", false, visited, false);
+
+        assertThat(result).isSameAs(jsonObjectSchema);
+        assertThat(result.description()).isEqualTo("same-desc");
     }
 
     @Test


### PR DESCRIPTION
## Issue
Fixes #3628 

## Change
In this PR, we aim to return the received description instead of using the one from the visited `JsonObjectSchema`. For this, we need to build a new `JsonObjectSchema` with all properties from the visited one, but with the received description.

## General checklist
- [x] There are no breaking changes
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)