### PR TITLE
feat: Added support to auto reinitialize session if not found

### DIFF
--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpServerHelper.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpServerHelper.java
@@ -6,16 +6,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.mcp.McpToolProvider;
-import dev.langchain4j.mcp.client.McpClient;
-import dev.langchain4j.service.tool.ToolExecutor;
-import dev.langchain4j.service.tool.ToolProvider;
-import dev.langchain4j.service.tool.ToolProviderResult;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import org.slf4j.Logger;
@@ -29,10 +21,12 @@ public class McpServerHelper {
         return startServerHttp(scriptName, 8080);
     }
 
-    static Process startServerHttp(String scriptName, int port) throws InterruptedException, TimeoutException, IOException {
+    static Process startServerHttp(String scriptName, int port)
+            throws InterruptedException, TimeoutException, IOException {
         skipTestsIfJbangNotAvailable();
         String path = getPathToScript(scriptName);
-        String[] command = new String[] {getJBangCommand(), "--quiet", "--fresh", "run", "-Dquarkus.http.port=" + port, path};
+        String[] command =
+                new String[] {getJBangCommand(), "--quiet", "--fresh", "run", "-Dquarkus.http.port=" + port, path};
         log.info("Starting the MCP server using command: " + Arrays.toString(command));
         Process process = new ProcessBuilder().command(command).inheritIO().start();
         waitForPort(port, 120);

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolsStreamableHttpTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolsStreamableHttpTransportIT.java
@@ -3,14 +3,18 @@ package dev.langchain4j.mcp.client.integration;
 import static dev.langchain4j.mcp.client.integration.McpServerHelper.skipTestsIfJbangNotAvailable;
 import static dev.langchain4j.mcp.client.integration.McpServerHelper.startServerHttp;
 
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,5 +46,27 @@ class McpToolsStreamableHttpTransportIT extends McpToolsTestBase {
         if (process != null && process.isAlive()) {
             process.destroyForcibly();
         }
+    }
+
+    @Test
+    void reinitializesSessionWhenMissingFromServer() throws Exception {
+        // Initial call to establish session and verify MCP server is up
+        List<ToolSpecification> toolSpecifications = mcpClient.listTools();
+        Assertions.assertNotNull(toolSpecifications, "Tool specifications should not be null");
+        Assertions.assertDoesNotThrow(() -> mcpClient.checkHealth(), "Health check should pass initially");
+
+        // Simulate server crash
+        process.destroyForcibly();
+
+        // Expect failure as server is down
+        Assertions.assertThrows(
+                Exception.class, () -> mcpClient.checkHealth(), "Expected exception when server is down");
+
+        // Restart the server
+        process = startServerHttp("tools_mcp_server.java");
+
+        // Subsequent call should reinitialize session and succeed
+        Assertions.assertDoesNotThrow(
+                () -> mcpClient.checkHealth(), "Session should be reinitialized and health check should pass");
     }
 }


### PR DESCRIPTION
## Issue
Closes #3802

## Change
This PR adds support to automatically reinitialize the session with the MCP server if it is not found (e.g., after a server restart). This ensures that clients can recover gracefully without manual intervention or a full restart.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
