### PR TITLE
SqlFilterParser: Support LikeExpression

### DIFF
--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
@@ -52,6 +52,7 @@ import static java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR;
  * - {@link IsLessThanOrEqualTo}: {@code age <= 18}
  * - {@link IsIn}: {@code name IN ('Klaus', 'Francine')}
  * - {@link IsNotIn}: {@code id NOT IN (1, 2, 3)}
+ * - {@link Like}: {@code name LIKE ('%Fra_cine%')}
  * - BETWEEN: {@code year BETWEEN 2000 AND 2020}: will be parsed into {@code key("year").gte(2000).and(key("year").lte(2020))}
  *
  * - {@link And}: {@code name = 'Klaus' AND age = 18}
@@ -162,7 +163,15 @@ public class SqlFilterParser implements FilterParser {
             return new IsLessThan(getKey(exp), getValue(exp));
         } else if (exp instanceof MinorThanEquals) {
             return new IsLessThanOrEqualTo(getKey(exp), getValue(exp));
-        } else {
+        } else if (exp instanceof LikeExpression likeExp) {
+            LikeExpression.KeyWord keyword = likeExp.getLikeKeyWord();
+            return new Like(
+                getKey(exp),
+                getValue(exp),
+                Like.Operator.valueOf(keyword.name()),
+                likeExp.isNot());
+        }
+         else {
             throw illegalArgument("Unsupported expression: '%s'%s", exp, createGithubIssueLink(exp));
         }
     }

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
@@ -1,5 +1,9 @@
 package dev.langchain4j.store.embedding.filter.parser.sql;
 
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.store.embedding.filter.Filter;
 import dev.langchain4j.store.embedding.filter.FilterParser;
@@ -7,6 +11,11 @@ import dev.langchain4j.store.embedding.filter.comparison.*;
 import dev.langchain4j.store.embedding.filter.logical.And;
 import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
+import java.net.URLEncoder;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.*;
 import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
