### PR TITLE
Rework MCP client to support structured content results

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolExecutor.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolExecutor.java
@@ -3,7 +3,9 @@ package dev.langchain4j.mcp;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 
 /**
@@ -19,6 +21,11 @@ public class McpToolExecutor implements ToolExecutor {
 
     @Override
     public String execute(ToolExecutionRequest executionRequest, Object memoryId) {
+        return mcpClient.executeTool(executionRequest).resultText();
+    }
+
+    @Override
+    public ToolExecutionResult executeWithContext(ToolExecutionRequest executionRequest, InvocationContext context) {
         return mcpClient.executeTool(executionRequest);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -30,6 +30,7 @@ import dev.langchain4j.mcp.client.protocol.McpReadResourceRequest;
 import dev.langchain4j.mcp.client.protocol.McpRootsListChangedNotification;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -90,7 +91,7 @@ public class DefaultMcpClient implements McpClient {
             key = getOrDefault(builder.key, () -> UUID.randomUUID().toString());
             clientName = getOrDefault(builder.clientName, "langchain4j");
             clientVersion = getOrDefault(builder.clientVersion, "1.0");
-            protocolVersion = getOrDefault(builder.protocolVersion, "2024-11-05");
+            protocolVersion = getOrDefault(builder.protocolVersion, "2025-06-18");
             initializationTimeout = getOrDefault(builder.initializationTimeout, Duration.ofSeconds(30));
             toolExecutionTimeout = getOrDefault(builder.toolExecutionTimeout, Duration.ofSeconds(60));
             resourcesTimeout = getOrDefault(builder.resourcesTimeout, Duration.ofSeconds(60));
@@ -227,7 +228,7 @@ public class DefaultMcpClient implements McpClient {
     }
 
     @Override
-    public String executeTool(ToolExecutionRequest executionRequest) {
+    public ToolExecutionResult executeTool(ToolExecutionRequest executionRequest) {
         assertNotClosed();
         ObjectNode arguments = null;
         try {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClient.java
@@ -2,6 +2,7 @@ package dev.langchain4j.mcp.client;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import java.util.List;
 import java.util.Map;
 
@@ -22,10 +23,10 @@ public interface McpClient extends AutoCloseable {
     List<ToolSpecification> listTools();
 
     /**
-     * Executes a tool on the MCP server and returns the result as a String.
-     * Currently, this expects a tool execution to only contain text-based results.
+     * Executes a tool on the MCP server and returns the result.
+     * Currently, this expects a tool execution to only contain text-based results or JSON structured content.
      */
