### PR TITLE
fix(sql-filter-parser): handle Function expressions in WHERE clause #3667

### DIFF
--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
@@ -1,5 +1,9 @@
 package dev.langchain4j.store.embedding.filter.parser.sql;
 
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.store.embedding.filter.Filter;
 import dev.langchain4j.store.embedding.filter.FilterParser;
@@ -7,6 +11,11 @@ import dev.langchain4j.store.embedding.filter.comparison.*;
 import dev.langchain4j.store.embedding.filter.logical.And;
 import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
+import java.net.URLEncoder;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.*;
 import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
@@ -19,16 +28,6 @@ import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.select.PlainSelect;
-
-import java.net.URLEncoder;
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-
-import static dev.langchain4j.internal.Exceptions.illegalArgument;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR;
 
 /**
  * Parses an SQL "WHERE" clause into a {@link Filter} object using
@@ -137,9 +136,9 @@ public class SqlFilterParser implements FilterParser {
 
     private static String createGithubIssueLink(Expression unsupportedExpression) {
         try {
-            return ". Please click the following link to open an issue on our GitHub: " +
-                    "https://github.com/langchain4j/langchain4j/issues/new?labels=SqlFilterParser&title=SqlFilterParser:%20Support%20new%20expression%20type&body=" +
-                    URLEncoder.encode(unsupportedExpression.toString(), "UTF-8");
+            return ". Please click the following link to open an issue on our GitHub: "
+                    + "https://github.com/langchain4j/langchain4j/issues/new?labels=SqlFilterParser&title=SqlFilterParser:%20Support%20new%20expression%20type&body="
+                    + URLEncoder.encode(unsupportedExpression.toString(), "UTF-8");
         } catch (Exception e) {
             return "";
         }
@@ -222,8 +221,7 @@ public class SqlFilterParser implements FilterParser {
                 }
             }
         }
-        throw illegalArgument("Unsupported expression: '%s'%s", 
-                expression, createGithubIssueLink(expression));
+        throw illegalArgument("Unsupported expression: '%s'%s", expression, createGithubIssueLink(expression));
     }
 
     private Comparable<?> getValue(BinaryExpression binaryExpression) {
@@ -293,7 +291,7 @@ public class SqlFilterParser implements FilterParser {
                             return currentHour();
                         case "MINUTE":
                             return currentMinute();
-                        // TODO add other
+                            // TODO add other
                     }
                 } else {
                     // TODO parse timestamp?

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
@@ -1689,5 +1689,16 @@ class SqlFilterParserTest {
         assertThat(filter).isEqualTo(metadataKey("year").isGreaterThanOrEqualTo(1990L).and(metadataKey("year").isLessThanOrEqualTo(1999L)));
     }
 
-    // TODO SELECT * FROM movies WHERE YEAR(year) = 2024 AND genre IN ('comedy', 'drama') ORDER BY RAND() LIMIT 1
+    @Test
+    void should_support_YEAR_function_in_WHERE_clause() {
+        // given
+        String sql = "SELECT * FROM movies WHERE YEAR(year) = 2024 AND genre IN ('comedy', 'drama')";
+
+        // when
+        Filter filter = parser.parse(sql);
+        
+        // then
+        assertThat(filter).isEqualTo(metadataKey("year").isEqualTo(2024L).and(metadataKey("genre").isIn("comedy", "drama")));
+    }
+
 }

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
@@ -1,20 +1,5 @@
 package dev.langchain4j.store.embedding.filter.parser.sql;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.store.embedding.filter.Filter;
-import dev.langchain4j.store.embedding.filter.FilterParser;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.time.Clock;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
-import java.util.stream.Stream;
-
 import static dev.langchain4j.store.embedding.filter.Filter.*;
 import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
 import static java.time.ZoneOffset.UTC;
@@ -23,6 +8,20 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.of;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.FilterParser;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class SqlFilterParserTest {
 
@@ -44,155 +43,62 @@ class SqlFilterParserTest {
         return Stream.<Arguments>builder()
 
                 // eq
-                .add(of(
-                        "name = 'Klaus'",
-                        metadataKey("name").isEqualTo("Klaus")
-                ))
-                .add(of(
-                        "age = 18",
-                        metadataKey("age").isEqualTo(18L)
-                ))
-                .add(of(
-                        "weight = 67.8",
-                        metadataKey("weight").isEqualTo(67.8d)
-                ))
-
+                .add(of("name = 'Klaus'", metadataKey("name").isEqualTo("Klaus")))
+                .add(of("age = 18", metadataKey("age").isEqualTo(18L)))
+                .add(of("weight = 67.8", metadataKey("weight").isEqualTo(67.8d)))
 
                 // ne
-                .add(of(
-                        "name != 'Klaus'",
-                        metadataKey("name").isNotEqualTo("Klaus")
-                ))
-                .add(of(
-                        "age != 18",
-                        metadataKey("age").isNotEqualTo(18L)
-                ))
-                .add(of(
-                        "weight != 67.8",
-                        metadataKey("weight").isNotEqualTo(67.8d)
-                ))
-
+                .add(of("name != 'Klaus'", metadataKey("name").isNotEqualTo("Klaus")))
+                .add(of("age != 18", metadataKey("age").isNotEqualTo(18L)))
+                .add(of("weight != 67.8", metadataKey("weight").isNotEqualTo(67.8d)))
 
                 // gt
-                .add(of(
-                        "name > 'Klaus'",
-                        metadataKey("name").isGreaterThan("Klaus")
-                ))
-                .add(of(
-                        "age > 18",
-                        metadataKey("age").isGreaterThan(18L)
-                ))
-                .add(of(
-                        "weight > 67.8",
-                        metadataKey("weight").isGreaterThan(67.8d)
-                ))
-
+                .add(of("name > 'Klaus'", metadataKey("name").isGreaterThan("Klaus")))
+                .add(of("age > 18", metadataKey("age").isGreaterThan(18L)))
+                .add(of("weight > 67.8", metadataKey("weight").isGreaterThan(67.8d)))
 
                 // gte
-                .add(of(
-                        "name >= 'Klaus'",
-                        metadataKey("name").isGreaterThanOrEqualTo("Klaus")
-                ))
-                .add(of(
-                        "age >= 18",
-                        metadataKey("age").isGreaterThanOrEqualTo(18L)
-                ))
-                .add(of(
-                        "weight >= 67.8",
-                        metadataKey("weight").isGreaterThanOrEqualTo(67.8d)
-                ))
-
+                .add(of("name >= 'Klaus'", metadataKey("name").isGreaterThanOrEqualTo("Klaus")))
+                .add(of("age >= 18", metadataKey("age").isGreaterThanOrEqualTo(18L)))
+                .add(of("weight >= 67.8", metadataKey("weight").isGreaterThanOrEqualTo(67.8d)))
 
                 // lt
-                .add(of(
-                        "name < 'Klaus'",
-                        metadataKey("name").isLessThan("Klaus")
-                ))
-                .add(of(
-                        "age < 18",
-                        metadataKey("age").isLessThan(18L)
-                ))
-                .add(of(
-                        "weight < 67.8",
-                        metadataKey("weight").isLessThan(67.8d)
-                ))
-
+                .add(of("name < 'Klaus'", metadataKey("name").isLessThan("Klaus")))
+                .add(of("age < 18", metadataKey("age").isLessThan(18L)))
+                .add(of("weight < 67.8", metadataKey("weight").isLessThan(67.8d)))
 
                 // lte
-                .add(of(
-                        "name <= 'Klaus'",
-                        metadataKey("name").isLessThanOrEqualTo("Klaus")
-                ))
-                .add(of(
-                        "age <= 18",
-                        metadataKey("age").isLessThanOrEqualTo(18L)
-                ))
-                .add(of(
-                        "weight <= 67.8",
-                        metadataKey("weight").isLessThanOrEqualTo(67.8d)
-                ))
-
+                .add(of("name <= 'Klaus'", metadataKey("name").isLessThanOrEqualTo("Klaus")))
+                .add(of("age <= 18", metadataKey("age").isLessThanOrEqualTo(18L)))
+                .add(of("weight <= 67.8", metadataKey("weight").isLessThanOrEqualTo(67.8d)))
 
                 // in
-                .add(of(
-                        "name IN ('Klaus', 'Francine')",
-                        metadataKey("name").isIn("Klaus", "Francine")
-                ))
-                .add(of(
-                        "age IN (18, 42)",
-                        metadataKey("age").isIn(18L, 42L)
-                ))
-                .add(of(
-                        "weight IN (67.8, 78.9)",
-                        metadataKey("weight").isIn(67.8d, 78.9d)
-                ))
-
+                .add(of("name IN ('Klaus', 'Francine')", metadataKey("name").isIn("Klaus", "Francine")))
+                .add(of("age IN (18, 42)", metadataKey("age").isIn(18L, 42L)))
+                .add(of("weight IN (67.8, 78.9)", metadataKey("weight").isIn(67.8d, 78.9d)))
 
                 // nin
-                .add(of(
-                        "name NOT IN ('Klaus', 'Francine')",
-                        metadataKey("name").isNotIn("Klaus", "Francine")
-                ))
-                .add(of(
-                        "age NOT IN (18, 42)",
-                        metadataKey("age").isNotIn(18L, 42L)
-                ))
-                .add(of(
-                        "weight NOT IN (67.8, 78.9)",
-                        metadataKey("weight").isNotIn(67.8d, 78.9d)
-                ))
-
+                .add(of("name NOT IN ('Klaus', 'Francine')", metadataKey("name").isNotIn("Klaus", "Francine")))
+                .add(of("age NOT IN (18, 42)", metadataKey("age").isNotIn(18L, 42L)))
+                .add(of("weight NOT IN (67.8, 78.9)", metadataKey("weight").isNotIn(67.8d, 78.9d)))
 
                 // and
                 .add(of(
                         "name = 'Klaus' AND age = 18",
                         and(
                                 metadataKey("name").isEqualTo("Klaus"),
-                                metadataKey("age").isEqualTo(18L)
-                        )
-                ))
-
+                                metadataKey("age").isEqualTo(18L))))
 
                 // not
-                .add(of(
-                        "NOT name = 'Klaus'",
-                        not(metadataKey("name").isEqualTo("Klaus"))
-                ))
-                .add(of(
-                        "NOT (name = 'Klaus')",
-                        not(metadataKey("name").isEqualTo("Klaus"))
-                ))
-
+                .add(of("NOT name = 'Klaus'", not(metadataKey("name").isEqualTo("Klaus"))))
+                .add(of("NOT (name = 'Klaus')", not(metadataKey("name").isEqualTo("Klaus"))))
 
                 // or
                 .add(of(
                         "name = 'Klaus' OR age = 18",
                         or(
                                 metadataKey("name").isEqualTo("Klaus"),
-                                metadataKey("age").isEqualTo(18L)
-                        )
-                ))
-
+                                metadataKey("age").isEqualTo(18L))))
 
                 // or x2
                 .add(of(
@@ -200,32 +106,22 @@ class SqlFilterParserTest {
                         or(
                                 or(
                                         metadataKey("color").isEqualTo("white"),
-                                        metadataKey("color").isEqualTo("black")
-                                ),
-                                metadataKey("color").isEqualTo("red")
-                        )
-                ))
+                                        metadataKey("color").isEqualTo("black")),
+                                metadataKey("color").isEqualTo("red"))))
                 .add(of(
                         "(color = 'white' OR color = 'black') OR color = 'red'",
                         or(
                                 or(
                                         metadataKey("color").isEqualTo("white"),
-                                        metadataKey("color").isEqualTo("black")
-                                ),
-                                metadataKey("color").isEqualTo("red")
-                        )
-                ))
+                                        metadataKey("color").isEqualTo("black")),
+                                metadataKey("color").isEqualTo("red"))))
                 .add(of(
                         "color = 'white' OR (color = 'black' OR color = 'red')",
                         or(
                                 metadataKey("color").isEqualTo("white"),
                                 or(
                                         metadataKey("color").isEqualTo("black"),
-                                        metadataKey("color").isEqualTo("red")
-                                )
-                        )
-                ))
-
+                                        metadataKey("color").isEqualTo("red")))))
 
                 // or + and
                 .add(of(
@@ -234,21 +130,14 @@ class SqlFilterParserTest {
                                 metadataKey("color").isEqualTo("white"),
                                 and(
                                         metadataKey("color").isEqualTo("black"),
-                                        metadataKey("form").isEqualTo("circle")
-                                )
-                        )
-                ))
+                                        metadataKey("form").isEqualTo("circle")))))
                 .add(of(
                         "(color = 'white' OR color = 'black') AND form = 'circle'",
                         and(
                                 or(
                                         metadataKey("color").isEqualTo("white"),
-                                        metadataKey("color").isEqualTo("black")
-                                ),
-                                metadataKey("form").isEqualTo("circle")
-                        )
-                ))
-
+                                        metadataKey("color").isEqualTo("black")),
+                                metadataKey("form").isEqualTo("circle"))))
 
                 // and + or
                 .add(of(
@@ -256,22 +145,15 @@ class SqlFilterParserTest {
                         or(
                                 and(
                                         metadataKey("color").isEqualTo("white"),
-                                        metadataKey("shape").isEqualTo("circle")
-                                ),
-                                metadataKey("color").isEqualTo("red")
-                        )
-                ))
+                                        metadataKey("shape").isEqualTo("circle")),
+                                metadataKey("color").isEqualTo("red"))))
                 .add(of(
                         "color = 'white' AND (shape = 'circle' OR color = 'red')",
                         and(
                                 metadataKey("color").isEqualTo("white"),
                                 or(
                                         metadataKey("shape").isEqualTo("circle"),
-                                        metadataKey("color").isEqualTo("red")
-                                )
-                        )
-                ))
-
+                                        metadataKey("color").isEqualTo("red")))))
 
                 // and x2
                 .add(of(
@@ -279,34 +161,26 @@ class SqlFilterParserTest {
                         and(
                                 and(
                                         metadataKey("color").isEqualTo("white"),
-                                        metadataKey("form").isEqualTo("circle")
-                                ),
-                                metadataKey("area").isGreaterThan(7L)
-                        )
-                ))
+                                        metadataKey("form").isEqualTo("circle")),
+                                metadataKey("area").isGreaterThan(7L))))
 
                 // complete SQL statements
                 .add(of(
                         "SELECT * from fake_table WHERE id = 7",
-                        metadataKey("id").isEqualTo(7L)
-                ))
+                        metadataKey("id").isEqualTo(7L)))
                 .add(of(
                         "select * from fake_table where id = 7",
-                        metadataKey("id").isEqualTo(7L)
-                ))
+                        metadataKey("id").isEqualTo(7L)))
                 .add(of(
                         "Select * From fake_table Where id = 7",
-                        metadataKey("id").isEqualTo(7L)
-                ))
-
+                        metadataKey("id").isEqualTo(7L)))
                 .build();
     }
 
     @ParameterizedTest
     @MethodSource
-    void should_filter_by_metadata(String sqlWhereExpression,
-                                   List<Metadata> matchingMetadatas,
-                                   List<Metadata> notMatchingMetadatas) {
+    void should_filter_by_metadata(
+            String sqlWhereExpression, List<Metadata> matchingMetadatas, List<Metadata> notMatchingMetadatas) {
 
         Filter filter = parser.parse(sqlWhereExpression);
 
@@ -325,111 +199,87 @@ class SqlFilterParserTest {
     static Stream<Arguments> should_filter_by_metadata() {
         return Stream.<Arguments>builder()
 
-
                 // === Equal ===
 
                 .add(Arguments.of(
                         "key = 'a'",
                         asList(
                                 new Metadata().put("key", "a"),
-                                new Metadata().put("key", "a").put("key2", "b")
-                        ),
+                                new Metadata().put("key", "a").put("key2", "b")),
                         asList(
                                 new Metadata().put("key", "A"),
                                 new Metadata().put("key", "b"),
                                 new Metadata().put("key", "aa"),
                                 new Metadata().put("key", "a a"),
-                                new Metadata().put("key2", "a")
-                        )
-                ))
+                                new Metadata().put("key2", "a"))))
 
                 // integer
                 .add(Arguments.of(
                         "key = -2147483648",
                         asList(
                                 new Metadata().put("key", Integer.MIN_VALUE),
-                                new Metadata().put("key", Integer.MIN_VALUE).put("key2", 0)
-                        ),
+                                new Metadata().put("key", Integer.MIN_VALUE).put("key2", 0)),
                         asList(
                                 new Metadata().put("key", Integer.MIN_VALUE + 1),
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key", Integer.MAX_VALUE),
-                                new Metadata().put("key2", Integer.MIN_VALUE)
-                        )
-
-                ))
+                                new Metadata().put("key2", Integer.MIN_VALUE))))
                 .add(Arguments.of(
                         "key = 0",
                         asList(
                                 new Metadata().put("key", 0),
-                                new Metadata().put("key", 0).put("key2", 1)
-                        ),
+                                new Metadata().put("key", 0).put("key2", 1)),
                         asList(
                                 new Metadata().put("key", -1),
                                 new Metadata().put("key", 1),
-                                new Metadata().put("key2", 0)
-                        )
-                ))
+                                new Metadata().put("key2", 0))))
                 .add(Arguments.of(
                         "key = 2147483647",
                         asList(
                                 new Metadata().put("key", Integer.MAX_VALUE),
-                                new Metadata().put("key", Integer.MAX_VALUE).put("key2", 0)
-                        ),
+                                new Metadata().put("key", Integer.MAX_VALUE).put("key2", 0)),
                         asList(
                                 new Metadata().put("key", Integer.MIN_VALUE),
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key", Integer.MAX_VALUE - 1),
-                                new Metadata().put("key2", Integer.MAX_VALUE)
-                        )
-                ))
+                                new Metadata().put("key2", Integer.MAX_VALUE))))
 
                 // long
                 .add(Arguments.of(
                         "key = -9223372036854775808",
                         asList(
                                 new Metadata().put("key", Long.MIN_VALUE),
-                                new Metadata().put("key", Long.MIN_VALUE).put("key2", 0L)
-                        ),
+                                new Metadata().put("key", Long.MIN_VALUE).put("key2", 0L)),
                         asList(
                                 new Metadata().put("key", Long.MIN_VALUE + 1L),
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key", Long.MAX_VALUE),
-                                new Metadata().put("key2", Long.MIN_VALUE)
-                        )
-                ))
+                                new Metadata().put("key2", Long.MIN_VALUE))))
                 .add(Arguments.of(
                         "key = 0",
                         asList(
                                 new Metadata().put("key", 0L),
-                                new Metadata().put("key", 0L).put("key2", 1L)
-                        ),
+                                new Metadata().put("key", 0L).put("key2", 1L)),
                         asList(
                                 new Metadata().put("key", -1L),
                                 new Metadata().put("key", 1L),
-                                new Metadata().put("key2", 0L)
-                        )
-                ))
+                                new Metadata().put("key2", 0L))))
                 .add(Arguments.of(
                         "key = 9223372036854775807",
                         asList(
                                 new Metadata().put("key", Long.MAX_VALUE),
-                                new Metadata().put("key", Long.MAX_VALUE).put("key2", 0L)
-                        ),
+                                new Metadata().put("key", Long.MAX_VALUE).put("key2", 0L)),
                         asList(
                                 new Metadata().put("key", Long.MIN_VALUE),
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key", Long.MAX_VALUE - 1L),
-                                new Metadata().put("key2", Long.MAX_VALUE)
-                        )
-                ))
+                                new Metadata().put("key2", Long.MAX_VALUE))))
 
                 // float
                 // TODO does it make sense to test float for equality?
 
                 // double
-                //TODO does it make sense to test double for equality?
-
+                // TODO does it make sense to test double for equality?
 
                 // === GreaterThan ===
 
@@ -437,67 +287,51 @@ class SqlFilterParserTest {
                         "key > 'b'",
                         asList(
                                 new Metadata().put("key", "c"),
-                                new Metadata().put("key", "c").put("key2", "a")
-                        ),
+                                new Metadata().put("key", "c").put("key2", "a")),
                         asList(
                                 new Metadata().put("key", "a"),
                                 new Metadata().put("key", "b"),
-                                new Metadata().put("key2", "c")
-                        )
-                ))
+                                new Metadata().put("key2", "c"))))
                 .add(Arguments.of(
                         "key > 1",
                         asList(
                                 new Metadata().put("key", 2),
-                                new Metadata().put("key", 2).put("key2", 0)
-                        ),
+                                new Metadata().put("key", 2).put("key2", 0)),
                         asList(
                                 new Metadata().put("key", -2),
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key", 1),
-                                new Metadata().put("key2", 2)
-                        )
-                ))
+                                new Metadata().put("key2", 2))))
                 .add(Arguments.of(
                         "key > 1",
                         asList(
                                 new Metadata().put("key", 2L),
-                                new Metadata().put("key", 2L).put("key2", 0L)
-                        ),
+                                new Metadata().put("key", 2L).put("key2", 0L)),
                         asList(
                                 new Metadata().put("key", -2L),
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key", 1L),
-                                new Metadata().put("key2", 2L)
-                        )
-                ))
+                                new Metadata().put("key2", 2L))))
                 .add(Arguments.of(
                         "key > 1.1",
                         asList(
                                 new Metadata().put("key", 1.2f),
-                                new Metadata().put("key", 1.2f).put("key2", 1.0f)
-                        ),
+                                new Metadata().put("key", 1.2f).put("key2", 1.0f)),
                         asList(
                                 new Metadata().put("key", -1.2f),
                                 new Metadata().put("key", 0.0f),
                                 new Metadata().put("key", 1.1f),
-                                new Metadata().put("key2", 1.2f)
-                        )
-                ))
+                                new Metadata().put("key2", 1.2f))))
                 .add(Arguments.of(
                         "key > 1.1",
                         asList(
                                 new Metadata().put("key", 1.2d),
-                                new Metadata().put("key", 1.2d).put("key2", 1.0d)
-                        ),
+                                new Metadata().put("key", 1.2d).put("key2", 1.0d)),
                         asList(
                                 new Metadata().put("key", -1.2d),
                                 new Metadata().put("key", 0.0d),
                                 new Metadata().put("key", 1.1d),
-                                new Metadata().put("key2", 1.2d)
-                        )
-                ))
-
+                                new Metadata().put("key2", 1.2d))))
 
                 // === GreaterThanOrEqual ==
 
@@ -506,212 +340,150 @@ class SqlFilterParserTest {
                         asList(
                                 new Metadata().put("key", "b"),
                                 new Metadata().put("key", "c"),
-                                new Metadata().put("key", "c").put("key2", "a")
-                        ),
-                        asList(
-                                new Metadata().put("key", "a"),
-                                new Metadata().put("key2", "b")
-                        )
-                ))
+                                new Metadata().put("key", "c").put("key2", "a")),
+                        asList(new Metadata().put("key", "a"), new Metadata().put("key2", "b"))))
                 .add(Arguments.of(
                         "key >= 1",
                         asList(
                                 new Metadata().put("key", 1),
                                 new Metadata().put("key", 2),
-                                new Metadata().put("key", 2).put("key2", 0)
-                        ),
+                                new Metadata().put("key", 2).put("key2", 0)),
                         asList(
                                 new Metadata().put("key", -2),
                                 new Metadata().put("key", -1),
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key2", 1),
-                                new Metadata().put("key2", 2)
-                        )
-                ))
+                                new Metadata().put("key2", 2))))
                 .add(Arguments.of(
                         "key >= 1",
                         asList(
                                 new Metadata().put("key", 1L),
                                 new Metadata().put("key", 2L),
-                                new Metadata().put("key", 2L).put("key2", 0L)
-                        ),
+                                new Metadata().put("key", 2L).put("key2", 0L)),
                         asList(
                                 new Metadata().put("key", -2L),
                                 new Metadata().put("key", -1L),
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key2", 1L),
-                                new Metadata().put("key2", 2L)
-                        )
-                ))
+                                new Metadata().put("key2", 2L))))
                 .add(Arguments.of(
                         "key >= 1.1",
                         asList(
                                 new Metadata().put("key", 1.1f),
                                 new Metadata().put("key", 1.2f),
-                                new Metadata().put("key", 1.2f).put("key2", 1.0f)
-                        ),
+                                new Metadata().put("key", 1.2f).put("key2", 1.0f)),
                         asList(
                                 new Metadata().put("key", -1.2f),
                                 new Metadata().put("key", -1.1f),
                                 new Metadata().put("key", 0.0f),
                                 new Metadata().put("key2", 1.1f),
-                                new Metadata().put("key2", 1.2f)
-                        )
-                ))
+                                new Metadata().put("key2", 1.2f))))
                 .add(Arguments.of(
                         "key >= 1.1",
                         asList(
                                 new Metadata().put("key", 1.1d),
                                 new Metadata().put("key", 1.2d),
-                                new Metadata().put("key", 1.2d).put("key2", 1.0d)
-                        ),
+                                new Metadata().put("key", 1.2d).put("key2", 1.0d)),
                         asList(
                                 new Metadata().put("key", -1.2d),
                                 new Metadata().put("key", -1.1d),
                                 new Metadata().put("key", 0.0d),
                                 new Metadata().put("key2", 1.1d),
-                                new Metadata().put("key2", 1.2d)
-                        )
-                ))
-
+                                new Metadata().put("key2", 1.2d))))
 
                 // === LessThan ==
 
                 .add(Arguments.of(
                         "key < 'b'",
                         asList(
-
                                 new Metadata().put("key", "a"),
-                                new Metadata().put("key", "a").put("key2", "c")
-                        ),
+                                new Metadata().put("key", "a").put("key2", "c")),
                         asList(
                                 new Metadata().put("key", "b"),
                                 new Metadata().put("key", "c"),
-                                new Metadata().put("key2", "a")
-                        )
-                ))
+                                new Metadata().put("key2", "a"))))
                 .add(Arguments.of(
                         "key < 1",
                         asList(
                                 new Metadata().put("key", -2),
                                 new Metadata().put("key", 0),
-                                new Metadata().put("key", 0).put("key2", 2)
-                        ),
+                                new Metadata().put("key", 0).put("key2", 2)),
                         asList(
                                 new Metadata().put("key", 1),
                                 new Metadata().put("key", 2),
-                                new Metadata().put("key2", 0)
-                        )
-                ))
+                                new Metadata().put("key2", 0))))
                 .add(Arguments.of(
                         "key < 1",
                         asList(
                                 new Metadata().put("key", -2L),
                                 new Metadata().put("key", 0L),
-                                new Metadata().put("key", 0L).put("key2", 2L)
-                        ),
+                                new Metadata().put("key", 0L).put("key2", 2L)),
                         asList(
                                 new Metadata().put("key", 1L),
                                 new Metadata().put("key", 2L),
-                                new Metadata().put("key2", 0L)
-                        )
-                ))
+                                new Metadata().put("key2", 0L))))
                 .add(Arguments.of(
                         "key < 1.1",
                         asList(
                                 new Metadata().put("key", -1.2f),
                                 new Metadata().put("key", 1.0f),
-                                new Metadata().put("key", 1.0f).put("key2", 1.2f)
-                        ),
+                                new Metadata().put("key", 1.0f).put("key2", 1.2f)),
                         asList(
                                 new Metadata().put("key", 1.1f),
                                 new Metadata().put("key", 1.2f),
-                                new Metadata().put("key2", 1.0f)
-                        )
-                ))
+                                new Metadata().put("key2", 1.0f))))
                 .add(Arguments.of(
                         "key < 1.1",
                         asList(
                                 new Metadata().put("key", -1.2d),
                                 new Metadata().put("key", 1.0d),
-                                new Metadata().put("key", 1.0d).put("key2", 1.2d)
-                        ),
+                                new Metadata().put("key", 1.0d).put("key2", 1.2d)),
                         asList(
                                 new Metadata().put("key", 1.1d),
                                 new Metadata().put("key", 1.2d),
-                                new Metadata().put("key2", 1.0d)
-                        )
-                ))
-
+                                new Metadata().put("key2", 1.0d))))
 
                 // === LessThanOrEqual ==
 
                 .add(Arguments.of(
                         "key <= 'b'",
                         asList(
-
                                 new Metadata().put("key", "a"),
                                 new Metadata().put("key", "b"),
-                                new Metadata().put("key", "b").put("key2", "c")
-                        ),
-                        asList(
-                                new Metadata().put("key", "c"),
-                                new Metadata().put("key2", "a")
-                        )
-                ))
+                                new Metadata().put("key", "b").put("key2", "c")),
+                        asList(new Metadata().put("key", "c"), new Metadata().put("key2", "a"))))
                 .add(Arguments.of(
                         "key <= 1",
                         asList(
                                 new Metadata().put("key", -2),
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key", 1),
-                                new Metadata().put("key", 1).put("key2", 2)
-                        ),
-                        asList(
-                                new Metadata().put("key", 2),
-                                new Metadata().put("key2", 0)
-                        )
-                ))
+                                new Metadata().put("key", 1).put("key2", 2)),
+                        asList(new Metadata().put("key", 2), new Metadata().put("key2", 0))))
                 .add(Arguments.of(
                         "key <= 1",
                         asList(
                                 new Metadata().put("key", -2L),
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key", 1L),
-                                new Metadata().put("key", 1L).put("key2", 2L)
-                        ),
-                        asList(
-                                new Metadata().put("key", 2L),
-                                new Metadata().put("key2", 0L)
-                        )
-                ))
+                                new Metadata().put("key", 1L).put("key2", 2L)),
+                        asList(new Metadata().put("key", 2L), new Metadata().put("key2", 0L))))
                 .add(Arguments.of(
                         "key <= 1.1",
                         asList(
                                 new Metadata().put("key", -1.2f),
                                 new Metadata().put("key", 1.0f),
                                 new Metadata().put("key", 1.1f),
-                                new Metadata().put("key", 1.1f).put("key2", 1.2f)
-                        ),
-                        asList(
-                                new Metadata().put("key", 1.2f),
-                                new Metadata().put("key2", 1.0f)
-                        )
-                ))
+                                new Metadata().put("key", 1.1f).put("key2", 1.2f)),
+                        asList(new Metadata().put("key", 1.2f), new Metadata().put("key2", 1.0f))))
                 .add(Arguments.of(
                         "key <= 1.1",
                         asList(
                                 new Metadata().put("key", -1.2d),
                                 new Metadata().put("key", 1.0d),
                                 new Metadata().put("key", 1.1d),
-                                new Metadata().put("key", 1.1d).put("key2", 1.2d)
-                        ),
-                        asList(
-                                new Metadata().put("key", 1.2d),
-                                new Metadata().put("key2", 1.0d)
-                        )
-                ))
-
+                                new Metadata().put("key", 1.1d).put("key2", 1.2d)),
+                        asList(new Metadata().put("key", 1.2d), new Metadata().put("key2", 1.0d))))
 
                 // === In ===
 
@@ -720,133 +492,86 @@ class SqlFilterParserTest {
                         "name IN ('Klaus')",
                         asList(
                                 new Metadata().put("name", "Klaus"),
-                                new Metadata().put("name", "Klaus").put("age", 42)
-                        ),
+                                new Metadata().put("name", "Klaus").put("age", 42)),
                         asList(
                                 new Metadata().put("name", "Klaus Heisler"),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name2", "Klaus")
-                        )
-                ))
+                                new Metadata().put("name2", "Klaus"))))
                 .add(Arguments.of(
                         "name IN ('Klaus', 'Alice')",
                         asList(
                                 new Metadata().put("name", "Klaus"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name", "Alice").put("age", 42)
-                        ),
+                                new Metadata().put("name", "Alice").put("age", 42)),
                         asList(
                                 new Metadata().put("name", "Klaus Heisler"),
                                 new Metadata().put("name", "Zoe"),
-                                new Metadata().put("name2", "Klaus")
-                        )
-                ))
+                                new Metadata().put("name2", "Klaus"))))
 
                 // In: integer
                 .add(Arguments.of(
                         "age IN (42)",
                         asList(
                                 new Metadata().put("age", 42),
-                                new Metadata().put("age", 42).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666),
-                                new Metadata().put("age2", 42)
-                        )
-                ))
+                                new Metadata().put("age", 42).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666), new Metadata().put("age2", 42))))
                 .add(Arguments.of(
                         "age IN (42, 18)",
                         asList(
                                 new Metadata().put("age", 42),
                                 new Metadata().put("age", 18),
                                 new Metadata().put("age", 42).put("name", "Klaus"),
-                                new Metadata().put("age", 18).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666),
-                                new Metadata().put("age2", 42)
-                        )
-                ))
+                                new Metadata().put("age", 18).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666), new Metadata().put("age2", 42))))
 
                 // In: long
                 .add(Arguments.of(
                         "age IN (42)",
                         asList(
                                 new Metadata().put("age", 42L),
-                                new Metadata().put("age", 42L).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666L),
-                                new Metadata().put("age2", 42L)
-                        )
-                ))
+                                new Metadata().put("age", 42L).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666L), new Metadata().put("age2", 42L))))
                 .add(Arguments.of(
                         "age IN (42, 18)",
                         asList(
                                 new Metadata().put("age", 42L),
                                 new Metadata().put("age", 18L),
                                 new Metadata().put("age", 42L).put("name", "Klaus"),
-                                new Metadata().put("age", 18L).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666L),
-                                new Metadata().put("age2", 42L)
-                        )
-                ))
+                                new Metadata().put("age", 18L).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666L), new Metadata().put("age2", 42L))))
 
                 // In: float
                 .add(Arguments.of(
                         "age IN (42.0)",
                         asList(
                                 new Metadata().put("age", 42.0f),
-                                new Metadata().put("age", 42.0f).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666.0f),
-                                new Metadata().put("age2", 42.0f)
-                        )
-                ))
+                                new Metadata().put("age", 42.0f).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666.0f), new Metadata().put("age2", 42.0f))))
                 .add(Arguments.of(
                         "age IN (42.0, 18.0)",
                         asList(
                                 new Metadata().put("age", 42.0f),
                                 new Metadata().put("age", 18.0f),
                                 new Metadata().put("age", 42.0f).put("name", "Klaus"),
-                                new Metadata().put("age", 18.0f).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666.0f),
-                                new Metadata().put("age2", 42.0f)
-                        )
-                ))
+                                new Metadata().put("age", 18.0f).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666.0f), new Metadata().put("age2", 42.0f))))
 
                 // In: double
                 .add(Arguments.of(
                         "age IN (42.0)",
                         asList(
                                 new Metadata().put("age", 42.0d),
-                                new Metadata().put("age", 42.0d).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666.0d),
-                                new Metadata().put("age2", 42.0d)
-                        )
-                ))
+                                new Metadata().put("age", 42.0d).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666.0d), new Metadata().put("age2", 42.0d))))
                 .add(Arguments.of(
                         "age IN (42.0, 18.0)",
                         asList(
                                 new Metadata().put("age", 42.0d),
                                 new Metadata().put("age", 18.0d),
                                 new Metadata().put("age", 42.0d).put("name", "Klaus"),
-                                new Metadata().put("age", 18.0d).put("name", "Klaus")
-                        ),
-                        asList(
-                                new Metadata().put("age", 666.0d),
-                                new Metadata().put("age2", 42.0d)
-                        )
-                ))
-
+                                new Metadata().put("age", 18.0d).put("name", "Klaus")),
+                        asList(new Metadata().put("age", 666.0d), new Metadata().put("age2", 42.0d))))
 
                 // === Or ===
 
@@ -857,36 +582,24 @@ class SqlFilterParserTest {
                                 new Metadata().put("name", "Klaus"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name", "Alice").put("age", 42)
-                        ),
-                        singletonList(
-                                new Metadata().put("name", "Zoe")
-                        )
-                ))
+                                new Metadata().put("name", "Alice").put("age", 42)),
+                        singletonList(new Metadata().put("name", "Zoe"))))
                 .add(Arguments.of(
                         "name = 'Alice' OR name = 'Klaus'",
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("name", "Alice").put("age", 42),
                                 new Metadata().put("name", "Klaus"),
-                                new Metadata().put("name", "Klaus").put("age", 42)
-                        ),
-                        singletonList(
-                                new Metadata().put("name", "Zoe")
-                        )
-                ))
+                                new Metadata().put("name", "Klaus").put("age", 42)),
+                        singletonList(new Metadata().put("name", "Zoe"))))
                 .add(Arguments.of(
                         "(name = 'Klaus' OR name = 'Alice')",
                         asList(
                                 new Metadata().put("name", "Klaus"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name", "Alice").put("age", 42)
-                        ),
-                        singletonList(
-                                new Metadata().put("name", "Zoe")
-                        )
-                ))
+                                new Metadata().put("name", "Alice").put("age", 42)),
+                        singletonList(new Metadata().put("name", "Zoe"))))
 
                 // Or: multiple keys
                 .add(Arguments.of(
@@ -908,14 +621,14 @@ class SqlFilterParserTest {
 
                                 // Or.left and Or.right are both true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
-                                new Metadata().put("name", "Alice").put("age", 666)
-                        )
-                ))
+                                new Metadata().put("name", "Alice").put("age", 666))))
                 .add(Arguments.of(
                         "age = 42 OR name = 'Klaus'",
                         asList(
@@ -935,14 +648,14 @@ class SqlFilterParserTest {
 
                                 // Or.left and Or.right are both true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
-                                new Metadata().put("name", "Alice").put("age", 666)
-                        )
-                ))
+                                new Metadata().put("name", "Alice").put("age", 666))))
 
                 // Or: x2
                 .add(Arguments.of(
@@ -955,7 +668,10 @@ class SqlFilterParserTest {
                                 // Or.left is true, Or.right is false
                                 new Metadata().put("name", "Klaus").put("age", 666),
                                 new Metadata().put("name", "Klaus").put("city", "Frankfurt"),
-                                new Metadata().put("name", "Klaus").put("age", 666).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"),
 
                                 // only Or.right is present and true
                                 new Metadata().put("age", 42),
@@ -963,30 +679,49 @@ class SqlFilterParserTest {
                                 new Metadata().put("city", "Munich"),
                                 new Metadata().put("city", "Munich").put("country", "Germany"),
                                 new Metadata().put("age", 42).put("city", "Munich"),
-                                new Metadata().put("age", 42).put("city", "Munich").put("country", "Germany"),
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
 
                                 // Or.right is true, Or.left is false
                                 new Metadata().put("age", 42).put("name", "Alice"),
                                 new Metadata().put("city", "Munich").put("name", "Alice"),
-                                new Metadata().put("age", 42).put("city", "Munich").put("name", "Alice"),
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("name", "Alice"),
 
                                 // Or.left and Or.right are both true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("city", "Munich").put("country", "Germany"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
                                 new Metadata().put("city", "Frankfurt"),
                                 new Metadata().put("name", "Alice").put("age", 666),
                                 new Metadata().put("name", "Alice").put("city", "Frankfurt"),
-                                new Metadata().put("name", "Alice").put("age", 666).put("city", "Frankfurt")
-                        )
-                ))
+                                new Metadata()
+                                        .put("name", "Alice")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"))))
                 .add(Arguments.of(
                         "(name = 'Klaus' OR age = 42) OR city = 'Munich'",
                         asList(
@@ -996,12 +731,18 @@ class SqlFilterParserTest {
                                 new Metadata().put("age", 42),
                                 new Metadata().put("age", 42).put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
 
                                 // Or.left is true, Or.right is false
                                 new Metadata().put("name", "Klaus").put("city", "Frankfurt"),
                                 new Metadata().put("age", 42).put("city", "Frankfurt"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only Or.right is present and true
                                 new Metadata().put("city", "Munich"),
@@ -1013,21 +754,34 @@ class SqlFilterParserTest {
 
                                 // Or.left and Or.right are both true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("city", "Munich").put("country", "Germany"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
                                 new Metadata().put("city", "Frankfurt"),
                                 new Metadata().put("name", "Alice").put("age", 666),
                                 new Metadata().put("name", "Alice").put("city", "Frankfurt"),
-                                new Metadata().put("name", "Alice").put("age", 666).put("city", "Frankfurt")
-                        )
-                ))
+                                new Metadata()
+                                        .put("name", "Alice")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"))))
                 .add(Arguments.of(
                         "name = 'Klaus' OR (age = 42 OR city = 'Munich')",
                         asList(
@@ -1037,12 +791,18 @@ class SqlFilterParserTest {
                                 new Metadata().put("age", 42),
                                 new Metadata().put("age", 42).put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
 
                                 // Or.left is true, Or.right is false
                                 new Metadata().put("name", "Klaus").put("city", "Frankfurt"),
                                 new Metadata().put("age", 42).put("city", "Frankfurt"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only Or.right is present and true
                                 new Metadata().put("city", "Munich"),
@@ -1054,21 +814,34 @@ class SqlFilterParserTest {
 
                                 // Or.left and Or.right are both true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("city", "Munich").put("country", "Germany"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
                                 new Metadata().put("city", "Frankfurt"),
                                 new Metadata().put("name", "Alice").put("age", 666),
                                 new Metadata().put("name", "Alice").put("city", "Frankfurt"),
-                                new Metadata().put("name", "Alice").put("age", 666).put("city", "Frankfurt")
-                        )
-                ))
+                                new Metadata()
+                                        .put("name", "Alice")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"))))
 
                 // === AND ===
 
@@ -1076,8 +849,10 @@ class SqlFilterParserTest {
                         "name = 'Klaus' AND age = 42",
                         asList(
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus"),
@@ -1092,15 +867,15 @@ class SqlFilterParserTest {
                                 new Metadata().put("age", 42).put("name", "Alice"),
 
                                 // And.left, And.right are both false
-                                new Metadata().put("age", 666).put("name", "Alice")
-                        )
-                ))
+                                new Metadata().put("age", 666).put("name", "Alice"))))
                 .add(Arguments.of(
                         "age = 42 AND name = 'Klaus'",
                         asList(
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("age", 42),
@@ -1115,17 +890,21 @@ class SqlFilterParserTest {
                                 new Metadata().put("name", "Klaus").put("age", 666),
 
                                 // And.left, And.right are both false
-                                new Metadata().put("age", 666).put("name", "Alice")
-                        )
-                ))
+                                new Metadata().put("age", 666).put("name", "Alice"))))
 
                 // And: x2
                 .add(Arguments.of(
                         "name = 'Klaus' AND age = 42 AND city = 'Munich'",
                         asList(
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus"),
@@ -1133,62 +912,95 @@ class SqlFilterParserTest {
                                 // And.left is true, And.right is false
                                 new Metadata().put("name", "Klaus").put("age", 42),
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 666).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 666)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only And.right is present and true
                                 new Metadata().put("age", 42).put("city", "Munich"),
 
                                 // And.right is true, And.left is false
-                                new Metadata().put("age", 42).put("city", "Munich").put("name", "Alice")
-                        )
-                ))
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("name", "Alice"))))
                 .add(Arguments.of(
                         "(name = 'Klaus' AND age = 42) AND city = 'Munich'",
                         asList(
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus").put("age", 42),
 
                                 // And.left is true, And.right is false
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only And.right is present and true
                                 new Metadata().put("city", "Munich"),
 
                                 // And.right is true, And.left is false
                                 new Metadata().put("city", "Munich").put("name", "Klaus"),
-                                new Metadata().put("city", "Munich").put("name", "Klaus").put("age", 666),
+                                new Metadata()
+                                        .put("city", "Munich")
+                                        .put("name", "Klaus")
+                                        .put("age", 666),
                                 new Metadata().put("city", "Munich").put("age", 42),
-                                new Metadata().put("city", "Munich").put("age", 42).put("name", "Alice")
-                        )
-                ))
+                                new Metadata()
+                                        .put("city", "Munich")
+                                        .put("age", 42)
+                                        .put("name", "Alice"))))
                 .add(Arguments.of(
                         "name = 'Klaus' AND (age = 42 AND city = 'Munich')",
                         asList(
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus").put("age", 42),
 
                                 // And.left is true, And.right is false
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only And.right is present and true
                                 new Metadata().put("city", "Munich"),
 
                                 // And.right is true, And.left is false
                                 new Metadata().put("city", "Munich").put("name", "Klaus"),
-                                new Metadata().put("city", "Munich").put("name", "Klaus").put("age", 666),
+                                new Metadata()
+                                        .put("city", "Munich")
+                                        .put("name", "Klaus")
+                                        .put("age", 666),
                                 new Metadata().put("city", "Munich").put("age", 42),
-                                new Metadata().put("city", "Munich").put("age", 42).put("name", "Alice")
-                        )
-                ))
+                                new Metadata()
+                                        .put("city", "Munich")
+                                        .put("age", 42)
+                                        .put("name", "Alice"))))
 
                 // === AND + nested OR ===
 
@@ -1196,12 +1008,24 @@ class SqlFilterParserTest {
                         "name = 'Klaus' AND (age = 42 OR city = 'Munich')",
                         asList(
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("city", "Munich").put("country", "Germany"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus"),
@@ -1218,19 +1042,32 @@ class SqlFilterParserTest {
                                 // And.right is true, And.left is false
                                 new Metadata().put("age", 42).put("name", "Alice"),
                                 new Metadata().put("city", "Munich").put("name", "Alice"),
-                                new Metadata().put("age", 42).put("city", "Munich").put("name", "Alice")
-                        )
-                ))
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("name", "Alice"))))
                 .add(Arguments.of(
                         "(name = 'Klaus' OR age = 42) AND city = 'Munich'",
                         asList(
                                 new Metadata().put("name", "Klaus").put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("city", "Munich").put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
                                 new Metadata().put("age", 42).put("city", "Munich"),
-                                new Metadata().put("age", 42).put("city", "Munich").put("country", "Germany"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 // only And.left is present and true
                                 new Metadata().put("name", "Klaus"),
@@ -1240,7 +1077,10 @@ class SqlFilterParserTest {
                                 // And.left is true, And.right is false
                                 new Metadata().put("name", "Klaus").put("city", "Frankfurt"),
                                 new Metadata().put("age", 42).put("city", "Frankfurt"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only And.right is present and true
                                 new Metadata().put("city", "Munich"),
@@ -1248,9 +1088,10 @@ class SqlFilterParserTest {
                                 // And.right is true, And.left is false
                                 new Metadata().put("city", "Munich").put("name", "Alice"),
                                 new Metadata().put("city", "Munich").put("age", 666),
-                                new Metadata().put("city", "Munich").put("name", "Alice").put("age", 666)
-                        )
-                ))
+                                new Metadata()
+                                        .put("city", "Munich")
+                                        .put("name", "Alice")
+                                        .put("age", 666))))
 
                 // === OR + nested AND ===
                 .add(Arguments.of(
@@ -1263,56 +1104,76 @@ class SqlFilterParserTest {
                                 // Or.left is true, Or.right is false
                                 new Metadata().put("name", "Klaus").put("age", 666),
                                 new Metadata().put("name", "Klaus").put("city", "Frankfurt"),
-                                new Metadata().put("name", "Klaus").put("age", 666).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"),
 
                                 // only Or.right is present and true
                                 new Metadata().put("age", 42).put("city", "Munich"),
-                                new Metadata().put("age", 42).put("city", "Munich").put("country", "Germany"),
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany"),
 
                                 // Or.right is true, Or.left is false
-                                new Metadata().put("age", 42).put("city", "Munich").put("name", "Alice")
-                        ),
+                                new Metadata()
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("name", "Alice")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
                                 new Metadata().put("city", "Frankfurt"),
-                                new Metadata().put("name", "Alice").put("age", 666).put("city", "Frankfurt")
-                        )
-                ))
+                                new Metadata()
+                                        .put("name", "Alice")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"))))
                 .add(Arguments.of(
                         "name = 'Klaus' AND age = 42 OR city = 'Munich'",
                         asList(
                                 // only Or.left is present and true
                                 new Metadata().put("name", "Klaus").put("age", 42),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("country", "Germany"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("country", "Germany"),
 
                                 // Or.left is true, Or.right is false
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Frankfurt"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Frankfurt"),
 
                                 // only Or.right is present and true
                                 new Metadata().put("city", "Munich"),
                                 new Metadata().put("city", "Munich").put("country", "Germany"),
 
                                 // Or.right is true, Or.left is true
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich"),
-                                new Metadata().put("name", "Klaus").put("age", 42).put("city", "Munich").put("country", "Germany")
-                        ),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich"),
+                                new Metadata()
+                                        .put("name", "Klaus")
+                                        .put("age", 42)
+                                        .put("city", "Munich")
+                                        .put("country", "Germany")),
                         asList(
                                 new Metadata().put("name", "Alice"),
                                 new Metadata().put("age", 666),
                                 new Metadata().put("city", "Frankfurt"),
-                                new Metadata().put("name", "Alice").put("age", 666).put("city", "Frankfurt")
-                        )
-                ))
-
+                                new Metadata()
+                                        .put("name", "Alice")
+                                        .put("age", 666)
+                                        .put("city", "Frankfurt"))))
                 .build();
     }
 
     @ParameterizedTest
     @MethodSource
-    void should_filter_by_metadata_not(String sqlWhereExpression,
-                                       List<Metadata> matchingMetadatas,
-                                       List<Metadata> notMatchingMetadatas) {
+    void should_filter_by_metadata_not(
+            String sqlWhereExpression, List<Metadata> matchingMetadatas, List<Metadata> notMatchingMetadatas) {
 
         Filter filter = parser.parse(sqlWhereExpression);
 
@@ -1334,26 +1195,16 @@ class SqlFilterParserTest {
                 // === Not ===
                 .add(Arguments.of(
                         "NOT(name = 'Klaus')",
-                        asList(
-                                new Metadata().put("name", "Alice"),
-                                new Metadata().put("age", 42)
-                        ),
+                        asList(new Metadata().put("name", "Alice"), new Metadata().put("age", 42)),
                         asList(
                                 new Metadata().put("name", "Klaus"),
-                                new Metadata().put("name", "Klaus").put("age", 42)
-                        )
-                )).add(Arguments.of(
+                                new Metadata().put("name", "Klaus").put("age", 42))))
+                .add(Arguments.of(
                         "NOT name = 'Klaus'",
-                        asList(
-                                new Metadata().put("name", "Alice"),
-                                new Metadata().put("age", 42)
-                        ),
+                        asList(new Metadata().put("name", "Alice"), new Metadata().put("age", 42)),
                         asList(
                                 new Metadata().put("name", "Klaus"),
-                                new Metadata().put("name", "Klaus").put("age", 42)
-                        )
-                ))
-
+                                new Metadata().put("name", "Klaus").put("age", 42))))
 
                 // === NotEqual ===
 
@@ -1364,13 +1215,10 @@ class SqlFilterParserTest {
                                 new Metadata().put("key", "b"),
                                 new Metadata().put("key", "aa"),
                                 new Metadata().put("key", "a a"),
-                                new Metadata().put("key2", "a")
-                        ),
+                                new Metadata().put("key2", "a")),
                         asList(
                                 new Metadata().put("key", "a"),
-                                new Metadata().put("key", "a").put("key2", "b")
-                        )
-                ))
+                                new Metadata().put("key", "a").put("key2", "b"))))
                 .add(Arguments.of(
                         "key != 1",
                         asList(
@@ -1378,13 +1226,10 @@ class SqlFilterParserTest {
                                 new Metadata().put("key", 0),
                                 new Metadata().put("key", 2),
                                 new Metadata().put("key", 10),
-                                new Metadata().put("key2", 1)
-                        ),
+                                new Metadata().put("key2", 1)),
                         asList(
                                 new Metadata().put("key", 1),
-                                new Metadata().put("key", 1).put("key2", 2)
-                        )
-                ))
+                                new Metadata().put("key", 1).put("key2", 2))))
                 .add(Arguments.of(
                         "key != 1",
                         asList(
@@ -1392,13 +1237,10 @@ class SqlFilterParserTest {
                                 new Metadata().put("key", 0L),
                                 new Metadata().put("key", 2L),
                                 new Metadata().put("key", 10L),
-                                new Metadata().put("key2", 1L)
-                        ),
+                                new Metadata().put("key2", 1L)),
                         asList(
                                 new Metadata().put("key", 1L),
-                                new Metadata().put("key", 1L).put("key2", 2L)
-                        )
-                ))
+                                new Metadata().put("key", 1L).put("key2", 2L))))
                 .add(Arguments.of(
                         "key != 1.1",
                         asList(
@@ -1406,13 +1248,10 @@ class SqlFilterParserTest {
                                 new Metadata().put("key", 0.0f),
                                 new Metadata().put("key", 1.11f),
                                 new Metadata().put("key", 2.2f),
-                                new Metadata().put("key2", 1.1f)
-                        ),
+                                new Metadata().put("key2", 1.1f)),
                         asList(
                                 new Metadata().put("key", 1.1f),
-                                new Metadata().put("key", 1.1f).put("key2", 2.2f)
-                        )
-                ))
+                                new Metadata().put("key", 1.1f).put("key2", 2.2f))))
                 .add(Arguments.of(
                         "key != 1.1",
                         asList(
@@ -1420,14 +1259,10 @@ class SqlFilterParserTest {
                                 new Metadata().put("key", 0.0),
                                 new Metadata().put("key", 1.11),
                                 new Metadata().put("key", 2.2),
-                                new Metadata().put("key2", 1.1)
-                        ),
+                                new Metadata().put("key2", 1.1)),
                         asList(
                                 new Metadata().put("key", 1.1),
-                                new Metadata().put("key", 1.1).put("key2", 2.2)
-                        )
-                ))
-
+                                new Metadata().put("key", 1.1).put("key2", 2.2))))
 
                 // === NotIn ===
 
@@ -1437,132 +1272,85 @@ class SqlFilterParserTest {
                         asList(
                                 new Metadata().put("name", "Klaus Heisler"),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name2", "Klaus")
-                        ),
+                                new Metadata().put("name2", "Klaus")),
                         asList(
                                 new Metadata().put("name", "Klaus"),
-                                new Metadata().put("name", "Klaus").put("age", 42)
-                        )
-                ))
+                                new Metadata().put("name", "Klaus").put("age", 42))))
                 .add(Arguments.of(
                         "name NOT IN ('Klaus', 'Alice')",
                         asList(
                                 new Metadata().put("name", "Klaus Heisler"),
                                 new Metadata().put("name", "Zoe"),
-                                new Metadata().put("name2", "Klaus")
-                        ),
+                                new Metadata().put("name2", "Klaus")),
                         asList(
                                 new Metadata().put("name", "Klaus"),
                                 new Metadata().put("name", "Klaus").put("age", 42),
                                 new Metadata().put("name", "Alice"),
-                                new Metadata().put("name", "Alice").put("age", 42)
-                        )
-                ))
+                                new Metadata().put("name", "Alice").put("age", 42))))
 
                 // NotIn: int
                 .add(Arguments.of(
                         "age NOT IN (42)",
-                        asList(
-                                new Metadata().put("age", 666),
-                                new Metadata().put("age2", 42)
-                        ),
+                        asList(new Metadata().put("age", 666), new Metadata().put("age2", 42)),
                         asList(
                                 new Metadata().put("age", 42),
-                                new Metadata().put("age", 42).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 42).put("name", "Klaus"))))
                 .add(Arguments.of(
                         "age NOT IN (42, 18)",
-                        asList(
-                                new Metadata().put("age", 666),
-                                new Metadata().put("age2", 42)
-                        ),
+                        asList(new Metadata().put("age", 666), new Metadata().put("age2", 42)),
                         asList(
                                 new Metadata().put("age", 42),
                                 new Metadata().put("age", 18),
                                 new Metadata().put("age", 42).put("name", "Klaus"),
-                                new Metadata().put("age", 18).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 18).put("name", "Klaus"))))
 
                 // NotIn: long
                 .add(Arguments.of(
                         "age NOT IN (42)",
-                        asList(
-                                new Metadata().put("age", 666L),
-                                new Metadata().put("age2", 42L)
-                        ),
+                        asList(new Metadata().put("age", 666L), new Metadata().put("age2", 42L)),
                         asList(
                                 new Metadata().put("age", 42L),
-                                new Metadata().put("age", 42L).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 42L).put("name", "Klaus"))))
                 .add(Arguments.of(
                         "age NOT IN (42, 18)",
-                        asList(
-                                new Metadata().put("age", 666L),
-                                new Metadata().put("age2", 42L)
-                        ),
+                        asList(new Metadata().put("age", 666L), new Metadata().put("age2", 42L)),
                         asList(
                                 new Metadata().put("age", 42L),
                                 new Metadata().put("age", 18L),
                                 new Metadata().put("age", 42L).put("name", "Klaus"),
-                                new Metadata().put("age", 18L).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 18L).put("name", "Klaus"))))
 
                 // NotIn: float
                 .add(Arguments.of(
                         "age NOT IN (42.0)",
-                        asList(
-                                new Metadata().put("age", 666.0f),
-                                new Metadata().put("age2", 42.0f)
-                        ),
+                        asList(new Metadata().put("age", 666.0f), new Metadata().put("age2", 42.0f)),
                         asList(
                                 new Metadata().put("age", 42.0f),
-                                new Metadata().put("age", 42.0f).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 42.0f).put("name", "Klaus"))))
                 .add(Arguments.of(
                         "age NOT IN (42.0, 18.0)",
-                        asList(
-                                new Metadata().put("age", 666.0f),
-                                new Metadata().put("age2", 42.0f)
-                        ),
+                        asList(new Metadata().put("age", 666.0f), new Metadata().put("age2", 42.0f)),
                         asList(
                                 new Metadata().put("age", 42.0f),
                                 new Metadata().put("age", 18.0f),
                                 new Metadata().put("age", 42.0f).put("name", "Klaus"),
-                                new Metadata().put("age", 18.0f).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 18.0f).put("name", "Klaus"))))
 
                 // NotIn: double
                 .add(Arguments.of(
                         "age NOT IN (42.0)",
-                        asList(
-                                new Metadata().put("age", 666.0d),
-                                new Metadata().put("age2", 42.0d)
-                        ),
+                        asList(new Metadata().put("age", 666.0d), new Metadata().put("age2", 42.0d)),
                         asList(
                                 new Metadata().put("age", 42.0d),
-                                new Metadata().put("age", 42.0d).put("name", "Klaus")
-                        )
-                ))
+                                new Metadata().put("age", 42.0d).put("name", "Klaus"))))
                 .add(Arguments.of(
                         "age NOT IN (42.0, 18.0)",
-                        asList(
-                                new Metadata().put("age", 666.0d),
-                                new Metadata().put("age2", 42.0d)
-                        ),
+                        asList(new Metadata().put("age", 666.0d), new Metadata().put("age2", 42.0d)),
                         asList(
                                 new Metadata().put("age", 42.0d),
                                 new Metadata().put("age", 18.0d),
                                 new Metadata().put("age", 42.0d).put("name", "Klaus"),
-                                new Metadata().put("age", 18.0d).put("name", "Klaus")
-                        )
-                ))
-
+                                new Metadata().put("age", 18.0d).put("name", "Klaus"))))
                 .build();
     }
 
@@ -1686,7 +1474,10 @@ class SqlFilterParserTest {
         Filter filter = parser.parse(sql);
 
         // then
-        assertThat(filter).isEqualTo(metadataKey("year").isGreaterThanOrEqualTo(1990L).and(metadataKey("year").isLessThanOrEqualTo(1999L)));
+        assertThat(filter)
+                .isEqualTo(metadataKey("year")
+                        .isGreaterThanOrEqualTo(1990L)
+                        .and(metadataKey("year").isLessThanOrEqualTo(1999L)));
     }
 
     @Test
@@ -1696,9 +1487,11 @@ class SqlFilterParserTest {
 
         // when
         Filter filter = parser.parse(sql);
-        
-        // then
-        assertThat(filter).isEqualTo(metadataKey("year").isEqualTo(2024L).and(metadataKey("genre").isIn("comedy", "drama")));
-    }
 
+        // then
+        assertThat(filter)
+                .isEqualTo(metadataKey("year")
+                        .isEqualTo(2024L)
+                        .and(metadataKey("genre").isIn("comedy", "drama")));
+    }
 }


### PR DESCRIPTION
## Issue

Fixes #3667

## Change

This PR fixes a `ClassCastException` that occurs when parsing SQL queries containing function expressions like `YEAR(column)` in WHERE clauses.

**Problem:**
When parsing expressions like `YEAR(year) = 2024`, the code was attempting to cast a `Function` expression directly to a `Column`, causing a `ClassCastException`.

**Solution:**
- Added a new `getKey(Expression expression)` method overload that handles both `Column` and `Function` types
- For `Function` expressions (e.g., `YEAR(year)`), the method extracts the column name from the function's parameter
- Currently supports `YEAR()` and `MONTH()` functions with column parameters
- Added unit test `should_support_YEAR_function_in_WHERE_clause()` to verify the fix

## Note

This PR includes two commits:
1. Bug fix: Fix ClassCastException for Function expressions
2. Style: Apply spotless formatting (auto-fixed by `spotless:apply`)

The formatting changes were necessary to pass the project's code style checks and do not affect any logic.