### PR TITLE
Make `JsonSchemaElement` a sealed interface

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonAnyOfSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonAnyOfSchema.java
@@ -8,7 +8,7 @@ import static java.util.Arrays.asList;
 import java.util.List;
 import java.util.Objects;
 
-public class JsonAnyOfSchema implements JsonSchemaElement {
+public final class JsonAnyOfSchema implements JsonSchemaElement {
 
     private final String description;
     private final List<JsonSchemaElement> anyOf;

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonArraySchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonArraySchema.java
@@ -4,7 +4,7 @@ import static dev.langchain4j.internal.Utils.quoted;
 
 import java.util.Objects;
 
-public class JsonArraySchema implements JsonSchemaElement {
+public final class JsonArraySchema implements JsonSchemaElement {
 
     private final String description;
     private final JsonSchemaElement items;

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonBooleanSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonBooleanSchema.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.model.chat.request.json;
 
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.quoted;
 
-public class JsonBooleanSchema implements JsonSchemaElement {
+import java.util.Objects;
+
+public final class JsonBooleanSchema implements JsonSchemaElement {
 
     private final String description;
 
@@ -54,8 +54,6 @@ public class JsonBooleanSchema implements JsonSchemaElement {
 
     @Override
     public String toString() {
-        return "JsonBooleanSchema {" +
-                "description = " + quoted(description) +
-                " }";
+        return "JsonBooleanSchema {" + "description = " + quoted(description) + " }";
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonEnumSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonEnumSchema.java
@@ -7,7 +7,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import java.util.List;
 import java.util.Objects;
 
-public class JsonEnumSchema implements JsonSchemaElement {
+public final class JsonEnumSchema implements JsonSchemaElement {
 
     private final String description;
     private final List<String> enumValues;

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonIntegerSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonIntegerSchema.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.model.chat.request.json;
 
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.quoted;
 
-public class JsonIntegerSchema implements JsonSchemaElement {
+import java.util.Objects;
+
+public final class JsonIntegerSchema implements JsonSchemaElement {
 
     private final String description;
 
@@ -54,8 +54,6 @@ public class JsonIntegerSchema implements JsonSchemaElement {
 
     @Override
     public String toString() {
-        return "JsonIntegerSchema {" +
-                "description = " + quoted(description) +
-                " }";
+        return "JsonIntegerSchema {" + "description = " + quoted(description) + " }";
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonNullSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonNullSchema.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.chat.request.json;
 
-public class JsonNullSchema implements JsonSchemaElement {
+public final class JsonNullSchema implements JsonSchemaElement {
 
     @Override
     public String description() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonNumberSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonNumberSchema.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.model.chat.request.json;
 
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.quoted;
 
-public class JsonNumberSchema implements JsonSchemaElement {
+import java.util.Objects;
+
+public final class JsonNumberSchema implements JsonSchemaElement {
 
     private final String description;
 
@@ -54,8 +54,6 @@ public class JsonNumberSchema implements JsonSchemaElement {
 
     @Override
     public String toString() {
-        return "JsonNumberSchema {" +
-                "description = " + quoted(description) +
-                " }";
+        return "JsonNumberSchema {" + "description = " + quoted(description) + " }";
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonObjectSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonObjectSchema.java
@@ -6,7 +6,7 @@ import static java.util.Arrays.asList;
 
 import java.util.*;
 
-public class JsonObjectSchema implements JsonSchemaElement {
+public final class JsonObjectSchema implements JsonSchemaElement {
 
     private final String description;
     private final Map<String, JsonSchemaElement> properties;

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonRawSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonRawSchema.java
@@ -5,7 +5,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 
 import java.util.Objects;
 
-public class JsonRawSchema implements JsonSchemaElement {
+public final class JsonRawSchema implements JsonSchemaElement {
 
     private final String schema;
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonReferenceSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonReferenceSchema.java
@@ -1,15 +1,15 @@
 package dev.langchain4j.model.chat.request.json;
 
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.quoted;
+
+import java.util.Objects;
 
 /**
  * Can reference {@link JsonObjectSchema} when recursion is required.
  * When used, the {@link JsonObjectSchema#definitions()} of the root JSON schema element
  * should contain an entry with a key equal to the {@link #reference()} of this {@link JsonReferenceSchema}.
  */
-public class JsonReferenceSchema implements JsonSchemaElement {
+public final class JsonReferenceSchema implements JsonSchemaElement {
 
     private final String reference;
 
@@ -59,8 +59,6 @@ public class JsonReferenceSchema implements JsonSchemaElement {
 
     @Override
     public String toString() {
-        return "JsonReferenceSchema {" +
-                "reference = " + quoted(reference) +
-                " }";
+        return "JsonReferenceSchema {" + "reference = " + quoted(reference) + " }";
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonSchema.java
@@ -1,8 +1,8 @@
 package dev.langchain4j.model.chat.request.json;
 
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.quoted;
+
+import java.util.Objects;
 
 public class JsonSchema {
 
@@ -51,8 +51,7 @@ public class JsonSchema {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         JsonSchema that = (JsonSchema) o;
-        return Objects.equals(this.name, that.name)
-                && Objects.equals(this.rootElement, that.rootElement);
+        return Objects.equals(this.name, that.name) && Objects.equals(this.rootElement, that.rootElement);
     }
 
     @Override
@@ -62,9 +61,6 @@ public class JsonSchema {
 
     @Override
     public String toString() {
-        return "JsonSchema {" +
-                " name = " + quoted(name) +
-                ", rootElement = " + rootElement +
-                " }";
+        return "JsonSchema {" + " name = " + quoted(name) + ", rootElement = " + rootElement + " }";
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonSchemaElement.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonSchemaElement.java
@@ -3,19 +3,19 @@ package dev.langchain4j.model.chat.request.json;
 /**
  * A base interface for a JSON schema element.
  *
- * @see JsonAnyOfSchema
- * @see JsonArraySchema
- * @see JsonBooleanSchema
- * @see JsonEnumSchema
- * @see JsonIntegerSchema
- * @see JsonNullSchema
- * @see JsonNumberSchema
- * @see JsonObjectSchema
- * @see JsonRawSchema
- * @see JsonReferenceSchema
- * @see JsonStringSchema
  */
-public interface JsonSchemaElement {
+public sealed interface JsonSchemaElement
+        permits JsonAnyOfSchema,
+                JsonArraySchema,
+                JsonBooleanSchema,
+                JsonEnumSchema,
+                JsonIntegerSchema,
+                JsonNullSchema,
+                JsonNumberSchema,
+                JsonObjectSchema,
+                JsonRawSchema,
+                JsonReferenceSchema,
+                JsonStringSchema {
 
     String description();
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonStringSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonStringSchema.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.model.chat.request.json;
 
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.quoted;
 
-public class JsonStringSchema implements JsonSchemaElement {
+import java.util.Objects;
+
+public final class JsonStringSchema implements JsonSchemaElement {
 
     private final String description;
 
@@ -54,8 +54,6 @@ public class JsonStringSchema implements JsonSchemaElement {
 
     @Override
     public String toString() {
-        return "JsonStringSchema {" +
-                "description = " + quoted(description) +
-                " }";
+        return "JsonStringSchema {" + "description = " + quoted(description) + " }";
     }
 }


### PR DESCRIPTION
This makes handling the subtypes safer, but it is a breaking change