-    String executeTool(ToolExecutionRequest executionRequest);
+    ToolExecutionResult executeTool(ToolExecutionRequest executionRequest);
 
     /**
      * Obtains the current list of resources available on the MCP server.

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/StructuredContentParsingTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/StructuredContentParsingTest.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.mcp.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class StructuredContentParsingTest {
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testComplexObject() throws JsonProcessingException {
+        // JSON
+        String response =
+                """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 2,
+                  "result": {
+                    "isError": false,
+                    "structuredContent": {
+                      "integer": 1,
+                      "string": "hello",
+                      "boolean": true,
+                      "innerObject": {
+                        "double": 1.0,
+                        "null": null
+                      }
+                    }
+                  }
+                }
+                """;
+        JsonNode responseNode = objectMapper.readTree(response);
+        ToolExecutionResult toolExecutionResult = ToolExecutionHelper.extractResult(responseNode);
+        assertThat(toolExecutionResult.result()).isInstanceOf(Map.class);
+        Map<String, Object> map = (Map<String, Object>) toolExecutionResult.result();
+        assertThat(map).hasSize(4);
+        assertThat(map.get("integer")).isEqualTo(1);
+        assertThat(map.get("string")).isEqualTo("hello");
+        assertThat(map.get("boolean")).isEqualTo(true);
+        assertThat(map.get("innerObject")).isInstanceOf(Map.class);
+        Map<String, Object> innerMap = (Map<String, Object>) map.get("innerObject");
+        assertThat(innerMap).hasSize(2);
+        assertThat(innerMap.get("double")).isEqualTo(1.0);
+        assertThat(innerMap.containsKey("null")).isTrue();
+        assertThat(innerMap.get("null")).isNull();
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpAutoHealthCheckIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpAutoHealthCheckIT.java
@@ -78,7 +78,7 @@ class McpAutoHealthCheckIT {
                 .name("echoString")
                 .arguments("{\"input\": \"abc\"}")
                 .build();
-        String result = mcpClient.executeTool(toolExecutionRequest);
+        String result = mcpClient.executeTool(toolExecutionRequest).resultText();
         assertThat(result).isEqualTo("abc");
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpLoggingTestBase.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpLoggingTestBase.java
@@ -24,8 +24,12 @@ public abstract class McpLoggingTestBase {
 
     @Test
     public void receiveInfoLogMessage() throws TimeoutException {
-        String result = mcpClient.executeTool(
-                ToolExecutionRequest.builder().arguments("{}").name("info").build());
+        String result = mcpClient
+                .executeTool(ToolExecutionRequest.builder()
+                        .arguments("{}")
+                        .name("info")
+                        .build())
+                .resultText();
         assertThat(result).isEqualTo("ok");
         List<McpLogMessage> receivedMessages = logMessageHandler.waitForAtLeastOneMessageAndGet(Duration.ofSeconds(10));
         assertThat(receivedMessages).hasSize(1);
@@ -37,8 +41,12 @@ public abstract class McpLoggingTestBase {
 
     @Test
     public void receiveDebugLogMessage() throws TimeoutException {
-        String result = mcpClient.executeTool(
-                ToolExecutionRequest.builder().arguments("{}").name("debug").build());
+        String result = mcpClient
+                .executeTool(ToolExecutionRequest.builder()
+                        .arguments("{}")
+                        .name("debug")
+                        .build())
+                .resultText();
         assertThat(result).isEqualTo("ok");
         List<McpLogMessage> receivedMessages = logMessageHandler.waitForAtLeastOneMessageAndGet(Duration.ofSeconds(10));
         assertThat(receivedMessages).hasSize(1);

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpReconnectIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpReconnectIT.java
@@ -65,7 +65,7 @@ class McpReconnectIT {
                 .name("echoString")
                 .arguments("{\"input\": \"abc\"}")
                 .build();
-        String result = mcpClient.executeTool(toolExecutionRequest);
+        String result = mcpClient.executeTool(toolExecutionRequest).resultText();
         assertThat(result).isEqualTo("abc");
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpRootsTestBase.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpRootsTestBase.java
@@ -23,7 +23,7 @@ public abstract class McpRootsTestBase {
                 .name("assertRoots")
                 .arguments("{}")
                 .build();
-        String result = mcpClient.executeTool(toolExecutionRequest);
+        String result = mcpClient.executeTool(toolExecutionRequest).resultText();
         assertThat(result).isEqualTo("OK");
 
         // now update the roots
@@ -36,7 +36,7 @@ public abstract class McpRootsTestBase {
                 .name("assertRootsAfterUpdate")
                 .arguments("{}")
                 .build();
-        result = mcpClient.executeTool(toolExecutionRequest);
+        result = mcpClient.executeTool(toolExecutionRequest).resultText();
         assertThat(result).isEqualTo("OK");
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/MultipleMcpToolsIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/MultipleMcpToolsIT.java
@@ -93,11 +93,18 @@ class MultipleMcpToolsIT {
                 .provideTools(null);
 
         Set<ToolSpecification> tools = toolProviderResult.tools().keySet();
-        assertThat(tools).hasSize(7);
+        assertThat(tools).hasSize(8);
         assertThat(tools)
                 .extracting(ToolSpecification::name)
-                .containsExactlyInAnyOrder("longOperation", "error", "errorResponse", "untypedArray",
-                        "getWeatherThrowingException", "getWeather", "wasCancellationReceived");
+                .containsExactlyInAnyOrder(
+                        "longOperation",
+                        "error",
+                        "errorResponse",
+                        "untypedArray",
+                        "getWeatherThrowingException",
+                        "getWeather",
+                        "wasCancellationReceived",
+                        "structuredContent");
     }
 
     @Test
@@ -144,7 +151,7 @@ class MultipleMcpToolsIT {
                         || mcpClient.key().equals("numeric-mcp"))
                 .build()
                 .provideTools(null);
-        assertThat(toolProviderResult.tools()).hasSize(13);
+        assertThat(toolProviderResult.tools()).hasSize(14);
 
         // Execute the numeric-mcp version of echoInteger which adds 1 to the input
         ToolExecutor executor = toolProviderResult.toolExecutorByName("echoInteger");

--- a/langchain4j-mcp/src/test/resources/logging_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/logging_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.25.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.4.0
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.4.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.5.3
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.5.3
 //Q:CONFIG quarkus.mcp.server.client-logging.default-level=DEBUG
 
 import java.util.List;

--- a/langchain4j-mcp/src/test/resources/prompts_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/prompts_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.25.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.4.0
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.4.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.5.3
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.5.3
 
 import java.util.ArrayList;
 import java.util.List;

--- a/langchain4j-mcp/src/test/resources/resources_alice_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/resources_alice_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.25.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.4.0
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.4.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.5.3
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.5.3
 
 import java.util.ArrayList;
 import java.util.List;

--- a/langchain4j-mcp/src/test/resources/resources_bob_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/resources_bob_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.25.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.4.0
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.4.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.5.3
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.5.3
 
 import java.util.ArrayList;
 import java.util.List;

--- a/langchain4j-mcp/src/test/resources/resources_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/resources_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.25.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.4.0
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.4.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.5.3
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.5.3
 
 import java.util.ArrayList;
 import java.util.List;

--- a/langchain4j-mcp/src/test/resources/roots_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/roots_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.25.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.4.0
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.4.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.5.3
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.5.3
 
 import java.util.ArrayList;
 import java.util.List;

--- a/langchain4j-mcp/src/test/resources/tool_list_updates_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/tool_list_updates_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.25.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.4.0
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.4.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.5.3
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.5.3
 
 import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.Tool;

--- a/langchain4j-mcp/src/test/resources/tools_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/tools_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.25.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.4.0
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.4.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.5.3
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.5.3
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,6 +19,13 @@ public class tools_mcp_server {
     @Tool(description = "Echoes a string")
     public String echoString(@ToolArg(description = "The string to be echoed") String input) {
         return input;
+    }
+
+    public record Foo(Integer bar, String baz) {}
+
+    @Tool(description = "Returns structured content", structuredContent = true)
+    public Foo structuredContent() {
+        return new Foo(1, "hello");
     }
 
     @Tool(description = "Echoes an integer")

--- a/langchain4j-mcp/src/test/resources/tools_numeric_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/tools_numeric_mcp_server.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-bom:${quarkus.version:3.25.0}@pom
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.4.0
-//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.4.0
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.5.3
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.5.3
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Fixes #3714 

Also bumps quarkus-mcp-server for integration tests to 1.5.3

@dliubars I'm not completely sure about changing the return type of `McpClient.executeTool`, if you prefer I can instead add a new method (`executeToolStructured`?) and keep the original one that returns String. The problem is I don't like the name `executeToolStructured` (better idea?) and it feels like it would unnecessarily clutter the API a bit.

The best long-term strategy is probably to have just `executeTool` that returns a `ToolExecutionResult`, but there's no way to achieve that without a breaking change. I would say most people use a `McpToolProvider` instead of directly working with `McpClient`, so the breakage should be relatively minor.