### PR TITLE
Remove model from GeminiGenerateContentRequest

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
@@ -107,7 +107,6 @@ class BaseGeminiChatModel {
         }
 
         return GeminiGenerateContentRequest.builder()
-                .model(chatRequest.modelName())
                 .contents(geminiContentList)
                 .systemInstruction(!systemInstruction.getParts().isEmpty() ? systemInstruction : null)
                 .generationConfig(GeminiGenerationConfig.builder()

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentRequest.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentRequest.java
@@ -1,8 +1,8 @@
 package dev.langchain4j.model.googleai;
 
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 record GeminiGenerateContentRequest(
@@ -27,8 +27,7 @@ record GeminiGenerateContentRequest(
         private GeminiGenerationConfig generationConfig;
         private String cachedContent;
 
-        GeminiGenerateContentRequestBuilder() {
-        }
+        GeminiGenerateContentRequestBuilder() {}
 
         GeminiGenerateContentRequestBuilder contents(List<GeminiContent> contents) {
             this.contents = contents;
@@ -73,8 +72,7 @@ record GeminiGenerateContentRequest(
                     this.safetySettings,
                     this.systemInstruction,
                     this.generationConfig,
-                    this.cachedContent
-            );
+                    this.cachedContent);
         }
     }
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentRequest.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentRequest.java
@@ -1,179 +1,24 @@
 package dev.langchain4j.model.googleai;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.List;
-
 @JsonIgnoreProperties(ignoreUnknown = true)
-class GeminiGenerateContentRequest {
-    private String model;
-    private List<GeminiContent> contents;
-    private GeminiTool tools;
-    private GeminiToolConfig toolConfig;
-    private List<GeminiSafetySetting> safetySettings;
-    private GeminiContent systemInstruction;
-    private GeminiGenerationConfig generationConfig;
-    private String cachedContent;
+record GeminiGenerateContentRequest(
+        @JsonProperty List<GeminiContent> contents,
+        @JsonProperty GeminiTool tools,
+        @JsonProperty GeminiToolConfig toolConfig,
+        @JsonProperty List<GeminiSafetySetting> safetySettings,
+        @JsonProperty GeminiContent systemInstruction,
+        @JsonProperty GeminiGenerationConfig generationConfig,
+        @JsonProperty String cachedContent) {
 
-    @JsonCreator
-    GeminiGenerateContentRequest(
-            @JsonProperty("model") String model,
-            @JsonProperty("contents") List<GeminiContent> contents,
-            @JsonProperty("tools") GeminiTool tools,
-            @JsonProperty("toolConfig") GeminiToolConfig toolConfig,
-            @JsonProperty("safetySettings") List<GeminiSafetySetting> safetySettings,
-            @JsonProperty("systemInstruction") GeminiContent systemInstruction,
-            @JsonProperty("generationConfig") GeminiGenerationConfig generationConfig,
-            @JsonProperty("cachedContent") String cachedContent) {
-        this.model = model;
-        this.contents = contents;
-        this.tools = tools;
-        this.toolConfig = toolConfig;
-        this.safetySettings = safetySettings;
-        this.systemInstruction = systemInstruction;
-        this.generationConfig = generationConfig;
-        this.cachedContent = cachedContent;
-    }
-
-    public static GeminiGenerateContentRequestBuilder builder() {
+    static GeminiGenerateContentRequestBuilder builder() {
         return new GeminiGenerateContentRequestBuilder();
     }
 
-    public String getModel() {
-        return this.model;
-    }
-
-    public List<GeminiContent> getContents() {
-        return this.contents;
-    }
-
-    public GeminiTool getTools() {
-        return this.tools;
-    }
-
-    public GeminiToolConfig getToolConfig() {
-        return this.toolConfig;
-    }
-
-    public List<GeminiSafetySetting> getSafetySettings() {
-        return this.safetySettings;
-    }
-
-    public GeminiContent getSystemInstruction() {
-        return this.systemInstruction;
-    }
-
-    public GeminiGenerationConfig getGenerationConfig() {
-        return this.generationConfig;
-    }
-
-    public String getCachedContent() {
-        return this.cachedContent;
-    }
-
-    public void setModel(String model) {
-        this.model = model;
-    }
-
-    public void setContents(List<GeminiContent> contents) {
-        this.contents = contents;
-    }
-
-    public void setTools(GeminiTool tools) {
-        this.tools = tools;
-    }
-
-    public void setToolConfig(GeminiToolConfig toolConfig) {
-        this.toolConfig = toolConfig;
-    }
-
-    public void setSafetySettings(List<GeminiSafetySetting> safetySettings) {
-        this.safetySettings = safetySettings;
-    }
-
-    public void setSystemInstruction(GeminiContent systemInstruction) {
-        this.systemInstruction = systemInstruction;
-    }
-
-    public void setGenerationConfig(GeminiGenerationConfig generationConfig) {
-        this.generationConfig = generationConfig;
-    }
-
-    public void setCachedContent(String cachedContent) {
-        this.cachedContent = cachedContent;
-    }
-
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof GeminiGenerateContentRequest)) return false;
-        final GeminiGenerateContentRequest other = (GeminiGenerateContentRequest) o;
-        if (!other.canEqual((Object) this)) return false;
-        final Object this$model = this.getModel();
-        final Object other$model = other.getModel();
-        if (this$model == null ? other$model != null : !this$model.equals(other$model)) return false;
-        final Object this$contents = this.getContents();
-        final Object other$contents = other.getContents();
-        if (this$contents == null ? other$contents != null : !this$contents.equals(other$contents)) return false;
-        final Object this$tools = this.getTools();
-        final Object other$tools = other.getTools();
-        if (this$tools == null ? other$tools != null : !this$tools.equals(other$tools)) return false;
-        final Object this$toolConfig = this.getToolConfig();
-        final Object other$toolConfig = other.getToolConfig();
-        if (this$toolConfig == null ? other$toolConfig != null : !this$toolConfig.equals(other$toolConfig))
-            return false;
-        final Object this$safetySettings = this.getSafetySettings();
-        final Object other$safetySettings = other.getSafetySettings();
-        if (this$safetySettings == null ? other$safetySettings != null : !this$safetySettings.equals(other$safetySettings))
-            return false;
-        final Object this$systemInstruction = this.getSystemInstruction();
-        final Object other$systemInstruction = other.getSystemInstruction();
-        if (this$systemInstruction == null ? other$systemInstruction != null : !this$systemInstruction.equals(other$systemInstruction))
-            return false;
-        final Object this$generationConfig = this.getGenerationConfig();
-        final Object other$generationConfig = other.getGenerationConfig();
-        if (this$generationConfig == null ? other$generationConfig != null : !this$generationConfig.equals(other$generationConfig))
-            return false;
-        final Object this$cachedContent = this.getCachedContent();
-        final Object other$cachedContent = other.getCachedContent();
-        if (this$cachedContent == null ? other$cachedContent != null : !this$cachedContent.equals(other$cachedContent))
-            return false;
-        return true;
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof GeminiGenerateContentRequest;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $model = this.getModel();
-        result = result * PRIME + ($model == null ? 43 : $model.hashCode());
-        final Object $contents = this.getContents();
-        result = result * PRIME + ($contents == null ? 43 : $contents.hashCode());
-        final Object $tools = this.getTools();
-        result = result * PRIME + ($tools == null ? 43 : $tools.hashCode());
-        final Object $toolConfig = this.getToolConfig();
-        result = result * PRIME + ($toolConfig == null ? 43 : $toolConfig.hashCode());
-        final Object $safetySettings = this.getSafetySettings();
-        result = result * PRIME + ($safetySettings == null ? 43 : $safetySettings.hashCode());
-        final Object $systemInstruction = this.getSystemInstruction();
-        result = result * PRIME + ($systemInstruction == null ? 43 : $systemInstruction.hashCode());
-        final Object $generationConfig = this.getGenerationConfig();
-        result = result * PRIME + ($generationConfig == null ? 43 : $generationConfig.hashCode());
-        final Object $cachedContent = this.getCachedContent();
-        result = result * PRIME + ($cachedContent == null ? 43 : $cachedContent.hashCode());
-        return result;
-    }
-
-    public String toString() {
-        return "GeminiGenerateContentRequest(model=" + this.getModel() + ", contents=" + this.getContents() + ", tools=" + this.getTools() + ", toolConfig=" + this.getToolConfig() + ", safetySettings=" + this.getSafetySettings() + ", systemInstruction=" + this.getSystemInstruction() + ", generationConfig=" + this.getGenerationConfig() + ", cachedContent=" + this.getCachedContent() + ")";
-    }
-
-    public static class GeminiGenerateContentRequestBuilder {
-        private String model;
+    static class GeminiGenerateContentRequestBuilder {
         private List<GeminiContent> contents;
         private GeminiTool tools;
         private GeminiToolConfig toolConfig;
@@ -185,52 +30,51 @@ class GeminiGenerateContentRequest {
         GeminiGenerateContentRequestBuilder() {
         }
 
-        public GeminiGenerateContentRequestBuilder model(String model) {
-            this.model = model;
-            return this;
-        }
-
-        public GeminiGenerateContentRequestBuilder contents(List<GeminiContent> contents) {
+        GeminiGenerateContentRequestBuilder contents(List<GeminiContent> contents) {
             this.contents = contents;
             return this;
         }
 
-        public GeminiGenerateContentRequestBuilder tools(GeminiTool tools) {
+        GeminiGenerateContentRequestBuilder tools(GeminiTool tools) {
             this.tools = tools;
             return this;
         }
 
-        public GeminiGenerateContentRequestBuilder toolConfig(GeminiToolConfig toolConfig) {
+        GeminiGenerateContentRequestBuilder toolConfig(GeminiToolConfig toolConfig) {
             this.toolConfig = toolConfig;
             return this;
         }
 
-        public GeminiGenerateContentRequestBuilder safetySettings(List<GeminiSafetySetting> safetySettings) {
+        GeminiGenerateContentRequestBuilder safetySettings(List<GeminiSafetySetting> safetySettings) {
             this.safetySettings = safetySettings;
             return this;
         }
 
-        public GeminiGenerateContentRequestBuilder systemInstruction(GeminiContent systemInstruction) {
+        GeminiGenerateContentRequestBuilder systemInstruction(GeminiContent systemInstruction) {
             this.systemInstruction = systemInstruction;
             return this;
         }
 
-        public GeminiGenerateContentRequestBuilder generationConfig(GeminiGenerationConfig generationConfig) {
+        GeminiGenerateContentRequestBuilder generationConfig(GeminiGenerationConfig generationConfig) {
             this.generationConfig = generationConfig;
             return this;
         }
 
-        public GeminiGenerateContentRequestBuilder cachedContent(String cachedContent) {
+        GeminiGenerateContentRequestBuilder cachedContent(String cachedContent) {
             this.cachedContent = cachedContent;
             return this;
         }
 
         public GeminiGenerateContentRequest build() {
-            return new GeminiGenerateContentRequest(this.model, this.contents, this.tools, this.toolConfig, this.safetySettings, this.systemInstruction, this.generationConfig, this.cachedContent);
-        }
-
-        public String toString() {
-            return "GeminiGenerateContentRequest.GeminiGenerateContentRequestBuilder(model=" + this.model + ", contents=" + this.contents + ", tools=" + this.tools + ", toolConfig=" + this.toolConfig + ", safetySettings=" + this.safetySettings + ", systemInstruction=" + this.systemInstruction + ", generationConfig=" + this.generationConfig + ", cachedContent=" + this.cachedContent + ")";
+            return new GeminiGenerateContentRequest(
+                    this.contents,
+                    this.tools,
+                    this.toolConfig,
+                    this.safetySettings,
+                    this.systemInstruction,
+                    this.generationConfig,
+                    this.cachedContent
+            );
         }
     }
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiTokenCountEstimator.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiTokenCountEstimator.java
@@ -13,10 +13,10 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.model.TokenCountEstimator;
-import org.slf4j.Logger;
 import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
+import org.slf4j.Logger;
 
 public class GoogleAiGeminiTokenCountEstimator implements TokenCountEstimator {
 

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiTokenCountEstimator.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiTokenCountEstimator.java
@@ -84,7 +84,6 @@ public class GoogleAiGeminiTokenCountEstimator implements TokenCountEstimator {
 
         GeminiCountTokensRequest countTokensRequestWithDummyContent = new GeminiCountTokensRequest();
         countTokensRequestWithDummyContent.setGenerateContentRequest(GeminiGenerateContentRequest.builder()
-                .model("models/" + this.modelName)
                 .contents(singletonList(dummyContent))
                 .tools(FunctionMapper.fromToolSepcsToGTool(allTools, false))
                 .build());

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelIT.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelIT.java
@@ -502,13 +502,17 @@ class GoogleAiGeminiChatModelIT {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
     @JsonSubTypes({@JsonSubTypes.Type(Circle.class), @JsonSubTypes.Type(Rectangle.class)})
-    interface Shape {}
+    interface Shape {
+    }
 
-    record Circle(double radius) implements Shape {}
+    record Circle(double radius) implements Shape {
+    }
 
-    record Rectangle(double width, double height) implements Shape {}
+    record Rectangle(double width, double height) implements Shape {
+    }
 
-    record Shapes(List<Shape> shapes) {}
+    record Shapes(List<Shape> shapes) {
+    }
 
     // TODO move to common tests
     @Test
@@ -543,10 +547,10 @@ class GoogleAiGeminiChatModelIT {
 
         UserMessage userMessage = UserMessage.from(
                 """
-                Extract information from the following text:
-                1. A circle with a radius of 5
-                2. A rectangle with a width of 10 and a height of 20
-                """);
+                        Extract information from the following text:
+                        1. A circle with a radius of 5
+                        2. A rectangle with a width of 10 and a height of 20
+                        """);
 
         ChatRequest chatRequest = ChatRequest.builder()
                 .messages(userMessage)

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelIT.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelIT.java
@@ -502,17 +502,13 @@ class GoogleAiGeminiChatModelIT {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
     @JsonSubTypes({@JsonSubTypes.Type(Circle.class), @JsonSubTypes.Type(Rectangle.class)})
-    interface Shape {
-    }
+    interface Shape {}
 
-    record Circle(double radius) implements Shape {
-    }
+    record Circle(double radius) implements Shape {}
 
-    record Rectangle(double width, double height) implements Shape {
-    }
+    record Rectangle(double width, double height) implements Shape {}
 
-    record Shapes(List<Shape> shapes) {
-    }
+    record Shapes(List<Shape> shapes) {}
 
     // TODO move to common tests
     @Test
@@ -547,10 +543,10 @@ class GoogleAiGeminiChatModelIT {
 
         UserMessage userMessage = UserMessage.from(
                 """
-                        Extract information from the following text:
-                        1. A circle with a radius of 5
-                        2. A rectangle with a width of 10 and a height of 20
-                        """);
+                Extract information from the following text:
+                1. A circle with a radius of 5
+                2. A rectangle with a width of 10 and a height of 20
+                """);
 
         ChatRequest chatRequest = ChatRequest.builder()
                 .messages(userMessage)

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
@@ -290,9 +290,8 @@ class GoogleAiGeminiChatModelTest {
             verify(mockGeminiService).generateContent(eq(TEST_MODEL_NAME), requestCaptor.capture());
 
             var request = requestCaptor.getValue();
-            assertThat(request.getModel()).isEqualTo(TEST_MODEL_NAME);
-            assertThat(request.getContents()).isNotEmpty();
-            assertThat(request.getGenerationConfig())
+            assertThat(request.contents()).isNotEmpty();
+            assertThat(request.generationConfig())
                     .isEqualTo(GeminiGenerationConfig.builder()
                             .temperature(0.8)
                             .responseMimeType("text/plain")

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
@@ -54,7 +54,7 @@ class GoogleAiGeminiStreamingChatModelTest {
                     .build();
             GeminiGenerateContentRequest result = chatModel.createGenerateContentRequest(DEFAULT_REQUEST);
 
-            assertThatCharSequence(Json.toJson(result.getGenerationConfig())).contains("\"seed\" : 42");
+            assertThatCharSequence(Json.toJson(result.generationConfig())).contains("\"seed\" : 42");
         }
 
         @Test
@@ -65,7 +65,7 @@ class GoogleAiGeminiStreamingChatModelTest {
                     .build();
             GeminiGenerateContentRequest result = chatModel.createGenerateContentRequest(DEFAULT_REQUEST);
 
-            assertThatCharSequence(Json.toJson(result.getGenerationConfig())).doesNotContain("\"seed\"");
+            assertThatCharSequence(Json.toJson(result.generationConfig())).doesNotContain("\"seed\"");
         }
     }
 }


### PR DESCRIPTION


## Change
Removed the model parameter from the `GeminiGenerateContentRequest`.

The model is a path variable only, there's no need to set this in the request body - it appears it's not even documented any more: https://ai.google.dev/api/generate-content#method:-models.generatecontent

I've also changed `GeminiGenerateContentRequest` to be a record to prevent missing members in equals/hashCode/toString implementations


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
