### PR TITLE
feat(memory): implement dynamic window sizing for chat memory

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -17,14 +17,14 @@ import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 
 /**
- * This chat memory operates as a sliding window whose size is controlled by a {@link #maxMessagesSupplier}.
+ * This chat memory operates as a sliding window whose size is controlled by a {@link #maxMessagesProvider}.
  * It retains as many of the most recent messages as can fit into the window.
  * If there isn't enough space for a new message, the oldest one is evicted.
  * <p>
  * The maximum number of messages can be provided either statically or dynamically
- * through the {@code maxMessagesSupplier}. When supplied dynamically, the effective
+ * through the {@code maxMessagesProvider}. When supplied dynamically, the effective
  * window size can change at runtime, and the sliding-window behavior always respects
- * the most recent value returned by the supplier.
+ * the most recent value returned by the provider.
  * <p>
  * Once added, a {@link SystemMessage} is always retained.
  * Only one {@code SystemMessage} can be held at a time.
@@ -42,13 +42,13 @@ public class MessageWindowChatMemory implements ChatMemory {
 
     private final Object id;
     private final ChatMemoryStore store;
-    private final Function<Object, Integer> maxMessagesSupplier;
+    private final Function<Object, Integer> maxMessagesProvider;
 
     private MessageWindowChatMemory(Builder builder) {
         this.id = ensureNotNull(builder.id, "id");
-        this.maxMessagesSupplier = ensureNotNull(builder.maxMessagesSupplier, "maxMessagesSupplier");
+        this.maxMessagesProvider = ensureNotNull(builder.maxMessagesProvider, "maxMessagesProvider");
         this.store = ensureNotNull(builder.store(), "store");
-        ensureGreaterThanZero(this.maxMessagesSupplier.apply(this.id), "maxMessages");
+        ensureGreaterThanZero(this.maxMessagesProvider.apply(this.id), "maxMessages");
     }
 
     @Override
@@ -58,7 +58,7 @@ public class MessageWindowChatMemory implements ChatMemory {
 
     @Override
     public void add(ChatMessage message) {
-        Integer maxMessages = this.maxMessagesSupplier.apply(this.id);
+        Integer maxMessages = this.maxMessagesProvider.apply(this.id);
         ensureGreaterThanZero(maxMessages, "maxMessages");
         List<ChatMessage> messages = messages();
         if (message instanceof SystemMessage) {
@@ -78,7 +78,7 @@ public class MessageWindowChatMemory implements ChatMemory {
 
     @Override
     public List<ChatMessage> messages() {
-        Integer maxMessages = this.maxMessagesSupplier.apply(this.id);
+        Integer maxMessages = this.maxMessagesProvider.apply(this.id);
         ensureGreaterThanZero(maxMessages, "maxMessages");
         List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
         ensureCapacity(messages, maxMessages);
@@ -117,7 +117,7 @@ public class MessageWindowChatMemory implements ChatMemory {
     public static class Builder {
 
         private Object id = ChatMemoryService.DEFAULT;
-        private Function<Object, Integer> maxMessagesSupplier;
+        private Function<Object, Integer> maxMessagesProvider;
         private ChatMemoryStore store;
 
         /**
@@ -136,19 +136,19 @@ public class MessageWindowChatMemory implements ChatMemory {
          * @return builder
          */
         public Builder maxMessages(Integer maxMessages) {
-            this.maxMessagesSupplier = (id) -> maxMessages;
+            this.maxMessagesProvider = (id) -> maxMessages;
             return this;
         }
 
         /**
-         * @param maxMessagesSupplier A supplier that provides the maximum number of messages to retain.
+         * @param maxMessagesProvider A provider that provides the maximum number of messages to retain.
          *                                   The returned value may change dynamically at runtime.
          *                                   If there isn't enough space for a new message under the current limit,
          *                                   the oldest one is evicted.
          * @return builder
          */
