### PR TITLE
feat: Add onPartialToolCall callbacks to TokenStream

### DIFF
--- a/docs/docs/tutorials/ai-services.md
+++ b/docs/docs/tutorials/ai-services.md
@@ -60,9 +60,9 @@ Then, we create our low-level components. These components will be used under th
 In this case, we just need the `ChatModel`:
 ```java
 ChatModel model = OpenAiChatModel.builder()
-        .apiKey(System.getenv("OPENAI_API_KEY"))
-        .modelName(GPT_4_O_MINI)
-        .build();
+    .apiKey(System.getenv("OPENAI_API_KEY"))
+    .modelName(GPT_4_O_MINI)
+    .build();
 ```
 
 Finally, we can use the `AiServices` class to create an instance of our AI Service:
@@ -132,9 +132,9 @@ This will be converted into a `SystemMessage` behind the scenes and sent to the 
 System messages can also be defined dynamically with the system message provider:
 ```java
 Friend friend = AiServices.builder(Friend.class)
-        .chatModel(model)
-        .systemMessageProvider(chatMemoryId -> "You are a good friend of mine. Answer using slang.")
-        .build();
+    .chatModel(model)
+    .systemMessageProvider(chatMemoryId -> "You are a good friend of mine. Answer using slang.")
+    .build();
 ```
 As you can see, you can provide different system messages based on a chat memory ID (user or conversation).
 
@@ -182,9 +182,9 @@ It is possible to do so by configuring the AI Service with a `UnaryOperator<Chat
 
 ```java
 Assistant assistant = AiServices.builder(Assistant.class)
-        .chatModel(model)
-        .chatRequestTransformer(transformingFunction)  // Configures the transformation function to be applied to the ChatRequest
-        .build();
+    .chatModel(model)
+    .chatRequestTransformer(transformingFunction)  // Configures the transformation function to be applied to the ChatRequest
+    .build();
 ```
 
 In case it is needed to also access the `ChatMemory` to implement the required `ChatRequest` transformation, it is also possible to configure the `chatRequestTransformer` method with a `BiFunction<ChatRequest, Object, ChatRequest>`, where the second parameter passed to this function is the memory ID.
@@ -213,16 +213,16 @@ Build the AI Service:
 java
 ```java
 AssistantWithChatParams assistant = AiServices.builder(AssistantWithChatParams.class)
-        .chatModel(openAiChatModel)  // or whichever model
-        .build();
+    .chatModel(openAiChatModel)  // or whichever model
+    .build();
 ```
 
 Call it with any per-call parameters:
 
 ```java
 ChatRequestParameters customParams = ChatRequestParameters.builder()
-        .temperature(0.85)
-        .build();
+    .temperature(0.85)
+    .build();
 
 String answer = assistant.chat("Hi there!", customParams);
 ```
@@ -339,11 +339,11 @@ for more details on the available content types.
 AI Service method can return one of the following types:
 - `String` - in this case LLM-generated output is returned without any processing/parsing
 - Any type supported by [Structured Outputs](/tutorials/structured-outputs#supported-types) - in this case
-  AI service will parse LLM-generated output into a desired type before returning
+AI service will parse LLM-generated output into a desired type before returning
 
 Any type can be additionally wrapped into a `Result<T>` to get extra metadata about AI Service invocation:
 - `TokenUsage` - total number of tokens used during AI service invocation. If AI service did multiple calls to
-  the LLM (e.g., because tools were executed), it will sum token usages of all calls.
+the LLM (e.g., because tools were executed), it will sum token usages of all calls.
 - Sources - `Content`s retrieved during [RAG](/tutorials/ai-services#rag) retrieval
 - All [tools](/tutorials/ai-services#tools-function-calling) executed during AI Service invocation (both requests and results)
 - `FinishReason` of the final chat response
@@ -353,7 +353,7 @@ Any type can be additionally wrapped into a `Result<T>` to get extra metadata ab
 An example:
 ```java
 interface Assistant {
-
+    
     @UserMessage("Generate an outline for the article on the following topic: {{it}}")
     Result<List<String>> generateOutlineFor(String topic);
 }
@@ -402,7 +402,7 @@ enum Priority {
 }
 
 interface PriorityAnalyzer {
-
+    
     @UserMessage("Analyze the priority of the following issue: {{it}}")
     Priority analyzePriority(String issueDescription);
 }
