### PR TITLE
[BUG] Missing interrupt status restoration in InterruptedException handlers

### DIFF
--- a/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/AbstractInProcessEmbeddingModel.java
+++ b/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/AbstractInProcessEmbeddingModel.java
@@ -79,7 +79,10 @@ public abstract class AbstractInProcessEmbeddingModel extends DimensionAwareEmbe
                 EmbeddingAndTokenCount embeddingAndTokenCount = future.get();
                 embeddings.add(Embedding.from(embeddingAndTokenCount.embedding));
                 inputTokenCount += embeddingAndTokenCount.tokenCount - 2; // do not count special tokens [CLS] and [SEP]
-            } catch (InterruptedException | ExecutionException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt(); 
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
@@ -57,7 +57,10 @@ public class JdkHttpClient implements HttpClient {
             return fromJdkResponse(jdkResponse, jdkResponse.body());
         } catch (HttpTimeoutException e) {
             throw new TimeoutException(e);
-        } catch (IOException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();  
+            throw new RuntimeException(e);
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
## Issue
Closes #4339

## Change
Restore interrupt status by calling `Thread.currentThread().interrupt()` when catching `InterruptedException`:

- `AbstractInProcessEmbeddingModel.parallelizeEmbedding()`: Separate `InterruptedException` from `ExecutionException`
- `JdkHttpClient.execute()`: Separate `InterruptedException` from `IOException`

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

