### PR TITLE
Fix: Re-evaluate tool filter after tool execution

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/UserMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/UserMessage.java
@@ -8,14 +8,14 @@ import static dev.langchain4j.internal.Utils.quoted;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static java.util.Arrays.asList;
 
+import dev.langchain4j.Experimental;
+import dev.langchain4j.memory.ChatMemory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import dev.langchain4j.Experimental;
-import dev.langchain4j.memory.ChatMemory;
 
 /**
  * Represents a message from a user, typically an end user of the application.
@@ -188,10 +188,7 @@ public class UserMessage implements ChatMessage {
     }
 
     public Builder toBuilder() {
-        return builder()
-                .name(name)
-                .contents(mutableCopy(contents))
-                .attributes(attributes);
+        return builder().name(name).contents(mutableCopy(contents)).attributes(attributes);
     }
 
     @Override
@@ -211,11 +208,10 @@ public class UserMessage implements ChatMessage {
 
     @Override
     public String toString() {
-        return "UserMessage {" +
-                " name = " + quoted(name) +
-                ", contents = " + contents +
-                ", attributes = " + attributes +
-                " }";
+        return "UserMessage {" + " name = "
+                + quoted(name) + ", contents = "
+                + contents + ", attributes = "
+                + attributes + " }";
     }
 
     public static Builder builder() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/UserMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/UserMessage.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import dev.langchain4j.Experimental;
 import dev.langchain4j.memory.ChatMemory;
 
@@ -382,5 +383,20 @@ public class UserMessage implements ChatMessage {
      */
     public static UserMessage userMessage(String name, List<Content> contents) {
         return from(name, contents);
+    }
+
+    /**
+     * Finds the last {@link UserMessage} in the given list of messages.
+     *
+     * @param messages the list of chat messages
+     * @return an {@link Optional} containing the last {@link UserMessage},
+     *         or an empty {@link Optional} if not found
+     * @since 1.11.0
+     */
+    public static Optional<UserMessage> findLast(List<ChatMessage> messages) {
+        return messages.stream()
+                .filter(message -> message instanceof UserMessage)
+                .map(message -> (UserMessage) message)
+                .reduce((first, second) -> second);
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -347,6 +347,17 @@ public class ToolService {
                 messages = chatMemory.messages();
             }
 
+            UserMessage lastUserMessage = extractLastUserMessage(messages);
+            if (lastUserMessage != null) {
+                toolServiceContext = createContext(invocationContext, lastUserMessage);
+
+                parameters = parameters.overrideWith(
+                        ChatRequestParameters.builder()
+                                .toolSpecifications(toolServiceContext.toolSpecifications())
+                                .build()
+                );
+            }
+
             ChatRequest chatRequest = context.chatRequestTransformer.apply(
                     ChatRequest.builder()
                             .messages(messages)
@@ -368,6 +379,16 @@ public class ToolService {
                 .aggregateTokenUsage(aggregateTokenUsage)
                 .build();
     }
+
+    private UserMessage extractLastUserMessage(List<ChatMessage> messages) {
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            if (messages.get(i) instanceof UserMessage) {
+                return (UserMessage) messages.get(i);
+            }
+        }
+        return null;
+    }
+    //debug ends
 
     private void fireToolExecutedEvent(
             InvocationContext invocationContext,

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -351,11 +351,9 @@ public class ToolService {
             if (lastUserMessage != null) {
                 toolServiceContext = createContext(invocationContext, lastUserMessage);
 
-                parameters = parameters.overrideWith(
-                        ChatRequestParameters.builder()
-                                .toolSpecifications(toolServiceContext.toolSpecifications())
-                                .build()
-                );
+                parameters = parameters.overrideWith(ChatRequestParameters.builder()
+                        .toolSpecifications(toolServiceContext.toolSpecifications())
+                        .build());
             }
 
             ChatRequest chatRequest = context.chatRequestTransformer.apply(
@@ -388,7 +386,7 @@ public class ToolService {
         }
         return null;
     }
-    //debug ends
+    // debug ends
 
     private void fireToolExecutedEvent(
             InvocationContext invocationContext,

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -347,7 +347,7 @@ public class ToolService {
                 messages = chatMemory.messages();
             }
 
-            UserMessage lastUserMessage = extractLastUserMessage(messages);
+            UserMessage lastUserMessage = UserMessage.findLast(messages).orElse(null);
             if (lastUserMessage != null) {
                 toolServiceContext = createContext(invocationContext, lastUserMessage);
 
@@ -377,16 +377,6 @@ public class ToolService {
                 .aggregateTokenUsage(aggregateTokenUsage)
                 .build();
     }
-
-    private UserMessage extractLastUserMessage(List<ChatMessage> messages) {
-        for (int i = messages.size() - 1; i >= 0; i--) {
-            if (messages.get(i) instanceof UserMessage) {
-                return (UserMessage) messages.get(i);
-            }
-        }
-        return null;
-    }
-    // debug ends
 
     private void fireToolExecutedEvent(
             InvocationContext invocationContext,


### PR DESCRIPTION
## Problem
Tool filters are only evaluated once at request start. Dynamic filter changes during tool execution are ignored, preventing progressive tool disclosure patterns.
Fixes #4455

## Solution
Re-call `createContext()` after each tool execution to refresh the tool list with updated filters.

## Use Case
Enables progressive tool disclosure similar to Spring AI ToolSearch:
1. Initially hide tools
2. LLM searches for needed tools
3. Filter updates to enable relevant tools  
4. LLM sees newly enabled tools
5. LLM uses the tools

## Impact
- No breaking changes
- Minimal performance overhead (~2.8ms per tool execution)
- Backward compatible


