### PR TITLE
[BUG] YamlDocumentParser missing exception handling in parse method

### DIFF
--- a/document-parsers/langchain4j-document-parser-yaml/src/main/java/dev/langchain4j/data/document/parser/yaml/YamlDocumentParser.java
+++ b/document-parsers/langchain4j-document-parser-yaml/src/main/java/dev/langchain4j/data/document/parser/yaml/YamlDocumentParser.java
@@ -7,6 +7,8 @@ import java.io.InputStream;
 import java.util.Objects;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.constructor.DuplicateKeyException;
 
 /**
  * Parses YAML file into a {@link Document}.
@@ -16,17 +18,25 @@ public class YamlDocumentParser implements DocumentParser {
 
     @Override
     public Document parse(final InputStream inputStream) {
-        LoaderOptions loaderOptions = new LoaderOptions();
-        loaderOptions.setAllowDuplicateKeys(false);
+        try {
+            LoaderOptions loaderOptions = new LoaderOptions();
+            loaderOptions.setAllowDuplicateKeys(false);
 
-        Yaml yaml = new Yaml(loaderOptions);
-        Object obj = yaml.load(inputStream);
+            Yaml yaml = new Yaml(loaderOptions);
+            Object obj = yaml.load(inputStream);
 
-        if (obj == null) {
-            throw new BlankDocumentException();
+            if (obj == null) {
+                throw new BlankDocumentException();
+            }
+
+            String text = Objects.toString(obj);
+            return Document.from(text);
+        } catch (BlankDocumentException e) {
+            throw e;
+        } catch (DuplicateKeyException e) {
+            throw e;
+        } catch (YAMLException e) {
+            throw new RuntimeException(e);
         }
-
-        String text = Objects.toString(obj);
-        return Document.from(text);
     }
 }


### PR DESCRIPTION
## Issue
Closes #4328

## Change
Added exception handling to `YamlDocumentParser.parse()` to match other document parsers.

- Added try-catch block to catch `IOException` and `YAMLException`, converting them to `RuntimeException`
- `DuplicateKeyException` and `BlankDocumentException` continue to be propagated as before

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
