### PR TITLE
Anthropic server tool result returned to attributes

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -47,6 +47,7 @@ AnthropicChatModel model = AnthropicChatModel.builder()
     .toolChoiceName(...)
     .disableParallelToolUse(...)
     .serverTools(...)
+    .returnServerToolResults(...)
     .toolMetadataKeysToSend(...)
     .cacheSystemMessages(...)
     .cacheTools(...)
@@ -138,6 +139,33 @@ String answer = model.chat("What is the weather in Munich?");
 ```
 
 Tools specified via `serverTools` will be included in every request to the Anthropic API.
+
+### Retrieving Server Tool Results
+
+To access the raw results from server tools (e.g., web search results, code execution output,
+fileIds from generated files), enable `returnServerToolResults(true)`.
+The results will be available in `AiMessage.attributes()` under the key `"server_tool_results"`:
+
+```java
+ChatModel model = AnthropicChatModel.builder()
+        .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+        .modelName("claude-sonnet-4-5")
+        .serverTools(webSearchTool)
+        .returnServerToolResults(true)
+        .build();
+
+ChatResponse response = model.chat("What is the weather in Munich?");
+AiMessage aiMessage = response.aiMessage();
+
+List<AnthropicServerToolResult> results = aiMessage.attribute("server_tool_results", List.class);
+for (AnthropicServerToolResult result : results) {
+    System.out.println("Type: " + result.type());
+    System.out.println("Tool Use ID: " + result.toolUseId());
+    System.out.println("Content: " + result.content());
+}
+```
+
+This is disabled by default to avoid storing potentially large data in ChatMemory.
 
 ## Tool Search Tool
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -70,7 +70,6 @@ public class AnthropicChatModel implements ChatModel {
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
     private final boolean returnThinking;
-    private final boolean returnServerToolResults;
     private final boolean sendThinking;
     private final int maxRetries;
     private final List<ChatModelListener> listeners;
@@ -78,6 +77,7 @@ public class AnthropicChatModel implements ChatModel {
     private final String toolChoiceName;
     private final Boolean disableParallelToolUse;
     private final List<AnthropicServerTool> serverTools;
+    private final boolean returnServerToolResults;
     private final Set<String> toolMetadataKeysToSend;
     private final String userId;
     private final Map<String, Object> customParameters;
@@ -102,13 +102,13 @@ public class AnthropicChatModel implements ChatModel {
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
         this.returnThinking = getOrDefault(builder.returnThinking, false);
-        this.returnServerToolResults = getOrDefault(builder.returnServerToolResults, false);
         this.sendThinking = getOrDefault(builder.sendThinking, true);
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
         this.listeners = copy(builder.listeners);
         this.toolChoiceName = builder.toolChoiceName;
         this.disableParallelToolUse = builder.disableParallelToolUse;
         this.serverTools = copy(builder.serverTools);
+        this.returnServerToolResults = getOrDefault(builder.returnServerToolResults, false);
         this.toolMetadataKeysToSend = copy(builder.toolMetadataKeysToSend);
         this.userId = builder.userId;
         this.customParameters = copy(builder.customParameters);
@@ -160,13 +160,13 @@ public class AnthropicChatModel implements ChatModel {
         private String toolChoiceName;
         private Boolean disableParallelToolUse;
         private List<AnthropicServerTool> serverTools;
+        private Boolean returnServerToolResults;
         private Set<String> toolMetadataKeysToSend;
         private Boolean cacheSystemMessages;
         private Boolean cacheTools;
         private String thinkingType;
         private Integer thinkingBudgetTokens;
         private Boolean returnThinking;
-        private Boolean returnServerToolResults;
         private Boolean sendThinking;
         private Duration timeout;
         private Integer maxRetries;
@@ -286,6 +286,21 @@ public class AnthropicChatModel implements ChatModel {
         }
 
         /**
+         * Controls whether to return server tool results (e.g., web_search, code_execution)
+         * inside {@link AiMessage#attributes()} under the key "server_tool_results".
+         * <p>
+         * Disabled by default to avoid polluting ChatMemory with potentially large data.
+         * If enabled, server tool results will be stored as a {@code List<AnthropicServerToolResult>}
+         * within the AiMessage attributes.
+         *
+         * @see #serverTools(List)
+         */
+        public AnthropicChatModelBuilder returnServerToolResults(Boolean returnServerToolResults) {
+            this.returnServerToolResults = returnServerToolResults;
+            return this;
+        }
+
+        /**
          * Specifies server tools to be included in each request to the Anthropic API. For example:
          * <pre>
          * AnthropicServerTool webSearchTool = AnthropicServerTool.builder()
@@ -357,21 +372,6 @@ public class AnthropicChatModel implements ChatModel {
          */
         public AnthropicChatModelBuilder returnThinking(Boolean returnThinking) {
             this.returnThinking = returnThinking;
-            return this;
-        }
-
-        /**
-         * Controls whether to return server tool results (e.g., web_search, code_execution)
-         * inside {@link AiMessage#attributes()} under the key "server_tool_results".
-         * <p>
-         * Disabled by default to avoid polluting ChatMemory with potentially large data.
-         * If enabled, server tool results will be stored as a {@code List<AnthropicServerToolResult>}
-         * within the AiMessage attributes.
-         *
-         * @see #serverTools(List)
-         */
-        public AnthropicChatModelBuilder returnServerToolResults(Boolean returnServerToolResults) {
-            this.returnServerToolResults = returnServerToolResults;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -70,6 +70,7 @@ public class AnthropicChatModel implements ChatModel {
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
     private final boolean returnThinking;
+    private final boolean returnServerToolResults;
     private final boolean sendThinking;
     private final int maxRetries;
     private final List<ChatModelListener> listeners;
@@ -101,6 +102,7 @@ public class AnthropicChatModel implements ChatModel {
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
         this.returnThinking = getOrDefault(builder.returnThinking, false);
+        this.returnServerToolResults = getOrDefault(builder.returnServerToolResults, false);
         this.sendThinking = getOrDefault(builder.sendThinking, true);
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
         this.listeners = copy(builder.listeners);
@@ -110,7 +112,7 @@ public class AnthropicChatModel implements ChatModel {
         this.toolMetadataKeysToSend = copy(builder.toolMetadataKeysToSend);
         this.userId = builder.userId;
         this.customParameters = copy(builder.customParameters);
-        this.strictTools= builder.strictTools;
+        this.strictTools = builder.strictTools;
         this.supportedCapabilities = copy(builder.supportedCapabilities);
 
         ChatRequestParameters commonParameters;
@@ -164,6 +166,7 @@ public class AnthropicChatModel implements ChatModel {
         private String thinkingType;
         private Integer thinkingBudgetTokens;
         private Boolean returnThinking;
+        private Boolean returnServerToolResults;
         private Boolean sendThinking;
         private Duration timeout;
         private Integer maxRetries;
@@ -277,7 +280,7 @@ public class AnthropicChatModel implements ChatModel {
          *     .build();
          * </pre>
          */
-        public  AnthropicChatModelBuilder serverTools(List<AnthropicServerTool> serverTools) {
+        public AnthropicChatModelBuilder serverTools(List<AnthropicServerTool> serverTools) {
             this.serverTools = serverTools;
             return this;
         }
@@ -293,7 +296,7 @@ public class AnthropicChatModel implements ChatModel {
          *     .build();
          * </pre>
          */
-        public  AnthropicChatModelBuilder serverTools(AnthropicServerTool... serverTools) {
+        public AnthropicChatModelBuilder serverTools(AnthropicServerTool... serverTools) {
             return serverTools(asList(serverTools));
         }
 
@@ -354,6 +357,21 @@ public class AnthropicChatModel implements ChatModel {
          */
         public AnthropicChatModelBuilder returnThinking(Boolean returnThinking) {
             this.returnThinking = returnThinking;
+            return this;
+        }
+
+        /**
+         * Controls whether to return server tool results (e.g., web_search, code_execution)
+         * inside {@link AiMessage#attributes()} under the key "server_tool_results".
+         * <p>
+         * Disabled by default to avoid polluting ChatMemory with potentially large data.
+         * If enabled, server tool results will be stored as a {@code List<AnthropicServerToolResult>}
+         * within the AiMessage attributes.
+         *
+         * @see #serverTools(List)
+         */
+        public AnthropicChatModelBuilder returnServerToolResults(Boolean returnServerToolResults) {
+            this.returnServerToolResults = returnServerToolResults;
             return this;
         }
 
@@ -487,7 +505,7 @@ public class AnthropicChatModel implements ChatModel {
                 .build();
 
         return ChatResponse.builder()
-                .aiMessage(toAiMessage(response.content, returnThinking))
+                .aiMessage(toAiMessage(response.content, returnThinking, returnServerToolResults))
                 .metadata(responseMetadata)
                 .build();
     }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicServerToolResult.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicServerToolResult.java
@@ -1,0 +1,101 @@
+package dev.langchain4j.model.anthropic;
+
+import dev.langchain4j.Experimental;
+import java.util.Objects;
+
+/**
+ * Represents a result from an Anthropic server-executed tool (e.g., web_search, code_execution).
+ * <p>
+ * Content is stored as raw {@link Object} to be flexible and survive API changes.
+ * Users can cast to {@code Map<String, Object>} or {@code List<Map<String, Object>>} as needed.
+ *
+ * @since 1.10.0
+ */
+@Experimental
+public class AnthropicServerToolResult {
+
+    private final String type;
+    private final String toolUseId;
+    private final Object content;
+
+    public AnthropicServerToolResult(Builder builder) {
+        this.type = builder.type;
+        this.toolUseId = builder.toolUseId;
+        this.content = builder.content;
+    }
+
+    /**
+     * The type of server tool result (e.g., "web_search_tool_result", "code_execution_tool_result").
+     */
+    public String type() {
+        return type;
+    }
+
+    /**
+     * The ID linking this result to the corresponding server_tool_use block.
+     */
+    public String toolUseId() {
+        return toolUseId;
+    }
+
+    /**
+     * The raw content from the API response.
+     * For web_search: typically a {@code List<Map<String, Object>>} with search results.
+     * For code_execution: typically a {@code Map<String, Object>} with stdout, stderr, return_code, etc.
+     */
+    public Object content() {
+        return content;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        AnthropicServerToolResult that = (AnthropicServerToolResult) o;
+        return Objects.equals(type, that.type)
+                && Objects.equals(toolUseId, that.toolUseId)
+                && Objects.equals(content, that.content);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, toolUseId, content);
+    }
+
+    @Override
+    public String toString() {
+        return "AnthropicServerToolResult{" + "type='"
+                + type + '\'' + ", toolUseId='"
+                + toolUseId + '\'' + ", content="
+                + content + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String type;
+        private String toolUseId;
+        private Object content;
+
+        public Builder type(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder toolUseId(String toolUseId) {
+            this.toolUseId = toolUseId;
+            return this;
+        }
+
+        public Builder content(Object content) {
+            this.content = content;
+            return this;
+        }
+
+        public AnthropicServerToolResult build() {
+            return new AnthropicServerToolResult(this);
+        }
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -67,13 +67,13 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
     private final boolean returnThinking;
-    private final boolean returnServerToolResults;
     private final boolean sendThinking;
     private final List<ChatModelListener> listeners;
     private final ChatRequestParameters defaultRequestParameters;
     private final String toolChoiceName;
     private final Boolean disableParallelToolUse;
     private final List<AnthropicServerTool> serverTools;
+    private final boolean returnServerToolResults;
     private final Set<String> toolMetadataKeysToSend;
     private final String userId;
     private final Map<String, Object> customParameters;
@@ -116,12 +116,12 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
         this.returnThinking = getOrDefault(builder.returnThinking, false);
-        this.returnServerToolResults = getOrDefault(builder.returnServerToolResults, false);
         this.sendThinking = getOrDefault(builder.sendThinking, true);
         this.listeners = copy(builder.listeners);
         this.toolChoiceName = builder.toolChoiceName;
         this.disableParallelToolUse = builder.disableParallelToolUse;
         this.serverTools = copy(builder.serverTools);
+        this.returnServerToolResults = getOrDefault(builder.returnServerToolResults, false);
         this.toolMetadataKeysToSend = copy(builder.toolMetadataKeysToSend);
         this.userId = builder.userId;
         this.customParameters = copy(builder.customParameters);
@@ -153,7 +153,6 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         private String thinkingType;
         private Integer thinkingBudgetTokens;
         private Boolean returnThinking;
-        private Boolean returnServerToolResults;
         private Boolean sendThinking;
         private Duration timeout;
         private Boolean logRequests;
@@ -164,6 +163,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         private String toolChoiceName;
         private Boolean disableParallelToolUse;
         private List<AnthropicServerTool> serverTools;
+        private Boolean returnServerToolResults;
         private Set<String> toolMetadataKeysToSend;
         private String userId;
         private Map<String, Object> customParameters;
@@ -291,21 +291,6 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         }
 
         /**
-         * Controls whether to return server tool results (e.g., web_search, code_execution)
-         * inside {@link AiMessage#attributes()} under the key "server_tool_results".
-         * <p>
-         * Disabled by default to avoid polluting ChatMemory with potentially large data.
-         * If enabled, server tool results will be stored as a {@code List<AnthropicServerToolResult>}
-         * within the AiMessage attributes.
-         *
-         * @see #serverTools(List)
-         */
-        public AnthropicStreamingChatModelBuilder returnServerToolResults(Boolean returnServerToolResults) {
-            this.returnServerToolResults = returnServerToolResults;
-            return this;
-        }
-
-        /**
          * Controls whether to send thinking/reasoning text to the LLM in follow-up requests.
          * <p>
          * Enabled by default.
@@ -394,6 +379,21 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
          */
         public AnthropicStreamingChatModelBuilder serverTools(AnthropicServerTool... serverTools) {
             return serverTools(asList(serverTools));
+        }
+
+        /**
+         * Controls whether to return server tool results (e.g., web_search, code_execution)
+         * inside {@link AiMessage#attributes()} under the key "server_tool_results".
+         * <p>
+         * Disabled by default to avoid polluting ChatMemory with potentially large data.
+         * If enabled, server tool results will be stored as a {@code List<AnthropicServerToolResult>}
+         * within the AiMessage attributes.
+         *
+         * @see #serverTools(List)
+         */
+        public AnthropicStreamingChatModelBuilder returnServerToolResults(Boolean returnServerToolResults) {
+            this.returnServerToolResults = returnServerToolResults;
+            return this;
         }
 
         /**

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -67,6 +67,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
     private final boolean returnThinking;
+    private final boolean returnServerToolResults;
     private final boolean sendThinking;
     private final List<ChatModelListener> listeners;
     private final ChatRequestParameters defaultRequestParameters;
@@ -115,6 +116,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
         this.returnThinking = getOrDefault(builder.returnThinking, false);
+        this.returnServerToolResults = getOrDefault(builder.returnServerToolResults, false);
         this.sendThinking = getOrDefault(builder.sendThinking, true);
         this.listeners = copy(builder.listeners);
         this.toolChoiceName = builder.toolChoiceName;
@@ -123,7 +125,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         this.toolMetadataKeysToSend = copy(builder.toolMetadataKeysToSend);
         this.userId = builder.userId;
         this.customParameters = copy(builder.customParameters);
-        this.strictTools= builder.strictTools;
+        this.strictTools = builder.strictTools;
         this.supportedCapabilities = copy(builder.supportedCapabilities);
     }
 
@@ -151,6 +153,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         private String thinkingType;
         private Integer thinkingBudgetTokens;
         private Boolean returnThinking;
+        private Boolean returnServerToolResults;
         private Boolean sendThinking;
         private Duration timeout;
         private Boolean logRequests;
@@ -284,6 +287,21 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
          */
         public AnthropicStreamingChatModelBuilder returnThinking(Boolean returnThinking) {
             this.returnThinking = returnThinking;
+            return this;
+        }
+
+        /**
+         * Controls whether to return server tool results (e.g., web_search, code_execution)
+         * inside {@link AiMessage#attributes()} under the key "server_tool_results".
+         * <p>
+         * Disabled by default to avoid polluting ChatMemory with potentially large data.
+         * If enabled, server tool results will be stored as a {@code List<AnthropicServerToolResult>}
+         * within the AiMessage attributes.
+         *
+         * @see #serverTools(List)
+         */
+        public AnthropicStreamingChatModelBuilder returnServerToolResults(Boolean returnServerToolResults) {
+            this.returnServerToolResults = returnServerToolResults;
             return this;
         }
 
@@ -450,7 +468,8 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 userId,
                 customParameters,
                 strictTools);
-        client.createMessage(anthropicRequest, new AnthropicCreateMessageOptions(returnThinking), handler);
+        client.createMessage(
+                anthropicRequest, new AnthropicCreateMessageOptions(returnThinking, returnServerToolResults), handler);
     }
 
     @Override

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicContent.java
@@ -1,13 +1,12 @@
 package dev.langchain4j.model.anthropic.internal.api;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.util.Map;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonInclude(NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -30,4 +29,8 @@ public class AnthropicContent {
 
     // when type = "redacted_thinking"
     public String data;
+
+    // when type ends with "_tool_result" (e.g., web_search_tool_result, code_execution_tool_result)
+    public String toolUseId;
+    public Object content; // Raw content - structure varies by tool type
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/AnthropicCreateMessageOptions.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/AnthropicCreateMessageOptions.java
@@ -9,12 +9,22 @@ import dev.langchain4j.Internal;
 public class AnthropicCreateMessageOptions {
 
     private final boolean returnThinking;
+    private final boolean returnServerToolResults;
 
     public AnthropicCreateMessageOptions(boolean returnThinking) {
+        this(returnThinking, false);
+    }
+
+    public AnthropicCreateMessageOptions(boolean returnThinking, boolean returnServerToolResults) {
         this.returnThinking = returnThinking;
+        this.returnServerToolResults = returnServerToolResults;
     }
 
     public boolean returnThinking() {
         return returnThinking;
+    }
+
+    public boolean returnServerToolResults() {
+        return returnServerToolResults;
     }
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
@@ -1,48 +1,5 @@
 package dev.langchain4j.model.anthropic.internal.client;
 
-import dev.langchain4j.Internal;
-import dev.langchain4j.http.client.sse.ServerSentEventContext;
-import dev.langchain4j.model.anthropic.AnthropicChatResponseMetadata;
-import dev.langchain4j.model.anthropic.internal.api.AnthropicCountTokensRequest;
-import dev.langchain4j.http.client.sse.CancellationUnsupportedHandle;
-import dev.langchain4j.model.chat.response.CompleteToolCall;
-import dev.langchain4j.model.chat.response.PartialToolCall;
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.http.client.HttpClient;
-import dev.langchain4j.http.client.HttpClientBuilder;
-import dev.langchain4j.http.client.HttpClientBuilderLoader;
-import dev.langchain4j.http.client.HttpRequest;
-import dev.langchain4j.http.client.SuccessfulHttpResponse;
-import dev.langchain4j.http.client.log.LoggingHttpClient;
-import dev.langchain4j.http.client.sse.ServerSentEvent;
-import dev.langchain4j.http.client.sse.ServerSentEventListener;
-import dev.langchain4j.internal.ExceptionMapper;
-import dev.langchain4j.internal.ToolCallBuilder;
-import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
-import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
-import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageResponse;
-import dev.langchain4j.model.anthropic.internal.api.AnthropicDelta;
-import dev.langchain4j.model.anthropic.internal.api.AnthropicResponseMessage;
-import dev.langchain4j.model.anthropic.internal.api.AnthropicStreamingData;
-import dev.langchain4j.model.anthropic.internal.api.AnthropicUsage;
-import dev.langchain4j.model.anthropic.internal.api.MessageTokenCountResponse;
-import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.ChatResponseMetadata;
-import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
-import dev.langchain4j.model.chat.response.StreamingHandle;
-import dev.langchain4j.model.output.FinishReason;
-
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-
 import static dev.langchain4j.http.client.HttpMethod.POST;
 import static dev.langchain4j.http.client.sse.ServerSentEventParsingHandleUtils.toStreamingHandle;
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteResponse;
@@ -59,10 +16,54 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.anthropic.internal.client.Json.fromJson;
 import static dev.langchain4j.model.anthropic.internal.client.Json.toJson;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.REDACTED_THINKING_KEY;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.SERVER_TOOL_RESULTS_KEY;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.THINKING_SIGNATURE_KEY;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toFinishReason;
 import static java.util.Collections.synchronizedList;
 import static java.util.stream.Collectors.joining;
+
+import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.http.client.HttpClientBuilderLoader;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.log.LoggingHttpClient;
+import dev.langchain4j.http.client.sse.CancellationUnsupportedHandle;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.http.client.sse.ServerSentEventContext;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.internal.ExceptionMapper;
+import dev.langchain4j.internal.ToolCallBuilder;
+import dev.langchain4j.model.anthropic.AnthropicChatResponseMetadata;
+import dev.langchain4j.model.anthropic.AnthropicServerToolResult;
+import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCountTokensRequest;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageResponse;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicDelta;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicResponseMessage;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicStreamingData;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicUsage;
+import dev.langchain4j.model.anthropic.internal.api.MessageTokenCountResponse;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.StreamingHandle;
+import dev.langchain4j.model.output.FinishReason;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Internal
 public class DefaultAnthropicClient extends AnthropicClient {
@@ -98,7 +99,8 @@ public class DefaultAnthropicClient extends AnthropicClient {
 
         if (builder.logRequests != null && builder.logRequests
                 || builder.logResponses != null && builder.logResponses) {
-            this.httpClient = new LoggingHttpClient(httpClient, builder.logRequests, builder.logResponses, builder.logger);
+            this.httpClient =
+                    new LoggingHttpClient(httpClient, builder.logRequests, builder.logResponses, builder.logger);
         } else {
             this.httpClient = httpClient;
         }
@@ -118,14 +120,16 @@ public class DefaultAnthropicClient extends AnthropicClient {
     public ParsedAndRawResponse createMessageWithRawResponse(AnthropicCreateMessageRequest request) {
         HttpRequest httpRequest = toHttpRequest(toJson(request), "messages");
         SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
-        AnthropicCreateMessageResponse parsedResponse = fromJson(rawResponse.body(), AnthropicCreateMessageResponse.class);
+        AnthropicCreateMessageResponse parsedResponse =
+                fromJson(rawResponse.body(), AnthropicCreateMessageResponse.class);
         return new ParsedAndRawResponse(parsedResponse, rawResponse);
     }
 
     @Override
-    public void createMessage(AnthropicCreateMessageRequest request,
-                              AnthropicCreateMessageOptions options,
-                              StreamingChatResponseHandler handler) {
+    public void createMessage(
+            AnthropicCreateMessageRequest request,
+            AnthropicCreateMessageOptions options,
+            StreamingChatResponseHandler handler) {
 
         ServerSentEventListener eventListener = new ServerSentEventListener() {
 
@@ -136,6 +140,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
             final StringBuffer thinkingBuilder = new StringBuffer();
             final List<String> thinkingSignatures = synchronizedList(new ArrayList<>());
             final List<String> redactedThinkings = synchronizedList(new ArrayList<>());
+            final List<AnthropicServerToolResult> serverToolResults = synchronizedList(new ArrayList<>());
 
             volatile String currentContentBlockStartType;
 
@@ -255,7 +260,18 @@ public class DefaultAnthropicClient extends AnthropicClient {
                     toolCallBuilder.updateIndex(toolCallBuilder.index() + 1);
                     toolCallBuilder.updateId(data.contentBlock.id);
                     toolCallBuilder.updateName(data.contentBlock.name);
+                } else if (isServerToolResultType(currentContentBlockStartType) && options.returnServerToolResults()) {
+                    AnthropicServerToolResult result = AnthropicServerToolResult.builder()
+                            .type(data.contentBlock.type)
+                            .toolUseId(data.contentBlock.toolUseId)
+                            .content(data.contentBlock.content)
+                            .build();
+                    serverToolResults.add(result);
                 }
+            }
+
+            private boolean isServerToolResultType(String type) {
+                return type != null && type.endsWith("_tool_result");
             }
 
             private void handleContentBlockDelta(AnthropicStreamingData data, StreamingHandle streamingHandle) {
@@ -315,7 +331,8 @@ public class DefaultAnthropicClient extends AnthropicClient {
                                 .index(completeToolCall.index())
                                 .id(completeToolCall.toolExecutionRequest().id())
                                 .name(completeToolCall.toolExecutionRequest().name())
-                                .partialArguments(completeToolCall.toolExecutionRequest().arguments())
+                                .partialArguments(
+                                        completeToolCall.toolExecutionRequest().arguments())
                                 .build();
                         onPartialToolCall(handler, partialToolRequest, streamingHandle);
                     }
@@ -343,13 +360,11 @@ public class DefaultAnthropicClient extends AnthropicClient {
 
             private ChatResponse build() {
 
-                String text = contents.stream()
-                        .filter(content -> !content.isEmpty())
-                        .collect(joining("\n"));
+                String text =
+                        contents.stream().filter(content -> !content.isEmpty()).collect(joining("\n"));
 
-                String thinking = thinkings.stream()
-                        .filter(content -> !content.isEmpty())
-                        .collect(joining("\n"));
+                String thinking =
+                        thinkings.stream().filter(content -> !content.isEmpty()).collect(joining("\n"));
 
                 Map<String, Object> attributes = new HashMap<>();
                 String thinkingSignature = thinkingSignatures.stream()
@@ -360,6 +375,9 @@ public class DefaultAnthropicClient extends AnthropicClient {
                 }
                 if (!redactedThinkings.isEmpty()) {
                     attributes.put(REDACTED_THINKING_KEY, redactedThinkings);
+                }
+                if (options.returnServerToolResults() && !serverToolResults.isEmpty()) {
+                    attributes.put(SERVER_TOOL_RESULTS_KEY, serverToolResults);
                 }
 
                 List<ToolExecutionRequest> toolExecutionRequests = List.of();

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
@@ -140,11 +140,11 @@ public class DefaultAnthropicClient extends AnthropicClient {
             final StringBuffer thinkingBuilder = new StringBuffer();
             final List<String> thinkingSignatures = synchronizedList(new ArrayList<>());
             final List<String> redactedThinkings = synchronizedList(new ArrayList<>());
-            final List<AnthropicServerToolResult> serverToolResults = synchronizedList(new ArrayList<>());
 
             volatile String currentContentBlockStartType;
 
             final ToolCallBuilder toolCallBuilder = new ToolCallBuilder(-1);
+            final List<AnthropicServerToolResult> serverToolResults = synchronizedList(new ArrayList<>());
 
             final AtomicInteger inputTokenCount = new AtomicInteger();
             final AtomicInteger outputTokenCount = new AtomicInteger();

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelIT.java
@@ -548,10 +548,12 @@ class AnthropicChatModelIT {
 
         // given
         record Edit(String type) {}
-        record ContextManagement(List<Edit> edits) { }
-        Map<String, Object> customParameters = Map.of("context_management", new ContextManagement(List.of(new Edit("clear_tool_uses_20250919"))));
+        record ContextManagement(List<Edit> edits) {}
+        Map<String, Object> customParameters =
+                Map.of("context_management", new ContextManagement(List.of(new Edit("clear_tool_uses_20250919"))));
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         ChatModel model = AnthropicChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
@@ -590,7 +592,8 @@ class AnthropicChatModelIT {
                 .name("code_execution")
                 .build();
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         ChatModel model = AnthropicChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
@@ -627,7 +630,8 @@ class AnthropicChatModelIT {
                 .addAttribute("allowed_domains", List.of("accuweather.com"))
                 .build();
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         ChatModel model = AnthropicChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
@@ -652,69 +656,72 @@ class AnthropicChatModelIT {
         assertThat(chatResponse.aiMessage().toolExecutionRequests()).isEmpty();
     }
 
-     @Test
-     void should_support_tool_search_tool() {
+    @Test
+    void should_support_tool_search_tool() {
 
-         // given
-         AnthropicServerTool toolSearchTool = AnthropicServerTool.builder()
-                 .type("tool_search_tool_regex_20251119")
-                 .name("tool_search_tool_regex")
-                 .build();
+        // given
+        AnthropicServerTool toolSearchTool = AnthropicServerTool.builder()
+                .type("tool_search_tool_regex_20251119")
+                .name("tool_search_tool_regex")
+                .build();
 
-         Map<String, Object> toolMetadata = Map.of("defer_loading", true);
+        Map<String, Object> toolMetadata = Map.of("defer_loading", true);
 
-         ToolSpecification weatherTool = ToolSpecification.builder()
-                 .name("get_weather")
-                 .parameters(JsonObjectSchema.builder()
-                         .addStringProperty("location")
-                         .required("location")
-                         .build())
-                 .metadata(toolMetadata)
-                 .build();
+        ToolSpecification weatherTool = ToolSpecification.builder()
+                .name("get_weather")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("location")
+                        .required("location")
+                        .build())
+                .metadata(toolMetadata)
+                .build();
 
-         ToolSpecification timeTool = ToolSpecification.builder()
-                 .name("get_time")
-                 .parameters(JsonObjectSchema.builder()
-                         .addStringProperty("location")
-                         .required("location")
-                         .build())
-                 .build();
+        ToolSpecification timeTool = ToolSpecification.builder()
+                .name("get_time")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("location")
+                        .required("location")
+                        .build())
+                .build();
 
-         SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
-         ChatModel model = AnthropicChatModel.builder()
-                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
-                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
-                 .modelName(CLAUDE_SONNET_4_5_20250929)
-                 .beta("advanced-tool-use-2025-11-20")
-                 .serverTools(toolSearchTool)
-                 .toolMetadataKeysToSend(toolMetadata.keySet())
-                 .logRequests(true)
-                 .logResponses(true)
-                 .build();
+        ChatModel model = AnthropicChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(CLAUDE_SONNET_4_5_20250929)
+                .beta("advanced-tool-use-2025-11-20")
+                .serverTools(toolSearchTool)
+                .toolMetadataKeysToSend(toolMetadata.keySet())
+                .logRequests(true)
+                .logResponses(true)
+                .build();
 
-         ChatRequest chatRequest = ChatRequest.builder()
-                 .messages(UserMessage.from("What is the weather in Munich? Use tool search if needed."))
-                 .toolSpecifications(weatherTool, timeTool)
-                 .build();
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("What is the weather in Munich? Use tool search if needed."))
+                .toolSpecifications(weatherTool, timeTool)
+                .build();
 
-         // when
-         ChatResponse chatResponse = model.chat(chatRequest);
+        // when
+        ChatResponse chatResponse = model.chat(chatRequest);
 
-         // then
-         assertThat(spyingHttpClient.request().body())
-                 .contains(toolSearchTool.type())
-                 .contains(toolMetadata.keySet().iterator().next());
+        // then
+        assertThat(spyingHttpClient.request().body())
+                .contains(toolSearchTool.type())
+                .contains(toolMetadata.keySet().iterator().next());
 
-         List<ToolExecutionRequest> toolExecutionRequests = chatResponse.aiMessage().toolExecutionRequests();
-         assertThat(toolExecutionRequests).hasSize(1);
-         assertThat(toolExecutionRequests.get(0).name()).isEqualTo(weatherTool.name());
-     }
+        List<ToolExecutionRequest> toolExecutionRequests =
+                chatResponse.aiMessage().toolExecutionRequests();
+        assertThat(toolExecutionRequests).hasSize(1);
+        assertThat(toolExecutionRequests.get(0).name()).isEqualTo(weatherTool.name());
+    }
 
     @Test
     void should_send_strict_true_in_tools_definition() {
         // given
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         ChatModel model = AnthropicChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
@@ -723,7 +730,7 @@ class AnthropicChatModelIT {
                 .temperature(0.0)
                 .toolChoice(ToolChoice.REQUIRED)
                 .disableParallelToolUse(true)
-                //when
+                // when
                 .beta("structured-outputs-2025-11-13")
                 .strictTools(true)
                 .logRequests(true)
@@ -740,9 +747,8 @@ class AnthropicChatModelIT {
                 .build();
 
         ChatRequest chatRequest = ChatRequest.builder()
-                .messages(UserMessage.from(
-                        "What's the weather in Munich? " +
-                                "When calling tools, include a parameter unit='celsius' in the tool input."))
+                .messages(UserMessage.from("What's the weather in Munich? "
+                        + "When calling tools, include a parameter unit='celsius' in the tool input."))
                 .toolSpecifications(weatherTool)
                 .build();
 
@@ -764,11 +770,47 @@ class AnthropicChatModelIT {
         ToolExecutionRequest call = toolCalls.get(0);
         assertThat(call.name()).isEqualTo("get_weather");
 
-        assertThat(call.arguments())
-                .contains("\"location\"")
-                .doesNotContain("\"unit\"");
+        assertThat(call.arguments()).contains("\"location\"").doesNotContain("\"unit\"");
     }
 
+    @Test
+    void should_return_server_tool_results_in_attributes_when_enabled() {
+
+        // given
+        AnthropicServerTool webSearchTool = AnthropicServerTool.builder()
+                .type("web_search_20250305")
+                .name("web_search")
+                .addAttribute("max_uses", 3)
+                .build();
+
+        ChatModel model = AnthropicChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(CLAUDE_SONNET_4_5_20250929)
+                .serverTools(webSearchTool)
+                .returnServerToolResults(true)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("What is the weather in Munich right now?"))
+                .build();
+
+        // when
+        ChatResponse chatResponse = model.chat(chatRequest);
+
+        // then
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).isNotBlank();
+
+        List<AnthropicServerToolResult> results = aiMessage.attribute("server_tool_results", List.class);
+        assertThat(results).isNotEmpty();
+
+        AnthropicServerToolResult result = results.get(0);
+        assertThat(result.type()).isEqualTo("web_search_tool_result");
+        assertThat(result.toolUseId()).isNotBlank();
+        assertThat(result.content()).isNotNull();
+    }
 
     static String randomString(int length) {
         String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -2,9 +2,11 @@ package dev.langchain4j.model.anthropic;
 
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.ASSISTANT;
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.USER;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.SERVER_TOOL_RESULTS_KEY;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.retainKeys;
-import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicSchema;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAiMessage;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicMessages;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicSchema;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicTool;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -28,6 +30,7 @@ import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicImageContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicMessage;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicPdfContent;
@@ -359,6 +362,51 @@ class AnthropicMapperTest {
         assertThat(retainKeys(Map.of("one", "one"), Set.of("two"))).isEqualTo(Map.of());
         assertThat(retainKeys(Map.of("one", "one", "two", "two"), Set.of("one")))
                 .isEqualTo(Map.of("one", "one"));
+    }
+
+    @Test
+    void should_extract_server_tool_results_when_enabled() {
+        // given
+        AnthropicContent textContent = new AnthropicContent();
+        textContent.type = "text";
+        textContent.text = "Here are the search results";
+
+        AnthropicContent webSearchResult = new AnthropicContent();
+        webSearchResult.type = "web_search_tool_result";
+        webSearchResult.toolUseId = "srvtoolu_123";
+        webSearchResult.content = List.of(Map.of(
+                "type", "web_search_result",
+                "url", "https://example.com",
+                "title", "Example"));
+
+        List<AnthropicContent> contents = List.of(textContent, webSearchResult);
+
+        // when
+        AiMessage aiMessage = toAiMessage(contents, false, true);
+
+        // then
+        assertThat(aiMessage.text()).isEqualTo("Here are the search results");
+
+        List<AnthropicServerToolResult> results = aiMessage.attribute(SERVER_TOOL_RESULTS_KEY, List.class);
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).type()).isEqualTo("web_search_tool_result");
+        assertThat(results.get(0).toolUseId()).isEqualTo("srvtoolu_123");
+        assertThat(results.get(0).content()).isNotNull();
+    }
+
+    @Test
+    void should_not_extract_server_tool_results_when_disabled() {
+        // given
+        AnthropicContent webSearchResult = new AnthropicContent();
+        webSearchResult.type = "web_search_tool_result";
+        webSearchResult.toolUseId = "srvtoolu_123";
+        webSearchResult.content = List.of(Map.of("url", "https://example.com"));
+
+        // when
+        AiMessage aiMessage = toAiMessage(List.of(webSearchResult), false, false);
+
+        // then
+        assertThat(aiMessage.attributes()).doesNotContainKey(SERVER_TOOL_RESULTS_KEY);
     }
 
     @SafeVarargs

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelIT.java
@@ -24,7 +24,6 @@ import dev.langchain4j.http.client.jdk.JdkHttpClient;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
@@ -244,9 +243,11 @@ class AnthropicStreamingChatModelIT {
     void should_set_custom_parameters_and_get_raw_response() {
 
         // given
-        Map<String, Object> customParameters = Map.of("context_management", Map.of("edits", List.of(Map.of("type", "clear_tool_uses_20250919"))));
+        Map<String, Object> customParameters =
+                Map.of("context_management", Map.of("edits", List.of(Map.of("type", "clear_tool_uses_20250919"))));
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         StreamingChatModel model = AnthropicStreamingChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
@@ -280,7 +281,8 @@ class AnthropicStreamingChatModelIT {
 
     @Test
     void should_send_strict_true_in_tools_definition_streaming() {
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         AnthropicStreamingChatModel model = AnthropicStreamingChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
@@ -304,9 +306,8 @@ class AnthropicStreamingChatModelIT {
                 .build();
 
         ChatRequest request = ChatRequest.builder()
-                .messages(UserMessage.from(
-                        "What's the weather in Munich? " +
-                                "When calling tools, include a parameter unit='celsius' in the tool input."))
+                .messages(UserMessage.from("What's the weather in Munich? "
+                        + "When calling tools, include a parameter unit='celsius' in the tool input."))
                 .toolSpecifications(weatherTool)
                 .build();
 
@@ -329,9 +330,64 @@ class AnthropicStreamingChatModelIT {
         ToolExecutionRequest call = toolCalls.get(0);
         assertThat(call.name()).isEqualTo("get_weather");
 
-        assertThat(call.arguments())
-                .contains("\"location\"")
-                .doesNotContain("\"unit\"");
+        assertThat(call.arguments()).contains("\"location\"").doesNotContain("\"unit\"");
     }
 
+    @Test
+    void should_return_server_tool_results_in_attributes_when_enabled_streaming() throws Exception {
+
+        // given
+        AnthropicServerTool webSearchTool = AnthropicServerTool.builder()
+                .type("web_search_20250305")
+                .name("web_search")
+                .addAttribute("max_uses", 3)
+                .build();
+
+        StreamingChatModel model = AnthropicStreamingChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(CLAUDE_SONNET_4_5_20250929)
+                .serverTools(webSearchTool)
+                .returnServerToolResults(true)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("What is the weather in Munich right now?"))
+                .build();
+
+        // when
+        // Note: Using simple handler instead of TestStreamingChatResponseHandler because
+        // server tools cause text to be split across multiple content blocks (similar to
+        // tool_use), making the strict text equality assertion invalid
+        // Didn't want to include anthropic specific check in generic TestStreamingChatResponseHandler
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        model.chat(chatRequest, new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {}
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+        ChatResponse chatResponse = future.get(60, SECONDS);
+
+        // then
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).isNotBlank();
+
+        List<AnthropicServerToolResult> results = aiMessage.attribute("server_tool_results", List.class);
+        assertThat(results).isNotEmpty();
+
+        AnthropicServerToolResult result = results.get(0);
+        assertThat(result.type()).isEqualTo("web_search_tool_result");
+        assertThat(result.toolUseId()).isNotBlank();
+        assertThat(result.content()).isNotNull();
+    }
 }


### PR DESCRIPTION
Follow-up to https://github.com/langchain4j/langchain4j/pull/4211

## Change
Include anthropic server tools results in AnthropicContent and then map them into the attributes of AiMessage when enabled in ChatModel.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases (existing tests cover negative cases)
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
