### PR TITLE
feat(anthropic): propagate user id in Anthropic models

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -56,6 +56,7 @@ AnthropicChatModel model = AnthropicChatModel.builder()
     .logResponses(...)
     .listeners(...)
     .defaultRequestParameters(...)
+    .userId(...)
     .build();
 ```
 See the description of some of the parameters above [here](https://docs.anthropic.com/claude/reference/messages_post).

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -16,7 +16,6 @@ import static java.util.Arrays.asList;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
@@ -34,10 +33,9 @@ import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
-import org.slf4j.Logger;
-
 import java.time.Duration;
 import java.util.List;
+import org.slf4j.Logger;
 
 /**
  * Represents an Anthropic language model with a Messages (chat) API.
@@ -69,6 +67,7 @@ public class AnthropicChatModel implements ChatModel {
     private final int maxRetries;
     private final List<ChatModelListener> listeners;
     private final ChatRequestParameters defaultRequestParameters;
+    private final String userId;
 
     public AnthropicChatModel(AnthropicChatModelBuilder builder) {
         this.client = AnthropicClient.builder()
@@ -91,6 +90,7 @@ public class AnthropicChatModel implements ChatModel {
         this.sendThinking = getOrDefault(builder.sendThinking, true);
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
         this.listeners = copy(builder.listeners);
+        this.userId = builder.userId;
 
         ChatRequestParameters commonParameters;
         if (builder.defaultRequestParameters != null) {
@@ -105,7 +105,8 @@ public class AnthropicChatModel implements ChatModel {
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
                 .topK(getOrDefault(builder.topK, commonParameters.topK()))
-                .maxOutputTokens(getOrDefault(builder.maxTokens, getOrDefault(commonParameters.maxOutputTokens(), 1024)))
+                .maxOutputTokens(
+                        getOrDefault(builder.maxTokens, getOrDefault(commonParameters.maxOutputTokens(), 1024)))
                 .stopSequences(getOrDefault(builder.stopSequences, commonParameters.stopSequences()))
                 .toolSpecifications(getOrDefault(builder.toolSpecifications, commonParameters.toolSpecifications()))
                 .toolChoice(getOrDefault(builder.toolChoice, commonParameters.toolChoice()))
@@ -144,6 +145,7 @@ public class AnthropicChatModel implements ChatModel {
         private Logger logger;
         private List<ChatModelListener> listeners;
         private ChatRequestParameters defaultRequestParameters;
+        private String userId;
 
         public AnthropicChatModelBuilder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
             this.httpClientBuilder = httpClientBuilder;
@@ -319,6 +321,20 @@ public class AnthropicChatModel implements ChatModel {
             return this;
         }
 
+        /**
+         * Sets the user ID for the requests.
+         * This should be a uuid, hash value, or other opaque identifier.
+         * Anthropic may use this id to help detect abuse.
+         * Do not include any identifying information such as name, email address, or phone number.
+         *
+         * @param userId the user identifier
+         * @return this builder
+         */
+        public AnthropicChatModelBuilder userId(String userId) {
+            this.userId = userId;
+            return this;
+        }
+
         public AnthropicChatModel build() {
             return new AnthropicChatModel(this);
         }
@@ -328,12 +344,14 @@ public class AnthropicChatModel implements ChatModel {
     public ChatResponse doChat(ChatRequest chatRequest) {
         validate(chatRequest.parameters());
 
-        AnthropicCreateMessageRequest anthropicRequest = createAnthropicRequest(chatRequest,
+        AnthropicCreateMessageRequest anthropicRequest = createAnthropicRequest(
+                chatRequest,
                 toThinking(thinkingType, thinkingBudgetTokens),
                 sendThinking,
                 cacheSystemMessages ? EPHEMERAL : NO_CACHE,
                 cacheTools ? EPHEMERAL : NO_CACHE,
-                false);
+                false,
+                userId);
 
         AnthropicCreateMessageResponse response =
                 withRetryMappingExceptions(() -> client.createMessage(anthropicRequest), maxRetries);

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
@@ -1,28 +1,26 @@
 package dev.langchain4j.model.anthropic;
 
-import dev.langchain4j.Internal;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.exception.UnsupportedFeatureException;
-import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType;
-import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
-import dev.langchain4j.model.anthropic.internal.api.AnthropicTextContent;
-import dev.langchain4j.model.anthropic.internal.api.AnthropicThinking;
-import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicMessages;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicSystemPrompt;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicToolChoice;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicTools;
 
+import dev.langchain4j.Internal;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicMetadata;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicThinking;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import java.util.ArrayList;
+import java.util.List;
+
 @Internal
 class InternalAnthropicHelper {
 
-    private InternalAnthropicHelper() { }
+    private InternalAnthropicHelper() {}
 
     static void validate(ChatRequestParameters parameters) {
         List<String> unsupportedFeatures = new ArrayList<>();
@@ -40,19 +38,21 @@ class InternalAnthropicHelper {
             if (unsupportedFeatures.size() == 1) {
                 throw new UnsupportedFeatureException(unsupportedFeatures.get(0) + " is not supported by Anthropic");
             }
-            throw new UnsupportedFeatureException(String.join(", ", unsupportedFeatures) + " are not supported by Anthropic");
+            throw new UnsupportedFeatureException(
+                    String.join(", ", unsupportedFeatures) + " are not supported by Anthropic");
         }
     }
 
-    static AnthropicCreateMessageRequest createAnthropicRequest(ChatRequest chatRequest,
-                                                                AnthropicThinking thinking,
-                                                                boolean sendThinking,
-                                                                AnthropicCacheType cacheType,
-                                                                AnthropicCacheType toolsCacheType,
-                                                                boolean stream) {
+    static AnthropicCreateMessageRequest createAnthropicRequest(
+            ChatRequest chatRequest,
+            AnthropicThinking thinking,
+            boolean sendThinking,
+            AnthropicCacheType cacheType,
+            AnthropicCacheType toolsCacheType,
+            boolean stream,
+            String userId) {
 
-        AnthropicCreateMessageRequest.Builder requestBuilder = AnthropicCreateMessageRequest.builder()
-                .stream(stream)
+        AnthropicCreateMessageRequest.Builder requestBuilder = AnthropicCreateMessageRequest.builder().stream(stream)
                 .model(chatRequest.modelName())
                 .messages(toAnthropicMessages(chatRequest.messages(), sendThinking))
                 .system(toAnthropicSystemPrompt(chatRequest.messages(), cacheType))
@@ -68,6 +68,10 @@ class InternalAnthropicHelper {
         }
         if (chatRequest.toolChoice() != null) {
             requestBuilder.toolChoice(toAnthropicToolChoice(chatRequest.toolChoice()));
+        }
+
+        if (!isNullOrEmpty(userId)) {
+            requestBuilder.metadata(AnthropicMetadata.builder().userId(userId).build());
         }
 
         return requestBuilder.build();

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCreateMessageRequest.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCreateMessageRequest.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.util.List;
 
 @JsonInclude(NON_NULL)
@@ -26,6 +25,7 @@ public class AnthropicCreateMessageRequest {
     public List<AnthropicTool> tools;
     public AnthropicToolChoice toolChoice;
     public AnthropicThinking thinking;
+    public AnthropicMetadata metadata;
 
     public AnthropicCreateMessageRequest() {}
 
@@ -41,7 +41,8 @@ public class AnthropicCreateMessageRequest {
             Integer topK,
             List<AnthropicTool> tools,
             AnthropicToolChoice toolChoice,
-            AnthropicThinking thinking) {
+            AnthropicThinking thinking,
+            AnthropicMetadata metadata) {
         this.model = model;
         this.messages = messages;
         this.system = system;
@@ -54,6 +55,7 @@ public class AnthropicCreateMessageRequest {
         this.tools = tools;
         this.toolChoice = toolChoice;
         this.thinking = thinking;
+        this.metadata = metadata;
     }
 
     public String getModel() {
@@ -152,23 +154,33 @@ public class AnthropicCreateMessageRequest {
         this.thinking = thinking;
     }
 
+    public AnthropicMetadata getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(AnthropicMetadata metadata) {
+        this.metadata = metadata;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
 
     public Builder toBuilder() {
-        return new Builder().model(this.model)
-                .messages(this.messages)
-                .system(this.system)
-                .maxTokens(this.maxTokens)
-                .stopSequences(this.stopSequences)
-                .stream(this.stream)
-                .temperature(this.temperature)
-                .topP(this.topP)
-                .topK(this.topK)
-                .tools(this.tools)
-                .toolChoice(this.toolChoice)
-                .thinking(this.thinking);
+        return new Builder()
+                        .model(this.model)
+                        .messages(this.messages)
+                        .system(this.system)
+                        .maxTokens(this.maxTokens)
+                        .stopSequences(this.stopSequences)
+                        .stream(this.stream)
+                        .temperature(this.temperature)
+                        .topP(this.topP)
+                        .topK(this.topK)
+                        .tools(this.tools)
+                        .toolChoice(this.toolChoice)
+                        .thinking(this.thinking)
+                        .metadata(this.metadata);
     }
 
     public static class Builder {
@@ -185,6 +197,7 @@ public class AnthropicCreateMessageRequest {
         private List<AnthropicTool> tools;
         private AnthropicToolChoice toolChoice;
         private AnthropicThinking thinking;
+        private AnthropicMetadata metadata;
 
         public Builder model(String model) {
             this.model = model;
@@ -246,6 +259,11 @@ public class AnthropicCreateMessageRequest {
             return this;
         }
 
+        public Builder metadata(AnthropicMetadata metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
         public AnthropicCreateMessageRequest build() {
             return new AnthropicCreateMessageRequest(
                     model,
@@ -259,7 +277,8 @@ public class AnthropicCreateMessageRequest {
                     topK,
                     tools,
                     toolChoice,
-                    thinking);
+                    thinking,
+                    metadata);
         }
     }
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicMetadata.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicMetadata.java
@@ -1,0 +1,80 @@
+package dev.langchain4j.model.anthropic.internal.api;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * Represents metadata for Anthropic API requests.
+ * Currently supports user_id for tracking and abuse detection.
+ */
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class AnthropicMetadata {
+
+    /**
+     * An external identifier for the user who is associated with the request.
+     * This should be a uuid, hash value, or other opaque identifier.
+     * Anthropic may use this id to help detect abuse.
+     * Do not include any identifying information such as name, email address, or phone number.
+     */
+    public String userId;
+
+    public AnthropicMetadata() {}
+
+    public AnthropicMetadata(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder().userId(this.userId);
+    }
+
+    public static class Builder {
+
+        private String userId;
+
+        public Builder userId(String userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public AnthropicMetadata build() {
+            return new AnthropicMetadata(userId);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AnthropicMetadata that = (AnthropicMetadata) o;
+        return java.util.Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(userId);
+    }
+
+    @Override
+    public String toString() {
+        return "AnthropicMetadata{" + "userId='" + userId + '\'' + '}';
+    }
+}

--- a/langchain4j-anthropic/src/main/resources/META-INF/native-image/dev.langchain4j/langchain4j-anthropic/reflect-config.json
+++ b/langchain4j-anthropic/src/main/resources/META-INF/native-image/dev.langchain4j/langchain4j-anthropic/reflect-config.json
@@ -90,6 +90,15 @@
       "allPublicFields": true
     },
     {
+        "name": "dev.langchain4j.model.anthropic.internal.api.AnthropicMetadata",
+        "allDeclaredConstructors": true,
+        "allPublicConstructors": true,
+        "allDeclaredMethods": true,
+        "allPublicMethods": true,
+        "allDeclaredFields": true,
+        "allPublicFields": true
+    },
+    {
         "name": "dev.langchain4j.model.anthropic.internal.api.AnthropicMessage",
         "allDeclaredConstructors": true,
         "allPublicConstructors": true,

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelIT.java
@@ -35,7 +35,6 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -126,9 +125,11 @@ class AnthropicStreamingChatModelIT {
     }
 
     @ParameterizedTest
-    @EnumSource(value = AnthropicChatModelName.class, mode = EXCLUDE, names = {
-            "CLAUDE_OPUS_4_20250514" // Run manually before release. Expensive to run very often.
-    })
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = EXCLUDE,
+            names = {"CLAUDE_OPUS_4_20250514" // Run manually before release. Expensive to run very often.
+            })
     void should_support_all_enum_model_names(AnthropicChatModelName modelName) {
 
         // given
@@ -530,6 +531,27 @@ class AnthropicStreamingChatModelIT {
         Throwable error = futureError.get(5, SECONDS);
 
         assertThat(error).isExactlyInstanceOf(dev.langchain4j.exception.TimeoutException.class);
+    }
+
+    @Test
+    void should_work_with_userId() {
+        // given
+        StreamingChatModel model = AnthropicStreamingChatModel.builder()
+                .apiKey(getenv("ANTHROPIC_API_KEY"))
+                .modelName(CLAUDE_3_5_HAIKU_20241022)
+                .userId("test-user-12345")
+                .maxTokens(10)
+                .build();
+
+        String userMessage = "Say hello";
+
+        // when
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        model.chat(userMessage, handler);
+        ChatResponse response = handler.get();
+
+        // then
+        assertThat(response.aiMessage().text()).isNotBlank();
     }
 
     private static void assertTokenUsage(@NotNull TokenUsage tokenUsage) {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicUserIdIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicUserIdIT.java
@@ -1,0 +1,168 @@
+package dev.langchain4j.model.anthropic;
+
+import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_3_5_HAIKU_20241022;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
+import dev.langchain4j.model.anthropic.internal.client.AnthropicClient;
+import dev.langchain4j.model.anthropic.internal.client.AnthropicCreateMessageOptions;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.mockito.ArgumentCaptor;
+
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+class AnthropicUserIdIT {
+
+    private static final String TEST_USER_ID = "test-user-123";
+
+    @Test
+    void should_include_userId_in_chat_model_request() {
+        // given
+        AnthropicClient mockClient = mock(AnthropicClient.class);
+
+        ChatModel model = AnthropicChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(CLAUDE_3_5_HAIKU_20241022)
+                .userId(TEST_USER_ID)
+                .maxTokens(10)
+                .build();
+
+        // Use reflection to replace the client with our mock
+        try {
+            java.lang.reflect.Field clientField = AnthropicChatModel.class.getDeclaredField("client");
+            clientField.setAccessible(true);
+            clientField.set(model, mockClient);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        UserMessage userMessage = UserMessage.from("Hello");
+
+        // when
+        model.chat(userMessage);
+
+        // then
+        ArgumentCaptor<AnthropicCreateMessageRequest> requestCaptor =
+                ArgumentCaptor.forClass(AnthropicCreateMessageRequest.class);
+        verify(mockClient).createMessage(requestCaptor.capture());
+
+        AnthropicCreateMessageRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.getMetadata()).isNotNull();
+        assertThat(capturedRequest.getMetadata().getUserId()).isEqualTo(TEST_USER_ID);
+    }
+
+    @Test
+    void should_include_userId_in_streaming_chat_model_request() {
+        // given
+        AnthropicClient mockClient = mock(AnthropicClient.class);
+
+        StreamingChatModel model = AnthropicStreamingChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(CLAUDE_3_5_HAIKU_20241022)
+                .userId(TEST_USER_ID)
+                .maxTokens(10)
+                .build();
+
+        // Use reflection to replace the client with our mock
+        try {
+            java.lang.reflect.Field clientField = AnthropicStreamingChatModel.class.getDeclaredField("client");
+            clientField.setAccessible(true);
+            clientField.set(model, mockClient);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        UserMessage userMessage = UserMessage.from("Hello");
+        StreamingChatResponseHandler handler = mock(StreamingChatResponseHandler.class);
+
+        // when
+        model.chat(List.of(userMessage), handler);
+
+        // then
+        ArgumentCaptor<AnthropicCreateMessageRequest> requestCaptor =
+                ArgumentCaptor.forClass(AnthropicCreateMessageRequest.class);
+        verify(mockClient)
+                .createMessage(requestCaptor.capture(), any(AnthropicCreateMessageOptions.class), eq(handler));
+
+        AnthropicCreateMessageRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.getMetadata()).isNotNull();
+        assertThat(capturedRequest.getMetadata().getUserId()).isEqualTo(TEST_USER_ID);
+    }
+
+    @Test
+    void should_not_include_metadata_when_userId_is_null() {
+        // given
+        AnthropicClient mockClient = mock(AnthropicClient.class);
+
+        ChatModel model = AnthropicChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(CLAUDE_3_5_HAIKU_20241022)
+                .maxTokens(10)
+                .build();
+
+        // Use reflection to replace the client with our mock
+        try {
+            java.lang.reflect.Field clientField = AnthropicChatModel.class.getDeclaredField("client");
+            clientField.setAccessible(true);
+            clientField.set(model, mockClient);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        UserMessage userMessage = UserMessage.from("Hello");
+
+        // when
+        model.chat(userMessage);
+
+        // then
+        ArgumentCaptor<AnthropicCreateMessageRequest> requestCaptor =
+                ArgumentCaptor.forClass(AnthropicCreateMessageRequest.class);
+        verify(mockClient).createMessage(requestCaptor.capture());
+
+        AnthropicCreateMessageRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.getMetadata()).isNull();
+    }
+
+    @Test
+    void should_not_include_metadata_when_userId_is_empty() {
+        // given
+        AnthropicClient mockClient = mock(AnthropicClient.class);
+
+        ChatModel model = AnthropicChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(CLAUDE_3_5_HAIKU_20241022)
+                .userId("")
+                .maxTokens(10)
+                .build();
+
+        // Use reflection to replace the client with our mock
+        try {
+            java.lang.reflect.Field clientField = AnthropicChatModel.class.getDeclaredField("client");
+            clientField.setAccessible(true);
+            clientField.set(model, mockClient);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        UserMessage userMessage = UserMessage.from("Hello");
+
+        // when
+        model.chat(userMessage);
+
+        // then
+        ArgumentCaptor<AnthropicCreateMessageRequest> requestCaptor =
+                ArgumentCaptor.forClass(AnthropicCreateMessageRequest.class);
+        verify(mockClient).createMessage(requestCaptor.capture());
+
+        AnthropicCreateMessageRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.getMetadata()).isNull();
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/internal/api/AnthropicMetadataTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/internal/api/AnthropicMetadataTest.java
@@ -1,0 +1,117 @@
+package dev.langchain4j.model.anthropic.internal.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class AnthropicMetadataTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void should_create_metadata_with_userId() {
+        // given
+        String userId = "test-user-123";
+
+        // when
+        AnthropicMetadata metadata = new AnthropicMetadata(userId);
+
+        // then
+        assertThat(metadata.getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void should_create_metadata_using_builder() {
+        // given
+        String userId = "test-user-456";
+
+        // when
+        AnthropicMetadata metadata = AnthropicMetadata.builder().userId(userId).build();
+
+        // then
+        assertThat(metadata.getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void should_serialize_to_json_with_snake_case() throws Exception {
+        // given
+        AnthropicMetadata metadata =
+                AnthropicMetadata.builder().userId("test-user-789").build();
+
+        // when
+        String json = OBJECT_MAPPER.writeValueAsString(metadata);
+
+        // then
+        assertThat(json).contains("\"user_id\":\"test-user-789\"");
+    }
+
+    @Test
+    void should_deserialize_from_json_with_snake_case() throws Exception {
+        // given
+        String json = "{\"user_id\":\"test-user-abc\"}";
+
+        // when
+        AnthropicMetadata metadata = OBJECT_MAPPER.readValue(json, AnthropicMetadata.class);
+
+        // then
+        assertThat(metadata.getUserId()).isEqualTo("test-user-abc");
+    }
+
+    @Test
+    void should_not_serialize_null_userId() throws Exception {
+        // given
+        AnthropicMetadata metadata = new AnthropicMetadata();
+
+        // when
+        String json = OBJECT_MAPPER.writeValueAsString(metadata);
+
+        // then
+        assertThat(json).isEqualTo("{}");
+    }
+
+    @Test
+    void should_handle_equals_and_hashCode() {
+        // given
+        AnthropicMetadata metadata1 =
+                AnthropicMetadata.builder().userId("user1").build();
+        AnthropicMetadata metadata2 =
+                AnthropicMetadata.builder().userId("user1").build();
+        AnthropicMetadata metadata3 =
+                AnthropicMetadata.builder().userId("user2").build();
+
+        // then
+        assertThat(metadata1).isEqualTo(metadata2);
+        assertThat(metadata1).isNotEqualTo(metadata3);
+        assertThat(metadata1.hashCode()).isEqualTo(metadata2.hashCode());
+        assertThat(metadata1.hashCode()).isNotEqualTo(metadata3.hashCode());
+    }
+
+    @Test
+    void should_have_meaningful_toString() {
+        // given
+        AnthropicMetadata metadata =
+                AnthropicMetadata.builder().userId("test-user").build();
+
+        // when
+        String toString = metadata.toString();
+
+        // then
+        assertThat(toString).contains("AnthropicMetadata");
+        assertThat(toString).contains("userId='test-user'");
+    }
+
+    @Test
+    void should_create_builder_from_existing_metadata() {
+        // given
+        AnthropicMetadata original =
+                AnthropicMetadata.builder().userId("original-user").build();
+
+        // when
+        AnthropicMetadata copy = original.toBuilder().build();
+
+        // then
+        assertThat(copy.getUserId()).isEqualTo("original-user");
+        assertThat(copy).isEqualTo(original);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #3648

## Change
Added user id to Anthropic chat models, passed it in request as `metadata.user_id` per [Anthropic docs](https://docs.anthropic.com/en/api/messages#body-metadata).


## General checklist
- [X] There are no breaking changes
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)