### PR TITLE
Fix FileSystemDocumentLoaderExtensions.loadDocuments() to skip failed…

### DIFF
--- a/langchain4j-kotlin/src/main/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensions.kt
+++ b/langchain4j-kotlin/src/main/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensions.kt
@@ -67,12 +67,18 @@ public suspend fun loadDocuments(
         matchedFiles
             .map { file ->
                 async(context) {
-                    documentParser.parseAsync(
-                        FileSystemSource(file),
-                        context
-                    )
+                    try {
+                        documentParser.parseAsync(
+                            FileSystemSource(file),
+                            context
+                        )
+                    } catch (e: Exception) {
+                        logger.warn("Failed to load '{}': {}", file, e.message)
+                        null
+                    }
                 }
             }.awaitAll()
+            .filterNotNull()
             .map { document ->
                 val metadata = document.metadata()
                 logger.info(

--- a/langchain4j-kotlin/src/test/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensionsTest.kt
+++ b/langchain4j-kotlin/src/test/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensionsTest.kt
@@ -1,0 +1,99 @@
+package dev.langchain4j.kotlin.data.document.loader
+
+import dev.langchain4j.data.document.Document
+import dev.langchain4j.data.document.parser.TextDocumentParser
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal class FileSystemDocumentLoaderExtensionsTest {
+
+    private val parser: TextDocumentParser = TextDocumentParser()
+
+    @Test
+    internal fun `should skip failed documents and continue processing`(@TempDir tempDir: Path): Unit = runTest {
+        // Create test files
+        val validFile1 = tempDir.resolve("valid1.txt")
+        val validFile2 = tempDir.resolve("valid2.txt")
+
+        // Write content to valid files
+        Files.writeString(validFile1, "This is valid content 1")
+        Files.writeString(validFile2, "This is valid content 2")
+
+        // Load documents - this should not throw an exception
+        val documents: List<Document> = loadDocuments(
+            directoryPaths = listOf(tempDir),
+            documentParser = parser,
+            recursive = false
+        )
+
+        // Should have loaded some documents (at least the valid ones)
+        documents shouldHaveSize 2
+
+        // Verify that we got the expected content
+        val texts = documents.map { it.text() }.toSet()
+        texts shouldBe setOf("This is valid content 1", "This is valid content 2")
+    }
+
+    @Test
+    internal fun `should skip documents that cause parsing exceptions`(@TempDir tempDir: Path): Unit = runTest {
+        // Create test files
+        val validFile = tempDir.resolve("valid.txt")
+        val problematicFile = tempDir.resolve("problematic.txt")
+
+        // Write valid content
+        Files.writeString(validFile, "This is valid content")
+
+        // Create a file that will cause parsing issues by writing null bytes
+        Files.write(problematicFile, byteArrayOf(0, 0, 0, 0))
+
+        // Load documents - this should not throw an exception even though one file fails
+        val documents: List<Document> = loadDocuments(
+            directoryPaths = listOf(tempDir),
+            documentParser = parser,
+            recursive = false
+        )
+
+        // Should have loaded only the valid document
+        documents shouldHaveSize 1
+        documents.first().text() shouldBe "This is valid content"
+    }
+
+    @Test
+    internal fun `should handle empty directory gracefully`(@TempDir tempDir: Path): Unit = runTest {
+        val documents: List<Document> = loadDocuments(
+            directoryPaths = listOf(tempDir),
+            documentParser = parser,
+            recursive = false
+        )
+
+        documents shouldHaveSize 0
+    }
+
+    @Test
+    internal fun `should process multiple directories with some failures`(@TempDir tempDir: Path): Unit = runTest {
+        val subDir1 = tempDir.resolve("subdir1")
+        val subDir2 = tempDir.resolve("subdir2")
+        Files.createDirectories(subDir1)
+        Files.createDirectories(subDir2)
+
+        // Create valid files in both directories
+        Files.writeString(subDir1.resolve("file1.txt"), "Content from file 1")
+        Files.writeString(subDir2.resolve("file2.txt"), "Content from file 2")
+
+        val documents: List<Document> = loadDocuments(
+            directoryPaths = listOf(subDir1, subDir2),
+            documentParser = parser,
+            recursive = false
+        )
+
+        documents shouldHaveSize 2
+        val texts = documents.map { it.text() }.toSet()
+        texts shouldBe setOf("Content from file 1", "Content from file 2")
+    }
+}
+


### PR DESCRIPTION

## Issue
Closes #4347 

## Change
- This fixes issue #4347 where the Kotlin extension function loadDocuments() would fail completely if any document failed to parse, instead of skipping the failed documents and continuing with the rest. Changes: 
- Added exception handling in the async document processing to catch parsing failures 
- Failed documents now return null and are filtered out with filterNotNull() 
- Added warning log messages for failed documents 
- Added comprehensive test cases to verify the fix works correctly.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
