### PR TITLE
Anthropic: return raw HTTP response and SSE events

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatResponseMetadata.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatResponseMetadata.java
@@ -1,0 +1,96 @@
+package dev.langchain4j.model.anthropic;
+
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+
+import java.util.List;
+import java.util.Objects;
+
+import static dev.langchain4j.internal.Utils.copy;
+
+/**
+ * @since 1.10.0
+ */
+public class AnthropicChatResponseMetadata extends ChatResponseMetadata {
+
+    private final SuccessfulHttpResponse rawHttpResponse;
+    private final List<ServerSentEvent> rawServerSentEvents;
+
+    private AnthropicChatResponseMetadata(Builder builder) {
+        super(builder);
+        this.rawHttpResponse = builder.rawHttpResponse;
+        this.rawServerSentEvents = copy(builder.rawServerSentEvents);
+    }
+
+    @Override
+    public AnthropicTokenUsage tokenUsage() {
+        return (AnthropicTokenUsage) super.tokenUsage();
+    }
+
+    public SuccessfulHttpResponse rawHttpResponse() {
+        return rawHttpResponse;
+    }
+
+    public List<ServerSentEvent> rawServerSentEvents() {
+        return rawServerSentEvents;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return ((Builder) super.toBuilder(builder()))
+                .rawHttpResponse(rawHttpResponse)
+                .rawServerSentEvents(rawServerSentEvents);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        AnthropicChatResponseMetadata that = (AnthropicChatResponseMetadata) o;
+        return Objects.equals(rawHttpResponse, that.rawHttpResponse)
+                && Objects.equals(rawServerSentEvents, that.rawServerSentEvents);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), rawHttpResponse, rawServerSentEvents);
+    }
+
+    @Override
+    public String toString() {
+        return "AnthropicChatResponseMetadata{" + "id='"
+                + id() + '\'' + ", modelName='"
+                + modelName() + '\'' + ", tokenUsage="
+                + tokenUsage() + ", finishReason="
+                + finishReason() + ", created="
+                + rawHttpResponse + ", rawServerSentEvents="
+                + rawServerSentEvents + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends ChatResponseMetadata.Builder<Builder> {
+
+        private SuccessfulHttpResponse rawHttpResponse;
+        private List<ServerSentEvent> rawServerSentEvents;
+
+        public Builder rawHttpResponse(SuccessfulHttpResponse rawHttpResponse) {
+            this.rawHttpResponse = rawHttpResponse;
+            return this;
+        }
+
+        public Builder rawServerSentEvents(List<ServerSentEvent> rawServerSentEvents) {
+            this.rawServerSentEvents = rawServerSentEvents;
+            return this;
+        }
+
+        @Override
+        public AnthropicChatResponseMetadata build() {
+            return new AnthropicChatResponseMetadata(this);
+        }
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/AnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/AnthropicClient.java
@@ -17,6 +17,11 @@ public abstract class AnthropicClient {
 
     public abstract AnthropicCreateMessageResponse createMessage(AnthropicCreateMessageRequest request);
 
+    public ParsedAndRawResponse createMessageWithRawResponse(AnthropicCreateMessageRequest request) {
+        AnthropicCreateMessageResponse parsedResponse = createMessage(request);
+        return new ParsedAndRawResponse(parsedResponse, null);
+    }
+
     /**
      * @since 1.2.0
      */

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.anthropic.internal.client;
 
 import dev.langchain4j.Internal;
 import dev.langchain4j.http.client.sse.ServerSentEventContext;
+import dev.langchain4j.model.anthropic.AnthropicChatResponseMetadata;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCountTokensRequest;
 import dev.langchain4j.http.client.sse.CancellationUnsupportedHandle;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
@@ -37,6 +38,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -108,9 +111,15 @@ public class DefaultAnthropicClient extends AnthropicClient {
 
     @Override
     public AnthropicCreateMessageResponse createMessage(AnthropicCreateMessageRequest request) {
+        return createMessageWithRawResponse(request).parsedResponse();
+    }
+
+    @Override
+    public ParsedAndRawResponse createMessageWithRawResponse(AnthropicCreateMessageRequest request) {
         HttpRequest httpRequest = toHttpRequest(toJson(request), "messages");
-        SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
-        return fromJson(successfulHttpResponse.body(), AnthropicCreateMessageResponse.class);
+        SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
+        AnthropicCreateMessageResponse parsedResponse = fromJson(rawResponse.body(), AnthropicCreateMessageResponse.class);
+        return new ParsedAndRawResponse(parsedResponse, rawResponse);
     }
 
     @Override
@@ -144,6 +153,14 @@ public class DefaultAnthropicClient extends AnthropicClient {
             volatile String stopReason;
             volatile StreamingHandle streamingHandle;
 
+            final AtomicReference<SuccessfulHttpResponse> rawHttpResponse = new AtomicReference<>();
+            final Queue<ServerSentEvent> rawServerSentEvents = new ConcurrentLinkedQueue<>();
+
+            @Override
+            public void onOpen(SuccessfulHttpResponse response) {
+                rawHttpResponse.set(response);
+            }
+
             @Override
             public void onEvent(ServerSentEvent event) {
                 onEvent(event, new ServerSentEventContext(new CancellationUnsupportedHandle()));
@@ -172,6 +189,8 @@ public class DefaultAnthropicClient extends AnthropicClient {
                 } else if ("error".equals(event.event())) {
                     handleError(event.data());
                 }
+
+                rawServerSentEvents.add(event);
             }
 
             private void handleMessageStart(AnthropicStreamingData data) {
@@ -373,7 +392,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
             }
 
             private ChatResponseMetadata createMetadata(AnthropicTokenUsage tokenUsage, FinishReason finishReason) {
-                var metadataBuilder = ChatResponseMetadata.builder();
+                var metadataBuilder = AnthropicChatResponseMetadata.builder();
                 if (responseId.get() != null) {
                     metadataBuilder.id(responseId.get());
                 }
@@ -385,6 +404,12 @@ public class DefaultAnthropicClient extends AnthropicClient {
                 }
                 if (finishReason != null) {
                     metadataBuilder.finishReason(finishReason);
+                }
+                if (rawHttpResponse.get() != null) {
+                    metadataBuilder.rawHttpResponse(rawHttpResponse.get());
+                }
+                if (!rawServerSentEvents.isEmpty()) {
+                    metadataBuilder.rawServerSentEvents(new ArrayList<>(rawServerSentEvents));
                 }
                 return metadataBuilder.build();
             }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/ParsedAndRawResponse.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/ParsedAndRawResponse.java
@@ -1,0 +1,28 @@
+package dev.langchain4j.model.anthropic.internal.client;
+
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageResponse;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+/**
+ * @since 1.10.0
+ */
+public class ParsedAndRawResponse {
+
+    private final AnthropicCreateMessageResponse parsedResponse;
+    private final SuccessfulHttpResponse rawResponse;
+
+    public ParsedAndRawResponse(AnthropicCreateMessageResponse parsedResponse, SuccessfulHttpResponse rawResponse) {
+        this.parsedResponse = ensureNotNull(parsedResponse, "parsedResponse");
+        this.rawResponse = rawResponse;
+    }
+
+    public AnthropicCreateMessageResponse parsedResponse() {
+        return parsedResponse;
+    }
+
+    public SuccessfulHttpResponse rawResponse() {
+        return rawResponse;
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelIT.java
@@ -544,7 +544,7 @@ class AnthropicChatModelIT {
     }
 
     @Test
-    void should_send_custom_parameters() {
+    void should_set_custom_parameters_and_get_raw_response() {
 
         // given
         record Edit(String type) {}
@@ -574,6 +574,11 @@ class AnthropicChatModelIT {
         assertThat(chatResponse.aiMessage().text()).contains("Berlin");
 
         assertThat(spyingHttpClient.request().body()).contains("context_management");
+
+        AnthropicChatResponseMetadata metadata = (AnthropicChatResponseMetadata) chatResponse.metadata();
+        assertThat(metadata.rawHttpResponse().headers()).containsKey("anthropic-organization-id");
+        assertThat(metadata.rawHttpResponse().body()).contains("Berlin");
+        assertThat(metadata.rawServerSentEvents()).isEmpty();
     }
 
     @Test

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelIT.java
@@ -238,7 +238,7 @@ class AnthropicStreamingChatModelIT {
     }
 
     @Test
-    void should_send_custom_parameters() {
+    void should_set_custom_parameters_and_get_raw_response() {
 
         // given
         Map<String, Object> customParameters = Map.of("context_management", Map.of("edits", List.of(Map.of("type", "clear_tool_uses_20250919"))));
@@ -268,5 +268,10 @@ class AnthropicStreamingChatModelIT {
         assertThat(chatResponse.aiMessage().text()).contains("Berlin");
 
         assertThat(spyingHttpClient.request().body().contains("context_management"));
+
+        AnthropicChatResponseMetadata metadata = (AnthropicChatResponseMetadata) chatResponse.metadata();
+        assertThat(metadata.rawHttpResponse().headers()).containsKey("anthropic-organization-id");
+        assertThat(metadata.rawHttpResponse().body()).isNull();
+        assertThat(metadata.rawServerSentEvents()).isNotEmpty();
     }
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicUserIdIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicUserIdIT.java
@@ -6,12 +6,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageResponse;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicUsage;
 import dev.langchain4j.model.anthropic.internal.client.AnthropicClient;
 import dev.langchain4j.model.anthropic.internal.client.AnthropicCreateMessageOptions;
+import dev.langchain4j.model.anthropic.internal.client.ParsedAndRawResponse;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
@@ -36,7 +38,7 @@ class AnthropicUserIdIT {
         // then
         ArgumentCaptor<AnthropicCreateMessageRequest> requestCaptor =
                 ArgumentCaptor.forClass(AnthropicCreateMessageRequest.class);
-        verify(mockClient).createMessage(requestCaptor.capture());
+        verify(mockClient).createMessageWithRawResponse(requestCaptor.capture());
 
         AnthropicCreateMessageRequest capturedRequest = requestCaptor.getValue();
         assertThat(capturedRequest.getMetadata()).isNotNull();
@@ -78,7 +80,7 @@ class AnthropicUserIdIT {
         // then
         ArgumentCaptor<AnthropicCreateMessageRequest> requestCaptor =
                 ArgumentCaptor.forClass(AnthropicCreateMessageRequest.class);
-        verify(mockClient).createMessage(requestCaptor.capture());
+        verify(mockClient).createMessageWithRawResponse(requestCaptor.capture());
 
         AnthropicCreateMessageRequest capturedRequest = requestCaptor.getValue();
         assertThat(capturedRequest.getMetadata()).isNull();
@@ -96,7 +98,7 @@ class AnthropicUserIdIT {
         // then
         ArgumentCaptor<AnthropicCreateMessageRequest> requestCaptor =
                 ArgumentCaptor.forClass(AnthropicCreateMessageRequest.class);
-        verify(mockClient).createMessage(requestCaptor.capture());
+        verify(mockClient).createMessageWithRawResponse(requestCaptor.capture());
 
         AnthropicCreateMessageRequest capturedRequest = requestCaptor.getValue();
         assertThat(capturedRequest.getMetadata()).isNull();
@@ -114,7 +116,12 @@ class AnthropicUserIdIT {
         mockResponse.stopReason = "end_turn";
         mockResponse.usage = createUsage();
 
-        when(mockClient.createMessage(any(AnthropicCreateMessageRequest.class))).thenReturn(mockResponse);
+        SuccessfulHttpResponse rawResponse = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .build();
+        ParsedAndRawResponse parsedAndRawResponse = new ParsedAndRawResponse(mockResponse, rawResponse);
+
+        when(mockClient.createMessageWithRawResponse(any(AnthropicCreateMessageRequest.class))).thenReturn(parsedAndRawResponse);
         return mockClient;
     }
 

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicAiServiceIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicAiServiceIT.java
@@ -4,7 +4,6 @@ import static dev.langchain4j.model.anthropic.common.AnthropicChatModelIT.ANTHRO
 
 import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
 import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.service.common.AbstractAiServiceIT;
 import java.util.List;

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicChatModelIT.java
@@ -1,10 +1,12 @@
 package dev.langchain4j.model.anthropic.common;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.anthropic.AnthropicChatResponseMetadata;
 import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.common.AbstractChatModelIT;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.output.TokenUsage;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
@@ -56,6 +58,11 @@ class AnthropicChatModelIT extends AbstractChatModelIT {
     @Override
     protected Class<? extends TokenUsage> tokenUsageType(ChatModel chatModel) {
         return AnthropicTokenUsage.class;
+    }
+
+    @Override
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(ChatModel model) {
+        return AnthropicChatResponseMetadata.class;
     }
 
     @Override

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicStreamingAiServiceIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicStreamingAiServiceIT.java
@@ -2,8 +2,10 @@ package dev.langchain4j.model.anthropic.common;
 
 import static dev.langchain4j.model.anthropic.common.AnthropicStreamingChatModelIT.ANTHROPIC_STREAMING_CHAT_MODEL;
 
+import dev.langchain4j.model.anthropic.AnthropicChatResponseMetadata;
 import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
 import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.service.common.AbstractStreamingAiServiceIT;
 import java.util.List;
@@ -18,7 +20,12 @@ class AnthropicStreamingAiServiceIT extends AbstractStreamingAiServiceIT {
     }
 
     @Override
-    protected Class<? extends TokenUsage> tokenUsageType(StreamingChatModel streamingChatModel) {
+    protected Class<? extends TokenUsage> tokenUsageType(StreamingChatModel model) {
         return AnthropicTokenUsage.class;
+    }
+
+    @Override
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(StreamingChatModel model) {
+        return AnthropicChatResponseMetadata.class;
     }
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicStreamingChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicStreamingChatModelIT.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeast;
 
+import dev.langchain4j.model.anthropic.AnthropicChatResponseMetadata;
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel;
 import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -14,6 +15,7 @@ import java.util.List;
 
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.TokenUsage;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -64,8 +66,13 @@ class AnthropicStreamingChatModelIT extends AbstractStreamingChatModelIT {
     }
 
     @Override
-    protected Class<? extends TokenUsage> tokenUsageType(StreamingChatModel streamingChatModel) {
+    protected Class<? extends TokenUsage> tokenUsageType(StreamingChatModel model) {
         return AnthropicTokenUsage.class;
+    }
+
+    @Override
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(StreamingChatModel model) {
+        return AnthropicChatResponseMetadata.class;
     }
 
     @Override


### PR DESCRIPTION
## Issue
Partially addresses https://github.com/langchain4j/langchain4j/issues/4222 and https://github.com/langchain4j/langchain4j/pull/4211#issuecomment-3652334988

## Change
Introduced `AnthropicChatResponseMetadata` that expses raw HTTP response and SEE events (for streaming model).

`AnthropicChatResponseMetadata` is now exposed from `AnthropicChatModel` and `AnthropicStreamingChatModel` inside the `ChatRequest`.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)