### PR TITLE
Prevent an infinite loop when using AiService with ToolChoice.REQUIRED

### DIFF
--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxAIServiceIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxAIServiceIT.java
@@ -1,0 +1,66 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.watsonx.WatsonxChatModel;
+import dev.langchain4j.service.AiServices;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+public class WatsonxAIServiceIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
+    static final String URL = System.getenv("WATSONX_URL");
+
+    record Result(Double result) {}
+    ;
+
+    static class Calculator {
+        @Tool("Adds two given numbers")
+        double add(double a, double b) {
+            return a + b;
+        }
+
+        @Tool("Multiplies two given numbers")
+        String multiply(double a, double b) {
+            return String.valueOf(a * b);
+        }
+    }
+
+    interface Assistant {
+        Result chat(String userMessage);
+    }
+
+    @Test
+    public void should_not_loop_when_tool_choice_required() {
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(WatsonxChatModel.builder()
+                        .url(URL)
+                        .apiKey(API_KEY)
+                        .projectId(PROJECT_ID)
+                        .modelName("ibm/granite-4-h-small")
+                        .logRequests(true)
+                        .logResponses(true)
+                        .timeLimit(Duration.ofSeconds(30))
+                        .toolChoice(ToolChoice.REQUIRED)
+                        .temperature(0.5)
+                        .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
+                        .build())
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(new Calculator())
+                .build();
+
+        var result = assistant.chat("What is the result of 2 + 2?");
+        assertEquals(4, result.result());
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceWithToolChoice.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceWithToolChoice.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AiServiceWithToolChoice {
+
+    @Mock
+    ChatModel chatModel;
+
+    static class Calculator {
+        @Tool("Adds two given numbers")
+        double add(double a, double b) {
+            return a + b;
+        }
+    }
+
+    interface Assistant {
+        String chat(String userMessage);
+    }
+
+    @Test
+    void should_not_loop_when_tool_choice_required() {
+
+        when(chatModel.defaultRequestParameters())
+                .thenReturn(ChatRequestParameters.builder()
+                        .toolChoice(ToolChoice.REQUIRED)
+                        .build());
+
+        ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
+                .id("id")
+                .name("add")
+                .arguments("{\"arg0\": 2, \"arg1\": 2}")
+                .build();
+
+        ChatResponse response1 = ChatResponse.builder()
+                .aiMessage(AiMessage.from(toolExecutionRequest))
+                .finishReason(FinishReason.TOOL_EXECUTION)
+                .build();
+
+        ChatResponse response2 = ChatResponse.builder()
+                .aiMessage(AiMessage.from("4"))
+                .finishReason(FinishReason.STOP)
+                .build();
+
+        when(chatModel.chat(any(ChatRequest.class))).thenReturn(response1).thenReturn(response2);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(new Calculator())
+                .build();
+
+        assistant.chat("What is the result of 2 + 2");
+
+        ArgumentCaptor<ChatRequest> captor = ArgumentCaptor.forClass(ChatRequest.class);
+        verify(chatModel, times(2)).chat(captor.capture());
+
+        List<ChatRequest> capturedRequests = captor.getAllValues();
+        assertEquals(ToolChoice.NONE, capturedRequests.get(1).toolChoice());
+    }
+}


### PR DESCRIPTION
Closes #3481

<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
The issue occurs when using AiService with a ChatModel that is configured with `ToolChoice.REQUIRED`. 
During message execution, AiService invoked the chat model multiple times, first to request tool execution and then again to produce the final response. Because the `ToolChoice` remained `REQUIRED` in both calls, the model repeatedly requested tool execution, leading to an infinite loop.  

The fix ensures that AiService automatically switches `ToolChoice.NONE` after the tool has been executed.

@dliubarskyi I have added a JUnit test and an IT test. However, from my understanding, watsonx's IT tests are not executed from the pipeline. It might be better to move the IT test under another model provider.

One more thing, I didn't run the IT tests for the other model providers.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit ~and integration tests~ in the module I have added/changed, and they are all green
- [x] I have manually run all the unit ~and integration tests~ in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
