### PR TITLE
Update chat message types count in documentation

### DIFF
--- a/docs/docs/tutorials/chat-and-language-models.md
+++ b/docs/docs/tutorials/chat-and-language-models.md
@@ -93,7 +93,7 @@ ChatResponse chatResponse = chatModel.chat(chatRequest);
 ```
 
 ### Types of `ChatMessage`
-There are currently four types of chat messages, one for each "source" of the message:
+There are currently five types of chat messages, one for each "source" of the message:
 
 - `UserMessage`: This is a message from the user.
   The user can be either an end user of your application (a human) or your application itself.


### PR DESCRIPTION
The documentation lists only four chat message types, but there are actually five: the missing one is CustomMessage, a newer type supported in some models like Ollama. This causes confusion or mismatch in the docs.