@@ -440,13 +440,13 @@ interface PersonExtractor {
 PersonExtractor personExtractor = AiServices.create(PersonExtractor.class, model);
 
 String text = """
-        In 1968, amidst the fading echoes of Independence Day,
-        a child named John arrived under the calm evening sky.
-        This newborn, bearing the surname Doe, marked the start of a new journey.
-        He was welcomed into the world at 345 Whispering Pines Avenue
-        a quaint street nestled in the heart of Springfield
-        an abode that echoed with the gentle hum of suburban dreams and aspirations.
-        """;
+            In 1968, amidst the fading echoes of Independence Day,
+            a child named John arrived under the calm evening sky.
+            This newborn, bearing the surname Doe, marked the start of a new journey.
+            He was welcomed into the world at 345 Whispering Pines Avenue
+            a quaint street nestled in the heart of Springfield
+            an abode that echoed with the gentle hum of suburban dreams and aspirations.
+            """;
 
 Person person = personExtractor.extractPersonFrom(text);
 
@@ -481,36 +481,36 @@ but now we have the JSON mode feature, which is more suitable for this purpose.
 Here is how to enable JSON mode:
 
 - For OpenAI:
-    - For newer models that support [Structured Outputs](https://openai.com/index/introducing-structured-outputs-in-the-api/) (e.g., `gpt-4o-mini`, `gpt-4o-2024-08-06`):
-      ```java
-      OpenAiChatModel.builder()
-          ...
-          .supportedCapabilities(RESPONSE_FORMAT_JSON_SCHEMA)
-          .strictJsonSchema(true)
-          .build();
-      ```
-      See more details [here](/integrations/language-models/open-ai#structured-outputs).
-    - For older models (e.g. gpt-3.5-turbo, gpt-4):
-      ```java
-      OpenAiChatModel.builder()
-          ...
-          .responseFormat("json_object")
-          .build();
-      ```
+  - For newer models that support [Structured Outputs](https://openai.com/index/introducing-structured-outputs-in-the-api/) (e.g., `gpt-4o-mini`, `gpt-4o-2024-08-06`):
+    ```java
+    OpenAiChatModel.builder()
+        ...
+        .supportedCapabilities(RESPONSE_FORMAT_JSON_SCHEMA)
+        .strictJsonSchema(true)
+        .build();
+    ```
+    See more details [here](/integrations/language-models/open-ai#structured-outputs).
+  - For older models (e.g. gpt-3.5-turbo, gpt-4):
+    ```java
+    OpenAiChatModel.builder()
+        ...
+        .responseFormat("json_object")
+        .build();
+    ```
 
 - For Azure OpenAI:
 ```java
 AzureOpenAiChatModel.builder()
     ...
-            .responseFormat(new ChatCompletionsJsonResponseFormat())
-        .build();
+    .responseFormat(new ChatCompletionsJsonResponseFormat())
+    .build();
 ```
 
 - For Vertex AI Gemini:
 ```java
 VertexAiGeminiChatModel.builder()
     ...
-            .responseMimeType("application/json")
+    .responseMimeType("application/json")
     .build();
 ```
 
@@ -519,8 +519,8 @@ Or by specifying an explicit schema from a Java class:
 ```java
 VertexAiGeminiChatModel.builder()
     ...
-            .responseSchema(SchemaHelper.fromClass(Person.class))
-        .build();
+    .responseSchema(SchemaHelper.fromClass(Person.class))
+    .build();
 ```
 
 From a JSON schema:
@@ -528,15 +528,15 @@ From a JSON schema:
 ```java
 VertexAiGeminiChatModel.builder()
     ...
-            .responseSchema(Schema.builder()...build())
-        .build();
+    .responseSchema(Schema.builder()...build())
+    .build();
 ```
 
 - For Google AI Gemini:
 ```java
 GoogleAiGeminiChatModel.builder()
     ...
-            .responseFormat(ResponseFormat.JSON)
+    .responseFormat(ResponseFormat.JSON)
     .build();
 ```
 
@@ -545,11 +545,11 @@ Or by specifying an explicit schema from a Java class:
 ```java
 GoogleAiGeminiChatModel.builder()
     ...
-            .responseFormat(ResponseFormat.builder()
+    .responseFormat(ResponseFormat.builder()
         .type(JSON)
         .jsonSchema(JsonSchemas.jsonSchemaFrom(Person.class).get())
         .build())
-        .build();
+    .build();
 ```
 
 From a JSON schema:
@@ -557,18 +557,18 @@ From a JSON schema:
 ```java
 GoogleAiGeminiChatModel.builder()
     ...
-            .responseFormat(ResponseFormat.builder()
+    .responseFormat(ResponseFormat.builder()
         .type(JSON)
         .jsonSchema(JsonSchema.builder()...build())
         .build())
-        .build();
+    .build();
 ```
 
 - For Mistral AI:
 ```java
 MistralAiChatModel.builder()
     ...
-            .responseFormat(MistralAiResponseFormatType.JSON_OBJECT)
+    .responseFormat(MistralAiResponseFormatType.JSON_OBJECT)
     .build();
 ```
 
@@ -576,12 +576,12 @@ MistralAiChatModel.builder()
 ```java
 OllamaChatModel.builder()
     ...
-            .responseFormat(JSON)
+    .responseFormat(JSON)
     .build();
 ```
 
 - For other model providers: if the underlying model provider does not support JSON mode,
-  prompt engineering is your best bet. Also, try lowering the `temperature` for more determinism.
+prompt engineering is your best bet. Also, try lowering the `temperature` for more determinism.
 
 [More examples](https://github.com/langchain4j/langchain4j-examples/blob/main/other-examples/src/main/java/OtherServiceExamples.java)
 
@@ -598,9 +598,9 @@ interface Assistant {
 }
 
 StreamingChatModel model = OpenAiStreamingChatModel.builder()
-        .apiKey(System.getenv("OPENAI_API_KEY"))
-        .modelName(GPT_4_O_MINI)
-        .build();
+    .apiKey(System.getenv("OPENAI_API_KEY"))
+    .modelName(GPT_4_O_MINI)
+    .build();
 
 Assistant assistant = AiServices.create(Assistant.class, model);
 
@@ -609,17 +609,19 @@ TokenStream tokenStream = assistant.chat("Tell me a joke");
 CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
 
 tokenStream
-        .onPartialResponse((String partialResponse) -> System.out.println(partialResponse))
-        .onPartialThinking((PartialThinking partialThinking) -> System.out.println(partialThinking))
-        .onRetrieved((List<Content> contents) -> System.out.println(contents))
-        .onIntermediateResponse((ChatResponse intermediateResponse) -> System.out.println(intermediateResponse))
-        // This will be invoked right before a tool is executed. BeforeToolExecution contains ToolExecutionRequest (e.g. tool name, tool arguments, etc.)  
-        .beforeToolExecution((BeforeToolExecution beforeToolExecution) -> System.out.println(beforeToolExecution))
-        // This will be invoked right after a tool is executed. ToolExecution contains ToolExecutionRequest and tool execution result. 
-        .onToolExecuted((ToolExecution toolExecution) -> System.out.println(toolExecution))
-        .onCompleteResponse((ChatResponse response) -> futureResponse.complete(response))
-        .onError((Throwable error) -> futureResponse.completeExceptionally(error))
-        .start();
+    .onPartialResponse((String partialResponse) -> System.out.println(partialResponse))
+    .onPartialThinking((PartialThinking partialThinking) -> System.out.println(partialThinking))
+    .onRetrieved((List<Content> contents) -> System.out.println(contents))
+    .onIntermediateResponse((ChatResponse intermediateResponse) -> System.out.println(intermediateResponse))
+     // This will be invoked every time a new partial tool call (usually containing a single token of the tool's arguments) is available.
+    .onPartialToolCall((PartialToolCall partialToolCall) -> System.out.println(partialToolCall))
+     // This will be invoked right before a tool is executed. BeforeToolExecution contains ToolExecutionRequest (e.g. tool name, tool arguments, etc.)
+    .beforeToolExecution((BeforeToolExecution beforeToolExecution) -> System.out.println(beforeToolExecution))
+     // This will be invoked right after a tool is executed. ToolExecution contains ToolExecutionRequest and tool execution result.
+    .onToolExecuted((ToolExecution toolExecution) -> System.out.println(toolExecution))
+    .onCompleteResponse((ChatResponse response) -> futureResponse.complete(response))
+    .onError((Throwable error) -> futureResponse.completeExceptionally(error))
+    .start();
 
 futureResponse.join(); // Blocks the main thread until the streaming process (running in another thread) is complete
 ```
@@ -633,15 +635,15 @@ If you wish to cancel the streaming, you can do so from one of the following cal
 For example:
 ```java
 tokenStream
-        .onPartialResponseWithContext((PartialResponse partialResponse, PartialResponseContext context) -> {
-process(partialResponse);
+    .onPartialResponseWithContext((PartialResponse partialResponse, PartialResponseContext context) -> {
+        process(partialResponse);
         if (shouldCancel()) {
-        context.streamingHandle().cancel();
+            context.streamingHandle().cancel();
         }
-                })
-                .onCompleteResponse((ChatResponse response) -> futureResponse.complete(response))
-        .onError((Throwable error) -> futureResponse.completeExceptionally(error))
-        .start();
+    })
+    .onCompleteResponse((ChatResponse response) -> futureResponse.complete(response))
+    .onError((Throwable error) -> futureResponse.completeExceptionally(error))
+    .start();
 ```
 
 When `StreamingHandle.cancel()` is called, LangChain4j will close the connection and stop the streaming.
@@ -660,7 +662,7 @@ For this, please import `langchain4j-reactor` module:
 ```java
 interface Assistant {
 
-    Flux<String> chat(String message);
+  Flux<String> chat(String message);
 }
 ```
 
@@ -672,9 +674,9 @@ interface Assistant {
 The AI Service can use [chat memory](/tutorials/chat-memory) in order to "remember" previous interactions:
 ```java
 Assistant assistant = AiServices.builder(Assistant.class)
-        .chatModel(model)
-        .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
-        .build();
+    .chatModel(model)
+    .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+    .build();
 ```
 In this scenario, the same `ChatMemory` instance will be used for all invocations of the AI Service.
 However, this approach will not work if you have multiple users,
@@ -688,9 +690,9 @@ interface Assistant  {
 }
 
 Assistant assistant = AiServices.builder(Assistant.class)
-        .chatModel(model)
-        .chatMemoryProvider(memoryId -> MessageWindowChatMemory.withMaxMessages(10))
-        .build();
+    .chatModel(model)
+    .chatMemoryProvider(memoryId -> MessageWindowChatMemory.withMaxMessages(10))
+    .build();
 
 String answerToKlaus = assistant.chat(1, "Hello, my name is Klaus");
 String answerToFrancine = assistant.chat(2, "Hello, my name is Francine");
@@ -738,7 +740,7 @@ AI Service can be configured with tools that LLM can use:
 ```java
 
 class Tools {
-
+    
     @Tool
     int add(int a, int b) {
         return a + b;
@@ -751,9 +753,9 @@ class Tools {
 }
 
 Assistant assistant = AiServices.builder(Assistant.class)
-        .chatModel(model)
-        .tools(new Tools())
-        .build();
+    .chatModel(model)
+    .tools(new Tools())
+    .build();
 
 String answer = assistant.chat("What is 1+2 and 3*4?");
 ```
@@ -775,9 +777,9 @@ EmbeddingModel embeddingModel = ...
 ContentRetriever contentRetriever = new EmbeddingStoreContentRetriever(embeddingStore, embeddingModel);
 
 Assistant assistant = AiServices.builder(Assistant.class)
-        .chatModel(model)
-        .contentRetriever(contentRetriever)
-        .build();
+    .chatModel(model)
+    .contentRetriever(contentRetriever)
+    .build();
 ```
 
 Configuring a `RetrievalAugmentor` provides even more flexibility,
@@ -792,9 +794,9 @@ RetrievalAugmentor retrievalAugmentor = DefaultRetrievalAugmentor.builder()
         .build();
 
 Assistant assistant = AiServices.builder(Assistant.class)
-        .chatModel(model)
-        .retrievalAugmentor(retrievalAugmentor)
-        .build();
+    .chatModel(model)
+    .retrievalAugmentor(retrievalAugmentor)
+    .build();
 ```
 
 More details about RAG can be found [here](/tutorials/rag).
@@ -811,9 +813,9 @@ Auto-moderation can be configured when building the AI Service:
 
 ```java
 Assistant assistant = AiServices.builder(Assistant.class)
-        .chatModel(model)
-        .moderationModel(moderationModel)  // Configures moderation  model
-        .build();
+    .chatModel(model)
+    .moderationModel(moderationModel)  // Configures moderation  model
+    .build();
 ```
 
 
@@ -846,7 +848,7 @@ The point is, smaller and more specific components are easier and cheaper to dev
 
 Another aspect to consider involves two extremes:
 - Do you prefer your application to be highly deterministic,
-  where the application controls the flow and the LLM is just one of the components?
+where the application controls the flow and the LLM is just one of the components?
 - Or do you want the LLM to have complete autonomy and drive your application?
 
 Or perhaps a mix of both, depending on the situation?
@@ -888,7 +890,7 @@ class MilesOfSmiles {
     private final ChatBot chatBot;
     
     ...
-
+    
     public String handle(String userMessage) {
         if (greetingExpert.isGreeting(userMessage)) {
             return "Greetings from Miles of Smiles! How can I make your day better?";
@@ -901,9 +903,9 @@ class MilesOfSmiles {
 GreetingExpert greetingExpert = AiServices.create(GreetingExpert.class, llama2);
 
 ChatBot chatBot = AiServices.builder(ChatBot.class)
-        .chatModel(gpt4)
-        .contentRetriever(milesOfSmilesContentRetriever)
-        .build();
+    .chatModel(gpt4)
+    .contentRetriever(milesOfSmilesContentRetriever)
+    .build();
 
 MilesOfSmiles milesOfSmiles = new MilesOfSmiles(greetingExpert, chatBot);
 

--- a/docs/docs/tutorials/ai-services.md
+++ b/docs/docs/tutorials/ai-services.md
@@ -60,9 +60,9 @@ Then, we create our low-level components. These components will be used under th
 In this case, we just need the `ChatModel`:
 ```java
 ChatModel model = OpenAiChatModel.builder()
-    .apiKey(System.getenv("OPENAI_API_KEY"))
-    .modelName(GPT_4_O_MINI)
-    .build();
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .modelName(GPT_4_O_MINI)
+        .build();
 ```
 
 Finally, we can use the `AiServices` class to create an instance of our AI Service:
@@ -132,9 +132,9 @@ This will be converted into a `SystemMessage` behind the scenes and sent to the 
 System messages can also be defined dynamically with the system message provider:
 ```java
 Friend friend = AiServices.builder(Friend.class)
-    .chatModel(model)
-    .systemMessageProvider(chatMemoryId -> "You are a good friend of mine. Answer using slang.")
-    .build();
+        .chatModel(model)
+        .systemMessageProvider(chatMemoryId -> "You are a good friend of mine. Answer using slang.")
+        .build();
 ```
 As you can see, you can provide different system messages based on a chat memory ID (user or conversation).
 
@@ -182,9 +182,9 @@ It is possible to do so by configuring the AI Service with a `UnaryOperator<Chat
 
 ```java
 Assistant assistant = AiServices.builder(Assistant.class)
-    .chatModel(model)
-    .chatRequestTransformer(transformingFunction)  // Configures the transformation function to be applied to the ChatRequest
-    .build();
+        .chatModel(model)
+        .chatRequestTransformer(transformingFunction)  // Configures the transformation function to be applied to the ChatRequest
+        .build();
 ```
 
 In case it is needed to also access the `ChatMemory` to implement the required `ChatRequest` transformation, it is also possible to configure the `chatRequestTransformer` method with a `BiFunction<ChatRequest, Object, ChatRequest>`, where the second parameter passed to this function is the memory ID.
@@ -213,16 +213,16 @@ Build the AI Service:
 java
 ```java
 AssistantWithChatParams assistant = AiServices.builder(AssistantWithChatParams.class)
-    .chatModel(openAiChatModel)  // or whichever model
-    .build();
+        .chatModel(openAiChatModel)  // or whichever model
+        .build();
 ```
 
 Call it with any per-call parameters:
 
 ```java
 ChatRequestParameters customParams = ChatRequestParameters.builder()
-    .temperature(0.85)
-    .build();
+        .temperature(0.85)
+        .build();
 
 String answer = assistant.chat("Hi there!", customParams);
 ```
@@ -339,11 +339,11 @@ for more details on the available content types.
 AI Service method can return one of the following types:
 - `String` - in this case LLM-generated output is returned without any processing/parsing
 - Any type supported by [Structured Outputs](/tutorials/structured-outputs#supported-types) - in this case
-AI service will parse LLM-generated output into a desired type before returning
+  AI service will parse LLM-generated output into a desired type before returning
 
 Any type can be additionally wrapped into a `Result<T>` to get extra metadata about AI Service invocation:
 - `TokenUsage` - total number of tokens used during AI service invocation. If AI service did multiple calls to
-the LLM (e.g., because tools were executed), it will sum token usages of all calls.
+  the LLM (e.g., because tools were executed), it will sum token usages of all calls.
 - Sources - `Content`s retrieved during [RAG](/tutorials/ai-services#rag) retrieval
 - All [tools](/tutorials/ai-services#tools-function-calling) executed during AI Service invocation (both requests and results)
 - `FinishReason` of the final chat response
@@ -353,7 +353,7 @@ the LLM (e.g., because tools were executed), it will sum token usages of all cal
 An example:
 ```java
 interface Assistant {
-    
+
     @UserMessage("Generate an outline for the article on the following topic: {{it}}")
     Result<List<String>> generateOutlineFor(String topic);
 }
@@ -402,7 +402,7 @@ enum Priority {
 }
 
 interface PriorityAnalyzer {
-    
+
     @UserMessage("Analyze the priority of the following issue: {{it}}")
     Priority analyzePriority(String issueDescription);
 }
@@ -440,13 +440,13 @@ interface PersonExtractor {
 PersonExtractor personExtractor = AiServices.create(PersonExtractor.class, model);
 
 String text = """
-            In 1968, amidst the fading echoes of Independence Day,
-            a child named John arrived under the calm evening sky.
-            This newborn, bearing the surname Doe, marked the start of a new journey.
-            He was welcomed into the world at 345 Whispering Pines Avenue
-            a quaint street nestled in the heart of Springfield
-            an abode that echoed with the gentle hum of suburban dreams and aspirations.
-            """;
+        In 1968, amidst the fading echoes of Independence Day,
+        a child named John arrived under the calm evening sky.
+        This newborn, bearing the surname Doe, marked the start of a new journey.
+        He was welcomed into the world at 345 Whispering Pines Avenue
+        a quaint street nestled in the heart of Springfield
+        an abode that echoed with the gentle hum of suburban dreams and aspirations.
+        """;
 
 Person person = personExtractor.extractPersonFrom(text);
 
@@ -481,36 +481,36 @@ but now we have the JSON mode feature, which is more suitable for this purpose.
 Here is how to enable JSON mode:
 
 - For OpenAI:
-  - For newer models that support [Structured Outputs](https://openai.com/index/introducing-structured-outputs-in-the-api/) (e.g., `gpt-4o-mini`, `gpt-4o-2024-08-06`):
-    ```java
-    OpenAiChatModel.builder()
-        ...
-        .supportedCapabilities(RESPONSE_FORMAT_JSON_SCHEMA)
-        .strictJsonSchema(true)
-        .build();
-    ```
-    See more details [here](/integrations/language-models/open-ai#structured-outputs).
-  - For older models (e.g. gpt-3.5-turbo, gpt-4):
-    ```java
-    OpenAiChatModel.builder()
-        ...
-        .responseFormat("json_object")
-        .build();
-    ```
+    - For newer models that support [Structured Outputs](https://openai.com/index/introducing-structured-outputs-in-the-api/) (e.g., `gpt-4o-mini`, `gpt-4o-2024-08-06`):
+      ```java
+      OpenAiChatModel.builder()
+          ...
+          .supportedCapabilities(RESPONSE_FORMAT_JSON_SCHEMA)
+          .strictJsonSchema(true)
+          .build();
+      ```
+      See more details [here](/integrations/language-models/open-ai#structured-outputs).
+    - For older models (e.g. gpt-3.5-turbo, gpt-4):
+      ```java
+      OpenAiChatModel.builder()
+          ...
+          .responseFormat("json_object")
+          .build();
+      ```
 
 - For Azure OpenAI:
 ```java
 AzureOpenAiChatModel.builder()
     ...
-    .responseFormat(new ChatCompletionsJsonResponseFormat())
-    .build();
+            .responseFormat(new ChatCompletionsJsonResponseFormat())
+        .build();
 ```
 
 - For Vertex AI Gemini:
 ```java
 VertexAiGeminiChatModel.builder()
     ...
-    .responseMimeType("application/json")
+            .responseMimeType("application/json")
     .build();
 ```
 
@@ -519,8 +519,8 @@ Or by specifying an explicit schema from a Java class:
 ```java
 VertexAiGeminiChatModel.builder()
     ...
-    .responseSchema(SchemaHelper.fromClass(Person.class))
-    .build();
+            .responseSchema(SchemaHelper.fromClass(Person.class))
+        .build();
 ```
 
 From a JSON schema:
@@ -528,15 +528,15 @@ From a JSON schema:
 ```java
 VertexAiGeminiChatModel.builder()
     ...
-    .responseSchema(Schema.builder()...build())
-    .build();
+            .responseSchema(Schema.builder()...build())
+        .build();
 ```
 
 - For Google AI Gemini:
 ```java
 GoogleAiGeminiChatModel.builder()
     ...
-    .responseFormat(ResponseFormat.JSON)
+            .responseFormat(ResponseFormat.JSON)
     .build();
 ```
 
@@ -545,11 +545,11 @@ Or by specifying an explicit schema from a Java class:
 ```java
 GoogleAiGeminiChatModel.builder()
     ...
-    .responseFormat(ResponseFormat.builder()
+            .responseFormat(ResponseFormat.builder()
         .type(JSON)
         .jsonSchema(JsonSchemas.jsonSchemaFrom(Person.class).get())
         .build())
-    .build();
+        .build();
 ```
 
 From a JSON schema:
@@ -557,18 +557,18 @@ From a JSON schema:
 ```java
 GoogleAiGeminiChatModel.builder()
     ...
-    .responseFormat(ResponseFormat.builder()
+            .responseFormat(ResponseFormat.builder()
         .type(JSON)
         .jsonSchema(JsonSchema.builder()...build())
         .build())
-    .build();
+        .build();
 ```
 
 - For Mistral AI:
 ```java
 MistralAiChatModel.builder()
     ...
-    .responseFormat(MistralAiResponseFormatType.JSON_OBJECT)
+            .responseFormat(MistralAiResponseFormatType.JSON_OBJECT)
     .build();
 ```
 
@@ -576,12 +576,12 @@ MistralAiChatModel.builder()
 ```java
 OllamaChatModel.builder()
     ...
-    .responseFormat(JSON)
+            .responseFormat(JSON)
     .build();
 ```
 
 - For other model providers: if the underlying model provider does not support JSON mode,
-prompt engineering is your best bet. Also, try lowering the `temperature` for more determinism.
+  prompt engineering is your best bet. Also, try lowering the `temperature` for more determinism.
 
 [More examples](https://github.com/langchain4j/langchain4j-examples/blob/main/other-examples/src/main/java/OtherServiceExamples.java)
 
@@ -598,9 +598,9 @@ interface Assistant {
 }
 
 StreamingChatModel model = OpenAiStreamingChatModel.builder()
-    .apiKey(System.getenv("OPENAI_API_KEY"))
-    .modelName(GPT_4_O_MINI)
-    .build();
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .modelName(GPT_4_O_MINI)
+        .build();
 
 Assistant assistant = AiServices.create(Assistant.class, model);
 
@@ -609,17 +609,17 @@ TokenStream tokenStream = assistant.chat("Tell me a joke");
 CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
 
 tokenStream
-    .onPartialResponse((String partialResponse) -> System.out.println(partialResponse))
-    .onPartialThinking((PartialThinking partialThinking) -> System.out.println(partialThinking))
-    .onRetrieved((List<Content> contents) -> System.out.println(contents))
-    .onIntermediateResponse((ChatResponse intermediateResponse) -> System.out.println(intermediateResponse))
-     // This will be invoked right before a tool is executed. BeforeToolExecution contains ToolExecutionRequest (e.g. tool name, tool arguments, etc.)  
-    .beforeToolExecution((BeforeToolExecution beforeToolExecution) -> System.out.println(beforeToolExecution))
-     // This will be invoked right after a tool is executed. ToolExecution contains ToolExecutionRequest and tool execution result. 
-    .onToolExecuted((ToolExecution toolExecution) -> System.out.println(toolExecution))
-    .onCompleteResponse((ChatResponse response) -> futureResponse.complete(response))
-    .onError((Throwable error) -> futureResponse.completeExceptionally(error))
-    .start();
+        .onPartialResponse((String partialResponse) -> System.out.println(partialResponse))
+        .onPartialThinking((PartialThinking partialThinking) -> System.out.println(partialThinking))
+        .onRetrieved((List<Content> contents) -> System.out.println(contents))
+        .onIntermediateResponse((ChatResponse intermediateResponse) -> System.out.println(intermediateResponse))
+        // This will be invoked right before a tool is executed. BeforeToolExecution contains ToolExecutionRequest (e.g. tool name, tool arguments, etc.)  
+        .beforeToolExecution((BeforeToolExecution beforeToolExecution) -> System.out.println(beforeToolExecution))
+        // This will be invoked right after a tool is executed. ToolExecution contains ToolExecutionRequest and tool execution result. 
+        .onToolExecuted((ToolExecution toolExecution) -> System.out.println(toolExecution))
+        .onCompleteResponse((ChatResponse response) -> futureResponse.complete(response))
+        .onError((Throwable error) -> futureResponse.completeExceptionally(error))
+        .start();
 
 futureResponse.join(); // Blocks the main thread until the streaming process (running in another thread) is complete
 ```
@@ -633,15 +633,15 @@ If you wish to cancel the streaming, you can do so from one of the following cal
 For example:
 ```java
 tokenStream
-    .onPartialResponseWithContext((PartialResponse partialResponse, PartialResponseContext context) -> {
-        process(partialResponse);
+        .onPartialResponseWithContext((PartialResponse partialResponse, PartialResponseContext context) -> {
+process(partialResponse);
         if (shouldCancel()) {
-            context.streamingHandle().cancel();
+        context.streamingHandle().cancel();
         }
-    })
-    .onCompleteResponse((ChatResponse response) -> futureResponse.complete(response))
-    .onError((Throwable error) -> futureResponse.completeExceptionally(error))
-    .start();
+                })
+                .onCompleteResponse((ChatResponse response) -> futureResponse.complete(response))
+        .onError((Throwable error) -> futureResponse.completeExceptionally(error))
+        .start();
 ```
 
 When `StreamingHandle.cancel()` is called, LangChain4j will close the connection and stop the streaming.
@@ -660,7 +660,7 @@ For this, please import `langchain4j-reactor` module:
 ```java
 interface Assistant {
 
-  Flux<String> chat(String message);
+    Flux<String> chat(String message);
 }
 ```
 
@@ -672,9 +672,9 @@ interface Assistant {
 The AI Service can use [chat memory](/tutorials/chat-memory) in order to "remember" previous interactions:
 ```java
 Assistant assistant = AiServices.builder(Assistant.class)
-    .chatModel(model)
-    .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
-    .build();
+        .chatModel(model)
+        .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+        .build();
 ```
 In this scenario, the same `ChatMemory` instance will be used for all invocations of the AI Service.
 However, this approach will not work if you have multiple users,
@@ -688,9 +688,9 @@ interface Assistant  {
 }
 
 Assistant assistant = AiServices.builder(Assistant.class)
-    .chatModel(model)
-    .chatMemoryProvider(memoryId -> MessageWindowChatMemory.withMaxMessages(10))
-    .build();
+        .chatModel(model)
+        .chatMemoryProvider(memoryId -> MessageWindowChatMemory.withMaxMessages(10))
+        .build();
 
 String answerToKlaus = assistant.chat(1, "Hello, my name is Klaus");
 String answerToFrancine = assistant.chat(2, "Hello, my name is Francine");
@@ -738,7 +738,7 @@ AI Service can be configured with tools that LLM can use:
 ```java
 
 class Tools {
-    
+
     @Tool
     int add(int a, int b) {
         return a + b;
@@ -751,9 +751,9 @@ class Tools {
 }
 
 Assistant assistant = AiServices.builder(Assistant.class)
-    .chatModel(model)
-    .tools(new Tools())
-    .build();
+        .chatModel(model)
+        .tools(new Tools())
+        .build();
 
 String answer = assistant.chat("What is 1+2 and 3*4?");
 ```
@@ -775,9 +775,9 @@ EmbeddingModel embeddingModel = ...
 ContentRetriever contentRetriever = new EmbeddingStoreContentRetriever(embeddingStore, embeddingModel);
 
 Assistant assistant = AiServices.builder(Assistant.class)
-    .chatModel(model)
-    .contentRetriever(contentRetriever)
-    .build();
+        .chatModel(model)
+        .contentRetriever(contentRetriever)
+        .build();
 ```
 
 Configuring a `RetrievalAugmentor` provides even more flexibility,
@@ -792,9 +792,9 @@ RetrievalAugmentor retrievalAugmentor = DefaultRetrievalAugmentor.builder()
         .build();
 
 Assistant assistant = AiServices.builder(Assistant.class)
-    .chatModel(model)
-    .retrievalAugmentor(retrievalAugmentor)
-    .build();
+        .chatModel(model)
+        .retrievalAugmentor(retrievalAugmentor)
+        .build();
 ```
 
 More details about RAG can be found [here](/tutorials/rag).
@@ -811,9 +811,9 @@ Auto-moderation can be configured when building the AI Service:
 
 ```java
 Assistant assistant = AiServices.builder(Assistant.class)
-    .chatModel(model)
-    .moderationModel(moderationModel)  // Configures moderation  model
-    .build();
+        .chatModel(model)
+        .moderationModel(moderationModel)  // Configures moderation  model
+        .build();
 ```
 
 
@@ -846,7 +846,7 @@ The point is, smaller and more specific components are easier and cheaper to dev
 
 Another aspect to consider involves two extremes:
 - Do you prefer your application to be highly deterministic,
-where the application controls the flow and the LLM is just one of the components?
+  where the application controls the flow and the LLM is just one of the components?
 - Or do you want the LLM to have complete autonomy and drive your application?
 
 Or perhaps a mix of both, depending on the situation?
@@ -888,7 +888,7 @@ class MilesOfSmiles {
     private final ChatBot chatBot;
     
     ...
-    
+
     public String handle(String userMessage) {
         if (greetingExpert.isGreeting(userMessage)) {
             return "Greetings from Miles of Smiles! How can I make your day better?";
@@ -901,9 +901,9 @@ class MilesOfSmiles {
 GreetingExpert greetingExpert = AiServices.create(GreetingExpert.class, llama2);
 
 ChatBot chatBot = AiServices.builder(ChatBot.class)
-    .chatModel(gpt4)
-    .contentRetriever(milesOfSmilesContentRetriever)
-    .build();
+        .chatModel(gpt4)
+        .contentRetriever(milesOfSmilesContentRetriever)
+        .build();
 
 MilesOfSmiles milesOfSmiles = new MilesOfSmiles(greetingExpert, chatBot);
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -24,6 +24,8 @@ import dev.langchain4j.model.chat.response.PartialResponse;
 import dev.langchain4j.model.chat.response.PartialResponseContext;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.PartialThinkingContext;
+import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.model.chat.response.PartialToolCallContext;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.observability.api.event.AiServiceCompletedEvent;
@@ -70,6 +72,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final BiConsumer<PartialResponse, PartialResponseContext> partialResponseWithContextHandler;
     private final Consumer<PartialThinking> partialThinkingHandler;
     private final BiConsumer<PartialThinking, PartialThinkingContext> partialThinkingWithContextHandler;
+    private final Consumer<PartialToolCall> partialToolCallHandler;
+    private final BiConsumer<PartialToolCall, PartialToolCallContext> partialToolCallWithContextHandler;
     private final Consumer<BeforeToolExecution> beforeToolExecutionHandler;
     private final Consumer<ToolExecution> toolExecutionHandler;
     private final Consumer<ChatResponse> intermediateResponseHandler;
@@ -103,6 +107,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             BiConsumer<PartialResponse, PartialResponseContext> partialResponseWithContextHandler,
             Consumer<PartialThinking> partialThinkingHandler,
             BiConsumer<PartialThinking, PartialThinkingContext> partialThinkingWithContextHandler,
+            Consumer<PartialToolCall> partialToolCallHandler,
+            BiConsumer<PartialToolCall, PartialToolCallContext> partialToolCallWithContextHandler,
             Consumer<BeforeToolExecution> beforeToolExecutionHandler,
             Consumer<ToolExecution> toolExecutionHandler,
             Consumer<ChatResponse> intermediateResponseHandler,
@@ -128,6 +134,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         this.partialResponseWithContextHandler = partialResponseWithContextHandler;
         this.partialThinkingHandler = partialThinkingHandler;
         this.partialThinkingWithContextHandler = partialThinkingWithContextHandler;
+        this.partialToolCallHandler = partialToolCallHandler;
+        this.partialToolCallWithContextHandler = partialToolCallWithContextHandler;
         this.intermediateResponseHandler = intermediateResponseHandler;
         this.completeResponseHandler = completeResponseHandler;
         this.beforeToolExecutionHandler = beforeToolExecutionHandler;
@@ -190,6 +198,29 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             partialThinkingHandler.accept(partialThinking);
         } else if (partialThinkingWithContextHandler != null) {
             partialThinkingWithContextHandler.accept(partialThinking, context);
+        }
+    }
+
+    @Override
+    public void onPartialToolCall(PartialToolCall partialToolCall) {
+        if (partialToolCallHandler != null) {
+            partialToolCallHandler.accept(partialToolCall);
+            return;
+        }
+        if (partialToolCallWithContextHandler != null) {
+            PartialToolCallContext context = new PartialToolCallContext(new CancellationUnsupportedStreamingHandle());
+            partialToolCallWithContextHandler.accept(partialToolCall, context);
+        }
+    }
+
+    @Override
+    public void onPartialToolCall(PartialToolCall partialToolCall, PartialToolCallContext context) {
+        if (partialToolCallHandler != null) {
+            partialToolCallHandler.accept(partialToolCall);
+            return;
+        }
+        if (partialToolCallWithContextHandler != null) {
+            partialToolCallWithContextHandler.accept(partialToolCall, context);
         }
     }
 
@@ -316,6 +347,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     partialResponseWithContextHandler,
                     partialThinkingHandler,
                     partialThinkingWithContextHandler,
+                    partialToolCallHandler,
+                    partialToolCallWithContextHandler,
                     beforeToolExecutionHandler,
                     toolExecutionHandler,
                     intermediateResponseHandler,

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -205,9 +205,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     public void onPartialToolCall(PartialToolCall partialToolCall) {
         if (partialToolCallHandler != null) {
             partialToolCallHandler.accept(partialToolCall);
-            return;
-        }
-        if (partialToolCallWithContextHandler != null) {
+        } else if (partialToolCallWithContextHandler != null) {
             PartialToolCallContext context = new PartialToolCallContext(new CancellationUnsupportedStreamingHandle());
             partialToolCallWithContextHandler.accept(partialToolCall, context);
         }
@@ -217,9 +215,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     public void onPartialToolCall(PartialToolCall partialToolCall, PartialToolCallContext context) {
         if (partialToolCallHandler != null) {
             partialToolCallHandler.accept(partialToolCall);
-            return;
-        }
-        if (partialToolCallWithContextHandler != null) {
+        } else if (partialToolCallWithContextHandler != null) {
             partialToolCallWithContextHandler.accept(partialToolCall, context);
         }
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -19,6 +19,8 @@ import dev.langchain4j.model.chat.response.PartialResponse;
 import dev.langchain4j.model.chat.response.PartialResponseContext;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.PartialThinkingContext;
+import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.model.chat.response.PartialToolCallContext;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.service.tool.BeforeToolExecution;
@@ -53,6 +55,8 @@ public class AiServiceTokenStream implements TokenStream {
     private BiConsumer<PartialResponse, PartialResponseContext> partialResponseWithContextHandler;
     private Consumer<PartialThinking> partialThinkingHandler;
     private BiConsumer<PartialThinking, PartialThinkingContext> partialThinkingWithContextHandler;
+    private Consumer<PartialToolCall> partialToolCallHandler;
+    private BiConsumer<PartialToolCall, PartialToolCallContext> partialToolCallWithContextHandler;
     private Consumer<List<Content>> contentsHandler;
     private Consumer<ChatResponse> intermediateResponseHandler;
     private Consumer<BeforeToolExecution> beforeToolExecutionHandler;
@@ -64,6 +68,8 @@ public class AiServiceTokenStream implements TokenStream {
     private int onPartialResponseWithContextInvoked;
     private int onPartialThinkingInvoked;
     private int onPartialThinkingWithContextInvoked;
+    private int onPartialToolCallInvoked;
+    private int onPartialToolCallWithContextInvoked;
     private int onIntermediateResponseInvoked;
     private int onCompleteResponseInvoked;
     private int onRetrievedInvoked;
@@ -118,6 +124,20 @@ public class AiServiceTokenStream implements TokenStream {
     public TokenStream onPartialThinkingWithContext(BiConsumer<PartialThinking, PartialThinkingContext> handler) {
         this.partialThinkingWithContextHandler = handler;
         this.onPartialThinkingWithContextInvoked++;
+        return this;
+    }
+
+    @Override
+    public TokenStream onPartialToolCall(Consumer<PartialToolCall> partialToolCallHandler) {
+        this.partialToolCallHandler = partialToolCallHandler;
+        this.onPartialToolCallInvoked++;
+        return this;
+    }
+
+    @Override
+    public TokenStream onPartialToolCall(BiConsumer<PartialToolCall, PartialToolCallContext> handler) {
+        this.partialToolCallWithContextHandler = handler;
+        this.onPartialToolCallWithContextInvoked++;
         return this;
     }
 
@@ -195,6 +215,8 @@ public class AiServiceTokenStream implements TokenStream {
                 partialResponseWithContextHandler,
                 partialThinkingHandler,
                 partialThinkingWithContextHandler,
+                partialToolCallHandler,
+                partialToolCallWithContextHandler,
                 beforeToolExecutionHandler,
                 toolExecutionHandler,
                 intermediateResponseHandler,
@@ -226,6 +248,9 @@ public class AiServiceTokenStream implements TokenStream {
         if (onPartialThinkingInvoked + onPartialThinkingWithContextInvoked > 1) {
             throw new IllegalConfigurationException("One of [onPartialThinking, onPartialThinkingWithContext] "
                     + "can be invoked on TokenStream at most 1 time");
+        }
+        if (onPartialToolCallInvoked + onPartialToolCallWithContextInvoked > 1) {
+            throw new IllegalConfigurationException("onPartialToolCall can be invoked on TokenStream at most 1 time");
         }
         if (onIntermediateResponseInvoked > 1) {
             throw new IllegalConfigurationException(

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -135,7 +135,7 @@ public class AiServiceTokenStream implements TokenStream {
     }
 
     @Override
-    public TokenStream onPartialToolCall(BiConsumer<PartialToolCall, PartialToolCallContext> handler) {
+    public TokenStream onPartialToolCallWithContext(BiConsumer<PartialToolCall, PartialToolCallContext> handler) {
         this.partialToolCallWithContextHandler = handler;
         this.onPartialToolCallWithContextInvoked++;
         return this;
@@ -250,7 +250,8 @@ public class AiServiceTokenStream implements TokenStream {
                     + "can be invoked on TokenStream at most 1 time");
         }
         if (onPartialToolCallInvoked + onPartialToolCallWithContextInvoked > 1) {
-            throw new IllegalConfigurationException("onPartialToolCall can be invoked on TokenStream at most 1 time");
+            throw new IllegalConfigurationException("One of [onPartialToolCall, onPartialToolCallWithContext] can be "
+                    + "invoked on TokenStream at most 1 time");
         }
         if (onIntermediateResponseInvoked > 1) {
             throw new IllegalConfigurationException(

--- a/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
@@ -7,6 +7,8 @@ import dev.langchain4j.model.chat.response.PartialResponse;
 import dev.langchain4j.model.chat.response.PartialResponseContext;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.PartialThinkingContext;
+import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.model.chat.response.PartialToolCallContext;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.service.tool.BeforeToolExecution;
@@ -84,6 +86,40 @@ public interface TokenStream {
      */
     @Experimental
     default TokenStream onPartialThinkingWithContext(BiConsumer<PartialThinking, PartialThinkingContext> handler) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    /**
+     * The provided consumer will be invoked every time a new partial tool call
+     * (usually containing a single token of the tool's arguments) from a language model is available.
+     * <p>
+     * Either this or the {@link #onPartialToolCall(BiConsumer)} callback can be used
+     * if you want to consume partial tool calls as soon as they become available.
+     *
+     * @param partialToolCallHandler lambda that will be invoked when a model generates a new partial tool call
+     * @return token stream instance used to configure or start stream processing
+     * @see #onPartialToolCall(BiConsumer)
+     * @since 1.12.0
+     */
+    @Experimental
+    default TokenStream onPartialToolCall(Consumer<PartialToolCall> partialToolCallHandler) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    /**
+     * The provided consumer will be invoked every time a new partial tool call
+     * (usually containing a single token of the tool's arguments) from a language model is available.
+     * <p>
+     * Either this or the {@link #onPartialToolCall(Consumer)} callback can be used
+     * if you want to consume partial tool calls as soon as they become available.
+     *
+     * @param handler lambda that will be invoked when a model generates a new partial tool call
+     * @return token stream instance used to configure or start stream processing
+     * @see #onPartialToolCall(Consumer)
+     * @since 1.12.0
+     */
+    @Experimental
+    default TokenStream onPartialToolCall(BiConsumer<PartialToolCall, PartialToolCallContext> handler) {
         throw new UnsupportedOperationException("not implemented");
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
@@ -93,13 +93,13 @@ public interface TokenStream {
      * The provided consumer will be invoked every time a new partial tool call
      * (usually containing a single token of the tool's arguments) from a language model is available.
      * <p>
-     * Either this or the {@link #onPartialToolCall(BiConsumer)} callback can be used
+     * Either this or the {@link #onPartialToolCallWithContext(BiConsumer)} callback can be used
      * if you want to consume partial tool calls as soon as they become available.
      *
      * @param partialToolCallHandler lambda that will be invoked when a model generates a new partial tool call
      * @return token stream instance used to configure or start stream processing
-     * @see #onPartialToolCall(BiConsumer)
-     * @since 1.12.0
+     * @see #onPartialToolCallWithContext(BiConsumer)
+     * @since 1.11.0
      */
     @Experimental
     default TokenStream onPartialToolCall(Consumer<PartialToolCall> partialToolCallHandler) {
@@ -116,10 +116,10 @@ public interface TokenStream {
      * @param handler lambda that will be invoked when a model generates a new partial tool call
      * @return token stream instance used to configure or start stream processing
      * @see #onPartialToolCall(Consumer)
-     * @since 1.12.0
+     * @since 1.11.0
      */
     @Experimental
-    default TokenStream onPartialToolCall(BiConsumer<PartialToolCall, PartialToolCallContext> handler) {
+    default TokenStream onPartialToolCallWithContext(BiConsumer<PartialToolCall, PartialToolCallContext> handler) {
         throw new UnsupportedOperationException("not implemented");
     }
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
@@ -15,6 +15,8 @@ import dev.langchain4j.model.chat.response.PartialResponse;
 import dev.langchain4j.model.chat.response.PartialResponseContext;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.PartialThinkingContext;
+import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.model.chat.response.PartialToolCallContext;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.ToolErrorHandlerResult;
@@ -41,9 +43,14 @@ class AiServiceTokenStreamTest {
             .build();
 
     static Consumer<String> DUMMY_PARTIAL_RESPONSE_HANDLER = (partialResponse) -> {};
-    static BiConsumer<PartialResponse, PartialResponseContext> DUMMY_PARTIAL_RESPONSE_WITH_CONTEXT_HANDLER = (pr, ctx) -> {};
+    static BiConsumer<PartialResponse, PartialResponseContext> DUMMY_PARTIAL_RESPONSE_WITH_CONTEXT_HANDLER =
+            (pr, ctx) -> {};
     static Consumer<PartialThinking> DUMMY_PARTIAL_THINKING_HANDLER = (partialThinking) -> {};
-    static BiConsumer<PartialThinking, PartialThinkingContext> DUMMY_PARTIAL_THINKING_WITH_CONTEXT_HANDLER = (pt, ctx) -> {};
+    static BiConsumer<PartialThinking, PartialThinkingContext> DUMMY_PARTIAL_THINKING_WITH_CONTEXT_HANDLER =
+            (pt, ctx) -> {};
+    static Consumer<PartialToolCall> DUMMY_PARTIAL_TOOL_CALL_HANDLER = (partialToolCall) -> {};
+    static BiConsumer<PartialToolCall, PartialToolCallContext> DUMMY_PARTIAL_TOOL_CALL_WITH_CONTEXT_HANDLER =
+            (ptc, ctx) -> {};
     static Consumer<Throwable> DUMMY_ERROR_HANDLER = (error) -> {};
     static Consumer<ChatResponse> DUMMY_CHAT_RESPONSE_HANDLER = (chatResponse) -> {};
     static Consumer<BeforeToolExecution> DUMMY_BEFORE_TOOL_EXECUTION_HANDLER = (beforeToolExecution) -> {};
@@ -97,7 +104,8 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("One of [onPartialResponse, onPartialResponseWithContext] can be invoked on TokenStream at most 1 time");
+                .hasMessage(
+                        "One of [onPartialResponse, onPartialResponseWithContext] can be invoked on TokenStream at most 1 time");
     }
 
     @Test
@@ -109,14 +117,13 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("One of [onPartialResponse, onPartialResponseWithContext] can be invoked on TokenStream at most 1 time");
+                .hasMessage(
+                        "One of [onPartialResponse, onPartialResponseWithContext] can be invoked on TokenStream at most 1 time");
     }
 
     @Test
     void start_beforeToolExecutionInvoked_shouldNotThrowException() {
-        tokenStream
-                .beforeToolExecution(DUMMY_BEFORE_TOOL_EXECUTION_HANDLER)
-                .ignoreErrors();
+        tokenStream.beforeToolExecution(DUMMY_BEFORE_TOOL_EXECUTION_HANDLER).ignoreErrors();
 
         assertThatNoException().isThrownBy(() -> tokenStream.start());
     }
@@ -144,9 +151,7 @@ class AiServiceTokenStreamTest {
 
     @Test
     void start_onErrorAndIgnoreErrorsInvoked_shouldThrowException() {
-        tokenStream
-                .onError(DUMMY_ERROR_HANDLER)
-                .ignoreErrors();
+        tokenStream.onError(DUMMY_ERROR_HANDLER).ignoreErrors();
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
@@ -162,7 +167,8 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("One of [onPartialThinking, onPartialThinkingWithContext] can be invoked on TokenStream at most 1 time");
+                .hasMessage(
+                        "One of [onPartialThinking, onPartialThinkingWithContext] can be invoked on TokenStream at most 1 time");
     }
 
     @Test
@@ -174,7 +180,48 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("One of [onPartialThinking, onPartialThinkingWithContext] can be invoked on TokenStream at most 1 time");
+                .hasMessage(
+                        "One of [onPartialThinking, onPartialThinkingWithContext] can be invoked on TokenStream at most 1 time");
+    }
+
+    @Test
+    void start_with_onPartialToolCall_Consumer_shouldNotThrowException() {
+        tokenStream.onPartialToolCall(DUMMY_PARTIAL_TOOL_CALL_HANDLER).ignoreErrors();
+
+        assertThatNoException().isThrownBy(() -> tokenStream.start());
+    }
+
+    @Test
+    void start_with_onPartialToolCall_BiConsumer_shouldNotThrowException() {
+        tokenStream
+                .onPartialToolCall(DUMMY_PARTIAL_TOOL_CALL_WITH_CONTEXT_HANDLER)
+                .ignoreErrors();
+
+        assertThatNoException().isThrownBy(() -> tokenStream.start());
+    }
+
+    @Test
+    void start_onPartialToolCallInvokedMultipleTimes_shouldThrowException() {
+        tokenStream
+                .onPartialToolCall(DUMMY_PARTIAL_TOOL_CALL_HANDLER)
+                .onPartialToolCall(DUMMY_PARTIAL_TOOL_CALL_HANDLER)
+                .ignoreErrors();
+
+        assertThatThrownBy(() -> tokenStream.start())
+                .isExactlyInstanceOf(IllegalConfigurationException.class)
+                .hasMessage("onPartialToolCall can be invoked on TokenStream at most 1 time");
+    }
+
+    @Test
+    void start_onPartialToolCall_Consumer_and_BiConsumer_shouldThrowException() {
+        tokenStream
+                .onPartialToolCall(DUMMY_PARTIAL_TOOL_CALL_HANDLER)
+                .onPartialToolCall(DUMMY_PARTIAL_TOOL_CALL_WITH_CONTEXT_HANDLER)
+                .ignoreErrors();
+
+        assertThatThrownBy(() -> tokenStream.start())
+                .isExactlyInstanceOf(IllegalConfigurationException.class)
+                .hasMessage("onPartialToolCall can be invoked on TokenStream at most 1 time");
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
@@ -44,13 +44,13 @@ class AiServiceTokenStreamTest {
 
     static Consumer<String> DUMMY_PARTIAL_RESPONSE_HANDLER = (partialResponse) -> {};
     static BiConsumer<PartialResponse, PartialResponseContext> DUMMY_PARTIAL_RESPONSE_WITH_CONTEXT_HANDLER =
-            (pr, ctx) -> {};
+            (partialResponse, partialResponseContext) -> {};
     static Consumer<PartialThinking> DUMMY_PARTIAL_THINKING_HANDLER = (partialThinking) -> {};
     static BiConsumer<PartialThinking, PartialThinkingContext> DUMMY_PARTIAL_THINKING_WITH_CONTEXT_HANDLER =
-            (pt, ctx) -> {};
+            (partialThinking, partialThinkingContext) -> {};
     static Consumer<PartialToolCall> DUMMY_PARTIAL_TOOL_CALL_HANDLER = (partialToolCall) -> {};
     static BiConsumer<PartialToolCall, PartialToolCallContext> DUMMY_PARTIAL_TOOL_CALL_WITH_CONTEXT_HANDLER =
-            (ptc, ctx) -> {};
+            (partialToolCall, partialToolCallContext) -> {};
     static Consumer<Throwable> DUMMY_ERROR_HANDLER = (error) -> {};
     static Consumer<ChatResponse> DUMMY_CHAT_RESPONSE_HANDLER = (chatResponse) -> {};
     static Consumer<BeforeToolExecution> DUMMY_BEFORE_TOOL_EXECUTION_HANDLER = (beforeToolExecution) -> {};
@@ -104,8 +104,8 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage(
-                        "One of [onPartialResponse, onPartialResponseWithContext] can be invoked on TokenStream at most 1 time");
+                .hasMessage("One of [onPartialResponse, onPartialResponseWithContext] can be invoked on TokenStream "
+                        + "at most 1 time");
     }
 
     @Test
@@ -117,8 +117,8 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage(
-                        "One of [onPartialResponse, onPartialResponseWithContext] can be invoked on TokenStream at most 1 time");
+                .hasMessage("One of [onPartialResponse, onPartialResponseWithContext] can be invoked on TokenStream "
+                        + "at most 1 time");
     }
 
     @Test
@@ -167,8 +167,8 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage(
-                        "One of [onPartialThinking, onPartialThinkingWithContext] can be invoked on TokenStream at most 1 time");
+                .hasMessage("One of [onPartialThinking, onPartialThinkingWithContext] can be invoked on TokenStream "
+                        + "at most 1 time");
     }
 
     @Test
@@ -180,8 +180,8 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage(
-                        "One of [onPartialThinking, onPartialThinkingWithContext] can be invoked on TokenStream at most 1 time");
+                .hasMessage("One of [onPartialThinking, onPartialThinkingWithContext] can be invoked on TokenStream "
+                        + "at most 1 time");
     }
 
     @Test
@@ -192,9 +192,9 @@ class AiServiceTokenStreamTest {
     }
 
     @Test
-    void start_with_onPartialToolCall_BiConsumer_shouldNotThrowException() {
+    void start_with_onPartialToolCallWithContext_BiConsumer_shouldNotThrowException() {
         tokenStream
-                .onPartialToolCall(DUMMY_PARTIAL_TOOL_CALL_WITH_CONTEXT_HANDLER)
+                .onPartialToolCallWithContext(DUMMY_PARTIAL_TOOL_CALL_WITH_CONTEXT_HANDLER)
                 .ignoreErrors();
 
         assertThatNoException().isThrownBy(() -> tokenStream.start());
@@ -209,19 +209,21 @@ class AiServiceTokenStreamTest {
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("onPartialToolCall can be invoked on TokenStream at most 1 time");
+                .hasMessage("One of [onPartialToolCall, onPartialToolCallWithContext] can be "
+                        + "invoked on TokenStream at most 1 time");
     }
 
     @Test
-    void start_onPartialToolCall_Consumer_and_BiConsumer_shouldThrowException() {
+    void start_onPartialToolCall_Consumer_and_onPartialToolCallWithContext_BiConsumer_shouldThrowException() {
         tokenStream
                 .onPartialToolCall(DUMMY_PARTIAL_TOOL_CALL_HANDLER)
-                .onPartialToolCall(DUMMY_PARTIAL_TOOL_CALL_WITH_CONTEXT_HANDLER)
+                .onPartialToolCallWithContext(DUMMY_PARTIAL_TOOL_CALL_WITH_CONTEXT_HANDLER)
                 .ignoreErrors();
 
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("onPartialToolCall can be invoked on TokenStream at most 1 time");
+                .hasMessage("One of [onPartialToolCall, onPartialToolCallWithContext] can be "
+                        + "invoked on TokenStream at most 1 time");
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/TestTokenStreamHandler.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/TestTokenStreamHandler.java
@@ -1,12 +1,13 @@
 package dev.langchain4j.service;
 
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialThinking;
+import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.service.tool.BeforeToolExecution;
+import dev.langchain4j.service.tool.ToolExecution;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.PartialThinking;
-import dev.langchain4j.service.tool.BeforeToolExecution;
-import dev.langchain4j.service.tool.ToolExecution;
 
 public class TestTokenStreamHandler {
 
@@ -15,6 +16,7 @@ public class TestTokenStreamHandler {
 
     Map<String, Set<Thread>> beforeToolExecutionThreads = new ConcurrentHashMap<>();
     Map<String, Set<Thread>> onToolExecutedThreads = new ConcurrentHashMap<>();
+    Map<String, Set<Thread>> onPartialToolCallThreads = new ConcurrentHashMap<>();
 
     void onPartialResponse(String partialResponse) {
         addThread(Thread.currentThread(), "onPartialResponse");
@@ -31,16 +33,24 @@ public class TestTokenStreamHandler {
     void beforeToolExecution(BeforeToolExecution beforeToolExecution) {
         addThread(Thread.currentThread(), "beforeToolExecution");
 
-        Set<Thread> threads = beforeToolExecutionThreads.computeIfAbsent(beforeToolExecution.request().name(),
-                ignored -> ConcurrentHashMap.newKeySet());
+        Set<Thread> threads = beforeToolExecutionThreads.computeIfAbsent(
+                beforeToolExecution.request().name(), ignored -> ConcurrentHashMap.newKeySet());
+        threads.add(Thread.currentThread());
+    }
+
+    void onPartialToolCall(PartialToolCall partialToolCall) {
+        addThread(Thread.currentThread(), "onPartialToolCall");
+
+        Set<Thread> threads = onPartialToolCallThreads.computeIfAbsent(
+                partialToolCall.name(), ignored -> ConcurrentHashMap.newKeySet());
         threads.add(Thread.currentThread());
     }
 
     void onToolExecuted(ToolExecution toolExecution) {
         addThread(Thread.currentThread(), "onToolExecuted");
 
-        Set<Thread> threads = onToolExecutedThreads.computeIfAbsent(toolExecution.request().name(),
-                ignored -> ConcurrentHashMap.newKeySet());
+        Set<Thread> threads = onToolExecutedThreads.computeIfAbsent(
+                toolExecution.request().name(), ignored -> ConcurrentHashMap.newKeySet());
         threads.add(Thread.currentThread());
     }
 


### PR DESCRIPTION
## Change
Added `onPartialToolCall` callbacks to the `TokenStream` interface, enabling AI Services to consume partial tool call arguments as they stream from the LLM.

This feature complements the existing `onPartialToolCall` support in `StreamingChatResponseHandler` (added in v1.8.0) by exposing it through the higher-level `TokenStream` API used in AI Services.

### Implementation Details:

**TokenStream.java**
- Added two overloaded `onPartialToolCall` methods:
  - `onPartialToolCall(Consumer<PartialToolCall>)` - simple callback
  - `onPartialToolCall(BiConsumer<PartialToolCall, PartialToolCallContext>)` - with context for streaming cancellation
- Both methods are marked `@Experimental` and `@since 1.12.0`

**AiServiceTokenStream.java**
- Added handler fields and invocation counters
- Implemented callback registration methods
- Added validation to ensure only one variant is used at a time
- Updated handler instantiation to pass callbacks

**AiServiceStreamingResponseHandler.java**
- Added handler fields and constructor parameters
- Implemented `onPartialToolCall` interface methods from `StreamingChatResponseHandler`
- Updated recursive handler creation for tool execution loops

**AiServiceTokenStreamTest.java**
- Added tests for validation of multiple invocations
- Added tests for mutual exclusion between overloaded methods

### Supported Providers:
Works automatically with providers that already implement partial tool call streaming:
- Anthropic
- OpenAI
- Azure OpenAI

### Example usage

```java
assistant.chat("What's the weather?")
    .onPartialToolCall(partialToolCall -> {
        System.out.print(partialToolCall.partialArguments());
    })
    .onCompleteResponse(response -> System.out.println("Done"))
    .onError(Throwable::printStackTrace)
    .start();
````
> **Simple callback variant** — prints partial tool-call argument chunks as they stream (suitable for progressive assembly / UI updates).

```java
assistant.chat("What's the weather?")
    .onPartialToolCall((partialToolCall, partialToolCallContext) -> {
        System.out.print(partialToolCall.partialArguments());
    })
    .onCompleteResponse(response -> System.out.println("Done"))
    .onError(Throwable::printStackTrace)
    .start();
````
> **Context-aware variant** — same streaming partial arguments, plus access to `PartialToolCallContext` for stream control (e.g., cancellation) when needed.

### Manual / integration evidence

The screenshots below show partial tool-call chunks being emitted and consumed during streaming (both callback variants).

![onPartialToolCall\_01](https://github.com/user-attachments/assets/14731ef3-6812-4c2f-9231-90cf1a38ef15)
> Callback receives streamed partial arguments while the model is still producing output.

![onPartialToolCall\_02](https://github.com/user-attachments/assets/f05ffb2a-7163-46aa-a0a9-d79318de5910)
> Partial arguments are delivered in multiple chunks and can be progressively assembled/forwarded.

![onPartialToolCall\_05](https://github.com/user-attachments/assets/87f294e8-eb7c-471b-947c-56ebc6ea09d1)
> Context-enabled callback variant works as expected (e.g., allowing cancellation / stream control).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green

<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change
<!-- Please describe the changes you made. -->


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [x] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
