### PR TITLE
Fill name support in PromptTemplate

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/model/input/PromptTemplate.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/input/PromptTemplate.java
@@ -69,7 +69,7 @@ public class PromptTemplate {
      * @param clock    the clock to use for the special variables.
      */
     public PromptTemplate(String template, Clock clock) {
-    	this(template, null, clock);
+        this(template, null, clock);
     }
 
     /**
@@ -82,9 +82,9 @@ public class PromptTemplate {
     public PromptTemplate(String template, String name, Clock clock) {
         this.templateString = ensureNotBlank(template, "template");
         if (name == null) {
-          this.template = FACTORY.create(() -> template);
+            this.template = FACTORY.create(() -> template);
         } else {
-        	this.template = FACTORY.create(new PromptTemplateFactory.Input() {
+            this.template = FACTORY.create(new PromptTemplateFactory.Input() {
 
                 @Override
                 public String getTemplate() {
@@ -149,7 +149,7 @@ public class PromptTemplate {
      * @return the PromptTemplate.
      */
     public static PromptTemplate from(String template) {
-        return from(template, null);
+        return from(template, null, null);
     }
 
     /**
@@ -160,6 +160,29 @@ public class PromptTemplate {
      * @return the PromptTemplate.
      */
     public static PromptTemplate from(String template, String name) {
-        return new PromptTemplate(template, name);
+        return from(template, name, null);
+    }
+
+    /**
+     * Create a new PromptTemplate.
+     *
+     * @param template the template string of the prompt.
+     * @param clock    the clock to use for the special variables.
+     * @return the PromptTemplate.
+     */
+    public static PromptTemplate from(String template, Clock clock) {
+        return from(template, null, clock);
+    }
+
+    /**
+     * Create a new PromptTemplate.
+     *
+     * @param template the template string of the prompt.
+     * @param name the template name of the prompt.
+     * @param clock    the clock to use for the special variables.
+     * @return the PromptTemplate.
+     */
+    public static PromptTemplate from(String template, String name, Clock clock) {
+        return new PromptTemplate(template, name, clock != null ? clock : Clock.systemDefaultZone());
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/input/PromptTemplate.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/input/PromptTemplate.java
@@ -47,7 +47,19 @@ public class PromptTemplate {
      * @param template the template string of the prompt.
      */
     public PromptTemplate(String template) {
-        this(template, Clock.systemDefaultZone());
+        this(template, (String) null);
+    }
+
+    /**
+     * Create a new PromptTemplate.
+     *
+     * <p>The {@code Clock} will be the system clock.</p>
+     *
+     * @param template the template string of the prompt.
+     * @param name the template name of the prompt.
+     */
+    public PromptTemplate(String template, String name) {
+        this(template, name, Clock.systemDefaultZone());
     }
 
     /**
@@ -56,9 +68,35 @@ public class PromptTemplate {
      * @param template the template string of the prompt.
      * @param clock    the clock to use for the special variables.
      */
-    PromptTemplate(String template, Clock clock) {
+    public PromptTemplate(String template, Clock clock) {
+    	this(template, null, clock);
+    }
+
+    /**
+     * Create a new PromptTemplate.
+     *
+     * @param template the template string of the prompt.
+     * @param name the template name of the prompt.
+     * @param clock    the clock to use for the special variables.
+     */
+    public PromptTemplate(String template, String name, Clock clock) {
         this.templateString = ensureNotBlank(template, "template");
-        this.template = FACTORY.create(() -> template);
+        if (name == null) {
+          this.template = FACTORY.create(() -> template);
+        } else {
+        	this.template = FACTORY.create(new PromptTemplateFactory.Input() {
+
+                @Override
+                public String getTemplate() {
+                    return template;
+                }
+
+                @Override
+                public String getName() {
+                    return name;
+                }
+            });
+        }
         this.clock = ensureNotNull(clock, "clock");
     }
 
@@ -111,6 +149,17 @@ public class PromptTemplate {
      * @return the PromptTemplate.
      */
     public static PromptTemplate from(String template) {
-        return new PromptTemplate(template);
+        return from(template, null);
+    }
+
+    /**
+     * Create a new PromptTemplate.
+     *
+     * @param template the template string of the prompt.
+     * @param name the template name of the prompt.
+     * @return the PromptTemplate.
+     */
+    public static PromptTemplate from(String template, String name) {
+        return new PromptTemplate(template, name);
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/input/PromptTemplateTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/input/PromptTemplateTest.java
@@ -1,8 +1,9 @@
 package dev.langchain4j.model.input;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -12,11 +13,9 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
-
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class PromptTemplateTest {
 
@@ -146,7 +145,7 @@ class PromptTemplateTest {
         // given
         Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
 
-        PromptTemplate promptTemplate = new PromptTemplate("My name is {{it}} and now is {{current_time}}", clock);
+        PromptTemplate promptTemplate = PromptTemplate.from("My name is {{it}} and now is {{current_time}}", clock);
 
         // when
         Prompt prompt = promptTemplate.apply("Klaus");
@@ -161,7 +160,8 @@ class PromptTemplateTest {
         // given
         Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
 
-        PromptTemplate promptTemplate = new PromptTemplate("My name is {{name}} and now is {{current_date_time}}", clock);
+        PromptTemplate promptTemplate =
+                PromptTemplate.from("My name is {{name}} and now is {{current_date_time}}", clock);
 
         Map<String, Object> variables = new HashMap<>();
         variables.put("name", "Klaus");
@@ -174,23 +174,24 @@ class PromptTemplateTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-            "$",
-            "$$",
-            "{",
-            "{{",
-            "}",
-            "}}",
-            "{}",
-            "{{}}",
-            "*",
-            "**",
-            "\\",
-            "\\\\",
-            "${}*\\",
-            "${ *hello* }",
-            "\\$\\{ \\*hello\\* \\}"
-    })
+    @ValueSource(
+            strings = {
+                "$",
+                "$$",
+                "{",
+                "{{",
+                "}",
+                "}}",
+                "{}",
+                "{{}}",
+                "*",
+                "**",
+                "\\",
+                "\\\\",
+                "${}*\\",
+                "${ *hello* }",
+                "\\$\\{ \\*hello\\* \\}"
+            })
     void should_support_special_characters(String s) {
 
         // given


### PR DESCRIPTION
`PromptTemplateFactory.Input` defines the template and the name.  `PromptTemplate`  creates input only with template and doesn't provide the capability to define a template name.

This PR provides the capability to set the template name with a new method 

`public static PromptTemplate from(String template, String name)`

In my case I need to fill this template name for Quarkus LangChain4J which defines promp template with Quarkus Qute syntax. I need this template name to provide the capability to debug (with IDE breakpoint) this Qute template.

## General checklist
 * [x]  There are no breaking changes (API, behaviour)
 * [ ]  I have added unit and/or integration tests for my change
 * [ ]  The tests cover both positive and negative cases
 * [ ]  I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
 * [ ]  I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
 * [ ]  I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)