### PR TITLE
Add omni-moderation models to OpenAiModerationModelName

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModelName.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModelName.java
@@ -1,9 +1,11 @@
 package dev.langchain4j.model.openai;
 
 public enum OpenAiModerationModelName {
-
     TEXT_MODERATION_STABLE("text-moderation-stable"),
-    TEXT_MODERATION_LATEST("text-moderation-latest");
+    TEXT_MODERATION_LATEST("text-moderation-latest"),
+
+    OMNI_MODERATION_LATEST("omni-moderation-latest"),
+    OMNI_MODERATION_2024_09_26("omni-moderation-2024-09-26");
 
     private final String stringValue;
 


### PR DESCRIPTION
## Issue
Closes #3926

## Change
Add new OpenAI moderation models to `OpenAiModerationModelName` enum:
- `OMNI_MODERATION_LATEST` ("omni-moderation-latest")
- `OMNI_MODERATION_2024_09_26` ("omni-moderation-2024-09-26")


## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)