### PR TITLE
[BUG] Azure ACADS documentation missing Examples section and broken link in code

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-azure-acads/src/main/java/dev/langchain4j/code/azure/acads/SessionsREPLTool.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-azure-acads/src/main/java/dev/langchain4j/code/azure/acads/SessionsREPLTool.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A tool for executing code in Azure ACA dynamic sessions.
- * See the examples here for more information:
- * https://github.com/langchain4j/langchain4j-examples/tree/main/code-execution/azure-acads-examples
  *
  * Overview:
  * SessionsREPLTool provides a mechanism to execute code snippets within an Azure

--- a/docs/docs/integrations/code-execution-engines/azure-acads.md
+++ b/docs/docs/integrations/code-execution-engines/azure-acads.md
@@ -17,3 +17,7 @@ sidebar_position: 1
 ## APIs
 
 - `SessionsREPLTool`
+
+## Examples
+
+- [SessionsREPLToolTest](https://github.com/langchain4j/langchain4j/blob/main/code-execution-engines/langchain4j-code-execution-engine-azure-acads/src/test/java/dev/langchain4j/code/azure/acads/SessionsREPLToolTest.java)


### PR DESCRIPTION
## Issue
Closes #4324

## Change
Added Examples section to `azure-acads.md` and removed broken link from `SessionsREPLTool.java` Javadoc.

- Added Examples section to `docs/docs/integrations/code-execution-engines/azure-acads.md` with link to `SessionsREPLToolTest` following the pattern used in `graalvm-polyglot.md`
- Removed lines 38-39 from `SessionsREPLTool.java` containing reference to non-existent example repository path


## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
