### PR TITLE
docs: Support Spring Boot 3.5

### DIFF
--- a/docs/docs/tutorials/spring-boot-integration.md
+++ b/docs/docs/tutorials/spring-boot-integration.md
@@ -271,7 +271,9 @@ created by one of our Spring Boot starters.
 
 ## Supported versions
 
-LangChain4j Spring Boot integration requires Java 17 and Spring Boot 3.2.
+LangChain4j Spring Boot integration requires Java 17 and Spring Boot 3.5, in line with the [Spring Boot OSS support policy](https://spring.io/projects/spring-boot#support).
+
+Support for Spring Boot 4.x is not available yet in LangChain4j, but it's planned for a future release.
 
 ## Examples
 - [Low-level Spring Boot example](https://github.com/langchain4j/langchain4j-examples/blob/main/spring-boot-example/src/main/java/dev/langchain4j/example/lowlevel/ChatModelController.java) using [ChatModel API](/tutorials/chat-and-language-models)


### PR DESCRIPTION
## Change

After the changes in https://github.com/langchain4j/langchain4j-spring/pull/155#issuecomment-3719407966, the documentation is now updated to reflect the supported versions of Spring Boot in LangChain4j.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)