### PR TITLE
Explicitly for the ResponseFormat instead of checking whether it's null when validating a ChatRequest for any Anthropic model

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
@@ -14,9 +14,11 @@ import dev.langchain4j.model.anthropic.internal.api.AnthropicMetadata;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicThinking;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Internal
 class InternalAnthropicHelper {
@@ -25,7 +27,7 @@ class InternalAnthropicHelper {
 
     static void validate(ChatRequestParameters parameters) {
         List<String> unsupportedFeatures = new ArrayList<>();
-        if (parameters.responseFormat() != null) {
+        if (Objects.equals(ResponseFormat.JSON, parameters.responseFormat())) {
             unsupportedFeatures.add("JSON response format");
         }
         if (parameters.frequencyPenalty() != null) {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/InternalAnthropicHelperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/InternalAnthropicHelperTest.java
@@ -1,0 +1,71 @@
+package dev.langchain4j.model.anthropic;
+
+import static dev.langchain4j.model.anthropic.InternalAnthropicHelper.validate;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import org.junit.jupiter.api.Test;
+
+class InternalAnthropicHelperTest {
+
+    @Test
+    void validate_WithNoUnsupportedFeatures_ShouldNotThrowException() {
+        // Given
+        ChatRequestParameters parameters = ChatRequestParameters.builder().responseFormat(ResponseFormat.TEXT).build();
+
+        // When-Then
+        assertDoesNotThrow(() -> validate(parameters));
+    }
+
+    @Test
+    void validate_WithJsonResponseFormat_ShouldThrowException() {
+        // Given
+        ChatRequestParameters parameters = ChatRequestParameters.builder().responseFormat(ResponseFormat.JSON).build();
+
+        // When
+        UnsupportedFeatureException exception = assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
+
+        // Then
+        assertEquals("JSON response format is not supported by Anthropic", exception.getMessage());
+    }
+
+    @Test
+    void validate_WithFrequencyPenalty_ShouldThrowException() {
+        // Given
+        ChatRequestParameters parameters = ChatRequestParameters.builder().responseFormat(ResponseFormat.TEXT).frequencyPenalty(0.5).build();
+
+        // When
+        UnsupportedFeatureException exception = assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
+
+        // Then
+        assertEquals("Frequency Penalty is not supported by Anthropic", exception.getMessage());
+    }
+
+    @Test
+    void validate_WithPresencePenalty_ShouldThrowException() {
+        // Given
+        ChatRequestParameters parameters = ChatRequestParameters.builder().responseFormat(ResponseFormat.TEXT).presencePenalty(0.5).build();
+
+        // When
+        UnsupportedFeatureException exception = assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
+
+        // Then
+        assertEquals("Presence Penalty is not supported by Anthropic", exception.getMessage());
+    }
+
+    @Test
+    void validate_WithTwoUnsupportedFeatures_ShouldThrowExceptionWithCombinedMessage() {
+        // Given
+        ChatRequestParameters parameters = ChatRequestParameters.builder().responseFormat(ResponseFormat.JSON).frequencyPenalty(0.5).build();
+
+        // When
+        UnsupportedFeatureException exception = assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
+
+        // Then
+        assertEquals("JSON response format, Frequency Penalty are not supported by Anthropic", exception.getMessage());
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/InternalAnthropicHelperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/InternalAnthropicHelperTest.java
@@ -15,7 +15,9 @@ class InternalAnthropicHelperTest {
     @Test
     void validate_WithNoUnsupportedFeatures_ShouldNotThrowException() {
         // Given
-        ChatRequestParameters parameters = ChatRequestParameters.builder().responseFormat(ResponseFormat.TEXT).build();
+        ChatRequestParameters parameters = ChatRequestParameters.builder()
+                .responseFormat(ResponseFormat.TEXT)
+                .build();
 
         // When-Then
         assertDoesNotThrow(() -> validate(parameters));
@@ -24,10 +26,13 @@ class InternalAnthropicHelperTest {
     @Test
     void validate_WithJsonResponseFormat_ShouldThrowException() {
         // Given
-        ChatRequestParameters parameters = ChatRequestParameters.builder().responseFormat(ResponseFormat.JSON).build();
+        ChatRequestParameters parameters = ChatRequestParameters.builder()
+                .responseFormat(ResponseFormat.JSON)
+                .build();
 
         // When
-        UnsupportedFeatureException exception = assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
+        UnsupportedFeatureException exception =
+                assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
 
         // Then
         assertEquals("JSON response format is not supported by Anthropic", exception.getMessage());
@@ -36,10 +41,14 @@ class InternalAnthropicHelperTest {
     @Test
     void validate_WithFrequencyPenalty_ShouldThrowException() {
         // Given
-        ChatRequestParameters parameters = ChatRequestParameters.builder().responseFormat(ResponseFormat.TEXT).frequencyPenalty(0.5).build();
+        ChatRequestParameters parameters = ChatRequestParameters.builder()
+                .responseFormat(ResponseFormat.TEXT)
+                .frequencyPenalty(0.5)
+                .build();
 
         // When
-        UnsupportedFeatureException exception = assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
+        UnsupportedFeatureException exception =
+                assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
 
         // Then
         assertEquals("Frequency Penalty is not supported by Anthropic", exception.getMessage());
@@ -48,10 +57,14 @@ class InternalAnthropicHelperTest {
     @Test
     void validate_WithPresencePenalty_ShouldThrowException() {
         // Given
-        ChatRequestParameters parameters = ChatRequestParameters.builder().responseFormat(ResponseFormat.TEXT).presencePenalty(0.5).build();
+        ChatRequestParameters parameters = ChatRequestParameters.builder()
+                .responseFormat(ResponseFormat.TEXT)
+                .presencePenalty(0.5)
+                .build();
 
         // When
-        UnsupportedFeatureException exception = assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
+        UnsupportedFeatureException exception =
+                assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
 
         // Then
         assertEquals("Presence Penalty is not supported by Anthropic", exception.getMessage());
@@ -60,10 +73,14 @@ class InternalAnthropicHelperTest {
     @Test
     void validate_WithTwoUnsupportedFeatures_ShouldThrowExceptionWithCombinedMessage() {
         // Given
-        ChatRequestParameters parameters = ChatRequestParameters.builder().responseFormat(ResponseFormat.JSON).frequencyPenalty(0.5).build();
+        ChatRequestParameters parameters = ChatRequestParameters.builder()
+                .responseFormat(ResponseFormat.JSON)
+                .frequencyPenalty(0.5)
+                .build();
 
         // When
-        UnsupportedFeatureException exception = assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
+        UnsupportedFeatureException exception =
+                assertThrows(UnsupportedFeatureException.class, () -> validate(parameters));
 
         // Then
         assertEquals("JSON response format, Frequency Penalty are not supported by Anthropic", exception.getMessage());


### PR DESCRIPTION
Claude supports ResponseFormat.TEXT but not JSON, so ensure to not throw an Exception when ResponseFormat.TEXT is explicitly set on the ChatRequestParameters. Also added some tests for the validate method.


## Issue
Closes # -

## Change
Because of how `ChatParameters` are build in our application `ResponseFormat` is always set. This results in an exception when using any Anthropic model as the InternalAnthropicHelper only checks for `null`. This PR simply checks the actualt ResponseFormat set.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
