### PR TITLE
[BUG] GraalVM execution engines lose stdout/stderr output

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngine.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngine.java
@@ -6,7 +6,7 @@ import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.SandboxPolicy;
 
 import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
 import static org.graalvm.polyglot.SandboxPolicy.CONSTRAINED;
@@ -20,15 +20,26 @@ public class GraalVmJavaScriptExecutionEngine implements CodeExecutionEngine {
 
     @Override
     public String execute(String code) {
-        OutputStream outputStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (Context context = Context.newBuilder("js")
-            .sandbox(CONSTRAINED)
-            .allowHostAccess(UNTRUSTED)
-            .out(outputStream)
-            .err(outputStream)
-            .build()) {
+                .sandbox(CONSTRAINED)
+                .allowHostAccess(UNTRUSTED)
+                .option("engine.WarnInterpreterOnly", "false")
+                .out(outputStream)
+                .err(outputStream)
+                .build()) {
             Object result = context.eval("js", code).as(Object.class);
-            return String.valueOf(result);
+
+            String output = outputStream.toString(StandardCharsets.UTF_8).trim();
+            String resultStr = String.valueOf(result);
+
+            if (output.isEmpty()) {
+                return resultStr;
+            } else if (resultStr.equals("undefined") || resultStr.equals("null")) {
+                return output;
+            } else {
+                return output + "\n" + resultStr;
+            }
         }
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngine.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngine.java
@@ -6,7 +6,7 @@ import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.SandboxPolicy;
 
 import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
 import static org.graalvm.polyglot.SandboxPolicy.TRUSTED;
@@ -20,15 +20,26 @@ public class GraalVmPythonExecutionEngine implements CodeExecutionEngine {
 
     @Override
     public String execute(String code) {
-        OutputStream outputStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (Context context = Context.newBuilder("python")
-            .sandbox(TRUSTED)
-            .allowHostAccess(UNTRUSTED)
-            .out(outputStream)
-            .err(outputStream)
-            .build()) {
+                .sandbox(TRUSTED)
+                .allowHostAccess(UNTRUSTED)
+                .option("engine.WarnInterpreterOnly", "false")
+                .out(outputStream)
+                .err(outputStream)
+                .build()) {
             Object result = context.eval("python", code).as(Object.class);
-            return String.valueOf(result);
+
+            String output = outputStream.toString(StandardCharsets.UTF_8).trim();
+            String resultStr = String.valueOf(result);
+
+            if (output.isEmpty()) {
+                return resultStr;
+            } else if (resultStr.equals("None")) {
+                return output;
+            } else {
+                return output + "\n" + resultStr;
+            }
         }
     }
 }


### PR DESCRIPTION
## Issue
Closes #4334

## Change
Fixed stdout/stderr output loss in `GraalVmJavaScriptExecutionEngine` and `GraalVmPythonExecutionEngine`.

- Read captured output from `ByteArrayOutputStream` and combine with `eval()` return value
- Return only output when result is undefined/null/None
- Return only result when no output is present
- Disable GraalVM interpreter warnings

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
