### PR TITLE
docs: Remove examples from YugabyteDB documentation

### DIFF
--- a/docs/docs/integrations/embedding-stores/yugabytedb.md
+++ b/docs/docs/integrations/embedding-stores/yugabytedb.md
@@ -372,7 +372,6 @@ YugabyteDBEmbeddingStore smartStore = YugabyteDBEmbeddingStore.builder()
 
 ## Examples
 
-- [YugabyteDBEmbeddingStoreExample](https://github.com/langchain4j/langchain4j-examples/blob/main/yugabytedb-example/src/main/java/YugabyteDBEmbeddingStoreExample.java) - Basic example with Testcontainers
-- [YugabyteDBEmbeddingStoreWithMetadataExample](https://github.com/langchain4j/langchain4j-examples/blob/main/yugabytedb-example/src/main/java/YugabyteDBEmbeddingStoreWithMetadataExample.java) - Metadata filtering with JSONB storage
-- [YugabyteDBWithPostgreSQLDriverExample](https://github.com/langchain4j/langchain4j-examples/blob/main/yugabytedb-example/src/main/java/YugabyteDBWithPostgreSQLDriverExample.java) - Using PostgreSQL JDBC driver
-- [YugabyteDBWithSmartDriverExample](https://github.com/langchain4j/langchain4j-examples/blob/main/yugabytedb-example/src/main/java/YugabyteDBWithSmartDriverExample.java) - Using YugabyteDB Smart Driver
+:::note
+Code examples demonstrating YugabyteDB integration will be added soon.
+:::


### PR DESCRIPTION
- Remove example links from yugabyte docs that are not yet available
- Add note that examples will be added soon

Removes example links from YugabyteDB embedding store documentation.

Since the version is currently `1.8.0-beta15-SNAPSHOT` (not yet released), the examples repository doesn't have these examples available yet.

Current link: https://github.com/yugabyte/langchain4j-community/commit/90c2f0fae2f71b786c96d246de220a7529dc88fc

Examples PR currently under review, it will be merged once the version is officially released.
Link: https://github.com/langchain4j/langchain4j-examples/pull/175