### PR TITLE
[BUG] Azure and GCS document loaders do not skip failed documents in loadDocuments()

### DIFF
--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
@@ -35,13 +35,26 @@ public class AzureBlobStorageDocumentLoader {
         return DocumentLoader.load(source, parser);
     }
 
+    /**
+     * Loads all documents from an Azure Blob Storage container.
+     * Skips any documents that fail to load.
+     *
+     * @param containerName The name of the container to load from.
+     * @param parser The parser to be used for parsing text from the blob.
+     * @return A list of documents.
+     */
     public List<Document> loadDocuments(String containerName, DocumentParser parser) {
         List<Document> documents = new ArrayList<>();
 
         blobServiceClient.getBlobContainerClient(containerName)
                 .listBlobs()
-                .forEach(blob ->
-                        documents.add(loadDocument(containerName, blob.getName(), parser)));
+                .forEach(blob -> {
+                    try {
+                        documents.add(loadDocument(containerName, blob.getName(), parser));
+                    } catch (Exception e) {
+                        log.warn("Failed to load blob '{}' from container '{}', skipping it.", blob.getName(), containerName, e);
+                    }
+                });
 
         return documents;
     }


### PR DESCRIPTION
## Issue
Closes #4326

## Change
Added exception handling to skip failed documents in `AzureBlobStorageDocumentLoader.loadDocuments()` and `GoogleCloudStorageDocumentLoader.loadDocuments()`, matching the behavior of `AmazonS3DocumentLoader` and `TencentCosDocumentLoader`.

- Added try-catch blocks to skip failed documents and log warnings
- Updated Javadoc to document skip behavior

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
