### PR TITLE
test: Add comprehensive test coverage for AiServices, Metadata, and StringSetOutputParsert

### DIFF
--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/query/MetadataTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/query/MetadataTest.java
@@ -77,4 +77,103 @@ class MetadataTest {
                         + "AiMessage { text = \"Hi, how can I help you today?\", thinking = null, toolExecutionRequests = [], attributes = {} }] "
                         + "}");
     }
+
+    @Test
+    void create_with_empty_chat_memory() {
+        // given
+        UserMessage userMessage = UserMessage.from("user message");
+        int chatMemoryId = 1;
+        List<ChatMessage> chatMemory = asList();
+
+        // when
+        Metadata metadata = Metadata.from(userMessage, chatMemoryId, chatMemory);
+
+        // then
+        assertThat(metadata.chatMessage()).isSameAs(userMessage);
+        assertThat(metadata.chatMemoryId()).isSameAs(chatMemoryId);
+        assertThat(metadata.chatMemory()).isEmpty();
+    }
+
+    @Test
+    void create_with_different_message_types() {
+        // given
+        AiMessage aiMessage = AiMessage.from("ai response");
+        int chatMemoryId = 1;
+        List<ChatMessage> chatMemory =
+                asList(UserMessage.from("Question 1"), AiMessage.from("Answer 1"), UserMessage.from("Question 2"));
+
+        // when
+        Metadata metadata = Metadata.from(aiMessage, chatMemoryId, chatMemory);
+
+        // then
+        assertThat(metadata.chatMessage()).isSameAs(aiMessage);
+        assertThat(metadata.chatMemoryId()).isSameAs(chatMemoryId);
+        assertThat(metadata.chatMemory()).hasSize(3);
+    }
+
+    @Test
+    void create_with_zero_chat_memory_id() {
+        // given
+        UserMessage userMessage = UserMessage.from("test message");
+        int chatMemoryId = 0;
+        List<ChatMessage> chatMemory = asList(UserMessage.from("Hello"));
+
+        // when
+        Metadata metadata = Metadata.from(userMessage, chatMemoryId, chatMemory);
+
+        // then
+        assertThat(metadata.chatMemoryId()).isEqualTo(0);
+    }
+
+    @Test
+    void equals_with_null_chat_memory() {
+        // given
+        Metadata metadata1 = Metadata.from(UserMessage.from("message"), 1, null);
+
+        Metadata metadata2 = Metadata.from(UserMessage.from("message"), 1, null);
+
+        // then
+        assertThat(metadata1).isEqualTo(metadata2).hasSameHashCodeAs(metadata2);
+    }
+
+    @Test
+    void equals_with_different_chat_memory_ids() {
+        // given
+        List<ChatMessage> chatMemory = asList(UserMessage.from("Hello"));
+
+        Metadata metadata1 = Metadata.from(UserMessage.from("message"), 1, chatMemory);
+
+        Metadata metadata2 = Metadata.from(UserMessage.from("message"), 2, chatMemory);
+
+        // then
+        assertThat(metadata1).isNotEqualTo(metadata2).doesNotHaveSameHashCodeAs(metadata2);
+    }
+
+    @Test
+    void equals_with_different_chat_messages() {
+        // given
+        List<ChatMessage> chatMemory = asList(UserMessage.from("Hello"));
+
+        Metadata metadata1 = Metadata.from(UserMessage.from("message1"), 1, chatMemory);
+
+        Metadata metadata2 = Metadata.from(UserMessage.from("message2"), 1, chatMemory);
+
+        // then
+        assertThat(metadata1).isNotEqualTo(metadata2).doesNotHaveSameHashCodeAs(metadata2);
+    }
+
+    @Test
+    void chat_memory_immutability() {
+        // given
+        List<ChatMessage> originalChatMemory = asList(UserMessage.from("Hello"), AiMessage.from("Hi"));
+
+        Metadata metadata = Metadata.from(UserMessage.from("message"), 1, originalChatMemory);
+
+        // when
+        List<ChatMessage> retrievedChatMemory = metadata.chatMemory();
+
+        // then - verify defensive copy was made
+        assertThat(retrievedChatMemory).isNotSameAs(originalChatMemory);
+        assertThat(retrievedChatMemory).isEqualTo(originalChatMemory);
+    }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/StringSetOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/StringSetOutputParserTest.java
@@ -94,4 +94,74 @@ class StringSetOutputParserTest {
                 .hasMessageContaining("Failed to parse")
                 .hasMessageContaining("java.util.Set<java.lang.String>");
     }
