### PR TITLE
test: Add comprehensive test coverage for JSONMetadataHandler

### DIFF
--- a/langchain4j-mariadb/src/test/java/dev/langchain4j/store/embedding/mariadb/JSONMetadataHandlerTest.java
+++ b/langchain4j-mariadb/src/test/java/dev/langchain4j/store/embedding/mariadb/JSONMetadataHandlerTest.java
@@ -189,8 +189,7 @@ class JSONMetadataHandlerTest {
 
         List<String> metadataKeys = Arrays.asList("key1", "key2", "key3");
 
-        JSONMetadataHandler jsonMetadataHandler =
-                new JSONMetadataHandler(metadataStorageConfig, metadataKeys);
+        JSONMetadataHandler jsonMetadataHandler = new JSONMetadataHandler(metadataStorageConfig, metadataKeys);
 
         assertThat(jsonMetadataHandler).isNotNull();
     }

--- a/langchain4j-mariadb/src/test/java/dev/langchain4j/store/embedding/mariadb/JSONMetadataHandlerTest.java
+++ b/langchain4j-mariadb/src/test/java/dev/langchain4j/store/embedding/mariadb/JSONMetadataHandlerTest.java
@@ -74,4 +74,162 @@ class JSONMetadataHandlerTest {
 
         assertThat(sqlStatementQueries).isEmpty();
     }
