### PR TITLE
fix: TokenStream should not require onPartialResponse() if onCompleteResponse() is used

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -108,7 +108,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         this.invocationContext = ensureNotNull(invocationContext, "invocationContext");
         this.methodKey = methodKey;
 
-        this.partialResponseHandler = ensureNotNull(partialResponseHandler, "partialResponseHandler");
+        this.partialResponseHandler = partialResponseHandler;
         this.partialThinkingHandler = partialThinkingHandler;
         this.intermediateResponseHandler = intermediateResponseHandler;
         this.completeResponseHandler = completeResponseHandler;
@@ -134,7 +134,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         // If we're using output guardrails, then buffer the partial response until the guardrails have completed
         if (hasOutputGuardrails) {
             responseBuffer.add(partialResponse);
-        } else {
+        } else if (partialResponseHandler != null) {
             partialResponseHandler.accept(partialResponse);
         }
     }
@@ -296,7 +296,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
                     // If we have output guardrails, we should process all of the partial responses first before
                     // completing
-                    responseBuffer.forEach(partialResponseHandler::accept);
+                    if (partialResponseHandler != null) {
+                        responseBuffer.forEach(partialResponseHandler::accept);
+                    }
                     responseBuffer.clear();
                 }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -192,8 +192,8 @@ public class AiServiceTokenStream implements TokenStream {
     }
 
     private void validateConfiguration() {
-        if (onPartialResponseInvoked != 1) {
-            throw new IllegalConfigurationException("onPartialResponse must be invoked on TokenStream exactly 1 time");
+        if (onPartialResponseInvoked > 1) {
+            throw new IllegalConfigurationException("onPartialResponse can be invoked on TokenStream at most 1 time");
         }
         if (onPartialThinkingInvoked > 1) {
             throw new IllegalConfigurationException("onPartialThinking can be invoked on TokenStream at most 1 time");

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
@@ -66,12 +66,20 @@ class AiServiceTokenStreamTest {
     }
 
     @Test
-    void start_onPartialResponseNotInvoked_shouldThrowException() {
-        tokenStream.ignoreErrors();
+    void start_onPartialResponseNotInvoked_withOnCompleteResponse_shouldNotThrowException() {
+        tokenStream.onCompleteResponse(DUMMY_CHAT_RESPONSE_HANDLER).ignoreErrors();
 
-        assertThatThrownBy(() -> tokenStream.start())
-                .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("onPartialResponse must be invoked on TokenStream exactly 1 time");
+        assertThatNoException().isThrownBy(() -> tokenStream.start());
+    }
+
+    @Test
+    void start_withOnPartialResponseAndOnCompleteResponse_shouldNotThrowException() {
+        tokenStream
+                .onPartialResponse(DUMMY_PARTIAL_RESPONSE_HANDLER)
+                .onCompleteResponse(DUMMY_CHAT_RESPONSE_HANDLER)
+                .ignoreErrors();
+
+        assertThatNoException().isThrownBy(() -> tokenStream.start());
     }
 
     @Test
@@ -83,7 +91,7 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("onPartialResponse must be invoked on TokenStream exactly 1 time");
+                .hasMessage("onPartialResponse can be invoked on TokenStream at most 1 time");
     }
 
     @Test


### PR DESCRIPTION
## Issue

Closes #3770. 

## Change

As discussed with @dliubarskyi in #3770.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] N/A: I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] N/A: I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] N/A: I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