@@ -19,16 +28,6 @@ import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.select.PlainSelect;
-
-import java.net.URLEncoder;
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-
-import static dev.langchain4j.internal.Exceptions.illegalArgument;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR;
 
 /**
  * Parses an SQL "WHERE" clause into a {@link Filter} object using
@@ -138,9 +137,9 @@ public class SqlFilterParser implements FilterParser {
 
     private static String createGithubIssueLink(Expression unsupportedExpression) {
         try {
-            return ". Please click the following link to open an issue on our GitHub: " +
-                    "https://github.com/langchain4j/langchain4j/issues/new?labels=SqlFilterParser&title=SqlFilterParser:%20Support%20new%20expression%20type&body=" +
-                    URLEncoder.encode(unsupportedExpression.toString(), "UTF-8");
+            return ". Please click the following link to open an issue on our GitHub: "
+                    + "https://github.com/langchain4j/langchain4j/issues/new?labels=SqlFilterParser&title=SqlFilterParser:%20Support%20new%20expression%20type&body="
+                    + URLEncoder.encode(unsupportedExpression.toString(), "UTF-8");
         } catch (Exception e) {
             return "";
         }
@@ -165,13 +164,8 @@ public class SqlFilterParser implements FilterParser {
             return new IsLessThanOrEqualTo(getKey(exp), getValue(exp));
         } else if (exp instanceof LikeExpression likeExp) {
             LikeExpression.KeyWord keyword = likeExp.getLikeKeyWord();
-            return new Like(
-                getKey(exp),
-                getValue(exp),
-                Like.Operator.valueOf(keyword.name()),
-                likeExp.isNot());
-        }
-         else {
+            return new Like(getKey(exp), getValue(exp), Like.Operator.valueOf(keyword.name()), likeExp.isNot());
+        } else {
             throw illegalArgument("Unsupported expression: '%s'%s", exp, createGithubIssueLink(exp));
         }
     }
@@ -283,7 +277,7 @@ public class SqlFilterParser implements FilterParser {
                             return currentHour();
                         case "MINUTE":
                             return currentMinute();
-                        // TODO add other
+                            // TODO add other
                     }
                 } else {
                     // TODO parse timestamp?

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
@@ -1,22 +1,5 @@
 package dev.langchain4j.store.embedding.filter.parser.sql;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.store.embedding.filter.Filter;
-import dev.langchain4j.store.embedding.filter.FilterParser;
-import dev.langchain4j.store.embedding.filter.comparison.Like;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.time.Clock;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
-import java.util.stream.Stream;
-
 import static dev.langchain4j.store.embedding.filter.Filter.*;
 import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
 import static java.time.ZoneOffset.UTC;
@@ -25,6 +8,22 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.of;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.FilterParser;
+import dev.langchain4j.store.embedding.filter.comparison.Like;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class SqlFilterParserTest {
 
@@ -46,155 +45,62 @@ class SqlFilterParserTest {
         return Stream.<Arguments>builder()
 
                 // eq
-                .add(of(
-                        "name = 'Klaus'",
-                        metadataKey("name").isEqualTo("Klaus")
-                ))
-                .add(of(
-                        "age = 18",
-                        metadataKey("age").isEqualTo(18L)
-                ))
-                .add(of(
-                        "weight = 67.8",
-                        metadataKey("weight").isEqualTo(67.8d)
-                ))
-
+                .add(of("name = 'Klaus'", metadataKey("name").isEqualTo("Klaus")))
+                .add(of("age = 18", metadataKey("age").isEqualTo(18L)))
+                .add(of("weight = 67.8", metadataKey("weight").isEqualTo(67.8d)))
 
                 // ne
-                .add(of(
-                        "name != 'Klaus'",
-                        metadataKey("name").isNotEqualTo("Klaus")
-                ))
-                .add(of(
-                        "age != 18",
-                        metadataKey("age").isNotEqualTo(18L)
-                ))
-                .add(of(
-                        "weight != 67.8",
-                        metadataKey("weight").isNotEqualTo(67.8d)
-                ))
-
+                .add(of("name != 'Klaus'", metadataKey("name").isNotEqualTo("Klaus")))
+                .add(of("age != 18", metadataKey("age").isNotEqualTo(18L)))
+                .add(of("weight != 67.8", metadataKey("weight").isNotEqualTo(67.8d)))
 
                 // gt
-                .add(of(
-                        "name > 'Klaus'",
-                        metadataKey("name").isGreaterThan("Klaus")
-                ))
-                .add(of(
-                        "age > 18",
-                        metadataKey("age").isGreaterThan(18L)
-                ))
-                .add(of(
-                        "weight > 67.8",
-                        metadataKey("weight").isGreaterThan(67.8d)
-                ))
-
+                .add(of("name > 'Klaus'", metadataKey("name").isGreaterThan("Klaus")))
+                .add(of("age > 18", metadataKey("age").isGreaterThan(18L)))
+                .add(of("weight > 67.8", metadataKey("weight").isGreaterThan(67.8d)))
 
                 // gte
-                .add(of(
-                        "name >= 'Klaus'",
-                        metadataKey("name").isGreaterThanOrEqualTo("Klaus")
-                ))
-                .add(of(
-                        "age >= 18",
-                        metadataKey("age").isGreaterThanOrEqualTo(18L)
-                ))
-                .add(of(
-                        "weight >= 67.8",
-                        metadataKey("weight").isGreaterThanOrEqualTo(67.8d)
-                ))
-
+                .add(of("name >= 'Klaus'", metadataKey("name").isGreaterThanOrEqualTo("Klaus")))
+                .add(of("age >= 18", metadataKey("age").isGreaterThanOrEqualTo(18L)))
+                .add(of("weight >= 67.8", metadataKey("weight").isGreaterThanOrEqualTo(67.8d)))
 
                 // lt
-                .add(of(
-                        "name < 'Klaus'",
-                        metadataKey("name").isLessThan("Klaus")
-                ))
-                .add(of(
-                        "age < 18",
-                        metadataKey("age").isLessThan(18L)
-                ))
-                .add(of(
-                        "weight < 67.8",
-                        metadataKey("weight").isLessThan(67.8d)
-                ))
-
+                .add(of("name < 'Klaus'", metadataKey("name").isLessThan("Klaus")))
+                .add(of("age < 18", metadataKey("age").isLessThan(18L)))
+                .add(of("weight < 67.8", metadataKey("weight").isLessThan(67.8d)))
 
                 // lte
-                .add(of(
-                        "name <= 'Klaus'",
-                        metadataKey("name").isLessThanOrEqualTo("Klaus")
-                ))
-                .add(of(
-                        "age <= 18",
-                        metadataKey("age").isLessThanOrEqualTo(18L)
-                ))
-                .add(of(
-                        "weight <= 67.8",
-                        metadataKey("weight").isLessThanOrEqualTo(67.8d)
-                ))
-
+                .add(of("name <= 'Klaus'", metadataKey("name").isLessThanOrEqualTo("Klaus")))
+                .add(of("age <= 18", metadataKey("age").isLessThanOrEqualTo(18L)))
+                .add(of("weight <= 67.8", metadataKey("weight").isLessThanOrEqualTo(67.8d)))
 
                 // in
-                .add(of(
-                        "name IN ('Klaus', 'Francine')",
-                        metadataKey("name").isIn("Klaus", "Francine")
-                ))
-                .add(of(
-                        "age IN (18, 42)",
-                        metadataKey("age").isIn(18L, 42L)
-                ))
-                .add(of(
-                        "weight IN (67.8, 78.9)",
-                        metadataKey("weight").isIn(67.8d, 78.9d)
-                ))
-
+                .add(of("name IN ('Klaus', 'Francine')", metadataKey("name").isIn("Klaus", "Francine")))
+                .add(of("age IN (18, 42)", metadataKey("age").isIn(18L, 42L)))
+                .add(of("weight IN (67.8, 78.9)", metadataKey("weight").isIn(67.8d, 78.9d)))
 
                 // nin
-                .add(of(
-                        "name NOT IN ('Klaus', 'Francine')",
-                        metadataKey("name").isNotIn("Klaus", "Francine")
-                ))
-                .add(of(
-                        "age NOT IN (18, 42)",
-                        metadataKey("age").isNotIn(18L, 42L)
-                ))
-                .add(of(
-                        "weight NOT IN (67.8, 78.9)",
-                        metadataKey("weight").isNotIn(67.8d, 78.9d)
-                ))
-
+                .add(of("name NOT IN ('Klaus', 'Francine')", metadataKey("name").isNotIn("Klaus", "Francine")))
+                .add(of("age NOT IN (18, 42)", metadataKey("age").isNotIn(18L, 42L)))
+                .add(of("weight NOT IN (67.8, 78.9)", metadataKey("weight").isNotIn(67.8d, 78.9d)))
 
                 // and
                 .add(of(
                         "name = 'Klaus' AND age = 18",
                         and(
                                 metadataKey("name").isEqualTo("Klaus"),
-                                metadataKey("age").isEqualTo(18L)
-                        )
-                ))
-
+                                metadataKey("age").isEqualTo(18L))))
 
                 // not
-                .add(of(
-                        "NOT name = 'Klaus'",
-                        not(metadataKey("name").isEqualTo("Klaus"))
-                ))
-                .add(of(
-                        "NOT (name = 'Klaus')",
-                        not(metadataKey("name").isEqualTo("Klaus"))
-                ))
-
+                .add(of("NOT name = 'Klaus'", not(metadataKey("name").isEqualTo("Klaus"))))
+                .add(of("NOT (name = 'Klaus')", not(metadataKey("name").isEqualTo("Klaus"))))
 
                 // or
                 .add(of(
                         "name = 'Klaus' OR age = 18",
                         or(
                                 metadataKey("name").isEqualTo("Klaus"),
-                                metadataKey("age").isEqualTo(18L)
-                        )
-                ))
-
+                                metadataKey("age").isEqualTo(18L))))
 
                 // or x2
                 .add(of(
@@ -202,32 +108,22 @@ class SqlFilterParserTest {
                         or(
                                 or(
                                         metadataKey("color").isEqualTo("white"),
-                                        metadataKey("color").isEqualTo("black")
-                                ),
-                                metadataKey("color").isEqualTo("red")
-                        )
-                ))
+                                        metadataKey("color").isEqualTo("black")),
+                                metadataKey("color").isEqualTo("red"))))
                 .add(of(
                         "(color = 'white' OR color = 'black') OR color = 'red'",
                         or(
                                 or(
                                         metadataKey("color").isEqualTo("white"),
-                                        metadataKey("color").isEqualTo("black")
-                                ),
-                                metadataKey("color").isEqualTo("red")
-                        )
-                ))
+                                        metadataKey("color").isEqualTo("black")),
+                                metadataKey("color").isEqualTo("red"))))
                 .add(of(
                         "color = 'white' OR (color = 'black' OR color = 'red')",
                         or(
                                 metadataKey("color").isEqualTo("white"),
                                 or(
                                         metadataKey("color").isEqualTo("black"),
-                                        metadataKey("color").isEqualTo("red")
-                                )
-                        )
-                ))
-
+                                        metadataKey("color").isEqualTo("red")))))
 
                 // or + and
                 .add(of(
@@ -236,21 +132,14 @@ class SqlFilterParserTest {
                                 metadataKey("color").isEqualTo("white"),
                                 and(
                                         metadataKey("color").isEqualTo("black"),
-                                        metadataKey("form").isEqualTo("circle")
-                                )
-                        )
-                ))
+                                        metadataKey("form").isEqualTo("circle")))))
                 .add(of(
                         "(color = 'white' OR color = 'black') AND form = 'circle'",
                         and(
                                 or(
                                         metadataKey("color").isEqualTo("white"),
-                                        metadataKey("color").isEqualTo("black")
-                                ),
-                                metadataKey("form").isEqualTo("circle")
-                        )
-                ))
-
+                                        metadataKey("color").isEqualTo("black")),
+                                metadataKey("form").isEqualTo("circle"))))
 
                 // and + or
                 .add(of(
@@ -258,22 +147,15 @@ class SqlFilterParserTest {
                         or(
                                 and(
                                         metadataKey("color").isEqualTo("white"),
-                                        metadataKey("shape").isEqualTo("circle")
-                                ),
-                                metadataKey("color").isEqualTo("red")
-                        )
-                ))
+                                        metadataKey("shape").isEqualTo("circle")),
+                                metadataKey("color").isEqualTo("red"))))
                 .add(of(
                         "color = 'white' AND (shape = 'circle' OR color = 'red')",
                         and(
                                 metadataKey("color").isEqualTo("white"),
                                 or(
                                         metadataKey("shape").isEqualTo("circle"),
-                                        metadataKey("color").isEqualTo("red")
-                                )
-                        )
-                ))
-
+                                        metadataKey("color").isEqualTo("red")))))
 
                 // and x2
                 .add(of(
@@ -281,34 +163,26 @@ class SqlFilterParserTest {
                         and(
                                 and(
                                         metadataKey("color").isEqualTo("white"),
-                                        metadataKey("form").isEqualTo("circle")
-                                ),
-                                metadataKey("area").isGreaterThan(7L)
-                        )
-                ))
+                                        metadataKey("form").isEqualTo("circle")),
+                                metadataKey("area").isGreaterThan(7L))))
 
                 // complete SQL statements
                 .add(of(
                         "SELECT * from fake_table WHERE id = 7",
-                        metadataKey("id").isEqualTo(7L)
-                ))
+                        metadataKey("id").isEqualTo(7L)))
                 .add(of(
                         "select * from fake_table where id = 7",
-                        metadataKey("id").isEqualTo(7L)
-                ))
+                        metadataKey("id").isEqualTo(7L)))
                 .add(of(
                         "Select * From fake_table Where id = 7",
-                        metadataKey("id").isEqualTo(7L)
-                ))
-
+                        metadataKey("id").isEqualTo(7L)))
                 .build();
     }
 
     @ParameterizedTest
     @MethodSource
-    void should_filter_by_metadata(String sqlWhereExpression,
-                                   List<Metadata> matchingMetadatas,
-                                   List<Metadata> notMatchingMetadatas) {
+    void should_filter_by_metadata(
+            String sqlWhereExpression, List<Metadata> matchingMetadatas, List<Metadata> notMatchingMetadatas) {
 
         Filter filter = parser.parse(sqlWhereExpression);
 
@@ -327,111 +201,87 @@ class SqlFilterParserTest {
     static Stream<Arguments> should_filter_by_metadata() {
         return Stream.<Arguments>builder()
 
-
                 // === Equal ===
 
                 .add(Arguments.of(
                         "key = 'a'",
                         asList(
                                 new Metadata().put("key", "a"),
-                                new Metadata().put("key", "a").put("key2", "b")
-                        ),
+                                new Metadata().put("key", "a").put("key2", "b")),
                         asList(
                                 new Metadata().put("key", "A"),
                                 new Metadata().put("key", "b"),
                                 new Metadata().put("key", "aa"),
                                 new Metadata().put("key", "a a"),
-                                new Metadata().put("key2", "a")
-                        )
-                ))
+                                new Metadata().put("key2", "a"))))
 
                 // integer
                 .add(Arguments.of(
                         "key = -2147483648",
                         asList(
                                 new Metadata().put("key", Integer.MIN_VALUE),
-                                new Metadata().put("key", Integer.MIN_VALUE).put("key2", 0)
-                        ),
+                                new Metadata().put("key", Integer.MIN_VALUE).put("key2", 0)),
                         asList(
                                 new Metadata().put("key", Integer.MIN_VALUE + 1),
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key", Integer.MAX_VALUE),
-                                new Metadata().put("key2", Integer.MIN_VALUE)
-                        )
-
-                ))
+                                new Metadata().put("key2", Integer.MIN_VALUE))))
                 .add(Arguments.of(
                         "key = 0",
                         asList(
                                 new Metadata().put("key", 0),
-                                new Metadata().put("key", 0).put("key2", 1)
-                        ),
+                                new Metadata().put("key", 0).put("key2", 1)),
                         asList(
                                 new Metadata().put("key", -1),
                                 new Metadata().put("key", 1),
-                                new Metadata().put("key2", 0)
-                        )
-                ))
+                                new Metadata().put("key2", 0))))
                 .add(Arguments.of(
                         "key = 2147483647",
                         asList(
                                 new Metadata().put("key", Integer.MAX_VALUE),
-                                new Metadata().put("key", Integer.MAX_VALUE).put("key2", 0)
-                        ),
+                                new Metadata().put("key", Integer.MAX_VALUE).put("key2", 0)),
                         asList(
                                 new Metadata().put("key", Integer.MIN_VALUE),
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key", Integer.MAX_VALUE - 1),
-                                new Metadata().put("key2", Integer.MAX_VALUE)
-                        )
-                ))
+                                new Metadata().put("key2", Integer.MAX_VALUE))))
 
                 // long
                 .add(Arguments.of(
                         "key = -9223372036854775808",
                         asList(
                                 new Metadata().put("key", Long.MIN_VALUE),
-                                new Metadata().put("key", Long.MIN_VALUE).put("key2", 0L)
-                        ),
+                                new Metadata().put("key", Long.MIN_VALUE).put("key2", 0L)),
                         asList(
                                 new Metadata().put("key", Long.MIN_VALUE + 1L),
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key", Long.MAX_VALUE),
-                                new Metadata().put("key2", Long.MIN_VALUE)
-                        )
-                ))
+                                new Metadata().put("key2", Long.MIN_VALUE))))
                 .add(Arguments.of(
                         "key = 0",
                         asList(
                                 new Metadata().put("key", 0L),
-                                new Metadata().put("key", 0L).put("key2", 1L)
-                        ),
+                                new Metadata().put("key", 0L).put("key2", 1L)),
                         asList(
                                 new Metadata().put("key", -1L),
                                 new Metadata().put("key", 1L),
-                                new Metadata().put("key2", 0L)
-                        )
-                ))
+                                new Metadata().put("key2", 0L))))
                 .add(Arguments.of(
                         "key = 9223372036854775807",
                         asList(
                                 new Metadata().put("key", Long.MAX_VALUE),
-                                new Metadata().put("key", Long.MAX_VALUE).put("key2", 0L)
-                        ),
+                                new Metadata().put("key", Long.MAX_VALUE).put("key2", 0L)),
                         asList(
                                 new Metadata().put("key", Long.MIN_VALUE),
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key", Long.MAX_VALUE - 1L),
-                                new Metadata().put("key2", Long.MAX_VALUE)
-                        )
-                ))
+                                new Metadata().put("key2", Long.MAX_VALUE))))
 
                 // float
                 // TODO does it make sense to test float for equality?
 
                 // double
-                //TODO does it make sense to test double for equality?
-
+                // TODO does it make sense to test double for equality?
 
                 // === GreaterThan ===
 
@@ -439,67 +289,51 @@ class SqlFilterParserTest {
                         "key > 'b'",
                         asList(
                                 new Metadata().put("key", "c"),
-                                new Metadata().put("key", "c").put("key2", "a")
-                        ),
+                                new Metadata().put("key", "c").put("key2", "a")),
                         asList(
                                 new Metadata().put("key", "a"),
                                 new Metadata().put("key", "b"),
-                                new Metadata().put("key2", "c")
-                        )
-                ))
+                                new Metadata().put("key2", "c"))))
                 .add(Arguments.of(
                         "key > 1",
                         asList(
                                 new Metadata().put("key", 2),
-                                new Metadata().put("key", 2).put("key2", 0)
-                        ),
+                                new Metadata().put("key", 2).put("key2", 0)),
                         asList(
                                 new Metadata().put("key", -2),
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key", 1),
-                                new Metadata().put("key2", 2)
-                        )
-                ))
+                                new Metadata().put("key2", 2))))
                 .add(Arguments.of(
                         "key > 1",
                         asList(
                                 new Metadata().put("key", 2L),
-                                new Metadata().put("key", 2L).put("key2", 0L)
-                        ),
+                                new Metadata().put("key", 2L).put("key2", 0L)),
                         asList(
                                 new Metadata().put("key", -2L),
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key", 1L),
-                                new Metadata().put("key2", 2L)
-                        )
-                ))
+                                new Metadata().put("key2", 2L))))
                 .add(Arguments.of(
                         "key > 1.1",
                         asList(
                                 new Metadata().put("key", 1.2f),
-                                new Metadata().put("key", 1.2f).put("key2", 1.0f)
-                        ),
+                                new Metadata().put("key", 1.2f).put("key2", 1.0f)),
                         asList(
                                 new Metadata().put("key", -1.2f),
                                 new Metadata().put("key", 0.0f),
                                 new Metadata().put("key", 1.1f),
-                                new Metadata().put("key2", 1.2f)
-                        )
-                ))
+                                new Metadata().put("key2", 1.2f))))
                 .add(Arguments.of(
                         "key > 1.1",
                         asList(
                                 new Metadata().put("key", 1.2d),
-                                new Metadata().put("key", 1.2d).put("key2", 1.0d)
-                        ),
+                                new Metadata().put("key", 1.2d).put("key2", 1.0d)),
                         asList(
                                 new Metadata().put("key", -1.2d),
                                 new Metadata().put("key", 0.0d),
                                 new Metadata().put("key", 1.1d),
-                                new Metadata().put("key2", 1.2d)
-                        )
-                ))
-
+                                new Metadata().put("key2", 1.2d))))
 
                 // === GreaterThanOrEqual ==
 
@@ -508,212 +342,150 @@ class SqlFilterParserTest {
                         asList(
                                 new Metadata().put("key", "b"),
                                 new Metadata().put("key", "c"),
-                                new Metadata().put("key", "c").put("key2", "a")
-                        ),
-                        asList(
-                                new Metadata().put("key", "a"),
-                                new Metadata().put("key2", "b")
-                        )
-                ))
+                                new Metadata().put("key", "c").put("key2", "a")),
+                        asList(new Metadata().put("key", "a"), new Metadata().put("key2", "b"))))
                 .add(Arguments.of(
                         "key >= 1",
                         asList(
                                 new Metadata().put("key", 1),
                                 new Metadata().put("key", 2),
-                                new Metadata().put("key", 2).put("key2", 0)
-                        ),
+                                new Metadata().put("key", 2).put("key2", 0)),
                         asList(
                                 new Metadata().put("key", -2),
                                 new Metadata().put("key", -1),
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key2", 1),
-                                new Metadata().put("key2", 2)
-                        )
-                ))
+                                new Metadata().put("key2", 2))))
                 .add(Arguments.of(
                         "key >= 1",
                         asList(
                                 new Metadata().put("key", 1L),
                                 new Metadata().put("key", 2L),
-                                new Metadata().put("key", 2L).put("key2", 0L)
-                        ),
+                                new Metadata().put("key", 2L).put("key2", 0L)),
                         asList(
                                 new Metadata().put("key", -2L),
                                 new Metadata().put("key", -1L),
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key2", 1L),
-                                new Metadata().put("key2", 2L)
-                        )
-                ))
+                                new Metadata().put("key2", 2L))))
                 .add(Arguments.of(
                         "key >= 1.1",
                         asList(
                                 new Metadata().put("key", 1.1f),
                                 new Metadata().put("key", 1.2f),
-                                new Metadata().put("key", 1.2f).put("key2", 1.0f)
-                        ),
+                                new Metadata().put("key", 1.2f).put("key2", 1.0f)),
                         asList(
                                 new Metadata().put("key", -1.2f),
                                 new Metadata().put("key", -1.1f),
                                 new Metadata().put("key", 0.0f),
                                 new Metadata().put("key2", 1.1f),
-                                new Metadata().put("key2", 1.2f)
-                        )
-                ))
+                                new Metadata().put("key2", 1.2f))))
                 .add(Arguments.of(
                         "key >= 1.1",
                         asList(
                                 new Metadata().put("key", 1.1d),
                                 new Metadata().put("key", 1.2d),
-                                new Metadata().put("key", 1.2d).put("key2", 1.0d)
-                        ),
+                                new Metadata().put("key", 1.2d).put("key2", 1.0d)),
                         asList(
                                 new Metadata().put("key", -1.2d),
                                 new Metadata().put("key", -1.1d),
                                 new Metadata().put("key", 0.0d),
                                 new Metadata().put("key2", 1.1d),
-                                new Metadata().put("key2", 1.2d)
-                        )
-                ))
-
+                                new Metadata().put("key2", 1.2d))))
 
                 // === LessThan ==
 
                 .add(Arguments.of(
                         "key < 'b'",
                         asList(
-
                                 new Metadata().put("key", "a"),
-                                new Metadata().put("key", "a").put("key2", "c")
-                        ),
+                                new Metadata().put("key", "a").put("key2", "c")),
                         asList(
                                 new Metadata().put("key", "b"),
                                 new Metadata().put("key", "c"),
-                                new Metadata().put("key2", "a")
-                        )
-                ))
+                                new Metadata().put("key2", "a"))))
                 .add(Arguments.of(
                         "key < 1",
                         asList(
                                 new Metadata().put("key", -2),
                                 new Metadata().put("key", 0),
-                                new Metadata().put("key", 0).put("key2", 2)
-                        ),
+                                new Metadata().put("key", 0).put("key2", 2)),
                         asList(
                                 new Metadata().put("key", 1),
                                 new Metadata().put("key", 2),
-                                new Metadata().put("key2", 0)
-                        )
-                ))
+                                new Metadata().put("key2", 0))))
                 .add(Arguments.of(
                         "key < 1",
                         asList(
                                 new Metadata().put("key", -2L),
                                 new Metadata().put("key", 0L),
-                                new Metadata().put("key", 0L).put("key2", 2L)
-                        ),
+                                new Metadata().put("key", 0L).put("key2", 2L)),
                         asList(
                                 new Metadata().put("key", 1L),
                                 new Metadata().put("key", 2L),
-                                new Metadata().put("key2", 0L)
-                        )
-                ))
+                                new Metadata().put("key2", 0L))))
                 .add(Arguments.of(
                         "key < 1.1",
                         asList(
                                 new Metadata().put("key", -1.2f),
                                 new Metadata().put("key", 1.0f),
-                                new Metadata().put("key", 1.0f).put("key2", 1.2f)
-                        ),
+                                new Metadata().put("key", 1.0f).put("key2", 1.2f)),
                         asList(
                                 new Metadata().put("key", 1.1f),
                                 new Metadata().put("key", 1.2f),
-                                new Metadata().put("key2", 1.0f)
-                        )
-                ))
+                                new Metadata().put("key2", 1.0f))))
                 .add(Arguments.of(
                         "key < 1.1",
                         asList(
                                 new Metadata().put("key", -1.2d),
                                 new Metadata().put("key", 1.0d),
-                                new Metadata().put("key", 1.0d).put("key2", 1.2d)
-                        ),
+                                new Metadata().put("key", 1.0d).put("key2", 1.2d)),
                         asList(
                                 new Metadata().put("key", 1.1d),
                                 new Metadata().put("key", 1.2d),
-                                new Metadata().put("key2", 1.0d)
-                        )
-                ))
-
+                                new Metadata().put("key2", 1.0d))))
 
                 // === LessThanOrEqual ==
 
                 .add(Arguments.of(
                         "key <= 'b'",
                         asList(
-
                                 new Metadata().put("key", "a"),
                                 new Metadata().put("key", "b"),
-                                new Metadata().put("key", "b").put("key2", "c")
-                        ),
-                        asList(
-                                new Metadata().put("key", "c"),
-                                new Metadata().put("key2", "a")
-                        )
-                ))
+                                new Metadata().put("key", "b").put("key2", "c")),
+                        asList(new Metadata().put("key", "c"), new Metadata().put("key2", "a"))))
                 .add(Arguments.of(
                         "key <= 1",
                         asList(
                                 new Metadata().put("key", -2),
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key", 1),
-                                new Metadata().put("key", 1).put("key2", 2)
-                        ),
-                        asList(
-                                new Metadata().put("key", 2),
-                                new Metadata().put("key2", 0)
-                        )
-                ))
+                                new Metadata().put("key", 1).put("key2", 2)),
+                        asList(new Metadata().put("key", 2), new Metadata().put("key2", 0))))
                 .add(Arguments.of(
                         "key <= 1",
                         asList(
                                 new Metadata().put("key", -2L),
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key", 1L),
-                                new Metadata().put("key", 1L).put("key2", 2L)
-                        ),
-                        asList(
-                                new Metadata().put("key", 2L),
-                                new Metadata().put("key2", 0L)
-                        )
-                ))
+                                new Metadata().put("key", 1L).put("key2", 2L)),
+                        asList(new Metadata().put("key", 2L), new Metadata().put("key2", 0L))))
                 .add(Arguments.of(
                         "key <= 1.1",
                         asList(
                                 new Metadata().put("key", -1.2f),
                                 new Metadata().put("key", 1.0f),
                                 new Metadata().put("key", 1.1f),
-                                new Metadata().put("key", 1.1f).put("key2", 1.2f)
-                        ),
-                        asList(
-                                new Metadata().put("key", 1.2f),
-                                new Metadata().put("key2", 1.0f)
-                        )
-                ))
+                                new Metadata().put("key", 1.1f).put("key2", 1.2f)),
+                        asList(new Metadata().put("key", 1.2f), new Metadata().put("key2", 1.0f))))
                 .add(Arguments.of(
                         "key <= 1.1",
                         asList(
                                 new Metadata().put("key", -1.2d),
                                 new Metadata().put("key", 1.0d),
                                 new Metadata().put("key", 1.1d),
-                                new Metadata().put("key", 1.1d).put("key2", 1.2d)
-                        ),
-                        asList(
-                                new Metadata().put("key", 1.2d),
-                                new Metadata().put("key2", 1.0d)
-                        )
-                ))
-
+                                new Metadata().put("key", 1.1d).put("key2", 1.2d)),
+                        asList(new Metadata().put("key", 1.2d), new Metadata().put("key2", 1.0d))))
 
                 // === In ===
 
@@ -722,133 +494,86 @@ class SqlFilterParserTest {
                         "name IN ('Klaus')",
                         asList(
                                 new Metadata().put("name", "Klaus"),
-                                new Metadata().put("name", "Klaus").put("age", 42)
-                        ),
+                                new Metadata().put("name", "Klaus").put("age", 42)),
                         asList(
                                 new Metadata().put("name", "Klaus Heisler"),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name2", "Klaus")
-                        )
-                ))
+                                new Metadata().put("name2", "Klaus"))))
                 .add(Arguments.of(
                         "name IN ('Klaus', 'Alice')",
                         asList(
                                 new Metadata().put("name", "Klaus"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name", "Alice").put("age", 42)
-                        ),
+                                new Metadata().put("name", "Alice").put("age", 42)),
                         asList(
                                 new Metadata().put("name", "Klaus Heisler"),
                                 new Metadata().put("name", "Zoe"),
-                                new Metadata().put("name2", "Klaus")
-                        )
-                ))
+                                new Metadata().put("name2", "Klaus"))))
 
                 // In: integer
                 .add(Arguments.of(
                         "age IN (42)",
                         asList(
                                 new Metadata().put("age", 42),
-                                new Metadata().put("age", 42).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666),
-                                new Metadata().put("age2", 42)
-                        )
-                ))
+                                new Metadata().put("age", 42).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666), new Metadata().put("age2", 42))))
                 .add(Arguments.of(
                         "age IN (42, 18)",
                         asList(
                                 new Metadata().put("age", 42),
                                 new Metadata().put("age", 18),
                                 new Metadata().put("age", 42).put("name", "Klaus"),
-                                new Metadata().put("age", 18).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666),
-                                new Metadata().put("age2", 42)
-                        )
-                ))
+                                new Metadata().put("age", 18).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666), new Metadata().put("age2", 42))))
 
                 // In: long
                 .add(Arguments.of(
                         "age IN (42)",
                         asList(
                                 new Metadata().put("age", 42L),
-                                new Metadata().put("age", 42L).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666L),
-                                new Metadata().put("age2", 42L)
-                        )
-                ))
+                                new Metadata().put("age", 42L).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666L), new Metadata().put("age2", 42L))))
                 .add(Arguments.of(
                         "age IN (42, 18)",
                         asList(
                                 new Metadata().put("age", 42L),
                                 new Metadata().put("age", 18L),
                                 new Metadata().put("age", 42L).put("name", "Klaus"),
-                                new Metadata().put("age", 18L).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666L),
-                                new Metadata().put("age2", 42L)
-                        )
-                ))
+                                new Metadata().put("age", 18L).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666L), new Metadata().put("age2", 42L))))
 
                 // In: float
                 .add(Arguments.of(
                         "age IN (42.0)",
                         asList(
                                 new Metadata().put("age", 42.0f),
-                                new Metadata().put("age", 42.0f).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666.0f),
-                                new Metadata().put("age2", 42.0f)
-                        )
-                ))
+                                new Metadata().put("age", 42.0f).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666.0f), new Metadata().put("age2", 42.0f))))
                 .add(Arguments.of(
                         "age IN (42.0, 18.0)",
                         asList(
                                 new Metadata().put("age", 42.0f),
                                 new Metadata().put("age", 18.0f),
                                 new Metadata().put("age", 42.0f).put("name", "Klaus"),
-                                new Metadata().put("age", 18.0f).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666.0f),
-                                new Metadata().put("age2", 42.0f)
-                        )
-                ))
+                                new Metadata().put("age", 18.0f).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666.0f), new Metadata().put("age2", 42.0f))))
 
                 // In: double
                 .add(Arguments.of(
                         "age IN (42.0)",
                         asList(
                                 new Metadata().put("age", 42.0d),
-                                new Metadata().put("age", 42.0d).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666.0d),
-                                new Metadata().put("age2", 42.0d)
-                        )
-                ))
+                                new Metadata().put("age", 42.0d).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666.0d), new Metadata().put("age2", 42.0d))))
                 .add(Arguments.of(
                         "age IN (42.0, 18.0)",
                         asList(
                                 new Metadata().put("age", 42.0d),
                                 new Metadata().put("age", 18.0d),
                                 new Metadata().put("age", 42.0d).put("name", "Klaus"),
-                                new Metadata().put("age", 18.0d).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666.0d),
-                                new Metadata().put("age2", 42.0d)
-                        )
-                ))
-
+                                new Metadata().put("age", 18.0d).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666.0d), new Metadata().put("age2", 42.0d))))
 
                 // === Or ===
 
@@ -859,36 +584,24 @@ class SqlFilterParserTest {
                                 new Metadata().put("name", "Klaus"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name", "Alice").put("age", 42)
-                        ),
-                        singletonList(
-                                new Metadata().put("name", "Zoe")
-                        )
-                ))
+                                new Metadata().put("name", "Alice").put("age", 42)),
+                        singletonList(new Metadata().put("name", "Zoe"))))
                 .add(Arguments.of(
                         "name = 'Alice' OR name = 'Klaus'",
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("name", "Alice").put("age", 42),
                                 new Metadata().put("name", "Klaus"),
-                                new Metadata().put("name", "Klaus").put("age", 42)
-                        ),
-                        singletonList(
-                                new Metadata().put("name", "Zoe")
-                        )
-                ))
+                                new Metadata().put("name", "Klaus").put("age", 42)),
+                        singletonList(new Metadata().put("name", "Zoe"))))
                 .add(Arguments.of(
                         "(name = 'Klaus' OR name = 'Alice')",
                         asList(
                                 new Metadata().put("name", "Klaus"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name", "Alice").put("age", 42)
-                        ),
-                        singletonList(
-                                new Metadata().put("name", "Zoe")
-                        )
-                ))
+                                new Metadata().put("name", "Alice").put("age", 42)),
+                        singletonList(new Metadata().put("name", "Zoe"))))
 
                 // Or: multiple keys
                 .add(Arguments.of(
@@ -910,14 +623,14 @@ class SqlFilterParserTest {
 
                                 // Or.left and Or.right are both true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
-                                new Metadata().put("name", "Alice").put("age", 666)
-                        )
-                ))
+                                new Metadata().put("name", "Alice").put("age", 666))))
                 .add(Arguments.of(
                         "age = 42 OR name = 'Klaus'",
                         asList(
@@ -937,14 +650,14 @@ class SqlFilterParserTest {
 
                                 // Or.left and Or.right are both true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
-                                new Metadata().put("name", "Alice").put("age", 666)
-                        )
-                ))
+                                new Metadata().put("name", "Alice").put("age", 666))))
 
                 // Or: x2
                 .add(Arguments.of(
@@ -957,7 +670,10 @@ class SqlFilterParserTest {
                                 // Or.left is true, Or.right is false
                                 new Metadata().put("name", "Klaus").put("age", 666),
                                 new Metadata().put("name", "Klaus").put("city", "Frankfurt"),
-                                new Metadata().put("name", "Klaus").put("age", 666).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"),
 
                                 // only Or.right is present and true
                                 new Metadata().put("age", 42),
@@ -965,30 +681,49 @@ class SqlFilterParserTest {
                                 new Metadata().put("city", "Munich"),
                                 new Metadata().put("city", "Munich").put("country", "Germany"),
                                 new Metadata().put("age", 42).put("city", "Munich"),
-                                new Metadata().put("age", 42).put("city", "Munich").put("country", "Germany"),
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
 
                                 // Or.right is true, Or.left is false
                                 new Metadata().put("age", 42).put("name", "Alice"),
                                 new Metadata().put("city", "Munich").put("name", "Alice"),
-                                new Metadata().put("age", 42).put("city", "Munich").put("name", "Alice"),
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("name", "Alice"),
 
                                 // Or.left and Or.right are both true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("city", "Munich").put("country", "Germany"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
                                 new Metadata().put("city", "Frankfurt"),
                                 new Metadata().put("name", "Alice").put("age", 666),
                                 new Metadata().put("name", "Alice").put("city", "Frankfurt"),
-                                new Metadata().put("name", "Alice").put("age", 666).put("city", "Frankfurt")
-                        )
-                ))
+                                new Metadata()
+                                        .put("name", "Alice")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"))))
                 .add(Arguments.of(
                         "(name = 'Klaus' OR age = 42) OR city = 'Munich'",
                         asList(
@@ -998,12 +733,18 @@ class SqlFilterParserTest {
                                 new Metadata().put("age", 42),
                                 new Metadata().put("age", 42).put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
 
                                 // Or.left is true, Or.right is false
                                 new Metadata().put("name", "Klaus").put("city", "Frankfurt"),
                                 new Metadata().put("age", 42).put("city", "Frankfurt"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only Or.right is present and true
                                 new Metadata().put("city", "Munich"),
@@ -1015,21 +756,34 @@ class SqlFilterParserTest {
 
                                 // Or.left and Or.right are both true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("city", "Munich").put("country", "Germany"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
                                 new Metadata().put("city", "Frankfurt"),
                                 new Metadata().put("name", "Alice").put("age", 666),
                                 new Metadata().put("name", "Alice").put("city", "Frankfurt"),
-                                new Metadata().put("name", "Alice").put("age", 666).put("city", "Frankfurt")
-                        )
-                ))
+                                new Metadata()
+                                        .put("name", "Alice")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"))))
                 .add(Arguments.of(
                         "name = 'Klaus' OR (age = 42 OR city = 'Munich')",
                         asList(
@@ -1039,12 +793,18 @@ class SqlFilterParserTest {
                                 new Metadata().put("age", 42),
                                 new Metadata().put("age", 42).put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
 
                                 // Or.left is true, Or.right is false
                                 new Metadata().put("name", "Klaus").put("city", "Frankfurt"),
                                 new Metadata().put("age", 42).put("city", "Frankfurt"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only Or.right is present and true
                                 new Metadata().put("city", "Munich"),
@@ -1056,21 +816,34 @@ class SqlFilterParserTest {
 
                                 // Or.left and Or.right are both true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("city", "Munich").put("country", "Germany"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
                                 new Metadata().put("city", "Frankfurt"),
                                 new Metadata().put("name", "Alice").put("age", 666),
                                 new Metadata().put("name", "Alice").put("city", "Frankfurt"),
-                                new Metadata().put("name", "Alice").put("age", 666).put("city", "Frankfurt")
-                        )
-                ))
+                                new Metadata()
+                                        .put("name", "Alice")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"))))
 
                 // === AND ===
 
@@ -1078,8 +851,10 @@ class SqlFilterParserTest {
                         "name = 'Klaus' AND age = 42",
                         asList(
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus"),
@@ -1094,15 +869,15 @@ class SqlFilterParserTest {
                                 new Metadata().put("age", 42).put("name", "Alice"),
 
                                 // And.left, And.right are both false
-                                new Metadata().put("age", 666).put("name", "Alice")
-                        )
-                ))
+                                new Metadata().put("age", 666).put("name", "Alice"))))
                 .add(Arguments.of(
                         "age = 42 AND name = 'Klaus'",
                         asList(
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("age", 42),
@@ -1117,17 +892,21 @@ class SqlFilterParserTest {
                                 new Metadata().put("name", "Klaus").put("age", 666),
 
                                 // And.left, And.right are both false
-                                new Metadata().put("age", 666).put("name", "Alice")
-                        )
-                ))
+                                new Metadata().put("age", 666).put("name", "Alice"))))
 
                 // And: x2
                 .add(Arguments.of(
                         "name = 'Klaus' AND age = 42 AND city = 'Munich'",
                         asList(
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus"),
@@ -1135,62 +914,95 @@ class SqlFilterParserTest {
                                 // And.left is true, And.right is false
                                 new Metadata().put("name", "Klaus").put("age", 42),
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 666).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 666)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only And.right is present and true
                                 new Metadata().put("age", 42).put("city", "Munich"),
 
                                 // And.right is true, And.left is false
-                                new Metadata().put("age", 42).put("city", "Munich").put("name", "Alice")
-                        )
-                ))
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("name", "Alice"))))
                 .add(Arguments.of(
                         "(name = 'Klaus' AND age = 42) AND city = 'Munich'",
                         asList(
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus").put("age", 42),
 
                                 // And.left is true, And.right is false
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only And.right is present and true
                                 new Metadata().put("city", "Munich"),
 
                                 // And.right is true, And.left is false
                                 new Metadata().put("city", "Munich").put("name", "Klaus"),
-                                new Metadata().put("city", "Munich").put("name", "Klaus").put("age", 666),
+                                new Metadata()
+                                        .put("city", "Munich")
+                                        .put("name", "Klaus")
+                                        .put("age", 666),
                                 new Metadata().put("city", "Munich").put("age", 42),
-                                new Metadata().put("city", "Munich").put("age", 42).put("name", "Alice")
-                        )
-                ))
+                                new Metadata()
+                                        .put("city", "Munich")
+                                        .put("age", 42)
+                                        .put("name", "Alice"))))
                 .add(Arguments.of(
                         "name = 'Klaus' AND (age = 42 AND city = 'Munich')",
                         asList(
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus").put("age", 42),
 
                                 // And.left is true, And.right is false
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only And.right is present and true
                                 new Metadata().put("city", "Munich"),
 
                                 // And.right is true, And.left is false
                                 new Metadata().put("city", "Munich").put("name", "Klaus"),
-                                new Metadata().put("city", "Munich").put("name", "Klaus").put("age", 666),
+                                new Metadata()
+                                        .put("city", "Munich")
+                                        .put("name", "Klaus")
+                                        .put("age", 666),
                                 new Metadata().put("city", "Munich").put("age", 42),
-                                new Metadata().put("city", "Munich").put("age", 42).put("name", "Alice")
-                        )
-                ))
+                                new Metadata()
+                                        .put("city", "Munich")
+                                        .put("age", 42)
+                                        .put("name", "Alice"))))
 
                 // === AND + nested OR ===
 
@@ -1198,12 +1010,24 @@ class SqlFilterParserTest {
                         "name = 'Klaus' AND (age = 42 OR city = 'Munich')",
                         asList(
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("city", "Munich").put("country", "Germany"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus"),
@@ -1220,19 +1044,32 @@ class SqlFilterParserTest {
                                 // And.right is true, And.left is false
                                 new Metadata().put("age", 42).put("name", "Alice"),
                                 new Metadata().put("city", "Munich").put("name", "Alice"),
-                                new Metadata().put("age", 42).put("city", "Munich").put("name", "Alice")
-                        )
-                ))
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("name", "Alice"))))
                 .add(Arguments.of(
                         "(name = 'Klaus' OR age = 42) AND city = 'Munich'",
                         asList(
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("city", "Munich").put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
                                 new Metadata().put("age", 42).put("city", "Munich"),
-                                new Metadata().put("age", 42).put("city", "Munich").put("country", "Germany"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus"),
@@ -1242,7 +1079,10 @@ class SqlFilterParserTest {
                                 // And.left is true, And.right is false
                                 new Metadata().put("name", "Klaus").put("city", "Frankfurt"),
                                 new Metadata().put("age", 42).put("city", "Frankfurt"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only And.right is present and true
                                 new Metadata().put("city", "Munich"),
@@ -1250,9 +1090,10 @@ class SqlFilterParserTest {
                                 // And.right is true, And.left is false
                                 new Metadata().put("city", "Munich").put("name", "Alice"),
                                 new Metadata().put("city", "Munich").put("age", 666),
-                                new Metadata().put("city", "Munich").put("name", "Alice").put("age", 666)
-                        )
-                ))
+                                new Metadata()
+                                        .put("city", "Munich")
+                                        .put("name", "Alice")
+                                        .put("age", 666))))
 
                 // === OR + nested AND ===
                 .add(Arguments.of(
@@ -1265,56 +1106,76 @@ class SqlFilterParserTest {
                                 // Or.left is true, Or.right is false
                                 new Metadata().put("name", "Klaus").put("age", 666),
                                 new Metadata().put("name", "Klaus").put("city", "Frankfurt"),
-                                new Metadata().put("name", "Klaus").put("age", 666).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"),
 
                                 // only Or.right is present and true
                                 new Metadata().put("age", 42).put("city", "Munich"),
-                                new Metadata().put("age", 42).put("city", "Munich").put("country", "Germany"),
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
 
                                 // Or.right is true, Or.left is false
-                                new Metadata().put("age", 42).put("city", "Munich").put("name", "Alice")
-                        ),
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("name", "Alice")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
                                 new Metadata().put("city", "Frankfurt"),
-                                new Metadata().put("name", "Alice").put("age", 666).put("city", "Frankfurt")
-                        )
-                ))
+                                new Metadata()
+                                        .put("name", "Alice")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"))))
                 .add(Arguments.of(
                         "name = 'Klaus' AND age = 42 OR city = 'Munich'",
                         asList(
                                 // only Or.left is present and true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
 
                                 // Or.left is true, Or.right is false
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only Or.right is present and true
                                 new Metadata().put("city", "Munich"),
                                 new Metadata().put("city", "Munich").put("country", "Germany"),
 
                                 // Or.right is true, Or.left is true
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
                                 new Metadata().put("city", "Frankfurt"),
-                                new Metadata().put("name", "Alice").put("age", 666).put("city", "Frankfurt")
-                        )
-                ))
-
+                                new Metadata()
+                                        .put("name", "Alice")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"))))
                 .build();
     }
 
     @ParameterizedTest
     @MethodSource
-    void should_filter_by_metadata_not(String sqlWhereExpression,
-                                       List<Metadata> matchingMetadatas,
-                                       List<Metadata> notMatchingMetadatas) {
+    void should_filter_by_metadata_not(
+            String sqlWhereExpression, List<Metadata> matchingMetadatas, List<Metadata> notMatchingMetadatas) {
 
         Filter filter = parser.parse(sqlWhereExpression);
 
@@ -1336,26 +1197,16 @@ class SqlFilterParserTest {
                 // === Not ===
                 .add(Arguments.of(
                         "NOT(name = 'Klaus')",
-                        asList(
-                                new Metadata().put("name", "Alice"),
-                                new Metadata().put("age", 42)
-                        ),
+                        asList(new Metadata().put("name", "Alice"), new Metadata().put("age", 42)),
                         asList(
                                 new Metadata().put("name", "Klaus"),
-                                new Metadata().put("name", "Klaus").put("age", 42)
-                        )
-                )).add(Arguments.of(
+                                new Metadata().put("name", "Klaus").put("age", 42))))
+                .add(Arguments.of(
                         "NOT name = 'Klaus'",
-                        asList(
-                                new Metadata().put("name", "Alice"),
-                                new Metadata().put("age", 42)
-                        ),
+                        asList(new Metadata().put("name", "Alice"), new Metadata().put("age", 42)),
                         asList(
                                 new Metadata().put("name", "Klaus"),
-                                new Metadata().put("name", "Klaus").put("age", 42)
-                        )
-                ))
-
+                                new Metadata().put("name", "Klaus").put("age", 42))))
 
                 // === NotEqual ===
 
@@ -1366,13 +1217,10 @@ class SqlFilterParserTest {
                                 new Metadata().put("key", "b"),
                                 new Metadata().put("key", "aa"),
                                 new Metadata().put("key", "a a"),
-                                new Metadata().put("key2", "a")
-                        ),
+                                new Metadata().put("key2", "a")),
                         asList(
                                 new Metadata().put("key", "a"),
-                                new Metadata().put("key", "a").put("key2", "b")
-                        )
-                ))
+                                new Metadata().put("key", "a").put("key2", "b"))))
                 .add(Arguments.of(
                         "key != 1",
                         asList(
@@ -1380,13 +1228,10 @@ class SqlFilterParserTest {
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key", 2),
                                 new Metadata().put("key", 10),
-                                new Metadata().put("key2", 1)
-                        ),
+                                new Metadata().put("key2", 1)),
                         asList(
                                 new Metadata().put("key", 1),
-                                new Metadata().put("key", 1).put("key2", 2)
-                        )
-                ))
+                                new Metadata().put("key", 1).put("key2", 2))))
                 .add(Arguments.of(
                         "key != 1",
                         asList(
@@ -1394,13 +1239,10 @@ class SqlFilterParserTest {
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key", 2L),
                                 new Metadata().put("key", 10L),
-                                new Metadata().put("key2", 1L)
-                        ),
+                                new Metadata().put("key2", 1L)),
                         asList(
                                 new Metadata().put("key", 1L),
-                                new Metadata().put("key", 1L).put("key2", 2L)
-                        )
-                ))
+                                new Metadata().put("key", 1L).put("key2", 2L))))
                 .add(Arguments.of(
                         "key != 1.1",
                         asList(
@@ -1408,13 +1250,10 @@ class SqlFilterParserTest {
                                 new Metadata().put("key", 0.0f),
                                 new Metadata().put("key", 1.11f),
                                 new Metadata().put("key", 2.2f),
-                                new Metadata().put("key2", 1.1f)
-                        ),
+                                new Metadata().put("key2", 1.1f)),
                         asList(
                                 new Metadata().put("key", 1.1f),
-                                new Metadata().put("key", 1.1f).put("key2", 2.2f)
-                        )
-                ))
+                                new Metadata().put("key", 1.1f).put("key2", 2.2f))))
                 .add(Arguments.of(
                         "key != 1.1",
                         asList(
@@ -1422,14 +1261,10 @@ class SqlFilterParserTest {
                                 new Metadata().put("key", 0.0),
                                 new Metadata().put("key", 1.11),
                                 new Metadata().put("key", 2.2),
-                                new Metadata().put("key2", 1.1)
-                        ),
+                                new Metadata().put("key2", 1.1)),
                         asList(
                                 new Metadata().put("key", 1.1),
-                                new Metadata().put("key", 1.1).put("key2", 2.2)
-                        )
-                ))
-
+                                new Metadata().put("key", 1.1).put("key2", 2.2))))
 
                 // === NotIn ===
 
@@ -1439,132 +1274,85 @@ class SqlFilterParserTest {
                         asList(
                                 new Metadata().put("name", "Klaus Heisler"),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name2", "Klaus")
-                        ),
+                                new Metadata().put("name2", "Klaus")),
                         asList(
                                 new Metadata().put("name", "Klaus"),
-                                new Metadata().put("name", "Klaus").put("age", 42)
-                        )
-                ))
+                                new Metadata().put("name", "Klaus").put("age", 42))))
                 .add(Arguments.of(
                         "name NOT IN ('Klaus', 'Alice')",
                         asList(
                                 new Metadata().put("name", "Klaus Heisler"),
                                 new Metadata().put("name", "Zoe"),
-                                new Metadata().put("name2", "Klaus")
-                        ),
+                                new Metadata().put("name2", "Klaus")),
                         asList(
                                 new Metadata().put("name", "Klaus"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name", "Alice").put("age", 42)
-                        )
-                ))
+                                new Metadata().put("name", "Alice").put("age", 42))))
 
                 // NotIn: int
                 .add(Arguments.of(
                         "age NOT IN (42)",
-                        asList(
-                                new Metadata().put("age", 666),
-                                new Metadata().put("age2", 42)
-                        ),
+                        asList(new Metadata().put("age", 666), new Metadata().put("age2", 42)),
                         asList(
                                 new Metadata().put("age", 42),
-                                new Metadata().put("age", 42).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 42).put("name", "Klaus"))))
                 .add(Arguments.of(
                         "age NOT IN (42, 18)",
-                        asList(
-                                new Metadata().put("age", 666),
-                                new Metadata().put("age2", 42)
-                        ),
+                        asList(new Metadata().put("age", 666), new Metadata().put("age2", 42)),
                         asList(
                                 new Metadata().put("age", 42),
                                 new Metadata().put("age", 18),
                                 new Metadata().put("age", 42).put("name", "Klaus"),
-                                new Metadata().put("age", 18).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 18).put("name", "Klaus"))))
 
                 // NotIn: long
                 .add(Arguments.of(
                         "age NOT IN (42)",
-                        asList(
-                                new Metadata().put("age", 666L),
-                                new Metadata().put("age2", 42L)
-                        ),
+                        asList(new Metadata().put("age", 666L), new Metadata().put("age2", 42L)),
                         asList(
                                 new Metadata().put("age", 42L),
-                                new Metadata().put("age", 42L).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 42L).put("name", "Klaus"))))
                 .add(Arguments.of(
                         "age NOT IN (42, 18)",
-                        asList(
-                                new Metadata().put("age", 666L),
-                                new Metadata().put("age2", 42L)
-                        ),
+                        asList(new Metadata().put("age", 666L), new Metadata().put("age2", 42L)),
                         asList(
                                 new Metadata().put("age", 42L),
                                 new Metadata().put("age", 18L),
                                 new Metadata().put("age", 42L).put("name", "Klaus"),
-                                new Metadata().put("age", 18L).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 18L).put("name", "Klaus"))))
 
                 // NotIn: float
                 .add(Arguments.of(
                         "age NOT IN (42.0)",
-                        asList(
-                                new Metadata().put("age", 666.0f),
-                                new Metadata().put("age2", 42.0f)
-                        ),
+                        asList(new Metadata().put("age", 666.0f), new Metadata().put("age2", 42.0f)),
                         asList(
                                 new Metadata().put("age", 42.0f),
-                                new Metadata().put("age", 42.0f).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 42.0f).put("name", "Klaus"))))
                 .add(Arguments.of(
                         "age NOT IN (42.0, 18.0)",
-                        asList(
-                                new Metadata().put("age", 666.0f),
-                                new Metadata().put("age2", 42.0f)
-                        ),
+                        asList(new Metadata().put("age", 666.0f), new Metadata().put("age2", 42.0f)),
                         asList(
                                 new Metadata().put("age", 42.0f),
                                 new Metadata().put("age", 18.0f),
                                 new Metadata().put("age", 42.0f).put("name", "Klaus"),
-                                new Metadata().put("age", 18.0f).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 18.0f).put("name", "Klaus"))))
 
                 // NotIn: double
                 .add(Arguments.of(
                         "age NOT IN (42.0)",
-                        asList(
-                                new Metadata().put("age", 666.0d),
-                                new Metadata().put("age2", 42.0d)
-                        ),
+                        asList(new Metadata().put("age", 666.0d), new Metadata().put("age2", 42.0d)),
                         asList(
                                 new Metadata().put("age", 42.0d),
-                                new Metadata().put("age", 42.0d).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 42.0d).put("name", "Klaus"))))
                 .add(Arguments.of(
                         "age NOT IN (42.0, 18.0)",
-                        asList(
-                                new Metadata().put("age", 666.0d),
-                                new Metadata().put("age2", 42.0d)
-                        ),
+                        asList(new Metadata().put("age", 666.0d), new Metadata().put("age2", 42.0d)),
                         asList(
                                 new Metadata().put("age", 42.0d),
                                 new Metadata().put("age", 18.0d),
                                 new Metadata().put("age", 42.0d).put("name", "Klaus"),
-                                new Metadata().put("age", 18.0d).put("name", "Klaus")
-                        )
-                ))
-
+                                new Metadata().put("age", 18.0d).put("name", "Klaus"))))
                 .build();
     }
 
@@ -1688,27 +1476,29 @@ class SqlFilterParserTest {
         Filter filter = parser.parse(sql);
 
         // then
-        assertThat(filter).isEqualTo(metadataKey("year").isGreaterThanOrEqualTo(1990L).and(metadataKey("year").isLessThanOrEqualTo(1999L)));
+        assertThat(filter)
+                .isEqualTo(metadataKey("year")
+                        .isGreaterThanOrEqualTo(1990L)
+                        .and(metadataKey("year").isLessThanOrEqualTo(1999L)));
     }
 
     // TODO SELECT * FROM movies WHERE YEAR(year) = 2024 AND genre IN ('comedy', 'drama') ORDER BY RAND() LIMIT 1
 
     @ParameterizedTest
     @CsvSource({
-            // LIKE cases (case-sensitive)
-            "planet LIKE '%mars%', planet, %mars%, LIKE, false",
-            "planet NOT LIKE '%mars%', planet, %mars%, LIKE, true",
-            "planet LIKE 'Hello% M_rs', planet, Hello% M_rs, LIKE, false",
-            "planet ILIKE 'Hello% M_rs', planet, Hello% M_rs, ILIKE, false",
-            "planet NOT ILIKE '%mars%', planet, %mars%, ILIKE, true"
+        // LIKE cases (case-sensitive)
+        "planet LIKE '%mars%', planet, %mars%, LIKE, false",
+        "planet NOT LIKE '%mars%', planet, %mars%, LIKE, true",
+        "planet LIKE 'Hello% M_rs', planet, Hello% M_rs, LIKE, false",
+        "planet ILIKE 'Hello% M_rs', planet, Hello% M_rs, ILIKE, false",
+        "planet NOT ILIKE '%mars%', planet, %mars%, ILIKE, true"
     })
     void should_support_like_and_ilike(
             String expression,
             String expectedKey,
             String expectedPattern,
             String expectedOperator,
-            boolean expectedNegated
-    ) {
+            boolean expectedNegated) {
         Filter filter = parser.parse(expression);
 
         // Validate the type

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/MetadataFilterBuilder.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/MetadataFilterBuilder.java
@@ -272,13 +272,12 @@ public class MetadataFilterBuilder {
     }
 
     public Filter like(String pattern, boolean negated) {
-        return new dev.langchain4j.store.embedding.filter.comparison.Like(key, pattern,
-                dev.langchain4j.store.embedding.filter.comparison.Like.Operator.LIKE, negated);
+        return new dev.langchain4j.store.embedding.filter.comparison.Like(
+                key, pattern, dev.langchain4j.store.embedding.filter.comparison.Like.Operator.LIKE, negated);
     }
 
     public Filter ilike(String pattern, boolean negated) {
-        return new dev.langchain4j.store.embedding.filter.comparison.Like(key, pattern,
-                dev.langchain4j.store.embedding.filter.comparison.Like.Operator.ILIKE, negated);
+        return new dev.langchain4j.store.embedding.filter.comparison.Like(
+                key, pattern, dev.langchain4j.store.embedding.filter.comparison.Like.Operator.ILIKE, negated);
     }
-
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/MetadataFilterBuilder.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/MetadataFilterBuilder.java
@@ -270,4 +270,15 @@ public class MetadataFilterBuilder {
     public Filter isNotIn(Collection<?> values) {
         return new IsNotIn(key, values);
     }
+
+    public Filter like(String pattern, boolean negated) {
+        return new dev.langchain4j.store.embedding.filter.comparison.Like(key, pattern,
+                dev.langchain4j.store.embedding.filter.comparison.Like.Operator.LIKE, negated);
+    }
+
+    public Filter ilike(String pattern, boolean negated) {
+        return new dev.langchain4j.store.embedding.filter.comparison.Like(key, pattern,
+                dev.langchain4j.store.embedding.filter.comparison.Like.Operator.ILIKE, negated);
+    }
+
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/ContainsString.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/ContainsString.java
@@ -1,29 +1,29 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.store.embedding.filter.Filter;
 import java.util.Objects;
 
 /**
  * A filter that checks if the value of a metadata key contains a specific string.
  * The value of the metadata key must be a string.
+ * <p>
+ * ContainsString covers a subset (match whole string) of the like operator concept that why is considered a child of {@link Like}.
  */
