### PR TITLE
Add Supplier support for customHeaders in OpenAI models

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiEmbeddingModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiEmbeddingModel.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 /**
@@ -53,7 +54,7 @@ public class OpenAiEmbeddingModel extends DimensionAwareEmbeddingModel {
                 .logResponses(getOrDefault(builder.logResponses, false))
                 .logger(builder.logger)
                 .userAgent(DEFAULT_USER_AGENT)
-                .customHeaders(builder.customHeaders)
+                .customHeaders(builder.customHeadersSupplier)
                 .customQueryParams(builder.customQueryParams)
                 .build();
         this.modelName = builder.modelName;
@@ -160,7 +161,7 @@ public class OpenAiEmbeddingModel extends DimensionAwareEmbeddingModel {
         private Boolean logRequests;
         private Boolean logResponses;
         private Logger logger;
-        private Map<String, String> customHeaders;
+        private Supplier<Map<String, String>> customHeadersSupplier;
         private Map<String, String> customQueryParams;
         private String encodingFormat;
 
@@ -242,8 +243,21 @@ public class OpenAiEmbeddingModel extends DimensionAwareEmbeddingModel {
             return this;
         }
 
+        /**
+         * Sets custom HTTP headers.
+         */
         public OpenAiEmbeddingModelBuilder customHeaders(Map<String, String> customHeaders) {
-            this.customHeaders = customHeaders;
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         */
+        public OpenAiEmbeddingModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
@@ -19,6 +19,7 @@ import dev.langchain4j.model.output.Response;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
@@ -52,7 +53,7 @@ public class OpenAiImageModel implements ImageModel {
                 .logResponses(getOrDefault(builder.logResponses, false))
                 .logger(builder.logger)
                 .userAgent(DEFAULT_USER_AGENT)
-                .customHeaders(builder.customHeaders)
+                .customHeaders(builder.customHeadersSupplier)
                 .customQueryParams(builder.customQueryParams);
 
         this.client = cBuilder.build();
@@ -117,7 +118,7 @@ public class OpenAiImageModel implements ImageModel {
         private Boolean logRequests;
         private Boolean logResponses;
         private Logger logger;
-        private Map<String, String> customHeaders;
+        private Supplier<Map<String, String>> customHeadersSupplier;
         private Map<String, String> customQueryParams;
 
         public OpenAiImageModelBuilder() {
@@ -213,8 +214,21 @@ public class OpenAiImageModel implements ImageModel {
             return this;
         }
 
+        /**
+         * Sets custom HTTP headers.
+         */
         public OpenAiImageModelBuilder customHeaders(Map<String, String> customHeaders) {
-            this.customHeaders = customHeaders;
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         */
+        public OpenAiImageModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiLanguageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiLanguageModel.java
@@ -19,6 +19,7 @@ import dev.langchain4j.model.openai.spi.OpenAiLanguageModelBuilderFactory;
 import dev.langchain4j.model.output.Response;
 import java.time.Duration;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 /**
@@ -46,7 +47,7 @@ public class OpenAiLanguageModel implements LanguageModel {
                 .logResponses(getOrDefault(builder.logResponses, false))
                 .logger(builder.logger)
                 .userAgent(DEFAULT_USER_AGENT)
-                .customHeaders(builder.customHeaders)
+                .customHeaders(builder.customHeadersSupplier)
                 .customQueryParams(builder.customQueryParams)
                 .build();
         this.modelName = builder.modelName;
@@ -103,7 +104,7 @@ public class OpenAiLanguageModel implements LanguageModel {
         private Boolean logRequests;
         private Boolean logResponses;
         private Logger logger;
-        private Map<String, String> customHeaders;
+        private Supplier<Map<String, String>> customHeadersSupplier;
         private Map<String, String> customQueryParams;
 
         public OpenAiLanguageModelBuilder() {
@@ -179,8 +180,21 @@ public class OpenAiLanguageModel implements LanguageModel {
             return this;
         }
 
+        /**
+         * Sets custom HTTP headers.
+         */
         public OpenAiLanguageModelBuilder customHeaders(Map<String, String> customHeaders) {
-            this.customHeaders = customHeaders;
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         */
+        public OpenAiLanguageModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
@@ -25,6 +25,7 @@ import dev.langchain4j.model.output.Response;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 /**
@@ -50,7 +51,7 @@ public class OpenAiModerationModel implements ModerationModel {
                 .logResponses(getOrDefault(builder.logResponses, false))
                 .logger(builder.logger)
                 .userAgent(DEFAULT_USER_AGENT)
-                .customHeaders(builder.customHeaders)
+                .customHeaders(builder.customHeadersSupplier)
                 .customQueryParams(builder.customQueryParams)
                 .build();
         this.modelName = builder.modelName;
@@ -128,7 +129,7 @@ public class OpenAiModerationModel implements ModerationModel {
         private Boolean logRequests;
         private Boolean logResponses;
         private Logger logger;
-        private Map<String, String> customHeaders;
+        private Supplier<Map<String, String>> customHeadersSupplier;
         private Map<String, String> customQueryParams;
 
         public OpenAiModerationModelBuilder() {
@@ -199,8 +200,21 @@ public class OpenAiModerationModel implements ModerationModel {
             return this;
         }
 
+        /**
+         * Sets custom HTTP headers.
+         */
         public OpenAiModerationModelBuilder customHeaders(Map<String, String> customHeaders) {
-            this.customHeaders = customHeaders;
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         */
+        public OpenAiModerationModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -47,6 +47,7 @@ import dev.langchain4j.model.openai.spi.OpenAiStreamingChatModelBuilderFactory;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 /**
@@ -78,7 +79,7 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
                 .logResponses(getOrDefault(builder.logResponses, false))
                 .logger(builder.logger)
                 .userAgent(DEFAULT_USER_AGENT)
-                .customHeaders(builder.customHeaders)
+                .customHeaders(builder.customHeadersSupplier)
                 .customQueryParams(builder.customQueryParams)
                 .build();
 
@@ -141,7 +142,9 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
         validate(parameters);
 
         ChatCompletionRequest openAiRequest =
-                toOpenAiChatRequest(chatRequest, parameters, sendThinking, thinkingFieldName,strictTools, strictJsonSchema).stream(true)
+                toOpenAiChatRequest(
+                                chatRequest, parameters, sendThinking, thinkingFieldName, strictTools, strictJsonSchema)
+                        .stream(true)
                         .streamOptions(
                                 StreamOptions.builder().includeUsage(true).build())
                         .build();
@@ -285,7 +288,7 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
         private Boolean logRequests;
         private Boolean logResponses;
         private Logger logger;
-        private Map<String, String> customHeaders;
+        private Supplier<Map<String, String>> customHeadersSupplier;
         private Map<String, String> customQueryParams;
         private Map<String, Object> customParameters;
         private List<ChatModelListener> listeners;
@@ -522,10 +525,20 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
         }
 
         /**
-         * Sets custom HTTP headers
+         * Sets custom HTTP headers.
          */
         public OpenAiStreamingChatModelBuilder customHeaders(Map<String, String> customHeaders) {
-            this.customHeaders = customHeaders;
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         */
+        public OpenAiStreamingChatModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingLanguageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingLanguageModel.java
@@ -20,6 +20,7 @@ import dev.langchain4j.model.openai.spi.OpenAiStreamingLanguageModelBuilderFacto
 import dev.langchain4j.model.output.Response;
 import java.time.Duration;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 /**
@@ -47,7 +48,7 @@ public class OpenAiStreamingLanguageModel implements StreamingLanguageModel {
                 .logResponses(getOrDefault(builder.logResponses, false))
                 .logger(builder.logger)
                 .userAgent(DEFAULT_USER_AGENT)
-                .customHeaders(builder.customHeaders)
+                .customHeaders(builder.customHeadersSupplier)
                 .customQueryParams(builder.customQueryParams)
                 .build();
         this.modelName = builder.modelName;
@@ -115,7 +116,7 @@ public class OpenAiStreamingLanguageModel implements StreamingLanguageModel {
         private Boolean logRequests;
         private Boolean logResponses;
         private Logger logger;
-        private Map<String, String> customHeaders;
+        private Supplier<Map<String, String>> customHeadersSupplier;
         private Map<String, String> customQueryParams;
 
         public OpenAiStreamingLanguageModelBuilder() {
@@ -186,8 +187,21 @@ public class OpenAiStreamingLanguageModel implements StreamingLanguageModel {
             return this;
         }
 
+        /**
+         * Sets custom HTTP headers.
+         */
         public OpenAiStreamingLanguageModelBuilder customHeaders(Map<String, String> customHeaders) {
-            this.customHeaders = customHeaders;
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         */
+        public OpenAiStreamingLanguageModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiClient.java
@@ -18,6 +18,7 @@ import dev.langchain4j.model.openai.internal.spi.OpenAiClientBuilderFactory;
 import dev.langchain4j.model.openai.internal.spi.ServiceHelper;
 import java.time.Duration;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 public abstract class OpenAiClient {
@@ -63,7 +64,7 @@ public abstract class OpenAiClient {
         public boolean logRequests;
         public boolean logResponses;
         public Logger logger;
-        public Map<String, String> customHeaders;
+        public Supplier<Map<String, String>> customHeadersSupplier;
         public Map<String, String> customQueryParams;
 
         public abstract T build();
@@ -155,7 +156,20 @@ public abstract class OpenAiClient {
          * @return builder
          */
         public B customHeaders(Map<String, String> customHeaders) {
-            this.customHeaders = customHeaders;
+            this.customHeadersSupplier = () -> customHeaders;
+            return (B) this;
+        }
+
+        /**
+         * A supplier for custom headers to be added to each HTTP request.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         *
+         * @param customHeadersSupplier a supplier that provides a map of headers
+         * @return builder
+         */
+        public B customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return (B) this;
         }
 

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiCustomHeadersSupplierTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiCustomHeadersSupplierTest.java
@@ -1,0 +1,134 @@
+package dev.langchain4j.model.openai;
+
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.ktor.http.HttpStatusCode;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import me.kpavlov.aimocks.openai.MockOpenai;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+class OpenAiCustomHeadersSupplierTest {
+
+    private static final MockOpenai MOCK = new MockOpenai();
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    private static final String MOCK_RESPONSE =
+            """
+            {
+              "id": "chatcmpl-test",
+              "object": "chat.completion",
+              "created": 1721596428,
+              "model": "gpt-4o-mini",
+              "choices": [
+                {
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "Hello!"
+                  },
+                  "finish_reason": "stop"
+                }
+              ],
+              "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15
+              }
+            }
+            """;
+
+    @Test
+    void should_call_supplier_for_each_request_with_chat_model() {
+        // given
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        Supplier<Map<String, String>> headerSupplier = () -> {
+            callCount.incrementAndGet();
+            return Map.of("X-Custom-Token", "token-" + callCount.get());
+        };
+
+        OpenAiChatModel model = OpenAiChatModel.builder()
+                .baseUrl(MOCK.baseUrl())
+                .modelName(GPT_4_O_MINI)
+                .timeout(TIMEOUT)
+                .maxRetries(0)
+                .customHeaders(headerSupplier)
+                .build();
+
+        MOCK.completion(req -> req.userMessageContains("first")).respondsError(res -> {
+            res.setHttpStatus(HttpStatusCode.Companion.fromValue(200));
+            res.setBody(MOCK_RESPONSE);
+        });
+        MOCK.completion(req -> req.userMessageContains("second")).respondsError(res -> {
+            res.setHttpStatus(HttpStatusCode.Companion.fromValue(200));
+            res.setBody(MOCK_RESPONSE);
+        });
+
+        // when
+        model.chat("first");
+        int countAfterFirst = callCount.get();
+        model.chat("second");
+        int countAfterSecond = callCount.get();
+
+        // then
+        assertThat(countAfterFirst).isGreaterThan(0);
+        assertThat(countAfterSecond).isGreaterThan(countAfterFirst);
+    }
+
+    @Test
+    void should_work_with_static_map_for_backwards_compatibility() {
+        // given
+        Map<String, String> staticHeaders = Map.of("X-Static-Header", "static-value");
+
+        OpenAiChatModel model = OpenAiChatModel.builder()
+                .baseUrl(MOCK.baseUrl())
+                .modelName(GPT_4_O_MINI)
+                .timeout(TIMEOUT)
+                .maxRetries(0)
+                .customHeaders(staticHeaders)
+                .build();
+
+        MOCK.completion(req -> req.userMessageContains("test")).respondsError(res -> {
+            res.setHttpStatus(HttpStatusCode.Companion.fromValue(200));
+            res.setBody(MOCK_RESPONSE);
+        });
+
+        // when-then
+        model.chat("test");
+    }
+
+    @Test
+    void should_handle_null_from_supplier() {
+        // given
+        Supplier<Map<String, String>> nullSupplier = () -> null;
+
+        OpenAiChatModel model = OpenAiChatModel.builder()
+                .baseUrl(MOCK.baseUrl())
+                .modelName(GPT_4_O_MINI)
+                .timeout(TIMEOUT)
+                .maxRetries(0)
+                .customHeaders(nullSupplier)
+                .build();
+
+        MOCK.completion(req -> req.userMessageContains("test")).respondsError(res -> {
+            res.setHttpStatus(HttpStatusCode.Companion.fromValue(200));
+            res.setBody(MOCK_RESPONSE);
+        });
+
+        // when-then
+        model.chat("test");
+    }
+
+    @AfterEach
+    void afterEach() {
+        MOCK.verifyNoUnmatchedRequests();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #3408
Related to #3306 (dynamic customHeaders part)

## Change

Add `Supplier<Map<String, String>>` support for `customHeaders` in `langchain4j-open-ai` module.

### Problem
OAuth2 tokens expire, requiring ChatModel rebuild - impractical for production use.

### Solution
```java
// Before: fixed at build time
.customHeaders(Map.of("Authorization", "Bearer " + token))

// After: fresh on each request  
.customHeaders(() -> Map.of("Authorization", "Bearer " + tokenProvider.getToken()))
```

### Implementation
- Follow existing pattern from `StreamableHttpMcpTransport` in `langchain4j-mcp` module
- Add `customHeaders(Supplier<Map<String, String>>)` overload to all OpenAI model builders
- Use `getOrDefault` pattern for null safety (same as MCP Transport)
- Backward compatible: existing `customHeaders(Map)` still works (wrapped internally as `() -> map`)

### Modified files
- `OpenAiClient.java` - Add Supplier field and overloaded method in Builder
- `DefaultOpenAiClient.java` - Add `buildRequestHeaders()` helper, call Supplier per request
- 7 model classes: `OpenAiChatModel`, `OpenAiStreamingChatModel`, `OpenAiEmbeddingModel`, `OpenAiImageModel`, `OpenAiModerationModel`, `OpenAiLanguageModel`, `OpenAiStreamingLanguageModel`
- New test: `OpenAiCustomHeadersSupplierTest.java`

### Scope
This PR covers `langchain4j-open-ai` module only. If this approach is approved, I'm happy to apply the same pattern to other modules (e.g., `langchain4j-azure-open-ai`, `langchain4j-ollama`) in follow-up PRs for consistency.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)