### PR TITLE
Support anyOf and null JSON schema elements in googleai.SchemaMapper

### DIFF
--- a/docs/docs/tutorials/structured-outputs.md
+++ b/docs/docs/tutorials/structured-outputs.md
@@ -329,7 +329,7 @@ System.out.println(chatResponse.aiMessage().text()); // {"shapes":[{"radius":5},
 ```
 
 :::note
-The `JsonAnyOfSchema` is currently supported only by OpenAI and Azure OpenAI.
+The `JsonAnyOfSchema` is currently supported only by OpenAI, Azure OpenAI and Google AI Gemini.
 :::
 
 #### `JsonRawSchema`

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiSchema.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiSchema.java
@@ -3,7 +3,6 @@ package dev.langchain4j.model.googleai;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 import java.util.Map;
 
@@ -13,14 +12,27 @@ class GeminiSchema {
     private String format;
     private String description;
     private Boolean nullable;
+
     @JsonProperty("enum")
     private List<String> enumeration;
+
     private String maxItems;
     private Map<String, GeminiSchema> properties;
     private List<String> required;
     private GeminiSchema items;
+    private List<GeminiSchema> anyOf;
 
-    GeminiSchema(GeminiType type, String format, String description, Boolean nullable, List<String> enumeration, String maxItems, Map<String, GeminiSchema> properties, List<String> required, GeminiSchema items) {
+    GeminiSchema(
+            GeminiType type,
+            String format,
+            String description,
+            Boolean nullable,
+            List<String> enumeration,
+            String maxItems,
+            Map<String, GeminiSchema> properties,
+            List<String> required,
+            GeminiSchema items,
+            List<GeminiSchema> anyOf) {
         this.type = type;
         this.format = format;
         this.description = description;
@@ -30,6 +42,7 @@ class GeminiSchema {
         this.properties = properties;
         this.required = required;
         this.items = items;
+        this.anyOf = anyOf;
     }
 
     public static GeminiSchemaBuilder builder() {
@@ -73,6 +86,10 @@ class GeminiSchema {
         return this.items;
     }
 
+    public List<GeminiSchema> getAnyOf() {
+        return this.anyOf;
+    }
+
     public void setType(GeminiType type) {
         this.type = type;
     }
@@ -107,6 +124,10 @@ class GeminiSchema {
 
     public void setItems(GeminiSchema items) {
         this.items = items;
+    }
+
+    public void setAnyOf(List<GeminiSchema> anyOf) {
+        this.anyOf = anyOf;
     }
 
     public boolean equals(final Object o) {
@@ -144,6 +165,10 @@ class GeminiSchema {
         final Object this$items = this.getItems();
         final Object other$items = other.getItems();
         if (this$items == null ? other$items != null : !this$items.equals(other$items)) return false;
+        final Object this$anyOf = this.getAnyOf();
+        final Object other$anyOf = other.getAnyOf();
+        if (this$anyOf == null ? other$anyOf != null : !this$anyOf.equals(other$anyOf)) return false;
+
         return true;
     }
 
@@ -172,11 +197,16 @@ class GeminiSchema {
         result = result * PRIME + ($required == null ? 43 : $required.hashCode());
         final Object $items = this.getItems();
         result = result * PRIME + ($items == null ? 43 : $items.hashCode());
+        final Object $anyOf = this.getAnyOf();
+        result = result * PRIME + ($anyOf == null ? 43 : $anyOf.hashCode());
         return result;
     }
 
     public String toString() {
-        return "GeminiSchema(type=" + this.getType() + ", format=" + this.getFormat() + ", description=" + this.getDescription() + ", nullable=" + this.getNullable() + ", enumeration=" + this.getEnumeration() + ", maxItems=" + this.getMaxItems() + ", properties=" + this.getProperties() + ", required=" + this.getRequired() + ", items=" + this.getItems() + ")";
+        return "GeminiSchema(type=" + this.getType() + ", format=" + this.getFormat() + ", description="
+                + this.getDescription() + ", nullable=" + this.getNullable() + ", enumeration=" + this.getEnumeration()
+                + ", maxItems=" + this.getMaxItems() + ", properties=" + this.getProperties() + ", required="
+                + this.getRequired() + ", items=" + this.getItems() + ", anyOf=" + this.getAnyOf() + ")";
     }
 
     public static class GeminiSchemaBuilder {
@@ -189,9 +219,9 @@ class GeminiSchema {
         private Map<String, GeminiSchema> properties;
         private List<String> required;
         private GeminiSchema items;
+        private List<GeminiSchema> anyOf;
 
-        GeminiSchemaBuilder() {
-        }
+        GeminiSchemaBuilder() {}
 
         public GeminiSchemaBuilder type(GeminiType type) {
             this.type = type;
@@ -238,12 +268,30 @@ class GeminiSchema {
             return this;
         }
 
+        public GeminiSchemaBuilder anyOf(List<GeminiSchema> anyOf) {
+            this.anyOf = anyOf;
+            return this;
+        }
+
         public GeminiSchema build() {
-            return new GeminiSchema(this.type, this.format, this.description, this.nullable, this.enumeration, this.maxItems, this.properties, this.required, this.items);
+            return new GeminiSchema(
+                    this.type,
+                    this.format,
+                    this.description,
+                    this.nullable,
+                    this.enumeration,
+                    this.maxItems,
+                    this.properties,
+                    this.required,
+                    this.items,
+                    this.anyOf);
         }
 
         public String toString() {
-            return "GeminiSchema.GeminiSchemaBuilder(type=" + this.type + ", format=" + this.format + ", description=" + this.description + ", nullable=" + this.nullable + ", enumeration=" + this.enumeration + ", maxItems=" + this.maxItems + ", properties=" + this.properties + ", required=" + this.required + ", items=" + this.items + ")";
+            return "GeminiSchema.GeminiSchemaBuilder(type=" + this.type + ", format=" + this.format + ", description="
+                    + this.description + ", nullable=" + this.nullable + ", enumeration=" + this.enumeration
+                    + ", maxItems=" + this.maxItems + ", properties=" + this.properties + ", required=" + this.required
+                    + ", items=" + this.items + ", anyOf=" + this.anyOf + ")";
         }
     }
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiType.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiType.java
@@ -6,7 +6,8 @@ enum GeminiType {
     INTEGER,
     BOOLEAN,
     ARRAY,
-    OBJECT;
+    OBJECT,
+    NULL;
 
     @Override
     public String toString() {

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelIT.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelIT.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.googleai;
 
+import static dev.langchain4j.internal.JsonSchemaElementUtils.jsonSchemaElementFrom;
 import static dev.langchain4j.internal.Utils.readBytes;
 import static dev.langchain4j.model.chat.request.ResponseFormatType.JSON;
 import static dev.langchain4j.model.googleai.FinishReasonMapper.fromGFinishReasonToFinishReason;
@@ -14,6 +15,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -26,8 +29,10 @@ import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.message.VideoContent;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
 import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
@@ -541,6 +546,68 @@ class GoogleAiGeminiChatModelIT {
         }
 
         assertThat(aiMessage.text() != null || hasGeneratedImages(aiMessage)).isTrue();
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+    @JsonSubTypes({@JsonSubTypes.Type(Circle.class), @JsonSubTypes.Type(Rectangle.class)})
+    interface Shape {}
+
+    record Circle(double radius) implements Shape {}
+
+    record Rectangle(double width, double height) implements Shape {}
+
+    record Shapes(List<Shape> shapes) {}
+
+    // TODO move to common tests
+    @Test
+    void should_generate_valid_json_with_anyof() throws JsonProcessingException {
+
+        // given
+        ChatModel model = GoogleAiGeminiChatModel.builder()
+                .apiKey(GOOGLE_AI_GEMINI_API_KEY)
+                .modelName("gemini-2.5-flash")
+                .logRequestsAndResponses(true)
+                .build();
+
+        JsonSchemaElement circleSchema = jsonSchemaElementFrom(Circle.class);
+        JsonSchemaElement rectangleSchema = jsonSchemaElementFrom(Rectangle.class);
+
+        JsonSchema jsonSchema = JsonSchema.builder()
+                .name("Shapes")
+                .rootElement(JsonObjectSchema.builder()
+                        .addProperty(
+                                "shapes",
+                                JsonArraySchema.builder()
+                                        .items(JsonAnyOfSchema.builder()
+                                                .anyOf(circleSchema, rectangleSchema)
+                                                .build())
+                                        .build())
+                        .required(List.of("shapes"))
+                        .build())
+                .build();
+
+        ResponseFormat responseFormat =
+                ResponseFormat.builder().type(JSON).jsonSchema(jsonSchema).build();
+
+        UserMessage userMessage = UserMessage.from(
+                """
+                Extract information from the following text:
+                1. A circle with a radius of 5
+                2. A rectangle with a width of 10 and a height of 20
+                """);
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(userMessage)
+                .responseFormat(responseFormat)
+                .build();
+
+        // when
+        ChatResponse chatResponse = model.chat(chatRequest);
+
+        // then
+        Shapes shapes = new ObjectMapper().readValue(chatResponse.aiMessage().text(), Shapes.class);
+        assertThat(shapes).isNotNull();
+        assertThat(shapes.shapes()).isNotNull().containsExactlyInAnyOrder(new Circle(5), new Rectangle(10, 20));
     }
 
     @AfterEach

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/SchemaMapperTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/SchemaMapperTest.java
@@ -3,10 +3,12 @@ package dev.langchain4j.model.googleai;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
 import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
 import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNullSchema;
 import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonRawSchema;
@@ -225,6 +227,38 @@ public class SchemaMapperTest {
         assertThat(options.getType()).isEqualTo(GeminiType.OBJECT);
         assertThat(options.getProperties()).hasSize(2);
         assertThat(options.getRequired()).containsExactly("includeHourly");
+    }
+
+    @Test
+    public void should_handle_anyof_schema() {
+        // given
+        JsonSchemaElement anyOfSchema = JsonAnyOfSchema.builder()
+                .description("A value that can be either a string or a number")
+                .anyOf(
+                        JsonStringSchema.builder().build(),
+                        JsonNumberSchema.builder().build())
+                .build();
+
+        // when
+        GeminiSchema result = SchemaMapper.fromJsonSchemaToGSchema(anyOfSchema);
+
+        // then
+        assertThat(result.getDescription()).isEqualTo("A value that can be either a string or a number");
+        assertThat(result.getAnyOf()).hasSize(2);
+        assertThat(result.getAnyOf().get(0).getType()).isEqualTo(GeminiType.STRING);
+        assertThat(result.getAnyOf().get(1).getType()).isEqualTo(GeminiType.NUMBER);
+    }
+
+    @Test
+    public void should_handle_null_schema() {
+        // given
+        JsonSchemaElement nullSchema = new JsonNullSchema();
+
+        // when
+        GeminiSchema result = SchemaMapper.fromJsonSchemaToGSchema(nullSchema);
+
+        // then
+        assertThat(result.getType()).isEqualTo(GeminiType.NULL);
     }
 
     @Test

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/SchemaMapperTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/SchemaMapperTest.java
@@ -1,0 +1,241 @@
+package dev.langchain4j.model.googleai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonRawSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class SchemaMapperTest {
+    @Test
+    public void should_map_string_schema() {
+        // given
+        JsonStringSchema stringSchema =
+                JsonStringSchema.builder().description("The name of the tool").build();
+
+        // when
+        GeminiSchema result = SchemaMapper.fromJsonSchemaToGSchema(stringSchema);
+
+        // then
+        assertThat(result.getType()).isEqualTo(GeminiType.STRING);
+        assertThat(result.getDescription()).isEqualTo("The name of the tool");
+    }
+
+    @Test
+    public void should_map_boolean_schema() {
+        // given
+        JsonBooleanSchema boolSchema = JsonBooleanSchema.builder()
+                .description("Whether the tool is enabled")
+                .build();
+
+        // when
+        GeminiSchema result = SchemaMapper.fromJsonSchemaToGSchema(boolSchema);
+
+        // then
+        assertThat(result.getType()).isEqualTo(GeminiType.BOOLEAN);
+        assertThat(result.getDescription()).isEqualTo("Whether the tool is enabled");
+    }
+
+    @Test
+    public void should_map_number_schema() {
+        // given
+        JsonNumberSchema numberSchema = JsonNumberSchema.builder()
+                .description("The confidence threshold for tool execution")
+                .build();
+
+        // when
+        GeminiSchema result = SchemaMapper.fromJsonSchemaToGSchema(numberSchema);
+
+        // then
+        assertThat(result.getType()).isEqualTo(GeminiType.NUMBER);
+        assertThat(result.getDescription()).isEqualTo("The confidence threshold for tool execution");
+    }
+
+    @Test
+    public void should_map_integer_schema() {
+        // given
+        JsonIntegerSchema integerSchema = JsonIntegerSchema.builder()
+                .description("Maximum number of tool calls allowed")
+                .build();
+
+        // when
+        GeminiSchema result = SchemaMapper.fromJsonSchemaToGSchema(integerSchema);
+
+        // then
+        assertThat(result.getType()).isEqualTo(GeminiType.INTEGER);
+        assertThat(result.getDescription()).isEqualTo("Maximum number of tool calls allowed");
+    }
+
+    @Test
+    public void should_map_enum_schema() {
+        // given
+        List<String> values = Arrays.asList("search", "calculate", "retrieve");
+        JsonEnumSchema enumSchema = JsonEnumSchema.builder()
+                .description("Type of tool operation")
+                .enumValues(values)
+                .build();
+
+        // when
+        GeminiSchema result = SchemaMapper.fromJsonSchemaToGSchema(enumSchema);
+
+        // then
+        assertThat(result.getType()).isEqualTo(GeminiType.STRING);
+        assertThat(result.getDescription()).isEqualTo("Type of tool operation");
+        assertThat(result.getEnumeration()).containsExactlyElementsOf(values);
+    }
+
+    @Test
+    public void should_map_array_schema() {
+        // given
+        JsonArraySchema arraySchema = JsonArraySchema.builder()
+                .description("List of supported file formats")
+                .items(JsonStringSchema.builder()
+                        .description("File format extension")
+                        .build())
+                .build();
+
+        // when
+        GeminiSchema result = SchemaMapper.fromJsonSchemaToGSchema(arraySchema);
+
+        // then
+        assertThat(result.getType()).isEqualTo(GeminiType.ARRAY);
+        assertThat(result.getDescription()).isEqualTo("List of supported file formats");
+        assertThat(result.getItems()).isNotNull();
+        assertThat(result.getItems().getType()).isEqualTo(GeminiType.STRING);
+        assertThat(result.getItems().getDescription()).isEqualTo("File format extension");
+    }
+
+    @Test
+    public void should_map_object_schema() {
+        // given
+        Map<String, JsonSchemaElement> properties = new HashMap<>();
+        properties.put(
+                "query",
+                JsonStringSchema.builder().description("Search query string").build());
+        properties.put(
+                "limit",
+                JsonIntegerSchema.builder()
+                        .description("Maximum number of results")
+                        .build());
+
+        JsonObjectSchema objectSchema = JsonObjectSchema.builder()
+                .description("Search tool parameters")
+                .addProperties(properties)
+                .required("query")
+                .build();
+
+        // when
+        GeminiSchema result = SchemaMapper.fromJsonSchemaToGSchema(objectSchema);
+
+        // then
+        assertThat(result.getType()).isEqualTo(GeminiType.OBJECT);
+        assertThat(result.getDescription()).isEqualTo("Search tool parameters");
+        assertThat(result.getProperties()).hasSize(2);
+        assertThat(result.getProperties().get("query").getType()).isEqualTo(GeminiType.STRING);
+        assertThat(result.getProperties().get("limit").getType()).isEqualTo(GeminiType.INTEGER);
+        assertThat(result.getRequired()).containsExactly("query");
+    }
+
+    @Test
+    public void should_map_nested_object_schema() {
+        // given
+        JsonObjectSchema filterSchema = JsonObjectSchema.builder()
+                .description("Search filters")
+                .addStringProperty("category", "Category to filter by")
+                .addStringProperty("domain", "Domain to limit search to")
+                .build();
+
+        JsonObjectSchema searchSchema = JsonObjectSchema.builder()
+                .description("Web search tool")
+                .addStringProperty("query", "Search query text")
+                .addProperty("filters", filterSchema)
+                .build();
+
+        // when
+        GeminiSchema result = SchemaMapper.fromJsonSchemaToGSchema(searchSchema);
+
+        // then
+        assertThat(result.getType()).isEqualTo(GeminiType.OBJECT);
+        assertThat(result.getProperties()).hasSize(2);
+        assertThat(result.getProperties().get("filters").getType()).isEqualTo(GeminiType.OBJECT);
+        assertThat(result.getProperties().get("filters").getProperties()).hasSize(2);
+    }
+
+    @Test
+    public void should_map_complex_schema() {
+        // given
+        JsonSchema schema = JsonSchema.builder()
+                .name("WeatherTool")
+                .rootElement(JsonObjectSchema.builder()
+                        .description("Weather forecast tool")
+                        .addStringProperty("location", "City or address to check weather for")
+                        .addIntegerProperty("days", "Number of days to forecast")
+                        .addProperty(
+                                "units",
+                                JsonEnumSchema.builder()
+                                        .description("Temperature units")
+                                        .enumValues("celsius", "fahrenheit")
+                                        .build())
+                        .addProperty(
+                                "features",
+                                JsonArraySchema.builder()
+                                        .description("Weather data features to include")
+                                        .items(JsonStringSchema.builder().build())
+                                        .build())
+                        .addProperty(
+                                "options",
+                                JsonObjectSchema.builder()
+                                        .description("Additional query options")
+                                        .addBooleanProperty("includeHourly", "Include hourly breakdown")
+                                        .addBooleanProperty("includeAlerts", "Include weather alerts")
+                                        .required("includeHourly")
+                                        .build())
+                        .required("location", "days")
+                        .build())
+                .build();
+
+        // when
+        GeminiSchema result = SchemaMapper.fromJsonSchemaToGSchema(schema);
+
+        // then
+        assertThat(result.getType()).isEqualTo(GeminiType.OBJECT);
+        assertThat(result.getProperties()).hasSize(5);
+        assertThat(result.getRequired()).containsExactly("location", "days");
+
+        // Check features array
+        GeminiSchema features = result.getProperties().get("features");
+        assertThat(features.getType()).isEqualTo(GeminiType.ARRAY);
+        assertThat(features.getItems().getType()).isEqualTo(GeminiType.STRING);
+
+        // Check options object
+        GeminiSchema options = result.getProperties().get("options");
+        assertThat(options.getType()).isEqualTo(GeminiType.OBJECT);
+        assertThat(options.getProperties()).hasSize(2);
+        assertThat(options.getRequired()).containsExactly("includeHourly");
+    }
+
+    @Test
+    public void should_throw_exception_for_unsupported_schema_type() {
+        // given
+        JsonSchemaElement unsupportedSchema =
+                new JsonRawSchema.Builder().schema("{ \"type\": \"string\" }").build();
+
+        // when/then
+        assertThrows(IllegalArgumentException.class, () -> {
+            SchemaMapper.fromJsonSchemaToGSchema(unsupportedSchema);
+        });
+    }
+}


### PR DESCRIPTION
## Issue
Fixes #3780

## Change
Support anyOf and null JSON schema elements in googleai.SchemaMapper.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and ~integration~ tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green