### PR TITLE
#4413 - PGVector does not escape values in an IN (notIn) filter

### DIFF
--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorFilterMapper.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorFilterMapper.java
@@ -144,7 +144,16 @@ abstract class PgVectorFilterMapper {
         }
     }
 
+    String formatCollectionValue(Object value) {
+        if (value instanceof String stringValue) {
+            final String escapedValue = stringValue.replace("'", "''");
+            return '\'' + escapedValue + '\'';
+        } else {
+            return '\'' + value.toString() + '\'';
+        }
+    }
+
     String formatValuesAsString(Collection<?> values) {
-        return "(" + values.stream().map(v -> format("'%s'", v)).collect(Collectors.joining(",")) + ")";
+        return "(" + values.stream().map(this::formatCollectionValue).collect(Collectors.joining(",")) + ")";
     }
 }

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreIT.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreIT.java
@@ -92,5 +92,18 @@ class PgVectorEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
         EmbeddingMatch<TextSegment> match = searchResult.matches().get(0);
         assertThat(match.score()).isCloseTo(1, withPercentage(1));
         assertThat(match.embeddingId()).isEqualTo(ids.get(0));
+
+        // In filter escapes values as well
+        Filter filterNotIN = metadataKey("text").isNotIn("This must be escaped '");
+        EmbeddingSearchRequest notInSearchRequest = EmbeddingSearchRequest.builder()
+                .maxResults(1)
+                .queryEmbedding(embeddings.get(0))
+                .filter(filterNotIN)
+                .build();
+
+        searchResult = embeddingStore().search(notInSearchRequest);
+        match = searchResult.matches().get(0);
+        // It must retrieve the second embedding
+        assertThat(match.embeddingId()).isEqualTo(ids.get(1));
     }
 }

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreIT.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStoreIT.java
@@ -1,12 +1,27 @@
 package dev.langchain4j.store.embedding.pgvector;
 
+import static dev.langchain4j.store.embedding.TestUtils.awaitUntilAsserted;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
 import static org.testcontainers.shaded.org.apache.commons.lang3.RandomUtils.nextInt;
 
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreWithFilteringIT;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -48,5 +63,34 @@ class PgVectorEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
     @Override
     protected boolean supportsContains() {
         return true;
+    }
+
+    @Test
+    void test_escape_in() {
+        TextSegment[] segments = new TextSegment[] {
+            TextSegment.from("toEscape", Metadata.from(Map.of("text", "This must be escaped '"))),
+            TextSegment.from("notEscape", Metadata.from(Map.of("text", "This does not require to be escaped")))
+        };
+        List<Embedding> embeddings = new ArrayList<>(segments.length);
+        for (TextSegment segment : segments) {
+            Embedding embedding = embeddingModel().embed(segment.text()).content();
+            embeddings.add(embedding);
+        }
+
+        List<String> ids = embeddingStore().addAll(embeddings, Arrays.asList(segments));
+        awaitUntilAsserted(() -> assertThat(getAllEmbeddings()).hasSameSizeAs(segments));
+
+        // In filter escapes values as well
+        Filter filterIN = metadataKey("text").isIn("This must be escaped '");
+        EmbeddingSearchRequest inSearchRequest = EmbeddingSearchRequest.builder()
+                .maxResults(1)
+                .queryEmbedding(embeddings.get(0))
+                .filter(filterIN)
+                .build();
+
+        EmbeddingSearchResult<TextSegment> searchResult = embeddingStore().search(inSearchRequest);
+        EmbeddingMatch<TextSegment> match = searchResult.matches().get(0);
+        assertThat(match.score()).isCloseTo(1, withPercentage(1));
+        assertThat(match.embeddingId()).isEqualTo(ids.get(0));
     }
 }


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Fixes #4413

## Change
<!-- Please describe the changes you made. -->
Changed the method `dev.langchain4j.store.embedding.pgvector.PgVectorFilterMapper#formatValuesAsString`. Instead of formatting always the value as '<value>', now, for String values, we call to the method `formatValue` that is already used in the other filters that does not use collections.

It is important that for values that are not String, we return a text value ('<value>') instead of the `value.toString()` that returns the `formatValue` method because otherwise, IN filters with integer (for instance) will fail with a required CAST between text and integer. With the changes of this PR, I just keep the current behaviour of the filter.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases (existing tests already cover negative cases)
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
