### PR TITLE
Introduce `langchain4j.http.clientBuilderFactory` system property

### DIFF
--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/FormDataFile.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/FormDataFile.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.http.client;
 
 import dev.langchain4j.Experimental;
-
 import java.util.Arrays;
 import java.util.Objects;
 

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClientBuilderLoader.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClientBuilderLoader.java
@@ -3,27 +3,48 @@ package dev.langchain4j.http.client;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class HttpClientBuilderLoader {
 
     public static HttpClientBuilder loadHttpClientBuilder() {
+        String selectedClassName = System.getProperty("langchain4j.http.clientBuilderFactory");
+
+        HttpClientBuilderFactory effectiveFactory = null;
         Collection<HttpClientBuilderFactory> factories = loadFactories(HttpClientBuilderFactory.class);
-
-        if (factories.size() > 1) {
-            List<String> factoryNames = factories.stream()
-                    .map(factory -> factory.getClass().getName())
-                    .toList();
-            throw new IllegalStateException(String.format(
-                    "Conflict: multiple HTTP clients have been found "
-                            + "in the classpath: %s. Please explicitly specify the one you wish to use.",
-                    factoryNames));
-        }
-
         for (HttpClientBuilderFactory factory : factories) {
-            return factory.create();
+            if (effectiveFactory != null) {
+                throw new IllegalStateException(String.format(
+                        "Conflict: multiple HTTP clients have been found "
+                                + "in the classpath: %s. Please explicitly specify the one you wish to use using the `langchain4j.http.clientBuilderFactory` system property.",
+                        factoryNames(factories)));
+            } else {
+                if (selectedClassName == null) {
+                    effectiveFactory = factory;
+                } else {
+                    if (selectedClassName.equals(factory.getClass().getName())) {
+                        effectiveFactory = factory;
+                        break;
+                    }
+                }
+            }
         }
 
-        throw new IllegalStateException("No HTTP client has been found in the classpath");
+        if (effectiveFactory == null) {
+            if ((selectedClassName == null) || factories.isEmpty()) {
+                throw new IllegalStateException("No HTTP client has been found in the classpath");
+            } else {
+                throw new IllegalStateException(String.format(
+                        "The value of the `langchain4j.http.clientBuilderFactory` system property does not match any of the available HTTP Clients in the classpath: %s.",
+                        factoryNames(factories)));
+            }
+        }
+
+        return effectiveFactory.create();
+    }
+
+    private static Set<String> factoryNames(Collection<HttpClientBuilderFactory> factories) {
+        return factories.stream().map(f -> f.getClass().getName()).collect(Collectors.toSet());
     }
 }

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
@@ -1,14 +1,5 @@
 package dev.langchain4j.http.client;
 
