### PR TITLE
Add immutability and validation tests for DefaultQueryRouter

### DIFF
--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/query/router/DefaultQueryRouterTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/query/router/DefaultQueryRouterTest.java
@@ -121,4 +121,41 @@ class DefaultQueryRouterTest {
         // then - router returns retrievers even with null query
         assertThat(retrievers).containsExactly(retriever);
     }
+
+    @Test
+    void should_return_unmodifiable_collection() {
+        // given
+        ContentRetriever retriever1 = mock(ContentRetriever.class);
+        ContentRetriever retriever2 = mock(ContentRetriever.class);
+        QueryRouter router = new DefaultQueryRouter(retriever1, retriever2);
+
+        // when
+        Collection<ContentRetriever> retrievers = router.route(Query.from("query"));
+
+        // then
+        assertThatThrownBy(() -> retrievers.add(mock(ContentRetriever.class)))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> retrievers.remove(retriever1)).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> retrievers.clear()).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void should_handle_whitespace_only_query() {
+        // when/then
+        assertThatThrownBy(() -> Query.from("   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("text cannot be null or blank");
+
+        assertThatThrownBy(() -> Query.from("\t\n\r"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("text cannot be null or blank");
+    }
+
+    @Test
+    void should_handle_null_query_text() {
+        // when/then
+        assertThatThrownBy(() -> Query.from(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("text cannot be null or blank");
+    }
 }


### PR DESCRIPTION
This PR adds additional test coverage for the `DefaultQueryRouter` and `Query` classes focusing on API contract enforcement and input validation.

### Changes

**Immutability tests:**
- Added test to verify that the collection returned by `route()` is unmodifiable
- Tests attempt to modify returned collection via `add()`, `remove()`, and `clear()` operations
- Ensures callers cannot accidentally modify internal router state

**Input validation tests:**
- Added test for `Query.from()` with null input
- Added test for `Query.from()` with whitespace-only strings (spaces, tabs, newlines)
- Verifies proper `IllegalArgumentException` is thrown with correct error messages

### Test Coverage

These tests complement the existing routing tests by covering:
- API contract: immutability of returned collections
- Edge cases: null and whitespace validation
- Error handling: proper exception types and messages