### PR TITLE
fix: handle empty embeddings in OnnxBertBiEncoder

### DIFF
--- a/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoder.java
+++ b/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoder.java
@@ -83,6 +83,10 @@ public class OnnxBertBiEncoder {
         List<String> tokens = tokenizer.tokenize(text);
         List<List<String>> partitions = partition(tokens, MAX_SEQUENCE_LENGTH);
 
+        if (partitions.isEmpty()) {
+            throw illegalArgument("Cannot embed empty or whitespace-only text");
+        }
+
         List<float[]> embeddings = new ArrayList<>();
         for (List<String> partition : partitions) {
             try (Result result = encode(partition)) {

--- a/embeddings/langchain4j-embeddings/src/test/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoderTest.java
+++ b/embeddings/langchain4j-embeddings/src/test/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoderTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.embedding.onnx;
 
 import static dev.langchain4j.model.embedding.onnx.OnnxBertBiEncoder.partition;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -91,5 +92,19 @@ class OnnxBertBiEncoderTest {
 
         // then
         assertThat(partitions).containsExactly(asList("I", "have", "a"));
+    }
+
+    @Test
+    public void testPartitionWithOnlySpecialTokens() {
+
+        // given - simulates empty or whitespace-only input
+        List<String> tokens = asList("[CLS]", "[SEP]");
+        int partitionSize = 10;
+
+        // when
+        List<List<String>> partitions = partition(tokens, partitionSize);
+
+        // then - should return empty list (no content tokens between CLS and SEP)
+        assertThat(partitions).isEqualTo(emptyList());
     }
 }


### PR DESCRIPTION
## Issue
Closes #923

## Change
Added an empty list check in the `embed()` method of `OnnxBertBiEncoder` to prevent `IndexOutOfBoundsException` when embedding empty or whitespace-only text.

**Root cause**: When tokenizing empty/whitespace text, the tokenizer returns only special tokens `[CLS]` and `[SEP]`. The `partition()` method skips these, resulting in an empty partitions list. Subsequently, `weightedAverage()` fails when accessing `embeddings.get(0)` on an empty list.

**Fix**: Added early validation in `embed()` to throw `IllegalArgumentException` with a clear message before processing empty partitions.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for \"big\" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)