### PR TITLE
[BUG] Fixes 'NPE when retreiving Gemini Batch API job results #4423'

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BatchRequestResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BatchRequestResponse.java
@@ -23,7 +23,7 @@ public final class BatchRequestResponse {
     /**
      * Represents a successful batch operation.
      */
-    public record BatchSuccess<T>(BatchName batchName, List<T> responses, List<Operation.Status> errors)
+    public record BatchSuccess<T>(BatchName batchName, List<T> responses, @Nullable List<Operation.Status> errors)
             implements BatchResponse<T> {}
 
     /**

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BatchRequestResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BatchRequestResponse.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.model.googleai.BatchRequestResponse.Operation.Status;
 import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
@@ -22,7 +23,8 @@ public final class BatchRequestResponse {
     /**
      * Represents a successful batch operation.
      */
-    public record BatchSuccess<T>(BatchName batchName, List<T> responses) implements BatchResponse<T> {}
+    public record BatchSuccess<T>(BatchName batchName, List<T> responses, List<Operation.Status> errors)
+            implements BatchResponse<T> {}
 
     /**
      * Represents an error that occurred during a batch operation.
@@ -139,12 +141,13 @@ public final class BatchRequestResponse {
         record InlinedResponses<RESP>(List<InlinedResponseWrapper<RESP>> inlinedResponses) {}
 
         /**
-         * Wrapper for an individual response.
+         * Wrapper for an individual (successful) response OR error.
          *
-         * @param response The actual Gemini response.
+         * @param response A successful Gemini response.
+         * @param error An error including message and code
          */
         @JsonIgnoreProperties(ignoreUnknown = true)
-        record InlinedResponseWrapper<RESP>(RESP response) {}
+        record InlinedResponseWrapper<RESP>(@Nullable RESP response, @Nullable Status error) {}
     }
 
     /**
@@ -164,14 +167,14 @@ public final class BatchRequestResponse {
          * @param details A list of messages that carry the error details.
          */
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public record Status(int code, String message, List<Map<String, Object>> details) {}
+        public record Status(int code, String message, @Nullable List<Map<String, Object>> details) {}
     }
 
     /**
      * Represents a response containing a list of operations and a token for pagination.
      *
-     * @param <RESP> the type of the response for each operation
-     * @param operations a list of operations to be performed
+     * @param <RESP>        the type of the response for each operation
+     * @param operations    a list of operations to be performed
      * @param nextPageToken a token for retrieving the next page of operations, if available; null if there are no more pages
      */
     record ListOperationsResponse<RESP>(@Nullable List<Operation<RESP>> operations, @Nullable String nextPageToken) {}
