### PR TITLE
test: improve PojoListOutputParser test coverage for edge cases

### DIFF
--- a/langchain4j/src/test/java/dev/langchain4j/service/output/PojoListOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/PojoListOutputParserTest.java
@@ -1,21 +1,19 @@
 package dev.langchain4j.service.output;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 class PojoListOutputParserTest {
 
-    record Person(String name) {
-    }
+    record Person(String name) {}
 
     @ParameterizedTest
     @MethodSource
@@ -31,12 +29,13 @@ class PojoListOutputParserTest {
     static Stream<Arguments> should_parse_list_of_pojo() {
         return Stream.of(
                 Arguments.of("{\"values\":[{\"name\":\"Klaus\"}]}", List.of(new Person("Klaus"))),
-                Arguments.of("{\"values\":[{\"name\":\"Klaus\"}, {\"name\":\"Franny\"}]}", List.of(new Person("Klaus"), new Person("Franny"))),
+                Arguments.of(
+                        "{\"values\":[{\"name\":\"Klaus\"}, {\"name\":\"Franny\"}]}",
+                        List.of(new Person("Klaus"), new Person("Franny"))),
                 Arguments.of("", List.of()),
                 Arguments.of(" ", List.of()),
                 Arguments.of("{\"values\":[]}", List.of()),
-                Arguments.of(" {\"values\":[{\"name\":\"Klaus\"}]} ", List.of(new Person("Klaus")))
-        );
+                Arguments.of(" {\"values\":[{\"name\":\"Klaus\"}]} ", List.of(new Person("Klaus"))));
     }
 
     @ParameterizedTest
@@ -51,19 +50,134 @@ class PojoListOutputParserTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-            "banana",
-            "{\"values\": \"\"}",
-            "{\"values\":\"banana\"}",
-            "{\"values\":[\"banana\"]}",
-            "{\"values\":{\"name\":\"Klaus\"}}",
-            "{\"banana\":[{\"name\":\"Klaus\"}]}",
-    })
+    @ValueSource(
+            strings = {
+                "banana",
+                "{\"values\": \"\"}",
+                "{\"values\":\"banana\"}",
+                "{\"values\":[\"banana\"]}",
+                "{\"values\":{\"name\":\"Klaus\"}}",
+                "{\"banana\":[{\"name\":\"Klaus\"}]}",
+            })
     void should_fail_to_parse_invalid_input(String text) {
 
         assertThatThrownBy(() -> new PojoListOutputParser<>(Person.class).parse(text))
                 .isExactlyInstanceOf(OutputParsingException.class)
                 .hasMessageContaining("Failed to parse")
                 .hasMessageContaining("Person");
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void should_parse_person_with_null_name(String json, List<Person> expected) {
+        // when
+        List<Person> people = new PojoListOutputParser<>(Person.class).parse(json);
+
+        // then
+        assertThat(people).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> should_parse_person_with_null_name() {
+        return Stream.of(
+                Arguments.of("{\"values\":[{\"name\":null}]}", List.of(new Person(null))),
+                Arguments.of(
+                        "{\"values\":[{\"name\":\"Alice\"},{\"name\":null},{\"name\":\"Bob\"}]}",
+                        List.of(new Person("Alice"), new Person(null), new Person("Bob"))));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void should_parse_person_with_missing_name(String json, List<Person> expected) {
+        // when
+        List<Person> people = new PojoListOutputParser<>(Person.class).parse(json);
+
+        // then
+        assertThat(people).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> should_parse_person_with_missing_name() {
+        return Stream.of(
+                Arguments.of("{\"values\":[{}]}", List.of(new Person(null))),
+                Arguments.of(
+                        "{\"values\":[{},{\"name\":\"Alice\"},{}]}",
+                        List.of(new Person(null), new Person("Alice"), new Person(null))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "{\"values\":{\"name\":\"Alice\"}}",
+                "[{\"name\":\"Alice\"}]",
+                "{\"values\":[\"Alice\"]}",
+            })
+    void should_fail_to_parse_malformed_json(String malformedJson) {
+        assertThatThrownBy(() -> new PojoListOutputParser<>(Person.class).parse(malformedJson))
+                .isExactlyInstanceOf(OutputParsingException.class)
+                .hasMessageContaining("Failed to parse");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "{\"values\":[{\"name\":[\"array\"]}]}",
+                "{\"values\":[{\"name\":{\"object\":\"value\"}}]}",
+            })
+    void should_fail_to_parse_wrong_type_for_name(String json) {
+        assertThatThrownBy(() -> new PojoListOutputParser<>(Person.class).parse(json))
+                .isExactlyInstanceOf(OutputParsingException.class)
+                .hasMessageContaining("Failed to parse");
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void should_handle_whitespace_in_json(String json, List<Person> expected) {
+        // when
+        List<Person> people = new PojoListOutputParser<>(Person.class).parse(json);
+
+        // then
+        assertThat(people).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> should_handle_whitespace_in_json() {
+        return Stream.of(
+                Arguments.of("  {  \"values\"  :  [  ]  }  ", List.of()),
+                Arguments.of("\n{\n\"values\"\n:\n[\n]\n}\n", List.of()),
+                Arguments.of("\t{\t\"values\"\t:\t[\t]\t}\t", List.of()),
+                Arguments.of(
+                        "   {   \"values\"   :   [   {   \"name\"   :   \"Alice\"   }   ]   }   ",
+                        List.of(new Person("Alice"))));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void should_parse_escaped_characters(String json, List<Person> expected) {
+        // when
+        List<Person> people = new PojoListOutputParser<>(Person.class).parse(json);
+
+        // then
+        assertThat(people).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> should_parse_escaped_characters() {
+        return Stream.of(
+                Arguments.of("{\"values\":[{\"name\":\"Alice\\\"Bob\"}]}", List.of(new Person("Alice\"Bob"))),
+                Arguments.of("{\"values\":[{\"name\":\"Line\\nBreak\"}]}", List.of(new Person("Line\nBreak"))),
+                Arguments.of("{\"values\":[{\"name\":\"Tab\\tCharacter\"}]}", List.of(new Person("Tab\tCharacter"))),
+                Arguments.of("{\"values\":[{\"name\":\"Back\\\\slash\"}]}", List.of(new Person("Back\\slash"))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "{\"values\":[{\"name\":\"Alice\",\"name\":\"Bob\"}]}",
+                "{\"values\":[{\"name\":\"Alice\"}],\"values\":[{\"name\":\"Bob\"}]}",
+            })
+    void should_handle_or_fail_duplicate_keys(String json) {
+        try {
+            List<Person> people = new PojoListOutputParser<>(Person.class).parse(json);
+            assertThat(people).isNotNull();
+        } catch (OutputParsingException e) {
+            assertThat(e.getMessage()).contains("Failed to parse");
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR enhances the test coverage for `PojoListOutputParser` by adding comprehensive test cases for various edge cases and special scenarios that were previously untested.

## Changes
- Added tests for null field values in parsed POJOs
- Added tests for missing/absent fields in JSON objects
- Added tests for malformed JSON structures (wrong types, invalid arrays)
- Added tests for incorrect data types in JSON fields
- Added tests for various whitespace handling scenarios
- Added tests for escaped characters in string values
- Added tests for duplicate JSON keys handling

## Test Coverage Details
The new tests cover:
**Null handling**: Parsing objects with explicitly null name fields
**Missing fields**: Parsing objects where the name field is completely absent
**Invalid JSON structures**: Testing parser behavior with malformed JSON (values not as array, missing root object, strings instead of objects)
**Type mismatches**: Verifying proper error handling when name field contains non-string types (arrays, objects)
**Whitespace tolerance**: Ensuring parser handles various whitespace patterns correctly
**Escaped characters**: Validating proper parsing of escaped quotes, newlines, tabs, and backslashes
**Duplicate keys**: Testing behavior when JSON contains duplicate keys

## Impact
- No production code changes
- Improves test coverage and confidence in `PojoListOutputParser` robustness
- Helps prevent regressions in JSON parsing edge cases