-public class ContainsString implements Filter {
+public class ContainsString extends Like {
 
-    private final String key;
     private final String comparisonValue;
 
     public ContainsString(String key, String comparisonValue) {
-        this.key = ensureNotBlank(key, "key");
+        super(key, comparisonValue);
         this.comparisonValue = ensureNotNull(comparisonValue, "comparisonValue with key '" + key + "'");
     }
 
+    @Override
     public String key() {
-        return key;
+        return super.key();
     }
 
     public String comparisonValue() {
@@ -36,11 +36,11 @@ public class ContainsString implements Filter {
             return false;
         }
 
-        if (!metadata.containsKey(key)) {
+        if (!metadata.containsKey(key())) {
             return false;
         }
 
-        Object actualValue = metadata.toMap().get(key);
+        Object actualValue = metadata.toMap().get(key());
 
         if (actualValue instanceof String str) {
             return str.contains(comparisonValue);
@@ -49,7 +49,7 @@ public class ContainsString implements Filter {
         throw illegalArgument(
                 "Type mismatch: actual value of metadata key \"%s\" (%s) has type %s, "
                         + "while it is expected to be a string",
-                key, actualValue, actualValue.getClass().getName());
+                key(), actualValue, actualValue.getClass().getName());
     }
 
     @Override
@@ -57,16 +57,17 @@ public class ContainsString implements Filter {
         if (o == this) return true;
         if (!(o instanceof ContainsString other)) return false;
 
-        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValue, other.comparisonValue);
+        return Objects.equals(this.key(), other.key()) &&
+                Objects.equals(this.comparisonValue, other.comparisonValue);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(key, comparisonValue);
+        return Objects.hash(key(), comparisonValue);
     }
 
     @Override
     public String toString() {
-        return "ContainsString(key=" + this.key + ", comparisonValue=" + this.comparisonValue + ")";
+        return "ContainsString(key=" + key() + ", comparisonValue=" + comparisonValue + ")";
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/ContainsString.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/ContainsString.java
@@ -57,8 +57,7 @@ public class ContainsString extends Like {
         if (o == this) return true;
         if (!(o instanceof ContainsString other)) return false;
 
-        return Objects.equals(this.key(), other.key()) &&
-                Objects.equals(this.comparisonValue, other.comparisonValue);
+        return Objects.equals(this.key(), other.key()) && Objects.equals(this.comparisonValue, other.comparisonValue);
     }
 
     @Override

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/Like.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/Like.java
@@ -92,6 +92,7 @@ public class Like implements Filter {
 
     @Override
     public String toString() {
-        return "Like(column=" + key + ", pattern=" + pattern + ", like-operator=" + operator + ")";
+        return "Like(column=" + key + ", pattern=" + pattern + ", like-operator=" + operator + ", negated=" + negated
+                + ")";
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/Like.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/Like.java
@@ -1,0 +1,94 @@
+package dev.langchain4j.store.embedding.filter.comparison;
+
+import dev.langchain4j.store.embedding.filter.Filter;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import java.util.Objects;
+
+/**
+ * A filter that represents a SQL-like pattern match on a metadata key.
+ * <p>
+ * This class is a descriptor and does not implement actual matching logic,
+ * because each {@link dev.langchain4j.store.embedding.EmbeddingStore}
+ * implementations handle LIKE/ILIKE differently.
+ */
+public class Like implements Filter {
+
+    /**
+     * Supported LIKE operators.
+     */
+    public enum Operator {
+        LIKE, ILIKE, RLIKE, REGEXP
+    }
+
+    private final String key;
+    private final String pattern;
+    private final Operator operator;
+    private final Boolean negated;
+
+    /**
+     * Main constructor with explicit likeKeyword.
+     */
+    public Like(String key, Object pattern, Operator operator,boolean negated) {
+        this.key = ensureNotBlank(key, "key");
+        this.pattern = ensureNotNull(pattern, "comparisonValue with key '" + key + "'").toString();
+        this.operator = ensureNotNull(operator, "operator");
+        this.negated = negated;
+    }
+
+    /**
+     * Minimum constructor for like-operator concept
+     * Allows subclasses like ContainsString to keep functioning as-is with super(key, comparisonValue).
+     */
+    protected Like(String key, Object comparisonValue) {
+        this(key, comparisonValue, Operator.LIKE, false);
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public String pattern() {
+        return pattern;
+    }
+
+    public Operator operator() {
+        return operator;
+    }
+
+    public Boolean negated() {
+        return negated;
+    }
+
+    /**
+     * Test method is not implemented because actual matching depends on the underlying EmbeddingStore.
+     */
+    @Override
+    public boolean test(Object object) {
+        throw new UnsupportedOperationException(
+                "Direct evaluation is not supported for Like. Matching is store-specific.");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Like other)) return false;
+
+        return Objects.equals(this.key, other.key)
+                && Objects.equals(this.pattern, other.pattern)
+                && Objects.equals(this.operator, other.operator)
+                && Objects.equals(this.negated, other.negated);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, pattern, operator, negated);
+    }
+
+    @Override
+    public String toString() {
+        return "Like(column=" + key + ", pattern=" + pattern + ", like-operator=" + operator + ")";
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/Like.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/Like.java
@@ -1,10 +1,9 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
-import dev.langchain4j.store.embedding.filter.Filter;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
+import dev.langchain4j.store.embedding.filter.Filter;
 import java.util.Objects;
 
 /**
@@ -20,7 +19,10 @@ public class Like implements Filter {
      * Supported LIKE operators.
      */
     public enum Operator {
-        LIKE, ILIKE, RLIKE, REGEXP
+        LIKE,
+        ILIKE,
+        RLIKE,
+        REGEXP
     }
 
     private final String key;
@@ -31,9 +33,10 @@ public class Like implements Filter {
     /**
      * Main constructor with explicit likeKeyword.
      */
-    public Like(String key, Object pattern, Operator operator,boolean negated) {
+    public Like(String key, Object pattern, Operator operator, boolean negated) {
         this.key = ensureNotBlank(key, "key");
-        this.pattern = ensureNotNull(pattern, "comparisonValue with key '" + key + "'").toString();
+        this.pattern =
+                ensureNotNull(pattern, "comparisonValue with key '" + key + "'").toString();
         this.operator = ensureNotNull(operator, "operator");
         this.negated = negated;
     }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/LikeTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/LikeTest.java
@@ -1,9 +1,10 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import dev.langchain4j.data.document.Metadata;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LikeTest {
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/LikeTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/LikeTest.java
@@ -1,0 +1,26 @@
+package dev.langchain4j.store.embedding.filter.comparison;
+
+import dev.langchain4j.data.document.Metadata;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LikeTest {
+
+    @Test
+    void testShouldThrowUnsupportedOperationException() {
+        Like like = new Like("name", "%Mars%", Like.Operator.LIKE, false);
+        Metadata metadata = Metadata.from("name", "Hello from Mars");
+
+        assertThrows(UnsupportedOperationException.class, () -> like.test(metadata));
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        Like like1 = new Like("name", "%Mars%", Like.Operator.LIKE, false);
+        Like like2 = new Like("name", "%Mars%", Like.Operator.LIKE, false);
+
+        assertEquals(like1, like2);
+        assertEquals(like1.hashCode(), like2.hashCode());
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/LikeTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/LikeTest.java
@@ -10,18 +10,26 @@ class LikeTest {
 
     @Test
     void testShouldThrowUnsupportedOperationException() {
-        Like like = new Like("name", "%Mars%", Like.Operator.LIKE, false);
-        Metadata metadata = Metadata.from("name", "Hello from Mars");
+        Like like = new Like("planet", "%Mars%", Like.Operator.LIKE, false);
+        Metadata metadata = Metadata.from("planet", "Hello from Mars");
 
         assertThrows(UnsupportedOperationException.class, () -> like.test(metadata));
     }
 
     @Test
     void testEqualsAndHashCode() {
-        Like like1 = new Like("name", "%Mars%", Like.Operator.LIKE, false);
-        Like like2 = new Like("name", "%Mars%", Like.Operator.LIKE, false);
+        Like like1 = new Like("planet", "%Mars%", Like.Operator.LIKE, false);
+        Like like2 = new Like("planet", "%Mars%", Like.Operator.LIKE, false);
 
         assertEquals(like1, like2);
         assertEquals(like1.hashCode(), like2.hashCode());
+    }
+
+    @Test
+    void testToString() {
+        Like like = new Like("planet", "%Mars%", Like.Operator.LIKE, false);
+
+        String expected = "Like(column=planet, pattern=%Mars%, like-operator=LIKE, negated=false)";
+        assertEquals(expected, like.toString());
     }
 }

--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapper.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapper.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.store.embedding.elasticsearch;
 
+import static java.util.stream.Collectors.toList;
+
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
@@ -9,12 +11,9 @@ import dev.langchain4j.store.embedding.filter.comparison.*;
 import dev.langchain4j.store.embedding.filter.logical.And;
 import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
-
-import static java.util.stream.Collectors.toList;
 
 class ElasticsearchMetadataFilterMapper {
 
@@ -44,78 +43,77 @@ class ElasticsearchMetadataFilterMapper {
         } else if (filter instanceof Like) {
             return mapLike((Like) filter);
         } else {
-            throw new UnsupportedOperationException("Unsupported filter type: " + filter.getClass().getName());
+            throw new UnsupportedOperationException(
+                    "Unsupported filter type: " + filter.getClass().getName());
         }
     }
 
     private static Query mapEqual(IsEqualTo isEqualTo) {
-        return new Query.Builder().bool(b -> b.filter(f -> f.term(t ->
-                t.field(formatKey(isEqualTo.key(), isEqualTo.comparisonValue()))
-                        .value(v -> v.anyValue(JsonData.of(isEqualTo.comparisonValue())))
-        ))).build();
+        return new Query.Builder()
+                .bool(b -> b.filter(f -> f.term(t -> t.field(formatKey(isEqualTo.key(), isEqualTo.comparisonValue()))
+                        .value(v -> v.anyValue(JsonData.of(isEqualTo.comparisonValue()))))))
+                .build();
     }
 
     private static Query mapNotEqual(IsNotEqualTo isNotEqualTo) {
-        return new Query.Builder().bool(b -> b.mustNot(mn -> mn.term(t ->
-                t.field(formatKey(isNotEqualTo.key(), isNotEqualTo.comparisonValue()))
-                        .value(v -> v.anyValue(JsonData.of(isNotEqualTo.comparisonValue())))
-        ))).build();
+        return new Query.Builder()
+                .bool(b -> b.mustNot(
+                        mn -> mn.term(t -> t.field(formatKey(isNotEqualTo.key(), isNotEqualTo.comparisonValue()))
+                                .value(v -> v.anyValue(JsonData.of(isNotEqualTo.comparisonValue()))))))
+                .build();
     }
 
     private static Query mapGreaterThan(IsGreaterThan isGreaterThan) {
-        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                r.untyped(nf -> nf
-                        .field("metadata." + isGreaterThan.key())
-                        .gt(JsonData.of(isGreaterThan.comparisonValue()))
-                )))).build();
+        return new Query.Builder()
+                .bool(b -> b.filter(f -> f.range(r -> r.untyped(nf ->
+                        nf.field("metadata." + isGreaterThan.key()).gt(JsonData.of(isGreaterThan.comparisonValue()))))))
+                .build();
     }
 
     private static Query mapGreaterThanOrEqual(IsGreaterThanOrEqualTo isGreaterThanOrEqualTo) {
-        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                r.untyped(nf -> nf
-                        .field("metadata." + isGreaterThanOrEqualTo.key())
-                        .gte(JsonData.of(isGreaterThanOrEqualTo.comparisonValue()))
-                )))).build();
+        return new Query.Builder()
+                .bool(b ->
+                        b.filter(f -> f.range(r -> r.untyped(nf -> nf.field("metadata." + isGreaterThanOrEqualTo.key())
+                                .gte(JsonData.of(isGreaterThanOrEqualTo.comparisonValue()))))))
+                .build();
     }
 
     private static Query mapLessThan(IsLessThan isLessThan) {
-        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                r.untyped(nf -> nf
-                        .field("metadata." + isLessThan.key())
-                        .lt(JsonData.of(isLessThan.comparisonValue()))
-                )))).build();
+        return new Query.Builder()
+                .bool(b -> b.filter(f -> f.range(r -> r.untyped(
+                        nf -> nf.field("metadata." + isLessThan.key()).lt(JsonData.of(isLessThan.comparisonValue()))))))
+                .build();
     }
 
     private static Query mapLessThanOrEqual(IsLessThanOrEqualTo isLessThanOrEqualTo) {
-        return new Query.Builder().bool(b -> b.filter(f -> f.range(r ->
-                r.untyped(nf -> nf
-                        .field("metadata." + isLessThanOrEqualTo.key())
-                        .lte(JsonData.of(isLessThanOrEqualTo.comparisonValue()))
-                )))).build();
+        return new Query.Builder()
+                .bool(b -> b.filter(f -> f.range(r -> r.untyped(nf -> nf.field("metadata." + isLessThanOrEqualTo.key())
+                        .lte(JsonData.of(isLessThanOrEqualTo.comparisonValue()))))))
+                .build();
     }
 
     public static Query mapIn(IsIn isIn) {
-        return new Query.Builder().bool(b -> b.filter(f -> f.terms(t ->
-                t.field(formatKey(isIn.key(), isIn.comparisonValues()))
+        return new Query.Builder()
+                .bool(b -> b.filter(f -> f.terms(t -> t.field(formatKey(isIn.key(), isIn.comparisonValues()))
                         .terms(terms -> {
                             List<FieldValue> values = isIn.comparisonValues().stream()
                                     .map(it -> FieldValue.of(JsonData.of(it)))
                                     .collect(toList());
                             return terms.value(values);
-                        })
-        ))).build();
+                        }))))
+                .build();
     }
 
     public static Query mapNotIn(IsNotIn isNotIn) {
-        return new Query.Builder().bool(b -> b.mustNot(mn -> mn.terms(t ->
-                t.field(formatKey(isNotIn.key(), isNotIn.comparisonValues()))
+        return new Query.Builder()
+                .bool(b -> b.mustNot(mn -> mn.terms(t -> t.field(formatKey(isNotIn.key(), isNotIn.comparisonValues()))
                         .terms(terms -> {
                             List<FieldValue> values = isNotIn.comparisonValues().stream()
                                     .map(it -> FieldValue.of(JsonData.of(it)))
                                     .collect(toList());
                             return terms.value(values);
-                        })
-        ))).build();
+                        }))))
+                .build();
     }
 
     private static Query mapAnd(And and) {
@@ -127,9 +125,8 @@ class ElasticsearchMetadataFilterMapper {
     }
 
     private static Query mapNot(Not not) {
-        BoolQuery boolQuery = new BoolQuery.Builder()
-                .mustNot(map(not.expression()))
-                .build();
+        BoolQuery boolQuery =
+                new BoolQuery.Builder().mustNot(map(not.expression())).build();
         return new Query.Builder().bool(boolQuery).build();
     }
 
@@ -148,21 +145,23 @@ class ElasticsearchMetadataFilterMapper {
 
         if (Boolean.TRUE.equals(like.negated())) {
             // NOT LIKE -> must_not wildcard
-            return new Query.Builder().bool(b -> b.mustNot(mn -> mn.wildcard(w -> w
-                    .field(like.operator() == Like.Operator.ILIKE
-                            ? "metadata." + like.key() + ".lowercase"
-                            : "metadata." + like.key() + ".keyword")
-                    .value(esPattern)
-            ))).build();
+            return new Query.Builder()
+                    .bool(b -> b.mustNot(mn -> mn.wildcard(w -> w.field(
+                                    like.operator() == Like.Operator.ILIKE
+                                            ? "metadata." + like.key() + ".lowercase"
+                                            : "metadata." + like.key() + ".keyword")
+                            .value(esPattern))))
+                    .build();
 
         } else {
             // LIKE -> filter wildcard
-            return new Query.Builder().bool(b -> b.filter(f -> f.wildcard(w -> w
-                    .field(like.operator() == Like.Operator.ILIKE
-                            ? "metadata." + like.key() + ".lowercase"
-                            : "metadata." + like.key() + ".keyword")
-                    .value(esPattern)
-            ))).build();
+            return new Query.Builder()
+                    .bool(b -> b.filter(f -> f.wildcard(w -> w.field(
+                                    like.operator() == Like.Operator.ILIKE
+                                            ? "metadata." + like.key() + ".lowercase"
+                                            : "metadata." + like.key() + ".keyword")
+                            .value(esPattern))))
+                    .build();
         }
     }
 

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapperTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapperTest.java
@@ -17,8 +17,8 @@ class ElasticsearchMetadataFilterMapperTest {
         "%mars, LIKE, metadata.planet.keyword, *mars",
         "_ars, LIKE, metadata.planet.keyword, ?ars",
         "%mars%, LIKE, metadata.planet.keyword, *mars*",
-        "%mars%, ILIKE, metadata.planet.lowercase, *mars*",
-        "%mars%, ILIKE, metadata.planet.lowercase, *mars*",
+        "%Mars%, ILIKE, metadata.planet.lowercase, *mars*",
+        "%m_rs%, ILIKE, metadata.planet.lowercase, *m?rs*",
         "m_r%, LIKE, metadata.planet.keyword, m?r*"
     })
     void map_likeFilter_nonNegated(String pattern, String operator, String expectedField, String expectedValue) {

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapperTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapperTest.java
@@ -1,0 +1,65 @@
+package dev.langchain4j.store.embedding.elasticsearch;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.WildcardQuery;
+import dev.langchain4j.store.embedding.filter.comparison.Like;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ElasticsearchMetadataFilterMapperTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "%mars%, LIKE, metadata.planet.keyword, *mars*",
+            "mars%, LIKE, metadata.planet.keyword, mars*",
+            "%mars, LIKE, metadata.planet.keyword, *mars",
+            "_ars, LIKE, metadata.planet.keyword, ?ars",
+            "%mars%, LIKE, metadata.planet.keyword, *mars*",
+            "%mars%, ILIKE, metadata.planet.lowercase, *mars*",
+            "%mars%, ILIKE, metadata.planet.lowercase, *mars*",
+            "m_r%, LIKE, metadata.planet.keyword, m?r*"
+    })
+    void map_likeFilter_nonNegated(String pattern,
+                                   String operator,
+                                   String expectedField,
+                                   String expectedValue) {
+
+        Like like = new Like("planet", pattern, Like.Operator.valueOf(operator), false);
+        Query query = ElasticsearchMetadataFilterMapper.map(like);
+
+        assertThat(query.bool().filter()).isNotEmpty();
+        WildcardQuery wildcard = query.bool().filter().get(0).wildcard();
+        assertWildcard(wildcard, expectedField,expectedValue);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "%mars%, LIKE, metadata.planet.keyword, *mars*",
+            "_ars%, ILIKE, metadata.planet.lowercase, ?ars*"
+    })
+    void map_likeFilter_negated(String pattern,
+                                String operator,
+                                String expectedField,
+                                String expectedValue) {
+
+        Like like = new Like("planet", pattern, Like.Operator.valueOf(operator), true);
+        Query query = ElasticsearchMetadataFilterMapper.map(like);
+
+        // validate usage of mustnot
+        assertThat(query.bool().mustNot()).isNotEmpty();
+        WildcardQuery wildcard = query.bool().mustNot().get(0).wildcard();
+        assertWildcard(wildcard, expectedField,expectedValue);
+    }
+
+    private void assertWildcard(WildcardQuery wildcard,
+                                String expectedField,
+                                String expectedValue) {
+        assertThat(wildcard).isNotNull();
+        assertThat(wildcard.field()).isEqualTo(expectedField);
+        assertThat(wildcard.value()).isEqualTo(expectedValue);
+
+    }
+
+}

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapperTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapperTest.java
@@ -1,48 +1,39 @@
 package dev.langchain4j.store.embedding.elasticsearch;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.WildcardQuery;
 import dev.langchain4j.store.embedding.filter.comparison.Like;
