### PR TITLE
demo possible approach to dynamic value injection into http layer

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/context/RequestContext.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/context/RequestContext.java
@@ -1,0 +1,7 @@
+package dev.langchain4j.internal.context;
+
+import java.util.Map;
+
+public record RequestContext(Map<String, String> extraHeaders, Map<String, String> extraQueryParams) {
+    public static final RequestContext EMPTY = new RequestContext(Map.of(), Map.of());
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ChatRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ChatRequest.java
@@ -7,6 +7,7 @@ import static java.util.Arrays.asList;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.internal.context.RequestContext;
 import java.util.List;
 import java.util.Objects;
 
@@ -14,8 +15,11 @@ public class ChatRequest {
 
     private final List<ChatMessage> messages;
     private final ChatRequestParameters parameters;
+    private final RequestContext context;
 
     protected ChatRequest(Builder builder) {
+        this.context = Objects.requireNonNullElse(builder.context, RequestContext.EMPTY);
+
         this.messages = copy(ensureNotEmpty(builder.messages, "messages"));
 
         DefaultChatRequestParameters.Builder<?> parametersBuilder = ChatRequestParameters.builder();
@@ -76,6 +80,10 @@ public class ChatRequest {
         return messages;
     }
 
+    public RequestContext context() {
+        return context;
+    }
+
     public ChatRequestParameters parameters() {
         return parameters;
     }
@@ -129,17 +137,17 @@ public class ChatRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ChatRequest that = (ChatRequest) o;
-        return Objects.equals(this.messages, that.messages) && Objects.equals(this.parameters, that.parameters);
+        return Objects.equals(this.messages, that.messages) && Objects.equals(this.parameters, that.parameters) && Objects.equals(this.context, that.context);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(messages, parameters);
+        return Objects.hash(messages, parameters, context);
     }
 
     @Override
     public String toString() {
-        return "ChatRequest {" + " messages = " + messages + ", parameters = " + parameters + " }";
+        return "ChatRequest {" + " messages = " + messages + ", parameters = " + parameters + ", context = " + context + " }";
     }
 
     /**
@@ -155,6 +163,7 @@ public class ChatRequest {
 
     public static class Builder {
 
+        private RequestContext context;
         private List<ChatMessage> messages;
         private ChatRequestParameters parameters;
 
@@ -170,11 +179,13 @@ public class ChatRequest {
         private ToolChoice toolChoice;
         private ResponseFormat responseFormat;
 
-        public Builder() {}
+        public Builder() {
+        }
 
         public Builder(ChatRequest chatRequest) {
             this.messages = chatRequest.messages;
             this.parameters = chatRequest.parameters;
+            this.context = chatRequest.context;
         }
 
         public Builder messages(List<ChatMessage> messages) {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
@@ -19,6 +19,7 @@ import static java.util.Arrays.asList;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.internal.context.RequestContext;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.ChatModel;
@@ -146,8 +147,10 @@ public class OpenAiChatModel implements ChatModel {
                         chatRequest, parameters, strictTools, strictJsonSchema)
                 .build();
 
+        RequestContext requestContext = chatRequest.context();
+
         ParsedAndRawResponse<ChatCompletionResponse> parsedAndRawResponse = withRetryMappingExceptions(
-                () -> client.chatCompletion(openAiRequest).executeRaw(), maxRetries);
+                () -> client.chatCompletion(openAiRequest, requestContext).executeRaw(), maxRetries);
 
         ChatCompletionResponse openAiResponse = parsedAndRawResponse.parsedResponse();
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiEmbeddingModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiEmbeddingModel.java
@@ -12,6 +12,7 @@ import static java.time.Duration.ofSeconds;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.internal.context.RequestContext;
 import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
 import dev.langchain4j.model.openai.internal.OpenAiClient;
 import dev.langchain4j.model.openai.internal.embedding.EmbeddingRequest;
@@ -126,7 +127,7 @@ public class OpenAiEmbeddingModel extends DimensionAwareEmbeddingModel {
                 .build();
 
         EmbeddingResponse response =
-                withRetryMappingExceptions(() -> client.embedding(request).execute(), maxRetries);
+                withRetryMappingExceptions(() -> client.embedding(request, RequestContext.EMPTY).execute(), maxRetries);
 
         List<Embedding> embeddings = response.data().stream()
                 .map(openAiEmbedding -> Embedding.from(openAiEmbedding.embedding()))

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
@@ -9,6 +9,7 @@ import static java.time.Duration.ofSeconds;
 
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.internal.context.RequestContext;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.openai.internal.OpenAiClient;
 import dev.langchain4j.model.openai.internal.image.GenerateImagesRequest;
@@ -74,7 +75,7 @@ public class OpenAiImageModel implements ImageModel {
     public Response<Image> generate(String prompt) {
         GenerateImagesRequest request = requestBuilder(prompt).build();
 
-        GenerateImagesResponse response = withRetryMappingExceptions(() -> client.imagesGeneration(request), maxRetries)
+        GenerateImagesResponse response = withRetryMappingExceptions(() -> client.imagesGeneration(request, RequestContext.EMPTY), maxRetries)
                 .execute();
 
         return Response.from(fromImageData(response.data().get(0)));
@@ -84,7 +85,7 @@ public class OpenAiImageModel implements ImageModel {
     public Response<List<Image>> generate(String prompt, int n) {
         GenerateImagesRequest request = requestBuilder(prompt).n(n).build();
 
-        GenerateImagesResponse response = withRetryMappingExceptions(() -> client.imagesGeneration(request), maxRetries)
+        GenerateImagesResponse response = withRetryMappingExceptions(() -> client.imagesGeneration(request, RequestContext.EMPTY), maxRetries)
                 .execute();
 
         return Response.from(

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiLanguageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiLanguageModel.java
@@ -10,6 +10,7 @@ import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.time.Duration.ofSeconds;
 
 import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.internal.context.RequestContext;
 import dev.langchain4j.model.language.LanguageModel;
 import dev.langchain4j.model.openai.internal.OpenAiClient;
 import dev.langchain4j.model.openai.internal.completion.CompletionChoice;
@@ -68,7 +69,7 @@ public class OpenAiLanguageModel implements LanguageModel {
                 .build();
 
         CompletionResponse response =
-                withRetryMappingExceptions(() -> client.completion(request).execute(), maxRetries);
+                withRetryMappingExceptions(() -> client.completion(request, RequestContext.EMPTY).execute(), maxRetries);
 
         CompletionChoice completionChoice = response.choices().get(0);
         return Response.from(

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
@@ -14,6 +14,7 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.internal.context.RequestContext;
 import dev.langchain4j.model.moderation.Moderation;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.openai.internal.OpenAiClient;
@@ -72,7 +73,7 @@ public class OpenAiModerationModel implements ModerationModel {
                 ModerationRequest.builder().model(modelName).input(inputs).build();
 
         ModerationResponse response =
-                withRetryMappingExceptions(() -> client.moderation(request).execute(), maxRetries);
+                withRetryMappingExceptions(() -> client.moderation(request, RequestContext.EMPTY).execute(), maxRetries);
 
         int i = 0;
         for (ModerationResult moderationResult : response.results()) {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -23,6 +23,7 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.internal.ExceptionMapper;
 import dev.langchain4j.internal.ToolCallBuilder;
+import dev.langchain4j.internal.context.RequestContext;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -141,10 +142,12 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
                                 StreamOptions.builder().includeUsage(true).build())
                         .build();
 
+        RequestContext requestContext = chatRequest.context();
+
         OpenAiStreamingResponseBuilder openAiResponseBuilder = new OpenAiStreamingResponseBuilder(returnThinking);
         ToolCallBuilder toolCallBuilder = new ToolCallBuilder();
 
-        client.chatCompletion(openAiRequest)
+        client.chatCompletion(openAiRequest, requestContext)
                 .onRawPartialResponse(parsedAndRawResponse -> {
                     openAiResponseBuilder.append(parsedAndRawResponse);
                     handle(parsedAndRawResponse.parsedResponse(), toolCallBuilder, handler);

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingLanguageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingLanguageModel.java
@@ -9,6 +9,7 @@ import static java.time.Duration.ofSeconds;
 
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.internal.ExceptionMapper;
+import dev.langchain4j.internal.context.RequestContext;
 import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.language.StreamingLanguageModel;
@@ -70,7 +71,7 @@ public class OpenAiStreamingLanguageModel implements StreamingLanguageModel {
 
         OpenAiStreamingResponseBuilder responseBuilder = new OpenAiStreamingResponseBuilder();
 
-        client.completion(request)
+        client.completion(request, RequestContext.EMPTY)
                 .onPartialResponse(partialResponse -> {
                     responseBuilder.append(partialResponse);
                     for (CompletionChoice choice : partialResponse.choices()) {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiClient.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.model.openai.internal;
 
 import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.internal.context.RequestContext;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
 import dev.langchain4j.model.openai.internal.completion.CompletionRequest;
@@ -19,15 +20,15 @@ import org.slf4j.Logger;
 
 public abstract class OpenAiClient {
 
-    public abstract SyncOrAsyncOrStreaming<CompletionResponse> completion(CompletionRequest request);
+    public abstract SyncOrAsyncOrStreaming<CompletionResponse> completion(CompletionRequest request, RequestContext context);
 
-    public abstract SyncOrAsyncOrStreaming<ChatCompletionResponse> chatCompletion(ChatCompletionRequest request);
+    public abstract SyncOrAsyncOrStreaming<ChatCompletionResponse> chatCompletion(ChatCompletionRequest request, RequestContext context);
 
-    public abstract SyncOrAsync<EmbeddingResponse> embedding(EmbeddingRequest request);
+    public abstract SyncOrAsync<EmbeddingResponse> embedding(EmbeddingRequest request, RequestContext context);
 
-    public abstract SyncOrAsync<ModerationResponse> moderation(ModerationRequest request);
+    public abstract SyncOrAsync<ModerationResponse> moderation(ModerationRequest request, RequestContext context);
 
-    public abstract SyncOrAsync<GenerateImagesResponse> imagesGeneration(GenerateImagesRequest request);
+    public abstract SyncOrAsync<GenerateImagesResponse> imagesGeneration(GenerateImagesRequest request, RequestContext context);
 
     @SuppressWarnings("rawtypes")
     public static Builder builder() {


### PR DESCRIPTION
Might be helpful with move towards #2218 resolution. This is definitely a breaking change but i just wanted to discuss if this would be a viable approach in which case i guess we could add overloads with defaults etc etc


## Issue
Closes #2218 (not really, just sticking to the pr template)

## Change
We add a new RequestContext record to help carry dynamic values like headers/query parameters (and potentially any other number of values that might have to be dynamically injected). Main use-case is to be able to pass these values from external systems/integrations/contexts. For instance, ADK has its own langchain4j shim, and its own internal request (`LlmRequest`) which has the capability to carry context similarly to `AgenticScope` but there is no way affect per-request behaviour dynamically. 

Actually, if we simplify this even further, the basic use-case is attaching tracing headers or any other sort of "scoped" data.

This doesn't have tests or docs updated because again, i dont know what's the maintainers' take on this approach but i would be willing to work on this further by e.g. adding useful overloads that would preserve API compatibility, adding tests/docs etc etc if we agree on the approach.


I'm in no rush to get this reviewed/discussed so even tho this PR breaks some checklists, i hope we could discuss potential solutions here at the pace that's comfortable for everyone.