### PR TITLE
[ferature][rag] support deduplicate retrieved contents

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/ContentRetriever.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/ContentRetriever.java
@@ -3,13 +3,17 @@ package dev.langchain4j.rag.content.retriever;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 
 import dev.langchain4j.Experimental;
+import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.retriever.listener.ContentRetrieverListener;
 import dev.langchain4j.rag.query.Query;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Retrieves {@link Content}s from an underlying data source using a given {@link Query}.
@@ -41,6 +45,22 @@ public interface ContentRetriever {
      * @return A list of retrieved {@link Content}s.
      */
     List<Content> retrieve(Query query);
+
+    /**
+     * Deduplicate the retrieved {@link Content}s using a given {@link Query} based on {@link ContentRetriever#retrieve}.
+     * @param query
+     * @return
+     */
+    default List<Content> deduplicateRetrieve(Query query) {
+        Set<TextSegment> segmentSet = new HashSet<>();
+        List<Content> res = new LinkedList<>();
+        for (Content content : retrieve(query)) {
+            if (segmentSet.add(content.textSegment())) {
+                res.add(content);
+            }
+        }
+        return res;
+    }
 
     /**
      * Wraps this {@link ContentRetriever} with a listening retriever that dispatches events to the provided listener.

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/ContentRetriever.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/ContentRetriever.java
@@ -7,7 +7,6 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.retriever.listener.ContentRetrieverListener;
 import dev.langchain4j.rag.query.Query;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.aggregator.ContentAggregator;
 import dev.langchain4j.rag.content.injector.ContentInjector;
@@ -378,6 +379,117 @@ class DefaultRetrievalAugmentorTest {
         public List<Content> retrieve(Query query) {
             return contents;
         }
+    }
+
+    @Test
+    void should_deduplicate_retrieve_contents() {
+        // given
+        dev.langchain4j.data.document.Metadata metadata1 = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadata2 = new dev.langchain4j.data.document.Metadata().put("source", "doc2");
+        dev.langchain4j.data.document.Metadata metadata1Duplicate = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+
+        TextSegment segment1 = TextSegment.from("content 1", metadata1);
+        TextSegment segment2 = TextSegment.from("content 2", metadata2);
+        TextSegment segment1Dup = TextSegment.from("content 1", metadata1Duplicate);
+
+        Content content1 = Content.from(segment1);
+        Content content2 = Content.from(segment2);
+        Content content1Dup = Content.from(segment1Dup);
+
+        ContentRetriever contentRetriever = new TestContentRetriever(content1, content2, content1Dup);
+
+        Query query = Query.from("test query");
+
+        // when
+        List<Content> deduplicatedContents = contentRetriever.deduplicateRetrieve(query);
+
+        // then
+        assertThat(deduplicatedContents).hasSize(2);
+        assertThat(deduplicatedContents.get(0).textSegment().text()).isEqualTo("content 1");
+        assertThat(deduplicatedContents.get(1).textSegment().text()).isEqualTo("content 2");
+    }
+
+    @Test
+    void should_deduplicate_retrieve_all_duplicates() {
+        // given
+        dev.langchain4j.data.document.Metadata metadata = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadataDup1 = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadataDup2 = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+
+        TextSegment segment1 = TextSegment.from("same content", metadata);
+        TextSegment segment1Dup1 = TextSegment.from("same content", metadataDup1);
+        TextSegment segment1Dup2 = TextSegment.from("same content", metadataDup2);
+
+        Content content1 = Content.from(segment1);
+        Content content1Dup1 = Content.from(segment1Dup1);
+        Content content1Dup2 = Content.from(segment1Dup2);
+
+        ContentRetriever contentRetriever = new TestContentRetriever(content1, content1Dup1, content1Dup2);
+
+        Query query = Query.from("test query");
+
+        // when
+        List<Content> deduplicatedContents = contentRetriever.deduplicateRetrieve(query);
+
+        // then
+        assertThat(deduplicatedContents).hasSize(1);
+        assertThat(deduplicatedContents.get(0).textSegment().text()).isEqualTo("same content");
+    }
+
+    @Test
+    void should_deduplicate_retrieve_no_duplicates() {
+        // given
+        dev.langchain4j.data.document.Metadata metadata1 = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadata2 = new dev.langchain4j.data.document.Metadata().put("source", "doc2");
+        dev.langchain4j.data.document.Metadata metadata3 = new dev.langchain4j.data.document.Metadata().put("source", "doc3");
+
+        TextSegment segment1 = TextSegment.from("content 1", metadata1);
+        TextSegment segment2 = TextSegment.from("content 2", metadata2);
+        TextSegment segment3 = TextSegment.from("content 3", metadata3);
+
+        Content content1 = Content.from(segment1);
+        Content content2 = Content.from(segment2);
+        Content content3 = Content.from(segment3);
+
+        ContentRetriever contentRetriever = new TestContentRetriever(content1, content2, content3);
+
+        Query query = Query.from("test query");
+
+        // when
+        List<Content> deduplicatedContents = contentRetriever.deduplicateRetrieve(query);
+
+        // then
+        assertThat(deduplicatedContents).hasSize(3);
+        assertThat(deduplicatedContents.get(0).textSegment().text()).isEqualTo("content 1");
+        assertThat(deduplicatedContents.get(1).textSegment().text()).isEqualTo("content 2");
+        assertThat(deduplicatedContents.get(2).textSegment().text()).isEqualTo("content 3");
+    }
+
+    @Test
+    void should_deduplicate_retrieve_same_text_different_metadata_treated_as_different() {
+        // given
+        dev.langchain4j.data.document.Metadata metadata1 = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadata2 = new dev.langchain4j.data.document.Metadata().put("source", "doc2");
+
+        TextSegment segment1 = TextSegment.from("same text", metadata1);
+        TextSegment segment2 = TextSegment.from("same text", metadata2);
+
+        Content content1 = Content.from(segment1);
+        Content content2 = Content.from(segment2);
+
+        ContentRetriever contentRetriever = new TestContentRetriever(content1, content2);
+
+        Query query = Query.from("test query");
+
+        // when
+        List<Content> deduplicatedContents = contentRetriever.deduplicateRetrieve(query);
+
+        // then
+        assertThat(deduplicatedContents).hasSize(2);
+        assertThat(deduplicatedContents.get(0).textSegment().text()).isEqualTo("same text");
+        assertThat(deduplicatedContents.get(0).textSegment().metadata().getString("source")).isEqualTo("doc1");
+        assertThat(deduplicatedContents.get(1).textSegment().text()).isEqualTo("same text");
+        assertThat(deduplicatedContents.get(1).textSegment().metadata().getString("source")).isEqualTo("doc2");
     }
 
     static class TestContentAggregator implements ContentAggregator {

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/DefaultRetrievalAugmentorTest.java
@@ -104,9 +104,7 @@ class DefaultRetrievalAugmentorTest {
 
         // then
         UserMessage augmented = (UserMessage) result.chatMessage();
-        assertThat(augmented.singleText())
-                .isEqualTo(
-                        """
+        assertThat(augmented.singleText()).isEqualTo("""
                 query
                 content 1
                 content 2
@@ -191,9 +189,7 @@ class DefaultRetrievalAugmentorTest {
 
         // then
         UserMessage augmented = (UserMessage) result.chatMessage();
-        assertThat(augmented.singleText())
-                .isEqualTo(
-                        """
+        assertThat(augmented.singleText()).isEqualTo("""
                 query
                 content 1
                 content 2
@@ -270,8 +266,7 @@ class DefaultRetrievalAugmentorTest {
 
         // then
         UserMessage augmented = (UserMessage) result.chatMessage();
-        assertThat(augmented.singleText())
-                .isEqualTo("""
+        assertThat(augmented.singleText()).isEqualTo("""
                 query
                 content 1
                 content 2""");
@@ -384,9 +379,12 @@ class DefaultRetrievalAugmentorTest {
     @Test
     void should_deduplicate_retrieve_contents() {
         // given
-        dev.langchain4j.data.document.Metadata metadata1 = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
-        dev.langchain4j.data.document.Metadata metadata2 = new dev.langchain4j.data.document.Metadata().put("source", "doc2");
-        dev.langchain4j.data.document.Metadata metadata1Duplicate = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadata1 =
+                new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadata2 =
+                new dev.langchain4j.data.document.Metadata().put("source", "doc2");
+        dev.langchain4j.data.document.Metadata metadata1Duplicate =
+                new dev.langchain4j.data.document.Metadata().put("source", "doc1");
 
         TextSegment segment1 = TextSegment.from("content 1", metadata1);
         TextSegment segment2 = TextSegment.from("content 2", metadata2);
@@ -412,9 +410,12 @@ class DefaultRetrievalAugmentorTest {
     @Test
     void should_deduplicate_retrieve_all_duplicates() {
         // given
-        dev.langchain4j.data.document.Metadata metadata = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
-        dev.langchain4j.data.document.Metadata metadataDup1 = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
-        dev.langchain4j.data.document.Metadata metadataDup2 = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadata =
+                new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadataDup1 =
+                new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadataDup2 =
+                new dev.langchain4j.data.document.Metadata().put("source", "doc1");
 
         TextSegment segment1 = TextSegment.from("same content", metadata);
         TextSegment segment1Dup1 = TextSegment.from("same content", metadataDup1);
@@ -439,9 +440,12 @@ class DefaultRetrievalAugmentorTest {
     @Test
     void should_deduplicate_retrieve_no_duplicates() {
         // given
-        dev.langchain4j.data.document.Metadata metadata1 = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
-        dev.langchain4j.data.document.Metadata metadata2 = new dev.langchain4j.data.document.Metadata().put("source", "doc2");
-        dev.langchain4j.data.document.Metadata metadata3 = new dev.langchain4j.data.document.Metadata().put("source", "doc3");
+        dev.langchain4j.data.document.Metadata metadata1 =
+                new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadata2 =
+                new dev.langchain4j.data.document.Metadata().put("source", "doc2");
+        dev.langchain4j.data.document.Metadata metadata3 =
+                new dev.langchain4j.data.document.Metadata().put("source", "doc3");
 
         TextSegment segment1 = TextSegment.from("content 1", metadata1);
         TextSegment segment2 = TextSegment.from("content 2", metadata2);
@@ -468,8 +472,10 @@ class DefaultRetrievalAugmentorTest {
     @Test
     void should_deduplicate_retrieve_same_text_different_metadata_treated_as_different() {
         // given
-        dev.langchain4j.data.document.Metadata metadata1 = new dev.langchain4j.data.document.Metadata().put("source", "doc1");
-        dev.langchain4j.data.document.Metadata metadata2 = new dev.langchain4j.data.document.Metadata().put("source", "doc2");
+        dev.langchain4j.data.document.Metadata metadata1 =
+                new dev.langchain4j.data.document.Metadata().put("source", "doc1");
+        dev.langchain4j.data.document.Metadata metadata2 =
+                new dev.langchain4j.data.document.Metadata().put("source", "doc2");
 
         TextSegment segment1 = TextSegment.from("same text", metadata1);
         TextSegment segment2 = TextSegment.from("same text", metadata2);
@@ -487,9 +493,11 @@ class DefaultRetrievalAugmentorTest {
         // then
         assertThat(deduplicatedContents).hasSize(2);
         assertThat(deduplicatedContents.get(0).textSegment().text()).isEqualTo("same text");
-        assertThat(deduplicatedContents.get(0).textSegment().metadata().getString("source")).isEqualTo("doc1");
+        assertThat(deduplicatedContents.get(0).textSegment().metadata().getString("source"))
+                .isEqualTo("doc1");
         assertThat(deduplicatedContents.get(1).textSegment().text()).isEqualTo("same text");
-        assertThat(deduplicatedContents.get(1).textSegment().metadata().getString("source")).isEqualTo("doc2");
+        assertThat(deduplicatedContents.get(1).textSegment().metadata().getString("source"))
+                .isEqualTo("doc2");
     }
 
     static class TestContentAggregator implements ContentAggregator {


### PR DESCRIPTION
## Issue
Closes #1323

## Change
in rag building phase, we often created duplications, thus during retrieval phase we need to deduplicate these entites. As dev.langchain4j.rag.content.Content#textSegment interface is declared and TextSegment is a equal-able class. i propose a default method to distinct retrieved one. this may also help above issue.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