-import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class ElasticsearchMetadataFilterMapperTest {
 
     @ParameterizedTest
     @CsvSource({
-            "%mars%, LIKE, metadata.planet.keyword, *mars*",
-            "mars%, LIKE, metadata.planet.keyword, mars*",
-            "%mars, LIKE, metadata.planet.keyword, *mars",
-            "_ars, LIKE, metadata.planet.keyword, ?ars",
-            "%mars%, LIKE, metadata.planet.keyword, *mars*",
-            "%mars%, ILIKE, metadata.planet.lowercase, *mars*",
-            "%mars%, ILIKE, metadata.planet.lowercase, *mars*",
-            "m_r%, LIKE, metadata.planet.keyword, m?r*"
+        "%mars%, LIKE, metadata.planet.keyword, *mars*",
+        "mars%, LIKE, metadata.planet.keyword, mars*",
+        "%mars, LIKE, metadata.planet.keyword, *mars",
+        "_ars, LIKE, metadata.planet.keyword, ?ars",
+        "%mars%, LIKE, metadata.planet.keyword, *mars*",
+        "%mars%, ILIKE, metadata.planet.lowercase, *mars*",
+        "%mars%, ILIKE, metadata.planet.lowercase, *mars*",
+        "m_r%, LIKE, metadata.planet.keyword, m?r*"
     })
-    void map_likeFilter_nonNegated(String pattern,
-                                   String operator,
-                                   String expectedField,
-                                   String expectedValue) {
+    void map_likeFilter_nonNegated(String pattern, String operator, String expectedField, String expectedValue) {
 
         Like like = new Like("planet", pattern, Like.Operator.valueOf(operator), false);
         Query query = ElasticsearchMetadataFilterMapper.map(like);
 
         assertThat(query.bool().filter()).isNotEmpty();
         WildcardQuery wildcard = query.bool().filter().get(0).wildcard();
-        assertWildcard(wildcard, expectedField,expectedValue);
+        assertWildcard(wildcard, expectedField, expectedValue);
     }
 
     @ParameterizedTest
-    @CsvSource({
-            "%mars%, LIKE, metadata.planet.keyword, *mars*",
-            "_ars%, ILIKE, metadata.planet.lowercase, ?ars*"
-    })
-    void map_likeFilter_negated(String pattern,
-                                String operator,
-                                String expectedField,
-                                String expectedValue) {
+    @CsvSource({"%mars%, LIKE, metadata.planet.keyword, *mars*", "_ars%, ILIKE, metadata.planet.lowercase, ?ars*"})
+    void map_likeFilter_negated(String pattern, String operator, String expectedField, String expectedValue) {
 
         Like like = new Like("planet", pattern, Like.Operator.valueOf(operator), true);
         Query query = ElasticsearchMetadataFilterMapper.map(like);
@@ -50,16 +41,12 @@ class ElasticsearchMetadataFilterMapperTest {
         // validate usage of mustnot
         assertThat(query.bool().mustNot()).isNotEmpty();
         WildcardQuery wildcard = query.bool().mustNot().get(0).wildcard();
-        assertWildcard(wildcard, expectedField,expectedValue);
+        assertWildcard(wildcard, expectedField, expectedValue);
     }
 
-    private void assertWildcard(WildcardQuery wildcard,
-                                String expectedField,
-                                String expectedValue) {
+    private void assertWildcard(WildcardQuery wildcard, String expectedField, String expectedValue) {
         assertThat(wildcard).isNotNull();
         assertThat(wildcard.field()).isEqualTo(expectedField);
         assertThat(wildcard.value()).isEqualTo(expectedValue);
-
     }
-
 }

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapperTestIT.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchMetadataFilterMapperTestIT.java
@@ -1,0 +1,110 @@
+package dev.langchain4j.store.embedding.elasticsearch;
+
+import static dev.langchain4j.data.document.Metadata.metadata;
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ElasticsearchMetadataFilterMapperTestIT {
+
+    static ElasticsearchClientHelper elasticsearchClientHelper = new ElasticsearchClientHelper();
+    String indexName;
+
+    @BeforeAll
+    static void startServices() throws IOException {
+        elasticsearchClientHelper.startServices();
+        assertThat(elasticsearchClientHelper.restClient).isNotNull();
+        assertThat(elasticsearchClientHelper.client).isNotNull();
+    }
+
+    @AfterAll
+    static void stopServices() throws IOException {
+        elasticsearchClientHelper.stopServices();
+    }
+
+    @BeforeEach
+    void createEmbeddingStore() {
+        indexName = randomUUID();
+    }
+
+    @AfterEach
+    void removeDataStore() throws IOException {
+        // We remove the indices in case we were running with a local test instance
+        // we don't keep dirty things around
+        elasticsearchClientHelper.removeDataStore(indexName);
+    }
+
+    /**
+     * test like operator filter
+     */
+    @ParameterizedTest
+    @MethodSource("filters")
+    void should_use_like_operator_to_filter(Filter filter, String expectedPlanet) throws Exception {
+
+        TextSegment segmentVenus = TextSegment.from(
+                "It's like earth but closest to the sun",
+                metadata("planet", "Venus").put("type", "Earth-sized"));
+        TextSegment segmentMars =
+                TextSegment.from("It's like earth", metadata("planet", "Mars").put("type", "Sub-Earth"));
+
+        EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+        // configuration is irrelevant
+        EmbeddingStore<TextSegment> embeddingStore = ElasticsearchEmbeddingStore.builder()
+                .configuration(ElasticsearchConfigurationKnn.builder()
+                        .numCandidates(10)
+                        .build())
+                .restClient(elasticsearchClientHelper.restClient)
+                .indexName(indexName)
+                .build();
+
+        embeddingStore.add(embeddingModel.embed(segmentVenus).content(), segmentVenus);
+        embeddingStore.add(embeddingModel.embed(segmentMars).content(), segmentMars);
+
+        // needed to avoid search delays and test failures
+        elasticsearchClientHelper.refreshIndex(indexName);
+
+        ContentRetriever contentRetriever = EmbeddingStoreContentRetriever.builder()
+                .embeddingStore(embeddingStore)
+                .embeddingModel(embeddingModel)
+                .filter(filter)
+                .build();
+
+        List<Content> retrieved = contentRetriever.retrieve(Query.from("Recommend me a planet like earth"));
+
+        assertThat(retrieved)
+                .as("Expected at least one result for filter " + filter)
+                .isNotEmpty();
+
+        assertThat(retrieved.get(0).textSegment().metadata().getString("planet"))
+                .isEqualTo(expectedPlanet);
+    }
+
+    static Stream<Arguments> filters() {
+        return Stream.of(
+                // LIKE %_rs -  only Mars remains
+                Arguments.of(metadataKey("planet").like("%_rs", false), "Mars"),
+                // Not LIKE %_rs  -  only Venus remains
+                Arguments.of(metadataKey("planet").like("%_rs", true), "Venus"));
+    }
+}


### PR DESCRIPTION
## Issue
Closes #3866

## Change

- Added the concept of LikeExpression (jsqlParser) through the Like.java in the SQLFilterParser.java

- Added like filter for ElasticSearch

- Modified existing filter of ContainsString as it serves a subset of Like operator as a concept.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)

