### PR TITLE
Injecting context into header providers & support for MCP listeners

### DIFF
--- a/docs/docs/tutorials/mcp.md
+++ b/docs/docs/tutorials/mcp.md
@@ -265,6 +265,18 @@ McpClient mcpClient = new DefaultMcpClient.Builder()
     .build();
 ```
 
+## MCP listeners
+
+The MCP client supports listeners that can listen to events happening
+during the lifetime of the client. The interface
+`dev.langchain4j.mcp.client.McpClientListener` serves as the base
+for listener implementations. The listener will
+be invoked before and after every tool call, prompt rendering
+and resource access. The respective `McpCallContext` is injected when calling
+the listeners. This object contains the actual MCP message being sent to the
+server and an instance of `InvocationContext` when applicable (only when this
+call happens as part of an AI service invocation).
+
 ## Resources
 
 There are two ways how to work with resources. Either the application can call the MCP client's

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/mock/ChatModelMock.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/mock/ChatModelMock.java
@@ -118,6 +118,10 @@ public class ChatModelMock implements ChatModel {
         return new ChatModelMock(ignored -> queue.poll());
     }
 
+    public static ChatModelMock thatResponds(Function<ChatRequest, AiMessage> aiMessageGenerator) {
+        return new ChatModelMock(aiMessageGenerator);
+    }
+
     public static ChatModelMock thatAlwaysThrowsException() {
         return thatAlwaysThrowsExceptionWithMessage("Something went wrong, but this is an expected exception");
     }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolExecutor.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolExecutor.java
@@ -31,19 +31,22 @@ public class McpToolExecutor implements ToolExecutor {
 
     @Override
     public String execute(ToolExecutionRequest executionRequest, Object memoryId) {
-        return mcpClient.executeTool(sanitizeToolName(executionRequest)).resultText();
+        InvocationContext invocationContext =
+                InvocationContext.builder().chatMemoryId(memoryId).build();
+        return mcpClient
+                .executeTool(sanitizeToolName(executionRequest), invocationContext)
+                .resultText();
     }
 
     @Override
-    public ToolExecutionResult executeWithContext(ToolExecutionRequest executionRequest, InvocationContext context) {
-        return mcpClient.executeTool(sanitizeToolName(executionRequest));
+    public ToolExecutionResult executeWithContext(
+            ToolExecutionRequest executionRequest, InvocationContext invocationContext) {
+        return mcpClient.executeTool(sanitizeToolName(executionRequest), invocationContext);
     }
 
     private ToolExecutionRequest sanitizeToolName(ToolExecutionRequest executionRequest) {
         if (fixedToolName.isPresent()) {
-            return executionRequest.toBuilder()
-                    .name(fixedToolName.get())
-                    .build();
+            return executionRequest.toBuilder().name(fixedToolName.get()).build();
         } else {
             return executionRequest;
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpCallContext.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpCallContext.java
@@ -1,0 +1,13 @@
+package dev.langchain4j.mcp.client;
+
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.mcp.protocol.McpClientMessage;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Context information for any invocation made towards an MCP server.
+ *
+ * It contains the AI service invocation context when this is during
+ * an AI service invocation (in other cases, the invocation context is null).
+ */
+public record McpCallContext(@Nullable InvocationContext invocationContext, McpClientMessage message) {}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClient.java
@@ -2,6 +2,7 @@ package dev.langchain4j.mcp.client;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import java.util.List;
 import java.util.Map;
@@ -23,10 +24,21 @@ public interface McpClient extends AutoCloseable {
     List<ToolSpecification> listTools();
 
     /**
+     * Obtains a list of tools from the MCP server.
+     */
+    List<ToolSpecification> listTools(InvocationContext invocationContext);
+
+    /**
      * Executes a tool on the MCP server and returns the result.
      * Currently, this expects a tool execution to only contain text-based results or JSON structured content.
      */
     ToolExecutionResult executeTool(ToolExecutionRequest executionRequest);
+
+    /**
+     * Executes a tool on the MCP server and returns the result.
+     * Currently, this expects a tool execution to only contain text-based results or JSON structured content.
+     */
+    ToolExecutionResult executeTool(ToolExecutionRequest executionRequest, InvocationContext invocationContext);
 
     /**
      * Obtains the current list of resources available on the MCP server.
@@ -34,15 +46,31 @@ public interface McpClient extends AutoCloseable {
     List<McpResource> listResources();
 
     /**
+     * Obtains the current list of resources available on the MCP server.
+     */
+    List<McpResource> listResources(InvocationContext invocationContext);
+
+    /**
      * Obtains the current list of resource templates (dynamic resources) available on the MCP server.
      */
     List<McpResourceTemplate> listResourceTemplates();
+
+    /**
+     * Obtains the current list of resource templates (dynamic resources) available on the MCP server.
+     */
+    List<McpResourceTemplate> listResourceTemplates(InvocationContext invocationContext);
 
     /**
      * Retrieves the contents of the resource with the specified URI. This also
      * works for dynamic resources (templates).
      */
     McpReadResourceResult readResource(String uri);
+
+    /**
+     * Retrieves the contents of the resource with the specified URI. This also
+     * works for dynamic resources (templates).
+     */
+    McpReadResourceResult readResource(String uri, InvocationContext invocationContext);
 
     /**
      * Obtain a list of prompts available on the MCP server.

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClientListener.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClientListener.java
@@ -1,0 +1,26 @@
+package dev.langchain4j.mcp.client;
+
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.util.Map;
+
+public interface McpClientListener {
+
+    default void beforeExecuteTool(McpCallContext context) {}
+
+    default void afterExecuteTool(McpCallContext context, ToolExecutionResult result, Map<String, Object> rawResult) {}
+
+    default void onExecuteToolError(McpCallContext context, Throwable error) {}
+
+    default void beforeResourceGet(McpCallContext context) {}
+
+    default void afterResourceGet(
+            McpCallContext context, McpReadResourceResult result, Map<String, Object> rawResult) {}
+
+    default void onResourceGetError(McpCallContext context, Throwable error) {}
+
+    default void beforePromptGet(McpCallContext context) {}
+
+    default void afterPromptGet(McpCallContext context, McpGetPromptResult result, Map<String, Object> rawResult) {}
+
+    default void onPromptGetError(McpCallContext context, Throwable error) {}
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpHeadersSupplier.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpHeadersSupplier.java
@@ -1,0 +1,10 @@
+package dev.langchain4j.mcp.client;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * A functional interface that supplies HTTP headers for MCP client requests
+ * based on the given {@link McpCallContext}.
+ */
+public interface McpHeadersSupplier extends Function<McpCallContext, Map<String, String>> {}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpHeadersSupplier.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpHeadersSupplier.java
@@ -7,4 +7,5 @@ import java.util.function.Function;
  * A functional interface that supplies HTTP headers for MCP client requests
  * based on the given {@link McpCallContext}.
  */
+@FunctionalInterface
 public interface McpHeadersSupplier extends Function<McpCallContext, Map<String, String>> {}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolExecutionHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolExecutionHelper.java
@@ -60,7 +60,7 @@ class ToolExecutionHelper {
     /**
      * Converts any JsonNode into a recursive Map using basic Java types
      */
-    private static Object toObject(JsonNode content) {
+    static Object toObject(JsonNode content) {
         return switch (content.getNodeType()) {
             case BOOLEAN -> content.asBoolean();
             case NUMBER ->

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
@@ -1,8 +1,10 @@
 package dev.langchain4j.mcp.client.transport;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.mcp.client.McpCallContext;
+import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializeRequest;
-import dev.langchain4j.mcp.protocol.McpJsonRpcMessage;
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
@@ -25,13 +27,24 @@ public interface McpTransport extends Closeable {
     /**
      * Executes an operation that expects a response from the server.
      */
-    CompletableFuture<JsonNode> executeOperationWithResponse(McpJsonRpcMessage request);
+    CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage request);
+
+    /**
+     * Executes an operation that expects a response from the server.
+     */
+    CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context);
 
     /**
      * Sends a message that does not expect a response from the server - either a
      * client-initiated notification or a response to a server-initiated request.
      */
-    void executeOperationWithoutResponse(McpJsonRpcMessage request);
+    void executeOperationWithoutResponse(McpClientMessage request);
+
+    /**
+     * Sends a message that does not expect a response from the server - either a
+     * client-initiated notification or a response to a server-initiated request.
+     */
+    void executeOperationWithoutResponse(McpCallContext context);
 
     /**
      * Performs transport-specific health checks, if applicable. This is called

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpTransport.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.mcp.client.transport;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializeRequest;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
@@ -6,11 +6,14 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.mcp.client.McpCallContext;
+import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
 import dev.langchain4j.mcp.protocol.McpInitializeRequest;
-import dev.langchain4j.mcp.protocol.McpJsonRpcMessage;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
@@ -39,7 +42,7 @@ public class HttpMcpTransport implements McpTransport {
 
     private static final Logger log = LoggerFactory.getLogger(HttpMcpTransport.class);
     private final String sseUrl;
-    private final Supplier<Map<String, String>> customHeadersSupplier;
+    private final McpHeadersSupplier customHeadersSupplier;
     private final OkHttpClient client;
     private final boolean logResponses;
     private final boolean logRequests;
@@ -66,7 +69,7 @@ public class HttpMcpTransport implements McpTransport {
         }
         this.logResponses = builder.logResponses;
         sseUrl = ensureNotNull(builder.sseUrl, "Missing SSE endpoint URL");
-        customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, () -> Map::of);
+        customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, (i) -> Map.of());
         client = httpClientBuilder.build();
     }
 
@@ -81,8 +84,8 @@ public class HttpMcpTransport implements McpTransport {
         Request httpRequest = null;
         Request initializationNotification = null;
         try {
-            httpRequest = createRequest(operation);
-            initializationNotification = createRequest(new McpInitializationNotification());
+            httpRequest = createRequest(new McpCallContext(null, operation));
+            initializationNotification = createRequest(new McpCallContext(null, new McpInitializationNotification()));
         } catch (JsonProcessingException e) {
             return CompletableFuture.failedFuture(e);
         }
@@ -93,19 +96,29 @@ public class HttpMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpJsonRpcMessage operation) {
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
+        return executeOperationWithResponse(new McpCallContext(null, operation));
+    }
+
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
         try {
-            Request httpRequest = createRequest(operation);
-            return execute(httpRequest, operation.getId());
+            Request httpRequest = createRequest(context);
+            return execute(httpRequest, context.message().getId());
         } catch (JsonProcessingException e) {
             return CompletableFuture.failedFuture(e);
         }
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpJsonRpcMessage operation) {
+    public void executeOperationWithoutResponse(McpClientMessage operation) {
+        executeOperationWithoutResponse(new McpCallContext(null, operation));
+    }
+
+    @Override
+    public void executeOperationWithoutResponse(McpCallContext context) {
         try {
-            Request httpRequest = createRequest(operation);
+            Request httpRequest = createRequest(context);
             execute(httpRequest, null);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
@@ -155,8 +168,10 @@ public class HttpMcpTransport implements McpTransport {
     }
 
     private EventSource startSseChannel(boolean logResponses) {
-        Request request =
-                new Request.Builder().url(sseUrl).headers(buildCommonHeaders()).build();
+        Request request = new Request.Builder()
+                .url(sseUrl)
+                .headers(buildCommonHeaders(null))
+                .build();
         CompletableFuture<String> initializationFinished = new CompletableFuture<>();
         SseEventListener listener =
                 new SseEventListener(messageHandler, logResponses, initializationFinished, onFailure);
@@ -182,18 +197,18 @@ public class HttpMcpTransport implements McpTransport {
         }
     }
 
-    private Headers buildCommonHeaders() {
+    private Headers buildCommonHeaders(McpCallContext callContext) {
         Headers.Builder headerBuilder = new Headers.Builder();
-        Map<String, String> headers = customHeadersSupplier.get();
+        Map<String, String> headers = customHeadersSupplier.apply(callContext);
         if (headers != null) {
             headers.forEach(headerBuilder::add);
         }
         return headerBuilder.build();
     }
 
-    private Request createRequest(McpJsonRpcMessage message) throws JsonProcessingException {
+    private Request createRequest(McpCallContext callContext) throws JsonProcessingException {
         Headers.Builder headerBuilder = new Headers.Builder().add(CONTENT_TYPE, CONTENT_TYPE_JSON);
-        Map<String, String> headers = customHeadersSupplier.get();
+        Map<String, String> headers = customHeadersSupplier.apply(callContext);
         if (headers != null) {
             headers.forEach(headerBuilder::add);
         }
@@ -201,7 +216,7 @@ public class HttpMcpTransport implements McpTransport {
         return new Request.Builder()
                 .url(postUrl)
                 .headers(headerBuilder.build())
-                .post(RequestBody.create(OBJECT_MAPPER.writeValueAsBytes(message)))
+                .post(RequestBody.create(OBJECT_MAPPER.writeValueAsBytes(callContext.message())))
                 .build();
     }
 
@@ -222,7 +237,7 @@ public class HttpMcpTransport implements McpTransport {
     public static class Builder {
 
         private String sseUrl;
-        private Supplier<Map<String, String>> customHeadersSupplier;
+        private McpHeadersSupplier customHeadersSupplier;
         private Duration timeout;
         private boolean logRequests = false;
         private boolean logResponses = false;
@@ -238,12 +253,17 @@ public class HttpMcpTransport implements McpTransport {
         }
 
         public Builder customHeaders(Map<String, String> customHeaders) {
-            this.customHeadersSupplier = () -> customHeaders;
+            this.customHeadersSupplier = (i) -> customHeaders;
             return this;
         }
 
         public Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
-            this.customHeadersSupplier = customHeadersSupplier;
+            this.customHeadersSupplier = (i) -> customHeadersSupplier.get();
+            return this;
+        }
+
+        public Builder customHeaders(McpHeadersSupplier customMcpHeadersSupplier) {
+            this.customHeadersSupplier = customMcpHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
@@ -6,7 +6,6 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -6,7 +6,6 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
@@ -83,7 +82,8 @@ public class StreamableHttpMcpTransport implements McpTransport {
                     initializeInProgress.set(null);
                     return CompletableFuture.completedFuture(originalResponse);
                 })
-                .thenCompose(originalResponse -> execute(new McpCallContext(null, new McpInitializationNotification()), false)
+                .thenCompose(originalResponse -> execute(
+                                new McpCallContext(null, new McpInitializationNotification()), false)
                         .thenCompose(nullNode -> CompletableFuture.completedFuture(originalResponse)));
     }
 
@@ -150,7 +150,8 @@ public class StreamableHttpMcpTransport implements McpTransport {
         }
         HttpRequest request = null;
         try {
-            request = createRequest(context.message(), new McpCallContext(context.invocationContext(), context.message()));
+            request = createRequest(
+                    context.message(), new McpCallContext(context.invocationContext(), context.message()));
         } catch (JsonProcessingException e) {
             return CompletableFuture.failedFuture(e);
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -6,8 +6,12 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.mcp.client.McpCallContext;
+import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
 import dev.langchain4j.mcp.protocol.McpInitializeRequest;
 import dev.langchain4j.mcp.protocol.McpJsonRpcMessage;
@@ -34,7 +38,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
     private static final Logger DEFAULT_TRAFFIC_LOG = LoggerFactory.getLogger("MCP");
     private static final Logger LOG = LoggerFactory.getLogger(StreamableHttpMcpTransport.class);
     private final String url;
-    private final Supplier<Map<String, String>> customHeadersSupplier;
+    private final McpHeadersSupplier customHeadersSupplier;
     private final boolean logResponses;
     private final boolean logRequests;
     private final Logger trafficLog;
@@ -52,7 +56,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
         logResponses = builder.logResponses;
         trafficLog = getOrDefault(builder.logger, DEFAULT_TRAFFIC_LOG);
         Duration timeout = getOrDefault(builder.timeout, Duration.ofSeconds(60));
-        customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, () -> Map::of);
+        customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, (i) -> Map.of());
         sslContext = builder.sslContext;
         HttpClient.Builder clientBuilder = HttpClient.newBuilder().connectTimeout(timeout);
         if (builder.executor != null) {
@@ -72,18 +76,19 @@ public class StreamableHttpMcpTransport implements McpTransport {
     @Override
     public CompletableFuture<JsonNode> initialize(McpInitializeRequest operation) {
         this.initializeRequest = operation;
-        CompletableFuture<JsonNode> completableFuture = execute(operation, operation.getId());
+        CompletableFuture<JsonNode> completableFuture = execute(new McpCallContext(null, operation), false);
         initializeInProgress.set(completableFuture);
         return completableFuture
                 .thenCompose(originalResponse -> {
                     initializeInProgress.set(null);
                     return CompletableFuture.completedFuture(originalResponse);
                 })
-                .thenCompose(originalResponse -> execute(new McpInitializationNotification(), null)
+                .thenCompose(originalResponse -> execute(new McpCallContext(null, new McpInitializationNotification()), false)
                         .thenCompose(nullNode -> CompletableFuture.completedFuture(originalResponse)));
     }
 
-    private HttpRequest createRequest(McpJsonRpcMessage message) throws JsonProcessingException {
+    private HttpRequest createRequest(McpJsonRpcMessage message, McpCallContext callContext)
+            throws JsonProcessingException {
         String body = OBJECT_MAPPER.writeValueAsString(message);
         HttpRequest.BodyPublisher bodyPublisher = HttpRequest.BodyPublishers.ofString(body);
         if (logRequests) {
@@ -94,7 +99,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
         if (sessionId != null && !(message instanceof McpInitializeRequest)) {
             builder.header("Mcp-Session-Id", sessionId);
         }
-        Map<String, String> headers = customHeadersSupplier.get();
+        Map<String, String> headers = customHeadersSupplier.apply(callContext);
         if (headers != null) {
             headers.forEach(builder::header);
         }
@@ -106,13 +111,23 @@ public class StreamableHttpMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpJsonRpcMessage operation) {
-        return execute(operation, operation.getId());
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
+        return executeOperationWithResponse(new McpCallContext(null, operation));
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpJsonRpcMessage operation) {
-        execute(operation, null);
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+        return execute(context, false);
+    }
+
+    @Override
+    public void executeOperationWithoutResponse(McpClientMessage operation) {
+        executeOperationWithoutResponse(new McpCallContext(null, operation));
+    }
+
+    @Override
+    public void executeOperationWithoutResponse(McpCallContext context) {
+        execute(context, false);
     }
 
     @Override
@@ -125,12 +140,9 @@ public class StreamableHttpMcpTransport implements McpTransport {
         // nothing to do here, we don't maintain a long-running SSE channel (yet)
     }
 
-    private CompletableFuture<JsonNode> execute(McpJsonRpcMessage message, Long id) {
-        return execute(message, id, false);
-    }
-
-    private CompletableFuture<JsonNode> execute(McpJsonRpcMessage message, Long id, boolean isRetry) {
-        if (!(message instanceof McpInitializeRequest)) {
+    private CompletableFuture<JsonNode> execute(McpCallContext context, boolean isRetry) {
+        Long id = context.message().getId();
+        if (!(context.message() instanceof McpInitializeRequest)) {
             CompletableFuture<JsonNode> reinitializeInProgress = this.initializeInProgress.get();
             if (reinitializeInProgress != null) {
                 reinitializeInProgress.join();
@@ -138,7 +150,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
         }
         HttpRequest request = null;
         try {
-            request = createRequest(message);
+            request = createRequest(context.message(), new McpCallContext(context.invocationContext(), context.message()));
         } catch (JsonProcessingException e) {
             return CompletableFuture.failedFuture(e);
         }
@@ -150,11 +162,11 @@ public class StreamableHttpMcpTransport implements McpTransport {
         httpClient
                 .sendAsync(request, responseInfo -> {
                     if (!isExpectedStatusCode(responseInfo.statusCode())) {
-                        if (!(message instanceof McpInitializeRequest) && responseInfo.statusCode() == 404) {
+                        if (!(context.message() instanceof McpInitializeRequest) && responseInfo.statusCode() == 404) {
                             if (!isRetry) {
                                 initialize(StreamableHttpMcpTransport.this.initializeRequest)
                                         .thenAccept(node -> {
-                                            execute(message, id, true)
+                                            execute(context, true)
                                                     .thenAccept(future::complete)
                                                     .exceptionally(t -> {
                                                         future.completeExceptionally(t);
@@ -235,7 +247,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
 
         private Executor executor;
         private String url;
-        private Supplier<Map<String, String>> customHeadersSupplier;
+        private McpHeadersSupplier customHeadersSupplier;
         private Duration timeout;
         private boolean logRequests = false;
         private boolean logResponses = false;
@@ -254,7 +266,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
          * The request headers of the MCP server.
          */
         public StreamableHttpMcpTransport.Builder customHeaders(Map<String, String> customHeaders) {
-            this.customHeadersSupplier = () -> customHeaders;
+            this.customHeadersSupplier = (i) -> customHeaders;
             return this;
         }
 
@@ -263,6 +275,15 @@ public class StreamableHttpMcpTransport implements McpTransport {
          * The supplier is called for each request, allowing headers to be updated dynamically.
          */
         public StreamableHttpMcpTransport.Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = i -> customHeadersSupplier.get();
+            return this;
+        }
+
+        /**
+         * A supplier for dynamic request headers of the MCP server.
+         * The supplier is called for each request, allowing headers to be updated dynamically.
+         */
+        public StreamableHttpMcpTransport.Builder customHeaders(McpHeadersSupplier customHeadersSupplier) {
             this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
@@ -5,11 +5,12 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
 import dev.langchain4j.mcp.protocol.McpInitializeRequest;
-import dev.langchain4j.mcp.protocol.McpJsonRpcMessage;
 import dev.langchain4j.mcp.transport.stdio.JsonRpcIoHandler;
 import java.io.IOException;
 import java.util.List;
@@ -75,19 +76,29 @@ public class StdioMcpTransport implements McpTransport {
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpJsonRpcMessage operation) {
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage operation) {
+        return executeOperationWithResponse(new McpCallContext(null, operation));
+    }
+
+    @Override
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
         try {
-            String requestString = OBJECT_MAPPER.writeValueAsString(operation);
-            return execute(requestString, operation.getId());
+            String requestString = OBJECT_MAPPER.writeValueAsString(context.message());
+            return execute(requestString, context.message().getId());
         } catch (JsonProcessingException e) {
             return CompletableFuture.failedFuture(e);
         }
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpJsonRpcMessage operation) {
+    public void executeOperationWithoutResponse(McpClientMessage operation) {
+        executeOperationWithoutResponse(new McpCallContext(null, operation));
+    }
+
+    @Override
+    public void executeOperationWithoutResponse(McpCallContext context) {
         try {
-            String requestString = OBJECT_MAPPER.writeValueAsString(operation);
+            String requestString = OBJECT_MAPPER.writeValueAsString(context.message());
             execute(requestString, null);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
@@ -5,11 +5,14 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.mcp.client.McpCallContext;
+import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.protocol.McpClientMessage;
 import dev.langchain4j.mcp.protocol.McpInitializationNotification;
 import dev.langchain4j.mcp.protocol.McpInitializeRequest;
-import dev.langchain4j.mcp.protocol.McpJsonRpcMessage;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.ConnectException;
@@ -33,7 +36,7 @@ public class WebSocketMcpTransport implements McpTransport {
     private static final Logger DEFAULT_TRAFFIC_LOG = LoggerFactory.getLogger("MCP");
     private static final Logger LOG = LoggerFactory.getLogger(WebSocketMcpTransport.class);
     private final String url;
-    private final Supplier<Map<String, String>> headersSupplier;
+    private final McpHeadersSupplier headersSupplier;
     private final boolean logResponses;
     private final boolean logRequests;
     private final Logger trafficLog;
@@ -54,7 +57,7 @@ public class WebSocketMcpTransport implements McpTransport {
         this.logRequests = builder.logRequests;
         this.trafficLog = getOrDefault(builder.logger, DEFAULT_TRAFFIC_LOG);
         this.connectTimeout = getOrDefault(builder.timeout, Duration.ofSeconds(60));
-        this.headersSupplier = getOrDefault(builder.headersSupplier, (Supplier<Map<String, String>>) () -> Map.of());
+        this.headersSupplier = getOrDefault(builder.headersSupplier, (i) -> Map.of());
         this.executor = builder.executor;
         this.sslContext = builder.sslContext;
         this.httpClient = createHttpClient();
@@ -111,7 +114,7 @@ public class WebSocketMcpTransport implements McpTransport {
         // if there is no initialization in progress (this means either the current one is broken
         // or we are initializing for the first time) -> start a new one
         WebSocket.Builder builder = this.httpClient.newWebSocketBuilder();
-        headersSupplier.get().forEach((key, value) -> builder.header(key, value));
+        headersSupplier.apply(null).forEach((key, value) -> builder.header(key, value));
         builder.connectTimeout(connectTimeout);
         CompletableFuture<WebSocket> newWebSocketFuture = builder.buildAsync(
                 URI.create(url),
@@ -132,9 +135,10 @@ public class WebSocketMcpTransport implements McpTransport {
         // a new initialization right away
         if (this.initializeRequest != null) {
             newWebSocketFuture = newWebSocketFuture.thenCompose(
-                    webSocket -> execute(this.initializeRequest, this.initializeRequest.getId(), Optional.of(webSocket))
+                    webSocket -> execute(new McpCallContext(null, this.initializeRequest), Optional.of(webSocket))
                             .thenCompose(originalResponse -> execute(
-                                            new McpInitializationNotification(), null, Optional.of(webSocket))
+                                            new McpCallContext(null, new McpInitializationNotification()),
+                                            Optional.of(webSocket))
                                     .thenCompose(nullNode -> CompletableFuture.completedFuture(webSocket))));
         }
         this.webSocketRef.set(newWebSocketFuture);
@@ -144,23 +148,34 @@ public class WebSocketMcpTransport implements McpTransport {
     @Override
     public CompletableFuture<JsonNode> initialize(McpInitializeRequest operation) {
         this.initializeRequest = operation;
-        CompletableFuture<JsonNode> completableFuture = execute(operation, operation.getId(), Optional.empty());
+        CompletableFuture<JsonNode> completableFuture = execute(new McpCallContext(null, operation), Optional.empty());
         return completableFuture
                 .thenCompose(originalResponse -> {
                     return CompletableFuture.completedFuture(originalResponse);
                 })
-                .thenCompose(originalResponse -> execute(new McpInitializationNotification(), null, Optional.empty())
+                .thenCompose(originalResponse -> execute(
+                                new McpCallContext(null, new McpInitializationNotification()), Optional.empty())
                         .thenCompose(nullNode -> CompletableFuture.completedFuture(originalResponse)));
     }
 
     @Override
-    public CompletableFuture<JsonNode> executeOperationWithResponse(McpJsonRpcMessage request) {
-        return execute(request, request.getId(), Optional.empty());
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpClientMessage request) {
+        return executeOperationWithResponse(new McpCallContext(null, request));
     }
 
     @Override
-    public void executeOperationWithoutResponse(McpJsonRpcMessage request) {
-        execute(request, null, Optional.empty());
+    public CompletableFuture<JsonNode> executeOperationWithResponse(McpCallContext context) {
+        return execute(context, Optional.empty());
+    }
+
+    @Override
+    public void executeOperationWithoutResponse(McpClientMessage request) {
+        executeOperationWithoutResponse(new McpCallContext(null, request));
+    }
+
+    @Override
+    public void executeOperationWithoutResponse(McpCallContext context) {
+        execute(context, Optional.empty());
     }
 
     @Override
@@ -204,17 +219,18 @@ public class WebSocketMcpTransport implements McpTransport {
         }
     }
 
-    private CompletableFuture<JsonNode> execute(McpJsonRpcMessage message, Long id, Optional<WebSocket> webSocket) {
+    private CompletableFuture<JsonNode> execute(McpCallContext context, Optional<WebSocket> webSocket) {
         CompletableFuture<JsonNode> future = new CompletableFuture<>();
         if (closed) {
             future.completeExceptionally(new IllegalStateException("Transport is closed"));
             return future;
         }
+        Long id = context.message().getId();
         if (id != null) {
             operationHandler.startOperation(id, future);
         }
         try {
-            String messageJson = OBJECT_MAPPER.writeValueAsString(message);
+            String messageJson = OBJECT_MAPPER.writeValueAsString(context.message());
             WebSocket wsToUse = webSocket.orElseGet(() -> getWebSocket());
             if (logRequests) {
                 trafficLog.info("> " + messageJson);
@@ -259,7 +275,7 @@ public class WebSocketMcpTransport implements McpTransport {
         private Executor executor;
         private Duration timeout;
         private SSLContext sslContext;
-        private Supplier<Map<String, String>> headersSupplier;
+        private McpHeadersSupplier headersSupplier;
 
         public Builder logResponses(boolean logResponses) {
             this.logResponses = logResponses;
@@ -311,6 +327,11 @@ public class WebSocketMcpTransport implements McpTransport {
         }
 
         public Builder headersSupplier(Supplier<Map<String, String>> headersSupplier) {
+            this.headersSupplier = (i) -> headersSupplier.get();
+            return this;
+        }
+
+        public Builder headersSupplier(McpHeadersSupplier headersSupplier) {
             this.headersSupplier = headersSupplier;
             return this;
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
@@ -5,7 +5,6 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolRequest.java
@@ -7,16 +7,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Internal
-public class McpCallToolRequest extends McpJsonRpcMessage {
-
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.TOOLS_CALL;
+public class McpCallToolRequest extends McpClientMessage {
 
     @JsonInclude
     private Map<String, Object> params;
 
-    public McpCallToolRequest(final Long id, String toolName, ObjectNode arguments) {
-        super(id);
+    public McpCallToolRequest(Long id, String toolName, ObjectNode arguments) {
+        super(id, McpClientMethod.TOOLS_CALL);
         this.params = new HashMap<>();
         this.params.put("name", toolName);
         this.params.put("arguments", arguments);

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCancellationNotification.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCancellationNotification.java
@@ -7,16 +7,13 @@ import java.util.Map;
 import org.jspecify.annotations.NonNull;
 
 @Internal
-public class McpCancellationNotification extends McpJsonRpcMessage {
-
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.NOTIFICATION_CANCELLED;
+public class McpCancellationNotification extends McpClientMessage {
 
     @JsonInclude
     private Map<String, Object> params;
 
     public McpCancellationNotification(@NonNull Long requestId, String reason) {
-        super(null);
+        super(null, McpClientMethod.NOTIFICATION_CANCELLED);
         this.params = new HashMap<>();
         this.params.put("requestId", requestId);
         if (reason != null) {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpClientMessage.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpClientMessage.java
@@ -1,0 +1,16 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import dev.langchain4j.Internal;
+
+@Internal
+public class McpClientMessage extends McpJsonRpcMessage {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public final McpClientMethod method;
+
+    public McpClientMessage(Long id, McpClientMethod method) {
+        super(id);
+        this.method = method;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpGetPromptRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpGetPromptRequest.java
@@ -6,16 +6,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Internal
-public class McpGetPromptRequest extends McpJsonRpcMessage {
-
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.PROMPTS_GET;
+public class McpGetPromptRequest extends McpClientMessage {
 
     @JsonInclude
     private Map<String, Object> params;
 
     public McpGetPromptRequest(Long id, String promptName, Map<String, Object> arguments) {
-        super(id);
+        super(id, McpClientMethod.PROMPTS_GET);
         this.params = new HashMap<>();
         this.params.put("name", promptName);
         this.params.put("arguments", arguments);

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializationNotification.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializationNotification.java
@@ -1,15 +1,11 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
 @Internal
-public class McpInitializationNotification extends McpJsonRpcMessage {
-
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.NOTIFICATION_INITIALIZED;
+public class McpInitializationNotification extends McpClientMessage {
 
     public McpInitializationNotification() {
-        super(null);
+        super(null, McpClientMethod.NOTIFICATION_INITIALIZED);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeRequest.java
@@ -1,18 +1,14 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
 @Internal
-public class McpInitializeRequest extends McpJsonRpcMessage {
-
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.INITIALIZE;
+public class McpInitializeRequest extends McpClientMessage {
 
     private McpInitializeParams params;
 
-    public McpInitializeRequest(final Long id) {
-        super(id);
+    public McpInitializeRequest(Long id) {
+        super(id, McpClientMethod.INITIALIZE);
     }
 
     public McpInitializeParams getParams() {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListPromptsRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListPromptsRequest.java
@@ -1,15 +1,11 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
 @Internal
-public class McpListPromptsRequest extends McpJsonRpcMessage {
-
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.PROMPTS_LIST;
+public class McpListPromptsRequest extends McpClientMessage {
 
     public McpListPromptsRequest(Long id) {
-        super(id);
+        super(id, McpClientMethod.PROMPTS_LIST);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourceTemplatesRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourceTemplatesRequest.java
@@ -1,15 +1,11 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
 @Internal
-public class McpListResourceTemplatesRequest extends McpJsonRpcMessage {
+public class McpListResourceTemplatesRequest extends McpClientMessage {
 
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.RESOURCES_TEMPLATES_LIST;
-
-    public McpListResourceTemplatesRequest(final Long id) {
-        super(id);
+    public McpListResourceTemplatesRequest(Long id) {
+        super(id, McpClientMethod.RESOURCES_TEMPLATES_LIST);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourcesRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourcesRequest.java
@@ -1,15 +1,11 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
 @Internal
-public class McpListResourcesRequest extends McpJsonRpcMessage {
+public class McpListResourcesRequest extends McpClientMessage {
 
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.RESOURCES_LIST;
-
-    public McpListResourcesRequest(final Long id) {
-        super(id);
+    public McpListResourcesRequest(Long id) {
+        super(id, McpClientMethod.RESOURCES_LIST);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListToolsRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListToolsRequest.java
@@ -7,16 +7,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Internal
-public class McpListToolsRequest extends McpJsonRpcMessage {
-
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.TOOLS_LIST;
+public class McpListToolsRequest extends McpClientMessage {
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Map<String, Object> params;
 
-    public McpListToolsRequest(final Long id) {
-        super(id);
+    public McpListToolsRequest(Long id) {
+        super(id, McpClientMethod.TOOLS_LIST);
         this.params = new HashMap<>();
     }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpPingRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpPingRequest.java
@@ -1,15 +1,11 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
 @Internal
-public class McpPingRequest extends McpJsonRpcMessage {
-
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.PING;
+public class McpPingRequest extends McpClientMessage {
 
     public McpPingRequest(Long id) {
-        super(id);
+        super(id, McpClientMethod.PING);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpPingResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpPingResponse.java
@@ -6,14 +6,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Internal
-public class McpPingResponse extends McpJsonRpcMessage {
+public class McpPingResponse extends McpClientMessage {
 
     // has to be an empty object
     @JsonInclude(JsonInclude.Include.ALWAYS)
     private final Map<String, Object> result = new HashMap<>();
 
-    public McpPingResponse(final Long id) {
-        super(id);
+    public McpPingResponse(Long id) {
+        super(id, null);
     }
 
     public Map<String, Object> getResult() {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpReadResourceRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpReadResourceRequest.java
@@ -7,16 +7,13 @@ import java.util.Map;
 import java.util.Objects;
 
 @Internal
-public class McpReadResourceRequest extends McpJsonRpcMessage {
-
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.RESOURCES_READ;
+public class McpReadResourceRequest extends McpClientMessage {
 
     @JsonInclude
     private Map<String, Object> params;
 
     public McpReadResourceRequest(Long id, String uri) {
-        super(id);
+        super(id, McpClientMethod.RESOURCES_READ);
         this.params = new HashMap<>();
         Objects.requireNonNull(uri);
         this.params.put("uri", uri);

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpRootsListChangedNotification.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpRootsListChangedNotification.java
@@ -1,15 +1,11 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
 @Internal
-public class McpRootsListChangedNotification extends McpJsonRpcMessage {
-
-    @JsonInclude
-    public final McpClientMethod method = McpClientMethod.NOTIFICATION_ROOTS_LIST_CHANGED;
+public class McpRootsListChangedNotification extends McpClientMessage {
 
     public McpRootsListChangedNotification() {
-        super(null);
+        super(null, McpClientMethod.NOTIFICATION_ROOTS_LIST_CHANGED);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpRootsListResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpRootsListResponse.java
@@ -8,13 +8,13 @@ import java.util.List;
 import java.util.Map;
 
 @Internal
-public class McpRootsListResponse extends McpJsonRpcMessage {
+public class McpRootsListResponse extends McpClientMessage {
 
     @JsonInclude(JsonInclude.Include.ALWAYS)
     private final Map<String, Object> result = new HashMap<>();
 
     public McpRootsListResponse(Long id, List<McpRoot> roots) {
-        super(id);
+        super(id, null);
         result.put("roots", roots);
     }
 

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -149,7 +149,7 @@ public class DefaultMcpClientTest {
                 new DefaultMcpClient.Builder().transport(transport).build();
         final ObjectNode toolsJsonResult = getToolResultJson(
                 new ToolDefinition("testTool", "A test tool", new ToolArg("argument1", "string", "An argument")));
-        when(transport.executeOperationWithResponse(any()))
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
                 .thenReturn(CompletableFuture.completedFuture(toolsJsonResult));
 
         // when
@@ -171,7 +171,7 @@ public class DefaultMcpClientTest {
                 new DefaultMcpClient.Builder().transport(transport).build();
         final ObjectNode toolsJsonResult = getToolResultJson(
                 new ToolDefinition("testTool", "A test tool", new ToolArg("argument1", "string", "An argument")));
-        when(transport.executeOperationWithResponse(any()))
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
                 .thenReturn(CompletableFuture.completedFuture(toolsJsonResult));
 
         // when: asking for tools twice
@@ -183,7 +183,7 @@ public class DefaultMcpClientTest {
         // and: also do a sanity check
         assertThat(tools1).isNotNull().isNotEmpty();
         // and: the transport operation was executed only once
-        verify(transport, times(1)).executeOperationWithResponse(any());
+        verify(transport, times(1)).executeOperationWithResponse(any(McpCallContext.class));
     }
 
     @Test
@@ -194,7 +194,7 @@ public class DefaultMcpClientTest {
                 new DefaultMcpClient.Builder().transport(transport).build();
         final ObjectNode toolsJsonResult = getToolResultJson(
                 new ToolDefinition("testTool", "A test tool", new ToolArg("argument1", "string", "An argument")));
-        when(transport.executeOperationWithResponse(any()))
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
                 .thenReturn(CompletableFuture.completedFuture(toolsJsonResult));
 
         // and: the tools are cached
@@ -204,7 +204,7 @@ public class DefaultMcpClientTest {
                 "testToolAnother",
                 "Another test tool",
                 new ToolArg("argumentAnother1", "integer", "Another argument")));
-        when(transport.executeOperationWithResponse(any()))
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
                 .thenReturn(CompletableFuture.completedFuture(newToolsJsonResult));
 
         // when
@@ -219,7 +219,7 @@ public class DefaultMcpClientTest {
         assertThat(tools.get(0).name()).isEqualTo("testTool");
         assertThat(toolsAfterEviction.get(0).name()).isEqualTo("testToolAnother");
         // and: the transport operation was executed once more after the eviction
-        verify(transport, times(2)).executeOperationWithResponse(any());
+        verify(transport, times(2)).executeOperationWithResponse(any(McpCallContext.class));
     }
 
     @Test
@@ -232,7 +232,7 @@ public class DefaultMcpClientTest {
                 .build();
         final ObjectNode toolsJsonResult = getToolResultJson(
                 new ToolDefinition("testTool", "A test tool", new ToolArg("argument1", "string", "An argument")));
-        when(transport.executeOperationWithResponse(any()))
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
                 .thenReturn(CompletableFuture.completedFuture(toolsJsonResult));
 
         // and: an initial tool list is retrieved
@@ -242,7 +242,7 @@ public class DefaultMcpClientTest {
                 "testToolAnother",
                 "Another test tool",
                 new ToolArg("argumentAnother1", "integer", "Another argument")));
-        when(transport.executeOperationWithResponse(any()))
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
                 .thenReturn(CompletableFuture.completedFuture(newToolsJsonResult));
 
         // when
@@ -256,7 +256,7 @@ public class DefaultMcpClientTest {
         assertThat(initialTools.get(0).name()).isEqualTo("testTool");
         assertThat(subsequentTools.get(0).name()).isEqualTo("testToolAnother");
         // and: the transport operation was executed as many times as tools were retrieved
-        verify(transport, times(2)).executeOperationWithResponse(any());
+        verify(transport, times(2)).executeOperationWithResponse(any(McpCallContext.class));
     }
 
     private static McpTransport getMinimalMcpTransportMock() {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpClientListenerTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpClientListenerTest.java
@@ -1,0 +1,235 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getJBangCommand;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getPathToScript;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.skipTestsIfJbangNotAvailable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.exception.ToolExecutionException;
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpCallContext;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpClientListener;
+import dev.langchain4j.mcp.client.McpGetPromptResult;
+import dev.langchain4j.mcp.client.McpReadResourceResult;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
+import dev.langchain4j.mcp.protocol.McpClientMethod;
+import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class McpClientListenerTest {
+
+    static McpClient mcpClient;
+    static TestListener testListener;
+
+    @BeforeAll
+    static void setup() {
+        skipTestsIfJbangNotAvailable();
+        McpTransport transport = new StdioMcpTransport.Builder()
+                .command(List.of(
+                        getJBangCommand(),
+                        "--quiet",
+                        "--fresh",
+                        "run",
+                        "-Dquarkus.http.port=8180",
+                        getPathToScript("listener_mcp_server.java")))
+                .logEvents(true)
+                .build();
+        testListener = new TestListener();
+        mcpClient = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .listener(testListener)
+                .toolExecutionTimeout(Duration.ofSeconds(4))
+                .build();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        testListener.clear();
+    }
+
+    @Test
+    public void successfulToolCall() {
+        ToolExecutionResult result = mcpClient.executeTool(
+                ToolExecutionRequest.builder().name("nothing").build());
+        assertThat(result.isError()).isFalse();
+
+        // check that the beforeToolCall callback was invoked
+        assertThat(testListener.toolContext).isNotNull();
+        assertThat(testListener.toolContext.message().method).isEqualTo(McpClientMethod.TOOLS_CALL);
+        assertThat(testListener.toolContext.message().getId()).isNotNull();
+
+        // check that the afterToolCall callback was invoked
+        assertThat(testListener.toolResult).isNotNull();
+        assertThat(testListener.toolResult.resultText()).isEqualTo("OK");
+        assertThat(testListener.toolResultContext).isSameAs(testListener.toolContext);
+    }
+
+    @Test
+    public void toolCallWithApplicationLevelError() {
+        try {
+            ToolExecutionResult result = mcpClient.executeTool(
+                    ToolExecutionRequest.builder().name("withError").build());
+            Assertions.fail("Should have thrown an exception");
+        } catch (Exception e) {
+            assertThat(testListener.toolContext).isNotNull();
+            assertThat(testListener.toolContext.message().method).isEqualTo(McpClientMethod.TOOLS_CALL);
+            assertThat(testListener.toolContext.message().getId()).isNotNull();
+            assertThat(testListener.toolResultContext).isNull();
+            assertThat(testListener.toolError).isNotNull();
+            assertThat(testListener.toolError).isInstanceOf(ToolExecutionException.class);
+            assertThat(testListener.toolErrorContext).isSameAs(testListener.toolContext);
+        }
+    }
+
+    @Test
+    public void toolTimeout() {
+        ToolExecutionResult result = mcpClient.executeTool(
+                ToolExecutionRequest.builder().name("longOperation").build());
+
+        // check that the beforeToolCall callback was invoked
+        assertThat(testListener.toolContext).isNotNull();
+        assertThat(testListener.toolContext.message().method).isEqualTo(McpClientMethod.TOOLS_CALL);
+        assertThat(testListener.toolContext.message().getId()).isNotNull();
+
+        // check that the onToolCallError callback was invoked with TimeoutException
+        assertThat(testListener.toolError).isNotNull();
+        assertThat(testListener.toolError).isInstanceOf(java.util.concurrent.TimeoutException.class);
+        assertThat(testListener.toolErrorContext).isSameAs(testListener.toolContext);
+
+        // afterToolCall should NOT be invoked
+        assertThat(testListener.toolResultContext).isNull();
+    }
+
+    @Test
+    public void resourceGet() {
+        McpReadResourceResult result = mcpClient.readResource("file:///test-resource");
+        assertThat(result).isNotNull();
+
+        // check that the beforeResourceGet callback was invoked
+        assertThat(testListener.resourceContext).isNotNull();
+        assertThat(testListener.resourceContext.message().method).isEqualTo(McpClientMethod.RESOURCES_READ);
+        assertThat(testListener.resourceContext.message().getId()).isNotNull();
+
+        // check that the afterResourceGet callback was invoked
+        assertThat(testListener.resourceResult).isNotNull();
+        assertThat(testListener.resourceResultContext).isSameAs(testListener.resourceContext);
+    }
+
+    @Test
+    public void promptGet() {
+        McpGetPromptResult result = mcpClient.getPrompt("testPrompt", Map.of());
+        assertThat(result).isNotNull();
+
+        // check that the beforePromptGet callback was invoked
+        assertThat(testListener.prompt).isNotNull();
+        assertThat(testListener.prompt.message().method).isEqualTo(McpClientMethod.PROMPTS_GET);
+        assertThat(testListener.prompt.message().getId()).isNotNull();
+
+        // check that the afterPromptGet callback was invoked
+        assertThat(testListener.promptResult).isNotNull();
+        assertThat(testListener.promptResultContext).isSameAs(testListener.prompt);
+    }
+
+    static class TestListener implements McpClientListener {
+
+        volatile McpCallContext toolContext;
+        volatile ToolExecutionResult toolResult;
+        volatile McpCallContext toolResultContext;
+        volatile McpCallContext toolErrorContext;
+        volatile Throwable toolError;
+
+        volatile McpCallContext resourceContext;
+        volatile McpReadResourceResult resourceResult;
+        volatile McpCallContext resourceResultContext;
+        volatile McpCallContext resourceErrorContext;
+        volatile Throwable resourceError;
+
+        volatile McpCallContext prompt;
+        volatile McpGetPromptResult promptResult;
+        volatile McpCallContext promptResultContext;
+        volatile McpCallContext promptErrorContext;
+        volatile Throwable promptError;
+
+        @Override
+        public void beforeExecuteTool(McpCallContext context) {
+            toolContext = context;
+        }
+
+        @Override
+        public void afterExecuteTool(
+                McpCallContext context, ToolExecutionResult result, Map<String, Object> rawResult) {
+            toolResultContext = context;
+            toolResult = result;
+        }
+
+        @Override
+        public void onExecuteToolError(McpCallContext context, Throwable error) {
+            toolErrorContext = context;
+            toolError = error;
+        }
+
+        @Override
+        public void beforeResourceGet(McpCallContext context) {
+            resourceContext = context;
+        }
+
+        @Override
+        public void afterResourceGet(
+                McpCallContext context, McpReadResourceResult result, Map<String, Object> rawResult) {
+            resourceResultContext = context;
+            resourceResult = result;
+        }
+
+        @Override
+        public void onResourceGetError(McpCallContext context, Throwable error) {
+            resourceErrorContext = context;
+            resourceError = error;
+        }
+
+        @Override
+        public void beforePromptGet(McpCallContext context) {
+            prompt = context;
+        }
+
+        @Override
+        public void afterPromptGet(McpCallContext context, McpGetPromptResult result, Map<String, Object> rawResult) {
+            promptResultContext = context;
+            promptResult = result;
+        }
+
+        @Override
+        public void onPromptGetError(McpCallContext context, Throwable error) {
+            promptErrorContext = context;
+            promptError = error;
+        }
+
+        void clear() {
+            toolContext = null;
+            toolResult = null;
+            toolResultContext = null;
+            toolErrorContext = null;
+            toolError = null;
+
+            resourceContext = null;
+            resourceResult = null;
+            resourceResultContext = null;
+            resourceErrorContext = null;
+            resourceError = null;
+
+            prompt = null;
+            promptResult = null;
+            promptResultContext = null;
+            promptErrorContext = null;
+            promptError = null;
+        }
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHeadersHttpTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHeadersHttpTransportIT.java
@@ -20,7 +20,7 @@ class McpHeadersHttpTransportIT extends McpHeadersTestBase {
         process = startProcess();
         McpTransport transport = new HttpMcpTransport.Builder()
                 .sseUrl("http://localhost:8080/mcp/sse")
-                .customHeaders(() -> customHeaders)
+                .customHeaders(customHeaders)
                 .logRequests(true)
                 .logResponses(true)
                 .build();

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHeadersStreamableHttpTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHeadersStreamableHttpTransportIT.java
@@ -19,7 +19,7 @@ class McpHeadersStreamableHttpTransportIT extends McpHeadersTestBase {
         process = startProcess();
         StreamableHttpMcpTransport transport = new StreamableHttpMcpTransport.Builder()
                 .url("http://localhost:8080/mcp")
-                .customHeaders(() -> customHeaders)
+                .customHeaders(customHeaders)
                 .logRequests(true)
                 .logResponses(true)
                 .build();

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHeadersTestBase.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpHeadersTestBase.java
@@ -1,39 +1,156 @@
 package dev.langchain4j.mcp.client.integration;
 
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.startServerHttp;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.mcp.McpToolProvider;
+import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpClient;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Test;
+import dev.langchain4j.mcp.client.McpHeadersSupplier;
+import dev.langchain4j.mcp.protocol.McpCallToolRequest;
+import dev.langchain4j.mcp.protocol.McpInitializationNotification;
+import dev.langchain4j.mcp.protocol.McpInitializeRequest;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.UserMessage;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-import static dev.langchain4j.mcp.client.integration.McpServerHelper.startServerHttp;
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class McpHeadersTestBase {
+public abstract class McpHeadersTestBase {
 
     static Process process;
     static McpClient mcpClient;
-    static final Map<String, String> customHeaders = new HashMap<>();
+    static Map<String, String> headersMap = new HashMap<>();
+    static volatile InvocationContext
+            capturedInvocationContext; // will capture the invocation context from the tool call
 
-    @AfterAll
-    static void clearHeaders() {
-        customHeaders.clear();
-    }
+    private static volatile boolean
+            headerSupplierCalledForInitialize; // will be set to true when the supplier is called for the 'initialize'
+    // method
+    private static volatile boolean
+            headerSupplierCalledForInitializedNotification; // will be set to true when the supplier is called for the
+    // 'initialized' notification
+
+    // This is the supplier of headers for the MCP client.
+    // When the headersMap contains something, it will use that map as headers.
+    // Otherwise, if the call is a tool call, it will return a header "X-Test-Header" with value "12345".
+    static final McpHeadersSupplier customHeaders = new McpHeadersSupplier() {
+        @Override
+        public Map<String, String> apply(McpCallContext ctx) {
+            if (ctx != null) {
+                if (ctx.message() instanceof McpInitializeRequest) {
+                    headerSupplierCalledForInitialize = true;
+                }
+                if (ctx.message() instanceof McpInitializationNotification) {
+                    headerSupplierCalledForInitializedNotification = true;
+                }
+            }
+            if (headersMap.isEmpty()) {
+                if (ctx != null && ctx.message() instanceof McpCallToolRequest) {
+                    if (ctx.invocationContext() != null) {
+                        capturedInvocationContext = ctx.invocationContext();
+                    }
+                    return Map.of("X-Test-Header", "12345");
+                } else {
+                    return Map.of();
+                }
+            } else {
+                return headersMap;
+            }
+        }
+    };
 
     static Process startProcess() throws IOException, InterruptedException, TimeoutException {
         return startServerHttp("headers_mcp_server.java");
     }
 
-    @Test
-    void reconnect() throws IOException, TimeoutException, InterruptedException {
-        customHeaders.put("X-Test-Header", "headerValue1");
-        executeEchoHeadersToolAndAssertHeaderValue("headerValue1");
+    @AfterEach
+    public void cleanup() {
+        capturedInvocationContext = null;
+    }
 
-        customHeaders.put("X-Test-Header", "headerValue2");
-        executeEchoHeadersToolAndAssertHeaderValue("headerValue2");
+    @Test
+    void initializationHeaders() {
+        Assertions.assertThat(headerSupplierCalledForInitialize).isTrue();
+        Assertions.assertThat(headerSupplierCalledForInitializedNotification).isTrue();
+    }
+
+    @Test
+    void directToolCalls() {
+        try {
+            headersMap.put("X-Test-Header", "headerValue1");
+            executeEchoHeadersToolAndAssertHeaderValue("headerValue1");
+
+            headersMap.put("X-Test-Header", "headerValue2");
+            executeEchoHeadersToolAndAssertHeaderValue("headerValue2");
+        } finally {
+            headersMap.clear();
+        }
+    }
+
+    @Test
+    void toolCallsViaAiService() {
+        ChatModel mockChatModel = Mockito.mock(ChatModel.class);
+        ChatResponse toolRequestingResponse = ChatResponse.builder()
+                .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                        .name("echoHeader")
+                        .arguments("{\"headerName\": \"X-Test-Header\"}")
+                        .build()))
+                .build();
+
+        // when no tools are requested, return the tool requesting response
+        //        Mockito.when(mockChatModel.chat(Mockito.argThat((ArgumentMatcher<ChatRequest>) chatRequest ->
+        // chatRequest != null && chatRequest.toolSpecifications().isEmpty()))).thenReturn(toolRequestingResponse);
+        Mockito.when(mockChatModel.chat(Mockito.any(ChatRequest.class))).thenAnswer((i) -> {
+            ChatRequest request = i.getArgument(0);
+            if (request.messages().size() == 1) {
+                // this is the initial chat request, respond with tool requesting response
+                return toolRequestingResponse;
+            } else {
+                // this is the follow-up request containing the result from the MCP tool execution, so just forward that
+                // result as the final response
+                ToolExecutionResultMessage toolResult = (ToolExecutionResultMessage) request.messages().stream()
+                        .filter(m -> m instanceof ToolExecutionResultMessage)
+                        .findFirst()
+                        .get();
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.aiMessage(toolResult.text()))
+                        .build();
+            }
+        });
+
+        DummyAiService service = AiServices.builder(DummyAiService.class)
+                .chatModel(mockChatModel)
+                .toolProvider(McpToolProvider.builder().mcpClients(mcpClient).build())
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(5))
+                .build();
+
+        // call the AI service now - when it executes the tool using the MCP client, it should pass the proper
+        // X-Test-Header
+        Assertions.assertThat(service.chat()).isEqualTo("12345");
+        // verify that the invocation context was properly passed to the header supplier
+        Assertions.assertThat(capturedInvocationContext).isNotNull();
+        Assertions.assertThat(capturedInvocationContext.methodName()).isEqualTo("chat");
+        Assertions.assertThat(capturedInvocationContext.interfaceName())
+                .isEqualTo("dev.langchain4j.mcp.client.integration.McpHeadersTestBase$DummyAiService");
+    }
+
+    interface DummyAiService {
+        @UserMessage("Call the echoHeader tool with {headerName=X-Test-Header}")
+        String chat();
     }
 
     private void executeEchoHeadersToolAndAssertHeaderValue(String expectedValue) {
@@ -44,5 +161,4 @@ public class McpHeadersTestBase {
         String result = mcpClient.executeTool(toolExecutionRequest).resultText();
         assertThat(result).isEqualTo(expectedValue);
     }
-
 }

--- a/langchain4j-mcp/src/test/resources/listener_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/listener_mcp_server.java
@@ -1,0 +1,51 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS io.quarkus:quarkus-bom:${quarkus.version:3.27.0}@pom
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.8.1
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.ImageContent;
+import io.quarkiverse.mcp.server.Prompt;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
+import jakarta.inject.Inject;
+
+public class listener_mcp_server {
+
+
+    @Tool
+    public String nothing() {
+        return "OK";
+    }
+
+    @Tool
+    public ToolResponse withError() {
+        return ToolResponse.error("Something went wrong");
+    }
+
+    @Tool
+    public String longOperation() throws Exception {
+        TimeUnit.SECONDS.sleep(5);
+        return "FINISHED";
+    }
+
+    @Resource(uri = "file:///test-resource", description = "Test resource for listener", mimeType = "text/plain")
+    public TextResourceContents testResource() {
+        return TextResourceContents.create("file:///test-resource", "Test resource content");
+    }
+
+    @Prompt(description = "Test prompt for listener")
+    public PromptMessage testPrompt() {
+        return PromptMessage.withUserRole(new TextContent("Test prompt message"));
+    }
+
+}


### PR DESCRIPTION
This introduces a concept of `McpCallContext` that contains information about the context around an invocation to an MCP server. This context is injected into the newly added MCP header providers.

Building on top of that, I added support for MCP listeners that can be invoked before and after calls to MCP servers. They also inject a `McpCallContext`.

Further building on top of that, I've been working on Micrometer metrics support for MCP clients, this will live in the Quarkus extension and will be based on top of MCP listeners. I am drafting that, I'd like to get feedback on this part first before continuing the metrics thing because it builds on top of it.

Closes #4241 