### PR TITLE
Reinforce immutability (map)

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -444,8 +444,8 @@ public class Utils {
         if (map == null) {
             return Map.of();
         }
-
-        return unmodifiableMap(map);
+        // LinkedHashMap to preserve iteration order (important for deterministic toString)
+        return unmodifiableMap(new java.util.LinkedHashMap<>(map));
     }
 
     /**

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/CustomMessageTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/CustomMessageTest.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.data.message;
 
+import static org.assertj.core.api.Assertions.entry;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.assertj.core.api.WithAssertions;
@@ -12,7 +14,12 @@ class CustomMessageTest implements WithAssertions {
         attributes.put("content", "The sky is blue.");
         attributes.put("myAttribute", "myValue");
         CustomMessage message = new CustomMessage(attributes);
-        assertThat(message.attributes()).isEqualTo(attributes);
+
+        // mutate original
+        attributes.put("attributeAfterInstantiation", "valueAfterInstantiation");
+
+        assertThat(message.attributes())
+                .containsExactly(entry("content", "The sky is blue."), entry("myAttribute", "myValue"));
         assertThat(message.type()).isEqualTo(ChatMessageType.CUSTOM);
 
         assertThat(message)

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java
@@ -330,6 +330,19 @@ class UtilsTest {
     }
 
     @Test
+    void copied_map_should_not_change_if_original_map_is_updated() {
+        Map<String, Integer> original = new HashMap<>();
+        original.put("k1", 1);
+
+        Map<String, Integer> copy = Utils.copy(original);
+
+        // mutate original after copy
+        original.put("k2", 2);
+
+        assertThat(copy).containsExactly(entry("k1", 1));
+    }
+
+    @Test
     void ensure_trailing_forward_slash() {
         assertThat(Utils.ensureTrailingForwardSlash("https://example.com")).isEqualTo("https://example.com/");
         assertThat(Utils.ensureTrailingForwardSlash("https://example.com/")).isEqualTo("https://example.com/");


### PR DESCRIPTION
 With the code of `main`, if the original map changes after the copy, then the copied map is also updated.
 
 This [added test](https://github.com/langchain4j/langchain4j/blob/3ca486098673a2b6ec30c5066946572348fe9416/langchain4j-core/src/test/java/dev/langchain4j/internal/UtilsTest.java#L333) fails with the code of `main`.
 
 As a consequence, some LangChain4j objects can change after the object instanciation. I have updated a `CustomMessage` test:  https://github.com/langchain4j/langchain4j/blob/3ca486098673a2b6ec30c5066946572348fe9416/langchain4j-core/src/test/java/dev/langchain4j/data/message/CustomMessageTest.java#L19 It fails with the code of `main`.

Please also [see](https://github.com/langchain4j/langchain4j/pull/3937#discussion_r2454553429).