### PR TITLE
fix(ai-service): append output format instructions to last TextContent #3581

### DIFF
--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithCustomContentInjectorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithCustomContentInjectorTest.java
@@ -1,0 +1,145 @@
+package dev.langchain4j.service;
+
+import static dev.langchain4j.service.AiServicesIT.verifyNoMoreInteractionsFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.rag.DefaultRetrievalAugmentor;
+import dev.langchain4j.rag.RetrievalAugmentor;
+import dev.langchain4j.rag.content.injector.ContentInjector;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AiServicesWithCustomContentInjectorTest {
+
+    @Spy
+    ChatModel chatModel = ChatModelMock.thatAlwaysResponds("{\"value\":\"test\"}");
+
+    @AfterEach
+    void afterEach() {
+        verifyNoMoreInteractionsFor(chatModel);
+    }
+
+    private static final Image image = Image.builder()
+            .url("https://en.wikipedia.org/wiki/Llama#/media/File:Llamas,_Vernagt-Stausee,_Italy.jpg")
+            .build();
+
+    private static final ImageContent imageContent = ImageContent.from(image);
+
+    static class MyStructuredOutput {
+
+        private String value;
+
+        MyStructuredOutput() {}
+
+        MyStructuredOutput(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    interface MyAiService {
+        MyStructuredOutput chat(@UserMessage String text);
+    }
+
+    @Test
+    void should_append_output_format_instructions_to_the_last_text_content() {
+        // given
+        ContentInjector customContentInjector = (contents, chatMessage) -> {
+            return dev.langchain4j.data.message.UserMessage.from(
+                    TextContent.from("First text"), imageContent, TextContent.from("Second text"));
+        };
+
+        ContentRetriever customContentRetriever = query -> Collections.emptyList();
+
+        RetrievalAugmentor retrievalAugmentor = DefaultRetrievalAugmentor.builder()
+                .contentRetriever(customContentRetriever)
+                .contentInjector(customContentInjector)
+                .build();
+
+        MyAiService myAiService = AiServices.builder(MyAiService.class)
+                .chatModel(chatModel)
+                .retrievalAugmentor(retrievalAugmentor)
+                .build();
+
+        // when
+        myAiService.chat("How many lamas are there in this image?");
+        ArgumentCaptor<ChatRequest> chatRequestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        verify(chatModel).chat(chatRequestCaptor.capture());
+
+        dev.langchain4j.data.message.UserMessage userMessage = (dev.langchain4j.data.message.UserMessage)
+                chatRequestCaptor.getValue().messages().get(0);
+
+        assertThat(userMessage.contents()).hasSize(3);
+        assertThat(userMessage.contents().get(0)).isInstanceOf(TextContent.class);
+        assertThat(userMessage.contents().get(1)).isInstanceOf(ImageContent.class);
+        assertThat(userMessage.contents().get(2)).isInstanceOf(TextContent.class);
+
+        TextContent text1 = (TextContent) userMessage.contents().get(0);
+        TextContent text2 = (TextContent) userMessage.contents().get(2);
+        assertThat(text1.text()).isEqualTo("First text");
+        assertThat(text2.text())
+                .contains("Second text")
+                .contains("You must answer strictly in the following JSON format");
+
+        verify(chatModel).supportedCapabilities();
+    }
+
+    @Test
+    void should_create_new_text_content_of_output_format_instructions_if_there_is_no_text_content() {
+        // given
+        ContentInjector customContentInjector = (contents, chatMessage) -> {
+            return dev.langchain4j.data.message.UserMessage.from(imageContent, imageContent);
+        };
+
+        ContentRetriever customContentRetriever = query -> Collections.emptyList();
+
+        RetrievalAugmentor retrievalAugmentor = DefaultRetrievalAugmentor.builder()
+                .contentRetriever(customContentRetriever)
+                .contentInjector(customContentInjector)
+                .build();
+
+        MyAiService myAiService = AiServices.builder(MyAiService.class)
+                .chatModel(chatModel)
+                .retrievalAugmentor(retrievalAugmentor)
+                .build();
+
+        // when
+        myAiService.chat("How many lamas are there in this image?");
+        ArgumentCaptor<ChatRequest> chatRequestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        verify(chatModel).chat(chatRequestCaptor.capture());
+
+        dev.langchain4j.data.message.UserMessage userMessage = (dev.langchain4j.data.message.UserMessage)
+                chatRequestCaptor.getValue().messages().get(0);
+
+        assertThat(userMessage.contents()).hasSize(3);
+        assertThat(userMessage.contents().get(0)).isInstanceOf(ImageContent.class);
+        assertThat(userMessage.contents().get(1)).isInstanceOf(ImageContent.class);
+        assertThat(userMessage.contents().get(2)).isInstanceOf(TextContent.class);
+
+        TextContent textContent = (TextContent) userMessage.contents().get(2);
+        assertThat(textContent.text()).contains("You must answer strictly in the following JSON format");
+
+        verify(chatModel).supportedCapabilities();
+    }
+}


### PR DESCRIPTION
## Description

Fixes #3581

This PR fixes an issue where `DefaultAiService` throws an exception when `UserMessage` contains multiple `TextContent` elements. The `appendOutputFormatInstructions` method was calling `userMessage.singleText()`, which fails when there are multiple text contents.

## Changes

- Modified `appendOutputFormatInstructions` in `DefaultAiServices` to iterate backwards through contents and find the last `TextContent` to append instructions
- If no `TextContent` exists, create a new one with the output format instructions
- Added unit tests in `AiServicesWithCustomContentInjectorTest` to verify the fix works with `CustomContentInjector` scenarios

## Testing

- Added two test cases:
  1. `should_append_output_format_instructions_to_the_last_text_content`: Verifies that instructions are appended to the last `TextContent` when multiple text contents exist
  2. `should_create_new_text_content_of_output_format_instructions_if_there_is_no_text_content`: Verifies that a new `TextContent` is created when no text content exists

All existing tests pass, and the new tests verify the fix works correctly.

## Related Issues

Closes #3581