+
+    @Test
+    void should_handle_json_with_escaped_quotes() {
+        // Given
+        String toParse = "{\"values\":[\"He said \\\"hello\\\"\",\"Quote: \\\"test\\\"\"]}";
+
+        // When
+        Set<String> parsedSet = sut.parse(toParse);
+
+        // Then
+        assertThat(parsedSet).containsExactlyInAnyOrder("He said \"hello\"", "Quote: \"test\"");
+    }
+
+    @Test
+    void should_handle_single_line_with_multiple_separators() {
+        // Given
+        String toParse = "one\n\ntwo\n\n\nthree\n";
+
+        // When
+        Set<String> parsedSet = sut.parse(toParse);
+
+        // Then
+        assertThat(parsedSet).containsExactlyInAnyOrder("one", "two", "three");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "{\"values\":[\"test\", \"duplicate\", \"test\"]}",
+                "{\"values\":[\"A\", \"B\", \"A\", \"C\", \"B\"]}",
+                "duplicate\nvalue\nduplicate\nvalue\nunique"
+            })
+    void should_handle_duplicates_correctly(String input) {
+        // When
+        Set<String> parsedSet = sut.parse(input);
+
+        // Then
+        if (input.startsWith("{")) {
+            if (input.contains("test")) {
+                assertThat(parsedSet).containsExactlyInAnyOrder("test", "duplicate");
+            } else {
+                assertThat(parsedSet).containsExactlyInAnyOrder("A", "B", "C");
+            }
+        } else {
+            assertThat(parsedSet).containsExactlyInAnyOrder("duplicate", "value", "unique");
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{\"values\":[]}", "{\n  \"values\": [\n  ]\n}", "{ \"values\" : [ ] }"})
+    void should_handle_empty_json_arrays(String input) {
+        // When
+        Set<String> parsedSet = sut.parse(input);
+
+        // Then
+        assertThat(parsedSet).isEmpty();
+    }
+
+    @Test
+    void should_preserve_internal_spaces_in_plain_text() {
+        // Given
+        String toParse = "hello world\ntest  value\n  leading space\ntrailing space  ";
+
+        // When
+        Set<String> parsedSet = sut.parse(toParse);
+
+        // Then
+        assertThat(parsedSet)
+                .containsExactlyInAnyOrder("hello world", "test  value", "leading space", "trailing space");
+    }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/StringSetOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/StringSetOutputParserTest.java
@@ -1,18 +1,17 @@
 package dev.langchain4j.service.output;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import java.util.Iterator;
-import java.util.Set;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StringSetOutputParserTest {
 
@@ -63,8 +62,7 @@ class StringSetOutputParserTest {
                 Arguments.of("{\"values\":[\"CAT\",\"DOG\"]}", Set.of("CAT", "DOG")),
                 Arguments.of("{\"values\":[\"CAT\",\"DOG\",\"CAT\"]}", Set.of("CAT", "DOG")),
                 Arguments.of("{\"values\":[]}", Set.of()),
-                Arguments.of("  {\"values\":[\"CAT\",\"DOG\"]}  ", Set.of("CAT", "DOG"))
-        );
+                Arguments.of("  {\"values\":[\"CAT\",\"DOG\"]}  ", Set.of("CAT", "DOG")));
     }
 
     @ParameterizedTest
@@ -80,13 +78,14 @@ class StringSetOutputParserTest {
 
     @ParameterizedTest
     @NullSource
-    @ValueSource(strings = {
-            "{\"values\": \"\"}",
-            "{\"values\": false}",
-            "{\"values\":\"banana\"}",
-            "{\"values\":{\"name\":\"Klaus\"}}",
-            "{\"banana\":[{\"name\":\"Klaus\"}]}",
-    })
+    @ValueSource(
+            strings = {
+                "{\"values\": \"\"}",
+                "{\"values\": false}",
+                "{\"values\":\"banana\"}",
+                "{\"values\":{\"name\":\"Klaus\"}}",
+                "{\"banana\":[{\"name\":\"Klaus\"}]}",
+            })
     void should_fail_to_parse_invalid_input(String input) {
 
         assertThatThrownBy(() -> new StringSetOutputParser().parse(input))


### PR DESCRIPTION
This PR adds comprehensive test coverage for three key components:

**AiServicesModerationTest:**
- Added tests for moderation object preservation in exceptions
- Added edge case handling for whitespace-only flagged content
- Added tests for reusing completed futures multiple times

**MetadataTest:**
- Added tests for empty chat memory scenarios
- Added tests for different message types (AiMessage vs UserMessage)
- Added boundary value tests (zero chat memory ID)
- Added comprehensive equals/hashCode tests for null scenarios and different field values
- Added immutability verification tests to ensure defensive copying

**StringSetOutputParserTest:**
- Added tests for JSON escaped quotes handling
- Added tests for multiple line separators edge cases
- Added parameterized tests for duplicate handling across JSON and plain text formats
- Added tests for various empty JSON array formatting styles
- Added tests for internal whitespace preservation

These tests improve robustness by covering edge cases, error scenarios, and ensuring proper behavior of core functionality.