### PR TITLE
MistralAi: return raw HTTP response and SSE events

### DIFF
--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatModel.java
@@ -19,19 +19,17 @@ import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiChatCompletionRequest;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiChatCompletionResponse;
 import dev.langchain4j.model.mistralai.internal.client.MistralAiClient;
 import dev.langchain4j.model.mistralai.internal.client.ParsedAndRawResponse;
 import dev.langchain4j.model.mistralai.spi.MistralAiChatModelBuilderFactory;
-import org.slf4j.Logger;
-
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
 
 /**
  * Represents a Mistral AI Chat Model with a chat completion interface, such as open-mistral-7b and open-mixtral-8x7b
@@ -102,13 +100,14 @@ public class MistralAiChatModel implements ChatModel {
 
         MistralAiChatCompletionResponse mistralAiResponse = response.parsedResponse();
 
-         return ChatResponse.builder()
+        return ChatResponse.builder()
                 .aiMessage(aiMessageFrom(mistralAiResponse))
                 .metadata(MistralAiChatResponseMetadata.builder()
                         .id(mistralAiResponse.getId())
                         .modelName(mistralAiResponse.getModel())
                         .tokenUsage(tokenUsageFrom(mistralAiResponse.getUsage()))
-                        .finishReason(finishReasonFrom(mistralAiResponse.getChoices().get(0).getFinishReason()))
+                        .finishReason(finishReasonFrom(
+                                mistralAiResponse.getChoices().get(0).getFinishReason()))
                         .rawHttpResponse(response.rawResponse())
                         .build())
                 .build();

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatResponseMetadata.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatResponseMetadata.java
@@ -1,0 +1,86 @@
+package dev.langchain4j.model.mistralai;
+
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import java.util.List;
+import java.util.Objects;
+
+import static dev.langchain4j.internal.Utils.copy;
+
+public class MistralAiChatResponseMetadata extends ChatResponseMetadata {
+    private final SuccessfulHttpResponse rawHttpResponse;
+    private final List<ServerSentEvent> rawServerSentEvents;
+
+    private MistralAiChatResponseMetadata(Builder builder) {
+        super(builder);
+        this.rawHttpResponse = builder.rawHttpResponse;
+        this.rawServerSentEvents = copy(builder.rawServerSentEvents);
+    }
+
+    public SuccessfulHttpResponse rawHttpResponse() {
+        return rawHttpResponse;
+    }
+
+    public List<ServerSentEvent> rawServerSentEvents() {
+        return rawServerSentEvents;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return ((Builder) super.toBuilder(builder()))
+                .rawHttpResponse(rawHttpResponse)
+                .rawServerSentEvents(rawServerSentEvents);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        MistralAiChatResponseMetadata that = (MistralAiChatResponseMetadata) o;
+        return Objects.equals(rawHttpResponse, that.rawHttpResponse)
+                && Objects.equals(rawServerSentEvents, that.rawServerSentEvents);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), rawHttpResponse, rawServerSentEvents);
+    }
+
+    @Override
+    public String toString() {
+        return "MistralAiChatResponseMetadata{" + "id='"
+                + id() + '\'' + ", modelName='"
+                + modelName() + '\'' + ", tokenUsage="
+                + tokenUsage() + ", finishReason="
+                + finishReason() + ", created="
+                + rawHttpResponse + ", rawServerSentEvents="
+                + rawServerSentEvents + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends ChatResponseMetadata.Builder<Builder> {
+
+        private SuccessfulHttpResponse rawHttpResponse;
+        private List<ServerSentEvent> rawServerSentEvents;
+
+        public Builder rawHttpResponse(SuccessfulHttpResponse rawHttpResponse) {
+            this.rawHttpResponse = rawHttpResponse;
+            return this;
+        }
+
+        public Builder rawServerSentEvents(List<ServerSentEvent> rawServerSentEvents) {
+            this.rawServerSentEvents = rawServerSentEvents;
+            return this;
+        }
+
+        @Override
+        public MistralAiChatResponseMetadata build() {
+            return new MistralAiChatResponseMetadata(this);
+        }
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatResponseMetadata.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatResponseMetadata.java
@@ -1,12 +1,12 @@
 package dev.langchain4j.model.mistralai;
 
+import static dev.langchain4j.internal.Utils.copy;
+
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEvent;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import java.util.List;
 import java.util.Objects;
-
-import static dev.langchain4j.internal.Utils.copy;
 
 public class MistralAiChatResponseMetadata extends ChatResponseMetadata {
     private final SuccessfulHttpResponse rawHttpResponse;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
@@ -63,6 +63,11 @@ public class DefaultMistralAiClient extends MistralAiClient {
 
     @Override
     public MistralAiChatCompletionResponse chatCompletion(MistralAiChatCompletionRequest request) {
+        return chatCompletionWithRawResponse(request).parsedResponse();
+    }
+
+    @Override
+    public ParsedAndRawResponse<MistralAiChatCompletionResponse> chatCompletionWithRawResponse(MistralAiChatCompletionRequest request) {
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(POST)
                 .url(baseUrl, "chat/completions")
@@ -72,8 +77,9 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .body(toJson(request))
                 .build();
 
-        SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
-        return fromJson(successfulHttpResponse.body(), MistralAiChatCompletionResponse.class);
+        SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
+        MistralAiChatCompletionResponse parsedResponse = fromJson(rawResponse.body(), MistralAiChatCompletionResponse.class);
+        return new ParsedAndRawResponse<>(parsedResponse, rawResponse);
     }
 
     @Override
@@ -103,6 +109,11 @@ public class DefaultMistralAiClient extends MistralAiClient {
 
     @Override
     public MistralAiChatCompletionResponse fimCompletion(MistralAiFimCompletionRequest request) {
+        return fimCompletionWithRawResponse(request).parsedResponse();
+    }
+
+    @Override
+    public ParsedAndRawResponse<MistralAiChatCompletionResponse> fimCompletionWithRawResponse(MistralAiFimCompletionRequest request) {
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(POST)
                 .url(baseUrl, "fim/completions")
@@ -112,8 +123,9 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .body(toJson(request))
                 .build();
 
-        SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
-        return fromJson(successfulHttpResponse.body(), MistralAiChatCompletionResponse.class);
+        SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
+        MistralAiChatCompletionResponse parsedResponse = fromJson(rawResponse.body(), MistralAiChatCompletionResponse.class);
+        return new ParsedAndRawResponse<>(parsedResponse, rawResponse);
     }
 
     @Override
@@ -135,6 +147,11 @@ public class DefaultMistralAiClient extends MistralAiClient {
 
     @Override
     public MistralAiEmbeddingResponse embedding(MistralAiEmbeddingRequest request) {
+        return embeddingWithRawResponse(request).parsedResponse();
+    }
+
+    @Override
+    public ParsedAndRawResponse<MistralAiEmbeddingResponse> embeddingWithRawResponse(MistralAiEmbeddingRequest request) {
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(POST)
                 .url(baseUrl, "embeddings")
@@ -144,8 +161,9 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .body(toJson(request))
                 .build();
 
-        SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
-        return fromJson(successfulHttpResponse.body(), MistralAiEmbeddingResponse.class);
+        SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
+        MistralAiEmbeddingResponse parsedResponse = fromJson(rawResponse.body(), MistralAiEmbeddingResponse.class);
+        return new ParsedAndRawResponse<>(parsedResponse, rawResponse);
     }
 
     @Override

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
@@ -52,7 +52,8 @@ public class DefaultMistralAiClient extends MistralAiClient {
 
         if (builder.logRequests != null && builder.logRequests
                 || builder.logResponses != null && builder.logResponses) {
-            this.httpClient = new LoggingHttpClient(httpClient, builder.logRequests, builder.logResponses, builder.logger);
+            this.httpClient =
+                    new LoggingHttpClient(httpClient, builder.logRequests, builder.logResponses, builder.logger);
         } else {
             this.httpClient = httpClient;
         }
@@ -67,7 +68,8 @@ public class DefaultMistralAiClient extends MistralAiClient {
     }
 
     @Override
-    public ParsedAndRawResponse<MistralAiChatCompletionResponse> chatCompletionWithRawResponse(MistralAiChatCompletionRequest request) {
+    public ParsedAndRawResponse<MistralAiChatCompletionResponse> chatCompletionWithRawResponse(
+            MistralAiChatCompletionRequest request) {
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(POST)
                 .url(baseUrl, "chat/completions")
@@ -78,13 +80,13 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .build();
 
         SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
-        MistralAiChatCompletionResponse parsedResponse = fromJson(rawResponse.body(), MistralAiChatCompletionResponse.class);
+        MistralAiChatCompletionResponse parsedResponse =
+                fromJson(rawResponse.body(), MistralAiChatCompletionResponse.class);
         return new ParsedAndRawResponse<>(parsedResponse, rawResponse);
     }
 
     @Override
-    public void streamingChatCompletion(
-            MistralAiChatCompletionRequest request, StreamingChatResponseHandler handler) {
+    public void streamingChatCompletion(MistralAiChatCompletionRequest request, StreamingChatResponseHandler handler) {
         ensureNotEmpty(request.getMessages(), "messages");
 
         HttpRequest httpRequest = HttpRequest.builder()
@@ -113,7 +115,8 @@ public class DefaultMistralAiClient extends MistralAiClient {
     }
 
     @Override
-    public ParsedAndRawResponse<MistralAiChatCompletionResponse> fimCompletionWithRawResponse(MistralAiFimCompletionRequest request) {
+    public ParsedAndRawResponse<MistralAiChatCompletionResponse> fimCompletionWithRawResponse(
+            MistralAiFimCompletionRequest request) {
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(POST)
                 .url(baseUrl, "fim/completions")
@@ -124,7 +127,8 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .build();
 
         SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
-        MistralAiChatCompletionResponse parsedResponse = fromJson(rawResponse.body(), MistralAiChatCompletionResponse.class);
+        MistralAiChatCompletionResponse parsedResponse =
+                fromJson(rawResponse.body(), MistralAiChatCompletionResponse.class);
         return new ParsedAndRawResponse<>(parsedResponse, rawResponse);
     }
 
@@ -151,7 +155,8 @@ public class DefaultMistralAiClient extends MistralAiClient {
     }
 
     @Override
-    public ParsedAndRawResponse<MistralAiEmbeddingResponse> embeddingWithRawResponse(MistralAiEmbeddingRequest request) {
+    public ParsedAndRawResponse<MistralAiEmbeddingResponse> embeddingWithRawResponse(
+            MistralAiEmbeddingRequest request) {
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(POST)
                 .url(baseUrl, "embeddings")

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiClient.java
@@ -14,7 +14,8 @@ public abstract class MistralAiClient {
 
     public abstract MistralAiChatCompletionResponse chatCompletion(MistralAiChatCompletionRequest request);
 
-    public ParsedAndRawResponse<MistralAiChatCompletionResponse> chatCompletionWithRawResponse(MistralAiChatCompletionRequest request) {
+    public ParsedAndRawResponse<MistralAiChatCompletionResponse> chatCompletionWithRawResponse(
+            MistralAiChatCompletionRequest request) {
         MistralAiChatCompletionResponse parsedResponse = chatCompletion(request);
         return new ParsedAndRawResponse<>(parsedResponse, null);
     }
@@ -24,7 +25,8 @@ public abstract class MistralAiClient {
 
     public abstract MistralAiEmbeddingResponse embedding(MistralAiEmbeddingRequest request);
 
-    public ParsedAndRawResponse<MistralAiEmbeddingResponse> embeddingWithRawResponse(MistralAiEmbeddingRequest request) {
+    public ParsedAndRawResponse<MistralAiEmbeddingResponse> embeddingWithRawResponse(
+            MistralAiEmbeddingRequest request) {
         MistralAiEmbeddingResponse parsedResponse = embedding(request);
         return new ParsedAndRawResponse<>(parsedResponse, null);
     }
@@ -35,7 +37,8 @@ public abstract class MistralAiClient {
 
     public abstract MistralAiChatCompletionResponse fimCompletion(MistralAiFimCompletionRequest request);
 
-    public ParsedAndRawResponse<MistralAiChatCompletionResponse> fimCompletionWithRawResponse(MistralAiFimCompletionRequest request) {
+    public ParsedAndRawResponse<MistralAiChatCompletionResponse> fimCompletionWithRawResponse(
+            MistralAiFimCompletionRequest request) {
         MistralAiChatCompletionResponse parsedResponse = fimCompletion(request);
         return new ParsedAndRawResponse<>(parsedResponse, null);
     }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiClient.java
@@ -14,16 +14,31 @@ public abstract class MistralAiClient {
 
     public abstract MistralAiChatCompletionResponse chatCompletion(MistralAiChatCompletionRequest request);
 
+    public ParsedAndRawResponse<MistralAiChatCompletionResponse> chatCompletionWithRawResponse(MistralAiChatCompletionRequest request) {
+        MistralAiChatCompletionResponse parsedResponse = chatCompletion(request);
+        return new ParsedAndRawResponse<>(parsedResponse, null);
+    }
+
     public abstract void streamingChatCompletion(
             MistralAiChatCompletionRequest request, StreamingChatResponseHandler handler);
 
     public abstract MistralAiEmbeddingResponse embedding(MistralAiEmbeddingRequest request);
+
+    public ParsedAndRawResponse<MistralAiEmbeddingResponse> embeddingWithRawResponse(MistralAiEmbeddingRequest request) {
+        MistralAiEmbeddingResponse parsedResponse = embedding(request);
+        return new ParsedAndRawResponse<>(parsedResponse, null);
+    }
 
     public abstract MistralAiModerationResponse moderation(MistralAiModerationRequest request);
 
     public abstract MistralAiModelResponse listModels();
 
     public abstract MistralAiChatCompletionResponse fimCompletion(MistralAiFimCompletionRequest request);
+
+    public ParsedAndRawResponse<MistralAiChatCompletionResponse> fimCompletionWithRawResponse(MistralAiFimCompletionRequest request) {
+        MistralAiChatCompletionResponse parsedResponse = fimCompletion(request);
+        return new ParsedAndRawResponse<>(parsedResponse, null);
+    }
 
     public abstract void streamingFimCompletion(
             MistralAiFimCompletionRequest request, StreamingResponseHandler<String> handler);

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiServerSentEventListener.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiServerSentEventListener.java
@@ -11,6 +11,7 @@ import static dev.langchain4j.model.mistralai.internal.client.MistralAiJsonUtils
 import static dev.langchain4j.model.mistralai.internal.mapper.MistralAiMapper.*;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventContext;
 import dev.langchain4j.http.client.sse.CancellationUnsupportedHandle;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
@@ -20,9 +21,9 @@ import dev.langchain4j.http.client.sse.ServerSentEvent;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.internal.ExceptionMapper;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.response.StreamingHandle;
+import dev.langchain4j.model.mistralai.MistralAiChatResponseMetadata;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiChatCompletionChoice;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiChatCompletionResponse;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiToolCall;
@@ -30,7 +31,11 @@ import dev.langchain4j.model.mistralai.internal.api.MistralAiUsage;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 @Internal
@@ -48,11 +53,19 @@ class MistralAiServerSentEventListener implements ServerSentEventListener {
     private String id;
     private volatile StreamingHandle streamingHandle;
 
+    final AtomicReference<SuccessfulHttpResponse> rawHttpResponse = new AtomicReference<>();
+    final Queue<ServerSentEvent> rawServerSentEvents = new ConcurrentLinkedQueue<>();
+
     public MistralAiServerSentEventListener(
             StreamingChatResponseHandler handler, BiFunction<String, List<ToolExecutionRequest>, AiMessage> toResponse) {
         this.contentBuilder = new StringBuffer();
         this.handler = handler;
         this.toResponse = toResponse;
+    }
+
+    @Override
+    public void onOpen(final SuccessfulHttpResponse response) {
+        rawHttpResponse.set(response);
     }
 
     @Override
@@ -66,17 +79,14 @@ class MistralAiServerSentEventListener implements ServerSentEventListener {
             streamingHandle = toStreamingHandle(context.parsingHandle());
         }
 
+        rawServerSentEvents.add(event);
+
         String data = event.data();
         if ("[DONE]".equals(data)) {
             AiMessage responseContent = toResponse.apply(contentBuilder.toString(), toolExecutionRequests);
             ChatResponse response = ChatResponse.builder()
                     .aiMessage(responseContent)
-                    .metadata(ChatResponseMetadata.builder()
-                            .tokenUsage(tokenUsage)
-                            .finishReason(finishReason)
-                            .modelName(modelName)
-                            .id(id)
-                            .build())
+                    .metadata(createMetadata())
                     .build();
             onCompleteResponse(handler, response);
         } else {
@@ -114,6 +124,25 @@ class MistralAiServerSentEventListener implements ServerSentEventListener {
                 this.finishReason = finishReasonFrom(finishReasonString);
             }
         }
+    }
+
+    private MistralAiChatResponseMetadata createMetadata() {
+        var metadataBuilder = MistralAiChatResponseMetadata.builder();
+
+        metadataBuilder
+                .tokenUsage(tokenUsage)
+                .finishReason(finishReason)
+                .modelName(modelName)
+                .id(id);
+
+        if (rawHttpResponse.get() != null) {
+            metadataBuilder.rawHttpResponse(rawHttpResponse.get());
+        }
+        if (!rawServerSentEvents.isEmpty()) {
+            metadataBuilder.rawServerSentEvents(new ArrayList<>(rawServerSentEvents));
+        }
+
+        return metadataBuilder.build();
     }
 
     @Override

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiServerSentEventListener.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiServerSentEventListener.java
@@ -11,16 +11,16 @@ import static dev.langchain4j.model.mistralai.internal.client.MistralAiJsonUtils
 import static dev.langchain4j.model.mistralai.internal.mapper.MistralAiMapper.*;
 
 import dev.langchain4j.Internal;
-import dev.langchain4j.http.client.SuccessfulHttpResponse;
-import dev.langchain4j.http.client.sse.ServerSentEventContext;
-import dev.langchain4j.http.client.sse.CancellationUnsupportedHandle;
-import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.CancellationUnsupportedHandle;
 import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.http.client.sse.ServerSentEventContext;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.internal.ExceptionMapper;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.mistralai.MistralAiChatResponseMetadata;
@@ -30,7 +30,6 @@ import dev.langchain4j.model.mistralai.internal.api.MistralAiToolCall;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiUsage;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
@@ -57,7 +56,8 @@ class MistralAiServerSentEventListener implements ServerSentEventListener {
     final Queue<ServerSentEvent> rawServerSentEvents = new ConcurrentLinkedQueue<>();
 
     public MistralAiServerSentEventListener(
-            StreamingChatResponseHandler handler, BiFunction<String, List<ToolExecutionRequest>, AiMessage> toResponse) {
+            StreamingChatResponseHandler handler,
+            BiFunction<String, List<ToolExecutionRequest>, AiMessage> toResponse) {
         this.contentBuilder = new StringBuffer();
         this.handler = handler;
         this.toResponse = toResponse;

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/ParsedAndRawResponse.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/ParsedAndRawResponse.java
@@ -1,0 +1,22 @@
+package dev.langchain4j.model.mistralai.internal.client;
+
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+
+public class ParsedAndRawResponse<R> {
+
+    private final R parsedResponse;
+    private final SuccessfulHttpResponse rawResponse;
+
+    public ParsedAndRawResponse(R parsedResponse, SuccessfulHttpResponse rawResponse) {
+        this.parsedResponse = parsedResponse;
+        this.rawResponse = rawResponse;
+    }
+
+    public R parsedResponse() {
+        return parsedResponse;
+    }
+
+    public SuccessfulHttpResponse rawResponse() {
+        return rawResponse;
+    }
+}

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
@@ -159,5 +160,32 @@ class MistralAiChatModelIT {
         // when
         assertThatThrownBy(() -> model.chat("hi"))
                 .isExactlyInstanceOf(dev.langchain4j.exception.TimeoutException.class);
+    }
+
+    @Test
+    void should_get_raw_response() {
+        // given
+        ChatModel model = MistralAiChatModel.builder()
+                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .modelName(OPEN_MISTRAL_7B)
+                .temperature(0.0)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("What is the capital of Germany?"))
+                .build();
+
+        // when
+        ChatResponse chatResponse = model.chat(chatRequest);
+
+        // then
+        assertThat(chatResponse.aiMessage().text()).contains("Berlin");
+
+        MistralAiChatResponseMetadata metadata = (MistralAiChatResponseMetadata) chatResponse.metadata();
+        assertThat(metadata.rawHttpResponse().headers()).containsKey("mistral-correlation-id");
+        assertThat(metadata.rawHttpResponse().body()).contains("Berlin");
+        assertThat(metadata.rawServerSentEvents()).isEmpty();
     }
 }

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/common/MistralAiChatModelIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/common/MistralAiChatModelIT.java
@@ -2,7 +2,6 @@ package dev.langchain4j.model.mistralai.common;
 
 import static dev.langchain4j.model.mistralai.MistralAiChatModelName.MISTRAL_SMALL_LATEST;
 import static dev.langchain4j.model.mistralai.MistralAiChatModelName.OPEN_MISTRAL_7B;
-import static dev.langchain4j.model.mistralai.MistralAiChatModelName.OPEN_MIXTRAL_8X22B;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.common.AbstractChatModelIT;
@@ -10,9 +9,8 @@ import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.mistralai.MistralAiChatModel;
 import dev.langchain4j.model.mistralai.MistralAiChatResponseMetadata;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-
 import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+")
 class MistralAiChatModelIT extends AbstractChatModelIT {
@@ -52,9 +50,7 @@ class MistralAiChatModelIT extends AbstractChatModelIT {
 
     @Override
     protected ChatRequestParameters createIntegrationSpecificParameters(int maxOutputTokens) {
-        return ChatRequestParameters.builder()
-                .maxOutputTokens(maxOutputTokens)
-                .build();
+        return ChatRequestParameters.builder().maxOutputTokens(maxOutputTokens).build();
     }
 
     @Override

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/common/MistralAiChatModelIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/common/MistralAiChatModelIT.java
@@ -7,7 +7,9 @@ import static dev.langchain4j.model.mistralai.MistralAiChatModelName.OPEN_MIXTRA
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.common.AbstractChatModelIT;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.mistralai.MistralAiChatModel;
+import dev.langchain4j.model.mistralai.MistralAiChatResponseMetadata;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.util.List;
@@ -53,5 +55,10 @@ class MistralAiChatModelIT extends AbstractChatModelIT {
         return ChatRequestParameters.builder()
                 .maxOutputTokens(maxOutputTokens)
                 .build();
+    }
+
+    @Override
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(ChatModel model) {
+        return MistralAiChatResponseMetadata.class;
     }
 }

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/common/MistralAiStreamingAiServiceIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/common/MistralAiStreamingAiServiceIT.java
@@ -3,11 +3,12 @@ package dev.langchain4j.model.mistralai.common;
 import static dev.langchain4j.model.mistralai.common.MistralAiStreamingChatModelIT.MISTRAL_STREAMING_CHAT_MODEL;
 
 import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.mistralai.MistralAiChatResponseMetadata;
 import dev.langchain4j.service.common.AbstractStreamingAiServiceIT;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-
-import java.util.List;
 
 @EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+")
 class MistralAiStreamingAiServiceIT extends AbstractStreamingAiServiceIT {
@@ -20,4 +21,9 @@ class MistralAiStreamingAiServiceIT extends AbstractStreamingAiServiceIT {
     @Override
     @Disabled("Mistral is too strict and expects assistant message after tool message")
     protected void should_keep_memory_consistent_when_streaming_using_immediate_tool(StreamingChatModel model) {}
+
+    @Override
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(StreamingChatModel model) {
+        return MistralAiChatResponseMetadata.class;
+    }
 }

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/common/MistralAiStreamingChatModelIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/common/MistralAiStreamingChatModelIT.java
@@ -7,7 +7,9 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.common.AbstractStreamingChatModelIT;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.mistralai.MistralAiChatResponseMetadata;
 import dev.langchain4j.model.mistralai.MistralAiStreamingChatModel;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.InOrder;
@@ -54,6 +56,11 @@ class MistralAiStreamingChatModelIT extends AbstractStreamingChatModelIT {
         return ChatRequestParameters.builder()
                 .maxOutputTokens(maxOutputTokens)
                 .build();
+    }
+
+    @Override
+    protected Class<? extends ChatResponseMetadata> chatResponseMetadataType(StreamingChatModel model) {
+        return MistralAiChatResponseMetadata.class;
     }
 
     @Override

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/common/MistralAiStreamingChatModelIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/common/MistralAiStreamingChatModelIT.java
@@ -11,9 +11,9 @@ import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.mistralai.MistralAiChatResponseMetadata;
 import dev.langchain4j.model.mistralai.MistralAiStreamingChatModel;
+import java.util.List;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.InOrder;
-import java.util.List;
 
 @EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+")
 class MistralAiStreamingChatModelIT extends AbstractStreamingChatModelIT {
@@ -53,9 +53,7 @@ class MistralAiStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Override
     protected ChatRequestParameters createIntegrationSpecificParameters(int maxOutputTokens) {
-        return ChatRequestParameters.builder()
-                .maxOutputTokens(maxOutputTokens)
-                .build();
+        return ChatRequestParameters.builder().maxOutputTokens(maxOutputTokens).build();
     }
 
     @Override


### PR DESCRIPTION
## Issue
Closes #4222

## Change
Similiar to #4225: Exposes raw HTTP Header via `MistralAiChatResponseMetadata` for MistralAiChatModel by passing through the data from HTTP client.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

