### PR TITLE
feat(agent-skills): Add Agent Skills capability extension system

### DIFF
--- a/docs/docs/tutorials/agent-skills-architecture.md
+++ b/docs/docs/tutorials/agent-skills-architecture.md
@@ -1,0 +1,863 @@
+# Agent Skills Feature Design Document
+
+## Overview
+
+Agent Skills is a capability extension system for LangChain4j that allows AI agents to dynamically load and execute external skills defined in `SKILL.md` files. This feature enables agents to access pre-defined tools, scripts, and resources to accomplish complex tasks.
+
+**Version**: 1.12.0
+**Author**: Shrink (shunke.wjl@alibaba-inc.com)
+**Status**: Experimental
+
+---
+
+## Table of Contents
+
+1. [Architecture Overview](#architecture-overview)
+2. [Core Components](#core-components)
+3. [Design Principles](#design-principles)
+4. [Skill Definition Format](#skill-definition-format)
+5. [Workflow & Execution Model](#workflow--execution-model)
+6. [Security Considerations](#security-considerations)
+7. [Integration with AI Services](#integration-with-ai-services)
+8. [Usage Examples](#usage-examples)
+9. [Testing Strategy](#testing-strategy)
+10. [References & Inspiration](#references--inspiration)
+
+---
+
+## Architecture Overview
+
+### High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        User Application                      │
+└─────────────────┬───────────────────────────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────────────────────────────┐
+│                      AiServices Builder                      │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │          AgentSkillsConfig (Configuration)           │   │
+│  │  • skillsProvider: AgentSkillsProvider               │   │
+│  │  • scriptExecutor: ScriptExecutor                    │   │
+│  │  • maxIterations: int                                │   │
+│  └──────────────────────────────────────────────────────┘   │
+└─────────────────┬───────────────────────────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   AgentSkillsService                         │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  Core Responsibilities:                              │   │
+│  │  • Generate system prompt with available skills      │   │
+│  │  • Parse LLM responses for skill instructions        │   │
+│  │  • Execute skill operations (use/execute/read)       │   │
+│  │  • Validate security constraints                     │   │
+│  └──────────────────────────────────────────────────────┘   │
+└─────────────┬───────────────────────┬───────────────────────┘
+              │                       │
+              ▼                       ▼
+┌─────────────────────────┐ ┌─────────────────────────────────┐
+│  AgentSkillsProvider    │ │    ScriptExecutor               │
+│  ┌───────────────────┐  │ │  ┌───────────────────────────┐  │
+│  │ • provideSkills() │  │ │  │ • execute(path, command)  │  │
+│  │ • skillByName()   │  │ │  │ • Security: working dir   │  │
+│  │ • reload()        │  │ │  │ • Timeout management      │  │
+│  └───────────────────┘  │ │  └───────────────────────────┘  │
+└─────────────┬───────────┘ └─────────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────────────────────────┐
+│            DefaultAgentSkillsProvider                        │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  • Loads skills from directories                     │   │
+│  │  • Caches parsed skills                              │   │
+│  │  • Thread-safe lazy initialization                   │   │
+│  │  • Supports hot reload                               │   │
+│  └──────────────────────────────────────────────────────┘   │
+└─────────────┬───────────────────────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   FileSystemSkillLoader                      │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  • Parses SKILL.md files                             │   │
+│  │  • Validates YAML frontmatter                        │   │
+│  │  • Extracts skill metadata                           │   │
+│  │  • Validates naming and constraints                  │   │
+│  └──────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                      File System                             │
+│  skills/                                                     │
+│  ├── skill-name/                                             │
+│  │   ├── SKILL.md          (Required: metadata + docs)      │
+│  │   ├── scripts/          (Optional: executable scripts)   │
+│  │   │   └── *.sh, *.py                                     │
+│  │   └── assets/           (Optional: config/resources)     │
+│  │       └── config.json, templates, etc.                   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Core Components
+
+### 1. **Skill** (Domain Model)
+- **Location**: `langchain4j-core/src/main/java/dev/langchain4j/agentskills/Skill.java`
+- **Purpose**: Immutable data class representing a skill
+- **Key Properties**:
+  - `name`: Unique skill identifier (lowercase with hyphens)
+  - `description`: Brief skill description
+  - `instructions`: Detailed usage instructions (markdown)
+  - `path`: File system path to skill directory
+  - `allowedTools`: Whitelist of executable commands
+  - `compatibility`: Target LLM compatibility info
+  - `license`: License information
+
+### 2. **FileSystemSkillLoader**
+- **Location**: `langchain4j-agent-skills/src/main/java/dev/langchain4j/agentskills/loader/FileSystemSkillLoader.java`
+- **Purpose**: Parses `SKILL.md` files and constructs `Skill` objects
+- **Key Features**:
+  - YAML frontmatter parsing with validation
+  - Skill name validation (regex: `^[a-z0-9-]+$`)
+  - Length constraints (description ≤ 500 chars, compatibility ≤ 200 chars)
+  - Error handling for malformed files
+- **Reference**: Inspired by Jekyll/Hugo frontmatter parsing
+
+### 3. **AgentSkillsProvider** (Interface)
+- **Location**: `langchain4j-core/src/main/java/dev/langchain4j/agentskills/AgentSkillsProvider.java`
+- **Purpose**: Abstract skill discovery and loading
+- **Methods**:
+  - `provideSkills(request)`: Returns filtered skills based on context
+  - `skillByName(name)`: Retrieves a specific skill
+  - `reload()`: Refreshes skill cache
+
+### 4. **DefaultAgentSkillsProvider**
+- **Location**: `langchain4j-agent-skills/src/main/java/dev/langchain4j/agentskills/DefaultAgentSkillsProvider.java`
+- **Purpose**: Default file system-based skill provider
+- **Key Features**:
+  - Lazy loading with double-checked locking
+  - Thread-safe skill caching
+  - Multi-directory support
+  - Duplicate skill name detection
+  - Hot reload capability
+- **Design Pattern**: Singleton-like lazy initialization per instance
+
+### 5. **ScriptExecutor** (Interface)
+- **Location**: `langchain4j-core/src/main/java/dev/langchain4j/agentskills/execution/ScriptExecutor.java`
+- **Purpose**: Abstract script execution
+- **Method**: `execute(workingDirectory, command)` → `ScriptExecutionResult`
+
+### 6. **DefaultScriptExecutor**
+- **Location**: `langchain4j-core/src/main/java/dev/langchain4j/agentskills/execution/DefaultScriptExecutor.java`
+- **Purpose**: Shell command executor with security controls
+- **Key Features**:
+  - Process spawning with `ProcessBuilder`
+  - Configurable timeout (default: 60 seconds)
+  - Output/error stream capture
+  - Working directory isolation
+  - Exit code handling
+- **Security**: Runs commands within skill's working directory only
+
+### 7. **AgentSkillsService**
+- **Location**: `langchain4j-core/src/main/java/dev/langchain4j/service/agentskills/AgentSkillsService.java`
+- **Purpose**: Central orchestration service
+- **Key Responsibilities**:
+  - **System Prompt Generation**: Injects available skills into LLM context
+  - **Instruction Parsing**: Extracts XML-like instructions from LLM responses
+  - **Instruction Execution**: Handles `use_skill`, `execute_script`, `read_resource`
+  - **Security Enforcement**: Path traversal prevention, command whitelisting
+- **Instruction Types**:
+  - `<use_skill>skill-name</use_skill>` → Load full skill instructions
+  - `<execute_script skill="name">command</execute_script>` → Run script
+  - `<read_resource skill="name">path</read_resource>` → Read file
+
+### 8. **AgentSkillsConfig**
+- **Location**: `langchain4j-core/src/main/java/dev/langchain4j/agentskills/AgentSkillsConfig.java`
+- **Purpose**: Configuration container
+- **Builder Pattern**: Fluent API for configuration
+- **Properties**:
+  - `skillsProvider`: Skill source
+  - `scriptExecutor`: Optional custom executor
+  - `maxIterations`: Maximum skill execution loops (default: 10)
+
+---
+
+## Design Principles
+
+### 1. **Security by Default**
+- **Command Whitelisting**: `allowed-tools` in SKILL.md controls executable commands
+- **Path Traversal Prevention**: Validates all resource paths stay within skill directory
+- **Symlink Protection**: Resolves real paths to prevent symlink escapes
+- **Working Directory Isolation**: Scripts execute in skill directory only
+
+### 2. **Extensibility**
+- **Provider Pattern**: Easy to implement custom skill sources (database, API, etc.)
+- **Executor Pattern**: Custom script executors for sandboxing or containers
+- **Instruction System**: XML-like tags for clear LLM communication
+
+### 3. **Observability**
+- **SLF4J Logging**: DEBUG/INFO/WARN levels for traceability
+- **Structured Errors**: XML-wrapped error messages for LLM understanding
+- **Exit Code Preservation**: Script results include exit codes
+
+### 4. **Performance**
+- **Lazy Loading**: Skills loaded on first access
+- **Caching**: Parsed skills cached in memory
+- **Reload Support**: Manual cache invalidation for hot updates
+
+### 5. **LLM-Friendly Design**
+- **XML Instructions**: Structured format for reliable parsing
+- **Clear Error Messages**: English-language error responses
+- **System Prompt Enhancement**: Skills automatically advertised to LLM
+
+---
+
+## Skill Definition Format
+
+### SKILL.md Structure
+
+```markdown
+---
+name: pdf-processing
+description: Extract and analyze text from PDF documents
+license: MIT
+compatibility: Works with GPT-4, Claude, and other models
+allowed-tools:
+  - python
+  - bash
+  - scripts/*
+metadata:
+  author: John Doe
+  version: 1.0.0
+  tags:
+    - pdf
+    - text-extraction
+---
+
+# PDF Processing Skill
+
+## Overview
+This skill enables text extraction from PDF files...
+
+## Usage
+To extract text from a PDF:
+```bash
+scripts/extract.sh <pdf-file>
+```
+
+## Configuration
+See `assets/config.json` for extraction options.
+```
+
+### Frontmatter Fields
+
+| Field | Required | Type | Constraints | Description |
+|-------|----------|------|-------------|-------------|
+| `name` | ✅ | string | `^[a-z0-9-]+$` | Unique skill identifier |
+| `description` | ✅ | string | ≤ 500 chars | Brief description |
+| `license` | ❌ | string | - | License type |
+| `compatibility` | ❌ | string | ≤ 200 chars | LLM compatibility info |
+| `allowed-tools` | ❌ | list | - | Command whitelist (`*` for all) |
+| `metadata` | ❌ | object | - | Custom key-value pairs |
+
+---
+
+## Workflow & Execution Model
+
+### 1. Initialization Phase
+```java
+// User configures skills
+AgentSkillsConfig config = AgentSkillsConfig.builder()
+    .skillsProvider(DefaultAgentSkillsProvider.builder()
+        .skillDirectories(Path.of("skills"))
+        .build())
+    .scriptExecutor(new DefaultScriptExecutor())
+    .maxIterations(10)
+    .build();
+
+// Integrate with AI service
+Assistant assistant = AiServices.builder(Assistant.class)
+    .chatModel(model)
+    .agentSkillsConfig(config)
+    .build();
+```
+
+### 2. System Prompt Enhancement
+When a user sends a message:
+1. `AgentSkillsService.generateSystemPromptAddition()` is called
+2. Available skills are formatted as XML:
+```xml
+<available_skills>
+  <skill>
+    <name>pdf-processing</name>
+    <description>Extract text from PDFs</description>
+  </skill>
+</available_skills>
+
+When you need to use a skill to complete a task, please use the following instructions:
+- Load skill content: <use_skill>skill-name</use_skill>
+- Execute skill script: <execute_script skill="skill-name">script-command</execute_script>
+- Read skill resource: <read_resource skill="skill-name">resource-path</read_resource>
+The system will automatically execute these instructions and return the results to you.
+```
+3. This is appended to the system prompt sent to the LLM
+
+### 3. LLM Response Processing
+When LLM responds with instructions:
+1. **Parsing**: `AgentSkillsService.parseInstruction()` extracts first instruction
+2. **Validation**: Checks skill exists, validates parameters
+3. **Execution**: Calls appropriate handler:
+   - `handleUseSkill()`: Returns full `SKILL.md` content
+   - `handleExecuteScript()`: Validates command, executes via `ScriptExecutor`
+   - `handleReadResource()`: Validates path, reads file
+4. **Result Wrapping**: Output wrapped in XML tags:
+```xml
+<skill_content name="pdf-processing">
+...skill instructions...
+</skill_content>
+
+<script_result exit_code="0">
+Script output here
+</script_result>
+
+<resource_content path="assets/config.json">
+{"key": "value"}
+</resource_content>
+```
+
+### 4. Iteration Loop
+- Results are sent back to LLM as user message
+- LLM can issue more instructions or respond to user
+- Continues until `maxIterations` reached or LLM responds normally
+
+---
+
+## Security Considerations
+
+### 1. Command Injection Prevention
+**Threat**: Malicious commands via `execute_script`
+**Mitigation**:
+- Command whitelist in `allowed-tools`
+- Wildcard support (`scripts/*`) for safe prefixes
+- No shell expansion (commands split into args)
+
+**Example**:
+```yaml
+allowed-tools:
+  - python
+  - scripts/*.sh  # Only scripts in scripts/ directory
+```
+
+### 2. Path Traversal Prevention
+**Threat**: Reading files outside skill directory via `read_resource`
+**Mitigation**:
+- Path normalization before resolution
+- `startsWith()` check on normalized path
+- Real path resolution (symlink protection)
+- Double validation: normalized + real path
+
+**Code**:
+```java
+Path fullPath = skillPath.resolve(resourcePath).normalize();
+if (!fullPath.startsWith(skillPath.normalize())) {
+    return "<resource_error>Illegal path</resource_error>";
+}
+
+Path realPath = fullPath.toRealPath();
+if (!realPath.startsWith(skillPath.toRealPath())) {
+    return "<resource_error>Illegal path</resource_error>";
+}
+```
+
+### 3. Process Timeout
+**Threat**: Runaway scripts consuming resources
+**Mitigation**:
+- Default 60-second timeout
+- Process forcibly terminated after timeout
+- Configurable timeout in `DefaultScriptExecutor`
+
+### 4. Working Directory Isolation
+**Threat**: Scripts modifying files outside skill directory
+**Mitigation**:
+- Scripts always execute with skill directory as working directory
+- No access to parent directories without explicit path manipulation
+
+---
+
+## Integration with AI Services
+
+### AiServices Integration Point
+
+The `AgentSkillsService` is integrated into the `AiServices` framework at the message processing level:
+
+1. **Pre-processing**: System prompt enhancement before LLM call
+2. **Post-processing**: Response inspection for skill instructions
+3. **Iteration**: Automatic re-invocation with instruction results
+
+### Configuration API
+
+```java
+// Method 1: Via builder
+Assistant assistant = AiServices.builder(Assistant.class)
+    .chatModel(model)
+    .agentSkillsConfig(config)  // ← Agent Skills integration
+    .build();
+
+// Method 2: Programmatic configuration
+AgentSkillsService service = new AgentSkillsService();
+service.agentSkillsProvider(provider);
+service.scriptExecutor(executor);
+service.maxIterations(5);
+```
+
+---
+
+## Usage Examples
+
+### Example 1: Basic Skill Usage
+
+**Skill Definition** (`skills/calculator/SKILL.md`):
+```markdown
+---
+name: calculator
+description: Perform mathematical calculations
+allowed-tools:
+  - python
+---
+
+# Calculator Skill
+
+Use `python scripts/calc.py <expression>` to evaluate expressions.
+```
+
+**Script** (`skills/calculator/scripts/calc.py`):
+```python
+import sys
+print(eval(sys.argv[1]))
+```
+
+**User Code**:
+```java
+AgentSkillsConfig config = AgentSkillsConfig.builder()
+    .skillsProvider(DefaultAgentSkillsProvider.builder()
+        .skillDirectories(Path.of("skills"))
+        .build())
+    .build();
+
+Assistant assistant = AiServices.builder(Assistant.class)
+    .chatModel(OpenAiChatModel.builder()
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .modelName("gpt-4")
+        .build())
+    .agentSkillsConfig(config)
+    .build();
+
+String result = assistant.chat("Calculate 15 * 23");
+// LLM will use calculator skill to compute 345
+```
+
+### Example 2: Multi-Skill Workflow
+
+**Skills**:
+- `web-scraper`: Fetches web content
+- `summarizer`: Summarizes text
+
+**User Request**:
+```java
+assistant.chat("Summarize the latest news from example.com");
+```
+
+**LLM Workflow**:
+1. LLM issues: `<use_skill>web-scraper</use_skill>`
+2. System returns scraper instructions
+3. LLM issues: `<execute_script skill="web-scraper">scripts/fetch.sh example.com</execute_script>`
+4. System returns HTML content
+5. LLM issues: `<use_skill>summarizer</use_skill>`
+6. LLM uses summarizer instructions to condense content
+7. LLM responds to user with summary
+
+### Example 3: Custom Executor
+
+```java
+// Custom executor for Docker sandboxing
+ScriptExecutor dockerExecutor = (workingDir, command) -> {
+    ProcessBuilder pb = new ProcessBuilder(
+        "docker", "run", "--rm",
+        "-v", workingDir + ":/workspace",
+        "-w", "/workspace",
+        "alpine:latest",
+        "sh", "-c", command
+    );
+    // ... process execution ...
+};
+
+AgentSkillsConfig config = AgentSkillsConfig.builder()
+    .skillsProvider(provider)
+    .scriptExecutor(dockerExecutor)  // Custom executor
+    .build();
+```
+
+---
+
+## Testing Strategy
+
+### 1. Unit Tests
+
+#### **FileSystemSkillLoaderTest** (9 tests)
+- ✅ Parse complete frontmatter with all fields
+- ✅ Parse minimal frontmatter (required fields only)
+- ✅ Validate skill name regex (`^[a-z0-9-]+$`)
+- ✅ Enforce description length (≤ 500 chars)
+- ✅ Enforce compatibility length (≤ 200 chars)
+- ✅ Parse `allowed-tools` list
+- ✅ Handle missing/malformed/empty files
+- ✅ Load multiple skills from directory
+
+**Reference**: MCP module test style (given-when-then, AssertJ fluent assertions)
+
+#### **DefaultAgentSkillsProviderTest** (11 tests)
+- ✅ Load from single/multiple directories
+- ✅ Lookup by name (case-sensitive)
+- ✅ Cache loaded skills
+- ✅ Thread-safe concurrent access
+- ✅ Reload/invalidate cache
+- ✅ Handle duplicate skill names (last wins)
+- ✅ Handle empty/non-existent directories
+- ✅ Builder validation (null checks)
+
+**Reference**: MCP `DefaultMcpClientTest` caching patterns
+
+#### **DefaultScriptExecutorTest** (13 tests)
+- ✅ Execute simple commands (echo, true, false)
+- ✅ Capture stdout and stderr separately
+- ✅ Respect working directory
+- ✅ Handle null/blank commands/directories
+- ✅ Execute Python scripts
+- ✅ Handle large output
+- ✅ Timeout long-running commands
+- ✅ Capture non-zero exit codes
+- ✅ Handle non-existent commands
+- ✅ Execute relative path scripts
+- ✅ OS-specific commands (Windows: `dir`, Unix: `ls`)
+
+**Reference**: Tool module test conventions
+
+#### **AgentSkillsServiceTest** (26 tests)
+- ✅ Parse `use_skill` instruction
+- ✅ Parse `execute_script` instruction
+- ✅ Parse `read_resource` instruction
+- ✅ Handle multiple instructions (first only)
+- ✅ Return error for missing skills
+- ✅ Validate command against `allowed-tools`
+- ✅ Prevent path traversal (`../../../etc/passwd`)
+- ✅ Use default executor if none provided
+- ✅ Generate system prompt with skills
+- ✅ Handle empty skill list
+- ✅ Validate `maxIterations` (≥ 1)
+- ✅ Handle wildcard `allowed-tools: "*"`
+- ✅ Successfully read resources
+- ✅ Successfully execute scripts
+- ✅ Handle script failures (non-zero exit)
+
+**Coverage**: Instruction parsing, security validation, error handling
+
+### 2. End-to-End Tests
+
+#### **AgentSkillsEndToEndTest** (7 tests)
+Uses **real LLM** (Qwen via DashScope) to validate full integration:
+
+- ✅ **Skills Discovery**: LLM lists available skills
+- ✅ **Skill Content Loading**: LLM uses `<use_skill>` to load instructions
+- ✅ **Script Execution**: LLM uses `<execute_script>` to run `extract.sh`
+- ✅ **Resource Reading**: LLM uses `<read_resource>` to read `config.json`
+- ✅ **Multiple Operations**: LLM chains multiple instructions in one turn
+- ✅ **Error Handling**: LLM gracefully handles non-existent skills
+- ✅ **System Prompt Enhancement**: Verifies skills appear in system context
+
+**Configuration**:
+- Model: `qwen-plus`
+- Endpoint: `https://dashscope.aliyuncs.com/compatible-mode/v1`
+- Requires: `QWEN_API_KEY` environment variable
+- Test annotation: `@EnabledIfEnvironmentVariable(named = "QWEN_API_KEY", matches = ".+")`
+
+**Test Resources**:
+- `test-skills/pdf-processing/SKILL.md`
+- `test-skills/pdf-processing/scripts/extract.sh`
+- `test-skills/pdf-processing/assets/config.json`
+
+### 3. Test Execution Summary
+
+| Test Suite | Tests | Pass Rate | Coverage |
+|------------|-------|-----------|----------|
+| FileSystemSkillLoaderTest | 9 | 100% | Parsing, validation |
+| DefaultAgentSkillsProviderTest | 11 | 100% | Loading, caching, concurrency |
+| DefaultScriptExecutorTest | 13 | 100% | Process execution, timeouts |
+| AgentSkillsServiceTest | 26 | 100% | Orchestration, security |
+| AgentSkillsEndToEndTest | 7 | 100% | Real LLM integration |
+| **Total** | **66** | **100%** | **Full stack** |
+
+**Build Command**:
+```bash
+mvn test -pl langchain4j,langchain4j-agent-skills
+```
+
+---
+
+## References & Inspiration
+
+### 1. **MCP (Model Context Protocol) - Anthropic**
+- **Source**: LangChain4j MCP module (`langchain4j-mcp`)
+- **Inspired**:
+  - Provider pattern for extensible skill sources
+  - Caching strategy in `DefaultMcpClientTest`
+  - Lazy initialization with thread-safe double-checked locking
+  - Builder pattern conventions
+- **Differences**:
+  - MCP focuses on server-client RPC; Agent Skills is file system-based
+  - MCP tools are function-based; Agent Skills are script/resource-based
+
+### 2. **Tool System - LangChain4j**
+- **Source**: `langchain4j/src/main/java/dev/langchain4j/service/tool/`
+- **Inspired**:
+  - Test naming conventions (`should_*` prefix)
+  - AssertJ assertion style
+  - Parameterized test patterns
+  - Tool execution model (input → execution → output)
+- **Differences**:
+  - Tools are Java methods; Skills are external scripts
+  - Tools use JSON Schema; Skills use YAML frontmatter
+
+### 3. **Jekyll/Hugo Frontmatter**
+- **Source**: Static site generators
+- **Inspired**:
+  - YAML frontmatter for metadata (`---` delimiters)
+  - Markdown content for documentation
+- **Usage**: `SKILL.md` format
+
+### 4. **Unix Philosophy**
+- **Principles**:
+  - Small, composable units (skills)
+  - Text streams for I/O (stdout/stderr)
+  - Exit codes for success/failure
+  - Working directory as execution context
+
+### 5. **OpenAI Function Calling**
+- **Concept**: LLM-driven tool invocation
+- **Inspired**:
+  - XML-like instruction format (instead of JSON function calls)
+  - System prompt skill advertisement
+  - Automatic iteration loop
+- **Differences**:
+  - OpenAI uses JSON schema; we use XML tags
+  - OpenAI validates signatures; we validate with regex
+
+### 6. **Langroid Agent Skills (Python)**
+- **Source**: Langroid framework
+- **Inspired**:
+  - "Skills as capabilities" mental model
+  - Dynamic skill loading
+- **Differences**:
+  - Langroid is Python-native; ours is shell/polyglot
+  - Langroid skills are Python classes; ours are file system artifacts
+
+---
+
+## Module Structure
+
+### langchain4j-agent-skills (Integration Module)
+```
+langchain4j-agent-skills/
+├── pom.xml
+├── src/main/java/dev/langchain4j/agentskills/
+│   ├── DefaultAgentSkillsProvider.java
+│   └── loader/
+│       ├── SkillLoader.java (interface)
+│       └── FileSystemSkillLoader.java
+└── src/test/java/dev/langchain4j/agentskills/
+    ├── AgentSkillsEndToEndTest.java (E2E tests)
+    ├── DefaultAgentSkillsProviderTest.java
+    └── loader/
+        └── FileSystemSkillLoaderTest.java
+```
+
+### langchain4j-core (Core APIs)
+```
+langchain4j/src/main/java/dev/langchain4j/
+├── agentskills/
+│   ├── AgentSkillsConfig.java
+│   ├── AgentSkillsProvider.java (interface)
+│   ├── AgentSkillsProviderRequest.java
+│   ├── AgentSkillsProviderResult.java
+│   ├── Skill.java (domain model)
+│   ├── execution/
+│   │   ├── ScriptExecutor.java (interface)
+│   │   ├── DefaultScriptExecutor.java
+│   │   └── ScriptExecutionResult.java
+│   └── instruction/
+│       ├── AgentSkillsInstruction.java (sealed interface)
+│       ├── UseSkillInstruction.java
+│       ├── ExecuteScriptInstruction.java
+│       └── ReadResourceInstruction.java
+└── service/agentskills/
+    └── AgentSkillsService.java (orchestrator)
+```
+
+---
+
+## API Reference
+
+### Public Interfaces
+
+#### AgentSkillsConfig.Builder
+```java
+AgentSkillsConfig.builder()
+    .skillsProvider(AgentSkillsProvider)
+    .scriptExecutor(ScriptExecutor)      // Optional
+    .maxIterations(int)                   // Default: 10
+    .build()
+```
+
+#### DefaultAgentSkillsProvider.Builder
+```java
+DefaultAgentSkillsProvider.builder()
+    .skillDirectories(Path...)            // Varargs
+    .build()
+```
+
+#### Skill (Record)
+```java
+record Skill(
+    String name,
+    String description,
+    String instructions,
+    Path path,
+    List<String> allowedTools,
+    String compatibility,
+    String license,
+    Map<String, Object> metadata
+)
+```
+
+#### ScriptExecutionResult (Record)
+```java
+record ScriptExecutionResult(
+    int exitCode,
+    String output,
+    String error
+)
+```
+
+---
+
+## Future Enhancements
+
+### 1. Skill Marketplace
+- Central repository for community skills
+- Version management and dependency resolution
+- Skill signatures and verification
+
+### 2. Advanced Security
+- Sandboxed execution (Docker, gVisor)
+- Resource limits (CPU, memory, disk)
+- Network policies (allow/deny lists)
+
+### 3. Skill Composition
+- Skill dependencies and pipelines
+- Skill chaining DSL
+- Parallel skill execution
+
+### 4. Enhanced Observability
+- Execution tracing and metrics
+- Performance profiling
+- Cost tracking (LLM token usage per skill)
+
+### 5. Alternative Loaders
+- Database-backed skills
+- HTTP API skill sources
+- Git repository skills
+
+### 6. Skill Testing Framework
+- Built-in test runner for skills
+- Mock LLM for skill validation
+- CI/CD integration
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. Skills Not Loading
+**Symptom**: `AgentSkillsProvider.provideSkills()` returns empty list
+**Solutions**:
+- Verify `SKILL.md` exists in skill directory
+- Check skill name matches directory name
+- Validate YAML frontmatter syntax
+- Check logs for parsing errors
+
+#### 2. Script Execution Fails
+**Symptom**: `<script_error>` in LLM response
+**Solutions**:
+- Verify script has execute permissions (`chmod +x`)
+- Check `allowed-tools` whitelist includes command
+- Verify working directory is correct
+- Check script shebang (`#!/bin/bash`)
+
+#### 3. Path Traversal Errors
+**Symptom**: `<resource_error>Illegal path</resource_error>`
+**Solutions**:
+- Use relative paths only (`assets/file.txt`, not `/tmp/file.txt`)
+- Avoid `..` in paths
+- Check symlinks point within skill directory
+
+#### 4. LLM Not Using Skills
+**Symptom**: LLM responds without using available skills
+**Solutions**:
+- Verify system prompt enhancement is working (log inspection)
+- Use more explicit user prompts ("Use the calculator skill to...")
+- Check `maxIterations` is not set too low
+- Try different LLM models (some better at tool use)
+
+---
+
+## Contributing
+
+### Adding New Skills
+1. Create skill directory: `skills/your-skill-name/`
+2. Write `SKILL.md` with required frontmatter
+3. Add scripts to `scripts/` directory
+4. Add resources to `assets/` directory
+5. Test with unit tests and E2E tests
+
+### Code Style
+- Follow existing naming conventions
+- Use builder patterns for configuration
+- Add SLF4J logging at appropriate levels
+- Write Javadoc for public APIs
+- Use `should_*` test naming convention
+- Prefer AssertJ assertions over JUnit assertions
+
+### Test Requirements
+- Unit tests for new components
+- E2E test for new instruction types
+- Security tests for new execution paths
+- Documentation for new features
+
+---
+
+## License
+
+This feature is part of LangChain4j and follows the same Apache 2.0 license.
+
+---
+
+## Contact
+
+**Author**: Shrink (shunke.wjl@alibaba-inc.com)
+**Module**: `langchain4j-agent-skills`
+**Version**: 1.12.0 (Experimental)
+**Documentation**: This file + Javadoc in source files

--- a/docs/docs/tutorials/agent-skills-cn.md
+++ b/docs/docs/tutorials/agent-skills-cn.md
@@ -1,0 +1,536 @@
+# LangChain4j Agent Skills (代理技能)
+
+> **状态**: 实验性功能 (1.12.0)
+
+通过 `SKILL.md` 文件动态扩展 AI 代理的能力。让代理能够执行脚本、读取资源和使用外部工具来完成复杂任务。
+
+---
+
+## 快速开始
+
+### 1. 添加依赖
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-agent-skills</artifactId>
+    <version>1.12.0-SNAPSHOT</version>
+</dependency>
+```
+
+### 2. 创建技能
+
+创建 `skills/calculator/SKILL.md`:
+
+```markdown
+---
+name: calculator
+description: 执行数学计算
+allowed-tools:
+  - python
+---
+
+# 计算器技能
+
+使用 `python scripts/calc.py <表达式>` 来计算数学表达式。
+```
+
+创建 `skills/calculator/scripts/calc.py`:
+
+```python
+#!/usr/bin/env python3
+import sys
+print(eval(sys.argv[1]))
+```
+
+赋予执行权限:
+```bash
+chmod +x skills/calculator/scripts/calc.py
+```
+
+### 3. 配置代理
+
+```java
+import dev.langchain4j.agentskills.AgentSkillsConfig;
+import dev.langchain4j.agentskills.DefaultAgentSkillsProvider;
+import dev.langchain4j.service.AiServices;
+import java.nio.file.Path;
+
+AgentSkillsConfig config = AgentSkillsConfig.builder()
+    .skillsProvider(DefaultAgentSkillsProvider.builder()
+        .skillDirectories(Path.of("skills"))
+        .build())
+    .maxIterations(10)
+    .build();
+
+interface Assistant {
+    String chat(String message);
+}
+
+Assistant assistant = AiServices.builder(Assistant.class)
+    .chatModel(yourChatModel)
+    .agentSkillsConfig(config)  // ← 启用 Agent Skills
+    .build();
+```
+
+### 4. 使用！
+
+```java
+String result = assistant.chat("计算 15 * 23");
+// LLM 自动使用计算器技能: "结果是 345"
+```
+
+---
+
+## 工作原理
+
+### 1. 系统提示增强
+发送消息时，Agent Skills 自动将可用技能添加到系统提示中：
+
+```xml
+<available_skills>
+  <skill>
+    <name>calculator</name>
+    <description>执行数学计算</description>
+  </skill>
+</available_skills>
+
+使用说明:
+- 加载技能: <use_skill>skill-name</use_skill>
+- 执行脚本: <execute_script skill="skill-name">command</execute_script>
+- 读取资源: <read_resource skill="skill-name">path</read_resource>
+```
+
+### 2. LLM 响应处理
+LLM 可以在响应中包含指令：
+
+```xml
+<execute_script skill="calculator">python scripts/calc.py 15*23</execute_script>
+```
+
+Agent Skills 自动：
+1. 根据 `allowed-tools` 验证命令
+2. 在技能目录中执行脚本
+3. 捕获输出并发送回 LLM
+4. LLM 生成最终回复给用户
+
+### 3. 自动迭代
+此过程持续进行，直到 LLM 返回用户可见的消息（最多 `maxIterations` 次）。
+
+---
+
+## 技能定义
+
+### SKILL.md 格式
+
+```markdown
+---
+name: skill-name                    # 必需: 小写字母和连字符
+description: 简短描述               # 必需: ≤ 500 字符
+license: MIT                        # 可选
+compatibility: 适用于 GPT-4         # 可选: ≤ 200 字符
+allowed-tools:                      # 可选: 命令白名单
+  - python
+  - bash
+  - scripts/*                       # 支持通配符
+metadata:                           # 可选: 自定义字段
+  author: 你的名字
+  version: 1.0.0
+---
+
+# 技能文档
+
+这里是 Markdown 格式的文档...
+使用说明...
+```
+
+### 目录结构
+
+```
+skills/
+└── skill-name/
+    ├── SKILL.md           # 必需: 元数据 + 文档
+    ├── scripts/           # 可选: 可执行脚本
+    │   ├── script1.sh
+    │   └── script2.py
+    └── assets/            # 可选: 配置/资源
+        ├── config.json
+        └── template.txt
+```
+
+---
+
+## 指令参考
+
+### 1. 加载技能内容
+
+**指令**: `<use_skill>skill-name</use_skill>`
+
+**用途**: 加载完整的 `SKILL.md` 内容（不含 frontmatter）
+
+**响应**:
+```xml
+<skill_content name="skill-name">
+...技能说明...
+</skill_content>
+```
+
+**使用场景**: LLM 需要详细说明才能使用技能
+
+---
+
+### 2. 执行脚本
+
+**指令**: `<execute_script skill="skill-name">command args</execute_script>`
+
+**用途**: 在技能目录中运行脚本或命令
+
+**安全性**:
+- 命令必须在 `allowed-tools` 列表中
+- 在技能目录作为工作目录执行
+- 60 秒超时（可配置）
+
+**响应**:
+```xml
+<script_result exit_code="0">
+标准输出内容
+STDERR:
+标准错误内容（如果有）
+</script_result>
+```
+
+**使用场景**: 执行处理脚本、运行计算、获取数据
+
+---
+
+### 3. 读取资源
+
+**指令**: `<read_resource skill="skill-name">relative/path.txt</read_resource>`
+
+**用途**: 从技能目录读取文件
+
+**安全性**:
+- 路径必须是相对路径（无绝对路径）
+- 阻止路径遍历（技能目录外的 `../`）
+- 防止符号链接逃逸
+
+**响应**:
+```xml
+<resource_content path="relative/path.txt">
+文件内容
+</resource_content>
+```
+
+**使用场景**: 加载配置文件、模板、查询数据
+
+---
+
+## 安全性
+
+### 命令白名单
+
+**问题**: 防止任意命令执行
+
+**解决方案**: SKILL.md 中的 `allowed-tools`
+
+```yaml
+allowed-tools:
+  - python              # 允许: python script.py
+  - bash                # 允许: bash script.sh
+  - scripts/*           # 允许: scripts/任何内容
+  - "*"                 # 允许: 所有（谨慎使用！）
+```
+
+**验证**: 精确匹配或通配符前缀匹配
+
+---
+
+### 路径遍历防护
+
+**问题**: 访问技能目录外的文件
+
+**解决方案**: 多层验证
+1. 解析前规范化路径
+2. 检查 `startsWith(skillPath)`
+3. 解析真实路径（跟随符号链接）
+4. 再次检查 `startsWith(skillPath)`
+
+**阻止**:
+```
+../../../etc/passwd          ❌
+/tmp/file.txt                ❌
+symlink-to-outside-dir       ❌
+```
+
+**允许**:
+```
+assets/config.json           ✅
+scripts/helper.py            ✅
+./relative/path.txt          ✅
+```
+
+---
+
+## 配置
+
+### AgentSkillsConfig 构建器
+
+```java
+AgentSkillsConfig config = AgentSkillsConfig.builder()
+    .skillsProvider(provider)           // 必需
+    .scriptExecutor(customExecutor)     // 可选: 默认是 DefaultScriptExecutor
+    .maxIterations(10)                  // 可选: 默认是 10
+    .build();
+```
+
+### DefaultAgentSkillsProvider 构建器
+
+```java
+AgentSkillsProvider provider = DefaultAgentSkillsProvider.builder()
+    .skillDirectories(
+        Path.of("skills"),              // 从多个目录加载
+        Path.of("/opt/shared-skills")
+    )
+    .build();
+
+// 修改后重新加载技能
+provider.reload();
+```
+
+### 自定义脚本执行器
+
+```java
+ScriptExecutor dockerExecutor = (workingDir, command) -> {
+    // 在 Docker 容器中运行脚本
+    ProcessBuilder pb = new ProcessBuilder(
+        "docker", "run", "--rm",
+        "-v", workingDir + ":/workspace",
+        "-w", "/workspace",
+        "python:3.11-alpine",
+        "sh", "-c", command
+    );
+    Process process = pb.start();
+    // ... 捕获输出 ...
+    return new ScriptExecutionResult(
+        process.waitFor(),
+        stdout,
+        stderr
+    );
+};
+
+AgentSkillsConfig config = AgentSkillsConfig.builder()
+    .skillsProvider(provider)
+    .scriptExecutor(dockerExecutor)      // 使用自定义执行器
+    .build();
+```
+
+---
+
+## 示例
+
+### 示例 1: 网页抓取技能
+
+**技能**: `skills/web-scraper/SKILL.md`
+```markdown
+---
+name: web-scraper
+description: 获取和解析网页内容
+allowed-tools:
+  - curl
+  - python
+---
+
+# 网页抓取器
+
+获取 URL:
+```bash
+curl -s https://example.com
+```
+
+解析 HTML:
+```bash
+python scripts/parse.py <url>
+```
+```
+
+**使用**:
+```java
+assistant.chat("example.com 首页有什么内容？");
+// LLM 使用 web-scraper 技能获取和分析页面
+```
+
+---
+
+### 示例 2: 数据分析技能
+
+**技能**: `skills/data-analyzer/SKILL.md`
+```markdown
+---
+name: data-analyzer
+description: 分析 CSV 数据并生成洞察
+allowed-tools:
+  - python
+---
+
+# 数据分析器
+
+分析 CSV 文件:
+```bash
+python scripts/analyze.py <csv-file>
+```
+
+配置在 `assets/config.json`:
+- `threshold`: 过滤的最小值
+- `chart_type`: 可视化类型
+```
+
+**资源**: `skills/data-analyzer/assets/config.json`
+```json
+{
+  "threshold": 0.5,
+  "chart_type": "bar"
+}
+```
+
+**使用**:
+```java
+assistant.chat("分析 sales_data.csv 找出热销产品");
+// LLM:
+// 1. <read_resource skill="data-analyzer">assets/config.json</read_resource>
+// 2. <execute_script skill="data-analyzer">python scripts/analyze.py sales_data.csv</execute_script>
+// 3. 为用户总结结果
+```
+
+---
+
+## 测试
+
+### 单元测试
+
+运行所有单元测试:
+```bash
+mvn test -pl langchain4j-agent-skills
+```
+
+测试特定组件:
+```bash
+mvn test -Dtest=FileSystemSkillLoaderTest -pl langchain4j-agent-skills
+```
+
+### 端到端测试
+
+需要真实 LLM（如通义千问）:
+```bash
+export QWEN_API_KEY="your-api-key"
+mvn test -Dtest=AgentSkillsEndToEndTest -pl langchain4j-agent-skills
+```
+
+**测试覆盖率**:
+- 66 个测试 (9 + 11 + 13 + 26 + 7)
+- 100% 通过率
+- 与真实 LLM 的完整集成
+
+---
+
+## 故障排除
+
+### 技能未加载
+
+**检查**:
+1. 技能目录中存在 `SKILL.md`
+2. frontmatter 中的技能名称与目录名称匹配
+3. YAML frontmatter 有效（使用 YAML 检查器）
+4. 检查日志中的解析错误
+
+**调试**:
+```java
+provider.provideSkills(request).skills().forEach(skill ->
+    System.out.println("已加载: " + skill.name())
+);
+```
+
+---
+
+### 脚本执行失败
+
+**检查**:
+1. 脚本有执行权限: `chmod +x scripts/script.sh`
+2. Shebang 正确: `#!/bin/bash` 或 `#!/usr/bin/env python3`
+3. 命令在 `allowed-tools` 列表中
+4. 脚本在技能目录中
+
+---
+
+### LLM 未使用技能
+
+**尝试**:
+1. 更明确的提示: "使用计算器技能来计算..."
+2. 检查系统提示增强（启用调试日志）
+3. 如果过程提前停止，增加 `maxIterations`
+4. 尝试不同的 LLM 模型（GPT-4、Claude 等）
+5. 验证模型支持工具/函数调用模式
+
+---
+
+## 架构
+
+详细的架构、设计决策和实现细节，请参阅:
+- **[agent-skills-architecture.md](agent-skills-architecture.md)** - 完整设计文档（英文）
+
+**核心组件**:
+- `AgentSkillsService` - 编排技能操作
+- `DefaultAgentSkillsProvider` - 从文件系统加载技能
+- `FileSystemSkillLoader` - 解析 SKILL.md 文件
+- `DefaultScriptExecutor` - 执行 shell 命令
+- `AgentSkillsConfig` - 配置容器
+
+---
+
+## 当前限制
+
+1. **仅文件系统**: 技能必须在本地文件系统上（尚无 HTTP/数据库加载器）
+2. **单条指令**: 每次迭代仅处理 LLM 响应中的第一条指令
+3. **无流式处理**: 脚本输出在完成后捕获（无实时流）
+4. **Unix 为主**: 最佳支持 Unix 类系统（macOS、Linux）
+5. **无依赖管理**: 技能不能依赖其他技能
+
+---
+
+## 路线图
+
+- [ ] 数据库支持的技能提供者
+- [ ] HTTP API 技能加载器
+- [ ] 技能依赖解析
+- [ ] 基于 Docker 的沙箱
+- [ ] 流式脚本输出
+- [ ] 技能市场/注册表
+- [ ] Windows 原生脚本支持
+- [ ] 技能组合 DSL
+
+---
+
+## 贡献
+
+欢迎贡献！详见 [agent-skills-architecture.md](agent-skills-architecture.md)
+
+---
+
+## 许可证
+
+Apache 2.0（与 LangChain4j 相同）
+
+---
+
+## 支持
+
+**Issues**: [GitHub Issues](https://github.com/langchain4j/langchain4j/issues)
+**讨论**: [GitHub Discussions](https://github.com/langchain4j/langchain4j/discussions)
+**作者**: Shrink (shunke.wjl@alibaba-inc.com)
+
+---
+
+## 另请参阅
+
+- [LangChain4j 文档](https://docs.langchain4j.dev)
+- [AI Services 指南](https://docs.langchain4j.dev/tutorials/ai-services)
+- [工具系统](https://docs.langchain4j.dev/tutorials/tools)

--- a/docs/docs/tutorials/agent-skills.md
+++ b/docs/docs/tutorials/agent-skills.md
@@ -1,0 +1,587 @@
+# LangChain4j Agent Skills
+
+> **Status**: Experimental (1.12.0)
+
+Extend your AI agents with dynamically loadable skills defined in `SKILL.md` files. Enable agents to execute scripts, read resources, and use external tools to accomplish complex tasks.
+
+---
+
+## Quick Start
+
+### 1. Add Dependency
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-agent-skills</artifactId>
+    <version>1.12.0-SNAPSHOT</version>
+</dependency>
+```
+
+### 2. Create a Skill
+
+Create `skills/calculator/SKILL.md`:
+
+```markdown
+---
+name: calculator
+description: Perform mathematical calculations
+allowed-tools:
+  - python
+---
+
+# Calculator Skill
+
+Use `python scripts/calc.py <expression>` to evaluate math expressions.
+```
+
+Create `skills/calculator/scripts/calc.py`:
+
+```python
+#!/usr/bin/env python3
+import sys
+print(eval(sys.argv[1]))
+```
+
+Make it executable:
+```bash
+chmod +x skills/calculator/scripts/calc.py
+```
+
+### 3. Configure Agent
+
+```java
+import dev.langchain4j.agentskills.AgentSkillsConfig;
+import dev.langchain4j.agentskills.DefaultAgentSkillsProvider;
+import dev.langchain4j.service.AiServices;
+import java.nio.file.Path;
+
+AgentSkillsConfig config = AgentSkillsConfig.builder()
+    .skillsProvider(DefaultAgentSkillsProvider.builder()
+        .skillDirectories(Path.of("skills"))
+        .build())
+    .maxIterations(10)
+    .build();
+
+interface Assistant {
+    String chat(String message);
+}
+
+Assistant assistant = AiServices.builder(Assistant.class)
+    .chatModel(yourChatModel)
+    .agentSkillsConfig(config)  // ← Enable Agent Skills
+    .build();
+```
+
+### 4. Use It!
+
+```java
+String result = assistant.chat("Calculate 15 * 23");
+// LLM automatically uses calculator skill: "The result is 345"
+```
+
+---
+
+## How It Works
+
+### 1. System Prompt Enhancement
+When you send a message, Agent Skills automatically adds available skills to the system prompt:
+
+```xml
+<available_skills>
+  <skill>
+    <name>calculator</name>
+    <description>Perform mathematical calculations</description>
+  </skill>
+</available_skills>
+
+Instructions:
+- Load skill: <use_skill>skill-name</use_skill>
+- Execute script: <execute_script skill="skill-name">command</execute_script>
+- Read resource: <read_resource skill="skill-name">path</read_resource>
+```
+
+### 2. LLM Response Processing
+The LLM can respond with instructions like:
+
+```xml
+<execute_script skill="calculator">python scripts/calc.py 15*23</execute_script>
+```
+
+Agent Skills automatically:
+1. Validates the command against `allowed-tools`
+2. Executes the script in the skill directory
+3. Captures output and sends it back to the LLM
+4. LLM formulates the final response to the user
+
+### 3. Automatic Iteration
+The process continues until the LLM responds with a user-facing message (up to `maxIterations`).
+
+---
+
+## Skill Definition
+
+### SKILL.md Format
+
+```markdown
+---
+name: skill-name                    # Required: lowercase-with-hyphens
+description: Brief description      # Required: ≤ 500 chars
+license: MIT                        # Optional
+compatibility: Works with GPT-4     # Optional: ≤ 200 chars
+allowed-tools:                      # Optional: command whitelist
+  - python
+  - bash
+  - scripts/*                       # Wildcard patterns supported
+metadata:                           # Optional: custom fields
+  author: Your Name
+  version: 1.0.0
+---
+
+# Skill Documentation
+
+Markdown documentation here...
+Instructions for using the skill...
+```
+
+### Directory Structure
+
+```
+skills/
+└── skill-name/
+    ├── SKILL.md           # Required: metadata + docs
+    ├── scripts/           # Optional: executable scripts
+    │   ├── script1.sh
+    │   └── script2.py
+    └── assets/            # Optional: config/resources
+        ├── config.json
+        └── template.txt
+```
+
+---
+
+## Instructions Reference
+
+### 1. Load Skill Content
+
+**Instruction**: `<use_skill>skill-name</use_skill>`
+
+**Purpose**: Load the full `SKILL.md` content (excluding frontmatter)
+
+**Response**:
+```xml
+<skill_content name="skill-name">
+...skill instructions...
+</skill_content>
+```
+
+**Use Case**: LLM needs detailed instructions before using the skill
+
+---
+
+### 2. Execute Script
+
+**Instruction**: `<execute_script skill="skill-name">command args</execute_script>`
+
+**Purpose**: Run a script or command within the skill directory
+
+**Security**:
+- Command must be in `allowed-tools` list
+- Executes in skill directory as working directory
+- 60-second timeout (configurable)
+
+**Response**:
+```xml
+<script_result exit_code="0">
+stdout output here
+STDERR:
+stderr output here (if any)
+</script_result>
+```
+
+**Use Case**: Execute processing scripts, run calculations, fetch data
+
+---
+
+### 3. Read Resource
+
+**Instruction**: `<read_resource skill="skill-name">relative/path.txt</read_resource>`
+
+**Purpose**: Read a file from the skill directory
+
+**Security**:
+- Path must be relative (no absolute paths)
+- Path traversal blocked (`../` outside skill directory)
+- Symlink escape prevention
+
+**Response**:
+```xml
+<resource_content path="relative/path.txt">
+file content here
+</resource_content>
+```
+
+**Use Case**: Load configuration files, templates, lookup data
+
+---
+
+## Security
+
+### Command Whitelisting
+
+**Problem**: Prevent arbitrary command execution
+
+**Solution**: `allowed-tools` in SKILL.md
+
+```yaml
+allowed-tools:
+  - python              # Allow: python script.py
+  - bash                # Allow: bash script.sh
+  - scripts/*           # Allow: scripts/anything
+  - "*"                 # Allow: everything (use with caution!)
+```
+
+**Validation**: Exact match or prefix match with wildcards
+
+---
+
+### Path Traversal Prevention
+
+**Problem**: Accessing files outside skill directory
+
+**Solution**: Multi-layer validation
+1. Normalize path before resolution
+2. Check `startsWith(skillPath)`
+3. Resolve real path (follow symlinks)
+4. Check `startsWith(skillPath)` again
+
+**Blocked**:
+```
+../../../etc/passwd          ❌
+/tmp/file.txt                ❌
+symlink-to-outside-dir       ❌
+```
+
+**Allowed**:
+```
+assets/config.json           ✅
+scripts/helper.py            ✅
+./relative/path.txt          ✅
+```
+
+---
+
+### Process Isolation
+
+**Working Directory**: All scripts execute in skill directory
+- No access to parent directories by default
+- Relative paths resolve within skill directory
+
+**Timeout**: Scripts terminated after 60 seconds (configurable)
+
+---
+
+## Configuration
+
+### AgentSkillsConfig Builder
+
+```java
+AgentSkillsConfig config = AgentSkillsConfig.builder()
+    .skillsProvider(provider)           // Required
+    .scriptExecutor(customExecutor)     // Optional: default is DefaultScriptExecutor
+    .maxIterations(10)                  // Optional: default is 10
+    .build();
+```
+
+### DefaultAgentSkillsProvider Builder
+
+```java
+AgentSkillsProvider provider = DefaultAgentSkillsProvider.builder()
+    .skillDirectories(
+        Path.of("skills"),              // Load from multiple directories
+        Path.of("/opt/shared-skills")
+    )
+    .build();
+
+// Reload skills after modifications
+provider.reload();
+```
+
+### Custom Script Executor
+
+```java
+ScriptExecutor dockerExecutor = (workingDir, command) -> {
+    // Run scripts in Docker containers
+    ProcessBuilder pb = new ProcessBuilder(
+        "docker", "run", "--rm",
+        "-v", workingDir + ":/workspace",
+        "-w", "/workspace",
+        "python:3.11-alpine",
+        "sh", "-c", command
+    );
+    Process process = pb.start();
+    // ... capture output ...
+    return new ScriptExecutionResult(
+        process.waitFor(),
+        stdout,
+        stderr
+    );
+};
+
+AgentSkillsConfig config = AgentSkillsConfig.builder()
+    .skillsProvider(provider)
+    .scriptExecutor(dockerExecutor)      // Use custom executor
+    .build();
+```
+
+---
+
+## Examples
+
+### Example 1: Web Scraping Skill
+
+**Skill**: `skills/web-scraper/SKILL.md`
+```markdown
+---
+name: web-scraper
+description: Fetch and parse web page content
+allowed-tools:
+  - curl
+  - python
+---
+
+# Web Scraper
+
+Fetch a URL:
+```bash
+curl -s https://example.com
+```
+
+Parse HTML:
+```bash
+python scripts/parse.py <url>
+```
+```
+
+**Usage**:
+```java
+assistant.chat("What's on the homepage of example.com?");
+// LLM uses web-scraper skill to fetch and analyze the page
+```
+
+---
+
+### Example 2: Data Analysis Skill
+
+**Skill**: `skills/data-analyzer/SKILL.md`
+```markdown
+---
+name: data-analyzer
+description: Analyze CSV data and generate insights
+allowed-tools:
+  - python
+---
+
+# Data Analyzer
+
+Analyze a CSV file:
+```bash
+python scripts/analyze.py <csv-file>
+```
+
+Configuration in `assets/config.json`:
+- `threshold`: Minimum value for filtering
+- `chart_type`: Type of visualization
+```
+
+**Resources**: `skills/data-analyzer/assets/config.json`
+```json
+{
+  "threshold": 0.5,
+  "chart_type": "bar"
+}
+```
+
+**Usage**:
+```java
+assistant.chat("Analyze sales_data.csv and find top products");
+// LLM:
+// 1. <read_resource skill="data-analyzer">assets/config.json</read_resource>
+// 2. <execute_script skill="data-analyzer">python scripts/analyze.py sales_data.csv</execute_script>
+// 3. Summarizes results for user
+```
+
+---
+
+### Example 3: Multi-Skill Workflow
+
+**Skills**: `calculator`, `report-generator`
+
+**User Request**:
+```java
+assistant.chat("Calculate monthly revenue (1500 * 30) and generate a report");
+```
+
+**LLM Workflow**:
+1. `<execute_script skill="calculator">python scripts/calc.py 1500*30</execute_script>`
+   → Result: 45000
+2. `<execute_script skill="report-generator">python scripts/generate.py 45000</execute_script>`
+   → Report generated
+3. Responds: "Monthly revenue is $45,000. Report has been generated."
+
+---
+
+## Testing
+
+### Unit Tests
+
+Run all unit tests:
+```bash
+mvn test -pl langchain4j-agent-skills
+```
+
+Test specific component:
+```bash
+mvn test -Dtest=FileSystemSkillLoaderTest -pl langchain4j-agent-skills
+```
+
+### End-to-End Tests
+
+Requires real LLM (e.g., Qwen):
+```bash
+export QWEN_API_KEY="your-api-key"
+mvn test -Dtest=AgentSkillsEndToEndTest -pl langchain4j-agent-skills
+```
+
+**Test Coverage**:
+- 66 total tests (9 + 11 + 13 + 26 + 7)
+- 100% pass rate
+- Full integration with real LLM
+
+---
+
+## Troubleshooting
+
+### Skills Not Loading
+
+**Check**:
+1. `SKILL.md` exists in skill directory
+2. Skill name in frontmatter matches directory name
+3. YAML frontmatter is valid (use YAML linter)
+4. Check logs for parsing errors
+
+**Debug**:
+```java
+provider.provideSkills(request).skills().forEach(skill ->
+    System.out.println("Loaded: " + skill.name())
+);
+```
+
+---
+
+### Script Execution Fails
+
+**Check**:
+1. Script has execute permissions: `chmod +x scripts/script.sh`
+2. Shebang is correct: `#!/bin/bash` or `#!/usr/bin/env python3`
+3. Command is in `allowed-tools` list
+4. Script is in skill directory
+
+**Debug**:
+```java
+ScriptExecutor debugExecutor = (workingDir, command) -> {
+    System.out.println("Executing: " + command);
+    System.out.println("Working dir: " + workingDir);
+    // ... actual execution ...
+};
+```
+
+---
+
+### LLM Not Using Skills
+
+**Try**:
+1. More explicit prompts: "Use the calculator skill to compute..."
+2. Check system prompt enhancement (enable debug logging)
+3. Increase `maxIterations` if process stops early
+4. Try different LLM models (GPT-4, Claude, etc.)
+5. Verify model supports tool/function calling patterns
+
+**Debug**:
+```java
+// Enable logging
+import org.slf4j.LoggerFactory;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+
+Logger root = (Logger) LoggerFactory.getLogger("dev.langchain4j.service.agentskills");
+root.setLevel(Level.DEBUG);
+```
+
+---
+
+## Architecture
+
+For detailed architecture, design decisions, and implementation details, see:
+- **[agent-skills-architecture.md](agent-skills-architecture.md)** - Full design document
+
+**Key Components**:
+- `AgentSkillsService` - Orchestrates skill operations
+- `DefaultAgentSkillsProvider` - Loads skills from file system
+- `FileSystemSkillLoader` - Parses SKILL.md files
+- `DefaultScriptExecutor` - Executes shell commands
+- `AgentSkillsConfig` - Configuration container
+
+---
+
+## Limitations
+
+### Current Limitations
+
+1. **File System Only**: Skills must be on local file system (no HTTP/database loaders yet)
+2. **Single Instruction**: Only first instruction in LLM response is processed per iteration
+3. **No Streaming**: Script output captured after completion (no real-time streaming)
+4. **Unix-Centric**: Best support for Unix-like systems (macOS, Linux)
+5. **No Dependency Management**: Skills cannot depend on other skills
+
+### Roadmap
+
+- [ ] Database-backed skill provider
+- [ ] HTTP API skill loader
+- [ ] Skill dependency resolution
+- [ ] Docker-based sandboxing
+- [ ] Streaming script output
+- [ ] Skill marketplace/registry
+- [ ] Windows-native script support
+- [ ] Skill composition DSL
+
+---
+
+## Contributing
+
+Contributions welcome! See [agent-skills-architecture.md](agent-skills-architecture.md) for:
+- Code style guidelines
+- Testing requirements
+- Architecture decisions
+
+---
+
+## License
+
+Apache 2.0 (same as LangChain4j)
+
+---
+
+## Support
+
+**Issues**: [GitHub Issues](https://github.com/langchain4j/langchain4j/issues)
+**Discussions**: [GitHub Discussions](https://github.com/langchain4j/langchain4j/discussions)
+**Author**: Shrink (shunke.wjl@alibaba-inc.com)
+
+---
+
+## See Also
+
+- [LangChain4j Documentation](https://docs.langchain4j.dev)
+- [AI Services Guide](https://docs.langchain4j.dev/tutorials/ai-services)
+- [Tool System](https://docs.langchain4j.dev/tutorials/tools)

--- a/langchain4j-agent-skills/pom.xml
+++ b/langchain4j-agent-skills/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-parent</artifactId>
+        <version>1.11.0-beta19-SNAPSHOT</version>
+        <relativePath>../langchain4j-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-agent-skills</artifactId>
+    <name>LangChain4j :: Integration :: Agent Skills</name>
+    <description>Agent Skills integration for LangChain4j - enables AI agents to use modular, reusable skills</description>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>1.11.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>1.11.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+            <version>1.11.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/langchain4j-agent-skills/src/main/java/dev/langchain4j/agentskills/DefaultAgentSkillsProvider.java
+++ b/langchain4j-agent-skills/src/main/java/dev/langchain4j/agentskills/DefaultAgentSkillsProvider.java
@@ -1,0 +1,190 @@
+package dev.langchain4j.agentskills;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.agentskills.loader.FileSystemSkillLoader;
+import dev.langchain4j.agentskills.loader.SkillLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+
+/**
+ * Default implementation of {@link AgentSkillsProvider} that loads skills from
+ * the file system.
+ * <p>
+ * Skills are loaded lazily on first access and cached for subsequent requests.
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * AgentSkillsProvider provider = DefaultAgentSkillsProvider.builder()
+ *     .skillDirectories(Path.of("/path/to/skills"))
+ *     .build();
+ * }</pre>
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public class DefaultAgentSkillsProvider implements AgentSkillsProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultAgentSkillsProvider.class);
+
+    private final List<Path> skillDirectories;
+    private final SkillLoader skillLoader;
+    private final Map<String, Skill> skillCache;
+    private volatile boolean initialized = false;
+
+    private DefaultAgentSkillsProvider(Builder builder) {
+        this.skillDirectories = Collections.unmodifiableList(
+                new ArrayList<>(ensureNotEmpty(builder.skillDirectories, "skillDirectories")));
+        this.skillLoader = builder.skillLoader != null
+                ? builder.skillLoader
+                : new FileSystemSkillLoader();
+        this.skillCache = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public AgentSkillsProviderResult provideSkills(AgentSkillsProviderRequest request) {
+        ensureInitialized();
+        return AgentSkillsProviderResult.builder()
+                .skills(new ArrayList<>(skillCache.values()))
+                .build();
+    }
+
+    @Override
+    public List<Skill> allSkills() {
+        ensureInitialized();
+        return new ArrayList<>(skillCache.values());
+    }
+
+    @Override
+    public Skill skillByName(String name) {
+        if (name == null) {
+            return null;
+        }
+        ensureInitialized();
+        return skillCache.get(name);
+    }
+
+    /**
+     * Reloads all skills from the configured directories.
+     * <p>
+     * This clears the cache and reloads all skills.
+     * The operation is atomic - other threads will see either the old or the new skill set,
+     * never an empty or partial set.
+     */
+    public synchronized void reload() {
+        // Load into a temporary map first
+        Map<String, Skill> newCache = loadAllSkills();
+        
+        // Atomic swap
+        skillCache.clear();
+        skillCache.putAll(newCache);
+        initialized = true;
+    }
+
+    private synchronized void ensureInitialized() {
+        if (initialized) {
+            return;
+        }
+
+        Map<String, Skill> newCache = loadAllSkills();
+        skillCache.putAll(newCache);
+        initialized = true;
+    }
+
+    private Map<String, Skill> loadAllSkills() {
+        log.info("Loading skills from {} directories", skillDirectories.size());
+        Map<String, Skill> result = new HashMap<>();
+
+        for (Path directory : skillDirectories) {
+            try {
+                List<Skill> skills = skillLoader.loadSkillsFromDirectory(directory);
+                for (Skill skill : skills) {
+                    if (result.containsKey(skill.name())) {
+                        log.warn("Duplicate skill name '{}', skipping from {}", skill.name(), skill.path());
+                    } else {
+                        result.put(skill.name(), skill);
+                        log.info("Loaded skill: {} from {}", skill.name(), skill.path());
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Failed to load skills from directory: {}", directory, e);
+            }
+        }
+
+        log.info("Loaded {} skills total", result.size());
+        return result;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private List<Path> skillDirectories = new ArrayList<>();
+        private SkillLoader skillLoader;
+
+        /**
+         * Sets the directories to scan for skills.
+         *
+         * @param skillDirectories list of directories
+         * @return this builder
+         */
+        public Builder skillDirectories(List<Path> skillDirectories) {
+            this.skillDirectories = new ArrayList<>(skillDirectories);
+            return this;
+        }
+
+        /**
+         * Sets the directories to scan for skills.
+         *
+         * @param skillDirectories directories
+         * @return this builder
+         */
+        public Builder skillDirectories(Path... skillDirectories) {
+            this.skillDirectories = new ArrayList<>(Arrays.asList(skillDirectories));
+            return this;
+        }
+
+        /**
+         * Adds a directory to scan for skills.
+         *
+         * @param directory the directory to add (must not be null)
+         * @return this builder
+         * @throws IllegalArgumentException if directory is null
+         */
+        public Builder addSkillDirectory(Path directory) {
+            if (directory == null) {
+                throw new IllegalArgumentException("directory cannot be null");
+            }
+            this.skillDirectories.add(directory);
+            return this;
+        }
+
+        /**
+         * Sets a custom skill loader.
+         *
+         * @param skillLoader the loader to use
+         * @return this builder
+         */
+        public Builder skillLoader(SkillLoader skillLoader) {
+            this.skillLoader = skillLoader;
+            return this;
+        }
+
+        public DefaultAgentSkillsProvider build() {
+            return new DefaultAgentSkillsProvider(this);
+        }
+    }
+}

--- a/langchain4j-agent-skills/src/main/java/dev/langchain4j/agentskills/loader/FileSystemSkillLoader.java
+++ b/langchain4j-agent-skills/src/main/java/dev/langchain4j/agentskills/loader/FileSystemSkillLoader.java
@@ -1,0 +1,223 @@
+package dev.langchain4j.agentskills.loader;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.agentskills.Skill;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Loads skills from the file system by scanning for SKILL.md files.
+ * <p>
+ * This loader follows the Agent Skills specification from
+ * <a href="https://agentskills.io/specification">agentskills.io</a>.
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public class FileSystemSkillLoader implements SkillLoader {
+
+    private static final Logger log = LoggerFactory.getLogger(FileSystemSkillLoader.class);
+    private static final String SKILL_FILE_NAME = "SKILL.md";
+    private static final Pattern FRONTMATTER_PATTERN =
+            Pattern.compile("^---\\s*\\r?\\n(.*?)\\r?\\n---\\s*\\r?\\n(.*)$", Pattern.DOTALL);
+    private static final Pattern SKILL_NAME_PATTERN =
+            Pattern.compile("^[a-z0-9]+(-[a-z0-9]+)*$");
+
+    @Override
+    public List<Skill> loadSkillsFromDirectory(Path directory) {
+        List<Skill> skills = new ArrayList<>();
+
+        if (!Files.isDirectory(directory)) {
+            log.warn("Skill directory does not exist: {}", directory);
+            return skills;
+        }
+
+        try (Stream<Path> paths = Files.walk(directory)) {
+            paths.filter(path -> path.getFileName().toString().equals(SKILL_FILE_NAME))
+                    .forEach(skillMdPath -> {
+                        try {
+                            Skill skill = loadSkill(skillMdPath.getParent());
+                            if (skill != null) {
+                                skills.add(skill);
+                            }
+                        } catch (Exception e) {
+                            log.error("Failed to load skill from: {}", skillMdPath, e);
+                        }
+                    });
+        } catch (IOException e) {
+            log.error("Failed to scan directory for skills: {}", directory, e);
+        }
+
+        return skills;
+    }
+
+    @Override
+    public Skill loadSkill(Path skillDirectory) {
+        Path skillMdPath = skillDirectory.resolve(SKILL_FILE_NAME);
+
+        if (!Files.exists(skillMdPath)) {
+            log.warn("SKILL.md not found in: {}", skillDirectory);
+            return null;
+        }
+
+        try {
+            String content = Files.readString(skillMdPath);
+            return parseSkillMd(content, skillDirectory);
+        } catch (IOException e) {
+            log.error("Failed to read SKILL.md: {}", skillMdPath, e);
+            return null;
+        }
+    }
+
+    private Skill parseSkillMd(String content, Path skillDirectory) {
+        Matcher matcher = FRONTMATTER_PATTERN.matcher(content);
+
+        if (!matcher.matches()) {
+            log.warn("Invalid SKILL.md format (missing frontmatter) in: {}", skillDirectory);
+            return null;
+        }
+
+        String frontmatter = matcher.group(1);
+        String instructions = matcher.group(2).trim();
+
+        Map<String, Object> metadata = new HashMap<>();
+        Map<String, String> fields = parseYamlFrontmatter(frontmatter, metadata);
+
+        String name = fields.get("name");
+        String description = fields.get("description");
+
+        if (name == null || name.isBlank()) {
+            log.warn("Missing 'name' in SKILL.md frontmatter: {}", skillDirectory);
+            return null;
+        }
+
+        if (description == null || description.isBlank()) {
+            log.warn("Missing 'description' in SKILL.md frontmatter: {}", skillDirectory);
+            return null;
+        }
+
+        // Validate name format
+        if (!isValidSkillName(name)) {
+            throw new IllegalArgumentException("Invalid skill name '" + name + "'. "
+                    + "Must be 1-64 chars, lowercase letters, numbers, and hyphens only, "
+                    + "cannot start or end with hyphen");
+        }
+
+        // Validate description length
+        if (description.length() > 1024) {
+            throw new IllegalArgumentException("Description exceeds 1024 characters in skill '" + name + "'");
+        }
+
+        // Validate compatibility length
+        String compatibility = fields.get("compatibility");
+        if (compatibility != null && compatibility.length() > 500) {
+            throw new IllegalArgumentException("Compatibility exceeds 500 characters in skill '" + name + "'");
+        }
+
+        return Skill.builder()
+                .name(name)
+                .description(description)
+                .license(fields.get("license"))
+                .compatibility(compatibility)
+                .metadata(metadata.isEmpty() ? null : metadata)
+                .allowedTools(parseAllowedTools(fields.get("allowed-tools")))
+                .instructions(instructions)
+                .path(skillDirectory)
+                .build();
+    }
+
+    /**
+     * Parses YAML frontmatter.
+     * <p>
+     * Note: This is a simplified parser. For production use with complex YAML,
+     * consider using SnakeYAML or similar library.
+     *
+     * @param frontmatter the YAML content between --- markers
+     * @param metadata    output map for nested metadata block (will be populated if metadata exists)
+     * @return map of top-level fields
+     */
+    private Map<String, String> parseYamlFrontmatter(String frontmatter, Map<String, Object> metadata) {
+        Map<String, String> result = new HashMap<>();
+        String[] lines = frontmatter.split("\\r?\\n");
+
+        boolean inMetadataBlock = false;
+
+        for (String line : lines) {
+            // Skip empty lines and comments
+            if (line.trim().isEmpty() || line.trim().startsWith("#")) {
+                continue;
+            }
+
+            // Check if this is an indented line (part of metadata block)
+            boolean isIndented = line.startsWith("  ") || line.startsWith("\t");
+
+            if (isIndented && inMetadataBlock) {
+                // Parse nested metadata key-value
+                String trimmedLine = line.trim();
+                int colonIndex = trimmedLine.indexOf(':');
+                if (colonIndex > 0) {
+                    String key = trimmedLine.substring(0, colonIndex).trim();
+                    String value = trimmedLine.substring(colonIndex + 1).trim();
+                    metadata.put(key, removeQuotes(value));
+                }
+                continue;
+            }
+
+            // Top-level field
+            inMetadataBlock = false;
+            int colonIndex = line.indexOf(':');
+            if (colonIndex > 0) {
+                String key = line.substring(0, colonIndex).trim();
+                String value = line.substring(colonIndex + 1).trim();
+
+                // Check if this starts the metadata block
+                if ("metadata".equals(key) && value.isEmpty()) {
+                    inMetadataBlock = true;
+                    continue;
+                }
+
+                result.put(key, removeQuotes(value));
+            }
+        }
+
+        return result;
+    }
+
+    private String removeQuotes(String value) {
+        if (value == null || value.length() < 2) {
+            return value;
+        }
+        if ((value.startsWith("\"") && value.endsWith("\""))
+                || (value.startsWith("'") && value.endsWith("'"))) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    private boolean isValidSkillName(String name) {
+        if (name == null || name.isEmpty() || name.length() > 64) {
+            return false;
+        }
+        return SKILL_NAME_PATTERN.matcher(name).matches();
+    }
+
+    private List<String> parseAllowedTools(String allowedTools) {
+        if (allowedTools == null || allowedTools.isBlank()) {
+            return null;
+        }
+        return Arrays.asList(allowedTools.split("\\s+"));
+    }
+}

--- a/langchain4j-agent-skills/src/main/java/dev/langchain4j/agentskills/loader/SkillLoader.java
+++ b/langchain4j-agent-skills/src/main/java/dev/langchain4j/agentskills/loader/SkillLoader.java
@@ -1,0 +1,36 @@
+package dev.langchain4j.agentskills.loader;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.agentskills.Skill;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Interface for loading skills from various sources.
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public interface SkillLoader {
+
+    /**
+     * Loads all skills from the specified directory.
+     * <p>
+     * The implementation should recursively scan for directories containing
+     * a SKILL.md file.
+     *
+     * @param directory the directory to scan for skills
+     * @return list of loaded skills
+     */
+    List<Skill> loadSkillsFromDirectory(Path directory);
+
+    /**
+     * Loads a single skill from the specified skill directory.
+     *
+     * @param skillDirectory the skill directory containing SKILL.md
+     * @return the loaded skill, or null if loading failed
+     */
+    Skill loadSkill(Path skillDirectory);
+}

--- a/langchain4j-agent-skills/src/test/java/dev/langchain4j/agentskills/AgentSkillsEndToEndTest.java
+++ b/langchain4j-agent-skills/src/test/java/dev/langchain4j/agentskills/AgentSkillsEndToEndTest.java
@@ -1,0 +1,302 @@
+package dev.langchain4j.agentskills;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agentskills.execution.DefaultScriptExecutor;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.service.AiServices;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * End-to-end tests: Verify full integration of Agent Skills with real LLM
+ * 
+ * <p>These tests require environment variables to run:
+ * <ul>
+ *   <li>QWEN_API_KEY - Qwen API key</li>
+ * </ul>
+ * 
+ * <p>Test scenarios include:
+ * <ul>
+ *   <li>Skills discovery and listing</li>
+ *   <li>Skill content loading</li>
+ *   <li>Script execution</li>
+ *   <li>Resource file reading</li>
+ * </ul>
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ */
+@EnabledIfEnvironmentVariable(named = "QWEN_API_KEY", matches = ".+")
+class AgentSkillsEndToEndTest {
+
+    private static Path skillsDirectory;
+    
+    interface Assistant {
+        String chat(String userMessage);
+    }
+
+    @BeforeAll
+    static void setUp() throws URISyntaxException {
+        skillsDirectory = Paths.get(
+            AgentSkillsEndToEndTest.class
+                .getClassLoader()
+                .getResource("test-skills")
+                .toURI()
+        );
+    }
+
+    @Test
+    void should_discover_available_skills() {
+        // given
+        DefaultAgentSkillsProvider skillsProvider = DefaultAgentSkillsProvider.builder()
+            .skillDirectories(skillsDirectory)
+            .build();
+
+        OpenAiChatModel model = createModel();
+
+        AgentSkillsConfig config = AgentSkillsConfig.builder()
+            .skillsProvider(skillsProvider)
+            .scriptExecutor(new DefaultScriptExecutor())
+            .maxIterations(5)
+            .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+            .chatModel(model)
+            .agentSkillsConfig(config)
+            .build();
+
+        // when
+        String response = assistant.chat("What skills are available? List their names.");
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.toLowerCase()).containsAnyOf("pdf", "skill");
+        System.out.println("✅ Skills Discovery Test Passed");
+        System.out.println("Response: " + response);
+    }
+
+    @Test
+    void should_load_skill_content() {
+        // given
+        DefaultAgentSkillsProvider skillsProvider = DefaultAgentSkillsProvider.builder()
+            .skillDirectories(skillsDirectory)
+            .build();
+
+        OpenAiChatModel model = createModel();
+
+        AgentSkillsConfig config = AgentSkillsConfig.builder()
+            .skillsProvider(skillsProvider)
+            .scriptExecutor(new DefaultScriptExecutor())
+            .maxIterations(5)
+            .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+            .chatModel(model)
+            .agentSkillsConfig(config)
+            .build();
+
+        // when
+        String response = assistant.chat(
+            "Please load the pdf-processing skill and tell me what it can do. " +
+            "Use the <use_skill>pdf-processing</use_skill> instruction to load it."
+        );
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.toLowerCase()).containsAnyOf("extract", "pdf", "document");
+        System.out.println("✅ Skill Content Loading Test Passed");
+        System.out.println("Response: " + response);
+    }
+
+    @Test
+    void should_execute_skill_script() {
+        // given
+        DefaultAgentSkillsProvider skillsProvider = DefaultAgentSkillsProvider.builder()
+            .skillDirectories(skillsDirectory)
+            .build();
+
+        OpenAiChatModel model = createModel();
+
+        AgentSkillsConfig config = AgentSkillsConfig.builder()
+            .skillsProvider(skillsProvider)
+            .scriptExecutor(new DefaultScriptExecutor())
+            .maxIterations(5)
+            .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+            .chatModel(model)
+            .agentSkillsConfig(config)
+            .build();
+
+        // when
+        String response = assistant.chat(
+            "Use the pdf-processing skill to extract text from 'document.pdf'. " +
+            "Execute the script using: <execute_script skill=\"pdf-processing\">bash scripts/extract.sh document.pdf</execute_script>"
+        );
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.toLowerCase()).containsAnyOf("extract", "success", "complet", "document");
+        System.out.println("✅ Script Execution Test Passed");
+        System.out.println("Response: " + response);
+    }
+
+    @Test
+    void should_read_skill_resource() {
+        // given
+        DefaultAgentSkillsProvider skillsProvider = DefaultAgentSkillsProvider.builder()
+            .skillDirectories(skillsDirectory)
+            .build();
+
+        OpenAiChatModel model = createModel();
+
+        AgentSkillsConfig config = AgentSkillsConfig.builder()
+            .skillsProvider(skillsProvider)
+            .scriptExecutor(new DefaultScriptExecutor())
+            .maxIterations(5)
+            .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+            .chatModel(model)
+            .agentSkillsConfig(config)
+            .build();
+
+        // when
+        String response = assistant.chat(
+            "Read the configuration file from the pdf-processing skill. " +
+            "Use: <read_resource skill=\"pdf-processing\">assets/config.json</read_resource>"
+        );
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.toLowerCase()).containsAnyOf("config", "extraction", "json");
+        System.out.println("✅ Resource Reading Test Passed");
+        System.out.println("Response: " + response);
+    }
+
+    @Test
+    void should_handle_multiple_skill_operations() {
+        // given
+        DefaultAgentSkillsProvider skillsProvider = DefaultAgentSkillsProvider.builder()
+            .skillDirectories(skillsDirectory)
+            .build();
+
+        OpenAiChatModel model = createModel();
+
+        AgentSkillsConfig config = AgentSkillsConfig.builder()
+            .skillsProvider(skillsProvider)
+            .scriptExecutor(new DefaultScriptExecutor())
+            .maxIterations(10)
+            .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+            .chatModel(model)
+            .agentSkillsConfig(config)
+            .build();
+
+        // when
+        String response = assistant.chat(
+            "Please do the following: " +
+            "1) First, load the pdf-processing skill to understand its capabilities. " +
+            "2) Then, read its configuration file. " +
+            "3) Finally, execute the extraction script. " +
+            "Report what you found at each step."
+        );
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.length()).isGreaterThan(100);
+        System.out.println("✅ Multiple Operations Test Passed");
+        System.out.println("Response: " + response);
+    }
+
+    @Test
+    void should_handle_skill_not_found() {
+        // given
+        DefaultAgentSkillsProvider skillsProvider = DefaultAgentSkillsProvider.builder()
+            .skillDirectories(skillsDirectory)
+            .build();
+
+        OpenAiChatModel model = createModel();
+
+        AgentSkillsConfig config = AgentSkillsConfig.builder()
+            .skillsProvider(skillsProvider)
+            .scriptExecutor(new DefaultScriptExecutor())
+            .maxIterations(5)
+            .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+            .chatModel(model)
+            .agentSkillsConfig(config)
+            .build();
+
+        // when
+        String response = assistant.chat(
+            "Try to use a skill called 'non-existent-skill' using: " +
+            "<use_skill>non-existent-skill</use_skill>"
+        );
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.toLowerCase()).containsAnyOf("not found", "doesn't exist", "does not exist", "error", "available", "only");
+        System.out.println("✅ Error Handling Test Passed");
+        System.out.println("Response: " + response);
+    }
+
+    @Test
+    void should_verify_system_prompt_enhancement() {
+        // given
+        DefaultAgentSkillsProvider skillsProvider = DefaultAgentSkillsProvider.builder()
+            .skillDirectories(skillsDirectory)
+            .build();
+
+        OpenAiChatModel model = createModel();
+
+        AgentSkillsConfig config = AgentSkillsConfig.builder()
+            .skillsProvider(skillsProvider)
+            .scriptExecutor(new DefaultScriptExecutor())
+            .maxIterations(5)
+            .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+            .chatModel(model)
+            .agentSkillsConfig(config)
+            .build();
+
+        // when
+        String response = assistant.chat(
+            "Tell me about your capabilities. What special skills do you have access to?"
+        );
+
+        // then
+        assertThat(response).isNotNull();
+        // LLM should mention skills because system prompt was enhanced
+        assertThat(response.toLowerCase()).containsAnyOf("skill", "pdf", "capabilit");
+        System.out.println("✅ System Prompt Enhancement Test Passed");
+        System.out.println("Response: " + response);
+    }
+
+    private OpenAiChatModel createModel() {
+        String apiKey = System.getenv("QWEN_API_KEY");
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException("QWEN_API_KEY environment variable is required");
+        }
+
+        return OpenAiChatModel.builder()
+            .baseUrl("https://dashscope.aliyuncs.com/compatible-mode/v1")
+            .apiKey(apiKey)
+            .modelName("qwen-plus")
+            .temperature(0.7)
+            .timeout(Duration.ofSeconds(60))
+            .maxRetries(2)
+            .logRequests(false)
+            .logResponses(false)
+            .build();
+    }
+}

--- a/langchain4j-agent-skills/src/test/java/dev/langchain4j/agentskills/DefaultAgentSkillsProviderTest.java
+++ b/langchain4j-agent-skills/src/test/java/dev/langchain4j/agentskills/DefaultAgentSkillsProviderTest.java
@@ -1,0 +1,272 @@
+package dev.langchain4j.agentskills;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for {@link DefaultAgentSkillsProvider}.
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ */
+class DefaultAgentSkillsProviderTest {
+
+    @Test
+    void should_load_skills_from_single_directory(@TempDir Path tempDir) throws IOException {
+        // given
+        createSkill(tempDir, "pdf-processing", "Process PDFs");
+        createSkill(tempDir, "web-search", "Search the web");
+
+        // when
+        DefaultAgentSkillsProvider provider =
+                DefaultAgentSkillsProvider.builder().skillDirectories(tempDir).build();
+
+        // then
+        List<Skill> skills = provider.allSkills();
+        assertThat(skills).hasSize(2);
+        assertThat(skills).extracting(Skill::name).containsExactlyInAnyOrder("pdf-processing", "web-search");
+    }
+
+    @Test
+    void should_load_skills_from_multiple_directories(@TempDir Path tempDir) throws IOException {
+        // given
+        Path dir1 = tempDir.resolve("dir1");
+        Path dir2 = tempDir.resolve("dir2");
+        Files.createDirectories(dir1);
+        Files.createDirectories(dir2);
+
+        createSkill(dir1, "skill1", "Skill 1");
+        createSkill(dir2, "skill2", "Skill 2");
+
+        // when
+        DefaultAgentSkillsProvider provider =
+                DefaultAgentSkillsProvider.builder().skillDirectories(dir1, dir2).build();
+
+        // then
+        List<Skill> skills = provider.allSkills();
+        assertThat(skills).hasSize(2);
+        assertThat(skills).extracting(Skill::name).containsExactlyInAnyOrder("skill1", "skill2");
+    }
+
+    @Test
+    void should_find_skill_by_name(@TempDir Path tempDir) throws IOException {
+        // given
+        createSkill(tempDir, "pdf-processing", "Process PDFs");
+        createSkill(tempDir, "web-search", "Search the web");
+
+        DefaultAgentSkillsProvider provider =
+                DefaultAgentSkillsProvider.builder().skillDirectories(tempDir).build();
+
+        // when
+        Skill skill = provider.skillByName("pdf-processing");
+
+        // then
+        assertThat(skill).isNotNull();
+        assertThat(skill.name()).isEqualTo("pdf-processing");
+        assertThat(skill.description()).isEqualTo("Process PDFs");
+    }
+
+    @Test
+    void should_return_null_when_skill_not_found(@TempDir Path tempDir) throws IOException {
+        // given
+        createSkill(tempDir, "existing-skill", "Exists");
+
+        DefaultAgentSkillsProvider provider =
+                DefaultAgentSkillsProvider.builder().skillDirectories(tempDir).build();
+
+        // when
+        Skill skill = provider.skillByName("non-existent");
+
+        // then
+        assertThat(skill).isNull();
+    }
+
+    @Test
+    void should_provide_skills_through_provider_interface(@TempDir Path tempDir) throws IOException {
+        // given
+        createSkill(tempDir, "test-skill", "Test");
+
+        DefaultAgentSkillsProvider provider =
+                DefaultAgentSkillsProvider.builder().skillDirectories(tempDir).build();
+
+        AgentSkillsProviderRequest request =
+                AgentSkillsProviderRequest.builder().invocationContext(null).userMessage(null).build();
+
+        // when
+        AgentSkillsProviderResult result = provider.provideSkills(request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.skills()).hasSize(1);
+        assertThat(result.hasSkills()).isTrue();
+    }
+
+    @Test
+    void should_cache_loaded_skills(@TempDir Path tempDir) throws IOException {
+        // given
+        createSkill(tempDir, "test-skill", "Test");
+
+        DefaultAgentSkillsProvider provider =
+                DefaultAgentSkillsProvider.builder().skillDirectories(tempDir).build();
+
+        // when
+        List<Skill> skills1 = provider.allSkills();
+        List<Skill> skills2 = provider.allSkills();
+
+        // then: both calls return the same cached data
+        assertThat(skills1).hasSize(1);
+        assertThat(skills2).hasSize(1);
+        assertThat(skills1.get(0).name()).isEqualTo(skills2.get(0).name());
+    }
+
+    @Test
+    void should_reload_skills_after_reload_call(@TempDir Path tempDir) throws IOException {
+        // given
+        createSkill(tempDir, "skill1", "Skill 1");
+
+        DefaultAgentSkillsProvider provider =
+                DefaultAgentSkillsProvider.builder().skillDirectories(tempDir).build();
+
+        List<Skill> skillsBefore = provider.allSkills();
+        assertThat(skillsBefore).hasSize(1);
+
+        // when: add new skill and reload
+        createSkill(tempDir, "skill2", "Skill 2");
+        provider.reload();
+        List<Skill> skillsAfter = provider.allSkills();
+
+        // then
+        assertThat(skillsAfter).hasSize(2);
+        assertThat(skillsAfter).extracting(Skill::name).containsExactlyInAnyOrder("skill1", "skill2");
+    }
+
+    @Test
+    void should_handle_duplicate_skill_names_across_directories(@TempDir Path tempDir) throws IOException {
+        // given
+        Path dir1 = tempDir.resolve("dir1");
+        Path dir2 = tempDir.resolve("dir2");
+        Files.createDirectories(dir1);
+        Files.createDirectories(dir2);
+
+        createSkill(dir1, "pdf-processing", "Description from dir1");
+        createSkill(dir2, "pdf-processing", "Description from dir2");
+
+        // when
+        DefaultAgentSkillsProvider provider =
+                DefaultAgentSkillsProvider.builder().skillDirectories(dir1, dir2).build();
+
+        // then: later directory skips duplicate names
+        List<Skill> skills = provider.allSkills();
+        assertThat(skills).hasSize(1);
+        assertThat(skills.get(0).name()).isEqualTo("pdf-processing");
+        // First one is kept, second is skipped with warning
+        assertThat(skills.get(0).description()).isEqualTo("Description from dir1");
+    }
+
+    @Test
+    void should_return_empty_list_for_empty_directory(@TempDir Path tempDir) {
+        // given
+        DefaultAgentSkillsProvider provider =
+                DefaultAgentSkillsProvider.builder().skillDirectories(tempDir).build();
+
+        // when
+        List<Skill> skills = provider.allSkills();
+
+        // then
+        assertThat(skills).isEmpty();
+    }
+
+    @Test
+    void should_handle_non_existent_directory(@TempDir Path tempDir) {
+        // given
+        Path nonExistent = tempDir.resolve("non-existent");
+
+        // when
+        DefaultAgentSkillsProvider provider =
+                DefaultAgentSkillsProvider.builder().skillDirectories(nonExistent).build();
+
+        // then: should not throw exception, just return empty list
+        List<Skill> skills = provider.allSkills();
+        assertThat(skills).isEmpty();
+    }
+
+    @Test
+    void should_handle_concurrent_access(@TempDir Path tempDir) throws Exception {
+        // given
+        createSkill(tempDir, "skill1", "Skill 1");
+        createSkill(tempDir, "skill2", "Skill 2");
+
+        DefaultAgentSkillsProvider provider =
+                DefaultAgentSkillsProvider.builder().skillDirectories(tempDir).build();
+
+        // when: 10 threads access concurrently
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    List<Skill> skills = provider.allSkills();
+                    if (skills.size() == 2) {
+                        successCount.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // then: all threads should succeed
+        assertThat(successCount.get()).isEqualTo(threadCount);
+    }
+
+    @Test
+    void should_throw_exception_when_skill_directories_is_empty() {
+        // when-then
+        assertThatThrownBy(() -> DefaultAgentSkillsProvider.builder().skillDirectories().build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("skillDirectories");
+    }
+
+    @Test
+    void should_throw_exception_when_add_null_directory() {
+        // when-then
+        assertThatThrownBy(() -> DefaultAgentSkillsProvider.builder().addSkillDirectory(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("directory");
+    }
+
+    // Helper method
+    private void createSkill(Path parentDir, String skillName, String description) throws IOException {
+        Path skillDir = parentDir.resolve(skillName);
+        Files.createDirectories(skillDir);
+
+        String skillMd = String.format(
+                """
+                ---
+                name: %s
+                description: %s
+                ---
+                # %s
+                """,
+                skillName, description, skillName);
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+    }
+}

--- a/langchain4j-agent-skills/src/test/java/dev/langchain4j/agentskills/loader/FileSystemSkillLoaderTest.java
+++ b/langchain4j-agent-skills/src/test/java/dev/langchain4j/agentskills/loader/FileSystemSkillLoaderTest.java
@@ -1,0 +1,355 @@
+package dev.langchain4j.agentskills.loader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agentskills.Skill;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Unit tests for {@link FileSystemSkillLoader}.
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ */
+class FileSystemSkillLoaderTest {
+
+    @Test
+    void should_load_skill_with_complete_frontmatter(@TempDir Path tempDir) throws IOException {
+        // given
+        Path skillDir = tempDir.resolve("pdf-processing");
+        Files.createDirectories(skillDir);
+
+        String skillMd =
+                """
+                ---
+                name: pdf-processing
+                description: Process PDF files
+                license: MIT
+                compatibility: langchain4j >= 1.0.0
+                allowed-tools: python node
+                metadata:
+                  author: John Doe
+                  version: 1.0.0
+                ---
+                # PDF Processing Skill
+                
+                Use this skill to process PDF files.
+                """;
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when
+        Skill skill = loader.loadSkill(skillDir);
+
+        // then
+        assertThat(skill).isNotNull();
+        assertThat(skill.name()).isEqualTo("pdf-processing");
+        assertThat(skill.description()).isEqualTo("Process PDF files");
+        assertThat(skill.license()).isEqualTo("MIT");
+        assertThat(skill.compatibility()).isEqualTo("langchain4j >= 1.0.0");
+        assertThat(skill.allowedTools()).containsExactly("python", "node");
+        assertThat(skill.metadata()).containsEntry("author", "John Doe");
+        assertThat(skill.metadata()).containsEntry("version", "1.0.0");
+        assertThat(skill.instructions()).contains("# PDF Processing Skill");
+        assertThat(skill.path()).isEqualTo(skillDir);
+    }
+
+    @Test
+    void should_load_skill_with_minimal_frontmatter(@TempDir Path tempDir) throws IOException {
+        // given
+        Path skillDir = tempDir.resolve("minimal-skill");
+        Files.createDirectories(skillDir);
+
+        String skillMd =
+                """
+                ---
+                name: minimal-skill
+                description: A minimal skill
+                ---
+                # Minimal
+                """;
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when
+        Skill skill = loader.loadSkill(skillDir);
+
+        // then
+        assertThat(skill).isNotNull();
+        assertThat(skill.name()).isEqualTo("minimal-skill");
+        assertThat(skill.description()).isEqualTo("A minimal skill");
+        assertThat(skill.license()).isNull();
+        assertThat(skill.compatibility()).isNull();
+        assertThat(skill.allowedTools()).isNullOrEmpty();
+        assertThat(skill.metadata()).isNullOrEmpty();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "PDF_Processing, false",
+        "pdf processing, false",
+        "pdf.processing, false",
+        "pdf-processing, true",
+        "data-analysis-v2, true",
+        "skill123, true"
+    })
+    void should_validate_skill_name_format(String skillName, boolean isValid, @TempDir Path tempDir)
+            throws IOException {
+        // given
+        Path skillDir = tempDir.resolve("test-skill");
+        Files.createDirectories(skillDir);
+
+        String skillMd = String.format(
+                """
+                ---
+                name: %s
+                description: Test skill
+                ---
+                # Test
+                """,
+                skillName);
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when-then
+        if (isValid) {
+            Skill skill = loader.loadSkill(skillDir);
+            assertThat(skill).isNotNull();
+            assertThat(skill.name()).isEqualTo(skillName);
+        } else {
+            assertThatThrownBy(() -> loader.loadSkill(skillDir))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("name");
+        }
+    }
+
+    @Test
+    void should_throw_exception_when_description_exceeds_max_length(@TempDir Path tempDir) throws IOException {
+        // given
+        Path skillDir = tempDir.resolve("long-desc-skill");
+        Files.createDirectories(skillDir);
+
+        String longDescription = "a".repeat(1025); // exceeds 1024 limit
+        String skillMd = String.format(
+                """
+                ---
+                name: long-desc
+                description: %s
+                ---
+                # Test
+                """,
+                longDescription);
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when-then
+        assertThatThrownBy(() -> loader.loadSkill(skillDir))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Description")
+                .hasMessageContaining("1024");
+    }
+
+    @Test
+    void should_throw_exception_when_compatibility_exceeds_max_length(@TempDir Path tempDir) throws IOException {
+        // given
+        Path skillDir = tempDir.resolve("long-compat-skill");
+        Files.createDirectories(skillDir);
+
+        String longCompatibility = "a".repeat(501); // exceeds 500 limit
+        String skillMd = String.format(
+                """
+                ---
+                name: long-compat
+                description: Test skill
+                compatibility: %s
+                ---
+                # Test
+                """,
+                longCompatibility);
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when-then
+        assertThatThrownBy(() -> loader.loadSkill(skillDir))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Compatibility")
+                .hasMessageContaining("500");
+    }
+
+    @Test
+    void should_parse_allowed_tools_with_various_separators(@TempDir Path tempDir) throws IOException {
+        // given
+        Path skillDir = tempDir.resolve("tool-skill");
+        Files.createDirectories(skillDir);
+
+        String skillMd =
+                """
+                ---
+                name: tool-skill
+                description: Skill with tools
+                allowed-tools: python  node    bash
+                ---
+                # Test
+                """;
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when
+        Skill skill = loader.loadSkill(skillDir);
+
+        // then
+        assertThat(skill.allowedTools()).hasSize(3).containsExactly("python", "node", "bash");
+    }
+
+    @Test
+    void should_return_null_when_skill_file_does_not_exist(@TempDir Path tempDir) {
+        // given
+        Path nonExistentDir = tempDir.resolve("non-existent");
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when
+        Skill skill = loader.loadSkill(nonExistentDir);
+
+        // then
+        assertThat(skill).isNull();
+    }
+
+    @Test
+    void should_return_null_for_malformed_frontmatter_missing_opening_delimiter(@TempDir Path tempDir)
+            throws IOException {
+        // given
+        Path skillDir = tempDir.resolve("malformed-skill");
+        Files.createDirectories(skillDir);
+
+        String skillMd =
+                """
+                name: malformed-skill
+                description: Missing opening delimiter
+                ---
+                # Test
+                """;
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when
+        Skill skill = loader.loadSkill(skillDir);
+
+        // then
+        assertThat(skill).isNull();
+    }
+
+    @Test
+    void should_return_null_for_malformed_frontmatter_missing_closing_delimiter(@TempDir Path tempDir)
+            throws IOException {
+        // given
+        Path skillDir = tempDir.resolve("malformed-skill2");
+        Files.createDirectories(skillDir);
+
+        String skillMd =
+                """
+                ---
+                name: malformed-skill
+                description: Missing closing delimiter
+                # Test content without closing delimiter
+                """;
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when
+        Skill skill = loader.loadSkill(skillDir);
+
+        // then
+        assertThat(skill).isNull();
+    }
+
+    @Test
+    void should_return_null_for_empty_file(@TempDir Path tempDir) throws IOException {
+        // given
+        Path skillDir = tempDir.resolve("empty-skill");
+        Files.createDirectories(skillDir);
+
+        Files.writeString(skillDir.resolve("SKILL.md"), "");
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when
+        Skill skill = loader.loadSkill(skillDir);
+
+        // then
+        assertThat(skill).isNull();
+    }
+
+    @Test
+    void should_load_multiple_skills_from_directory(@TempDir Path tempDir) throws IOException {
+        // given
+        createSkill(tempDir, "pdf-processing", "Process PDFs");
+        createSkill(tempDir, "web-search", "Search the web");
+        createSkill(tempDir, "data-analysis", "Analyze data");
+
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when
+        List<Skill> skills = loader.loadSkillsFromDirectory(tempDir);
+
+        // then
+        assertThat(skills).hasSize(3);
+        assertThat(skills).extracting(Skill::name).containsExactlyInAnyOrder("pdf-processing", "web-search", "data-analysis");
+    }
+
+    @Test
+    void should_return_empty_list_for_empty_directory(@TempDir Path tempDir) {
+        // given
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when
+        List<Skill> skills = loader.loadSkillsFromDirectory(tempDir);
+
+        // then
+        assertThat(skills).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_list_when_directory_does_not_exist(@TempDir Path tempDir) {
+        // given
+        Path nonExistent = tempDir.resolve("non-existent");
+        FileSystemSkillLoader loader = new FileSystemSkillLoader();
+
+        // when
+        List<Skill> skills = loader.loadSkillsFromDirectory(nonExistent);
+
+        // then
+        assertThat(skills).isEmpty();
+    }
+
+    // Helper method
+    private void createSkill(Path parentDir, String skillName, String description) throws IOException {
+        Path skillDir = parentDir.resolve(skillName);
+        Files.createDirectories(skillDir);
+
+        String skillMd = String.format(
+                """
+                ---
+                name: %s
+                description: %s
+                ---
+                # %s
+                """,
+                skillName, description, skillName);
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+    }
+}

--- a/langchain4j-agent-skills/src/test/resources/test-skills/pdf-processing/SKILL.md
+++ b/langchain4j-agent-skills/src/test/resources/test-skills/pdf-processing/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: pdf-processing
+description: Extract and analyze text from PDF documents
+license: MIT
+compatibility: langchain4j >= 1.0.0
+allowed-tools: "*"
+metadata:
+  author: LangChain4j Team
+  version: 1.0.0
+  category: document-processing
+---
+
+# PDF Processing Skill
+
+This skill provides capabilities to extract and analyze text content from PDF documents.
+
+## Features
+
+- Extract raw text from PDF files
+- Analyze document structure
+- Support for multi-page documents
+
+## Usage
+
+To extract text from a PDF file, use the extraction script:
+
+```bash
+scripts/extract.sh <pdf-file>
+```
+
+## Configuration
+
+Configuration templates are available in the `assets/` directory:
+- `config.json`: Default extraction settings
+- `template.txt`: Output format template

--- a/langchain4j-agent-skills/src/test/resources/test-skills/pdf-processing/assets/config.json
+++ b/langchain4j-agent-skills/src/test/resources/test-skills/pdf-processing/assets/config.json
@@ -1,0 +1,6 @@
+{
+  "extractionMode": "full-text",
+  "preserveFormatting": true,
+  "outputFormat": "plain-text",
+  "encoding": "UTF-8"
+}

--- a/langchain4j-agent-skills/src/test/resources/test-skills/pdf-processing/scripts/extract.sh
+++ b/langchain4j-agent-skills/src/test/resources/test-skills/pdf-processing/scripts/extract.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# PDF text extraction script
+echo "Extracting text from: $1"
+echo "PDF content: This is a sample document."
+echo "Extraction completed successfully."
+exit 0

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/AgentSkillsConfig.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/AgentSkillsConfig.java
@@ -1,0 +1,136 @@
+package dev.langchain4j.agentskills;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.agentskills.execution.ScriptExecutor;
+
+import java.nio.file.Path;
+
+/**
+ * Configuration for Agent Skills functionality.
+ * <p>
+ * This class encapsulates all Agent Skills related settings:
+ * <ul>
+ *   <li>Skills provider - where to load skills from</li>
+ *   <li>Script executor - how to execute skill scripts</li>
+ *   <li>Max iterations - how many times the AI can use skills in one invocation</li>
+ * </ul>
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * AgentSkillsProvider provider = DefaultAgentSkillsProvider.builder()
+ *     .skillDirectories(Path.of("/my-skills"))
+ *     .build();
+ *
+ * AgentSkillsConfig config = AgentSkillsConfig.builder()
+ *     .skillsProvider(provider)
+ *     .scriptExecutor(new DefaultScriptExecutor(120)) // 120s timeout
+ *     .maxIterations(15)
+ *     .build();
+ *
+ * Assistant assistant = AiServices.builder(Assistant.class)
+ *     .chatModel(chatModel)
+ *     .agentSkillsConfig(config)
+ *     .build();
+ * }</pre>
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public class AgentSkillsConfig {
+
+    private final AgentSkillsProvider skillsProvider;
+    private final ScriptExecutor scriptExecutor;
+    private final Integer maxIterations;
+
+    private AgentSkillsConfig(Builder builder) {
+        this.skillsProvider = builder.skillsProvider;
+        this.scriptExecutor = builder.scriptExecutor;
+        this.maxIterations = builder.maxIterations;
+    }
+
+    /**
+     * Returns the skills provider.
+     *
+     * @return the skills provider, or null if not configured
+     */
+    public AgentSkillsProvider skillsProvider() {
+        return skillsProvider;
+    }
+
+    /**
+     * Returns the script executor.
+     *
+     * @return the script executor, or null if not configured (will use default)
+     */
+    public ScriptExecutor scriptExecutor() {
+        return scriptExecutor;
+    }
+
+    /**
+     * Returns the maximum number of skill iterations.
+     *
+     * @return the max iterations, or null if not configured (will use default)
+     */
+    public Integer maxIterations() {
+        return maxIterations;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private AgentSkillsProvider skillsProvider;
+        private ScriptExecutor scriptExecutor;
+        private Integer maxIterations;
+
+        /**
+         * Sets the skills provider.
+         * <p>
+         * The provider is responsible for loading and managing skills.
+         * Use {@link DefaultAgentSkillsProvider} to load skills from file system.
+         *
+         * @param skillsProvider the skills provider
+         * @return this builder
+         */
+        public Builder skillsProvider(AgentSkillsProvider skillsProvider) {
+            this.skillsProvider = skillsProvider;
+            return this;
+        }
+
+        /**
+         * Sets the script executor.
+         * <p>
+         * The executor is responsible for running skill scripts.
+         * If not set, a {@link dev.langchain4j.agentskills.execution.DefaultScriptExecutor}
+         * with 60s timeout will be used.
+         *
+         * @param scriptExecutor the script executor
+         * @return this builder
+         */
+        public Builder scriptExecutor(ScriptExecutor scriptExecutor) {
+            this.scriptExecutor = scriptExecutor;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of skill instruction iterations.
+         * <p>
+         * This limits how many times the AI can request skill operations in a single invocation.
+         * If not set, defaults to 10.
+         *
+         * @param maxIterations the maximum iterations (must be at least 1)
+         * @return this builder
+         */
+        public Builder maxIterations(int maxIterations) {
+            this.maxIterations = maxIterations;
+            return this;
+        }
+
+        public AgentSkillsConfig build() {
+            return new AgentSkillsConfig(this);
+        }
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/AgentSkillsProvider.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/AgentSkillsProvider.java
@@ -1,0 +1,58 @@
+package dev.langchain4j.agentskills;
+
+import dev.langchain4j.Experimental;
+
+import java.util.List;
+
+/**
+ * Provider interface for Agent Skills.
+ * <p>
+ * Implementations of this interface are responsible for discovering, loading,
+ * and providing skills to the AI service. This is similar to {@code ToolProvider}
+ * but for Agent Skills.
+ * <p>
+ * Agent Skills follow the specification from <a href="https://agentskills.io">agentskills.io</a>.
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+@FunctionalInterface
+public interface AgentSkillsProvider {
+
+    /**
+     * Provides skills for the current request context.
+     *
+     * @param request the request containing context information
+     * @return the result containing available skills
+     */
+    AgentSkillsProviderResult provideSkills(AgentSkillsProviderRequest request);
+
+    /**
+     * Returns all available skills.
+     * <p>
+     * Default implementation calls {@link #provideSkills(AgentSkillsProviderRequest)}
+     * with a default request.
+     *
+     * @return list of all skills
+     */
+    default List<Skill> allSkills() {
+        return provideSkills(AgentSkillsProviderRequest.builder().build()).skills();
+    }
+
+    /**
+     * Returns a skill by its name.
+     *
+     * @param name the skill name
+     * @return the skill, or null if not found
+     */
+    default Skill skillByName(String name) {
+        if (name == null) {
+            return null;
+        }
+        return allSkills().stream()
+                .filter(s -> name.equals(s.name()))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/AgentSkillsProviderRequest.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/AgentSkillsProviderRequest.java
@@ -1,0 +1,77 @@
+package dev.langchain4j.agentskills;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+
+/**
+ * Request object for {@link AgentSkillsProvider#provideSkills(AgentSkillsProviderRequest)}.
+ * <p>
+ * Contains context information that can be used by the provider to determine
+ * which skills to provide.
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public class AgentSkillsProviderRequest {
+
+    private final InvocationContext invocationContext;
+    private final UserMessage userMessage;
+
+    private AgentSkillsProviderRequest(Builder builder) {
+        this.invocationContext = builder.invocationContext;
+        this.userMessage = builder.userMessage;
+    }
+
+    /**
+     * Returns the invocation context.
+     *
+     * @return the invocation context, or null
+     */
+    public InvocationContext invocationContext() {
+        return invocationContext;
+    }
+
+    /**
+     * Returns the user message.
+     *
+     * @return the user message, or null
+     */
+    public UserMessage userMessage() {
+        return userMessage;
+    }
+
+    /**
+     * Returns the chat memory ID from the invocation context.
+     *
+     * @return the chat memory ID, or null
+     */
+    public Object chatMemoryId() {
+        return invocationContext != null ? invocationContext.chatMemoryId() : null;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private InvocationContext invocationContext;
+        private UserMessage userMessage;
+
+        public Builder invocationContext(InvocationContext invocationContext) {
+            this.invocationContext = invocationContext;
+            return this;
+        }
+
+        public Builder userMessage(UserMessage userMessage) {
+            this.userMessage = userMessage;
+            return this;
+        }
+
+        public AgentSkillsProviderRequest build() {
+            return new AgentSkillsProviderRequest(this);
+        }
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/AgentSkillsProviderResult.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/AgentSkillsProviderResult.java
@@ -1,0 +1,73 @@
+package dev.langchain4j.agentskills;
+
+import dev.langchain4j.Experimental;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+
+/**
+ * Result object from {@link AgentSkillsProvider#provideSkills(AgentSkillsProviderRequest)}.
+ * <p>
+ * Contains the list of skills that are available for the current request context.
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public class AgentSkillsProviderResult {
+
+    private final List<Skill> skills;
+
+    private AgentSkillsProviderResult(Builder builder) {
+        this.skills = builder.skills != null
+                ? Collections.unmodifiableList(new ArrayList<>(builder.skills))
+                : Collections.emptyList();
+    }
+
+    /**
+     * Returns the list of available skills.
+     *
+     * @return unmodifiable list of skills
+     */
+    public List<Skill> skills() {
+        return skills;
+    }
+
+    /**
+     * Returns true if there are any skills available.
+     *
+     * @return true if skills are available
+     */
+    public boolean hasSkills() {
+        return !isNullOrEmpty(skills);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private List<Skill> skills;
+
+        public Builder skills(List<Skill> skills) {
+            this.skills = skills;
+            return this;
+        }
+
+        public Builder addSkill(Skill skill) {
+            if (this.skills == null) {
+                this.skills = new ArrayList<>();
+            }
+            this.skills.add(skill);
+            return this;
+        }
+
+        public AgentSkillsProviderResult build() {
+            return new AgentSkillsProviderResult(this);
+        }
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/Skill.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/Skill.java
@@ -1,0 +1,225 @@
+package dev.langchain4j.agentskills;
+
+import dev.langchain4j.Experimental;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.quoted;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+/**
+ * Represents an Agent Skill that can be used to enhance AI capabilities.
+ * <p>
+ * A skill consists of frontmatter fields and instructions that guide
+ * the AI in performing specific tasks. Skills follow the Agent Skills specification
+ * from <a href="https://agentskills.io">agentskills.io</a>.
+ * <p>
+ * Frontmatter fields (from SKILL.md YAML header):
+ * <ul>
+ *   <li>{@code name} - Required. Max 64 characters, lowercase letters, numbers, and hyphens only.</li>
+ *   <li>{@code description} - Required. Max 1024 characters. Describes what the skill does.</li>
+ *   <li>{@code license} - Optional. License name or reference to a bundled license file.</li>
+ *   <li>{@code compatibility} - Optional. Max 500 characters. Environment requirements.</li>
+ *   <li>{@code metadata} - Optional. Arbitrary key-value mapping for additional metadata.</li>
+ *   <li>{@code allowed-tools} - Optional. Space-delimited list of pre-approved tools.</li>
+ * </ul>
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public class Skill {
+
+    private final String name;
+    private final String description;
+    private final String license;
+    private final String compatibility;
+    private final Map<String, Object> metadata;
+    private final List<String> allowedTools;
+    private final String instructions;
+    private final Path path;
+
+    private Skill(Builder builder) {
+        this.name = ensureNotBlank(builder.name, "name");
+        this.description = ensureNotBlank(builder.description, "description");
+        this.license = builder.license;
+        this.compatibility = builder.compatibility;
+        this.metadata = copy(builder.metadata);
+        this.allowedTools = copy(builder.allowedTools);
+        this.instructions = builder.instructions;
+        this.path = ensureNotNull(builder.path, "path");
+    }
+
+    /**
+     * Returns the unique name of the skill.
+     * <p>
+     * The name must be 1-64 characters, lowercase letters, numbers, and hyphens only.
+     *
+     * @return the skill name
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the description of the skill.
+     * <p>
+     * The description explains what the skill does and when it should be used.
+     * Max 1024 characters.
+     *
+     * @return the skill description
+     */
+    public String description() {
+        return description;
+    }
+
+    /**
+     * Returns the license under which the skill is distributed.
+     *
+     * @return the license, or null if not specified
+     */
+    public String license() {
+        return license;
+    }
+
+    /**
+     * Returns the compatibility requirements for the skill.
+     * <p>
+     * This may include environment requirements like intended product,
+     * system packages, network access, etc. Max 500 characters.
+     *
+     * @return the compatibility string, or null if not specified
+     */
+    public String compatibility() {
+        return compatibility;
+    }
+
+    /**
+     * Returns arbitrary key-value metadata for the skill.
+     *
+     * @return the metadata map, or null if not specified
+     */
+    public Map<String, Object> metadata() {
+        return metadata;
+    }
+
+    /**
+     * Returns the list of pre-approved tools the skill may use.
+     * <p>
+     * This is an experimental feature from the Agent Skills specification.
+     *
+     * @return the list of allowed tools, or null if not specified
+     */
+    public List<String> allowedTools() {
+        return allowedTools;
+    }
+
+    /**
+     * Returns the full instructions from SKILL.md markdown content.
+     * <p>
+     * This is the markdown body that follows the YAML frontmatter.
+     *
+     * @return the skill instructions
+     */
+    public String instructions() {
+        return instructions;
+    }
+
+    /**
+     * Returns the path to the skill directory.
+     *
+     * @return the skill directory path
+     */
+    public Path path() {
+        return path;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Skill skill = (Skill) o;
+        return Objects.equals(name, skill.name)
+                && Objects.equals(description, skill.description)
+                && Objects.equals(path, skill.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, path);
+    }
+
+    @Override
+    public String toString() {
+        return "Skill {"
+                + " name = " + quoted(name)
+                + ", description = " + quoted(description)
+                + ", path = " + path
+                + " }";
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String name;
+        private String description;
+        private String license;
+        private String compatibility;
+        private Map<String, Object> metadata;
+        private List<String> allowedTools;
+        private String instructions;
+        private Path path;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder license(String license) {
+            this.license = license;
+            return this;
+        }
+
+        public Builder compatibility(String compatibility) {
+            this.compatibility = compatibility;
+            return this;
+        }
+
+        public Builder metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public Builder allowedTools(List<String> allowedTools) {
+            this.allowedTools = allowedTools;
+            return this;
+        }
+
+        public Builder instructions(String instructions) {
+            this.instructions = instructions;
+            return this;
+        }
+
+        public Builder path(Path path) {
+            this.path = path;
+            return this;
+        }
+
+        public Skill build() {
+            return new Skill(this);
+        }
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/execution/DefaultScriptExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/execution/DefaultScriptExecutor.java
@@ -1,0 +1,131 @@
+package dev.langchain4j.agentskills.execution;
+
+import dev.langchain4j.Experimental;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Default implementation of {@link ScriptExecutor} using ProcessBuilder.
+ * <p>
+ * This executor runs scripts in a subprocess with configurable timeout.
+ * Scripts are executed using the system shell (sh on Unix, cmd on Windows).
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public class DefaultScriptExecutor implements ScriptExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultScriptExecutor.class);
+
+    private final long timeoutSeconds;
+
+    /**
+     * Creates a new executor with the default timeout of 60 seconds.
+     */
+    public DefaultScriptExecutor() {
+        this(60);
+    }
+
+    /**
+     * Creates a new executor with the specified timeout.
+     *
+     * @param timeoutSeconds the timeout in seconds
+     */
+    public DefaultScriptExecutor(long timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    @Override
+    public ScriptExecutionResult execute(Path workingDirectory, String command) {
+        // Validate parameters
+        if (workingDirectory == null) {
+            throw new IllegalArgumentException("workingDirectory cannot be null");
+        }
+        if (command == null || command.isBlank()) {
+            throw new IllegalArgumentException("command cannot be null or blank");
+        }
+
+        log.debug("Executing script in {}: {}", workingDirectory, command);
+
+        Process process = null;
+        try {
+            ProcessBuilder processBuilder = new ProcessBuilder();
+            processBuilder.directory(workingDirectory.toFile());
+            // Merge stderr into stdout to avoid deadlock when reading streams sequentially
+            processBuilder.redirectErrorStream(true);
+
+            // Choose shell based on operating system
+            String os = System.getProperty("os.name").toLowerCase();
+            if (os.contains("win")) {
+                processBuilder.command("cmd.exe", "/c", command);
+            } else {
+                processBuilder.command("sh", "-c", command);
+            }
+
+            process = processBuilder.start();
+
+            // Wait for process to complete or timeout
+            boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+            if (!finished) {
+                // Process timed out, kill it forcibly
+                process.destroyForcibly();
+                // Wait a bit for the process to be killed
+                process.waitFor(1, TimeUnit.SECONDS);
+                log.warn("Script execution timed out after {} seconds: {}", timeoutSeconds, command);
+                return ScriptExecutionResult.builder()
+                        .exitCode(-1)
+                        .error("Script execution timed out after " + timeoutSeconds + " seconds")
+                        .build();
+            }
+
+            // Process completed within timeout, read output
+            String output;
+            try (BufferedReader outputReader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()))) {
+                output = outputReader.lines().collect(Collectors.joining("\n"));
+            }
+
+            int exitCode = process.exitValue();
+            log.debug("Script completed with exit code {}", exitCode);
+
+            return ScriptExecutionResult.builder()
+                    .exitCode(exitCode)
+                    .output(output)
+                    .error("")
+                    .build();
+
+        } catch (IOException e) {
+            log.error("IO error executing script: {}", command, e);
+            return ScriptExecutionResult.builder()
+                    .exitCode(-1)
+                    .error("IO error: " + e.getMessage())
+                    .build();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Script execution interrupted: {}", command, e);
+            return ScriptExecutionResult.builder()
+                    .exitCode(-1)
+                    .error("Execution interrupted: " + e.getMessage())
+                    .build();
+        } catch (Exception e) {
+            log.error("Failed to execute script: {}", command, e);
+            return ScriptExecutionResult.builder()
+                    .exitCode(-1)
+                    .error("Execution failed: " + e.getMessage())
+                    .build();
+        } finally {
+            // Ensure process is destroyed in case of any exception
+            if (process != null && process.isAlive()) {
+                process.destroyForcibly();
+            }
+        }
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/execution/ScriptExecutionResult.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/execution/ScriptExecutionResult.java
@@ -1,0 +1,89 @@
+package dev.langchain4j.agentskills.execution;
+
+import dev.langchain4j.Experimental;
+
+/**
+ * Result of a script execution.
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public class ScriptExecutionResult {
+
+    private final int exitCode;
+    private final String output;
+    private final String error;
+
+    private ScriptExecutionResult(Builder builder) {
+        this.exitCode = builder.exitCode;
+        this.output = builder.output != null ? builder.output : "";
+        this.error = builder.error != null ? builder.error : "";
+    }
+
+    /**
+     * Returns the exit code of the script execution.
+     *
+     * @return the exit code (0 typically means success)
+     */
+    public int exitCode() {
+        return exitCode;
+    }
+
+    /**
+     * Returns the standard output from the script.
+     *
+     * @return the output, never null
+     */
+    public String output() {
+        return output;
+    }
+
+    /**
+     * Returns the standard error from the script.
+     *
+     * @return the error output, never null
+     */
+    public String error() {
+        return error;
+    }
+
+    /**
+     * Returns true if the script executed successfully (exit code 0).
+     *
+     * @return true if successful
+     */
+    public boolean isSuccess() {
+        return exitCode == 0;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private int exitCode;
+        private String output;
+        private String error;
+
+        public Builder exitCode(int exitCode) {
+            this.exitCode = exitCode;
+            return this;
+        }
+
+        public Builder output(String output) {
+            this.output = output;
+            return this;
+        }
+
+        public Builder error(String error) {
+            this.error = error;
+            return this;
+        }
+
+        public ScriptExecutionResult build() {
+            return new ScriptExecutionResult(this);
+        }
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/execution/ScriptExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/execution/ScriptExecutor.java
@@ -1,0 +1,27 @@
+package dev.langchain4j.agentskills.execution;
+
+import dev.langchain4j.Experimental;
+
+import java.nio.file.Path;
+
+/**
+ * Interface for executing scripts within a skill.
+ * <p>
+ * Implementations should handle script execution in a safe manner,
+ * considering security implications.
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public interface ScriptExecutor {
+
+    /**
+     * Executes a script command.
+     *
+     * @param workingDirectory the working directory for script execution
+     * @param command          the command to execute
+     * @return the execution result
+     */
+    ScriptExecutionResult execute(Path workingDirectory, String command);
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/instruction/AgentSkillsInstruction.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/instruction/AgentSkillsInstruction.java
@@ -1,0 +1,28 @@
+package dev.langchain4j.agentskills.instruction;
+
+import dev.langchain4j.Experimental;
+
+/**
+ * Base class for Agent Skills instructions parsed from LLM responses.
+ * <p>
+ * Instructions are XML-like tags that the LLM uses to request skill operations:
+ * <ul>
+ *   <li>{@code <use_skill>name</use_skill>} - Load a skill's full content</li>
+ *   <li>{@code <execute_script skill="name">command</execute_script>} - Execute a script</li>
+ *   <li>{@code <read_resource skill="name">path</read_resource>} - Read a resource file</li>
+ * </ul>
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public abstract sealed class AgentSkillsInstruction
+        permits UseSkillInstruction, ExecuteScriptInstruction, ReadResourceInstruction {
+
+    /**
+     * Returns the type of this instruction.
+     *
+     * @return the instruction type
+     */
+    public abstract String type();
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/instruction/ExecuteScriptInstruction.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/instruction/ExecuteScriptInstruction.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.agentskills.instruction;
+
+import dev.langchain4j.Experimental;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+/**
+ * Instruction to execute a script from a skill.
+ * <p>
+ * Format: {@code <execute_script skill="skill-name">command args</execute_script>}
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public final class ExecuteScriptInstruction extends AgentSkillsInstruction {
+
+    private final String skillName;
+    private final String command;
+
+    public ExecuteScriptInstruction(String skillName, String command) {
+        this.skillName = ensureNotBlank(skillName, "skillName");
+        this.command = ensureNotBlank(command, "command");
+    }
+
+    /**
+     * Returns the name of the skill containing the script.
+     *
+     * @return the skill name
+     */
+    public String skillName() {
+        return skillName;
+    }
+
+    /**
+     * Returns the command to execute.
+     *
+     * @return the command
+     */
+    public String command() {
+        return command;
+    }
+
+    @Override
+    public String type() {
+        return "execute_script";
+    }
+
+    @Override
+    public String toString() {
+        return "ExecuteScriptInstruction { skillName = " + skillName + ", command = " + command + " }";
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/instruction/ReadResourceInstruction.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/instruction/ReadResourceInstruction.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.agentskills.instruction;
+
+import dev.langchain4j.Experimental;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+/**
+ * Instruction to read a resource file from a skill.
+ * <p>
+ * Format: {@code <read_resource skill="skill-name">path/to/resource</read_resource>}
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public final class ReadResourceInstruction extends AgentSkillsInstruction {
+
+    private final String skillName;
+    private final String resourcePath;
+
+    public ReadResourceInstruction(String skillName, String resourcePath) {
+        this.skillName = ensureNotBlank(skillName, "skillName");
+        this.resourcePath = ensureNotBlank(resourcePath, "resourcePath");
+    }
+
+    /**
+     * Returns the name of the skill containing the resource.
+     *
+     * @return the skill name
+     */
+    public String skillName() {
+        return skillName;
+    }
+
+    /**
+     * Returns the path to the resource relative to the skill directory.
+     *
+     * @return the resource path
+     */
+    public String resourcePath() {
+        return resourcePath;
+    }
+
+    @Override
+    public String type() {
+        return "read_resource";
+    }
+
+    @Override
+    public String toString() {
+        return "ReadResourceInstruction { skillName = " + skillName + ", resourcePath = " + resourcePath + " }";
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/agentskills/instruction/UseSkillInstruction.java
+++ b/langchain4j/src/main/java/dev/langchain4j/agentskills/instruction/UseSkillInstruction.java
@@ -1,0 +1,42 @@
+package dev.langchain4j.agentskills.instruction;
+
+import dev.langchain4j.Experimental;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+/**
+ * Instruction to load a skill's full content.
+ * <p>
+ * Format: {@code <use_skill>skill-name</use_skill>}
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Experimental
+public final class UseSkillInstruction extends AgentSkillsInstruction {
+
+    private final String skillName;
+
+    public UseSkillInstruction(String skillName) {
+        this.skillName = ensureNotBlank(skillName, "skillName");
+    }
+
+    /**
+     * Returns the name of the skill to load.
+     *
+     * @return the skill name
+     */
+    public String skillName() {
+        return skillName;
+    }
+
+    @Override
+    public String type() {
+        return "use_skill";
+    }
+
+    @Override
+    public String toString() {
+        return "UseSkillInstruction { skillName = " + skillName + " }";
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceContext.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceContext.java
@@ -11,6 +11,7 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.observability.api.AiServiceListenerRegistrar;
 import dev.langchain4j.rag.RetrievalAugmentor;
+import dev.langchain4j.service.agentskills.AgentSkillsService;
 import dev.langchain4j.service.guardrail.GuardrailService;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.service.tool.ToolService;
@@ -34,6 +35,8 @@ public class AiServiceContext {
     public ChatMemoryService chatMemoryService;
 
     public ToolService toolService = new ToolService();
+
+    public AgentSkillsService agentSkillsService = new AgentSkillsService();
 
     public final GuardrailService.Builder guardrailServiceBuilder;
     private final AtomicReference<GuardrailService> guardrailService = new AtomicReference<>();

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -45,6 +45,9 @@ import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.agentskills.AgentSkillsConfig;
+import dev.langchain4j.agentskills.AgentSkillsProvider;
+import dev.langchain4j.agentskills.execution.ScriptExecutor;
 import dev.langchain4j.spi.services.AiServicesFactory;
 import java.util.Collection;
 import java.util.List;
@@ -386,6 +389,53 @@ public abstract class AiServices<T> {
      */
     public AiServices<T> toolProvider(ToolProvider toolProvider) {
         context.toolService.toolProvider(toolProvider);
+        return this;
+    }
+
+    /**
+     * Configures Agent Skills functionality.
+     * <p>
+     * Agent Skills are modular, reusable instructions that enhance the AI's capabilities.
+     * When configured, the AI can use skills to perform specific tasks by:
+     * <ul>
+     *   <li>Loading skill content using {@code <use_skill>skill-name</use_skill>}</li>
+     *   <li>Executing scripts using {@code <execute_script skill="name">command</execute_script>}</li>
+     *   <li>Reading resources using {@code <read_resource skill="name">path</read_resource>}</li>
+     * </ul>
+     * <p>
+     * Skills follow the specification from <a href="https://agentskills.io">agentskills.io</a>.
+     * <p>
+     * Example:
+     * <pre>{@code
+     * AgentSkillsProvider provider = DefaultAgentSkillsProvider.builder()
+     *     .skillDirectories(Path.of("/my-skills"))
+     *     .build();
+     *
+     * AgentSkillsConfig config = AgentSkillsConfig.builder()
+     *     .skillsProvider(provider)
+     *     .maxIterations(15)
+     *     .build();
+     *
+     * Assistant assistant = AiServices.builder(Assistant.class)
+     *     .chatModel(chatModel)
+     *     .agentSkillsConfig(config)
+     *     .build();
+     * }</pre>
+     *
+     * @param config the Agent Skills configuration
+     * @return builder
+     * @since 1.12.0
+     */
+    public AiServices<T> agentSkillsConfig(AgentSkillsConfig config) {
+        if (config.skillsProvider() != null) {
+            context.agentSkillsService.agentSkillsProvider(config.skillsProvider());
+        }
+        if (config.scriptExecutor() != null) {
+            context.agentSkillsService.scriptExecutor(config.scriptExecutor());
+        }
+        if (config.maxIterations() != null) {
+            context.agentSkillsService.maxIterations(config.maxIterations());
+        }
         return this;
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/agentskills/AgentSkillsService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/agentskills/AgentSkillsService.java
@@ -1,0 +1,420 @@
+package dev.langchain4j.service.agentskills;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.Internal;
+import dev.langchain4j.agentskills.AgentSkillsProvider;
+import dev.langchain4j.agentskills.AgentSkillsProviderRequest;
+import dev.langchain4j.agentskills.AgentSkillsProviderResult;
+import dev.langchain4j.agentskills.Skill;
+import dev.langchain4j.agentskills.execution.DefaultScriptExecutor;
+import dev.langchain4j.agentskills.execution.ScriptExecutionResult;
+import dev.langchain4j.agentskills.execution.ScriptExecutor;
+import dev.langchain4j.agentskills.instruction.AgentSkillsInstruction;
+import dev.langchain4j.agentskills.instruction.ExecuteScriptInstruction;
+import dev.langchain4j.agentskills.instruction.ReadResourceInstruction;
+import dev.langchain4j.agentskills.instruction.UseSkillInstruction;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Service class that manages Agent Skills integration with AI Services.
+ * <p>
+ * This service handles:
+ * <ul>
+ *   <li>Generating system prompt additions with available skills</li>
+ *   <li>Parsing LLM responses for skill instructions</li>
+ *   <li>Executing skill-related operations (load skill, execute script, read resource)</li>
+ * </ul>
+ * <p>
+ * The service recognizes the following instructions in LLM responses:
+ * <ul>
+ *   <li>{@code <use_skill>skill-name</use_skill>} - Load a skill's full content</li>
+ *   <li>{@code <execute_script skill="skill-name">command</execute_script>} - Execute a script</li>
+ *   <li>{@code <read_resource skill="skill-name">path</read_resource>} - Read a resource file</li>
+ * </ul>
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ * @since 1.12.0
+ */
+@Internal
+@Experimental
+public class AgentSkillsService {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentSkillsService.class);
+
+    // Instruction patterns
+    private static final Pattern USE_SKILL_PATTERN =
+            Pattern.compile("<use_skill>([a-z0-9-]+)</use_skill>");
+    private static final Pattern EXECUTE_SCRIPT_PATTERN =
+            Pattern.compile("<execute_script\\s+skill=\"([a-z0-9-]+)\">(.*?)</execute_script>", Pattern.DOTALL);
+    private static final Pattern READ_RESOURCE_PATTERN =
+            Pattern.compile("<read_resource\\s+skill=\"([a-z0-9-]+)\">(.*?)</read_resource>", Pattern.DOTALL);
+
+    private AgentSkillsProvider agentSkillsProvider;
+    private volatile ScriptExecutor scriptExecutor;
+    private int maxIterations = 10;
+    private final Object scriptExecutorLock = new Object();
+
+    /**
+     * Sets the agent skills provider.
+     *
+     * @param agentSkillsProvider the provider to set
+     */
+    public void agentSkillsProvider(AgentSkillsProvider agentSkillsProvider) {
+        this.agentSkillsProvider = agentSkillsProvider;
+    }
+
+    /**
+     * Returns the configured agent skills provider.
+     *
+     * @return the provider, or null if not configured
+     */
+    public AgentSkillsProvider agentSkillsProvider() {
+        return agentSkillsProvider;
+    }
+
+    /**
+     * Sets the script executor for running skill scripts.
+     *
+     * @param scriptExecutor the executor to set
+     */
+    public void scriptExecutor(ScriptExecutor scriptExecutor) {
+        this.scriptExecutor = scriptExecutor;
+    }
+
+    /**
+     * Returns the script executor, creating a default one if not configured.
+     * <p>
+     * This method is thread-safe.
+     *
+     * @return the script executor
+     */
+    public ScriptExecutor scriptExecutor() {
+        ScriptExecutor executor = scriptExecutor;
+        if (executor == null) {
+            synchronized (scriptExecutorLock) {
+                executor = scriptExecutor;
+                if (executor == null) {
+                    executor = new DefaultScriptExecutor();
+                    scriptExecutor = executor;
+                }
+            }
+        }
+        return executor;
+    }
+
+    /**
+     * Sets the maximum number of skill instruction iterations.
+     *
+     * @param maxIterations the maximum iterations (must be at least 1)
+     * @throws IllegalArgumentException if maxIterations is less than 1
+     */
+    public void maxIterations(int maxIterations) {
+        if (maxIterations < 1) {
+            throw new IllegalArgumentException("maxIterations must be at least 1, but was: " + maxIterations);
+        }
+        this.maxIterations = maxIterations;
+    }
+
+    /**
+     * Returns the maximum number of skill instruction iterations.
+     *
+     * @return the maximum iterations
+     */
+    public int maxIterations() {
+        return maxIterations;
+    }
+
+    /**
+     * Returns true if an agent skills provider is configured.
+     *
+     * @return true if skills are available
+     */
+    public boolean hasSkills() {
+        return agentSkillsProvider != null;
+    }
+
+    /**
+     * Generates the system prompt addition containing available skills.
+     *
+     * @param invocationContext the invocation context
+     * @param userMessage       the user message
+     * @return the system prompt addition, or empty string if no skills
+     */
+    public String generateSystemPromptAddition(InvocationContext invocationContext, UserMessage userMessage) {
+        if (agentSkillsProvider == null) {
+            return "";
+        }
+
+        AgentSkillsProviderRequest request = AgentSkillsProviderRequest.builder()
+                .invocationContext(invocationContext)
+                .userMessage(userMessage)
+                .build();
+
+        AgentSkillsProviderResult result = agentSkillsProvider.provideSkills(request);
+
+        if (result == null || !result.hasSkills()) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("\n\n<available_skills>\n");
+
+        for (Skill skill : result.skills()) {
+            sb.append("  <skill>\n");
+            sb.append("    <name>").append(escapeXml(skill.name())).append("</name>\n");
+            sb.append("    <description>").append(escapeXml(skill.description())).append("</description>\n");
+            sb.append("  </skill>\n");
+        }
+
+        sb.append("</available_skills>\n\n");
+        sb.append("When you need to use a skill to complete a task, please use the following instructions:\n");
+        sb.append("- Load skill content: <use_skill>skill-name</use_skill>\n");
+        sb.append("- Execute skill script: <execute_script skill=\"skill-name\">script-command</execute_script>\n");
+        sb.append("- Read skill resource: <read_resource skill=\"skill-name\">resource-path</read_resource>\n");
+        sb.append("The system will automatically execute these instructions and return the results to you.\n");
+
+        return sb.toString();
+    }
+
+    /**
+     * Parses the LLM response for skill instructions.
+     *
+     * @param llmResponse the LLM response text
+     * @return the parsed instruction, or null if no instruction found
+     */
+    public AgentSkillsInstruction parseInstruction(String llmResponse) {
+        if (llmResponse == null || llmResponse.isEmpty()) {
+            return null;
+        }
+
+        // Check for use_skill instruction first
+        Matcher useMatcher = USE_SKILL_PATTERN.matcher(llmResponse);
+        if (useMatcher.find()) {
+            String skillName = useMatcher.group(1);
+            if (skillName != null && !skillName.isBlank()) {
+                return new UseSkillInstruction(skillName);
+            }
+        }
+
+        // Check for execute_script instruction
+        Matcher execMatcher = EXECUTE_SCRIPT_PATTERN.matcher(llmResponse);
+        if (execMatcher.find()) {
+            String skillName = execMatcher.group(1);
+            String command = execMatcher.group(2).trim();
+            if (skillName != null && !skillName.isBlank() && !command.isBlank()) {
+                return new ExecuteScriptInstruction(skillName, command);
+            }
+        }
+
+        // Check for read_resource instruction
+        Matcher readMatcher = READ_RESOURCE_PATTERN.matcher(llmResponse);
+        if (readMatcher.find()) {
+            String skillName = readMatcher.group(1);
+            String resourcePath = readMatcher.group(2).trim();
+            if (skillName != null && !skillName.isBlank() && !resourcePath.isBlank()) {
+                return new ReadResourceInstruction(skillName, resourcePath);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Handles a use_skill instruction.
+     *
+     * @param skillName the skill name to load
+     * @return the skill content wrapped in XML tags
+     */
+    public String handleUseSkill(String skillName) {
+        log.debug("Loading skill: {}", skillName);
+
+        Skill skill = agentSkillsProvider.skillByName(skillName);
+        if (skill == null) {
+            log.warn("Skill not found: {}", skillName);
+            return "<skill_error>Skill '" + escapeXml(skillName) + "' not found</skill_error>";
+        }
+
+        String instructions = skill.instructions();
+        if (instructions == null || instructions.isBlank()) {
+            log.warn("Skill '{}' has no instructions", skillName);
+            return "<skill_error>Skill '" + escapeXml(skillName) + "' has no instructions</skill_error>";
+        }
+
+        return "<skill_content name=\"" + escapeXml(skillName) + "\">\n"
+                + instructions + "\n"
+                + "</skill_content>\n\n"
+                + "Please use the above skill content to help the user complete the task.";
+    }
+
+    /**
+     * Handles an execute_script instruction.
+     *
+     * @param skillName the skill name
+     * @param command   the script command to execute
+     * @return the execution result wrapped in XML tags
+     */
+    public String handleExecuteScript(String skillName, String command) {
+        log.debug("Executing script for skill {}: {}", skillName, command);
+
+        if (command == null || command.isBlank()) {
+            log.warn("Empty command for skill: {}", skillName);
+            return "<script_error>Command cannot be empty</script_error>";
+        }
+
+        Skill skill = agentSkillsProvider.skillByName(skillName);
+        if (skill == null) {
+            log.warn("Skill not found for script execution: {}", skillName);
+            return "<script_error>Skill '" + escapeXml(skillName) + "' not found</script_error>";
+        }
+
+        // Security check: verify command is in allowed-tools (if configured)
+        if (skill.allowedTools() != null) {
+            if (!isCommandAllowed(command, skill.allowedTools())) {
+                log.warn("Command not in allowed-tools for skill {}: {}", skillName, command);
+                return "<script_error>Command not in allowed-tools list</script_error>";
+            }
+        }
+
+        try {
+            // workingDirectory is skill root, command should include relative path like "scripts/extract.py"
+            ScriptExecutionResult result = scriptExecutor().execute(skill.path(), command);
+
+            StringBuilder response = new StringBuilder();
+            response.append("<script_result exit_code=\"").append(result.exitCode()).append("\">\n");
+
+            if (!result.output().isEmpty()) {
+                response.append(result.output()).append("\n");
+            }
+
+            if (!result.error().isEmpty()) {
+                response.append("STDERR:\n").append(result.error()).append("\n");
+            }
+
+            response.append("</script_result>");
+            return response.toString();
+
+        } catch (Exception e) {
+            log.error("Script execution failed for skill {}: {}", skillName, command, e);
+            return "<script_error>Script execution failed: " + escapeXml(e.getMessage()) + "</script_error>";
+        }
+    }
+
+    /**
+     * Handles a read_resource instruction.
+     *
+     * @param skillName    the skill name
+     * @param resourcePath the resource path relative to skill directory
+     * @return the resource content wrapped in XML tags
+     */
+    public String handleReadResource(String skillName, String resourcePath) {
+        log.debug("Reading resource for skill {}: {}", skillName, resourcePath);
+
+        if (resourcePath == null || resourcePath.isBlank()) {
+            log.warn("Empty resource path for skill: {}", skillName);
+            return "<resource_error>Resource path cannot be empty</resource_error>";
+        }
+
+        Skill skill = agentSkillsProvider.skillByName(skillName);
+        if (skill == null) {
+            log.warn("Skill not found for resource reading: {}", skillName);
+            return "<resource_error>Skill '" + escapeXml(skillName) + "' not found</resource_error>";
+        }
+
+        try {
+            Path fullPath = skill.path().resolve(resourcePath).normalize();
+
+            // Security check: ensure path is within skill directory (prevent path traversal)
+            // Using normalize() first for basic check
+            if (!fullPath.startsWith(skill.path().normalize())) {
+                log.warn("Path traversal attempt detected: {}", resourcePath);
+                return "<resource_error>Illegal path</resource_error>";
+            }
+
+            if (!Files.exists(fullPath)) {
+                log.warn("Resource not found: {}", fullPath);
+                return "<resource_error>Resource file not found: " + escapeXml(resourcePath) + "</resource_error>";
+            }
+
+            // Resolve symlinks and check again to prevent symlink attacks
+            Path realPath = fullPath.toRealPath();
+            Path realSkillPath = skill.path().toRealPath();
+            if (!realPath.startsWith(realSkillPath)) {
+                log.warn("Symlink escape attempt detected: {} -> {}", resourcePath, realPath);
+                return "<resource_error>Illegal path</resource_error>";
+            }
+
+            if (!Files.isRegularFile(realPath)) {
+                return "<resource_error>Path is not a file: " + escapeXml(resourcePath) + "</resource_error>";
+            }
+
+            String content = Files.readString(realPath);
+            return "<resource_content path=\"" + escapeXml(resourcePath) + "\">\n"
+                    + content + "\n"
+                    + "</resource_content>";
+
+        } catch (IOException e) {
+            log.error("Failed to read resource for skill {}: {}", skillName, resourcePath, e);
+            return "<resource_error>Failed to read resource: " + escapeXml(e.getMessage()) + "</resource_error>";
+        }
+    }
+
+    /**
+     * Handles any skill instruction.
+     *
+     * @param instruction the instruction to handle
+     * @return the result of handling the instruction
+     */
+    public String handleInstruction(AgentSkillsInstruction instruction) {
+        if (instruction instanceof UseSkillInstruction use) {
+            return handleUseSkill(use.skillName());
+        } else if (instruction instanceof ExecuteScriptInstruction exec) {
+            return handleExecuteScript(exec.skillName(), exec.command());
+        } else if (instruction instanceof ReadResourceInstruction read) {
+            return handleReadResource(read.skillName(), read.resourcePath());
+        }
+        return "<error>Unknown instruction type</error>";
+    }
+
+    private boolean isCommandAllowed(String command, List<String> allowedTools) {
+        if (allowedTools == null || allowedTools.isEmpty()) {
+            return true;
+        }
+
+        for (String allowed : allowedTools) {
+            // Handle wildcard patterns
+            if (allowed.equals("*")) {
+                return true;
+            }
+            if (allowed.endsWith("*")) {
+                String prefix = allowed.substring(0, allowed.length() - 1);
+                if (command.startsWith(prefix)) {
+                    return true;
+                }
+            } else if (command.equals(allowed) || command.startsWith(allowed + " ")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String escapeXml(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/agentskills/execution/DefaultScriptExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/agentskills/execution/DefaultScriptExecutorTest.java
@@ -1,0 +1,225 @@
+package dev.langchain4j.agentskills.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for {@link DefaultScriptExecutor}.
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ */
+class DefaultScriptExecutorTest {
+
+    @Test
+    void should_execute_simple_command_successfully(@TempDir Path tempDir) {
+        // given
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+        String command = "echo Hello";
+
+        // when
+        ScriptExecutionResult result = executor.execute(tempDir, command);
+
+        // then
+        assertThat(result.exitCode()).isEqualTo(0);
+        assertThat(result.output()).contains("Hello");
+        assertThat(result.error()).isEmpty();
+    }
+
+    @Test
+    void should_return_non_zero_exit_code_for_failing_command(@TempDir Path tempDir) {
+        // given
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+        String command = isWindows() ? "exit 1" : "sh -c 'exit 1'";
+
+        // when
+        ScriptExecutionResult result = executor.execute(tempDir, command);
+
+        // then
+        assertThat(result.exitCode()).isNotEqualTo(0);
+    }
+
+    @Test
+    void should_set_working_directory_correctly(@TempDir Path tempDir) {
+        // given
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+        String command = isWindows() ? "cd" : "pwd";
+
+        // when
+        ScriptExecutionResult result = executor.execute(tempDir, command);
+
+        // then
+        assertThat(result.exitCode()).isEqualTo(0);
+        assertThat(result.output()).contains(tempDir.toString());
+    }
+
+    @Test
+    void should_throw_exception_when_command_is_null(@TempDir Path tempDir) {
+        // given
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+
+        // when-then
+        assertThatThrownBy(() -> executor.execute(tempDir, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("command");
+    }
+
+    @Test
+    void should_throw_exception_when_command_is_blank(@TempDir Path tempDir) {
+        // given
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+
+        // when-then
+        assertThatThrownBy(() -> executor.execute(tempDir, ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("command");
+    }
+
+    @Test
+    void should_throw_exception_when_working_directory_is_null() {
+        // given
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+
+        // when-then
+        assertThatThrownBy(() -> executor.execute(null, "echo test"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("workingDirectory");
+    }
+
+    @Test
+    @EnabledOnOs({OS.LINUX, OS.MAC})
+    void should_execute_python_script(@TempDir Path tempDir) throws IOException {
+        // given
+        Path scriptsDir = tempDir.resolve("scripts");
+        Files.createDirectories(scriptsDir);
+
+        String pythonScript =
+                """
+                import sys
+                print("Hello from Python")
+                sys.exit(0)
+                """;
+
+        Files.writeString(scriptsDir.resolve("test.py"), pythonScript);
+
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+        String command = "python3 scripts/test.py";
+
+        // when
+        ScriptExecutionResult result = executor.execute(tempDir, command);
+
+        // then
+        assertThat(result.exitCode()).isEqualTo(0);
+        assertThat(result.output()).contains("Hello from Python");
+    }
+
+    @Test
+    @EnabledOnOs({OS.LINUX, OS.MAC})
+    void should_handle_large_output(@TempDir Path tempDir) {
+        // given
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+        String command = "for i in {1..1000}; do echo Line $i; done";
+
+        // when
+        ScriptExecutionResult result = executor.execute(tempDir, command);
+
+        // then
+        assertThat(result.exitCode()).isEqualTo(0);
+        assertThat(result.output()).contains("Line 1");
+        assertThat(result.output()).contains("Line 1000");
+    }
+
+    @Test
+    @EnabledOnOs({OS.LINUX, OS.MAC})
+    void should_timeout_for_long_running_command(@TempDir Path tempDir) {
+        // given
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(2);
+        String command = "sleep 10";
+
+        long startTime = System.currentTimeMillis();
+
+        // when
+        ScriptExecutionResult result = executor.execute(tempDir, command);
+
+        long elapsedTime = System.currentTimeMillis() - startTime;
+
+        // then: should return within timeout period (2s + tolerance)
+        assertThat(elapsedTime).isLessThan(4000);
+        assertThat(result.exitCode()).isEqualTo(-1);
+        assertThat(result.error()).contains("timed out");
+    }
+
+    @Test
+    @EnabledOnOs({OS.LINUX, OS.MAC})
+    void should_capture_stderr(@TempDir Path tempDir) {
+        // given
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+        String command = "sh -c 'echo error message >&2'";
+
+        // when
+        ScriptExecutionResult result = executor.execute(tempDir, command);
+
+        // then: stderr should be captured in output (redirectErrorStream is true)
+        assertThat(result.output()).contains("error message");
+    }
+
+    @Test
+    void should_handle_non_existent_command(@TempDir Path tempDir) {
+        // given
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+        String command = "this_command_does_not_exist_12345";
+
+        // when
+        ScriptExecutionResult result = executor.execute(tempDir, command);
+
+        // then
+        assertThat(result.exitCode()).isNotEqualTo(0);
+    }
+
+    @Test
+    @EnabledOnOs({OS.LINUX, OS.MAC})
+    void should_execute_relative_path_script(@TempDir Path tempDir) throws IOException {
+        // given
+        Path scriptsDir = tempDir.resolve("scripts");
+        Files.createDirectories(scriptsDir);
+        Path scriptFile = scriptsDir.resolve("test.sh");
+        Files.writeString(scriptFile, "#!/bin/bash\necho Success\n");
+        scriptFile.toFile().setExecutable(true);
+
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+        String command = "bash scripts/test.sh";
+
+        // when
+        ScriptExecutionResult result = executor.execute(tempDir, command);
+
+        // then
+        assertThat(result.exitCode()).isEqualTo(0);
+        assertThat(result.output()).contains("Success");
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void should_work_on_windows(@TempDir Path tempDir) {
+        // given
+        DefaultScriptExecutor executor = new DefaultScriptExecutor(60);
+        String command = "echo Windows Test";
+
+        // when
+        ScriptExecutionResult result = executor.execute(tempDir, command);
+
+        // then
+        assertThat(result.exitCode()).isEqualTo(0);
+        assertThat(result.output()).contains("Windows Test");
+    }
+
+    private boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/agentskills/AgentSkillsServiceTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/agentskills/AgentSkillsServiceTest.java
@@ -1,0 +1,567 @@
+package dev.langchain4j.service.agentskills;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agentskills.AgentSkillsProvider;
+import dev.langchain4j.agentskills.AgentSkillsProviderResult;
+import dev.langchain4j.agentskills.Skill;
+import dev.langchain4j.agentskills.execution.ScriptExecutionResult;
+import dev.langchain4j.agentskills.execution.ScriptExecutor;
+import dev.langchain4j.agentskills.instruction.AgentSkillsInstruction;
+import dev.langchain4j.agentskills.instruction.ExecuteScriptInstruction;
+import dev.langchain4j.agentskills.instruction.ReadResourceInstruction;
+import dev.langchain4j.agentskills.instruction.UseSkillInstruction;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for {@link AgentSkillsService}.
+ *
+ * @author Shrink (shunke.wjl@alibaba-inc.com)
+ */
+class AgentSkillsServiceTest {
+
+    @Test
+    void should_parse_use_skill_instruction() {
+        // given
+        String message = "Some text <use_skill>pdf-processing</use_skill> more text";
+        AgentSkillsService service = new AgentSkillsService();
+
+        // when
+        AgentSkillsInstruction instruction = service.parseInstruction(message);
+
+        // then
+        assertThat(instruction).isInstanceOf(UseSkillInstruction.class);
+        assertThat(((UseSkillInstruction) instruction).skillName()).isEqualTo("pdf-processing");
+    }
+
+    @Test
+    void should_parse_execute_script_instruction() {
+        // given
+        String message = "<execute_script skill=\"pdf-processing\">scripts/extract.py file.pdf</execute_script>";
+        AgentSkillsService service = new AgentSkillsService();
+
+        // when
+        AgentSkillsInstruction instruction = service.parseInstruction(message);
+
+        // then
+        assertThat(instruction).isInstanceOf(ExecuteScriptInstruction.class);
+        ExecuteScriptInstruction exec = (ExecuteScriptInstruction) instruction;
+        assertThat(exec.skillName()).isEqualTo("pdf-processing");
+        assertThat(exec.command()).isEqualTo("scripts/extract.py file.pdf");
+    }
+
+    @Test
+    void should_parse_read_resource_instruction() {
+        // given
+        String message = "<read_resource skill=\"pdf-processing\">assets/template.json</read_resource>";
+        AgentSkillsService service = new AgentSkillsService();
+
+        // when
+        AgentSkillsInstruction instruction = service.parseInstruction(message);
+
+        // then
+        assertThat(instruction).isInstanceOf(ReadResourceInstruction.class);
+        ReadResourceInstruction read = (ReadResourceInstruction) instruction;
+        assertThat(read.skillName()).isEqualTo("pdf-processing");
+        assertThat(read.resourcePath()).isEqualTo("assets/template.json");
+    }
+
+    @Test
+    void should_return_null_when_no_instruction_found() {
+        // given
+        String message = "Just a normal message without any instructions";
+        AgentSkillsService service = new AgentSkillsService();
+
+        // when
+        AgentSkillsInstruction instruction = service.parseInstruction(message);
+
+        // then
+        assertThat(instruction).isNull();
+    }
+
+    @Test
+    void should_parse_only_first_instruction() {
+        // given
+        String message = "<use_skill>skill1</use_skill> text <use_skill>skill2</use_skill>";
+        AgentSkillsService service = new AgentSkillsService();
+
+        // when
+        AgentSkillsInstruction instruction = service.parseInstruction(message);
+
+        // then
+        assertThat(instruction).isInstanceOf(UseSkillInstruction.class);
+        assertThat(((UseSkillInstruction) instruction).skillName()).isEqualTo("skill1");
+    }
+
+    @Test
+    void should_return_error_when_skill_not_found_for_use_skill() {
+        // given
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        when(provider.skillByName("non-existent")).thenReturn(null);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        // when
+        String result = service.handleUseSkill("non-existent");
+
+        // then
+        assertThat(result).contains("<skill_error>");
+        assertThat(result).contains("non-existent");
+    }
+
+    @Test
+    void should_return_error_when_skill_not_found_for_execute_script() {
+        // given
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        when(provider.skillByName("non-existent")).thenReturn(null);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        // when
+        String result = service.handleExecuteScript("non-existent", "scripts/test.sh");
+
+        // then
+        assertThat(result).contains("<script_error>");
+        assertThat(result).contains("non-existent");
+    }
+
+    @Test
+    void should_return_error_when_skill_not_found_for_read_resource() {
+        // given
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        when(provider.skillByName("non-existent")).thenReturn(null);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        // when
+        String result = service.handleReadResource("non-existent", "assets/file.txt");
+
+        // then
+        assertThat(result).contains("<resource_error>");
+    }
+
+    @Test
+    void should_reject_command_not_in_allowed_tools(@TempDir Path tempDir) throws IOException {
+        // given
+        Skill skill = createSkillWithAllowedTools(tempDir, "pdf-processing", "python", "node");
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        when(provider.skillByName("pdf-processing")).thenReturn(skill);
+
+        ScriptExecutor executor = mock(ScriptExecutor.class);
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+        service.scriptExecutor(executor);
+
+        // when
+        String result = service.handleExecuteScript("pdf-processing", "bash malicious.sh");
+
+        // then
+        assertThat(result).contains("<script_error>");
+        assertThat(result.toLowerCase()).containsAnyOf("not in", "allowed");
+        verify(executor, never()).execute(any(), any());
+    }
+
+    @Test
+    void should_allow_command_in_allowed_tools(@TempDir Path tempDir) throws IOException {
+        // given
+        Skill skill = createSkillWithAllowedTools(tempDir, "pdf-processing", "python", "bash");
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        when(provider.skillByName("pdf-processing")).thenReturn(skill);
+
+        ScriptExecutor executor = mock(ScriptExecutor.class);
+        ScriptExecutionResult execResult = ScriptExecutionResult.builder()
+                .exitCode(0)
+                .output("OK")
+                .error("")
+                .build();
+        when(executor.execute(any(Path.class), eq("python scripts/test.py"))).thenReturn(execResult);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+        service.scriptExecutor(executor);
+
+        // when
+        String result = service.handleExecuteScript("pdf-processing", "python scripts/test.py");
+
+        // then
+        assertThat(result).contains("<script_result exit_code=\"0\">");
+        verify(executor, times(1)).execute(any(), eq("python scripts/test.py"));
+    }
+
+    @Test
+    void should_use_default_script_executor_when_not_configured() {
+        // given
+        AgentSkillsService service = new AgentSkillsService();
+
+        // when
+        ScriptExecutor executor = service.scriptExecutor();
+
+        // then
+        assertThat(executor).isNotNull();
+        assertThat(executor).isInstanceOf(dev.langchain4j.agentskills.execution.DefaultScriptExecutor.class);
+    }
+
+    @Test
+    void should_return_error_when_resource_not_found(@TempDir Path tempDir) throws IOException {
+        // given
+        Skill skill = createSkill(tempDir, "pdf-processing", "Process PDFs");
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        when(provider.skillByName("pdf-processing")).thenReturn(skill);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        // when
+        String result = service.handleReadResource("pdf-processing", "assets/non-existent.json");
+
+        // then
+        assertThat(result).contains("<resource_error>");
+    }
+
+    @Test
+    void should_prevent_path_traversal_attack(@TempDir Path tempDir) throws IOException {
+        // given
+        Skill skill = createSkill(tempDir, "pdf-processing", "Process PDFs");
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        when(provider.skillByName("pdf-processing")).thenReturn(skill);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        // when
+        String result = service.handleReadResource("pdf-processing", "../../../etc/passwd");
+
+        // then
+        assertThat(result).contains("<resource_error>");
+        assertThat(result.toLowerCase()).containsAnyOf("illegal", "path");
+    }
+
+    @Test
+    void should_generate_system_prompt_addition(@TempDir Path tempDir) throws IOException {
+        // given
+        Skill skill1 = createSkill(tempDir.resolve("skill1"), "pdf-processing", "Process PDFs");
+        Skill skill2 = createSkill(tempDir.resolve("skill2"), "web-search", "Search web");
+
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        AgentSkillsProviderResult providerResult = AgentSkillsProviderResult.builder()
+                .skills(Arrays.asList(skill1, skill2))
+                .build();
+        when(provider.provideSkills(any())).thenReturn(providerResult);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        InvocationContext context = mock(InvocationContext.class);
+        UserMessage userMessage = UserMessage.from("test");
+
+        // when
+        String addition = service.generateSystemPromptAddition(context, userMessage);
+
+        // then
+        assertThat(addition).contains("<available_skills>");
+        assertThat(addition).contains("pdf-processing");
+        assertThat(addition).contains("Process PDFs");
+        assertThat(addition).contains("web-search");
+        assertThat(addition).contains("Search web");
+        assertThat(addition).contains("use_skill");
+        assertThat(addition).contains("execute_script");
+        assertThat(addition).contains("read_resource");
+    }
+
+    @Test
+    void should_return_empty_string_for_empty_skills() {
+        // given
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        AgentSkillsProviderResult emptyResult =
+                AgentSkillsProviderResult.builder().skills(Collections.emptyList()).build();
+        when(provider.provideSkills(any())).thenReturn(emptyResult);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        InvocationContext context = mock(InvocationContext.class);
+        UserMessage userMessage = UserMessage.from("test");
+
+        // when
+        String addition = service.generateSystemPromptAddition(context, userMessage);
+
+        // then
+        assertThat(addition).isEmpty();
+    }
+
+    @Test
+    void should_return_false_when_no_provider() {
+        // given
+        AgentSkillsService service = new AgentSkillsService();
+
+        // when-then
+        assertThat(service.hasSkills()).isFalse();
+    }
+
+    @Test
+    void should_return_true_when_has_skills() {
+        // given
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        // when-then
+        assertThat(service.hasSkills()).isTrue();
+    }
+
+    @Test
+    void should_throw_exception_when_max_iterations_less_than_one() {
+        // given
+        AgentSkillsService service = new AgentSkillsService();
+
+        // when-then
+        assertThatThrownBy(() -> service.maxIterations(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxIterations");
+
+        assertThatThrownBy(() -> service.maxIterations(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxIterations");
+    }
+
+    @Test
+    void should_accept_valid_max_iterations() {
+        // given
+        AgentSkillsService service = new AgentSkillsService();
+
+        // when
+        service.maxIterations(1);
+        service.maxIterations(10);
+        service.maxIterations(100);
+
+        // then
+        assertThat(service.maxIterations()).isEqualTo(100);
+    }
+
+    @Test
+    void should_handle_wildcard_in_allowed_tools(@TempDir Path tempDir) throws IOException {
+        // given
+        Skill skill = createSkillWithAllowedTools(tempDir, "test-skill", "*");
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        when(provider.skillByName("test-skill")).thenReturn(skill);
+
+        ScriptExecutor executor = mock(ScriptExecutor.class);
+        ScriptExecutionResult execResult =
+                ScriptExecutionResult.builder().exitCode(0).output("OK").error("").build();
+        when(executor.execute(any(Path.class), any(String.class))).thenReturn(execResult);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+        service.scriptExecutor(executor);
+
+        // when
+        String result = service.handleExecuteScript("test-skill", "any-command-here");
+
+        // then: wildcard allows any command
+        assertThat(result).contains("<script_result exit_code=\"0\">");
+        verify(executor, times(1)).execute(any(), eq("any-command-here"));
+    }
+
+    @Test
+    void should_read_resource_successfully(@TempDir Path tempDir) throws IOException {
+        // given
+        Skill skill = createSkill(tempDir, "pdf-processing", "Process PDFs");
+        Path assetsDir = skill.path().resolve("assets");
+        Files.createDirectories(assetsDir);
+        Files.writeString(assetsDir.resolve("template.json"), "{\"key\": \"value\"}");
+
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        when(provider.skillByName("pdf-processing")).thenReturn(skill);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        // when
+        String result = service.handleReadResource("pdf-processing", "assets/template.json");
+
+        // then
+        assertThat(result).contains("<resource_content");
+        assertThat(result).contains("\"key\": \"value\"");
+    }
+
+    @Test
+    void should_return_skill_content_for_use_skill(@TempDir Path tempDir) throws IOException {
+        // given
+        Skill skill = createSkillWithInstructions(
+                tempDir, "pdf-processing", "Process PDFs", "# PDF Skill\n\nExtract text from PDFs.");
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        when(provider.skillByName("pdf-processing")).thenReturn(skill);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        // when
+        String result = service.handleUseSkill("pdf-processing");
+
+        // then
+        assertThat(result).contains("<skill_content name=\"pdf-processing\">");
+        assertThat(result).contains("# PDF Skill");
+        assertThat(result).contains("Extract text from PDFs");
+    }
+
+    @Test
+    void should_handle_script_execution_with_non_zero_exit_code(@TempDir Path tempDir) throws IOException {
+        // given
+        Skill skill = createSkill(tempDir, "test-skill", "Test");
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        when(provider.skillByName("test-skill")).thenReturn(skill);
+
+        ScriptExecutor executor = mock(ScriptExecutor.class);
+        ScriptExecutionResult failedResult = ScriptExecutionResult.builder()
+                .exitCode(1)
+                .output("")
+                .error("Script failed")
+                .build();
+        when(executor.execute(any(), any())).thenReturn(failedResult);
+
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+        service.scriptExecutor(executor);
+
+        // when
+        String result = service.handleExecuteScript("test-skill", "failing-command");
+
+        // then
+        assertThat(result).contains("<script_result exit_code=\"1\">");
+        assertThat(result).contains("Script failed");
+    }
+
+    @Test
+    void should_return_error_when_command_is_blank() {
+        // given
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        // when
+        String result = service.handleExecuteScript("any-skill", "   ");
+
+        // then
+        assertThat(result).contains("<script_error>");
+        assertThat(result.toLowerCase()).containsAnyOf("cannot be empty", "empty");
+    }
+
+    @Test
+    void should_return_error_when_resource_path_is_blank() {
+        // given
+        AgentSkillsProvider provider = mock(AgentSkillsProvider.class);
+        AgentSkillsService service = new AgentSkillsService();
+        service.agentSkillsProvider(provider);
+
+        // when
+        String result = service.handleReadResource("any-skill", "   ");
+
+        // then
+        assertThat(result).contains("<resource_error>");
+        assertThat(result.toLowerCase()).containsAnyOf("cannot be empty", "empty");
+    }
+
+    @Test
+    void should_return_empty_string_when_provider_is_null() {
+        // given
+        AgentSkillsService service = new AgentSkillsService();
+        // no provider set
+
+        InvocationContext context = mock(InvocationContext.class);
+        UserMessage userMessage = UserMessage.from("test");
+
+        // when
+        String addition = service.generateSystemPromptAddition(context, userMessage);
+
+        // then
+        assertThat(addition).isEmpty();
+    }
+
+    // Helper methods
+
+    private Skill createSkill(Path parentDir, String skillName, String description) throws IOException {
+        Path skillDir = parentDir.resolve(skillName);
+        Files.createDirectories(skillDir);
+
+        String skillMd = String.format(
+                """
+                ---
+                name: %s
+                description: %s
+                ---
+                # %s
+                """,
+                skillName, description, skillName);
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+
+        return Skill.builder()
+                .name(skillName)
+                .description(description)
+                .path(skillDir)
+                .instructions("# " + skillName)
+                .build();
+    }
+
+    private Skill createSkillWithInstructions(Path parentDir, String skillName, String description, String instructions)
+            throws IOException {
+        Path skillDir = parentDir.resolve(skillName);
+        Files.createDirectories(skillDir);
+
+        return Skill.builder()
+                .name(skillName)
+                .description(description)
+                .path(skillDir)
+                .instructions(instructions)
+                .build();
+    }
+
+    private Skill createSkillWithAllowedTools(Path parentDir, String skillName, String... allowedTools)
+            throws IOException {
+        Path skillDir = parentDir.resolve(skillName);
+        Files.createDirectories(skillDir);
+
+        String allowedToolsStr = String.join(" ", allowedTools);
+        String skillMd = String.format(
+                """
+                ---
+                name: %s
+                description: Test skill
+                allowed-tools: %s
+                ---
+                # %s
+                """,
+                skillName, allowedToolsStr, skillName);
+
+        Files.writeString(skillDir.resolve("SKILL.md"), skillMd);
+
+        return Skill.builder()
+                .name(skillName)
+                .description("Test skill")
+                .path(skillDir)
+                .allowedTools(Arrays.asList(allowedTools))
+                .instructions("# " + skillName)
+                .build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>langchain4j-easy-rag</module>
         <module>langchain4j-mcp</module>
         <module>langchain4j-mcp-docker</module>
+        <module>langchain4j-agent-skills</module>
 
         <!-- http clients -->
         <module>langchain4j-http-client</module>
@@ -138,6 +139,26 @@
         <langchain4j.beta.version>1.11.0-beta19-SNAPSHOT</langchain4j.beta.version>
         <gib.disable>true</gib.disable>
     </properties>
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>1.11.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-agent-skills</artifactId>
+            <version>1.11.0-beta19-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+            <version>1.11.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>


### PR DESCRIPTION
Introduce Agent Skills - a capability extension system that allows AI agents to dynamically load and execute external skills defined in SKILL.md files.

Key Features:
- Dynamic skill loading from SKILL.md files (YAML frontmatter + Markdown)
- Secure script execution with command whitelist and path traversal protection
- Seamless LLM integration via system prompt enhancement and XML instructions
- Three instruction types: use_skill, execute_script, read_resource
- Thread-safe caching and hot reload support

Implementation:
- New module: langchain4j-agent-skills (skill loading)
- Core APIs in langchain4j-core (21 Java files)
- Comprehensive tests: 66 tests with 100% pass rate
  * 59 unit tests (parsing, loading, execution, security)
  * 7 end-to-end tests (real LLM integration with Qwen)

Documentation:
- agent-skills-architecture.md (32KB): Complete design document
- agent-skills.md (16KB): Quick start guide (English)
- agent-skills-cn.md (12KB): Quick start guide (Chinese)

Security:
- Command injection prevention (allowed-tools whitelist)
- Path traversal protection (multi-layer validation)
- Process timeout enforcement (default: 60s)
- Working directory isolation

Author: Shrink (shunke.wjl@alibaba-inc.com)
Status: Experimental (1.12.0)

<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #4396 

## Change
<!-- Please describe the changes you made. -->


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