+
+    @Test
+    void testEmptyIndexesList() throws SQLException {
+        Statement statement = mock(Statement.class);
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COMBINED_JSON)
+                .columnDefinitions(Collections.singletonList("metadata JSON"))
+                .indexes(Collections.emptyList())
+                .build();
+
+        JSONMetadataHandler jsonMetadataHandler =
+                new JSONMetadataHandler(metadataStorageConfig, Collections.emptyList());
+
+        // Should not throw exception with empty indexes
+        jsonMetadataHandler.createMetadataIndexes(statement, "embeddings");
+
+        verify(statement, never()).executeUpdate(anyString());
+    }
+
+    @Test
+    void testNullIndexesList() throws SQLException {
+        Statement statement = mock(Statement.class);
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COMBINED_JSON)
+                .columnDefinitions(Collections.singletonList("metadata JSON"))
+                .indexes(null)
+                .build();
+
+        JSONMetadataHandler jsonMetadataHandler =
+                new JSONMetadataHandler(metadataStorageConfig, Collections.emptyList());
+
+        // Should handle null indexes gracefully
+        jsonMetadataHandler.createMetadataIndexes(statement, "embeddings");
+
+        verify(statement, never()).executeUpdate(anyString());
+    }
+
+    @Test
+    void testMultipleIndexesThrowsException() {
+        Statement statement = mock(Statement.class);
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COMBINED_JSON)
+                .columnDefinitions(Collections.singletonList("metadata JSON"))
+                .indexes(Arrays.asList("index1", "index2", "index3"))
+                .build();
+
+        JSONMetadataHandler jsonMetadataHandler =
+                new JSONMetadataHandler(metadataStorageConfig, Collections.emptyList());
+
+        // JSON metadata doesn't support indexes
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> jsonMetadataHandler.createMetadataIndexes(statement, "embeddings"))
+                .withMessageContaining("Indexes are actually not allowed for JSON metadata");
+    }
+
+    @Test
+    void testNullTableName() {
+        Statement statement = mock(Statement.class);
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COMBINED_JSON)
+                .columnDefinitions(Collections.singletonList("metadata JSON"))
+                .indexes(Collections.singletonList("field1"))
+                .build();
+
+        JSONMetadataHandler jsonMetadataHandler =
+                new JSONMetadataHandler(metadataStorageConfig, Collections.emptyList());
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> jsonMetadataHandler.createMetadataIndexes(statement, null));
+    }
+
+    @Test
+    void testEmptyTableName() {
+        Statement statement = mock(Statement.class);
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COMBINED_JSON)
+                .columnDefinitions(Collections.singletonList("metadata JSON"))
+                .indexes(Collections.singletonList("field1"))
+                .build();
+
+        JSONMetadataHandler jsonMetadataHandler =
+                new JSONMetadataHandler(metadataStorageConfig, Collections.emptyList());
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> jsonMetadataHandler.createMetadataIndexes(statement, ""));
+    }
+
+    @Test
+    void testConstructorWithEmptyMetadataKeys() {
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COMBINED_JSON)
+                .columnDefinitions(Collections.singletonList("metadata JSON"))
+                .build();
+
+        // Should handle empty metadataKeys in constructor
+        JSONMetadataHandler jsonMetadataHandler =
+                new JSONMetadataHandler(metadataStorageConfig, Collections.emptyList());
+
+        assertThat(jsonMetadataHandler).isNotNull();
+    }
+
+    @Test
+    void testConstructorWithMetadataKeys() {
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COMBINED_JSON)
+                .columnDefinitions(Collections.singletonList("metadata JSON"))
+                .build();
+
+        List<String> metadataKeys = Arrays.asList("key1", "key2", "key3");
+
+        JSONMetadataHandler jsonMetadataHandler =
+                new JSONMetadataHandler(metadataStorageConfig, metadataKeys);
+
+        assertThat(jsonMetadataHandler).isNotNull();
+    }
+
+    @Test
+    void testStatementExecutionWithValidConfig() throws SQLException {
+        Statement statement = mock(Statement.class);
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COMBINED_JSON)
+                .columnDefinitions(Collections.singletonList("metadata JSON"))
+                .indexes(Collections.emptyList())
+                .build();
+
+        JSONMetadataHandler jsonMetadataHandler =
+                new JSONMetadataHandler(metadataStorageConfig, Arrays.asList("field1", "field2"));
+
+        jsonMetadataHandler.createMetadataIndexes(statement, "test_table");
+
+        // Verify no SQL execution for JSON metadata
+        verify(statement, never()).executeUpdate(anyString());
+    }
+
+    @Test
+    void testIndexesNotAllowedMessage() {
+        Statement statement = mock(Statement.class);
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COMBINED_JSON)
+                .columnDefinitions(Collections.singletonList("metadata JSON"))
+                .indexes(Collections.singletonList("some_index"))
+                .build();
+
+        JSONMetadataHandler jsonMetadataHandler =
+                new JSONMetadataHandler(metadataStorageConfig, Collections.emptyList());
+
+        // Verify the specific error message for JSON indexes
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> jsonMetadataHandler.createMetadataIndexes(statement, "embeddings"))
+                .withMessage("Indexes are actually not allowed for JSON metadata");
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for the `JSONMetadataHandler` class in the MariaDB embedding store module, focusing on index creation behavior and edge case handling.

## Changes
- Added tests for empty and null index lists
- Added tests for multiple indexes (verifying they're not allowed for JSON metadata)
- Added tests for null and empty table name validation
- Added tests for constructor behavior with different metadata key configurations
- Added tests to verify no SQL execution occurs for JSON metadata
- Added test to verify specific error message for JSON metadata index restriction

## Test Coverage Details
The new tests cover:
1. **Empty/Null indexes**: Verifying that empty or null index lists don't cause errors and no SQL is executed
2. **Multiple indexes**: Confirming that JSON metadata doesn't support indexes with appropriate error message
3. **Table name validation**: Testing null and empty table names throw appropriate exceptions
4. **Constructor tests**: Testing constructor with empty list and populated metadata keys
5. **SQL execution verification**: Ensuring no database operations occur for JSON metadata
6. **Error message validation**: Verifying the specific "Indexes are actually not allowed for JSON metadata" message

## Impact
- No production code changes
- Improves test coverage and confidence in `JSONMetadataHandler` behavior
- Documents expected behavior through tests
- Helps prevent regressions in JSON metadata handling