### PR TITLE
Whoops; Make GoogleAiGeminiBatchChatModel.builder() public.

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiBatchChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiBatchChatModel.java
@@ -209,7 +209,7 @@ public final class GoogleAiGeminiBatchChatModel {
         }
     }
 
-    static Builder builder() {
+    public static Builder builder() {
         return new Builder();
     }
 


### PR DESCRIPTION
## Change
Fixes access to the builder, right now GoogleAiGeminiBatchChatModel cannot be instantiated as the builder is not public 😢 


## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
