### PR TITLE
test: add missing test coverage for ParsingUtils collection parsing

### DIFF
--- a/langchain4j/src/test/java/dev/langchain4j/service/output/ParsingUtilsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/ParsingUtilsTest.java
@@ -3,6 +3,8 @@ package dev.langchain4j.service.output;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
@@ -98,4 +100,65 @@ class ParsingUtilsTest {
                 .isInstanceOf(OutputParsingException.class)
                 .hasCauseInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void should_parse_collection_from_json_with_values_field() {
+        // given
+        String text = "{\"values\": [\"item1\", \"item2\", \"item3\"]}";
+        Function<String, String> parser = Function.identity();
+
+        // when
+        List<String> result = ParsingUtils.parseAsStringOrJson(text, parser, ArrayList::new, "String");
+
+        // then
+        assertThat(result).containsExactly("item1", "item2", "item3");
+    }
+
+    @Test
+    void should_parse_collection_from_multiline_string_when_not_json() {
+        // given
+        String text = "line1\nline2\n\nline3\n  ";
+        Function<String, String> parser = Function.identity();
+
+        // when
+        List<String> result = ParsingUtils.parseAsStringOrJson(text, parser, ArrayList::new, "String");
+
+        // then
+        assertThat(result).containsExactly("line1", "line2", "line3");
+    }
+
+    @Test
+    void should_throw_when_null_text_for_collection() {
+        // given
+        String text = null;
+        Function<String, String> parser = Function.identity();
+
+        // when/then
+        assertThatThrownBy(() -> ParsingUtils.parseAsStringOrJson(text, parser, ArrayList::new, "String"))
+                .isInstanceOf(OutputParsingException.class)
+                .hasMessageContaining("Failed to parse");
+    }
+
+    @Test
+    void should_throw_when_json_missing_values_field_for_collection() {
+        // given
+        String text = "{\"value\": \"single\"}";
+        Function<String, String> parser = Function.identity();
+
+        // when/then
+        assertThatThrownBy(() -> ParsingUtils.parseAsStringOrJson(text, parser, ArrayList::new, "String"))
+                .isInstanceOf(OutputParsingException.class);
+    }
+
+    @Test
+    void should_throw_when_values_field_is_not_collection() {
+        // given
+        String text = "{\"values\": \"not a collection\"}";
+        Function<String, String> parser = Function.identity();
+
+        // when/then
+        assertThatThrownBy(() -> ParsingUtils.parseAsStringOrJson(text, parser, ArrayList::new, "String"))
+                .isInstanceOf(OutputParsingException.class);
+    }
+
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/ParsingUtilsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/ParsingUtilsTest.java
@@ -160,5 +160,4 @@ class ParsingUtilsTest {
         assertThatThrownBy(() -> ParsingUtils.parseAsStringOrJson(text, parser, ArrayList::new, "String"))
                 .isInstanceOf(OutputParsingException.class);
     }
-
 }


### PR DESCRIPTION
## Description
This PR adds comprehensive test coverage for the `ParsingUtils` class, specifically focusing on the collection parsing functionality.

## Changes
Added test coverage for the `parseAsStringOrJson` method's collection parsing capabilities:

### Tests
- Parse collections from JSON with "values" field
- Parse collections from multiline strings (non-JSON format)
- Null input validation for collection parsing
- Missing "values" field in JSON
- Invalid type for "values" field (non-collection)