### PR TITLE
Fix NPE with OpenAiChatRequestParameters

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatRequestParameters.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatRequestParameters.java
@@ -1,18 +1,18 @@
 package dev.langchain4j.model.openai;
 
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
-import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
-
-import java.util.Map;
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.quoted;
 
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import java.util.Map;
+import java.util.Objects;
+
 public class OpenAiChatRequestParameters extends DefaultChatRequestParameters {
 
-    public static final OpenAiChatRequestParameters EMPTY = OpenAiChatRequestParameters.builder().build();
+    public static final OpenAiChatRequestParameters EMPTY =
+            OpenAiChatRequestParameters.builder().build();
 
     private final Integer maxCompletionTokens;
     private final Map<String, Integer> logitBias;
@@ -118,35 +118,33 @@ public class OpenAiChatRequestParameters extends DefaultChatRequestParameters {
                 metadata,
                 serviceTier,
                 reasoningEffort,
-                customParameters
-        );
+                customParameters);
     }
 
     @Override
     public String toString() {
-        return "OpenAiChatRequestParameters{" +
-                "modelName=" + quoted(modelName()) +
-                ", temperature=" + temperature() +
-                ", topP=" + topP() +
-                ", topK=" + topK() +
-                ", frequencyPenalty=" + frequencyPenalty() +
-                ", presencePenalty=" + presencePenalty() +
-                ", maxOutputTokens=" + maxOutputTokens() +
-                ", stopSequences=" + stopSequences() +
-                ", toolSpecifications=" + toolSpecifications() +
-                ", toolChoice=" + toolChoice() +
-                ", responseFormat=" + responseFormat() +
-                ", maxCompletionTokens=" + maxCompletionTokens +
-                ", logitBias=" + logitBias +
-                ", parallelToolCalls=" + parallelToolCalls +
-                ", seed=" + seed +
-                ", user=" + quoted(user) +
-                ", store=" + store +
-                ", metadata=" + metadata +
-                ", serviceTier=" + quoted(serviceTier) +
-                ", reasoningEffort=" + quoted(reasoningEffort) +
-                ", customParameters=" + customParameters +
-                '}';
+        return "OpenAiChatRequestParameters{" + "modelName="
+                + quoted(modelName()) + ", temperature="
+                + temperature() + ", topP="
+                + topP() + ", topK="
+                + topK() + ", frequencyPenalty="
+                + frequencyPenalty() + ", presencePenalty="
+                + presencePenalty() + ", maxOutputTokens="
+                + maxOutputTokens() + ", stopSequences="
+                + stopSequences() + ", toolSpecifications="
+                + toolSpecifications() + ", toolChoice="
+                + toolChoice() + ", responseFormat="
+                + responseFormat() + ", maxCompletionTokens="
+                + maxCompletionTokens + ", logitBias="
+                + logitBias + ", parallelToolCalls="
+                + parallelToolCalls + ", seed="
+                + seed + ", user="
+                + quoted(user) + ", store="
+                + store + ", metadata="
+                + metadata + ", serviceTier="
+                + quoted(serviceTier) + ", reasoningEffort="
+                + quoted(reasoningEffort) + ", customParameters="
+                + customParameters + '}';
     }
 
     public static Builder builder() {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatRequestParameters.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatRequestParameters.java
@@ -185,7 +185,7 @@ public class OpenAiChatRequestParameters extends DefaultChatRequestParameters {
         }
 
         public Builder modelName(OpenAiChatModelName modelName) {
-            return super.modelName(modelName.toString());
+            return super.modelName(modelName == null ? null : modelName.toString());
         }
 
         public Builder maxCompletionTokens(Integer maxCompletionTokens) {

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiChatRequestParametersTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiChatRequestParametersTest.java
@@ -67,4 +67,13 @@ class OpenAiChatRequestParametersTest {
         assertThat(openAiResult.serviceTier()).isEqualTo("tier1");
         assertThat(openAiResult.reasoningEffort()).isEqualTo("low");
     }
+
+    @Test
+    void null_model_name() {
+        OpenAiChatRequestParameters params = OpenAiChatRequestParameters.builder()
+                .modelName((OpenAiChatModelName) null)
+                .build();
+
+        assertThat(params.modelName()).isNull();
+    }
 }


### PR DESCRIPTION
This [added test](https://github.com/langchain4j/langchain4j/blob/6df084ddd571672a84707582d4a734d2bcfdf22f/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiChatRequestParametersTest.java#L72) is failing with the code on `main`:

`java.lang.NullPointerException: Cannot invoke "dev.langchain4j.model.openai.OpenAiChatModelName.toString()" because "modelName" is null`

It seems that spotless was never applied on `OpenAiChatRequestParametersTest`. See [this second commit ](https://github.com/langchain4j/langchain4j/pull/3940/commits/d1bda13c5b5a7c3a8f030eff692335ae915f8493) to fix the spotless CI error.