### PR TITLE
test: enhance test coverage for IsEqualTo filter and Tablestore utilities

### DIFF
--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualToTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualToTest.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import dev.langchain4j.data.document.Metadata;
 import java.util.HashMap;
@@ -50,6 +51,54 @@ class IsEqualToTest {
                 put("key", uuid.toString());
             }
         });
+        assertThat(isEqualTo.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenValuesAreDifferent() {
+        IsEqualTo isEqualTo = new IsEqualTo("key", "value1");
+        Metadata metadata = new Metadata(Map.of("key", "value2"));
+        assertThat(isEqualTo.test(metadata)).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenComparingDifferentNumberTypes() {
+        IsEqualTo isEqualTo = new IsEqualTo("key", 1L);
+        Metadata metadata = new Metadata(Map.of("key", 1));
+        assertThat(isEqualTo.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldHandleCaseSensitiveStringComparison() {
+        IsEqualTo isEqualTo = new IsEqualTo("key", "Value");
+        Metadata metadata = new Metadata(Map.of("key", "value"));
+        assertThat(isEqualTo.test(metadata)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenTestingNullObject() {
+        IsEqualTo isEqualTo = new IsEqualTo("key", "value");
+        assertThat(isEqualTo.test(null)).isFalse();
+    }
+
+    @Test
+    void shouldThrowExceptionWhenComparisonValueIsNull() {
+        assertThatThrownBy(() -> new IsEqualTo("key", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("comparisonValue with key 'key' cannot be null");
+    }
+
+    @Test
+    void shouldHandleKeyWithSpecialCharacters() {
+        IsEqualTo isEqualTo = new IsEqualTo("key.with.dots", "value");
+        Metadata metadata = new Metadata(Map.of("key.with.dots", "value"));
+        assertThat(isEqualTo.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldHandleFloatingPointComparison() {
+        IsEqualTo isEqualTo = new IsEqualTo("key", 0.1);
+        Metadata metadata = new Metadata(Map.of("key", 0.1));
         assertThat(isEqualTo.test(metadata)).isTrue();
     }
 }

--- a/langchain4j-tablestore/src/test/java/dev/langchain4j/store/embedding/tablestore/TablestoreEmbeddingStoreTest.java
+++ b/langchain4j-tablestore/src/test/java/dev/langchain4j/store/embedding/tablestore/TablestoreEmbeddingStoreTest.java
@@ -73,4 +73,28 @@ class TablestoreEmbeddingStoreTest {
     void embedding_to_string_null_array() {
         assertThatThrownBy(() -> embeddingToString(null)).isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void testEmbeddingToStringWithEmptyArray() {
+        float[] embedding = {};
+        String result = embeddingToString(embedding);
+        assertThat(result).isEqualTo("[]");
+    }
+
+    @Test
+    void testEmbeddingToStringWithNullArray() {
+        assertThatThrownBy(() -> embeddingToString(null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testParseEmbeddingStringWithEmptyArray() {
+        String embeddingString = "[]";
+        float[] result = parseEmbeddingString(embeddingString);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testParseEmbeddingStringWithNullString() {
+        assertThatThrownBy(() -> parseEmbeddingString(null)).isInstanceOf(IllegalArgumentException.class);
+    }
 }


### PR DESCRIPTION
This PR enhances test coverage for the `IsEqualTo` filter class and `Tablestore` embedding utilities, focusing on edge cases, error conditions, and type conversion scenarios.

**Changes**
Added 7 new tests to `IsEqualToTest`:

- Value comparison: Tests inequality detection between different values
- Type conversion: Verifies number type conversion (Long to Integer)
- Case sensitivity: Ensures string comparisons are case-sensitive
- Null handling: Tests behavior with null objects and null comparison values
- Special characters: Validates keys containing dots work correctly
- Floating-point: Tests decimal number comparisons

Added 4 new tests to `TablestoreEmbeddingStoreTest`:

- Empty arrays: Tests serialization/deserialization of empty embeddings
- Null validation: Ensures proper exception handling for null inputs
- Round-trip consistency: Validates empty array parsing

**Impact**
The existing tests missed critical edge cases that could lead to runtime errors. These additions ensure proper null handling, validate type conversions work as expected, and document the API's behavior for edge cases like empty arrays and special characters.
