### PR TITLE
[feature] ChatMemory always keep system message on index 0

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/memory/ChatMemory.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/memory/ChatMemory.java
@@ -58,4 +58,11 @@ public interface ChatMemory {
      * Clears the chat memory.
      */
     void clear();
+
+    /**
+     * always keep system message on index 0
+     *
+     * @return true if system message should always be on index 0, false otherwise
+     */
+    boolean isSystemMessageFirst();
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/memory/ChatMemory.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/memory/ChatMemory.java
@@ -58,11 +58,4 @@ public interface ChatMemory {
      * Clears the chat memory.
      */
     void clear();
-
-    /**
-     * always keep system message on index 0
-     *
-     * @return true if system message should always be on index 0, false otherwise
-     */
-    boolean isSystemMessageFirst();
 }

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
  * the most recent value returned by the provider.
  * <p>
  * Once added, a {@link SystemMessage} is always retained.
+ * If {@link MessageWindowChatMemory#systemMessageFirst} is true, always keep system message on index 0.
  * Only one {@code SystemMessage} can be held at a time.
  * If a new {@code SystemMessage} with the same content is added, it is ignored.
  * If a new {@code SystemMessage} with different content is added, the previous {@code SystemMessage} is removed.
@@ -73,7 +74,7 @@ public class MessageWindowChatMemory implements ChatMemory {
                 }
             }
         }
