### PR TITLE
[BUG] Remove duplicate tool description in Bedrock API requests (#4035)

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AwsDocumentConverter.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AwsDocumentConverter.java
@@ -109,10 +109,6 @@ class AwsDocumentConverter {
         Map<String, Object> schemaMap = new HashMap<>();
         schemaMap.put("type", "object");
 
-        if (toolSpecification.description() != null) {
-            schemaMap.put("description", toolSpecification.description());
-        }
-
         if (toolSpecification.parameters() != null) {
             Map<String, Map<String, Object>> propertiesMap =
                     JsonSchemaElementUtils.toMap(toolSpecification.parameters().properties());

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/AwsDocumentConverterTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/AwsDocumentConverterTest.java
@@ -160,7 +160,7 @@ class AwsDocumentConverterTest {
         // Then
         Map<String, Document> docMap = document.asMap();
         assertThat(docMap.get("type").asString()).isEqualTo("object");
-        assertThat(docMap.get("description").asString()).isEqualTo("Test tool description");
+        assertThat(docMap.containsKey("description")).isFalse();
 
         Document properties = docMap.get("properties");
         assertThat(properties.asMap().keySet()).containsExactlyInAnyOrder("param1", "param2", "param3", "param4");
@@ -259,7 +259,7 @@ class AwsDocumentConverterTest {
         // Then - should not have properties or required fields
         Map<String, Document> docMap = document.asMap();
         assertThat(docMap.get("type").asString()).isEqualTo("object");
-        assertThat(docMap.get("description").asString()).isEqualTo("Tool with no parameters");
+        assertThat(docMap.containsKey("description")).isFalse();
         assertThat(docMap.containsKey("properties")).isFalse();
         assertThat(docMap.containsKey("required")).isFalse();
     }
@@ -447,7 +447,7 @@ class AwsDocumentConverterTest {
         // Then
         Map<String, Document> docMap = document.asMap();
         assertThat(docMap.get("type").asString()).isEqualTo("object");
-        assertThat(docMap.get("description").asString()).isEqualTo("Simple tool with no parameters");
+        assertThat(docMap.containsKey("description")).isFalse();
 
         // Should handle null/empty parameters gracefully
         if (docMap.containsKey("properties")) {


### PR DESCRIPTION
## Issue
Closes #4035

## Change
- Removed duplicate description field from inputSchema.json in AwsDocumentConverter
- Tool description now only appears in toolSpec level per AWS Bedrock documentation
- Updated tests to reflect single description placement

This fix reduces token usage by eliminating unnecessary duplication of tool descriptions in Bedrock API requests.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have written unit and/or integration tests for my change
- [x] I have manually verified that the affected modules build and run correctly

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified compatibility with data persisted using the latest released version of LangChain4j