### PR TITLE
Anthropic: allow setting custom parameters

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -35,6 +35,7 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 
 /**
@@ -70,6 +71,7 @@ public class AnthropicChatModel implements ChatModel {
     private final String toolChoiceName;
     private final Boolean disableParallelToolUse;
     private final String userId;
+    private final Map<String, Object> customParameters;
 
     public AnthropicChatModel(AnthropicChatModelBuilder builder) {
         this.client = AnthropicClient.builder()
@@ -95,6 +97,7 @@ public class AnthropicChatModel implements ChatModel {
         this.toolChoiceName = builder.toolChoiceName;
         this.disableParallelToolUse = builder.disableParallelToolUse;
         this.userId = builder.userId;
+        this.customParameters = copy(builder.customParameters);
 
         ChatRequestParameters commonParameters;
         if (builder.defaultRequestParameters != null) {
@@ -152,6 +155,7 @@ public class AnthropicChatModel implements ChatModel {
         private List<ChatModelListener> listeners;
         private ChatRequestParameters defaultRequestParameters;
         private String userId;
+        private Map<String, Object> customParameters;
 
         public AnthropicChatModelBuilder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
             this.httpClientBuilder = httpClientBuilder;
@@ -351,6 +355,11 @@ public class AnthropicChatModel implements ChatModel {
             return this;
         }
 
+        public AnthropicChatModelBuilder customParameters(Map<String, Object> customParameters) {
+            this.customParameters = customParameters;
+            return this;
+        }
+
         public AnthropicChatModel build() {
             return new AnthropicChatModel(this);
         }
@@ -369,7 +378,8 @@ public class AnthropicChatModel implements ChatModel {
                 false,
                 toolChoiceName,
                 disableParallelToolUse,
-                userId);
+                userId,
+                customParameters);
 
         AnthropicCreateMessageResponse response =
                 withRetryMappingExceptions(() -> client.createMessage(anthropicRequest), maxRetries);

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModelName.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModelName.java
@@ -5,6 +5,10 @@ package dev.langchain4j.model.anthropic;
  */
 public enum AnthropicChatModelName {
 
+    CLAUDE_SONNET_4_5_20250929("claude-sonnet-4-5-20250929"),
+
+    CLAUDE_OPUS_4_1_20250805("claude-opus-4-1-20250805"),
+
     CLAUDE_OPUS_4_20250514("claude-opus-4-20250514"),
     CLAUDE_SONNET_4_20250514("claude-sonnet-4-20250514"),
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -33,6 +33,7 @@ import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 
 /**
@@ -66,6 +67,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
     private final String toolChoiceName;
     private final Boolean disableParallelToolUse;
     private final String userId;
+    private final Map<String, Object> customParameters;
 
     /**
      * Constructs an instance of an {@code AnthropicStreamingChatModel} with the specified parameters.
@@ -107,6 +109,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         this.toolChoiceName = builder.toolChoiceName;
         this.disableParallelToolUse = builder.disableParallelToolUse;
         this.userId = builder.userId;
+        this.customParameters = copy(builder.customParameters);
     }
 
     public static AnthropicStreamingChatModelBuilder builder() {
@@ -142,6 +145,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         private String toolChoiceName;
         private Boolean disableParallelToolUse;
         private String userId;
+        private Map<String, Object> customParameters;
 
         public AnthropicStreamingChatModelBuilder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
             this.httpClientBuilder = httpClientBuilder;
@@ -332,6 +336,11 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
             return this;
         }
 
+        public AnthropicStreamingChatModelBuilder customParameters(Map<String, Object> customParameters) {
+            this.customParameters = customParameters;
+            return this;
+        }
+
         public AnthropicStreamingChatModel build() {
             return new AnthropicStreamingChatModel(this);
         }
@@ -350,7 +359,8 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 true,
                 toolChoiceName,
                 disableParallelToolUse,
-                userId);
+                userId,
+                customParameters);
         client.createMessage(anthropicRequest, new AnthropicCreateMessageOptions(returnThinking), handler);
     }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
@@ -16,6 +16,7 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Internal
 class InternalAnthropicHelper {
@@ -52,7 +53,8 @@ class InternalAnthropicHelper {
             boolean stream,
             String toolChoiceName,
             Boolean disableParallelToolUse,
-            String userId) {
+            String userId,
+            Map<String, Object> customParameters) {
 
         AnthropicCreateMessageRequest.Builder requestBuilder = AnthropicCreateMessageRequest.builder().stream(stream)
                 .model(chatRequest.modelName())
@@ -63,7 +65,8 @@ class InternalAnthropicHelper {
                 .temperature(chatRequest.temperature())
                 .topP(chatRequest.topP())
                 .topK(chatRequest.topK())
-                .thinking(thinking);
+                .thinking(thinking)
+                .customParameters(customParameters);
 
         if (!isNullOrEmpty(chatRequest.toolSpecifications())) {
             requestBuilder.tools(toAnthropicTools(chatRequest.toolSpecifications(), toolsCacheType));

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCreateMessageRequest.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCreateMessageRequest.java
@@ -2,11 +2,13 @@ package dev.langchain4j.model.anthropic.internal.api;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.List;
+import java.util.Map;
 
 @JsonInclude(NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -26,9 +28,28 @@ public class AnthropicCreateMessageRequest {
     public AnthropicToolChoice toolChoice;
     public AnthropicThinking thinking;
     public AnthropicMetadata metadata;
+    public Map<String, Object> customParameters;
 
     public AnthropicCreateMessageRequest() {}
 
+    public AnthropicCreateMessageRequest(Builder builder) {
+        this.model = builder.model;
+        this.messages = builder.messages;
+        this.system = builder.system;
+        this.maxTokens = builder.maxTokens;
+        this.stopSequences = builder.stopSequences;
+        this.stream = builder.stream;
+        this.temperature = builder.temperature;
+        this.topP = builder.topP;
+        this.topK = builder.topK;
+        this.tools = builder.tools;
+        this.toolChoice = builder.toolChoice;
+        this.thinking = builder.thinking;
+        this.metadata = builder.metadata;
+        this.customParameters = builder.customParameters;
+    }
+
+    @Deprecated(since = "1.7.0-beta13", forRemoval = true)
     public AnthropicCreateMessageRequest(
             String model,
             List<AnthropicMessage> messages,
@@ -162,6 +183,15 @@ public class AnthropicCreateMessageRequest {
         this.metadata = metadata;
     }
 
+    @JsonAnyGetter
+    public Map<String, Object> getCustomParameters() {
+        return customParameters;
+    }
+
+    public void setCustomParameters(Map<String, Object> customParameters) {
+        this.customParameters = customParameters;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -180,7 +210,8 @@ public class AnthropicCreateMessageRequest {
                         .tools(this.tools)
                         .toolChoice(this.toolChoice)
                         .thinking(this.thinking)
-                        .metadata(this.metadata);
+                        .metadata(this.metadata)
+                        .customParameters(this.customParameters);
     }
 
     public static class Builder {
@@ -198,6 +229,7 @@ public class AnthropicCreateMessageRequest {
         private AnthropicToolChoice toolChoice;
         private AnthropicThinking thinking;
         private AnthropicMetadata metadata;
+        private Map<String, Object> customParameters;
 
         public Builder model(String model) {
             this.model = model;
@@ -264,21 +296,13 @@ public class AnthropicCreateMessageRequest {
             return this;
         }
 
+        public Builder customParameters(Map<String, Object> customParameters) {
+            this.customParameters = customParameters;
+            return this;
+        }
+
         public AnthropicCreateMessageRequest build() {
-            return new AnthropicCreateMessageRequest(
-                    model,
-                    messages,
-                    system,
-                    maxTokens,
-                    stopSequences,
-                    stream,
-                    temperature,
-                    topP,
-                    topK,
-                    tools,
-                    toolChoice,
-                    thinking,
-                    metadata);
+            return new AnthropicCreateMessageRequest(this);
         }
     }
 }


### PR DESCRIPTION
## Change
Allow setting custom chat request parameters for Anthropic

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)