-        public Builder dynamicMaxMessages(Function<Object, Integer> maxMessagesSupplier) {
-            this.maxMessagesSupplier = maxMessagesSupplier;
+        public Builder dynamicMaxMessages(Function<Object, Integer> maxMessagesProvider) {
+            this.maxMessagesProvider = maxMessagesProvider;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -42,7 +42,7 @@ public class MessageWindowChatMemory implements ChatMemory {
 
     private final Object id;
     private final ChatMemoryStore store;
-    private final Function<Object,Integer> maxMessagesSupplier;
+    private final Function<Object, Integer> maxMessagesSupplier;
 
     private MessageWindowChatMemory(Builder builder) {
         this.id = ensureNotNull(builder.id, "id");
@@ -117,7 +117,7 @@ public class MessageWindowChatMemory implements ChatMemory {
     public static class Builder {
 
         private Object id = ChatMemoryService.DEFAULT;
-        private Function<Object,Integer> maxMessagesSupplier;
+        private Function<Object, Integer> maxMessagesSupplier;
         private ChatMemoryStore store;
 
         /**
@@ -136,10 +136,9 @@ public class MessageWindowChatMemory implements ChatMemory {
          * @return builder
          */
         public Builder maxMessages(Integer maxMessages) {
-            this.maxMessagesSupplier = (id)-> maxMessages;
+            this.maxMessagesSupplier = (id) -> maxMessages;
             return this;
         }
-
 
         /**
          * @param maxMessagesSupplier A supplier that provides the maximum number of messages to retain.
@@ -148,7 +147,7 @@ public class MessageWindowChatMemory implements ChatMemory {
          *                                   the oldest one is evicted.
          * @return builder
          */
-        public Builder dynamicMaxMessages(Function<Object,Integer> maxMessagesSupplier) {
+        public Builder dynamicMaxMessages(Function<Object, Integer> maxMessagesSupplier) {
             this.maxMessagesSupplier = maxMessagesSupplier;
             return this;
         }

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
@@ -43,7 +43,7 @@ import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 public class TokenWindowChatMemory implements ChatMemory {
 
     private final Object id;
-    private final Function<Object,Integer> maxTokensProvider;
+    private final Function<Object, Integer> maxTokensProvider;
     private final TokenCountEstimator tokenCountEstimator;
     private final ChatMemoryStore store;
 
@@ -134,7 +134,7 @@ public class TokenWindowChatMemory implements ChatMemory {
     public static class Builder {
 
         private Object id = ChatMemoryService.DEFAULT;
-        private Function<Object,Integer> maxTokensProvider;
+        private Function<Object, Integer> maxTokensProvider;
         private TokenCountEstimator tokenCountEstimator;
         private ChatMemoryStore store;
 
@@ -156,7 +156,7 @@ public class TokenWindowChatMemory implements ChatMemory {
          * @return builder
          */
         public Builder maxTokens(Integer maxTokens, TokenCountEstimator tokenCountEstimator) {
-            this.maxTokensProvider = (id)->maxTokens;
+            this.maxTokensProvider = (id) -> maxTokens;
             this.tokenCountEstimator = tokenCountEstimator;
             return this;
         }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
@@ -12,6 +12,7 @@ import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.memory.ChatMemory;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
+import java.util.function.Function;
 
 class MessageWindowChatMemoryTest implements WithAssertions {
     @Test
@@ -408,4 +409,126 @@ class MessageWindowChatMemoryTest implements WithAssertions {
         // then orphan toolExecutionResultMessage1 and toolExecutionResultMessage2 are evicted together with aiMessage
         assertThat(chatMemory.messages()).containsExactly(systemMessage, aiMessage2);
     }
+
+    @Test
+    void dynamic_max_messages_behavior() {
+
+        // Dynamic maxMessages function returns different limits based on memory ID
+        Function<Object, Integer> dynamicMaxMessages = id -> {
+            if ("short".equals(id)) return 2;
+            if ("long".equals(id)) return 4;
+            return 3;
+        };
+
+        var msgA = userMessage("a");
+        var msgB = userMessage("b");
+        var msgC = userMessage("c");
+        var msg1 = userMessage("1");
+        var msg2 = userMessage("2");
+        var msg3 = userMessage("3");
+        var msg4 = userMessage("4");
+        var msg5 = userMessage("5");
+        var msgX = userMessage("x");
+        var msgY = userMessage("y");
+        var msgZ = userMessage("z");
+        var msgW = userMessage("w");
+
+        // Create shortMemory with ID "short" (window size 2)
+        MessageWindowChatMemory shortMemory = MessageWindowChatMemory.builder()
+                .id("short")
+                .dynamicMaxMessages(dynamicMaxMessages)
+                .build();
+
+        // Create longMemory with ID "long" (window size 4)
+        MessageWindowChatMemory longMemory = MessageWindowChatMemory.builder()
+                .id("long")
+                .dynamicMaxMessages(dynamicMaxMessages)
+                .build();
+
+        // Add messages to shortMemory and exceed its limit
+        shortMemory.add(msgA);
+        shortMemory.add(msgB);
+        shortMemory.add(msgC); // Exceeds maxMessages
+
+        assertThat(shortMemory.messages())
+                .containsExactly(msgB, msgC); // Oldest message is evicted
+
+        // Test longMemory (window size 4)
+        longMemory.add(msg1);
+        longMemory.add(msg2);
+        longMemory.add(msg3);
+        longMemory.add(msg4);
+        longMemory.add(msg5); // Exceeds maxMessages
+
+        assertThat(longMemory.messages())
+                .containsExactly(msg2, msg3, msg4, msg5);
+
+        // Test default case (ID not matched, window size 3)
+        MessageWindowChatMemory defaultMemory = MessageWindowChatMemory.builder()
+                .id("other")
+                .dynamicMaxMessages(dynamicMaxMessages)
+                .build();
+
+        defaultMemory.add(msgX);
+        defaultMemory.add(msgY);
+        defaultMemory.add(msgZ);
+        defaultMemory.add(msgW); // Exceeds maxMessages
+
+        assertThat(defaultMemory.messages())
+                .containsExactly(msgY, msgZ, msgW);
+
+        // Clear memory test
+        shortMemory.clear();
+        assertThat(shortMemory.messages()).isEmpty();
+    }
+
+
+    @Test
+    void dynamic_max_messages_can_change_for_same_id() {
+
+        // Array to hold the current dynamic max value
+        int[] currentMax = {3};
+        Function<Object, Integer> dynamicMaxMessages = id -> currentMax[0];
+
+        // Create chat memory instance
+        MessageWindowChatMemory memory = MessageWindowChatMemory.builder()
+                .id("same-id")
+                .dynamicMaxMessages(dynamicMaxMessages)
+                .build();
+
+        var msgA = userMessage("A");
+        var msgB = userMessage("B");
+        var msgC = userMessage("C");
+        var msgD = userMessage("D");
+        var msgE = userMessage("E");
+
+        memory.add(msgA);
+        memory.add(msgB);
+        memory.add(msgC);
+
+        assertThat(memory.messages())
+                .containsExactly(msgA, msgB, msgC);
+
+        memory.add(msgD);
+
+        assertThat(memory.messages())
+                .containsExactly(msgB, msgC, msgD);
+
+        // Increase maxMessages to 5 and add another message
+        currentMax[0] = 5;
+
+        memory.add(msgE);
+        assertThat(memory.messages())
+                .containsExactly(msgB, msgC, msgD, msgE);
+
+        // Decrease maxMessages to 2, which should trigger eviction immediately
+        currentMax[0] = 2;
+
+        // Fetch messages list; excess messages are automatically evicted
+        var msgsAfterShrink = memory.messages();
+        assertThat(msgsAfterShrink)
+                .containsExactly(msgD, msgE); // Keep the most recent two messages
+    }
+
+
 }


### PR DESCRIPTION
## Issue
Closes #

## Change
- Refactored MessageWindowChatMemory to accept a maxMessagesSupplier function
- Added dynamicMaxMessages method to MessageWindowChatMemory builder
- Updated TokenWindowChatMemory to use maxTokensProvider for dynamic token limits
- Added dynamicMaxTokens method to TokenWindowChatMemory builder
- Modified message eviction logic to respect dynamic window sizes
- Added comprehensive tests for dynamic window behavior
- Updated documentation to reflect dynamic sizing capabilities
- Ensured backward compatibility with static window size configuration

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)