### PR TITLE
Add GPT_5_1 to open ai enum.

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModelName.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModelName.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.model.openai;
 
 public enum OpenAiChatModelName {
-
     GPT_3_5_TURBO("gpt-3.5-turbo"), // alias
     GPT_3_5_TURBO_1106("gpt-3.5-turbo-1106"),
     GPT_3_5_TURBO_0125("gpt-3.5-turbo-0125"),

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModelName.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModelName.java
@@ -54,7 +54,9 @@ public enum OpenAiChatModelName {
 
     GPT_5("gpt-5"),
     GPT_5_MINI("gpt-5-mini"),
-    GPT_5_NANO("gpt-5-nano")
+    GPT_5_NANO("gpt-5-nano"),
+
+    GPT_5_1("gpt-5.1")
     ;
 
     private final String stringValue;

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModelName.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModelName.java
@@ -56,8 +56,7 @@ public enum OpenAiChatModelName {
     GPT_5_MINI("gpt-5-mini"),
     GPT_5_NANO("gpt-5-nano"),
 
-    GPT_5_1("gpt-5.1")
-    ;
+    GPT_5_1("gpt-5.1");
 
     private final String stringValue;
 


### PR DESCRIPTION
## Change
Wanted to run some tests/benchmarks against the latest ChatGPT 5.1 and noticed it's wasn't available in the OpenAiChatModelName yet. 


## General checklist
- [x] There are no breaking changes (API, behaviour)