@@ -179,8 +182,8 @@ public final class BatchRequestResponse {
     /**
      * Represents a batch request for a file operation.
      *
-     * @param <REQ> the type of the request payload
-     * @param key a unique identifier for the request
+     * @param <REQ>   the type of the request payload
+     * @param key     a unique identifier for the request
      * @param request the actual request payload containing the details of the operation
      */
     public record BatchFileRequest<REQ>(String key, REQ request) {}

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiBatchProcessor.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiBatchProcessor.java
@@ -128,8 +128,9 @@ final class GeminiBatchProcessor<REQUEST, RESPONSE, API_REQUEST, API_RESPONSE> {
                         extractBatchState(operation.metadata()),
                         operation.error().details());
             } else {
+                var extractedResponses = preparer.extractResults(operation.response());
                 return new BatchSuccess<>(
-                        new BatchName(operation.name()), preparer.extractResponses(operation.response()));
+                        new BatchName(operation.name()), extractedResponses.responses(), extractedResponses.errors());
             }
         } else {
             return new BatchRequestResponse.BatchIncomplete<>(
@@ -154,6 +155,8 @@ final class GeminiBatchProcessor<REQUEST, RESPONSE, API_REQUEST, API_RESPONSE> {
         }
     }
 
+    record ExtractedBatchResults<T>(List<T> responses, List<BatchRequestResponse.Operation.Status> errors) {}
+
     /**
      * Interface for preparing requests and extracting responses.
      */
@@ -162,6 +165,6 @@ final class GeminiBatchProcessor<REQUEST, RESPONSE, API_REQUEST, API_RESPONSE> {
 
         API_REQUEST createInlinedRequest(REQUEST request);
 
-        List<RESPONSE> extractResponses(BatchCreateResponse<API_RESPONSE> response);
+        ExtractedBatchResults<RESPONSE> extractResults(BatchCreateResponse<API_RESPONSE> response);
     }
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiBatchProcessor.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiBatchProcessor.java
@@ -128,9 +128,9 @@ final class GeminiBatchProcessor<REQUEST, RESPONSE, API_REQUEST, API_RESPONSE> {
                         extractBatchState(operation.metadata()),
                         operation.error().details());
             } else {
-                var extractedResponses = preparer.extractResults(operation.response());
+                var extractedResults = preparer.extractResults(operation.response());
                 return new BatchSuccess<>(
-                        new BatchName(operation.name()), extractedResponses.responses(), extractedResponses.errors());
+                        new BatchName(operation.name()), extractedResults.responses(), extractedResults.errors());
             }
         } else {
             return new BatchRequestResponse.BatchIncomplete<>(

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiBatchChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiBatchChatModelTest.java
@@ -595,6 +595,35 @@ class GoogleAiGeminiBatchChatModelTest {
         }
 
         @Test
+        void should_return_success_with_errors_when_batch_processing_has_individual_failures() {
+            // given
+            var batchName = new BatchName("batches/test-partial-success");
+            var chatResponses = List.of(createChatResponse("Response 1"), createChatResponse("Response 2"));
+            var error = new BatchRequestResponse.Operation.Status(
+                    4, "Deadline expired before operation could complete.", null);
+            var successOperation =
+                    createSuccessOperationWithError("batches/test-partial-success", chatResponses, error);
+            when(mockGeminiService.<GeminiGenerateContentResponse>batchRetrieveBatch(batchName.value()))
+                    .thenReturn(successOperation);
+
+            // when
+            var result = subject.retrieveBatchResults(batchName);
+
+            // then
+            assertThat(result).isInstanceOf(BatchSuccess.class);
+            var successResult = (BatchSuccess<ChatResponse>) result;
+            assertThat(successResult.batchName()).isEqualTo(batchName);
+            assertThat(successResult.responses()).hasSize(2);
+            assertThat(successResult.responses().get(0).aiMessage().text()).isEqualTo("Response 1");
+            assertThat(successResult.responses().get(1).aiMessage().text()).isEqualTo("Response 2");
+
+            assertThat(successResult.errors()).hasSize(1);
+            assertThat(successResult.errors().get(0).code()).isEqualTo(4);
+            assertThat(successResult.errors().get(0).message())
+                    .isEqualTo("Deadline expired before operation could complete.");
+        }
+
+        @Test
         void should_return_success_with_empty_responses_when_response_is_null() {
             // given
             var batchName = new BatchName("batches/test-empty");
@@ -1000,38 +1029,140 @@ class GoogleAiGeminiBatchChatModelTest {
 
         private static final String PENDING_RESPONSE =
                 """
-                {
-                  "name": "batches/tti3ik8qob66dxcvynlg5swnutyntbi926ac",
-                  "metadata": {
-                    "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatch",
-                    "model": "models/gemini-2.5-flash-lite",
-                    "displayName": "capitals-batch",
-                    "createTime": "2025-12-03T17:23:06.004734302Z",
-                    "updateTime": "2025-12-03T17:23:06.004734302Z",
-                    "batchStats": {
-                      "requestCount": "3",
-                      "pendingRequestCount": "3"
-                    },
-                    "state": "BATCH_STATE_PENDING",
-                    "name": "batches/tti3ik8qob66dxcvynlg5swnutyntbi926ac"
-                  }
-                }
-                """;
+                        {
+                          "name": "batches/tti3ik8qob66dxcvynlg5swnutyntbi926ac",
+                          "metadata": {
+                            "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatch",
+                            "model": "models/gemini-2.5-flash-lite",
+                            "displayName": "capitals-batch",
+                            "createTime": "2025-12-03T17:23:06.004734302Z",
+                            "updateTime": "2025-12-03T17:23:06.004734302Z",
+                            "batchStats": {
+                              "requestCount": "3",
+                              "pendingRequestCount": "3"
+                            },
+                            "state": "BATCH_STATE_PENDING",
+                            "name": "batches/tti3ik8qob66dxcvynlg5swnutyntbi926ac"
+                          }
+                        }
+                        """;
 
         private static final String SUCCEEDED_RESPONSE =
+                """
+                        {
+                          "name": "batches/tti3ik8qob66dxcvynlg5swnutyntbi926ac",
+                          "metadata": {
+                            "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatch",
+                            "model": "models/gemini-2.5-flash-lite",
+                            "displayName": "capitals-batch",
+                            "createTime": "2025-12-03T17:23:06.004734302Z",
+                            "endTime": "2025-12-03T17:24:41.850709659Z",
+                            "updateTime": "2025-12-03T17:24:41.850709619Z",
+                            "batchStats": {
+                              "requestCount": "3",
+                              "successfulRequestCount": "3"
+                            },
+                            "state": "BATCH_STATE_SUCCEEDED",
+                            "name": "batches/tti3ik8qob66dxcvynlg5swnutyntbi926ac"
+                          },
+                          "done": true,
+                          "response": {
+                            "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatchOutput",
+                            "inlinedResponses": {
+                              "inlinedResponses": [
+                                {
+                                  "response": {
+                                    "candidates": [
+                                      {
+                                        "content": {
+                                          "parts": [
+                                            {
+                                              "text": "The capital of France is **Paris**."
+                                            }
+                                          ],
+                                          "role": "model"
+                                        },
+                                        "finishReason": "STOP",
+                                        "index": 0
+                                      }
+                                    ],
+                                    "usageMetadata": {
+                                      "promptTokenCount": 8,
+                                      "candidatesTokenCount": 8,
+                                      "totalTokenCount": 16
+                                    },
+                                    "modelVersion": "gemini-2.5-flash-lite"
+                                  }
+                                },
+                                {
+                                  "response": {
+                                    "candidates": [
+                                      {
+                                        "content": {
+                                          "parts": [
+                                            {
+                                              "text": "The capital of Japan is **Tokyo**."
+                                            }
+                                          ],
+                                          "role": "model"
+                                        },
+                                        "finishReason": "STOP",
+                                        "index": 0
+                                      }
+                                    ],
+                                    "usageMetadata": {
+                                      "promptTokenCount": 8,
+                                      "candidatesTokenCount": 8,
+                                      "totalTokenCount": 16
+                                    },
+                                    "modelVersion": "gemini-2.5-flash-lite"
+                                  }
+                                },
+                                {
+                                  "response": {
+                                    "candidates": [
+                                      {
+                                        "content": {
+                                          "parts": [
+                                            {
+                                              "text": "The capital of Brazil is **Brasília**."
+                                            }
+                                          ],
+                                          "role": "model"
+                                        },
+                                        "finishReason": "STOP",
+                                        "index": 0
+                                      }
+                                    ],
+                                    "usageMetadata": {
+                                      "promptTokenCount": 8,
+                                      "candidatesTokenCount": 9,
+                                      "totalTokenCount": 17
+                                    },
+                                    "modelVersion": "gemini-2.5-flash-lite"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                        """;
+
+        private String ERROR_RESPONSE =
                 """
                 {
                   "name": "batches/tti3ik8qob66dxcvynlg5swnutyntbi926ac",
                   "metadata": {
                     "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatch",
-                    "model": "models/gemini-2.5-flash-lite",
-                    "displayName": "capitals-batch",
+                    "model": "models/gemini-3-flash-preview",
+                    "displayName": "error-batch",
                     "createTime": "2025-12-03T17:23:06.004734302Z",
                     "endTime": "2025-12-03T17:24:41.850709659Z",
                     "updateTime": "2025-12-03T17:24:41.850709619Z",
                     "batchStats": {
                       "requestCount": "3",
-                      "successfulRequestCount": "3"
+                      "successfulRequestCount": "2",
+                      "failedRequestCount": "1"
                     },
                     "state": "BATCH_STATE_SUCCEEDED",
                     "name": "batches/tti3ik8qob66dxcvynlg5swnutyntbi926ac"
@@ -1048,7 +1179,7 @@ class GoogleAiGeminiBatchChatModelTest {
                                 "content": {
                                   "parts": [
                                     {
-                                      "text": "The capital of France is **Paris**."
+                                      "text": "{some json}"
                                     }
                                   ],
                                   "role": "model"
@@ -1058,11 +1189,17 @@ class GoogleAiGeminiBatchChatModelTest {
                               }
                             ],
                             "usageMetadata": {
-                              "promptTokenCount": 8,
-                              "candidatesTokenCount": 8,
-                              "totalTokenCount": 16
+                              "promptTokenCount": 13469,
+                              "candidatesTokenCount": 281,
+                              "totalTokenCount": 16109
                             },
-                            "modelVersion": "gemini-2.5-flash-lite"
+                            "modelVersion": "gemini-3-flash-preview"
+                          }
+                        },
+                        {
+                          "error": {
+                            "code": 4,
+                            "message": "Deadline expired before operation could complete."
                           }
                         },
                         {
@@ -1072,7 +1209,7 @@ class GoogleAiGeminiBatchChatModelTest {
                                 "content": {
                                   "parts": [
                                     {
-                                      "text": "The capital of Japan is **Tokyo**."
+                                      "text": "{...}"
                                     }
                                   ],
                                   "role": "model"
@@ -1082,35 +1219,11 @@ class GoogleAiGeminiBatchChatModelTest {
                               }
                             ],
                             "usageMetadata": {
-                              "promptTokenCount": 8,
-                              "candidatesTokenCount": 8,
-                              "totalTokenCount": 16
+                              "promptTokenCount": 6021,
+                              "candidatesTokenCount": 449,
+                              "totalTokenCount": 9070
                             },
-                            "modelVersion": "gemini-2.5-flash-lite"
-                          }
-                        },
-                        {
-                          "response": {
-                            "candidates": [
-                              {
-                                "content": {
-                                  "parts": [
-                                    {
-                                      "text": "The capital of Brazil is **Brasília**."
-                                    }
-                                  ],
-                                  "role": "model"
-                                },
-                                "finishReason": "STOP",
-                                "index": 0
-                              }
-                            ],
-                            "usageMetadata": {
-                              "promptTokenCount": 8,
-                              "candidatesTokenCount": 9,
-                              "totalTokenCount": 17
-                            },
-                            "modelVersion": "gemini-2.5-flash-lite"
+                            "modelVersion": "gemini-3-flash-preview"
                           }
                         }
                       ]
@@ -1118,6 +1231,41 @@ class GoogleAiGeminiBatchChatModelTest {
                   }
                 }
                 """;
+
+        @Test
+        void should_deserialize_batch_response_with_error() {
+            // given
+            var mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                    .body(ERROR_RESPONSE)
+                    .statusCode(200)
+                    .build());
+            var subject = GoogleAiGeminiBatchChatModel.builder()
+                    .apiKey("does not matter")
+                    .modelName("does not matter")
+                    .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                    .build();
+            var batchName = new BatchName("batches/tti3ik8qob66dxcvynlg5swnutyntbi926ac");
+
+            // when
+            var result = subject.retrieveBatchResults(batchName);
+
+            // then
+            assertThat(result).isInstanceOf(BatchSuccess.class);
+            var success = (BatchSuccess<ChatResponse>) result;
+            assertThat(success.batchName().value()).isEqualTo("batches/tti3ik8qob66dxcvynlg5swnutyntbi926ac");
+
+            var results = success.responses();
+            assertThat(results).hasSize(2);
+
+            // First response - successful
+            assertThat(results.get(0).aiMessage().text()).isEqualTo("{some json}");
+
+            // Second response - error (check how your model represents this)
+            assertThat(success.errors()).hasSize(1);
+            assertThat(success.errors().get(0).code()).isEqualTo(4);
+            assertThat(success.errors().get(0).message())
+                    .isEqualTo("Deadline expired before operation could complete.");
+        }
 
         @Test
         void should_deserialize_pending_batch_response() {
@@ -1188,8 +1336,35 @@ class GoogleAiGeminiBatchChatModelTest {
             String operationName, List<ChatResponse> chatResponses) {
         var inlinedResponses = chatResponses.stream()
                 .map(GoogleAiGeminiBatchChatModelTest::toGeminiResponse)
-                .map(BatchCreateResponse.InlinedResponseWrapper::new)
+                .map(response -> new BatchCreateResponse.InlinedResponseWrapper<>(response, null))
                 .toList();
+
+        var response = new BatchCreateResponse<>(
+                "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatchOutput",
+                new BatchCreateResponse.InlinedResponses<>(inlinedResponses));
+
+        return new Operation<>(operationName, Map.of("state", BATCH_STATE_SUCCEEDED.name()), true, null, response);
+    }
+
+    private static Operation<GeminiGenerateContentResponse> createSuccessOperationWithError(
+            String operationName, List<ChatResponse> chatResponses, BatchRequestResponse.Operation.Status error) {
+        List<BatchCreateResponse.InlinedResponseWrapper<GeminiGenerateContentResponse>> inlinedResponses =
+                new ArrayList<>();
+
+        // Add first successful response
+        if (!chatResponses.isEmpty()) {
+            inlinedResponses.add(
+                    new BatchCreateResponse.InlinedResponseWrapper<>(toGeminiResponse(chatResponses.get(0)), null));
+        }
+
+        // Add error
+        inlinedResponses.add(new BatchCreateResponse.InlinedResponseWrapper<>(null, error));
+
+        // Add remaining successful responses
+        for (int i = 1; i < chatResponses.size(); i++) {
+            inlinedResponses.add(
+                    new BatchCreateResponse.InlinedResponseWrapper<>(toGeminiResponse(chatResponses.get(i)), null));
+        }
 
         var response = new BatchCreateResponse<>(
                 "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatchOutput",

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiBatchImageModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiBatchImageModelTest.java
@@ -16,9 +16,13 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.data.image.Image;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.model.googleai.BatchRequestResponse.BatchCreateFileRequest;
 import dev.langchain4j.model.googleai.BatchRequestResponse.BatchCreateRequest;
 import dev.langchain4j.model.googleai.BatchRequestResponse.BatchCreateResponse;
+import dev.langchain4j.model.googleai.BatchRequestResponse.BatchCreateResponse.InlinedResponseWrapper;
 import dev.langchain4j.model.googleai.BatchRequestResponse.BatchError;
 import dev.langchain4j.model.googleai.BatchRequestResponse.BatchFileRequest;
 import dev.langchain4j.model.googleai.BatchRequestResponse.BatchIncomplete;
@@ -465,6 +469,37 @@ class GoogleAiGeminiBatchImageModelTest {
         }
 
         @Test
+        void should_return_success_with_errors_when_batch_processing_has_individual_failures() {
+            // given
+            var batchName = new BatchName("batches/test-partial-success");
+            var imageResponses = List.of(
+                    createImageResponse(TEST_IMAGE_BASE64, TEST_MIME_TYPE),
+                    createImageResponse("secondImageData", TEST_MIME_TYPE));
+            var error = new BatchRequestResponse.Operation.Status(
+                    4, "Deadline expired before operation could complete.", null);
+            var successOperation =
+                    createSuccessOperationWithError("batches/test-partial-success", imageResponses, error);
+            when(mockGeminiService.<GeminiGenerateContentResponse>batchRetrieveBatch(batchName.value()))
+                    .thenReturn(successOperation);
+
+            // when
+            var result = subject.retrieveBatchResults(batchName);
+
+            // then
+            assertThat(result).isInstanceOf(BatchSuccess.class);
+            var successResult = (BatchSuccess<Response<Image>>) result;
+            assertThat(successResult.batchName()).isEqualTo(batchName);
+            assertThat(successResult.responses()).hasSize(2);
+            assertThat(successResult.responses().get(0).content().base64Data()).isEqualTo(TEST_IMAGE_BASE64);
+            assertThat(successResult.responses().get(1).content().base64Data()).isEqualTo("secondImageData");
+
+            assertThat(successResult.errors()).hasSize(1);
+            assertThat(successResult.errors().get(0).code()).isEqualTo(4);
+            assertThat(successResult.errors().get(0).message())
+                    .isEqualTo("Deadline expired before operation could complete.");
+        }
+
+        @Test
         void should_return_success_with_empty_responses_when_response_is_null() {
             // given
             var batchName = new BatchName("batches/test-empty");
@@ -516,6 +551,280 @@ class GoogleAiGeminiBatchImageModelTest {
                     .isInstanceOf(BatchError.class)
                     .isEqualTo(
                             new BatchError<>(batchName, 500, "Internal Server Error", BATCH_STATE_FAILED, List.of()));
+        }
+    }
+
+    @Nested
+    class BatchImageSerialization {
+
+        private static final String IMAGE_PENDING_RESPONSE =
+                """
+                {
+                  "name": "batches/image-test-123",
+                  "metadata": {
+                    "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatch",
+                    "model": "models/gemini-2.5-flash-preview-image-generation",
+                    "displayName": "images-batch",
+                    "state": "BATCH_STATE_PENDING",
+                    "name": "batches/image-test-123"
+                  }
+                }
+                """;
+
+        private static final String IMAGE_SUCCEEDED_RESPONSE =
+                """
+                {
+                  "name": "batches/image-test-123",
+                  "metadata": {
+                    "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatch",
+                    "model": "models/gemini-2.5-flash-preview-image-generation",
+                    "displayName": "images-batch",
+                    "state": "BATCH_STATE_SUCCEEDED",
+                    "name": "batches/image-test-123"
+                  },
+                  "done": true,
+                  "response": {
+                    "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatchOutput",
+                    "inlinedResponses": {
+                      "inlinedResponses": [
+                        {
+                          "response": {
+                            "candidates": [
+                              {
+                                "content": {
+                                  "parts": [
+                                    {
+                                      "inlineData": {
+                                        "mimeType": "image/png",
+                                        "data": "aW1hZ2UxYmFzZTY0ZGF0YQ=="
+                                      }
+                                    }
+                                  ],
+                                  "role": "model"
+                                },
+                                "finishReason": "STOP",
+                                "index": 0
+                              }
+                            ],
+                            "usageMetadata": {
+                              "promptTokenCount": 10,
+                              "candidatesTokenCount": 256,
+                              "totalTokenCount": 266
+                            },
+                            "modelVersion": "gemini-2.5-flash-preview-image-generation"
+                          }
+                        },
+                        {
+                          "response": {
+                            "candidates": [
+                              {
+                                "content": {
+                                  "parts": [
+                                    {
+                                      "inlineData": {
+                                        "mimeType": "image/jpeg",
+                                        "data": "aW1hZ2UyYmFzZTY0ZGF0YQ=="
+                                      }
+                                    }
+                                  ],
+                                  "role": "model"
+                                },
+                                "finishReason": "STOP",
+                                "index": 0
+                              }
+                            ],
+                            "usageMetadata": {
+                              "promptTokenCount": 12,
+                              "candidatesTokenCount": 300,
+                              "totalTokenCount": 312
+                            },
+                            "modelVersion": "gemini-2.5-flash-preview-image-generation"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        @Test
+        void should_deserialize_pending_image_batch_response() {
+            // given
+            var mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .body(IMAGE_PENDING_RESPONSE)
+                    .build());
+            var subject = GoogleAiGeminiBatchImageModel.builder()
+                    .apiKey(API_KEY)
+                    .modelName("gemini-2.5-flash-preview-image-generation")
+                    .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                    .build();
+
+            var requests = List.of(
+                    new GoogleAiGeminiBatchImageModel.ImageGenerationRequest("A sunset over mountains"),
+                    new GoogleAiGeminiBatchImageModel.ImageGenerationRequest("A cat wearing a hat"));
+
+            // when
+            var result = subject.createBatchInline("images-batch", 0L, requests);
+
+            // then
+            assertThat(result).isInstanceOf(BatchIncomplete.class);
+            var incomplete = (BatchIncomplete<?>) result;
+            assertThat(incomplete.batchName().value()).isEqualTo("batches/image-test-123");
+            assertThat(incomplete.state()).isEqualTo(BATCH_STATE_PENDING);
+        }
+
+        @Test
+        void should_deserialize_succeeded_image_batch_response() {
+            // given
+            var mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .body(IMAGE_SUCCEEDED_RESPONSE)
+                    .build());
+            var subject = GoogleAiGeminiBatchImageModel.builder()
+                    .apiKey(API_KEY)
+                    .modelName("gemini-2.5-flash-preview-image-generation")
+                    .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                    .build();
+
+            var batchName = new BatchName("batches/image-test-123");
+
+            // when
+            var result = subject.retrieveBatchResults(batchName);
+
+            // then
+            assertThat(result).isInstanceOf(BatchSuccess.class);
+            var success = (BatchSuccess<Response<Image>>) result;
+            assertThat(success.batchName().value()).isEqualTo("batches/image-test-123");
+
+            var results = success.responses();
+            assertThat(results).hasSize(2);
+
+            assertThat(results.get(0).content().base64Data()).isEqualTo("aW1hZ2UxYmFzZTY0ZGF0YQ==");
+            assertThat(results.get(0).content().mimeType()).isEqualTo("image/png");
+
+            assertThat(results.get(1).content().base64Data()).isEqualTo("aW1hZ2UyYmFzZTY0ZGF0YQ==");
+            assertThat(results.get(1).content().mimeType()).isEqualTo("image/jpeg");
+        }
+
+        @Test
+        void should_deserialize_image_batch_response_with_error() {
+            // given
+            String IMAGE_ERROR_RESPONSE =
+                    """
+            {
+              "name": "batches/image-test-123",
+              "metadata": {
+                "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatch",
+                "model": "models/gemini-2.5-flash-preview-image-generation",
+                "displayName": "images-batch",
+                "state": "BATCH_STATE_SUCCEEDED",
+                "name": "batches/image-test-123"
+              },
+              "done": true,
+              "response": {
+                "@type": "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatchOutput",
+                "inlinedResponses": {
+                  "inlinedResponses": [
+                    {
+                      "response": {
+                        "candidates": [
+                          {
+                            "content": {
+                              "parts": [
+                                {
+                                  "inlineData": {
+                                    "mimeType": "image/png",
+                                    "data": "aW1hZ2UxYmFzZTY0ZGF0YQ=="
+                                  }
+                                }
+                              ],
+                              "role": "model"
+                            },
+                            "finishReason": "STOP",
+                            "index": 0
+                          }
+                        ],
+                        "usageMetadata": {
+                          "promptTokenCount": 10,
+                          "candidatesTokenCount": 256,
+                          "totalTokenCount": 266
+                        },
+                        "modelVersion": "gemini-2.5-flash-preview-image-generation"
+                      }
+                    },
+                    {
+                      "error": {
+                        "code": 4,
+                        "message": "Deadline expired before operation could complete."
+                      }
+                    },
+                    {
+                      "response": {
+                        "candidates": [
+                          {
+                            "content": {
+                              "parts": [
+                                {
+                                  "inlineData": {
+                                    "mimeType": "image/jpeg",
+                                    "data": "aW1hZ2UyYmFzZTY0ZGF0YQ=="
+                                  }
+                                }
+                              ],
+                              "role": "model"
+                            },
+                            "finishReason": "STOP",
+                            "index": 0
+                          }
+                        ],
+                        "usageMetadata": {
+                          "promptTokenCount": 12,
+                          "candidatesTokenCount": 300,
+                          "totalTokenCount": 312
+                        },
+                        "modelVersion": "gemini-2.5-flash-preview-image-generation"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+            """;
+
+            var mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .body(IMAGE_ERROR_RESPONSE)
+                    .build());
+            var subject = GoogleAiGeminiBatchImageModel.builder()
+                    .apiKey(API_KEY)
+                    .modelName("gemini-2.5-flash-preview-image-generation")
+                    .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                    .build();
+
+            var batchName = new BatchName("batches/image-test-123");
+
+            // when
+            var result = subject.retrieveBatchResults(batchName);
+
+            // then
+            assertThat(result).isInstanceOf(BatchSuccess.class);
+            var success = (BatchSuccess<Response<Image>>) result;
+            assertThat(success.batchName().value()).isEqualTo("batches/image-test-123");
+
+            var results = success.responses();
+            assertThat(results).hasSize(2);
+
+            assertThat(results.get(0).content().base64Data()).isEqualTo("aW1hZ2UxYmFzZTY0ZGF0YQ==");
+            assertThat(results.get(0).content().mimeType()).isEqualTo("image/png");
+
+            assertThat(results.get(1).content().base64Data()).isEqualTo("aW1hZ2UyYmFzZTY0ZGF0YQ==");
+            assertThat(results.get(1).content().mimeType()).isEqualTo("image/jpeg");
+
+            assertThat(success.errors()).hasSize(1);
+            assertThat(success.errors().get(0).code()).isEqualTo(4);
+            assertThat(success.errors().get(0).message())
+                    .isEqualTo("Deadline expired before operation could complete.");
         }
     }
 
@@ -675,8 +984,6 @@ class GoogleAiGeminiBatchImageModelTest {
         }
     }
 
-    // Helper methods
-
     private GoogleAiGeminiBatchImageModel createSubject() {
         return new GoogleAiGeminiBatchImageModel(
                 GoogleAiGeminiBatchImageModel.builder().apiKey(API_KEY).modelName(MODEL_NAME), mockGeminiService);
@@ -700,8 +1007,34 @@ class GoogleAiGeminiBatchImageModelTest {
     private static Operation<GeminiGenerateContentResponse> createSuccessOperation(
             String operationName, List<GeminiGenerateContentResponse> imageResponses) {
         var inlinedResponses = imageResponses.stream()
-                .map(BatchCreateResponse.InlinedResponseWrapper::new)
+                .map(response -> new InlinedResponseWrapper<>(response, null))
                 .toList();
+
+        var response = new BatchCreateResponse<>(
+                "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatchOutput",
+                new BatchCreateResponse.InlinedResponses<>(inlinedResponses));
+
+        return new Operation<>(operationName, Map.of("state", BATCH_STATE_SUCCEEDED.name()), true, null, response);
+    }
+
+    private static Operation<GeminiGenerateContentResponse> createSuccessOperationWithError(
+            String operationName,
+            List<GeminiGenerateContentResponse> imageResponses,
+            BatchRequestResponse.Operation.Status error) {
+        List<InlinedResponseWrapper<GeminiGenerateContentResponse>> inlinedResponses = new ArrayList<>();
+
+        // Add first successful response
+        if (!imageResponses.isEmpty()) {
+            inlinedResponses.add(new InlinedResponseWrapper<>(imageResponses.get(0), null));
+        }
+
+        // Add error
+        inlinedResponses.add(new InlinedResponseWrapper<>(null, error));
+
+        // Add remaining successful responses
+        for (int i = 1; i < imageResponses.size(); i++) {
+            inlinedResponses.add(new InlinedResponseWrapper<>(imageResponses.get(i), null));
+        }
 
         var response = new BatchCreateResponse<>(
                 "type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatchOutput",


### PR DESCRIPTION
## Issue
Closes #4423

## Change
This adds an `errors` field to the `BatchSuccess` record where erroneous responses are stored. I personally would've preferred to do this in the same manner as done in the Anthropic PR: Wrapping responses in `IndividualResponse<ChatResponse>` which can then be Success or Error using sealed interfaces. I opted to do it like this to not break existing implementations (even though it's marked `@Experimental`). 

Let me know what you prefer for the API to be, I'll make sure to change the Anthropic Batch PR as well to follow the same design as is decided here.

Current:
```java
if (result instanceof BatchSuccess<ChatResponse> success) {
    System.out.println("Batch completed!");
    System.out.println("Successful: " + success.responses().size());
    System.out.println("Failed: " + success.errors().size());

    // Process successful responses
    int index = 0;
    for (ChatResponse response : success.responses()) {
        System.out.println("Response " + index++ + ": " + response.aiMessage().text());
    }

    // Process errors
    for (var error : success.errors()) {
        System.err.println("Error [code=" + error.code() + "]: " + error.message());
    }
}
```


Alternative:
```java
if (result instanceof BatchSuccess<ChatResponse> success) {
    System.out.println("Batch completed with " + success.results().size() + " results");

    for (IndividualResult<ChatResponse> individualResult : success.results()) {
        switch (individualResult) {
            case IndividualResultSuccess<ChatResponse> s -> 
                System.out.println("Success: " + s.response().aiMessage().text());
            case IndividualResultError<ChatResponse> e -> 
                System.err.println("Error [code=" + e.code() + "]: " + e.message());
        }
    }
}
```


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core]