### PR TITLE
Add support for validation of content types in Ollama models and respective unit tests

### DIFF
--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaChatModelIT.java
@@ -5,17 +5,29 @@ import static dev.langchain4j.model.chat.request.ResponseFormat.JSON;
 import static dev.langchain4j.model.ollama.OllamaImage.TINY_DOLPHIN_MODEL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import dev.langchain4j.data.message.AudioContent;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ContentType;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.VideoContent;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.output.FinishReason;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class OllamaChatModelIT extends AbstractOllamaLanguageModelInfrastructure {
@@ -105,5 +117,94 @@ class OllamaChatModelIT extends AbstractOllamaLanguageModelInfrastructure {
         // when-then
         assertThatThrownBy(() -> model.chat("hi"))
                 .isExactlyInstanceOf(dev.langchain4j.exception.TimeoutException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("notSupportedContentTypesProvider")
+    void should_throw_when_not_supported_content_types_used(List<ContentType> contentTypes) {
+
+        // given
+        OllamaChatModel model = OllamaChatModel.builder()
+                .baseUrl(ollamaBaseUrl(ollama))
+                .modelName(MODEL_NAME)
+                .maxRetries(0)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+        final UserMessage userMessage = createUserMessageBasedOnContentTypes(contentTypes);
+
+        // when-then
+        assertThrows(UnsupportedFeatureException.class, () -> model.chat(userMessage));
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedContentTypesProvider")
+    void should_not_throw_when_supported_content_types_used(List<ContentType> contentTypes) {
+
+        // given
+
+        OllamaChatModel model = OllamaChatModel.builder()
+                .baseUrl(ollamaBaseUrl(ollama))
+                .modelName(MODEL_NAME)
+                .maxRetries(0)
+                .timeout(Duration.ofMillis(1))
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+        final UserMessage userMessage = createUserMessageBasedOnContentTypes(contentTypes);
+
+        // when-then
+        // check that chat() times out, ergo, did not throw the UnsupportedFeatureException
+        assertThrows(dev.langchain4j.exception.TimeoutException.class, () -> model.chat(userMessage));
+    }
+
+    static UserMessage createUserMessageBasedOnContentTypes(List<ContentType> contentTypes) {
+        return UserMessage.from(contentTypes.stream()
+                .map(OllamaChatModelIT::createContentBasedOnType)
+                .toList());
+    }
+
+    static Content createContentBasedOnType(ContentType contentType) {
+        return switch (contentType) {
+            case AUDIO -> AudioContent.from("VGhpcyBpcyBhIHRlc3QgY29udGVudHM=", "audio/mpeg");
+            case IMAGE -> ImageContent.from("VGhpcyBpcyBhIHRlc3QgY29udGVudHM=", "image/jpeg");
+            case PDF -> VideoContent.from("VGhpcyBpcyBhIHRlc3QgY29udGVudHM=", "application/pdf");
+            case TEXT -> TextContent.from("Test text content.");
+            case VIDEO -> VideoContent.from("VGhpcyBpcyBhIHRlc3QgY29udGVudHM=", "video/mp4");
+            default -> {
+                // keep defaults case to alert when ContentType gets extended
+                fail("Cannot create user message from content type: " + contentType);
+                yield TextContent.from("Text text content.");
+            }
+        };
+    }
+
+    static Stream<List<ContentType>> notSupportedContentTypesProvider() {
+        return Stream.of(
+                List.of(ContentType.AUDIO),
+                List.of(ContentType.PDF),
+                List.of(ContentType.VIDEO),
+                List.of(ContentType.TEXT, ContentType.AUDIO),
+                List.of(ContentType.TEXT, ContentType.PDF),
+                List.of(ContentType.TEXT, ContentType.VIDEO),
+                List.of(ContentType.IMAGE, ContentType.AUDIO),
+                List.of(ContentType.IMAGE, ContentType.PDF),
+                List.of(ContentType.IMAGE, ContentType.VIDEO),
+                List.of(ContentType.TEXT, ContentType.AUDIO, ContentType.IMAGE),
+                List.of(ContentType.TEXT, ContentType.PDF, ContentType.IMAGE),
+                List.of(ContentType.TEXT, ContentType.VIDEO, ContentType.IMAGE),
+                List.of(ContentType.AUDIO, ContentType.IMAGE, ContentType.PDF, ContentType.TEXT, ContentType.VIDEO)
+        );
+    }
+
+    static Stream<List<ContentType>> supportedContentTypesProvider() {
+        // note, only 1 of TEXT is allowed, zero or more of IMAGE
+        return Stream.of(
+                List.of(ContentType.TEXT),
+                List.of(ContentType.IMAGE, ContentType.TEXT),
+                List.of(ContentType.TEXT, ContentType.IMAGE),
+                List.of(ContentType.IMAGE, ContentType.IMAGE, ContentType.TEXT),
+                List.of(ContentType.IMAGE, ContentType.TEXT, ContentType.IMAGE)
+        );
     }
 }


### PR DESCRIPTION
…ective unit tests

<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #3889 

## Change
<!-- Please describe the changes you made. -->

I've added logic in InternalOllamaHelper.java that only focuses on ContentType.TEXT and .IMAGE. When any other ContentType is detected, the UnsupportedFeatureException is thrown. Code has been written to be understandable and modifiable.

Then two tests have been extended, where the reusable lists of not-supported and supported content types are defined in OllamaChatModelIT.java and reused in OllamaStreamingChatModelIT.java
There is a dependency: if at some point in time a  new ContentType is added, then the notSupported types provider should also be extended.

Note that I cannot run the test 'numPredict()' in OllamaStreamingChatModelIT : a timeout occurs. This may be due to my test machine setup. The numPredict() test is not dependent on, or affected by, my changes. In OllamaChatModelIT.numPredict() no error occurs.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`
n/a

## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`
n/a

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
n/a