### PR TITLE
programmatic tools return behavior

### DIFF
--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -700,14 +700,14 @@ Assistant assistant = AiServices.builder(Assistant.class)
     .build();
 ```
 
-Additionally, we can pass a list of tool names that should immediately/directly return their results and not send them to the llm for reprocessing.
+Additionally, we can pass a list of tool names that should [immediately/directly return](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) their results and not send them to the LLM for reprocessing.
 
 ```java
 Set<String> immediateReturnToolNames = new HashSet<>(Arrays.asList("get_booking_details"));
 
 Assistant assistant = AiServices.builder(Assistant.class)
     .chatModel(chatModel)
-    .tools(Map.of(toolSpecification, toolExecutor),immediateReturnToolNames)
+    .tools(Map.of(toolSpecification, toolExecutor), immediateReturnToolNames)
     .build();
 ```
 

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -703,7 +703,7 @@ Assistant assistant = AiServices.builder(Assistant.class)
 Additionally, we can pass a list of tool names that should [immediately/directly return](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) their results and not send them to the LLM for reprocessing.
 
 ```java
-Set<String> immediateReturnToolNames = new HashSet<>(Arrays.asList("get_booking_details"));
+Set<String> immediateReturnToolNames = Set.of("get_booking_details");
 
 Assistant assistant = AiServices.builder(Assistant.class)
     .chatModel(chatModel)

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -700,6 +700,17 @@ Assistant assistant = AiServices.builder(Assistant.class)
     .build();
 ```
 
+Additionally, we can pass a list of tool names that should immediately/directly return their results and not send them to the llm for reprocessing.
+
+```java
+Set<String> immediateReturnToolNames = new HashSet<>(Arrays.asList("get_booking_details"));
+
+Assistant assistant = AiServices.builder(Assistant.class)
+    .chatModel(chatModel)
+    .tools(Map.of(toolSpecification, toolExecutor),immediateReturnToolNames)
+    .build();
+```
+
 ### Specifying Tools Dynamically
 
 When using AI services, tools can also be specified dynamically for each invocation.

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -7,6 +7,7 @@ import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ReturnBehavior;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -47,6 +48,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
@@ -395,6 +397,24 @@ public abstract class AiServices<T> {
      */
     public AiServices<T> tools(Map<ToolSpecification, ToolExecutor> tools) {
         context.toolService.tools(tools);
+        return this;
+    }
+
+    /**
+     * Configures the tools that the LLM can use.
+     *
+     * @param tools A map of {@link ToolSpecification} to {@link ToolExecutor} entries.
+     * @param immediateReturnToolNames A set of Tool names {@link ToolSpecification#name()}
+     *               This method of configuring tools is useful when tools must be configured programmatically.
+     *               Otherwise, it is recommended to use the {@link Tool}-annotated java methods
+     *               and configure tools with the {@link #tools(Object...)} and {@link #tools(Collection)} methods.
+     *               Specifically, this method allows you to specify a set of tool that should not automatically
+     *               perform a llm with the tool result provided by the {@link ToolExecutor}.
+     *               This is similar to using the {@link ReturnBehavior#IMMEDIATE} when using the {@link Tool}-annotated java methods
+     * @return builder
+     */
+    public AiServices<T> tools(Map<ToolSpecification, ToolExecutor> tools, Set<String> immediateReturnToolNames) {
+        context.toolService.tools(tools,immediateReturnToolNames);
         return this;
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -414,7 +414,7 @@ public abstract class AiServices<T> {
      * @return builder
      */
     public AiServices<T> tools(Map<ToolSpecification, ToolExecutor> tools, Set<String> immediateReturnToolNames) {
-        context.toolService.tools(tools,immediateReturnToolNames);
+        context.toolService.tools(tools, immediateReturnToolNames);
         return this;
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -409,7 +409,7 @@ public abstract class AiServices<T> {
      *               Otherwise, it is recommended to use the {@link Tool}-annotated java methods
      *               and configure tools with the {@link #tools(Object...)} and {@link #tools(Collection)} methods.
      *               Specifically, this method allows you to specify a set of tool that should not automatically
-     *               perform a llm with the tool result provided by the {@link ToolExecutor}.
+     *               perform a llm call with the tool results provided by a {@link ToolExecutor}.
      *               This is similar to using the {@link ReturnBehavior#IMMEDIATE} when using the {@link Tool}-annotated java methods
      * @return builder
      */

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -86,13 +86,8 @@ public class ToolService {
     }
 
     public void tools(Map<ToolSpecification, ToolExecutor> tools, Set<String> immediateReturnToolNames) {
-        tools.forEach((toolSpecification, toolExecutor) -> {
-            toolSpecifications.add(toolSpecification);
-            toolExecutors.put(toolSpecification.name(), toolExecutor);
-            if (immediateReturnToolNames.contains(toolSpecification.name())) {
-                immediateReturnTools.add(toolSpecification.name());
-            }
-        });
+        this.tools(tools);
+        immediateReturnTools.addAll(immediateReturnToolNames);
     }
 
     public void tools(Collection<Object> objectsWithTools) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -85,6 +85,16 @@ public class ToolService {
         });
     }
 
+    public void tools(Map<ToolSpecification, ToolExecutor> tools, Set<String> immediateReturnToolNames) {
+        tools.forEach((toolSpecification, toolExecutor) -> {
+            toolSpecifications.add(toolSpecification);
+            toolExecutors.put(toolSpecification.name(), toolExecutor);
+            if (immediateReturnToolNames.contains(toolSpecification.name())) {
+                immediateReturnTools.add(toolSpecification.name());
+            }
+        });
+    }
+
     public void tools(Collection<Object> objectsWithTools) {
         for (Object objectWithTool : objectsWithTools) {
             if (objectWithTool instanceof Class) {


### PR DESCRIPTION
## Issue
Closes #

## Change
Added a new builder method to the AIservices allowing us to pass a Set of tool names. This will allow programmatically built tool to return immediately the result of a tool execution request.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)