-        if (message instanceof SystemMessage && this.isSystemMessageFirst()) {
+        if (message instanceof SystemMessage && this.systemMessageFirst) {
             messages.add(0, message);
         } else {
             messages.add(message);
@@ -116,7 +117,6 @@ public class MessageWindowChatMemory implements ChatMemory {
         store.deleteMessages(id);
     }
 
-    @Override
     public boolean isSystemMessageFirst() {
         return systemMessageFirst;
     }
@@ -180,7 +180,7 @@ public class MessageWindowChatMemory implements ChatMemory {
          * @param systemMessageFirst
          * @return
          */
-        public Builder systemMessageFirst(boolean systemMessageFirst) {
+        public Builder alwaysKeepSystemMessageFirst(boolean systemMessageFirst) {
             this.systemMessageFirst = systemMessageFirst;
             return this;
         }

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -3,10 +3,6 @@ package dev.langchain4j.memory.chat;
 import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
@@ -15,6 +11,10 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * This chat memory operates as a sliding window whose size is controlled by a {@link #maxMessagesProvider}.

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
@@ -3,10 +3,6 @@ package dev.langchain4j.memory.chat;
 import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
@@ -16,6 +12,10 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * This chat memory operates as a sliding window whose size is controlled by a {@link #maxTokensProvider}.
@@ -182,7 +182,8 @@ public class TokenWindowChatMemory implements ChatMemory {
          * @param tokenCountEstimator A {@link TokenCountEstimator} responsible for counting tokens in the messages.
          * @return builder
          */
-        public Builder dynamicMaxTokens(Function<Object,Integer> maxTokensProvider, TokenCountEstimator tokenCountEstimator) {
+        public Builder dynamicMaxTokens(
+                Function<Object, Integer> maxTokensProvider, TokenCountEstimator tokenCountEstimator) {
             this.maxTokensProvider = maxTokensProvider;
             this.tokenCountEstimator = tokenCountEstimator;
             return this;

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
  * respects the latest value returned by the provider.
  * <p>
  * Once added, a {@link SystemMessage} is always retained.
+ * If {@link TokenWindowChatMemory#systemMessageFirst} is true, always keep system message on index 0.
  * Only one {@code SystemMessage} can be held at a time.
  * If a new {@code SystemMessage} with the same content is added, it is ignored.
  * If a new {@code SystemMessage} with different content is added, the previous {@code SystemMessage} is removed.
@@ -75,7 +76,7 @@ public class TokenWindowChatMemory implements ChatMemory {
                 }
             }
         }
-        if (message instanceof SystemMessage && this.isSystemMessageFirst()) {
+        if (message instanceof SystemMessage && this.systemMessageFirst) {
             messages.add(0, message);
         } else {
             messages.add(message);
@@ -133,7 +134,6 @@ public class TokenWindowChatMemory implements ChatMemory {
         store.deleteMessages(id);
     }
 
-    @Override
     public boolean isSystemMessageFirst() {
         return systemMessageFirst;
     }
@@ -205,7 +205,7 @@ public class TokenWindowChatMemory implements ChatMemory {
          * @param systemMessageFirst
          * @return
          */
-        public Builder systemMessageFirst(boolean systemMessageFirst) {
+        public Builder alwaysKeepSystemMessageFirst(boolean systemMessageFirst) {
             this.systemMessageFirst = systemMessageFirst;
             return this;
         }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
@@ -524,9 +524,9 @@ class MessageWindowChatMemoryTest implements WithAssertions {
 
     @Test
     void system_message_first_enabled() {
-        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+        MessageWindowChatMemory chatMemory = MessageWindowChatMemory.builder()
                 .maxMessages(5)
-                .systemMessageFirst(true)
+                .alwaysKeepSystemMessageFirst(true)
                 .build();
 
         assertThat(chatMemory.isSystemMessageFirst()).isTrue();
@@ -545,7 +545,7 @@ class MessageWindowChatMemoryTest implements WithAssertions {
 
         chatMemory = MessageWindowChatMemory.builder()
                 .maxMessages(5)
-                .systemMessageFirst(true)
+                .alwaysKeepSystemMessageFirst(true)
                 .build();
 
         chatMemory.add(userMessage);
@@ -558,9 +558,9 @@ class MessageWindowChatMemoryTest implements WithAssertions {
 
     @Test
     void system_message_first_disabled() {
-        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+        MessageWindowChatMemory chatMemory = MessageWindowChatMemory.builder()
                 .maxMessages(5)
-                .systemMessageFirst(false)
+                .alwaysKeepSystemMessageFirst(false)
                 .build();
 
         assertThat(chatMemory.isSystemMessageFirst()).isFalse();
@@ -579,7 +579,7 @@ class MessageWindowChatMemoryTest implements WithAssertions {
 
         chatMemory = MessageWindowChatMemory.builder()
                 .maxMessages(5)
-                .systemMessageFirst(false)
+                .alwaysKeepSystemMessageFirst(false)
                 .build();
 
         chatMemory.add(userMessage);
@@ -592,7 +592,7 @@ class MessageWindowChatMemoryTest implements WithAssertions {
 
     @Test
     void system_message_first_default_is_false() {
-        ChatMemory chatMemory = MessageWindowChatMemory.builder().maxMessages(5).build();
+        MessageWindowChatMemory chatMemory = MessageWindowChatMemory.builder().maxMessages(5).build();
 
         // Default value should be false
         assertThat(chatMemory.isSystemMessageFirst()).isFalse();
@@ -602,7 +602,7 @@ class MessageWindowChatMemoryTest implements WithAssertions {
     void system_message_first_with_message_eviction() {
         ChatMemory chatMemory = MessageWindowChatMemory.builder()
                 .maxMessages(3)
-                .systemMessageFirst(true)
+                .alwaysKeepSystemMessageFirst(true)
                 .build();
 
         SystemMessage systemMessage = systemMessage("You are a helpful assistant");

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
@@ -10,9 +10,9 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.memory.ChatMemory;
+import java.util.function.Function;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
-import java.util.function.Function;
 
 class MessageWindowChatMemoryTest implements WithAssertions {
     @Test
@@ -450,8 +450,7 @@ class MessageWindowChatMemoryTest implements WithAssertions {
         shortMemory.add(msgB);
         shortMemory.add(msgC); // Exceeds maxMessages
 
-        assertThat(shortMemory.messages())
-                .containsExactly(msgB, msgC); // Oldest message is evicted
+        assertThat(shortMemory.messages()).containsExactly(msgB, msgC); // Oldest message is evicted
 
         // Test longMemory (window size 4)
         longMemory.add(msg1);
@@ -460,8 +459,7 @@ class MessageWindowChatMemoryTest implements WithAssertions {
         longMemory.add(msg4);
         longMemory.add(msg5); // Exceeds maxMessages
 
-        assertThat(longMemory.messages())
-                .containsExactly(msg2, msg3, msg4, msg5);
+        assertThat(longMemory.messages()).containsExactly(msg2, msg3, msg4, msg5);
 
         // Test default case (ID not matched, window size 3)
         MessageWindowChatMemory defaultMemory = MessageWindowChatMemory.builder()
@@ -474,14 +472,12 @@ class MessageWindowChatMemoryTest implements WithAssertions {
         defaultMemory.add(msgZ);
         defaultMemory.add(msgW); // Exceeds maxMessages
 
-        assertThat(defaultMemory.messages())
-                .containsExactly(msgY, msgZ, msgW);
+        assertThat(defaultMemory.messages()).containsExactly(msgY, msgZ, msgW);
 
         // Clear memory test
         shortMemory.clear();
         assertThat(shortMemory.messages()).isEmpty();
     }
-
 
     @Test
     void dynamic_max_messages_can_change_for_same_id() {
@@ -506,28 +502,24 @@ class MessageWindowChatMemoryTest implements WithAssertions {
         memory.add(msgB);
         memory.add(msgC);
 
-        assertThat(memory.messages())
-                .containsExactly(msgA, msgB, msgC);
+        assertThat(memory.messages()).containsExactly(msgA, msgB, msgC);
 
         memory.add(msgD);
 
-        assertThat(memory.messages())
-                .containsExactly(msgB, msgC, msgD);
+        assertThat(memory.messages()).containsExactly(msgB, msgC, msgD);
 
         // Increase maxMessages to 5 and add another message
         currentMax[0] = 5;
 
         memory.add(msgE);
-        assertThat(memory.messages())
-                .containsExactly(msgB, msgC, msgD, msgE);
+        assertThat(memory.messages()).containsExactly(msgB, msgC, msgD, msgE);
 
         // Decrease maxMessages to 2, which should trigger eviction immediately
         currentMax[0] = 2;
 
         // Fetch messages list; excess messages are automatically evicted
         var msgsAfterShrink = memory.messages();
-        assertThat(msgsAfterShrink)
-                .containsExactly(msgD, msgE); // Keep the most recent two messages
+        assertThat(msgsAfterShrink).containsExactly(msgD, msgE); // Keep the most recent two messages
     }
 
     @Test
@@ -549,8 +541,7 @@ class MessageWindowChatMemoryTest implements WithAssertions {
         chatMemory.add(aiMessage);
 
         // System message should be at the beginning
-        assertThat(chatMemory.messages())
-                .containsExactly(systemMessage, userMessage, aiMessage);
+        assertThat(chatMemory.messages()).containsExactly(systemMessage, userMessage, aiMessage);
 
         chatMemory = MessageWindowChatMemory.builder()
                 .maxMessages(5)
@@ -562,8 +553,7 @@ class MessageWindowChatMemoryTest implements WithAssertions {
         chatMemory.add(aiMessage);
 
         // System message should be at the beginning
-        assertThat(chatMemory.messages())
-                .containsExactly(systemMessage, userMessage, aiMessage);
+        assertThat(chatMemory.messages()).containsExactly(systemMessage, userMessage, aiMessage);
     }
 
     @Test
@@ -585,8 +575,7 @@ class MessageWindowChatMemoryTest implements WithAssertions {
         chatMemory.add(aiMessage);
 
         // System message should be at the beginning
-        assertThat(chatMemory.messages())
-                .containsExactly(systemMessage, userMessage, aiMessage);
+        assertThat(chatMemory.messages()).containsExactly(systemMessage, userMessage, aiMessage);
 
         chatMemory = MessageWindowChatMemory.builder()
                 .maxMessages(5)
@@ -598,15 +587,12 @@ class MessageWindowChatMemoryTest implements WithAssertions {
         chatMemory.add(aiMessage);
 
         // System message should NOT be at the beginning
-        assertThat(chatMemory.messages())
-                .containsExactly(userMessage, systemMessage, aiMessage);
+        assertThat(chatMemory.messages()).containsExactly(userMessage, systemMessage, aiMessage);
     }
 
     @Test
     void system_message_first_default_is_false() {
-        ChatMemory chatMemory = MessageWindowChatMemory.builder()
-                .maxMessages(5)
-                .build();
+        ChatMemory chatMemory = MessageWindowChatMemory.builder().maxMessages(5).build();
 
         // Default value should be false
         assertThat(chatMemory.isSystemMessageFirst()).isFalse();
@@ -629,15 +615,12 @@ class MessageWindowChatMemoryTest implements WithAssertions {
         chatMemory.add(msg2);
 
         // At capacity: systemMessage, msg1, msg2
-        assertThat(chatMemory.messages())
-                .containsExactly(systemMessage, msg1, msg2);
+        assertThat(chatMemory.messages()).containsExactly(systemMessage, msg1, msg2);
 
         UserMessage msg3 = userMessage("Message 3");
         chatMemory.add(msg3);
 
         // msg1 should be evicted, systemMessage should remain at the beginning
-        assertThat(chatMemory.messages())
-                .containsExactly(systemMessage, msg2, msg3);
+        assertThat(chatMemory.messages()).containsExactly(systemMessage, msg2, msg3);
     }
-
 }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
@@ -592,7 +592,8 @@ class MessageWindowChatMemoryTest implements WithAssertions {
 
     @Test
     void system_message_first_default_is_false() {
-        MessageWindowChatMemory chatMemory = MessageWindowChatMemory.builder().maxMessages(5).build();
+        MessageWindowChatMemory chatMemory =
+                MessageWindowChatMemory.builder().maxMessages(5).build();
 
         // Default value should be false
         assertThat(chatMemory.isSystemMessageFirst()).isFalse();

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
@@ -18,9 +18,9 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.model.openai.OpenAiChatModelName;
 import dev.langchain4j.model.openai.OpenAiTokenCountEstimator;
+import java.util.function.Function;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
-import java.util.function.Function;
 
 class TokenWindowChatMemoryTest implements WithAssertions {
 
@@ -30,8 +30,9 @@ class TokenWindowChatMemoryTest implements WithAssertions {
     @Test
     void id() {
         {
-            ChatMemory chatMemory =
-                    TokenWindowChatMemory.builder().maxTokens(2, TOKEN_COUNT_ESTIMATOR).build();
+            ChatMemory chatMemory = TokenWindowChatMemory.builder()
+                    .maxTokens(2, TOKEN_COUNT_ESTIMATOR)
+                    .build();
             assertThat(chatMemory.id()).isEqualTo("default");
         }
         {
@@ -243,7 +244,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         // when
         ToolExecutionResultMessage toolExecutionResultMessage =
                 ToolExecutionResultMessage.from(toolExecutionRequest, "4");
-        int toolExecutionResultMessageTokens = TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage);
+        int toolExecutionResultMessageTokens =
+                TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage);
         assertThat(toolExecutionResultMessageTokens).isEqualTo(5);
         chatMemory.add(toolExecutionResultMessage);
 
@@ -267,7 +269,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
     }
 
     @Test
-    void should_evict_orphan_ToolExecutionResultMessage_when_evicting_AiMessage_with_ToolExecutionRequest_when_SystemMessage_is_present() {
+    void
+            should_evict_orphan_ToolExecutionResultMessage_when_evicting_AiMessage_with_ToolExecutionRequest_when_SystemMessage_is_present() {
 
         // given
         ChatMemory chatMemory = TokenWindowChatMemory.withMaxTokens(48, TOKEN_COUNT_ESTIMATOR);
@@ -316,7 +319,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         // when
         ToolExecutionResultMessage toolExecutionResultMessage =
                 ToolExecutionResultMessage.from(toolExecutionRequest, "4");
-        int toolExecutionResultMessageTokens = TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage);
+        int toolExecutionResultMessageTokens =
+                TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage);
         assertThat(toolExecutionResultMessageTokens).isEqualTo(5);
         chatMemory.add(toolExecutionResultMessage);
 
@@ -343,7 +347,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
     }
 
     @Test
-    void should_evict_orphan_ToolExecutionResultMessage_when_evicting_AiMessage_with_ToolExecutionRequest_when_SystemMessage_is_present_2() {
+    void
+            should_evict_orphan_ToolExecutionResultMessage_when_evicting_AiMessage_with_ToolExecutionRequest_when_SystemMessage_is_present_2() {
 
         // given chat memory
         ChatMemory chatMemory = TokenWindowChatMemory.withMaxTokens(36, TOKEN_COUNT_ESTIMATOR);
@@ -392,7 +397,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         // when toolExecutionResultMessage is added and aiMessage has to be evicted
         ToolExecutionResultMessage toolExecutionResultMessage =
                 ToolExecutionResultMessage.from(toolExecutionRequest, "4");
-        int toolExecutionResultMessageTokens = TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage);
+        int toolExecutionResultMessageTokens =
+                TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage);
         assertThat(toolExecutionResultMessageTokens).isEqualTo(5);
         chatMemory.add(toolExecutionResultMessage);
 
@@ -448,7 +454,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         // when
         ToolExecutionResultMessage toolExecutionResultMessage1 =
                 ToolExecutionResultMessage.from(toolExecutionRequest1, "4");
-        int toolExecutionResultMessage1Tokens = TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage1);
+        int toolExecutionResultMessage1Tokens =
+                TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage1);
         assertThat(toolExecutionResultMessage1Tokens).isEqualTo(5);
         chatMemory.add(toolExecutionResultMessage1);
 
@@ -464,7 +471,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         // when
         ToolExecutionResultMessage toolExecutionResultMessage2 =
                 ToolExecutionResultMessage.from(toolExecutionRequest2, "6");
-        int toolExecutionResultMessage2Tokens = TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage2);
+        int toolExecutionResultMessage2Tokens =
+                TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage2);
         assertThat(toolExecutionResultMessage2Tokens).isEqualTo(5);
         chatMemory.add(toolExecutionResultMessage2);
 
@@ -492,7 +500,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
     }
 
     @Test
-    void should_evict_multiple_orphan_ToolExecutionResultMessages_when_evicting_AiMessage_with_ToolExecutionRequests_when_SystemMessage_is_present() {
+    void
+            should_evict_multiple_orphan_ToolExecutionResultMessages_when_evicting_AiMessage_with_ToolExecutionRequests_when_SystemMessage_is_present() {
 
         // given
         int maxTokens = 91;
@@ -548,7 +557,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         // when
         ToolExecutionResultMessage toolExecutionResultMessage1 =
                 ToolExecutionResultMessage.from(toolExecutionRequest1, "4");
-        int toolExecutionResultMessage1Tokens = TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage1);
+        int toolExecutionResultMessage1Tokens =
+                TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage1);
         assertThat(toolExecutionResultMessage1Tokens).isEqualTo(5);
         chatMemory.add(toolExecutionResultMessage1);
 
@@ -566,7 +576,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         // when
         ToolExecutionResultMessage toolExecutionResultMessage2 =
                 ToolExecutionResultMessage.from(toolExecutionRequest2, "6");
-        int toolExecutionResultMessage2Tokens = TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage2);
+        int toolExecutionResultMessage2Tokens =
+                TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessage(toolExecutionResultMessage2);
         assertThat(toolExecutionResultMessage2Tokens).isEqualTo(5);
         chatMemory.add(toolExecutionResultMessage2);
 
@@ -596,8 +607,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
 
     @Test
     void should_work_even_if_the_first_message_exceeds_max_tokens() {
-        ChatMemory chatMemory = TokenWindowChatMemory.withMaxTokens(2, new
-                OpenAiTokenCountEstimator(OpenAiChatModelName.GPT_3_5_TURBO));
+        ChatMemory chatMemory = TokenWindowChatMemory.withMaxTokens(
+                2, new OpenAiTokenCountEstimator(OpenAiChatModelName.GPT_3_5_TURBO));
 
         chatMemory.add(userMessageWithTokens(25));
         chatMemory.add(aiMessageWithTokens(10));
@@ -608,8 +619,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
 
     @Test
     void should_not_fail_even_with_just_system_message() {
-        ChatMemory chatMemory = TokenWindowChatMemory.withMaxTokens(2, new
-                OpenAiTokenCountEstimator(OpenAiChatModelName.GPT_3_5_TURBO));
+        ChatMemory chatMemory = TokenWindowChatMemory.withMaxTokens(
+                2, new OpenAiTokenCountEstimator(OpenAiChatModelName.GPT_3_5_TURBO));
         chatMemory.add(systemMessageWithTokens(10));
     }
 
@@ -642,8 +653,7 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         shortMemory.add(msgD);
 
         // Keep the most recent messages that fit within maxTokens
-        assertThat(shortMemory.messages())
-                .containsExactly(msgB, msgC, msgD);
+        assertThat(shortMemory.messages()).containsExactly(msgB, msgC, msgD);
 
         // longMemory: maxTokens = 60
         TokenWindowChatMemory longMemory = TokenWindowChatMemory.builder()
@@ -658,8 +668,7 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         longMemory.add(msgE);
 
         // Total tokens do not exceed 60, all messages are retained
-        assertThat(longMemory.messages())
-                .containsExactly(msgA, msgB, msgC, msgD, msgE);
+        assertThat(longMemory.messages()).containsExactly(msgA, msgB, msgC, msgD, msgE);
 
         // Default ID: maxTokens = 45
         TokenWindowChatMemory defaultMemory = TokenWindowChatMemory.builder()
@@ -673,10 +682,8 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         defaultMemory.add(msgD);
 
         // Keep the most recent messages that fit within maxTokens
-        assertThat(defaultMemory.messages())
-                .containsExactly(msgA, msgB, msgC, msgD);
+        assertThat(defaultMemory.messages()).containsExactly(msgA, msgB, msgC, msgD);
     }
-
 
     @Test
     void dynamic_max_tokens_can_change_for_same_id() {
@@ -702,19 +709,16 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         memory.add(msgB);
         memory.add(msgC);
 
-        assertThat(memory.messages())
-                .containsExactly(msgA, msgB, msgC);
+        assertThat(memory.messages()).containsExactly(msgA, msgB, msgC);
 
         // Add the fourth message, triggering eviction
         memory.add(msgD);
-        assertThat(memory.messages())
-                .containsExactly(msgB, msgC, msgD);
+        assertThat(memory.messages()).containsExactly(msgB, msgC, msgD);
 
         // Increase maxTokens = 43 and add a new message; no eviction triggered
         currentMaxTokens[0] = 43;
         memory.add(msgE);
-        assertThat(memory.messages())
-                .containsExactly(msgB, msgC, msgD, msgE);
+        assertThat(memory.messages()).containsExactly(msgB, msgC, msgD, msgE);
 
         // Decrease maxTokens = 33, which automatically evicts the oldest messages
         currentMaxTokens[0] = 33;
@@ -742,8 +746,7 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         chatMemory.add(aiMessage);
 
         // System message should be at the beginning
-        assertThat(chatMemory.messages())
-                .containsExactly(systemMessage, userMessage, aiMessage);
+        assertThat(chatMemory.messages()).containsExactly(systemMessage, userMessage, aiMessage);
 
         chatMemory = TokenWindowChatMemory.builder()
                 .maxTokens(100, TOKEN_COUNT_ESTIMATOR)
@@ -755,8 +758,7 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         chatMemory.add(aiMessage);
 
         // System message should be at the beginning
-        assertThat(chatMemory.messages())
-                .containsExactly(systemMessage, userMessage, aiMessage);
+        assertThat(chatMemory.messages()).containsExactly(systemMessage, userMessage, aiMessage);
     }
 
     @Test
@@ -778,8 +780,7 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         chatMemory.add(aiMessage);
 
         // System message should be at the beginning
-        assertThat(chatMemory.messages())
-                .containsExactly(systemMessage, userMessage, aiMessage);
+        assertThat(chatMemory.messages()).containsExactly(systemMessage, userMessage, aiMessage);
 
         chatMemory = TokenWindowChatMemory.builder()
                 .maxTokens(100, TOKEN_COUNT_ESTIMATOR)
@@ -791,8 +792,7 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         chatMemory.add(aiMessage);
 
         // System message should NOT be at the beginning
-        assertThat(chatMemory.messages())
-                .containsExactly(userMessage, systemMessage, aiMessage);
+        assertThat(chatMemory.messages()).containsExactly(userMessage, systemMessage, aiMessage);
     }
 
     @Test
@@ -822,14 +822,12 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         chatMemory.add(msg2);
 
         // At capacity: systemMessage, msg1, msg2
-        assertThat(chatMemory.messages())
-                .containsExactly(systemMessage, msg1, msg2);
+        assertThat(chatMemory.messages()).containsExactly(systemMessage, msg1, msg2);
 
         UserMessage msg3 = userMessageWithTokens(10);
         chatMemory.add(msg3);
 
         // msg1 should be evicted, systemMessage should remain at the beginning
-        assertThat(chatMemory.messages())
-                .containsExactly(systemMessage, msg2, msg3);
+        assertThat(chatMemory.messages()).containsExactly(systemMessage, msg2, msg3);
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
@@ -729,9 +729,9 @@ class TokenWindowChatMemoryTest implements WithAssertions {
 
     @Test
     void system_message_first_enabled() {
-        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+        TokenWindowChatMemory chatMemory = TokenWindowChatMemory.builder()
                 .maxTokens(100, TOKEN_COUNT_ESTIMATOR)
-                .systemMessageFirst(true)
+                .alwaysKeepSystemMessageFirst(true)
                 .build();
 
         assertThat(chatMemory.isSystemMessageFirst()).isTrue();
@@ -750,7 +750,7 @@ class TokenWindowChatMemoryTest implements WithAssertions {
 
         chatMemory = TokenWindowChatMemory.builder()
                 .maxTokens(100, TOKEN_COUNT_ESTIMATOR)
-                .systemMessageFirst(true)
+                .alwaysKeepSystemMessageFirst(true)
                 .build();
 
         chatMemory.add(userMessage);
@@ -763,9 +763,9 @@ class TokenWindowChatMemoryTest implements WithAssertions {
 
     @Test
     void system_message_first_disabled() {
-        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+        TokenWindowChatMemory chatMemory = TokenWindowChatMemory.builder()
                 .maxTokens(100, TOKEN_COUNT_ESTIMATOR)
-                .systemMessageFirst(false)
+                .alwaysKeepSystemMessageFirst(false)
                 .build();
 
         assertThat(chatMemory.isSystemMessageFirst()).isFalse();
@@ -784,7 +784,7 @@ class TokenWindowChatMemoryTest implements WithAssertions {
 
         chatMemory = TokenWindowChatMemory.builder()
                 .maxTokens(100, TOKEN_COUNT_ESTIMATOR)
-                .systemMessageFirst(false)
+                .alwaysKeepSystemMessageFirst(false)
                 .build();
 
         chatMemory.add(userMessage);
@@ -797,7 +797,7 @@ class TokenWindowChatMemoryTest implements WithAssertions {
 
     @Test
     void system_message_first_default_is_false() {
-        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+        TokenWindowChatMemory chatMemory = TokenWindowChatMemory.builder()
                 .maxTokens(100, TOKEN_COUNT_ESTIMATOR)
                 .build();
 
@@ -809,7 +809,7 @@ class TokenWindowChatMemoryTest implements WithAssertions {
     void system_message_first_with_message_eviction() {
         ChatMemory chatMemory = TokenWindowChatMemory.builder()
                 .maxTokens(35, TOKEN_COUNT_ESTIMATOR)
-                .systemMessageFirst(true)
+                .alwaysKeepSystemMessageFirst(true)
                 .build();
 
         SystemMessage systemMessage = systemMessageWithTokens(10);


### PR DESCRIPTION
## Issue
Closes #1111 

## Change
allow ChatMemory to always keep system message on index 0, impl this feature for MessageWindowChatMemory/TokenWindowChatMemory.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
