### PR TITLE
Disable `GlobalTestRetryExtension` by default and remove junit-platform.properties

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -95,8 +95,10 @@ jobs:
         run: |
           mvn -B -U verify \
             -Dgib.disable=false -Dgib.referenceBranch=__branch_before \
+            -Djunit.jupiter.extensions.autodetection.enabled=true \
             -Dtinylog.writer.level=info
         env:
+          LC4J_GLOBAL_TEST_RETRY_ENABLED: true
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/nightly_jdk17.yaml
+++ b/.github/workflows/nightly_jdk17.yaml
@@ -91,9 +91,11 @@ jobs:
             --fail-at-end \
             -DskipLocalAiITs -DskipMilvusITs -DskipOllamaITs \
             -Dmaven.test.failure.ignore=true \
+            -Djunit.jupiter.extensions.autodetection.enabled=true \
             -Dtinylog.writer.level=info
 
         env:
+          LC4J_GLOBAL_TEST_RETRY_ENABLED: true
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/nightly_jdk21.yaml
+++ b/.github/workflows/nightly_jdk21.yaml
@@ -87,9 +87,11 @@ jobs:
             --fail-at-end \
             -DskipLocalAiITs -DskipMilvusITs -DskipOllamaITs -DskipJlamaITs \
             -Dmaven.test.failure.ignore=true \
+            -Djunit.jupiter.extensions.autodetection.enabled=true \
             -Dtinylog.writer.level=info
 
         env:
+          LC4J_GLOBAL_TEST_RETRY_ENABLED: true
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/nightly_jdk25.yaml
+++ b/.github/workflows/nightly_jdk25.yaml
@@ -87,9 +87,11 @@ jobs:
             --fail-at-end \
             -DskipLocalAiITs -DskipMilvusITs -DskipOllamaITs -DskipJlamaITs \
             -Dmaven.test.failure.ignore=true \
+            -Djunit.jupiter.extensions.autodetection.enabled=true \
             -Dtinylog.writer.level=info
 
         env:
+          LC4J_GLOBAL_TEST_RETRY_ENABLED: true
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/langchain4j-core/src/test/resources/junit-platform.properties
+++ b/langchain4j-core/src/test/resources/junit-platform.properties
@@ -1,1 +1,0 @@
-junit.jupiter.extensions.autodetection.enabled=true


### PR DESCRIPTION
## Change
Disabled `GlobalTestRetryExtension` by default and removed `junit-platform.properties` in order to not interfere with custom JUnit setup of users of `langchain4j-core` test module.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)