-import dev.langchain4j.Experimental;
-
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
@@ -17,6 +8,14 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.joining;
+
+import dev.langchain4j.Experimental;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class HttpRequest {
 

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/log/HttpRequestLogger.java
@@ -45,8 +45,10 @@ class HttpRequestLogger {
     }
 
     static String format(String headerKey, List<String> headerValues) {
-        if (COMMON_SECRET_HEADERS.contains(headerKey.toLowerCase()) || headerKey.toLowerCase().contains("api-key")) {
-            headerValues = headerValues.stream().map(HttpRequestLogger::maskSecretKey).collect(toList());
+        if (COMMON_SECRET_HEADERS.contains(headerKey.toLowerCase())
+                || headerKey.toLowerCase().contains("api-key")) {
+            headerValues =
+                    headerValues.stream().map(HttpRequestLogger::maskSecretKey).collect(toList());
         }
 
         if (headerValues.size() == 1) {

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/CancellationUnsupportedHandle.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/CancellationUnsupportedHandle.java
@@ -11,9 +11,9 @@ public class CancellationUnsupportedHandle implements ServerSentEventParsingHand
 
     @Override
     public void cancel() {
-        throw new UnsupportedFeatureException("Streaming cancellation is not supported when calling " +
-                "ServerSentEventListener.onEvent(ServerSentEvent). Please call " +
-                "ServerSentEventListener.onEvent(ServerSentEvent, ServerSentEventContext) instead.");
+        throw new UnsupportedFeatureException("Streaming cancellation is not supported when calling "
+                + "ServerSentEventListener.onEvent(ServerSentEvent). Please call "
+                + "ServerSentEventListener.onEvent(ServerSentEvent, ServerSentEventContext) instead.");
     }
 
     @Override

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/ServerSentEventContext.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/ServerSentEventContext.java
@@ -1,8 +1,8 @@
 package dev.langchain4j.http.client.sse;
 
-import dev.langchain4j.Experimental;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.Experimental;
 
 /**
  * @since 1.8.0

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientBuilderLoaderTest.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientBuilderLoaderTest.java
@@ -1,0 +1,170 @@
+package dev.langchain4j.http.client;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import dev.langchain4j.spi.ServiceHelper;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+class HttpClientBuilderLoaderTest {
+
+    @Test
+    void noFactories() {
+        doNoFactories();
+    }
+
+    @Test
+    void noFactoriesAndProperty() {
+        try (var ignored = ResettableSystemProperties.of("langchain4j.http.clientBuilderFactory", "whatever")) {
+            doNoFactories();
+        }
+    }
+
+    private void doNoFactories() {
+        try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
+            mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
+                    .thenReturn(Collections.emptyList());
+
+            assertThatThrownBy(HttpClientBuilderLoader::loadHttpClientBuilder)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("No HTTP client");
+        }
+    }
+
+    @Test
+    void singleFactory() {
+        doSingleFactory();
+    }
+
+    @Test
+    void singleFactoryMatchingProperty() {
+        try (var ignored = ResettableSystemProperties.of(
+                "langchain4j.http.clientBuilderFactory", MockHttpClientBuilder.MockClientFactory.class.getName())) {
+            doSingleFactory();
+        }
+    }
+
+    private void doSingleFactory() {
+        try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
+            mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
+                    .thenReturn(List.of(MockHttpClientBuilder.MockClientFactory.of()));
+
+            assertThat(HttpClientBuilderLoader.loadHttpClientBuilder()).isInstanceOf(MockHttpClientBuilder.class);
+        }
+    }
+
+    @Test
+    void singleFactoryNonMatchingProperty() {
+        try (var ignored = ResettableSystemProperties.of("langchain4j.http.clientBuilderFactory", "whatever")) {
+            try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
+                mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
+                        .thenReturn(List.of(MockHttpClientBuilder.MockClientFactory.of()));
+
+                assertThatThrownBy(HttpClientBuilderLoader::loadHttpClientBuilder)
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("does not match any of the available HTTP Clients");
+            }
+        }
+    }
+
+    @Test
+    void multipleFactories() {
+        try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
+            mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
+                    .thenReturn(
+                            List.of(MockHttpClientBuilder.MockClientFactory.of(), TestHttpClientBuilderFactory.of()));
+
+            assertThatThrownBy(HttpClientBuilderLoader::loadHttpClientBuilder)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("multiple HTTP clients");
+        }
+    }
+
+    @Test
+    void multipleFactoriesNonMatchingProperty() {
+        try (var ignored = ResettableSystemProperties.of("langchain4j.http.clientBuilderFactory", "whatever")) {
+            try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
+                mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
+                        .thenReturn(List.of(
+                                MockHttpClientBuilder.MockClientFactory.of(), TestHttpClientBuilderFactory.of()));
+
+                assertThatThrownBy(HttpClientBuilderLoader::loadHttpClientBuilder)
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("does not match any of the available HTTP Clients");
+            }
+        }
+    }
+
+    @Test
+    void multipleFactoriesMatchingProperty() {
+        try (var ignored = ResettableSystemProperties.of(
+                "langchain4j.http.clientBuilderFactory", MockHttpClientBuilder.MockClientFactory.class.getName())) {
+            try (MockedStatic<ServiceHelper> mocked = Mockito.mockStatic(ServiceHelper.class)) {
+                mocked.when(() -> ServiceHelper.loadFactories(HttpClientBuilderFactory.class))
+                        .thenReturn(List.of(
+                                TestHttpClientBuilderFactory.of(),
+                                MockHttpClientBuilder.MockClientFactory.of(),
+                                TestHttpClientBuilderFactory.of()));
+
+                assertThat(HttpClientBuilderLoader.loadHttpClientBuilder()).isInstanceOf(MockHttpClientBuilder.class);
+            }
+        }
+    }
+
+    // Copied from `io.quarkus.runtime.ResettableSystemProperties`. Might be useful to make this accessible
+    private static class ResettableSystemProperties implements AutoCloseable {
+
+        private final Map<String, String> toRestore;
+
+        public ResettableSystemProperties(Map<String, String> toSet) {
+            Objects.requireNonNull(toSet);
+            if (toSet.isEmpty()) {
+                toRestore = Collections.emptyMap();
+                return;
+            }
+            toRestore = new HashMap<>();
+            for (var entry : toSet.entrySet()) {
+                String oldValue = System.setProperty(entry.getKey(), entry.getValue());
+                toRestore.put(entry.getKey(), oldValue);
+            }
+        }
+
+        public static ResettableSystemProperties of(String name, String value) {
+            return new ResettableSystemProperties(Map.of(name, value));
+        }
+
+        public static ResettableSystemProperties empty() {
+            return new ResettableSystemProperties(Collections.emptyMap());
+        }
+
+        @Override
+        public void close() {
+            for (var entry : toRestore.entrySet()) {
+                if (entry.getValue() != null) {
+                    System.setProperty(entry.getKey(), entry.getValue());
+                } else {
+                    System.clearProperty(entry.getKey());
+                }
+            }
+        }
+    }
+
+    private static class TestHttpClientBuilderFactory implements HttpClientBuilderFactory {
+
+        public static TestHttpClientBuilderFactory of() {
+            return new TestHttpClientBuilderFactory();
+        }
+
+        @Override
+        public HttpClientBuilder create() {
+            throw new IllegalStateException("should never be called");
+        }
+    }
+}

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientIT.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientIT.java
@@ -828,7 +828,8 @@ public abstract class HttpClientIT {
 
     @Test
     protected void should_return_successful_http_response_sync_form_data() throws Exception {
-        Path audioPath = Path.of(getClass().getClassLoader().getResource("sample.wav").toURI());
+        Path audioPath =
+                Path.of(getClass().getClassLoader().getResource("sample.wav").toURI());
 
         for (HttpClient client : clients()) {
 

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/MockHttpClient.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/MockHttpClient.java
@@ -3,13 +3,13 @@ package dev.langchain4j.http.client;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import dev.langchain4j.Internal;
 import dev.langchain4j.http.client.sse.ServerSentEvent;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 @Internal
 public class MockHttpClient implements HttpClient {

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/MockHttpClientBuilder.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/MockHttpClientBuilder.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.http.client;
 
 import dev.langchain4j.Internal;
-
 import java.time.Duration;
 
 @Internal
@@ -36,5 +35,17 @@ public class MockHttpClientBuilder implements HttpClientBuilder {
     @Override
     public HttpClient build() {
         return httpClient;
+    }
+
+    public static class MockClientFactory implements HttpClientBuilderFactory {
+
+        public static MockClientFactory of() {
+            return new MockClientFactory();
+        }
+
+        @Override
+        public HttpClientBuilder create() {
+            return new MockHttpClientBuilder(new MockHttpClient());
+        }
     }
 }

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/SpyingHttpClient.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/SpyingHttpClient.java
@@ -2,12 +2,12 @@ package dev.langchain4j.http.client;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import dev.langchain4j.Internal;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 @Internal
 public class SpyingHttpClient implements HttpClient {


### PR DESCRIPTION
This is done to allow users to select a specific implementation of `HttpClientBuilderFactory` when there are multiple ones on the classpath
