### PR TITLE
Test for 'data:' inside a SSE event

### DIFF
--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpLoggingTestBase.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpLoggingTestBase.java
@@ -32,7 +32,7 @@ public abstract class McpLoggingTestBase {
         McpLogMessage message = receivedMessages.get(0);
         assertThat(message.level()).isEqualTo(McpLogLevel.INFO);
         assertThat(message.logger()).isEqualTo("tool:info");
-        assertThat(message.data().asText()).isEqualTo("HELLO");
+        assertThat(message.data().asText()).isEqualTo("HELLO. data: 1234");
     }
 
     @Test

--- a/langchain4j-mcp/src/test/resources/logging_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/logging_mcp_server.java
@@ -16,7 +16,8 @@ public class logging_mcp_server {
 
     @Tool(description = "Log an INFO-level message")
     public String info(McpLog log) {
-        log.info("HELLO");
+        // put an additional 'data:' into the message just to test that it doesn't break the SSE event parsing logic
+        log.info("HELLO. data: 1234");
         return "ok";
     }
 


### PR DESCRIPTION
Follow-up on https://github.com/langchain4j/langchain4j/pull/3724/