### PR TITLE
vertex-ai-gemini: Expose vertex apiEndpoint in builder

### DIFF
--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -24,6 +24,7 @@ import com.google.cloud.vertexai.api.Tool;
 import com.google.cloud.vertexai.api.ToolConfig;
 import com.google.cloud.vertexai.generativeai.GenerativeModel;
 import com.google.cloud.vertexai.generativeai.ResponseHandler;
+import com.google.common.annotations.VisibleForTesting;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
@@ -189,6 +190,10 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
             GoogleCredentials scopedCredentials =
                     builder.credentials.createScoped("https://www.googleapis.com/auth/cloud-platform");
             vertexAiBuilder.setCredentials(scopedCredentials);
+        }
+
+        if (builder.apiEndpoint != null) {
+            vertexAiBuilder.setApiEndpoint(builder.apiEndpoint);
         }
 
         this.vertexAI = vertexAiBuilder.build();
@@ -532,6 +537,11 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         }
     }
 
+    @VisibleForTesting
+    VertexAI vertexAI() {
+        return this.vertexAI;
+    }
+
     @Override
     public Set<Capability> supportedCapabilities() {
         return supportedCapabilities;
@@ -577,6 +587,7 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         private List<ChatModelListener> listeners;
         private Set<Capability> supportedCapabilities;
         private GoogleCredentials credentials;
+        private String apiEndpoint;
 
         public VertexAiGeminiChatModelBuilder() {
             // This is public so it can be extended
@@ -689,6 +700,11 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
 
         public VertexAiGeminiChatModelBuilder credentials(GoogleCredentials credentials) {
             this.credentials = credentials;
+            return this;
+        }
+
+        public VertexAiGeminiChatModelBuilder apiEndpoint(String apiEndpoint) {
+            this.apiEndpoint = apiEndpoint;
             return this;
         }
 

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModel.java
@@ -183,6 +183,10 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
             vertexAiBuilder.setCredentials(scopedCredentials);
         }
 
+        if (builder.apiEndpoint != null) {
+            vertexAiBuilder.setApiEndpoint(builder.apiEndpoint);
+        }
+
         this.vertexAI = vertexAiBuilder.build();
 
         this.generativeModel = new GenerativeModel(builder.modelName, vertexAI).withGenerationConfig(generationConfig);
@@ -580,6 +584,7 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         private List<ChatModelListener> listeners;
         private Map<String, String> customHeaders;
         private GoogleCredentials credentials;
+        private String apiEndpoint;
 
         public VertexAiGeminiStreamingChatModelBuilder() {
             // This is public so it can be extended
@@ -674,6 +679,11 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
 
         public VertexAiGeminiStreamingChatModelBuilder listeners(List<ChatModelListener> listeners) {
             this.listeners = listeners;
+            return this;
+        }
+
+        public VertexAiGeminiStreamingChatModelBuilder apiEndpoint(String apiEndpoint) {
+            this.apiEndpoint = apiEndpoint;
             return this;
         }
 

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelBuilderTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelBuilderTest.java
@@ -1,0 +1,33 @@
+package dev.langchain4j.model.vertexai.gemini;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class VertexAiGeminiChatModelBuilderTest {
+
+    @Test
+    void setDefaultUserAgent() {
+        VertexAiGeminiChatModel model = VertexAiGeminiChatModel.builder()
+                .project("does-not-matter")
+                .location("does-not-matter")
+                .modelName("does-not-matter")
+                .build();
+
+        final String actualUserAgent = model.vertexAI().getHeaders().getOrDefault("user-agent", "error");
+        assertThat(actualUserAgent).contains("LangChain4j");
+    }
+
+    @Test
+    void setCustomApiEndpoint() {
+        String customEndpoint = "https://custom-endpoint.example.com";
+        VertexAiGeminiChatModel model = VertexAiGeminiChatModel.builder()
+                .project("does-not-matter")
+                .location("does-not-matter")
+                .modelName("does-not-matter")
+                .apiEndpoint(customEndpoint)
+                .build();
+
+        assertThat(model.vertexAI().getApiEndpoint()).isEqualTo(customEndpoint);
+    }
+}

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModelBuilderTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModelBuilderTest.java
@@ -44,4 +44,17 @@ class VertexAiGeminiStreamingChatModelBuilderTest {
         final String actualFooHeader = model.vertexAI().getHeaders().getOrDefault("user-agent", "error");
         assertThat(actualFooHeader).contains("my-custom-user-agent");
     }
+
+    @Test
+    void setCustomApiEndpoint() {
+        String customEndpoint = "https://custom-endpoint.example.com";
+        VertexAiGeminiStreamingChatModel model = VertexAiGeminiStreamingChatModel.builder()
+                .project("does-not-matter")
+                .location("does-not-matter")
+                .modelName("does-not-matter")
+                .apiEndpoint(customEndpoint)
+                .build();
+
+        assertThat(model.vertexAI().getApiEndpoint()).isEqualTo(customEndpoint);
+    }
 }


### PR DESCRIPTION
## Issue
Closes #4020 

## Change
I exposed the vertex ApiEndpoint in the builder for Vertex AI Gemini chat models, allowing users to specify a custom API endpoint.

This enhancement applies to both the synchronous and streaming chat model implementations


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
