### PR TITLE
add mongometadata on langchain4j

### DIFF
--- a/langchain4j-mongodb-atlas/.idea/.gitignore
+++ b/langchain4j-mongodb-atlas/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/langchain4j-mongodb-atlas/.idea/copilot.data.migration.agent.xml
+++ b/langchain4j-mongodb-atlas/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/langchain4j-mongodb-atlas/.idea/copilot.data.migration.edit.xml
+++ b/langchain4j-mongodb-atlas/.idea/copilot.data.migration.edit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EditMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/langchain4j-mongodb-atlas/.idea/vcs.xml
+++ b/langchain4j-mongodb-atlas/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/langchain4j-mongodb-atlas/pom.xml
+++ b/langchain4j-mongodb-atlas/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>5.2.0</version>
+            <version>5.6.0</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-mongodb-atlas/src/main/java/dev/langchain4j/store/embedding/mongodb/MongoDbEmbeddingStore.java
+++ b/langchain4j-mongodb-atlas/src/main/java/dev/langchain4j/store/embedding/mongodb/MongoDbEmbeddingStore.java
@@ -2,6 +2,7 @@ package dev.langchain4j.store.embedding.mongodb;
 
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
@@ -104,6 +105,7 @@ public class MongoDbEmbeddingStore implements EmbeddingStore<TextSegment> {
                                  Bson filter,
                                  IndexMapping indexMapping,
                                  Boolean createIndex) {
+        mongoClient = ensureNotNull(mongoClient, "mongoClient");
         databaseName = ensureNotNull(databaseName, "databaseName");
         collectionName = ensureNotNull(collectionName, "collectionName");
         createIndex = getOrDefault(createIndex, false);
@@ -114,6 +116,13 @@ public class MongoDbEmbeddingStore implements EmbeddingStore<TextSegment> {
                 .register(MongoDbDocument.class, MongoDbMatchedDocument.class)
                 .build());
         CodecRegistry codecRegistry = fromRegistries(MongoClientSettings.getDefaultCodecRegistry(), pojoCodecRegistry);
+
+        // append metadata to mongo client
+        mongoClient.appendMetadata(
+                MongoDriverInformation.builder()
+                        .driverName("langchain4j-mongodb-atlas")
+                        .build()
+        );
 
         // create collection if not exist
         MongoDatabase database = mongoClient.getDatabase(databaseName);


### PR DESCRIPTION
## Issue
Closes [#JAVAF-18](https://jira.mongodb.org/browse/JAVAF-18)


## Change
Since 5.6.0 Mongo driver added support for dynamic client metadata 
For this change: 
1. Upgraded mongo-client version to 5.6.0
2. Added langchain4j to driver name to Client Metadata in MongoDbEmbeddingStore, spring boot already does it [here](https://github.com/spring-projects/spring-boot/blob/c687998f56ff462e1bfb00bd905218a96a4e0315/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoClientFactorySupport.java#L62)
3. Added integration test to verify client metadata


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [ X ] There are no breaking changes (API, behaviour)
- [ X ] I have added unit and/or integration tests for my change
- [ X ] The tests cover both positive and negative cases
- [ X ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ X ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ X ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ X ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
