### PR TITLE
Add Supplier support for customHeaders in Voyage models

### DIFF
--- a/langchain4j-voyage-ai/pom.xml
+++ b/langchain4j-voyage-ai/pom.xml
@@ -24,7 +24,7 @@
             <artifactId>langchain4j-http-client</artifactId>
             <version>1.11.0-SNAPSHOT</version>
         </dependency>
-      
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-http-client-jdk</artifactId>
@@ -45,6 +45,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-http-client</artifactId>
+            <version>1.11.0-SNAPSHOT</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiCustomHeadersSupplierTest.java
+++ b/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiCustomHeadersSupplierTest.java
@@ -1,0 +1,134 @@
+package dev.langchain4j.model.voyageai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class VoyageAiCustomHeadersSupplierTest {
+
+    @Test
+    void should_invoke_supplier_and_propagate_headers() {
+        // given
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        Supplier<Map<String, String>> headerSupplier = () -> {
+            callCount.incrementAndGet();
+            return Map.of("X-Custom-Token", "token-" + callCount.get());
+        };
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        VoyageAiEmbeddingModel model = VoyageAiEmbeddingModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("https://api.voyageai.com/v1")
+                .apiKey("test-api-key")
+                .modelName("voyage-3")
+                .customHeaders(headerSupplier)
+                .maxRetries(0)
+                .build();
+
+        // when
+        try {
+            model.embed("test");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.request().headers()).containsEntry("X-Custom-Token", List.of("token-1"));
+    }
+
+    @Test
+    void should_call_supplier_for_each_request() {
+        // given
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        Supplier<Map<String, String>> headerSupplier = () -> {
+            callCount.incrementAndGet();
+            return Map.of("X-Custom-Token", "token-" + callCount.get());
+        };
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        VoyageAiEmbeddingModel model = VoyageAiEmbeddingModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("https://api.voyageai.com/v1")
+                .apiKey("test-api-key")
+                .modelName("voyage-3")
+                .customHeaders(headerSupplier)
+                .maxRetries(0)
+                .build();
+
+        // when
+        try {
+            model.embed("first");
+        } catch (Exception ignored) {
+        }
+
+        try {
+            model.embed("second");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.requests().get(0).headers()).containsEntry("X-Custom-Token", List.of("token-1"));
+        assertThat(mockHttpClient.requests().get(1).headers()).containsEntry("X-Custom-Token", List.of("token-2"));
+    }
+
+    @Test
+    void should_handle_null_from_supplier() {
+        // given
+        Supplier<Map<String, String>> nullSupplier = () -> null;
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        VoyageAiEmbeddingModel model = VoyageAiEmbeddingModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("https://api.voyageai.com/v1")
+                .apiKey("test-api-key")
+                .modelName("voyage-3")
+                .customHeaders(nullSupplier)
+                .maxRetries(0)
+                .build();
+
+        // when
+        try {
+            model.embed("test");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.requests()).hasSize(1);
+    }
+
+    @Test
+    void should_support_static_map_for_backward_compatibility() {
+        // given
+        Map<String, String> staticHeaders = Map.of("X-Static", "value");
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        VoyageAiEmbeddingModel model = VoyageAiEmbeddingModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("https://api.voyageai.com/v1")
+                .apiKey("test-api-key")
+                .modelName("voyage-3")
+                .customHeaders(staticHeaders)
+                .maxRetries(0)
+                .build();
+
+        // when
+        try {
+            model.embed("test");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.request().headers()).containsEntry("X-Static", List.of("value"));
+    }
+}


### PR DESCRIPTION
## Issue
Follow-up to #4403

Applying the same `Supplier<Map<String, String>>` pattern to Voyage AI module.

## Change
Add `Supplier<Map<String, String>>` support for `customHeaders` in `langchain4j-voyage-ai` module.

### Problem
OAuth2 tokens expire, requiring model rebuild - impractical for production use.

### Solution
```java
// Before: fixed at build time
.customHeaders(Map.of("Authorization", "Bearer " + token))

// After: fresh on each request  
.customHeaders(() -> Map.of("Authorization", "Bearer " + tokenProvider.getToken()))
```

### Modified files
- `VoyageAiClient.java` - Add Supplier field and `buildRequestHeaders()` helper
- `VoyageAiEmbeddingModel.java` - Add Supplier overload
- `VoyageAiScoringModel.java` - Add `httpClientBuilder()` and `customHeaders()` builder methods for extensibility
- `pom.xml` - Add test-jar dependency for MockHttpClient
- New test: `VoyageAiCustomHeadersSupplierTest.java`

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)