### PR TITLE
test: Add validation and instance identity tests for ClassInstanceLoader

### DIFF
--- a/integration-tests/integration-tests-class-instance-loader/src/test/java/dev/langchain4j/classinstance/generic/ClassInstanceLoaderTests.java
+++ b/integration-tests/integration-tests-class-instance-loader/src/test/java/dev/langchain4j/classinstance/generic/ClassInstanceLoaderTests.java
@@ -38,4 +38,32 @@ class ClassInstanceLoaderTests {
                 .isThrownBy(() -> ClassInstanceLoader.getClassInstance(Classes.Class3.class))
                 .withMessage("Unknown class: %s", Classes.Class3.class.getName());
     }
+
+    @Test
+    void shouldThrowExceptionForNullClass() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> ClassInstanceLoader.getClassInstance(null));
+    }
+
+    @Test
+    void shouldReturnDifferentInstancesOnMultipleCalls() {
+        var instance1 = ClassInstanceLoader.getClassInstance(Classes.Class1.class);
+        var instance2 = ClassInstanceLoader.getClassInstance(Classes.Class1.class);
+        var instance3 = ClassInstanceLoader.getClassInstance(Classes.Class1.class);
+
+        assertThat(instance1).isNotSameAs(instance2);
+        assertThat(instance2).isNotSameAs(instance3);
+        assertThat(instance1).isNotSameAs(instance3);
+    }
+
+    @Test
+    void shouldHandleMultipleClassTypes() {
+        var class1Instance = ClassInstanceLoader.getClassInstance(Classes.Class1.class);
+        var class2Instance = ClassInstanceLoader.getClassInstance(Classes.Class2.class);
+
+        assertThat(class1Instance).isNotNull().isExactlyInstanceOf(Classes.Class1.class);
+        assertThat(class2Instance).isNotNull().isExactlyInstanceOf(Classes.Class2.class);
+        assertThat(class1Instance).isNotInstanceOf(Classes.Class2.class);
+        assertThat(class2Instance).isNotInstanceOf(Classes.Class1.class);
+    }
 }


### PR DESCRIPTION
This PR adds explicit test coverage for input validation and instance creation behavior in `ClassInstanceLoader`.

### Changes

**Null input validation:**
- Added test verifying that `null` class parameter throws `NullPointerException`
- Ensures the API properly validates input at entry point

**Instance identity verification:**
- Added test confirming each call returns a new instance object
- Uses `isNotSameAs()` to verify object identity rather than equality
- Important for frameworks expecting fresh instances (not singletons)

**Cross-type validation:**
- Added test explicitly verifying type isolation between different classes
- Ensures `Class1` instances are never of type `Class2` and vice versa
- Makes type safety guarantees more explicit