### PR TITLE
feat: Support PDF input via URL for Anthropic Claude API

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -415,6 +415,34 @@ ChatModel model = AnthropicChatModel.builder()
         .build();
 ```
 
+## PDF Support
+
+Anthropic Claude supports processing PDF documents. You can send PDFs either via URL or base64-encoded data.
+
+### Sending PDF via URL
+```java
+UserMessage message = UserMessage.from(
+    PdfFileContent.from(URI.create("https://example.com/document.pdf")),
+    TextContent.from("What are the key findings in this document?")
+);
+
+ChatResponse response = model.chat(message);
+```
+
+### Sending PDF via Base64
+```java
+String base64Data = Base64.getEncoder().encodeToString(Files.readAllBytes(Path.of("document.pdf")));
+
+UserMessage message = UserMessage.from(
+    PdfFileContent.from(base64Data, "application/pdf"),
+    TextContent.from("Summarize this document.")
+);
+
+ChatResponse response = model.chat(message);
+```
+
+More info on PDF support can be found [here](https://docs.anthropic.com/en/docs/build-with-claude/pdf-support).
+
 ## Setting custom chat request parameters
 
 When building `AnthropicChatModel` and `AnthropicStreamingChatModel`,
@@ -510,3 +538,4 @@ langchain4j.anthropic.streaming-chat-model.api-key = ${ANTHROPIC_API_KEY}
 - [AnthropicChatModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/anthropic-examples/src/main/java/AnthropicChatModelTest.java)
 - [AnthropicStreamingChatModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/anthropic-examples/src/main/java/AnthropicStreamingChatModelTest.java)
 - [AnthropicToolsTest](https://github.com/langchain4j/langchain4j-examples/blob/main/anthropic-examples/src/main/java/AnthropicToolsTest.java)
+- [AnthropicPdfExample](https://github.com/langchain4j/langchain4j-examples/blob/main/anthropic-examples/src/main/java/AnthropicPdfExample.java)

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicPdfContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicPdfContent.java
@@ -15,6 +15,11 @@ public class AnthropicPdfContent extends AnthropicMessageContent {
 
     public AnthropicPdfContentSource source;
 
+    public AnthropicPdfContent(AnthropicPdfContentSource source) {
+        super("document");
+        this.source = source;
+    }
+
     public AnthropicPdfContent(String mediaType, String base64Data) {
         super("document");
         this.source = new AnthropicPdfContentSource("base64", mediaType, base64Data);
@@ -22,6 +27,14 @@ public class AnthropicPdfContent extends AnthropicMessageContent {
 
     public AnthropicPdfContent(String base64Data) {
         this("application/pdf", base64Data);
+    }
+
+    public static AnthropicPdfContent fromBase64(String mediaType, String data) {
+        return new AnthropicPdfContent(AnthropicPdfContentSource.fromBase64(mediaType, data));
+    }
+
+    public static AnthropicPdfContent fromUrl(String url) {
+        return new AnthropicPdfContent(AnthropicPdfContentSource.fromUrl(url));
     }
 
     @Override

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicPdfContentSource.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicPdfContentSource.java
@@ -1,11 +1,13 @@
 package dev.langchain4j.model.anthropic.internal.api;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static dev.langchain4j.internal.Utils.quoted;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import java.util.Objects;
 
 @JsonInclude(NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -15,10 +17,49 @@ public class AnthropicPdfContentSource {
     public String type;
     public String mediaType;
     public String data;
+    public String url;
 
-    public AnthropicPdfContentSource(String type, String mediaType, String data) {
+    public AnthropicPdfContentSource(String type, String mediaType, String data, String url) {
         this.type = type;
         this.mediaType = mediaType;
         this.data = data;
+        this.url = url;
+    }
+
+    public AnthropicPdfContentSource(String type, String mediaType, String data) {
+        this(type, mediaType, data, null);
+    }
+
+    public static AnthropicPdfContentSource fromBase64(String mediaType, String data) {
+        return new AnthropicPdfContentSource("base64", mediaType, data, null);
+    }
+
+    public static AnthropicPdfContentSource fromUrl(String url) {
+        return new AnthropicPdfContentSource("url", null, null, url);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AnthropicPdfContentSource that = (AnthropicPdfContentSource) o;
+        return Objects.equals(type, that.type)
+                && Objects.equals(mediaType, that.mediaType)
+                && Objects.equals(data, that.data)
+                && Objects.equals(url, that.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, mediaType, data, url);
+    }
+
+    @Override
+    public String toString() {
+        return "AnthropicPdfContentSource {" + " type = "
+                + quoted(type) + ", mediaType = "
+                + quoted(mediaType) + ", data = "
+                + quoted(data) + ", url = "
+                + quoted(url) + " }";
     }
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -127,7 +127,10 @@ public class AnthropicMapper {
                                 ensureNotBlank(image.base64Data(), "base64Data"));
                     } else if (content instanceof PdfFileContent pdfFileContent) {
                         PdfFile pdfFile = pdfFileContent.pdfFile();
-                        return new AnthropicPdfContent(
+                        if (pdfFile.url() != null) {
+                            return AnthropicPdfContent.fromUrl(pdfFile.url().toString());
+                        }
+                        return AnthropicPdfContent.fromBase64(
                                 pdfFile.mimeType(), ensureNotBlank(pdfFile.base64Data(), "base64Data"));
                     } else {
                         throw illegalArgument("Unknown content type: " + content);
@@ -358,9 +361,7 @@ public class AnthropicMapper {
     }
 
     public static List<AnthropicTool> toAnthropicTools(List<AnthropicServerTool> serverTools) {
-        return serverTools.stream()
-                .map(AnthropicMapper::toAnthropicTool)
-                .toList();
+        return serverTools.stream().map(AnthropicMapper::toAnthropicTool).toList();
     }
 
     public static AnthropicTool toAnthropicTool(AnthropicServerTool serverTool) {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -200,7 +199,25 @@ class AnthropicMapperTest {
                                 USER,
                                 asList(
                                         new AnthropicTextContent("Describe this image"),
-                                        AnthropicImageContent.fromUrl(DICE_IMAGE_URL))))));
+                                        AnthropicImageContent.fromUrl(DICE_IMAGE_URL))))),
+                Arguments.of(
+                        singletonList(
+                                UserMessage.from(PdfFileContent.from(URI.create("https://example.com/document.pdf")))),
+                        singletonList(new AnthropicMessage(
+                                USER, singletonList(AnthropicPdfContent.fromUrl("https://example.com/document.pdf"))))),
+                Arguments.of(
+                        singletonList(UserMessage.from(PdfFileContent.from("base64data", "application/pdf"))),
+                        singletonList(new AnthropicMessage(
+                                USER, singletonList(AnthropicPdfContent.fromBase64("application/pdf", "base64data"))))),
+                Arguments.of(
+                        singletonList(UserMessage.from(
+                                TextContent.from("Analyze this document"),
+                                PdfFileContent.from(URI.create("https://example.com/document.pdf")))),
+                        singletonList(new AnthropicMessage(
+                                USER,
+                                asList(
+                                        new AnthropicTextContent("Analyze this document"),
+                                        AnthropicPdfContent.fromUrl("https://example.com/document.pdf"))))));
     }
 
     @ParameterizedTest
@@ -249,7 +266,8 @@ class AnthropicMapperTest {
         assertThat(retainKeys(Map.of(), Set.of())).isEqualTo(Map.of());
         assertThat(retainKeys(Map.of("one", "one"), Set.of("one"))).isEqualTo(Map.of("one", "one"));
         assertThat(retainKeys(Map.of("one", "one"), Set.of("two"))).isEqualTo(Map.of());
-        assertThat(retainKeys(Map.of("one", "one", "two", "two"), Set.of("one"))).isEqualTo(Map.of("one", "one"));
+        assertThat(retainKeys(Map.of("one", "one", "two", "two"), Set.of("one")))
+                .isEqualTo(Map.of("one", "one"));
     }
 
     @SafeVarargs

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/internal/api/AnthropicPdfContentSourceTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/internal/api/AnthropicPdfContentSourceTest.java
@@ -1,0 +1,103 @@
+package dev.langchain4j.model.anthropic.internal.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AnthropicPdfContentSourceTest {
+
+    @Test
+    void should_create_from_base64() {
+        AnthropicPdfContentSource source = AnthropicPdfContentSource.fromBase64("application/pdf", "base64data");
+
+        assertThat(source.type).isEqualTo("base64");
+        assertThat(source.mediaType).isEqualTo("application/pdf");
+        assertThat(source.data).isEqualTo("base64data");
+        assertThat(source.url).isNull();
+    }
+
+    @Test
+    void should_create_from_url() {
+        AnthropicPdfContentSource source = AnthropicPdfContentSource.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(source.type).isEqualTo("url");
+        assertThat(source.mediaType).isNull();
+        assertThat(source.data).isNull();
+        assertThat(source.url).isEqualTo("https://example.com/doc.pdf");
+    }
+
+    @Test
+    void should_create_with_three_parameter_constructor() {
+        AnthropicPdfContentSource source = new AnthropicPdfContentSource("base64", "application/pdf", "data");
+
+        assertThat(source.type).isEqualTo("base64");
+        assertThat(source.mediaType).isEqualTo("application/pdf");
+        assertThat(source.data).isEqualTo("data");
+        assertThat(source.url).isNull();
+    }
+
+    @Test
+    void should_have_correct_equals_for_url_sources() {
+        AnthropicPdfContentSource source1 = AnthropicPdfContentSource.fromUrl("https://example.com/doc.pdf");
+        AnthropicPdfContentSource source2 = AnthropicPdfContentSource.fromUrl("https://example.com/doc.pdf");
+        AnthropicPdfContentSource source3 = AnthropicPdfContentSource.fromUrl("https://example.com/other.pdf");
+
+        assertThat(source1).isEqualTo(source2);
+        assertThat(source1).isNotEqualTo(source3);
+    }
+
+    @Test
+    void should_have_correct_equals_for_base64_sources() {
+        AnthropicPdfContentSource source1 = AnthropicPdfContentSource.fromBase64("application/pdf", "data");
+        AnthropicPdfContentSource source2 = AnthropicPdfContentSource.fromBase64("application/pdf", "data");
+        AnthropicPdfContentSource source3 = AnthropicPdfContentSource.fromBase64("application/pdf", "other");
+
+        assertThat(source1).isEqualTo(source2);
+        assertThat(source1).isNotEqualTo(source3);
+    }
+
+    @Test
+    void should_have_correct_equals_for_different_types() {
+        AnthropicPdfContentSource urlSource = AnthropicPdfContentSource.fromUrl("https://example.com/doc.pdf");
+        AnthropicPdfContentSource base64Source = AnthropicPdfContentSource.fromBase64("application/pdf", "data");
+
+        assertThat(urlSource).isNotEqualTo(base64Source);
+    }
+
+    @Test
+    void should_have_correct_hashCode() {
+        AnthropicPdfContentSource source1 = AnthropicPdfContentSource.fromUrl("https://example.com/doc.pdf");
+        AnthropicPdfContentSource source2 = AnthropicPdfContentSource.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(source1.hashCode()).isEqualTo(source2.hashCode());
+    }
+
+    @Test
+    void should_have_toString() {
+        AnthropicPdfContentSource source = AnthropicPdfContentSource.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(source.toString()).contains("url");
+        assertThat(source.toString()).contains("https://example.com/doc.pdf");
+    }
+
+    @Test
+    void should_not_equal_null() {
+        AnthropicPdfContentSource source = AnthropicPdfContentSource.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(source).isNotEqualTo(null);
+    }
+
+    @Test
+    void should_not_equal_different_class() {
+        AnthropicPdfContentSource source = AnthropicPdfContentSource.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(source).isNotEqualTo("not a source");
+    }
+
+    @Test
+    void should_equal_itself() {
+        AnthropicPdfContentSource source = AnthropicPdfContentSource.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(source).isEqualTo(source);
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/internal/api/AnthropicPdfContentTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/internal/api/AnthropicPdfContentTest.java
@@ -1,0 +1,124 @@
+package dev.langchain4j.model.anthropic.internal.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AnthropicPdfContentTest {
+
+    @Test
+    void should_create_from_base64() {
+        AnthropicPdfContent content = AnthropicPdfContent.fromBase64("application/pdf", "base64data");
+
+        assertThat(content.type).isEqualTo("document");
+        assertThat(content.source.type).isEqualTo("base64");
+        assertThat(content.source.mediaType).isEqualTo("application/pdf");
+        assertThat(content.source.data).isEqualTo("base64data");
+        assertThat(content.source.url).isNull();
+    }
+
+    @Test
+    void should_create_from_url() {
+        AnthropicPdfContent content = AnthropicPdfContent.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(content.type).isEqualTo("document");
+        assertThat(content.source.type).isEqualTo("url");
+        assertThat(content.source.url).isEqualTo("https://example.com/doc.pdf");
+        assertThat(content.source.mediaType).isNull();
+        assertThat(content.source.data).isNull();
+    }
+
+    @Test
+    void should_create_with_source_constructor() {
+        AnthropicPdfContentSource source = AnthropicPdfContentSource.fromUrl("https://example.com/doc.pdf");
+
+        AnthropicPdfContent content = new AnthropicPdfContent(source);
+
+        assertThat(content.type).isEqualTo("document");
+        assertThat(content.source).isEqualTo(source);
+    }
+
+    @Test
+    void should_maintain_backward_compatibility_with_two_parameter_constructor() {
+        AnthropicPdfContent content = new AnthropicPdfContent("application/pdf", "base64data");
+
+        assertThat(content.type).isEqualTo("document");
+        assertThat(content.source.type).isEqualTo("base64");
+        assertThat(content.source.mediaType).isEqualTo("application/pdf");
+        assertThat(content.source.data).isEqualTo("base64data");
+    }
+
+    @Test
+    void should_maintain_backward_compatibility_with_single_parameter_constructor() {
+        AnthropicPdfContent content = new AnthropicPdfContent("base64data");
+
+        assertThat(content.type).isEqualTo("document");
+        assertThat(content.source.type).isEqualTo("base64");
+        assertThat(content.source.mediaType).isEqualTo("application/pdf");
+        assertThat(content.source.data).isEqualTo("base64data");
+    }
+
+    @Test
+    void should_have_correct_equals_for_url_content() {
+        AnthropicPdfContent content1 = AnthropicPdfContent.fromUrl("https://example.com/doc.pdf");
+        AnthropicPdfContent content2 = AnthropicPdfContent.fromUrl("https://example.com/doc.pdf");
+        AnthropicPdfContent content3 = AnthropicPdfContent.fromUrl("https://example.com/other.pdf");
+
+        assertThat(content1).isEqualTo(content2);
+        assertThat(content1).isNotEqualTo(content3);
+    }
+
+    @Test
+    void should_have_correct_equals_for_base64_content() {
+        AnthropicPdfContent content1 = AnthropicPdfContent.fromBase64("application/pdf", "data");
+        AnthropicPdfContent content2 = AnthropicPdfContent.fromBase64("application/pdf", "data");
+        AnthropicPdfContent content3 = AnthropicPdfContent.fromBase64("application/pdf", "other");
+
+        assertThat(content1).isEqualTo(content2);
+        assertThat(content1).isNotEqualTo(content3);
+    }
+
+    @Test
+    void should_have_correct_equals_for_different_types() {
+        AnthropicPdfContent urlContent = AnthropicPdfContent.fromUrl("https://example.com/doc.pdf");
+        AnthropicPdfContent base64Content = AnthropicPdfContent.fromBase64("application/pdf", "data");
+
+        assertThat(urlContent).isNotEqualTo(base64Content);
+    }
+
+    @Test
+    void should_have_correct_hashCode() {
+        AnthropicPdfContent content1 = AnthropicPdfContent.fromUrl("https://example.com/doc.pdf");
+        AnthropicPdfContent content2 = AnthropicPdfContent.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(content1.hashCode()).isEqualTo(content2.hashCode());
+    }
+
+    @Test
+    void should_have_toString() {
+        AnthropicPdfContent content = AnthropicPdfContent.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(content.toString()).contains("source");
+    }
+
+    @Test
+    void should_not_equal_null() {
+        AnthropicPdfContent content = AnthropicPdfContent.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(content).isNotEqualTo(null);
+    }
+
+    @Test
+    void should_not_equal_different_class() {
+        AnthropicPdfContent content = AnthropicPdfContent.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(content).isNotEqualTo("not a content");
+    }
+
+    @Test
+    void should_equal_itself() {
+        AnthropicPdfContent content = AnthropicPdfContent.fromUrl("https://example.com/doc.pdf");
+
+        assertThat(content).isEqualTo(content);
+    }
+}


### PR DESCRIPTION
## Issue

Closes #2600 (partially - extends PDF support with URL capability)

## Change

Add support for sending PDFs via URL to the Anthropic API, in addition to the existing base64 support.

This enhancement aligns with [Anthropic's PDF Support API](https://docs.anthropic.com/en/docs/build-with-claude/pdf-support) that accepts PDFs through URL sources:

```json
{
  "type": "document",
  "source": {
    "type": "url",
    "url": "https://example.com/document.pdf"
  }
}
```

### Changes

- **AnthropicPdfContentSource**: Added `url` field and factory methods `fromUrl()` and `fromBase64()`
- **AnthropicPdfContent**: Added factory methods `fromUrl()` and `fromBase64()`
- **AnthropicMapper**: Updated to check for URL before falling back to base64

### Usage

```java
// URL-based PDF (NEW)
UserMessage.from(PdfFileContent.from(URI.create("https://example.com/doc.pdf")))

// Base64 PDF (existing - unchanged)
UserMessage.from(PdfFileContent.from(base64Data, "application/pdf"))
```

### Integration Test Evidence

**Test:** `should_accept_pdf_from_url`

![Test Evidence 1](https://github.com/user-attachments/assets/f2a27dbf-b534-41e4-a664-2f7dbb2ed2bc)

![Test Evidence 2](https://github.com/user-attachments/assets/e1915374-baff-48ab-9a5e-8995b0564eaa)

| Validation | Status |
|------------|--------|
| PDF URL correctly mapped to Anthropic API format | ✅ |
| Request sent with `"type": "url"` source | ✅ |
| Claude API responded with accurate document analysis | ✅ |

> ⚠️ **Note:** Integration tests with Google Cloud credentials are expected to fail for fork PRs due to GitHub's security restrictions on secrets.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [x] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module

N/A

## Checklist for adding new embedding store integration

N/A

## Checklist for changing existing embedding store integration

N/A
