### PR TITLE
Clarify the documentation by using static imports

### DIFF
--- a/docs/docs/integrations/embedding-models/open-ai-official.md
+++ b/docs/docs/integrations/embedding-models/open-ai-official.md
@@ -55,12 +55,14 @@ import com.openai.models.embeddings.EmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialEmbeddingModel;
 
+import static com.openai.models.embeddings.EmbeddingModel.TEXT_EMBEDDING_3_SMALL;
+
 // ....
 
 EmbeddingModel model = OpenAiOfficialEmbeddingModel.builder()
         .baseUrl(System.getenv("AZURE_OPENAI_ENDPOINT"))
         .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-        .modelName(EmbeddingModel.TEXT_EMBEDDING_3_SMALL)
+        .modelName(TEXT_EMBEDDING_3_SMALL)
         .build();
 ```
 
@@ -75,7 +77,7 @@ Azure OpenAI and GitHub Models, using the `isAzure()` and `isGitHubModels()` met
 EmbeddingModel model = OpenAiOfficialEmbeddingModel.builder()
         .baseUrl(System.getenv("AZURE_OPENAI_ENDPOINT"))
         .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-        .modelName(EmbeddingModel.TEXT_EMBEDDING_3_SMALL)
+        .modelName(TEXT_EMBEDDING_3_SMALL)
         .isAzure(true) // Not necessary if the base URL ends with `openai.azure.com`
         .build();
 ```
@@ -86,7 +88,7 @@ You can also use "passwordless" authentication, as described in the [OpenAI Offi
 
 ```java
 EmbeddingModel model = OpenAiOfficialEmbeddingModel.builder()
-        .modelName(EmbeddingModel.TEXT_EMBEDDING_3_SMALL)
+        .modelName(TEXT_EMBEDDING_3_SMALL)
         .isGitHubModels(true)
         .build();
 ```

--- a/docs/docs/integrations/image-models/open-ai-official.md
+++ b/docs/docs/integrations/image-models/open-ai-official.md
@@ -53,12 +53,14 @@ import com.openai.models.images.ImageModel;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel;
 
+import static com.openai.models.images.ImageModel.DALL_E_3;
+
 // ....
 
 ImageModel model = OpenAiOfficialImageModel.builder()
         .baseUrl(System.getenv("OPENAI_BASE_URL"))
         .apiKey(System.getenv("OPENAI_API_KEY"))
-        .modelName(ImageModel.DALL_E_3)
+        .modelName(DALL_E_3)
         .build();
 ```
 
@@ -73,7 +75,7 @@ Azure OpenAI and GitHub Models, using the `isAzure()` and `isGitHubModels()` met
 ImageModel model = OpenAiOfficialImageModel.builder()
         .baseUrl(System.getenv("AZURE_OPENAI_ENDPOINT"))
         .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-        .modelName(ImageModel.DALL_E_3)
+        .modelName(DALL_E_3)
         .isAzure(true) // Not necessary if the base URL ends with `openai.azure.com`
         .build();
 ```
@@ -84,7 +86,7 @@ You can also use "passwordless" authentication, as described in the [OpenAI Offi
 
 ```java
 ImageModel model = OpenAiOfficialImageModel.builder()
-        .modelName(ImageModel.DALL_E_3)
+        .modelName(DALL_E_3)
         .isGitHubModels(true)
         .build();
 ```

--- a/docs/docs/integrations/language-models/open-ai-official.md
+++ b/docs/docs/integrations/language-models/open-ai-official.md
@@ -60,12 +60,14 @@ import com.openai.models.ChatModel;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatModel;
 
+import static com.openai.models.ChatModel.GPT_5_MINI;
+
 // ....
 
 ChatModel model = OpenAiOfficialChatModel.builder()
         .baseUrl(System.getenv("OPENAI_BASE_URL"))
         .apiKey(System.getenv("OPENAI_API_KEY"))
-        .modelName(ChatModel.GPT_4O_MINI)
+        .modelName(GPT_5_MINI)
         .build();
 ```
 
@@ -76,7 +78,7 @@ The OpenAI `baseUrl` (`https://api.openai.com/v1`) is the default, so you can om
 ```java
 ChatModel model = OpenAiOfficialChatModel.builder()
         .apiKey(System.getenv("OPENAI_API_KEY"))
-        .modelName(ChatModel.GPT_4O_MINI)
+        .modelName(GPT_5_MINI)
         .build();
 ```
 
@@ -90,7 +92,7 @@ For Azure OpenAI, setting a `baseUrl` is mandatory, and Azure OpenAI will be aut
 ChatModel model = OpenAiOfficialChatModel.builder()
         .baseUrl(System.getenv("AZURE_OPENAI_ENDPOINT"))
         .apiKey(System.getenv("AZURE_OPENAI_KEY"))
-        .modelName(ChatModel.GPT_4O_MINI)
+        .modelName(GPT_5_MINI)
         .build();
 ```
 
@@ -101,7 +103,7 @@ ChatModel model = OpenAiOfficialChatModel.builder()
         .baseUrl(System.getenv("AZURE_OPENAI_ENDPOINT"))
         .apiKey(System.getenv("AZURE_OPENAI_KEY"))
         .isAzure(true)
-        .modelName(ChatModel.GPT_4O_MINI)
+        .modelName(GPT_5_MINI)
         .build();
 ```
 
@@ -147,7 +149,7 @@ For GitHub Models, you can use the default `baseUrl` (`https://models.inference.
 ChatModel model = OpenAiOfficialChatModel.builder()
         .baseUrl("https://models.inference.ai.azure.com")
         .apiKey(System.getenv("GITHUB_TOKEN"))
-        .modelName(ChatModel.GPT_4O_MINI)
+        .modelName(GPT_5_MINI)
         .build();
 ```
 
@@ -156,7 +158,7 @@ Or you can use the `isGitHubModels()` method to force the usage of GitHub Models
 ```java
 ChatModel model = OpenAiOfficialChatModel.builder()
         .apiKey(System.getenv("GITHUB_TOKEN"))
-        .modelName(ChatModel.GPT_4O_MINI)
+        .modelName(GPT_5_MINI)
         .isGitHubModels(true)
         .build();
 ```
@@ -165,7 +167,7 @@ As GitHub Models are usually configured using the `GITHUB_TOKEN` environment var
 
 ```java
 ChatModel model = OpenAiOfficialChatModel.builder()
-        .modelName(ChatModel.GPT_4O_MINI)
+        .modelName(GPT_5_MINI)
         .isGitHubModels(true)
         .build();
 ```
@@ -247,7 +249,7 @@ This is similar to the non-streaming mode, but you need to use the `OpenAiOffici
 StreamingChatModel model = OpenAiOfficialStreamingChatModel.builder()
         .baseUrl(System.getenv("OPENAI_BASE_URL"))
         .apiKey(System.getenv("OPENAI_API_KEY"))
-        .modelName(ChatModel.GPT_4O_MINI)
+        .modelName(GPT_5_MINI)
         .build();
 ```
 


### PR DESCRIPTION
This fixes a clash in import statements, for example between `import dev.langchain4j.model.chat.ChatModel;` and `import com.openai.models.ChatModel;`
