### PR TITLE
Add image URL support for Anthropic Claude vision models(#3691)

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContent.java
@@ -26,11 +26,11 @@ public class AnthropicImageContent extends AnthropicMessageContent {
     }
 
     public static AnthropicImageContent fromBase64(String mediaType, String data) {
-        return new AnthropicImageContent(AnthropicImageContentSource.forBase64(mediaType, data));
+        return new AnthropicImageContent(AnthropicImageContentSource.fromBase64(mediaType, data));
     }
 
     public static AnthropicImageContent fromUrl(String url) {
-        return new AnthropicImageContent(AnthropicImageContentSource.forUrl(url));
+        return new AnthropicImageContent(AnthropicImageContentSource.fromUrl(url));
     }
 
     @Override

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContent.java
@@ -15,12 +15,11 @@ public class AnthropicImageContent extends AnthropicMessageContent {
 
     public AnthropicImageContentSource source;
 
-    private AnthropicImageContent(AnthropicImageContentSource source) {
+    public AnthropicImageContent(AnthropicImageContentSource source) {
         super("image");
         this.source = source;
     }
 
-    @Deprecated
     public AnthropicImageContent(String mediaType, String data) {
         super("image");
         this.source = new AnthropicImageContentSource("base64", mediaType, data);

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContent.java
@@ -15,9 +15,23 @@ public class AnthropicImageContent extends AnthropicMessageContent {
 
     public AnthropicImageContentSource source;
 
+    private AnthropicImageContent(AnthropicImageContentSource source) {
+        super("image");
+        this.source = source;
+    }
+
+    @Deprecated
     public AnthropicImageContent(String mediaType, String data) {
         super("image");
         this.source = new AnthropicImageContentSource("base64", mediaType, data);
+    }
+
+    public static AnthropicImageContent fromBase64(String mediaType, String data) {
+        return new AnthropicImageContent(AnthropicImageContentSource.forBase64(mediaType, data));
+    }
+
+    public static AnthropicImageContent fromUrl(String url) {
+        return new AnthropicImageContent(AnthropicImageContentSource.forUrl(url));
     }
 
     @Override

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContentSource.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContentSource.java
@@ -20,7 +20,6 @@ public class AnthropicImageContentSource {
 
     private AnthropicImageContentSource() {}
 
-    @Deprecated
     public AnthropicImageContentSource(String type, String mediaType, String data) {
         this.type = type;
         this.mediaType = mediaType;

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContentSource.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContentSource.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Objects;
 
 @JsonInclude(NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -15,10 +16,54 @@ public class AnthropicImageContentSource {
     public String type;
     public String mediaType;
     public String data;
+    public String url;
 
+    private AnthropicImageContentSource() {}
+
+    @Deprecated
     public AnthropicImageContentSource(String type, String mediaType, String data) {
         this.type = type;
         this.mediaType = mediaType;
         this.data = data;
+    }
+
+    public static AnthropicImageContentSource forBase64(String mediaType, String data) {
+        AnthropicImageContentSource source = new AnthropicImageContentSource();
+        source.type = "base64";
+        source.mediaType = mediaType;
+        source.data = data;
+        return source;
+    }
+
+    public static AnthropicImageContentSource forUrl(String url) {
+        AnthropicImageContentSource source = new AnthropicImageContentSource();
+        source.type = "url";
+        source.url = url;
+        return source;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AnthropicImageContentSource that = (AnthropicImageContentSource) o;
+        return Objects.equals(type, that.type)
+                && Objects.equals(mediaType, that.mediaType)
+                && Objects.equals(data, that.data)
+                && Objects.equals(url, that.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, mediaType, data, url);
+    }
+
+    @Override
+    public String toString() {
+        return "AnthropicImageContentSource{" + "type='"
+                + type + '\'' + ", mediaType='"
+                + mediaType + '\'' + ", data='"
+                + data + '\'' + ", url='"
+                + url + '\'' + '}';
     }
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContentSource.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicImageContentSource.java
@@ -18,7 +18,12 @@ public class AnthropicImageContentSource {
     public String data;
     public String url;
 
-    private AnthropicImageContentSource() {}
+    public AnthropicImageContentSource(String type, String mediaType, String data, String url) {
+        this.type = type;
+        this.mediaType = mediaType;
+        this.data = data;
+        this.url = url;
+    }
 
     public AnthropicImageContentSource(String type, String mediaType, String data) {
         this.type = type;
@@ -26,19 +31,12 @@ public class AnthropicImageContentSource {
         this.data = data;
     }
 
-    public static AnthropicImageContentSource forBase64(String mediaType, String data) {
-        AnthropicImageContentSource source = new AnthropicImageContentSource();
-        source.type = "base64";
-        source.mediaType = mediaType;
-        source.data = data;
-        return source;
+    public static AnthropicImageContentSource fromBase64(String mediaType, String data) {
+        return new AnthropicImageContentSource("base64", mediaType, data, null);
     }
 
-    public static AnthropicImageContentSource forUrl(String url) {
-        AnthropicImageContentSource source = new AnthropicImageContentSource();
-        source.type = "url";
-        source.url = url;
-        return source;
+    public static AnthropicImageContentSource fromUrl(String url) {
+        return new AnthropicImageContentSource("url", null, null, url);
     }
 
     @Override

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -33,7 +33,6 @@ import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.pdf.PdfFile;
-import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicContent;
@@ -118,10 +117,9 @@ public class AnthropicMapper {
                     } else if (content instanceof ImageContent imageContent) {
                         Image image = imageContent.image();
                         if (image.url() != null) {
-                            throw new UnsupportedFeatureException(
-                                    "Anthropic does not support images as URLs, only as Base64-encoded strings");
+                            return AnthropicImageContent.fromUrl(image.url().toString());
                         }
-                        return new AnthropicImageContent(
+                        return AnthropicImageContent.fromBase64(
                                 ensureNotBlank(image.mimeType(), "mimeType"),
                                 ensureNotBlank(image.base64Data(), "base64Data"));
                     } else if (content instanceof PdfFileContent pdfFileContent) {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicChatModelIT.java
@@ -76,10 +76,4 @@ class AnthropicChatModelIT extends AbstractChatModelIT {
         // Anthropic does not support response format yet
         return false;
     }
-
-    @Override
-    protected boolean supportsSingleImageInputAsPublicURL() {
-        // Anthropic does not support images as URLs, only as Base64-encoded strings
-        return false;
-    }
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicStreamingChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicStreamingChatModelIT.java
@@ -87,12 +87,6 @@ class AnthropicStreamingChatModelIT extends AbstractStreamingChatModelIT {
     }
 
     @Override
-    protected boolean supportsSingleImageInputAsPublicURL() {
-        // Anthropic does not support images as URLs, only as Base64-encoded strings
-        return false;
-    }
-
-    @Override
     public StreamingChatModel createModelWith(ChatModelListener listener) {
         return AnthropicStreamingChatModel.builder()
                 .apiKey(getenv("ANTHROPIC_API_KEY"))


### PR DESCRIPTION
 ## Issue
  Closes #3691 Add image URL support for Anthropic Claude vision models

  ## Change
  Added image URL support for Anthropic Claude vision models alongside existing base64 image support:

  - Extended `AnthropicImageContent` to support URL type images
  - Updated `AnthropicImageContentSource` to handle both URL and base64 formats
  - Modified `AnthropicMapper` to process URL-based image content
  - Updated tests in `AnthropicMapperTest` to cover new URL functionality
  - Maintained full backward compatibility with existing base64 image handling

  ## General checklist
  - [x] There are no breaking changes
  - [x] I have added unit and/or integration tests for my change
  - [x] The tests cover both positive and negative cases
  - [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j)
  modules, and they are all green
  - [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
  - [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
  - [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)