### PR TITLE
[BUG] FileSystemDocumentLoaderExtensions.loadDocuments() does not skip failed documents

### DIFF
--- a/langchain4j-kotlin/src/main/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensions.kt
+++ b/langchain4j-kotlin/src/main/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensions.kt
@@ -1,5 +1,6 @@
 package dev.langchain4j.kotlin.data.document.loader
 
+import dev.langchain4j.data.document.BlankDocumentException
 import dev.langchain4j.data.document.Document
 import dev.langchain4j.data.document.DocumentParser
 import dev.langchain4j.data.document.loader.FileSystemDocumentLoader
@@ -67,12 +68,22 @@ public suspend fun loadDocuments(
         matchedFiles
             .map { file ->
                 async(context) {
-                    documentParser.parseAsync(
-                        FileSystemSource(file),
-                        context
-                    )
+                    try {
+                        documentParser.parseAsync(
+                            FileSystemSource(file),
+                            context
+                        )
+                    } catch (e: BlankDocumentException) {
+                        // blank/empty documents are ignored
+                        null
+                    } catch (e: Exception) {
+                        val message = e.cause?.message ?: e.message
+                        logger.warn("Failed to load '{}': {}", file, message)
+                        null
+                    }
                 }
             }.awaitAll()
+            .filterNotNull()  // Remove failed documents (null)
             .map { document ->
                 val metadata = document.metadata()
                 logger.info(


### PR DESCRIPTION
## Issue
Closes #4347

## Change

Added exception handling in `FileSystemDocumentLoaderExtensions.loadDocuments()` to catch `BlankDocumentException` and other exceptions, returning `null` for failed documents and filtering them out after `awaitAll()`.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
