### PR TITLE
Add Supplier support for customHeaders in Ollama models

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaEmbeddingModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaEmbeddingModel.java
@@ -15,6 +15,7 @@ import dev.langchain4j.model.output.Response;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -33,7 +34,7 @@ public class OllamaEmbeddingModel extends DimensionAwareEmbeddingModel {
                 .timeout(builder.timeout)
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
-                .customHeaders(builder.customHeaders)
+                .customHeaders(builder.customHeadersSupplier)
                 .build();
         this.modelName = ensureNotBlank(builder.modelName, "modelName");
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
@@ -73,7 +74,7 @@ public class OllamaEmbeddingModel extends DimensionAwareEmbeddingModel {
         private Integer maxRetries;
         private Boolean logRequests;
         private Boolean logResponses;
-        private Map<String, String> customHeaders;
+        private Supplier<Map<String, String>> customHeadersSupplier;
 
         public OllamaEmbeddingModelBuilder() {
             // This is public so it can be extended
@@ -120,8 +121,21 @@ public class OllamaEmbeddingModel extends DimensionAwareEmbeddingModel {
             return this;
         }
 
+        /**
+         * Sets custom HTTP headers.
+         */
         public OllamaEmbeddingModelBuilder customHeaders(Map<String, String> customHeaders) {
-            this.customHeaders = customHeaders;
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         */
+        public OllamaEmbeddingModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaLanguageModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaLanguageModel.java
@@ -16,6 +16,7 @@ import dev.langchain4j.model.output.TokenUsage;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * <a href="https://github.com/jmorganca/ollama/blob/main/docs/api.md">Ollama API reference</a>
@@ -37,7 +38,7 @@ public class OllamaLanguageModel implements LanguageModel {
                 .timeout(builder.timeout)
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
-                .customHeaders(builder.customHeaders)
+                .customHeaders(builder.customHeadersSupplier)
                 .build();
         this.modelName = ensureNotBlank(builder.modelName, "modelName");
         this.options = Options.builder()
@@ -96,7 +97,7 @@ public class OllamaLanguageModel implements LanguageModel {
         private Integer maxRetries;
         private Boolean logRequests;
         private Boolean logResponses;
-        private Map<String, String> customHeaders;
+        private Supplier<Map<String, String>> customHeadersSupplier;
 
         public OllamaLanguageModelBuilder() {
             // This is public so it can be extended
@@ -188,8 +189,21 @@ public class OllamaLanguageModel implements LanguageModel {
             return this;
         }
 
+        /**
+         * Sets custom HTTP headers.
+         */
         public OllamaLanguageModelBuilder customHeaders(Map<String, String> customHeaders) {
-            this.customHeaders = customHeaders;
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         */
+        public OllamaLanguageModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaStreamingLanguageModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaStreamingLanguageModel.java
@@ -13,6 +13,7 @@ import dev.langchain4j.model.ollama.spi.OllamaStreamingLanguageModelBuilderFacto
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * <a href="https://github.com/jmorganca/ollama/blob/main/docs/api.md">Ollama API reference</a>
@@ -33,7 +34,7 @@ public class OllamaStreamingLanguageModel implements StreamingLanguageModel {
                 .timeout(builder.timeout)
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
-                .customHeaders(builder.customHeaders)
+                .customHeaders(builder.customHeadersSupplier)
                 .build();
         this.modelName = ensureNotBlank(builder.modelName, "modelName");
         this.options = Options.builder()
@@ -85,7 +86,7 @@ public class OllamaStreamingLanguageModel implements StreamingLanguageModel {
         private List<String> stop;
         private ResponseFormat responseFormat;
         private Duration timeout;
-        private Map<String, String> customHeaders;
+        private Supplier<Map<String, String>> customHeadersSupplier;
         private Boolean logRequests;
         private Boolean logResponses;
 
@@ -164,8 +165,21 @@ public class OllamaStreamingLanguageModel implements StreamingLanguageModel {
             return this;
         }
 
+        /**
+         * Sets custom HTTP headers.
+         */
         public OllamaStreamingLanguageModelBuilder customHeaders(Map<String, String> customHeaders) {
-            this.customHeaders = customHeaders;
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         */
+        public OllamaStreamingLanguageModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaCustomHeadersSupplierTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaCustomHeadersSupplierTest.java
@@ -1,0 +1,130 @@
+package dev.langchain4j.model.ollama;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class OllamaCustomHeadersSupplierTest {
+
+    @Test
+    void should_invoke_supplier_and_propagate_headers() {
+        // given
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        Supplier<Map<String, String>> headerSupplier = () -> {
+            callCount.incrementAndGet();
+            return Map.of("X-Custom-Token", "token-" + callCount.get());
+        };
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        OllamaChatModel model = OllamaChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost:11434")
+                .modelName("llama3")
+                .customHeaders(headerSupplier)
+                .maxRetries(0)
+                .build();
+
+        // when
+        try {
+            model.chat("test");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.request().headers()).containsEntry("X-Custom-Token", List.of("token-1"));
+    }
+
+    @Test
+    void should_call_supplier_for_each_request() {
+        // given
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        Supplier<Map<String, String>> headerSupplier = () -> {
+            callCount.incrementAndGet();
+            return Map.of("X-Custom-Token", "token-" + callCount.get());
+        };
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        OllamaChatModel model = OllamaChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost:11434")
+                .modelName("llama3")
+                .customHeaders(headerSupplier)
+                .maxRetries(0)
+                .build();
+
+        // when
+        try {
+            model.chat("first");
+        } catch (Exception ignored) {
+        }
+
+        try {
+            model.chat("second");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.requests().get(0).headers()).containsEntry("X-Custom-Token", List.of("token-1"));
+        assertThat(mockHttpClient.requests().get(1).headers()).containsEntry("X-Custom-Token", List.of("token-2"));
+    }
+
+    @Test
+    void should_handle_null_from_supplier() {
+        // given
+        Supplier<Map<String, String>> nullSupplier = () -> null;
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        OllamaChatModel model = OllamaChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost:11434")
+                .modelName("llama3")
+                .customHeaders(nullSupplier)
+                .maxRetries(0)
+                .build();
+
+        // when
+        try {
+            model.chat("test");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.requests()).hasSize(1);
+    }
+
+    @Test
+    void should_support_static_map_for_backward_compatibility() {
+        // given
+        Map<String, String> staticHeaders = Map.of("X-Static", "value");
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        OllamaChatModel model = OllamaChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost:11434")
+                .modelName("llama3")
+                .customHeaders(staticHeaders)
+                .maxRetries(0)
+                .build();
+
+        // when
+        try {
+            model.chat("test");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.request().headers()).containsEntry("X-Static", List.of("value"));
+    }
+}


### PR DESCRIPTION
## Issue
Follow-up to #4403

Applying the same `Supplier<Map<String, String>>` pattern to Ollama module

## Change
Add `Supplier<Map<String, String>>` support for `customHeaders` in `langchain4j-ollama` module.

### Problem
OAuth2 tokens expire, requiring model rebuild - impractical for production use.

### Solution
```java
// Before: fixed at build time
.customHeaders(Map.of("Authorization", "Bearer " + token))

// After: fresh on each request  
.customHeaders(() -> Map.of("Authorization", "Bearer " + tokenProvider.getToken()))
```

### Modified files
- `OllamaClient.java` - Add Supplier field and `buildRequestHeaders()` helper
- `OllamaBaseChatModel.java` - Add Supplier overload (covers ChatModel & StreamingChatModel)
- `OllamaEmbeddingModel.java` - Add Supplier overload
- `OllamaLanguageModel.java` - Add Supplier overload
- `OllamaStreamingLanguageModel.java` - Add Supplier overload
- New test: `OllamaCustomHeadersSupplierTest.java`

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)