### PR TITLE
Add ModelCatalog support in watsonx.ai

### DIFF
--- a/docs/docs/integrations/embedding-models/watsonx.md
+++ b/docs/docs/integrations/embedding-models/watsonx.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 23
+---
+
+# watsonx.ai
+
+- [watsonx.ai API Reference](https://cloud.ibm.com/apidocs/watsonx-ai#text-embeddings)
+- [watsonx.ai Java SDK](https://github.com/IBM/watsonx-ai-java-sdk)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-watsonx</artifactId>
+    <version>1.10.0-beta18</version>
+</dependency>
+```
+
+## Authentication
+
+Watsonx.ai supports authentication via the `Authenticator` interface.
+
+This allows to use different authentication mechanisms depending on your deployment:
+
+- **IBMCloudAuthenticator** – authenticates with **IBM Cloud** using an API key. This is the simplest approach and is used when you provide the `apiKey(...)` builder method.
+- **CP4DAuthenticator** – authenticates with **Cloud Pak for Data** deployments.
+- **Custom authenticators** – any implementation of the `Authenticator` interface can be used.
+
+The `WatsonxEmbeddingModel` and other service builders accept either a shortcut via `.apiKey(...)` or a full `Authenticator` instance via `.authenticator(...)`.
+
+### Example
+```java
+WatsonxEmbeddingModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key") // Simple IBM Cloud authentication
+    .projectId("your-project-id")
+    .modelName("ibm/granite-embedding-278m-multilingual")
+    .build();
+
+WatsonxEmbeddingModel.builder()
+    .baseUrl("https://my-instance-url")
+    .authenticator( // For Cloud Pak for Data deployments
+        CP4DAuthenticator.builder()
+            .baseUrl("https://my-instance-url")
+            .username("username")
+            .apiKey("api-key")
+            .build()
+    )
+    .projectId("my-project-id")
+    .modelName("ibm/granite-embedding-278m-multilingual")
+    .build();
+```
+
+### Custom HttpClient
+
+All services and authenticators support a custom `HttpClient` instance through the builder pattern. This is particularly useful for Cloud Pak for Data environments where you may need to configure custom TLS/SSL settings, proxy configuration, or other HTTP client properties.
+```java
+HttpClient httpClient = HttpClient.newBuilder()
+    .sslContext(createCustomSSLContext())
+    .build();
+
+EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
+    .baseUrl("https://my-instance-url")
+    .modelName("ibm/granite-embedding-278m-multilingual")
+    .projectId("project-id")
+    .httpClient(httpClient)
+    .authenticator(
+        CP4DAuthenticator.builder()
+            .baseUrl("https://my-instance-url")
+            .username("username")
+            .apiKey("api-key")
+            .httpClient(httpClient)
+            .build()
+    )
+    .build();
+```
+
+> **Note:** When using a custom `HttpClient` with Cloud Pak for Data, make sure to set it on both the service builder and the authenticator builder to ensure consistent HTTP behavior across all requests.
+
+### How to create an IBM Cloud API Key
+
+You can create an API key at [https://cloud.ibm.com/iam/apikeys](https://cloud.ibm.com/iam/apikeys) by clicking **Create +**.
+
+### How to find your Project ID
+
+1. Visit [https://dataplatform.cloud.ibm.com/projects/?context=wx](https://dataplatform.cloud.ibm.com/projects/?context=wx)  
+2. Open your project  
+3. Go to the **Manage** tab  
+4. Copy the **Project ID** from the **Details** section 
+
+## WatsonxEmbeddingModel
+
+The `WatsonxEmbeddingModel` enables you to generate embeddings using IBM watsonx.ai and integrate them with LangChain4j's vector-based operations such as search, retrieval-augmented generation (RAG), and similarity comparison.
+
+It implements the LangChain4j `EmbeddingModel` interface.
+
+```java
+EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .projectId("your-project-id")
+    .modelName("ibm/granite-embedding-278m-multilingual")
+    .build();
+
+System.out.println(embeddingModel.embed("Hello from watsonx.ai"));
+```
+> 🔗 [View available embedding model IDs](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#embed)
+
+## Examples
+
+- [WatsonxEmbeddingModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxEmbeddingModelTest.java)

--- a/docs/docs/integrations/embedding-models/watsonx.md
+++ b/docs/docs/integrations/embedding-models/watsonx.md
@@ -52,31 +52,56 @@ WatsonxEmbeddingModel.builder()
     .build();
 ```
 
-### Custom HttpClient
+### Custom HttpClient and SSL Configuration
+
+#### Using a custom HttpClient
 
 All services and authenticators support a custom `HttpClient` instance through the builder pattern. This is particularly useful for Cloud Pak for Data environments where you may need to configure custom TLS/SSL settings, proxy configuration, or other HTTP client properties.
+
 ```java
 HttpClient httpClient = HttpClient.newBuilder()
     .sslContext(createCustomSSLContext())
+    .executor(ExecutorProvider.ioExecutor())
     .build();
 
 EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
     .baseUrl("https://my-instance-url")
     .modelName("ibm/granite-embedding-278m-multilingual")
     .projectId("project-id")
-    .httpClient(httpClient)
+    .httpClient(httpClient) // Custom HttpClient
     .authenticator(
         CP4DAuthenticator.builder()
             .baseUrl("https://my-instance-url")
             .username("username")
             .apiKey("api-key")
-            .httpClient(httpClient)
+            .httpClient(httpClient) // Custom HttpClient
             .build()
     )
     .build();
 ```
 
 > **Note:** When using a custom `HttpClient` with Cloud Pak for Data, make sure to set it on both the service builder and the authenticator builder to ensure consistent HTTP behavior across all requests.
+
+#### Disabling SSL verification
+
+If you only need to disable SSL certificate verification, you can use the `verifySsl(false)` option instead of providing a custom `HttpClient`:
+
+```java
+EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
+    .baseUrl("https://my-instance-url")
+    .modelName("ibm/granite-embedding-278m-multilingual")
+    .projectId("project-id")
+    .verifySsl(false) // Disable SSL verification
+    .authenticator(
+        CP4DAuthenticator.builder()
+            .baseUrl("https://my-instance-url")
+            .username("username")
+            .apiKey("api-key")
+            .verifySsl(false) // Disable SSL verification
+            .build()
+    )
+    .build();
+```
 
 ### How to create an IBM Cloud API Key
 

--- a/docs/docs/integrations/language-models/watsonx.md
+++ b/docs/docs/integrations/language-models/watsonx.md
@@ -59,35 +59,56 @@ WatsonxChatModel.builder()
     .build();
 ```
 
-### Custom HttpClient
+### Custom HttpClient and SSL Configuration
+
+#### Using a custom HttpClient
 
 All services and authenticators support a custom `HttpClient` instance through the builder pattern. This is particularly useful for Cloud Pak for Data environments where you may need to configure custom TLS/SSL settings, proxy configuration, or other HTTP client properties.
-```java
-import java.net.http.HttpClient;
-import dev.langchain4j.model.watsonx.WatsonxChatModel;
-import com.ibm.watsonx.ai.core.auth.cp4d.CP4DAuthenticator;
 
+```java
 HttpClient httpClient = HttpClient.newBuilder()
     .sslContext(createCustomSSLContext())
+    .executor(ExecutorProvider.ioExecutor())
     .build();
 
-ChatModel chatModel = WatsonxChatModel.builder()
+EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
     .baseUrl("https://my-instance-url")
-    .modelName("ibm/granite-4-h-small")
+    .modelName("ibm/granite-embedding-278m-multilingual")
     .projectId("project-id")
-    .httpClient(httpClient)
+    .httpClient(httpClient) // Custom HttpClient
     .authenticator(
         CP4DAuthenticator.builder()
             .baseUrl("https://my-instance-url")
             .username("username")
             .apiKey("api-key")
-            .httpClient(httpClient)
+            .httpClient(httpClient) // Custom HttpClient
             .build()
     )
     .build();
 ```
 
 > **Note:** When using a custom `HttpClient` with Cloud Pak for Data, make sure to set it on both the service builder and the authenticator builder to ensure consistent HTTP behavior across all requests.
+
+#### Disabling SSL verification
+
+If you only need to disable SSL certificate verification, you can use the `verifySsl(false)` option instead of providing a custom `HttpClient`:
+
+```java
+EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
+    .baseUrl("https://my-instance-url")
+    .modelName("ibm/granite-embedding-278m-multilingual")
+    .projectId("project-id")
+    .verifySsl(false) // Disable SSL verification
+    .authenticator(
+        CP4DAuthenticator.builder()
+            .baseUrl("https://my-instance-url")
+            .username("username")
+            .apiKey("api-key")
+            .verifySsl(false) // Disable SSL verification
+            .build()
+    )
+    .build();
+```
 
 ### How to create an IBM Cloud API Key
 

--- a/docs/docs/integrations/language-models/watsonx.md
+++ b/docs/docs/integrations/language-models/watsonx.md
@@ -4,7 +4,7 @@ sidebar_position: 22
 
 # watsonx.ai
 
-- [watsonx.ai API Reference](https://cloud.ibm.com/apidocs/watsonx-ai)
+- [watsonx.ai API Reference](https://cloud.ibm.com/apidocs/watsonx-ai#chat-completions)
 - [watsonx.ai Java SDK](https://github.com/IBM/watsonx-ai-java-sdk)
 
 ## Maven Dependency
@@ -64,17 +64,17 @@ WatsonxChatModel.builder()
 All services and authenticators support a custom `HttpClient` instance through the builder pattern. This is particularly useful for Cloud Pak for Data environments where you may need to configure custom TLS/SSL settings, proxy configuration, or other HTTP client properties.
 ```java
 import java.net.http.HttpClient;
-import com.ibm.watsonx.ai.chat.ChatService;
+import dev.langchain4j.model.watsonx.WatsonxChatModel;
 import com.ibm.watsonx.ai.core.auth.cp4d.CP4DAuthenticator;
 
 HttpClient httpClient = HttpClient.newBuilder()
     .sslContext(createCustomSSLContext())
     .build();
 
-ChatService chatService = ChatService.builder()
+ChatModel chatModel = WatsonxChatModel.builder()
     .baseUrl("https://my-instance-url")
-    .modelId("ibm/granite-4-h-small")
-    .projectId("my-project-id")
+    .modelName("ibm/granite-4-h-small")
+    .projectId("project-id")
     .httpClient(httpClient)
     .authenticator(
         CP4DAuthenticator.builder()
@@ -85,8 +85,6 @@ ChatService chatService = ChatService.builder()
             .build()
     )
     .build();
-
-var response = chatService.chat("How are you?");
 ```
 
 > **Note:** When using a custom `HttpClient` with Cloud Pak for Data, make sure to set it on both the service builder and the authenticator builder to ensure consistent HTTP behavior across all requests.
@@ -341,56 +339,25 @@ model.chat(chatRequest, new StreamingChatResponseHandler() {
 > - Use `ExtractionTags` for models that embed reasoning and response in a single text string.  
 > - Use `ThinkingEffort` or `thinking(true)` for models that already separate reasoning and response automatically.  
 
-## WatsonxEmbeddingModel
+## WatsonxModelCatalog
 
-The `WatsonxEmbeddingModel` enables you to generate embeddings using IBM watsonx.ai and integrate them with LangChain4j's vector-based operations such as search, retrieval-augmented generation (RAG), and similarity comparison.
-
-It implements the LangChain4j `EmbeddingModel` interface.
-
-```java
-EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
-    .baseUrl(CloudRegion.FRANKFURT)
-    .apiKey("your-api-key")
-    .projectId("your-project-id")
-    .modelName("ibm/granite-embedding-278m-multilingual")
-    .build();
-
-System.out.println(embeddingModel.embed("Hello from watsonx.ai"));
-```
-> 🔗 [View available embedding model IDs](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#embed)
-
-## WatsonxScoringModel
-
-The `WatsonxScoringModel` provides a LangChain4j implementation of a `ScoringModel` using IBM watsonx.ai models.
-
-It is particularly useful for ranking a list of documents (or text segments) based on their relevance to a user query.
+The `WatsonxModelCatalog` provides a programmatic way to discover and list all available foundation models on IBM watsonx.ai.
+It implements the LangChain4j `ModelCatalog` interface, allowing you to retrieve detailed information about each model.
 
 ### Example
 
 ```java
-ScoringModel scoringModel = WatsonxScoringModel.builder()
+import dev.langchain4j.model.catalog.ModelCatalog;
+import dev.langchain4j.model.catalog.ModelDescription;
+import dev.langchain4j.model.watsonx.WatsonxModelCatalog;
+import com.ibm.watsonx.ai.CloudRegion;
+
+ModelCatalog modelCatalog = WatsonxModelCatalog.builder()
     .baseUrl(CloudRegion.FRANKFURT)
-    .apiKey("your-api-key")
-    .projectId("your-project-id")
-    .modelName("cross-encoder/ms-marco-minilm-l-12-v2")
     .build();
 
-var scores = scoringModel.scoreAll(
-    List.of(
-        TextSegment.from("Example_1"),
-        TextSegment.from("Example_2")
-    ),
-    "Hello from watsonx.ai"
-);
-
-System.out.println(scores);
+var models = modelCatalog.listModels();
 ```
-
----
-
-> 🔗 [View available rerank model IDs](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#rerank)
-
----
 
 ## WatsonxModerationModel
 
@@ -435,6 +402,33 @@ Map<String, Object> metadata = response.metadata();
 System.out.println("Detection type: " + metadata.get("detection_type"));
 System.out.println("Score: " + metadata.get("score"));
 ```
+## Configuration via Environment Variables
+
+The LangChain4j watsonx integration allows customization of internal HTTP behavior through environment variables.  
+These settings are optional and sensible defaults are used when variables are not explicitly defined.
+
+### Retry Configuration
+
+HTTP requests are automatically retried in case of transient failures or expired authentication tokens.  
+Retry behavior can be customized using the following environment variables:
+
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `WATSONX_RETRY_TOKEN_EXPIRED_MAX_RETRIES` | Maximum number of retries when an authentication token has expired (HTTP 401 / 403) | `1` |
+| `WATSONX_RETRY_STATUS_CODES_MAX_RETRIES` | Maximum number of retries for transient HTTP status codes (`429`, `503`, `504`, `520`) | `10` |
+| `WATSONX_RETRY_STATUS_CODES_BACKOFF_ENABLED` | Enables exponential backoff for transient retries | `true` |
+| `WATSONX_RETRY_STATUS_CODES_INITIAL_INTERVAL_MS` | Initial retry interval in milliseconds (used as base for exponential backoff) | `20` |
+
+### HTTP IO Executor Configuration
+
+Streaming responses and HTTP response processing are handled by an internal IO executor.  
+By default, a single-threaded executor is used to ensure sequential processing of streaming events.
+
+This behavior can be customized using the following environment variable:
+
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `WATSONX_IO_EXECUTOR_THREADS` | Number of threads used for HTTP IO and SSE stream parsing | `1` |
 
 ## Quarkus
 
@@ -447,7 +441,5 @@ See more details [here](https://docs.quarkiverse.io/quarkus-langchain4j/dev/wats
 - [WatsonxStreamingChatModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxStreamingChatModelTest.java)
 - [WatsonxStreamingChatModelReasoningTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxStreamingChatModelTest.java)
 - [WatsonxToolsTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxToolsTest.java)
-- [WatsonxEmbeddingModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxEmbeddingModelTest.java)
-- [WatsonxScoringModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxScoringModelTest.java)
 - [WatsonxTokenCounterEstimatorTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxTokenCounterEstimatorTest.java)
 - [WatsonxModerationModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxModerationModelTest.java)

--- a/docs/docs/integrations/scoring-reranking-models/watsonx.md
+++ b/docs/docs/integrations/scoring-reranking-models/watsonx.md
@@ -1,0 +1,123 @@
+---
+sidebar_position: 7
+---
+
+# watsonx.ai
+
+- [watsonx.ai API Reference](https://cloud.ibm.com/apidocs/watsonx-ai#text-rerank)
+- [watsonx.ai Java SDK](https://github.com/IBM/watsonx-ai-java-sdk)
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-watsonx</artifactId>
+    <version>1.10.0-beta18</version>
+</dependency>
+```
+
+## Authentication
+
+Watsonx.ai supports authentication via the `Authenticator` interface.
+
+This allows to use different authentication mechanisms depending on your deployment:
+
+- **IBMCloudAuthenticator** – authenticates with **IBM Cloud** using an API key. This is the simplest approach and is used when you provide the `apiKey(...)` builder method.
+- **CP4DAuthenticator** – authenticates with **Cloud Pak for Data** deployments.
+- **Custom authenticators** – any implementation of the `Authenticator` interface can be used.
+
+The `WatsonxScoringModel` and other service builders accept either a shortcut via `.apiKey(...)` or a full `Authenticator` instance via `.authenticator(...)`.
+
+### Example
+```java
+WatsonxScoringModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key") // Simple IBM Cloud authentication
+    .projectId("your-project-id")
+    .modelName("cross-encoder/ms-marco-minilm-l-12-v2")
+    .build();
+
+WatsonxScoringModel.builder()
+    .baseUrl("https://my-instance-url")
+    .authenticator( // For Cloud Pak for Data deployments
+        CP4DAuthenticator.builder()
+            .baseUrl("https://my-instance-url")
+            .username("username")
+            .apiKey("api-key")
+            .build()
+    )
+    .projectId("my-project-id")
+    .modelName("cross-encoder/ms-marco-minilm-l-12-v2")
+    .build();
+```
+
+### Custom HttpClient
+
+All services and authenticators support a custom `HttpClient` instance through the builder pattern. This is particularly useful for Cloud Pak for Data environments where you may need to configure custom TLS/SSL settings, proxy configuration, or other HTTP client properties.
+```java
+HttpClient httpClient = HttpClient.newBuilder()
+    .sslContext(createCustomSSLContext())
+    .build();
+
+ScoringModel scoringModel = WatsonxScoringModel.builder()
+    .baseUrl("https://my-instance-url")
+    .modelName("cross-encoder/ms-marco-minilm-l-12-v2")
+    .projectId("project-id")
+    .httpClient(httpClient)
+    .authenticator(
+        CP4DAuthenticator.builder()
+            .baseUrl("https://my-instance-url")
+            .username("username")
+            .apiKey("api-key")
+            .httpClient(httpClient)
+            .build()
+    )
+    .build();
+```
+
+> **Note:** When using a custom `HttpClient` with Cloud Pak for Data, make sure to set it on both the service builder and the authenticator builder to ensure consistent HTTP behavior across all requests.
+
+### How to create an IBM Cloud API Key
+
+You can create an API key at [https://cloud.ibm.com/iam/apikeys](https://cloud.ibm.com/iam/apikeys) by clicking **Create +**.
+
+### How to find your Project ID
+
+1. Visit [https://dataplatform.cloud.ibm.com/projects/?context=wx](https://dataplatform.cloud.ibm.com/projects/?context=wx)  
+2. Open your project  
+3. Go to the **Manage** tab  
+4. Copy the **Project ID** from the **Details** section 
+
+## WatsonxScoringModel
+
+The `WatsonxScoringModel` provides a LangChain4j implementation of a `ScoringModel` using IBM watsonx.ai models.
+
+It is particularly useful for ranking a list of documents (or text segments) based on their relevance to a user query.
+
+### Example
+
+```java
+ScoringModel scoringModel = WatsonxScoringModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .projectId("your-project-id")
+    .modelName("cross-encoder/ms-marco-minilm-l-12-v2")
+    .build();
+
+var scores = scoringModel.scoreAll(
+    List.of(
+        TextSegment.from("Example_1"),
+        TextSegment.from("Example_2")
+    ),
+    "Hello from watsonx.ai"
+);
+
+System.out.println(scores);
+```
+
+> 🔗 [View available rerank model IDs](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx&audience=wdp#rerank)
+
+## Examples
+
+- [WatsonxScoringModelTest](https://github.com/langchain4j/langchain4j-examples/blob/main/watsonx-ai-examples/src/main/java/WatsonxScoringModelTest.java)

--- a/docs/docs/integrations/scoring-reranking-models/watsonx.md
+++ b/docs/docs/integrations/scoring-reranking-models/watsonx.md
@@ -52,31 +52,56 @@ WatsonxScoringModel.builder()
     .build();
 ```
 
-### Custom HttpClient
+### Custom HttpClient and SSL Configuration
+
+#### Using a custom HttpClient
 
 All services and authenticators support a custom `HttpClient` instance through the builder pattern. This is particularly useful for Cloud Pak for Data environments where you may need to configure custom TLS/SSL settings, proxy configuration, or other HTTP client properties.
+
 ```java
 HttpClient httpClient = HttpClient.newBuilder()
     .sslContext(createCustomSSLContext())
+    .executor(ExecutorProvider.ioExecutor())
     .build();
 
-ScoringModel scoringModel = WatsonxScoringModel.builder()
+EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
     .baseUrl("https://my-instance-url")
-    .modelName("cross-encoder/ms-marco-minilm-l-12-v2")
+    .modelName("ibm/granite-embedding-278m-multilingual")
     .projectId("project-id")
-    .httpClient(httpClient)
+    .httpClient(httpClient) // Custom HttpClient
     .authenticator(
         CP4DAuthenticator.builder()
             .baseUrl("https://my-instance-url")
             .username("username")
             .apiKey("api-key")
-            .httpClient(httpClient)
+            .httpClient(httpClient) // Custom HttpClient
             .build()
     )
     .build();
 ```
 
 > **Note:** When using a custom `HttpClient` with Cloud Pak for Data, make sure to set it on both the service builder and the authenticator builder to ensure consistent HTTP behavior across all requests.
+
+#### Disabling SSL verification
+
+If you only need to disable SSL certificate verification, you can use the `verifySsl(false)` option instead of providing a custom `HttpClient`:
+
+```java
+EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
+    .baseUrl("https://my-instance-url")
+    .modelName("ibm/granite-embedding-278m-multilingual")
+    .projectId("project-id")
+    .verifySsl(false) // Disable SSL verification
+    .authenticator(
+        CP4DAuthenticator.builder()
+            .baseUrl("https://my-instance-url")
+            .username("username")
+            .apiKey("api-key")
+            .verifySsl(false) // Disable SSL verification
+            .build()
+    )
+    .build();
+```
 
 ### How to create an IBM Cloud API Key
 

--- a/docs/docs/tutorials/structured-outputs.md
+++ b/docs/docs/tutorials/structured-outputs.md
@@ -111,6 +111,15 @@ ChatModel chatModel = MistralAiChatModel.builder()
         .logRequests(true)
         .logResponses(true)
         .build();
+// OR
+ChatModel chatModel = WatsonxChatModel.builder()
+        .baseUrl(System.getenv("WATSONX_URL"))
+        .projectId(System.getenv("WATSONX_PROJECT_ID"))
+        .apiKey(System.getenv("WATSONX_API_KEY"))
+        .modelName("ibm/granite-4-h-small")
+        .logRequests(true)
+        .logResponses(true)
+        .build();
 
 ChatResponse chatResponse = chatModel.chat(chatRequest);
 
@@ -429,6 +438,16 @@ ChatModel chatModel = MistralAiChatModel.builder()
          .logRequests(true)
          .logResponses(true)
          .build();
+// OR
+ChatModel chatModel = WatsonxChatModel.builder()
+        .baseUrl(System.getenv("WATSONX_URL"))
+        .projectId(System.getenv("WATSONX_PROJECT_ID"))
+        .apiKey(System.getenv("WATSONX_API_KEY"))
+        .modelName("ibm/granite-4-h-small")
+        .supportedCapabilities(RESPONSE_FORMAT_JSON_SCHEMA) // see [7] below
+        .logRequests(true)
+        .logResponses(true)
+        .build();
 
 PersonExtractor personExtractor = AiServices.create(PersonExtractor.class, chatModel); // see [1] below
 
@@ -452,6 +471,7 @@ as these beans are created automatically. More info on this:
 - [4] - This is required to enable the JSON Schema feature for [Google AI Gemini](/integrations/language-models/google-ai-gemini).
 - [5] - This is required to enable the JSON Schema feature for [Ollama](/integrations/language-models/ollama).
 - [6] - This is required to enable the JSON Schema feature for [Mistral](/integrations/language-models/mistral-ai).
+- [7] - This is required to enable the JSON Schema feature for [watsonx.ai](/integrations/language-models/watsonx).
 
 When all the following conditions are met:
 - AI Service method returns a POJO

--- a/langchain4j-watsonx/pom.xml
+++ b/langchain4j-watsonx/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.watsonx</groupId>
             <artifactId>watsonx-ai</artifactId>
-            <version>0.16.0</version>
+            <version>0.18.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
@@ -80,7 +80,7 @@ class Converter {
     public static PartialToolCall toPartialToolCall(com.ibm.watsonx.ai.chat.model.PartialToolCall partialToolCall) {
         return PartialToolCall.builder()
                 .id(partialToolCall.id())
-                .index(partialToolCall.index())
+                .index(partialToolCall.toolIndex())
                 .name(partialToolCall.name())
                 .partialArguments(partialToolCall.arguments())
                 .build();

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxBuilder.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxBuilder.java
@@ -19,6 +19,7 @@ abstract class WatsonxBuilder<T extends WatsonxBuilder<T>> {
     protected Duration timeout;
     protected Authenticator authenticator;
     protected HttpClient httpClient;
+    protected boolean verifySsl = true;
 
     public T baseUrl(CloudRegion baseUrl) {
         return baseUrl(baseUrl.mlEndpoint());
@@ -75,6 +76,11 @@ abstract class WatsonxBuilder<T extends WatsonxBuilder<T>> {
 
     public T httpClient(HttpClient httpClient) {
         this.httpClient = httpClient;
+        return (T) this;
+    }
+
+    public T verifySsl(boolean verifySsl) {
+        this.verifySsl = verifySsl;
         return (T) this;
     }
 }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxBuilder.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxBuilder.java
@@ -21,7 +21,7 @@ abstract class WatsonxBuilder<T extends WatsonxBuilder<T>> {
     protected HttpClient httpClient;
 
     public T baseUrl(CloudRegion baseUrl) {
-        return baseUrl(baseUrl.getMlEndpoint());
+        return baseUrl(baseUrl.mlEndpoint());
     }
 
     public T baseUrl(String url) {

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
@@ -102,6 +102,7 @@ abstract class WatsonxChat {
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
                 .httpClient(builder.httpClient)
+                .verifySsl(builder.verifySsl)
                 .build();
     }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
@@ -106,7 +106,7 @@ abstract class WatsonxChat {
                 .build();
     }
 
-    void validateThinkingIsAllowedForGraniteModel(
+    final void validateThinkingIsAllowedForGraniteModel(
             String modelName, List<ChatMessage> messages, List<ToolSpecification> tools) throws LangChain4jException {
 
         if (!"ibm/granite-3-3-8b-instruct".equals(modelName)) return;
@@ -121,7 +121,7 @@ abstract class WatsonxChat {
                     "The thinking/reasoning cannot be activated when a system message is present");
     }
 
-    void validate(ChatRequestParameters parameters) {
+    final void validate(ChatRequestParameters parameters) {
         if (nonNull(parameters.topK()))
             throw new UnsupportedFeatureException("'topK' parameter is not supported by watsonx.ai");
     }
@@ -159,16 +159,6 @@ abstract class WatsonxChat {
 
         public T modelName(String modelName) {
             this.modelName = modelName;
-            return (T) this;
-        }
-
-        public T projectId(String projectId) {
-            this.projectId = projectId;
-            return (T) this;
-        }
-
-        public T spaceId(String spaceId) {
-            this.spaceId = spaceId;
             return (T) this;
         }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
@@ -7,7 +7,6 @@ import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static java.util.Arrays.asList;
 import static java.util.Objects.nonNull;
 
-import com.ibm.watsonx.ai.CloudRegion;
 import com.ibm.watsonx.ai.chat.ChatService;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.Thinking;
@@ -152,10 +151,6 @@ abstract class WatsonxChat {
         private Double repetitionPenalty;
         private Double lengthPenalty;
         private Thinking thinking;
-
-        public T baseUrl(CloudRegion cloudRegion) {
-            return (T) super.baseUrl(cloudRegion.getMlEndpoint());
-        }
 
         public T modelName(String modelName) {
             this.modelName = modelName;

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatModel.java
@@ -64,7 +64,7 @@ public class WatsonxChatModel extends WatsonxChat implements ChatModel {
         List<ChatMessage> messages =
                 chatRequest.messages().stream().map(Converter::toChatMessage).collect(toCollection(ArrayList::new));
 
-        List<Tool> tools = nonNull(toolSpecifications) && toolSpecifications.size() > 0
+        List<Tool> tools = nonNull(toolSpecifications) && !toolSpecifications.isEmpty()
                 ? toolSpecifications.stream().map(Converter::toTool).toList()
                 : null;
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParameters.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParameters.java
@@ -256,6 +256,7 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
             return this;
         }
 
+        @Override
         public WatsonxChatRequestParameters build() {
             return new WatsonxChatRequestParameters(this);
         }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModel.java
@@ -3,7 +3,6 @@ package dev.langchain4j.model.watsonx;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
-import com.ibm.watsonx.ai.CloudRegion;
 import com.ibm.watsonx.ai.embedding.EmbeddingParameters;
 import com.ibm.watsonx.ai.embedding.EmbeddingResponse;
 import com.ibm.watsonx.ai.embedding.EmbeddingResponse.Result;
@@ -113,10 +112,6 @@ public class WatsonxEmbeddingModel implements EmbeddingModel {
         private String modelName;
 
         private Builder() {}
-
-        public Builder baseUrl(CloudRegion cloudRegion) {
-            return super.baseUrl(cloudRegion.getMlEndpoint());
-        }
 
         public Builder modelName(String modelName) {
             this.modelName = modelName;

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModel.java
@@ -123,16 +123,6 @@ public class WatsonxEmbeddingModel implements EmbeddingModel {
             return this;
         }
 
-        public Builder projectId(String projectId) {
-            this.projectId = projectId;
-            return this;
-        }
-
-        public Builder spaceId(String spaceId) {
-            this.spaceId = spaceId;
-            return this;
-        }
-
         public WatsonxEmbeddingModel build() {
             return new WatsonxEmbeddingModel(this);
         }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModel.java
@@ -49,6 +49,7 @@ public class WatsonxEmbeddingModel implements EmbeddingModel {
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
                 .httpClient(builder.httpClient)
+                .verifySsl(builder.verifySsl)
                 .build();
         this.modelName = builder.modelName;
     }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModelCatalog.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModelCatalog.java
@@ -38,6 +38,7 @@ public class WatsonxModelCatalog implements ModelCatalog {
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
                 .httpClient(builder.httpClient)
+                .verifySsl(builder.verifySsl)
                 .build();
         parameters =
                 FoundationModelParameters.builder().limit(200).techPreview(true).build();

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModelCatalog.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModelCatalog.java
@@ -3,7 +3,6 @@ package dev.langchain4j.model.watsonx;
 import static dev.langchain4j.model.ModelProvider.WATSONX;
 import static java.util.Objects.nonNull;
 
-import com.ibm.watsonx.ai.CloudRegion;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModel.Function;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModelParameters;
 import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
@@ -123,10 +122,6 @@ public class WatsonxModelCatalog implements ModelCatalog {
     public static class Builder extends WatsonxBuilder<Builder> {
 
         private Builder() {}
-
-        public Builder baseUrl(CloudRegion cloudRegion) {
-            return super.baseUrl(cloudRegion.getMlEndpoint());
-        }
 
         public WatsonxModelCatalog build() {
             return new WatsonxModelCatalog(this);

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModelCatalog.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModelCatalog.java
@@ -1,0 +1,135 @@
+package dev.langchain4j.model.watsonx;
+
+import static dev.langchain4j.model.ModelProvider.WATSONX;
+import static java.util.Objects.nonNull;
+
+import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.foundationmodel.FoundationModel.Function;
+import com.ibm.watsonx.ai.foundationmodel.FoundationModelParameters;
+import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.catalog.ModelCatalog;
+import dev.langchain4j.model.catalog.ModelDescription;
+import dev.langchain4j.model.catalog.ModelType;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * A {@link ModelCatalog} implementation that integrates IBM watsonx.ai with LangChain4j.
+ * <p>
+ * <b>Example usage:</b>
+ *
+ * <pre>{@code
+ * ModelCatalog modelCatalog = WatsonxModelCatalog.builder()
+ *     .baseUrl("https://...") // or use CloudRegion
+ *     .build();
+ * }</pre>
+ *
+ */
+public class WatsonxModelCatalog implements ModelCatalog {
+    private final FoundationModelService foundationModelService;
+    private final FoundationModelParameters parameters;
+
+    public WatsonxModelCatalog(Builder builder) {
+        foundationModelService = FoundationModelService.builder()
+                .baseUrl(builder.baseUrl)
+                .version(builder.version)
+                .timeout(builder.timeout)
+                .logRequests(builder.logRequests)
+                .logResponses(builder.logResponses)
+                .httpClient(builder.httpClient)
+                .build();
+        parameters =
+                FoundationModelParameters.builder().limit(200).techPreview(true).build();
+    }
+
+    @Override
+    public List<ModelDescription> listModels() {
+        return foundationModelService.getModels(parameters).resources().stream()
+                .map(model -> {
+                    var builder = ModelDescription.builder()
+                            .description(model.longDescription())
+                            .displayName(model.label())
+                            .name(model.modelId())
+                            .owner(model.provider())
+                            .provider(WATSONX)
+                            .type(resolveModelType(model.functions()));
+
+                    if (nonNull(model.lifecycle())) {
+                        var createdAt = model.lifecycle().stream()
+                                .filter(l -> l.id().equals("available"))
+                                .findFirst()
+                                .map(l -> LocalDate.parse(l.startDate())
+                                        .atStartOfDay()
+                                        .toInstant(ZoneOffset.UTC))
+                                .orElse(null);
+                        builder.createdAt(createdAt);
+                    }
+
+                    if (nonNull(model.modelLimits())) {
+                        builder.maxInputTokens(model.modelLimits().maxSequenceLength())
+                                .maxOutputTokens(model.modelLimits().maxOutputTokens());
+                    }
+
+                    return builder.build();
+                })
+                .toList();
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return WATSONX;
+    }
+
+    /**
+     * Returns a new {@link Builder} instance.
+     * <p>
+     * <b>Example usage:</b>
+     *
+     * <pre>{@code
+     * ModelCatalog modelCatalog = WatsonxModelCatalog.builder()
+     *     .baseUrl("https://...") // or use CloudRegion
+     *     .build();
+     * }</pre>
+     *
+     * @return {@link Builder} instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private ModelType resolveModelType(List<Function> functions) {
+        for (Function function : functions) {
+            switch (function.id()) {
+                case "text_chat", "image_chat" -> {
+                    return ModelType.CHAT;
+                }
+                case "embedding" -> {
+                    return ModelType.EMBEDDING;
+                }
+                case "rerank" -> {
+                    return ModelType.SCORING;
+                }
+                default -> {}
+            }
+        }
+        return ModelType.OTHER;
+    }
+
+    /**
+     * Builder class for constructing {@link WatsonxModelCatalog} instances with configurable parameters.
+     */
+    public static class Builder extends WatsonxBuilder<Builder> {
+
+        private Builder() {}
+
+        public Builder baseUrl(CloudRegion cloudRegion) {
+            return super.baseUrl(cloudRegion.getMlEndpoint());
+        }
+
+        public WatsonxModelCatalog build() {
+            return new WatsonxModelCatalog(this);
+        }
+    }
+}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
@@ -61,6 +61,7 @@ public class WatsonxModerationModel implements ModerationModel {
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
                 .httpClient(builder.httpClient)
+                .verifySsl(builder.verifySsl)
                 .build();
     }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxScoringModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxScoringModel.java
@@ -3,7 +3,6 @@ package dev.langchain4j.model.watsonx;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
-import com.ibm.watsonx.ai.CloudRegion;
 import com.ibm.watsonx.ai.rerank.RerankParameters;
 import com.ibm.watsonx.ai.rerank.RerankResponse;
 import com.ibm.watsonx.ai.rerank.RerankResponse.RerankResult;
@@ -109,10 +108,6 @@ public class WatsonxScoringModel implements ScoringModel {
         private String modelName;
 
         private Builder() {}
-
-        public Builder baseUrl(CloudRegion cloudRegion) {
-            return super.baseUrl(cloudRegion.getMlEndpoint());
-        }
 
         public Builder modelName(String modelName) {
             this.modelName = modelName;

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxScoringModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxScoringModel.java
@@ -49,6 +49,7 @@ public class WatsonxScoringModel implements ScoringModel {
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
                 .httpClient(builder.httpClient)
+                .verifySsl(builder.verifySsl)
                 .build();
     }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxScoringModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxScoringModel.java
@@ -119,16 +119,6 @@ public class WatsonxScoringModel implements ScoringModel {
             return this;
         }
 
-        public Builder projectId(String projectId) {
-            this.projectId = projectId;
-            return this;
-        }
-
-        public Builder spaceId(String spaceId) {
-            this.spaceId = spaceId;
-            return this;
-        }
-
         public WatsonxScoringModel build() {
             return new WatsonxScoringModel(this);
         }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxTokenCountEstimator.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxTokenCountEstimator.java
@@ -5,7 +5,6 @@ import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static java.util.Objects.nonNull;
 
-import com.ibm.watsonx.ai.CloudRegion;
 import com.ibm.watsonx.ai.tokenization.TokenizationParameters;
 import com.ibm.watsonx.ai.tokenization.TokenizationResponse;
 import com.ibm.watsonx.ai.tokenization.TokenizationResponse.Result;
@@ -179,10 +178,6 @@ public class WatsonxTokenCountEstimator implements TokenCountEstimator {
         private String modelName;
 
         private Builder() {}
-
-        public Builder baseUrl(CloudRegion cloudRegion) {
-            return super.baseUrl(cloudRegion.getMlEndpoint());
-        }
 
         public Builder modelName(String modelName) {
             this.modelName = modelName;

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxTokenCountEstimator.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxTokenCountEstimator.java
@@ -55,6 +55,7 @@ public class WatsonxTokenCountEstimator implements TokenCountEstimator {
                 .logRequests(builder.logRequests)
                 .logResponses(builder.logResponses)
                 .httpClient(builder.httpClient)
+                .verifySsl(builder.verifySsl)
                 .build();
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/ConverterTest.java
@@ -260,7 +260,7 @@ public class ConverterTest {
                 .build();
 
         var toConvert = new com.ibm.watsonx.ai.chat.model.PartialToolCall(
-                "completion-id", 10, "id", "name", "{\"name\":\"Klaus\"");
+                "completion-id", 0, 10, "id", "name", "{\"name\":\"Klaus\"");
         assertEquals(EXPECTED, Converter.toPartialToolCall(toConvert));
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
@@ -83,6 +84,7 @@ public class WatsonxChatModelTest {
         when(mockChatServiceBuilder.authenticator(any())).thenReturn(mockChatServiceBuilder);
         when(mockChatServiceBuilder.apiKey(any())).thenReturn(mockChatServiceBuilder);
         when(mockChatServiceBuilder.httpClient(any())).thenReturn(mockChatServiceBuilder);
+        when(mockChatServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockChatServiceBuilder);
         when(mockChatServiceBuilder.build()).thenReturn(mockChatService);
 
         var chatUsage = new ChatUsage(10, 10, 20);

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
@@ -32,15 +32,15 @@ public class WatsonxCustomHttpClientTest {
         Object chatService = getFieldValue(chatModel, "chatService");
         Object restclient = getFieldValue(chatService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
 
         Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
         assertEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
     }
 
     @Test
@@ -57,15 +57,15 @@ public class WatsonxCustomHttpClientTest {
         Object chatService = getFieldValue(chatModel, "chatService");
         Object restclient = getFieldValue(chatService, "client");
         assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
 
         Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
         assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(asyncHttpClient, "delegate"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
     }
 
     @Test
@@ -83,15 +83,15 @@ public class WatsonxCustomHttpClientTest {
         Object chatService = getFieldValue(streamingChatModel, "chatService");
         Object restclient = getFieldValue(chatService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
 
         Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
         assertEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
     }
 
     @Test
@@ -108,15 +108,15 @@ public class WatsonxCustomHttpClientTest {
         Object chatService = getFieldValue(streamingChatModel, "chatService");
         Object restclient = getFieldValue(chatService, "client");
         assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
 
         Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
         assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(asyncHttpClient, "delegate"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
     }
 
     @Test
@@ -134,11 +134,11 @@ public class WatsonxCustomHttpClientTest {
         Object embeddingService = getFieldValue(embeddingModel, "embeddingService");
         Object restclient = getFieldValue(embeddingService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @Test
@@ -155,11 +155,11 @@ public class WatsonxCustomHttpClientTest {
         Object embeddingService = getFieldValue(embeddingModel, "embeddingService");
         Object restclient = getFieldValue(embeddingService, "client");
         assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @Test
@@ -177,11 +177,11 @@ public class WatsonxCustomHttpClientTest {
         Object detectionService = getFieldValue(moderationModel, "detectionService");
         Object restclient = getFieldValue(detectionService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @Test
@@ -198,11 +198,11 @@ public class WatsonxCustomHttpClientTest {
         Object detectionService = getFieldValue(moderationModel, "detectionService");
         Object restclient = getFieldValue(detectionService, "client");
         assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @Test
@@ -220,11 +220,11 @@ public class WatsonxCustomHttpClientTest {
         Object rerankService = getFieldValue(scoringModel, "rerankService");
         Object restclient = getFieldValue(rerankService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @Test
@@ -241,11 +241,11 @@ public class WatsonxCustomHttpClientTest {
         Object rerankService = getFieldValue(scoringModel, "rerankService");
         Object restclient = getFieldValue(rerankService, "client");
         assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @Test
@@ -263,15 +263,15 @@ public class WatsonxCustomHttpClientTest {
         Object tokenizationService = getFieldValue(tokenCounterEstimator, "tokenizationService");
         Object restclient = getFieldValue(tokenizationService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
 
         Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
         assertEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
     }
 
     @Test
@@ -288,15 +288,15 @@ public class WatsonxCustomHttpClientTest {
         Object tokenizationService = getFieldValue(tokenCounterEstimator, "tokenizationService");
         Object restclient = getFieldValue(tokenizationService, "client");
         assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
 
         Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
         assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(asyncHttpClient, "delegate"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
     }
 
     @Test
@@ -311,11 +311,11 @@ public class WatsonxCustomHttpClientTest {
         Object foundationModelService = getFieldValue(modelCatalog, "foundationModelService");
         Object restclient = getFieldValue(foundationModelService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @Test
@@ -328,11 +328,11 @@ public class WatsonxCustomHttpClientTest {
         Object foundationModelService = getFieldValue(modelCatalog, "foundationModelService");
         Object restclient = getFieldValue(foundationModelService, "client");
         assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @SuppressWarnings("null")

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import com.ibm.watsonx.ai.core.provider.HttpClientProvider;
 import com.ibm.watsonx.ai.detection.detector.Pii;
 import dev.langchain4j.model.TokenCountEstimator;
+import dev.langchain4j.model.catalog.ModelCatalog;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -296,6 +297,42 @@ public class WatsonxCustomHttpClientTest {
         Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
         assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
         assertEquals(HttpClientProvider.httpClient(), getFieldValue(asyncHttpClient, "delegate"));
+    }
+
+    @Test
+    void should_use_custom_http_client_for_model_catalog() throws Exception {
+
+        HttpClient customClient = HttpClient.newHttpClient();
+        ModelCatalog modelCatalog = WatsonxModelCatalog.builder()
+                .baseUrl("https://localhost")
+                .httpClient(customClient)
+                .build();
+
+        Object foundationModelService = getFieldValue(modelCatalog, "foundationModelService");
+        Object restclient = getFieldValue(foundationModelService, "client");
+        assertEquals(customClient, getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+
+        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+        assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
+    }
+
+    @Test
+    void should_use_default_http_client_for_model_catalog() throws Exception {
+
+        HttpClient customClient = HttpClient.newHttpClient();
+        ModelCatalog modelCatalog =
+                WatsonxModelCatalog.builder().baseUrl("https://localhost").build();
+
+        Object foundationModelService = getFieldValue(modelCatalog, "foundationModelService");
+        Object restclient = getFieldValue(foundationModelService, "client");
+        assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+        assertEquals(HttpClientProvider.httpClient(), getFieldValue(restclient, "httpClient"));
+
+        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+        assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+        assertEquals(HttpClientProvider.httpClient(), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @SuppressWarnings("null")

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.watsonx;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.ibm.watsonx.ai.core.provider.HttpClientProvider;
 import com.ibm.watsonx.ai.detection.detector.Pii;
@@ -13,6 +14,7 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.scoring.ScoringModel;
 import java.net.http.HttpClient;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 public class WatsonxCustomHttpClientTest {
@@ -33,39 +35,51 @@ public class WatsonxCustomHttpClientTest {
         Object restclient = getFieldValue(chatService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
 
         Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
         assertEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(asyncHttpClient, "delegate"));
     }
 
     @Test
-    void should_use_default_http_client_for_chat_model() throws Exception {
+    void should_use_default_http_client_for_chat_model() {
 
-        HttpClient customClient = HttpClient.newHttpClient();
-        ChatModel chatModel = WatsonxChatModel.builder()
-                .baseUrl("https://localhost")
-                .modelName("modelId")
-                .apiKey("apiKey")
-                .projectId("projectId")
-                .build();
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
 
-        Object chatService = getFieldValue(chatModel, "chatService");
-        Object restclient = getFieldValue(chatService, "client");
-        assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+                HttpClient customClient = HttpClient.newHttpClient();
+                ChatModel chatModel = WatsonxChatModel.builder()
+                        .baseUrl("https://localhost")
+                        .modelName("modelId")
+                        .apiKey("apiKey")
+                        .projectId("projectId")
+                        .verifySsl(verifySsl)
+                        .build();
 
-        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
-        assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+                Object chatService = getFieldValue(chatModel, "chatService");
+                Object restclient = getFieldValue(chatService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
 
-        Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
-        assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+                Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
+                assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(asyncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
     }
 
     @Test
@@ -84,39 +98,51 @@ public class WatsonxCustomHttpClientTest {
         Object restclient = getFieldValue(chatService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
 
         Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
         assertEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(asyncHttpClient, "delegate"));
     }
 
     @Test
-    void should_use_default_http_client_for_streaming_chat_model() throws Exception {
+    void should_use_default_http_client_for_streaming_chat_model() {
 
-        HttpClient customClient = HttpClient.newHttpClient();
-        StreamingChatModel streamingChatModel = WatsonxStreamingChatModel.builder()
-                .baseUrl("https://localhost")
-                .modelName("modelId")
-                .apiKey("apiKey")
-                .projectId("projectId")
-                .build();
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
 
-        Object chatService = getFieldValue(streamingChatModel, "chatService");
-        Object restclient = getFieldValue(chatService, "client");
-        assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+                HttpClient customClient = HttpClient.newHttpClient();
+                StreamingChatModel streamingChatModel = WatsonxStreamingChatModel.builder()
+                        .baseUrl("https://localhost")
+                        .modelName("modelId")
+                        .apiKey("apiKey")
+                        .projectId("projectId")
+                        .verifySsl(verifySsl)
+                        .build();
 
-        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
-        assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+                Object chatService = getFieldValue(streamingChatModel, "chatService");
+                Object restclient = getFieldValue(chatService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
 
-        Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
-        assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+                Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
+                assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(asyncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
     }
 
     @Test
@@ -135,31 +161,42 @@ public class WatsonxCustomHttpClientTest {
         Object restclient = getFieldValue(embeddingService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
     }
 
     @Test
     void should_use_default_http_client_for_embedding_model() throws Exception {
 
-        HttpClient customClient = HttpClient.newHttpClient();
-        EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
-                .baseUrl("https://localhost")
-                .modelName("modelName")
-                .apiKey("apiKey")
-                .projectId("projectId")
-                .build();
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
 
-        Object embeddingService = getFieldValue(embeddingModel, "embeddingService");
-        Object restclient = getFieldValue(embeddingService, "client");
-        assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+                HttpClient customClient = HttpClient.newHttpClient();
+                EmbeddingModel embeddingModel = WatsonxEmbeddingModel.builder()
+                        .baseUrl("https://localhost")
+                        .modelName("modelName")
+                        .apiKey("apiKey")
+                        .projectId("projectId")
+                        .verifySsl(verifySsl)
+                        .build();
 
-        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
-        assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+                Object embeddingService = getFieldValue(embeddingModel, "embeddingService");
+                Object restclient = getFieldValue(embeddingService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
+
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
     }
 
     @Test
@@ -178,31 +215,42 @@ public class WatsonxCustomHttpClientTest {
         Object restclient = getFieldValue(detectionService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @Test
     void should_use_default_http_client_for_moderation_model() throws Exception {
 
-        HttpClient customClient = HttpClient.newHttpClient();
-        ModerationModel moderationModel = WatsonxModerationModel.builder()
-                .baseUrl("https://localhost")
-                .apiKey("apiKey")
-                .projectId("projectId")
-                .detectors(Pii.ofDefaults())
-                .build();
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
 
-        Object detectionService = getFieldValue(moderationModel, "detectionService");
-        Object restclient = getFieldValue(detectionService, "client");
-        assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+                HttpClient customClient = HttpClient.newHttpClient();
+                ModerationModel moderationModel = WatsonxModerationModel.builder()
+                        .baseUrl("https://localhost")
+                        .apiKey("apiKey")
+                        .projectId("projectId")
+                        .detectors(Pii.ofDefaults())
+                        .verifySsl(verifySsl)
+                        .build();
 
-        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
-        assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+                Object detectionService = getFieldValue(moderationModel, "detectionService");
+                Object restclient = getFieldValue(detectionService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
+
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
     }
 
     @Test
@@ -221,31 +269,42 @@ public class WatsonxCustomHttpClientTest {
         Object restclient = getFieldValue(rerankService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @Test
     void should_use_default_http_client_for_scoring_model() throws Exception {
 
-        HttpClient customClient = HttpClient.newHttpClient();
-        ScoringModel scoringModel = WatsonxScoringModel.builder()
-                .baseUrl("https://localhost")
-                .apiKey("apiKey")
-                .projectId("projectId")
-                .modelName("model-name")
-                .build();
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
 
-        Object rerankService = getFieldValue(scoringModel, "rerankService");
-        Object restclient = getFieldValue(rerankService, "client");
-        assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+                HttpClient customClient = HttpClient.newHttpClient();
+                ScoringModel scoringModel = WatsonxScoringModel.builder()
+                        .baseUrl("https://localhost")
+                        .apiKey("apiKey")
+                        .projectId("projectId")
+                        .modelName("model-name")
+                        .verifySsl(verifySsl)
+                        .build();
 
-        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
-        assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+                Object rerankService = getFieldValue(scoringModel, "rerankService");
+                Object restclient = getFieldValue(rerankService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
+
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
     }
 
     @Test
@@ -264,39 +323,51 @@ public class WatsonxCustomHttpClientTest {
         Object restclient = getFieldValue(tokenizationService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
 
         Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
         assertEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(asyncHttpClient, "delegate"));
     }
 
     @Test
     void should_use_default_http_client_for_token_count_estimator() throws Exception {
 
-        HttpClient customClient = HttpClient.newHttpClient();
-        TokenCountEstimator tokenCounterEstimator = WatsonxTokenCountEstimator.builder()
-                .baseUrl("https://localhost")
-                .modelName("modelName")
-                .apiKey("apiKey")
-                .projectId("projectId")
-                .build();
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
 
-        Object tokenizationService = getFieldValue(tokenCounterEstimator, "tokenizationService");
-        Object restclient = getFieldValue(tokenizationService, "client");
-        assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+                HttpClient customClient = HttpClient.newHttpClient();
+                TokenCountEstimator tokenCounterEstimator = WatsonxTokenCountEstimator.builder()
+                        .baseUrl("https://localhost")
+                        .modelName("modelName")
+                        .apiKey("apiKey")
+                        .projectId("projectId")
+                        .verifySsl(verifySsl)
+                        .build();
 
-        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
-        assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+                Object tokenizationService = getFieldValue(tokenCounterEstimator, "tokenizationService");
+                Object restclient = getFieldValue(tokenizationService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
 
-        Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
-        assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(asyncHttpClient, "delegate"));
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+                Object asyncHttpClient = getFieldValue(restclient, "asyncHttpClient");
+                assertNotEquals(customClient, getFieldValue(asyncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(asyncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
     }
 
     @Test
@@ -312,27 +383,39 @@ public class WatsonxCustomHttpClientTest {
         Object restclient = getFieldValue(foundationModelService, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
 
         Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
         assertEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+        assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(syncHttpClient, "delegate"));
     }
 
     @Test
     void should_use_default_http_client_for_model_catalog() throws Exception {
 
-        HttpClient customClient = HttpClient.newHttpClient();
-        ModelCatalog modelCatalog =
-                WatsonxModelCatalog.builder().baseUrl("https://localhost").build();
+        Stream.of(true, false).forEach(verifySsl -> {
+            try {
 
-        Object foundationModelService = getFieldValue(modelCatalog, "foundationModelService");
-        Object restclient = getFieldValue(foundationModelService, "client");
-        assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
+                HttpClient customClient = HttpClient.newHttpClient();
+                ModelCatalog modelCatalog = WatsonxModelCatalog.builder()
+                        .baseUrl("https://localhost")
+                        .verifySsl(verifySsl)
+                        .build();
 
-        Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
-        assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
-        assertEquals(HttpClientProvider.httpClient(true), getFieldValue(syncHttpClient, "delegate"));
+                Object foundationModelService = getFieldValue(modelCatalog, "foundationModelService");
+                Object restclient = getFieldValue(foundationModelService, "client");
+                assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
+
+                Object syncHttpClient = getFieldValue(restclient, "syncHttpClient");
+                assertNotEquals(customClient, getFieldValue(syncHttpClient, "delegate"));
+                assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(syncHttpClient, "delegate"));
+
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
     }
 
     @SuppressWarnings("null")

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModelTest.java
@@ -103,7 +103,6 @@ public class WatsonxEmbeddingModelTest {
             assertEquals("model-name", embeddingRequest.modelId());
             assertEquals("project-id", embeddingRequest.projectId());
             assertEquals("space-id", embeddingRequest.spaceId());
-            // 6. Test builder secondario
             assertDoesNotThrow(() -> WatsonxEmbeddingModel.builder()
                     .baseUrl("https://test.com")
                     .modelName("model-name")

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxEmbeddingModelTest.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.watsonx;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -59,6 +60,7 @@ public class WatsonxEmbeddingModelTest {
         when(mockEmbeddingServiceBuilder.authenticator(any())).thenReturn(mockEmbeddingServiceBuilder);
         when(mockEmbeddingServiceBuilder.apiKey(any())).thenReturn(mockEmbeddingServiceBuilder);
         when(mockEmbeddingServiceBuilder.httpClient(any())).thenReturn(mockEmbeddingServiceBuilder);
+        when(mockEmbeddingServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockEmbeddingServiceBuilder);
         when(mockEmbeddingServiceBuilder.build()).thenReturn(mockEmbeddingService);
     }
 
@@ -81,7 +83,7 @@ public class WatsonxEmbeddingModelTest {
                 .thenReturn(mockHttpResponse);
 
         try (MockedStatic<HttpClientProvider> httpClientProvider = mockStatic(HttpClientProvider.class)) {
-            httpClientProvider.when(HttpClientProvider::httpClient).thenReturn(mockHttpClient);
+            httpClientProvider.when(() -> HttpClientProvider.httpClient(true)).thenReturn(mockHttpClient);
 
             var embeddingModel = WatsonxEmbeddingModel.builder()
                     .baseUrl(CloudRegion.FRANKFURT)

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxModelCatalogTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxModelCatalogTest.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.watsonx;
 import static dev.langchain4j.model.ModelProvider.WATSONX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -48,6 +49,7 @@ public class WatsonxModelCatalogTest {
         when(mockFoundationModelServiceBuilder.authenticator(any())).thenReturn(mockFoundationModelServiceBuilder);
         when(mockFoundationModelServiceBuilder.apiKey(any())).thenReturn(mockFoundationModelServiceBuilder);
         when(mockFoundationModelServiceBuilder.httpClient(any())).thenReturn(mockFoundationModelServiceBuilder);
+        when(mockFoundationModelServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockFoundationModelServiceBuilder);
         when(mockFoundationModelServiceBuilder.build()).thenReturn(mockFoundationModelService);
     }
 
@@ -63,66 +65,66 @@ public class WatsonxModelCatalogTest {
         when(mockHttpResponse.body())
                 .thenReturn(
                         """
-                {
-                    "total_count": 28,
-                    "limit": 100,
-                    "first": {
-                        "href": "https://us-south.ml.cloud.ibm.com/ml/v1/foundation_model_specs?version=2025-12-05"
-                    },
-                    "resources": [
-                        {
-                            "model_id": "cross-encoder/ms-marco-minilm-l-12-v2",
-                            "label": "ms-marco-minilm-l-12-v2",
-                            "provider": "cross-encoder",
-                            "source": "cross-encoder",
-                            "indemnity": "NON_IBM",
-                            "functions": [
-                                {
-                                    "id": "rerank"
-                                }
-                            ],
-                            "short_description": "Used for Information Retrieval: Encode and sort a query will all possible passages.",
-                            "long_description": "The model can be used for Information Retrieval: Given a query, encode the query will all possible passages (e.g. retrieved with ElasticSearch). Then sort the passages in a decreasing order.",
-                            "input_tier": "class_11",
-                            "output_tier": "class_11",
-                            "number_params": "33.4m",
-                            "model_limits": {
-                                "max_sequence_length": 512,
-                                "max_output_tokens": 1024
-                            },
-                            "limits": {
-                                "19e27818-79cf-4137-ae58-da279f9e9d16": {
-                                    "call_time": "10m0s",
+                    {
+                        "total_count": 28,
+                        "limit": 100,
+                        "first": {
+                            "href": "https://us-south.ml.cloud.ibm.com/ml/v1/foundation_model_specs?version=2025-12-05"
+                        },
+                        "resources": [
+                            {
+                                "model_id": "cross-encoder/ms-marco-minilm-l-12-v2",
+                                "label": "ms-marco-minilm-l-12-v2",
+                                "provider": "cross-encoder",
+                                "source": "cross-encoder",
+                                "indemnity": "NON_IBM",
+                                "functions": [
+                                    {
+                                        "id": "rerank"
+                                    }
+                                ],
+                                "short_description": "Used for Information Retrieval: Encode and sort a query will all possible passages.",
+                                "long_description": "The model can be used for Information Retrieval: Given a query, encode the query will all possible passages (e.g. retrieved with ElasticSearch). Then sort the passages in a decreasing order.",
+                                "input_tier": "class_11",
+                                "output_tier": "class_11",
+                                "number_params": "33.4m",
+                                "model_limits": {
+                                    "max_sequence_length": 512,
                                     "max_output_tokens": 1024
                                 },
-                                "3f6acf43-ede8-413a-ac69-f8af3bb0cbfe": {
-                                    "call_time": "5m0s",
-                                    "max_output_tokens": 1024
+                                "limits": {
+                                    "19e27818-79cf-4137-ae58-da279f9e9d16": {
+                                        "call_time": "10m0s",
+                                        "max_output_tokens": 1024
+                                    },
+                                    "3f6acf43-ede8-413a-ac69-f8af3bb0cbfe": {
+                                        "call_time": "5m0s",
+                                        "max_output_tokens": 1024
+                                    },
+                                    "a3d2f92f-06f9-48d0-b2e6-a7ba2b4e0577": {
+                                        "call_time": "10m0s",
+                                        "max_output_tokens": 1024
+                                    },
+                                    "d18d88b9-be7a-46ec-be1e-aff14904f1e9": {
+                                        "call_time": "10m0s",
+                                        "max_output_tokens": 1024
+                                    }
                                 },
-                                "a3d2f92f-06f9-48d0-b2e6-a7ba2b4e0577": {
-                                    "call_time": "10m0s",
-                                    "max_output_tokens": 1024
-                                },
-                                "d18d88b9-be7a-46ec-be1e-aff14904f1e9": {
-                                    "call_time": "10m0s",
-                                    "max_output_tokens": 1024
-                                }
-                            },
-                            "lifecycle": [
-                                {
-                                    "id": "available",
-                                    "start_date": "2024-09-17"
-                                }
-                            ]
-                        }
-                    ]
-                }""");
+                                "lifecycle": [
+                                    {
+                                        "id": "available",
+                                        "start_date": "2024-09-17"
+                                    }
+                                ]
+                            }
+                        ]
+                    }""");
 
         when(mockHttpClient.send(mockHttpRequest.capture(), any(BodyHandler.class)))
                 .thenReturn(mockHttpResponse);
 
         try (MockedStatic<HttpClientProvider> httpClientProvider = mockStatic(HttpClientProvider.class)) {
-            httpClientProvider.when(HttpClientProvider::httpClient).thenReturn(mockHttpClient);
+            httpClientProvider.when(() -> HttpClientProvider.httpClient(true)).thenReturn(mockHttpClient);
 
             var modelCatalog = WatsonxModelCatalog.builder()
                     .baseUrl(CloudRegion.FRANKFURT)

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxModelCatalogTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxModelCatalogTest.java
@@ -1,0 +1,146 @@
+package dev.langchain4j.model.watsonx;
+
+import static dev.langchain4j.model.ModelProvider.WATSONX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.ibm.watsonx.ai.CloudRegion;
+import com.ibm.watsonx.ai.core.auth.ibmcloud.IBMCloudAuthenticator;
+import com.ibm.watsonx.ai.core.provider.HttpClientProvider;
+import com.ibm.watsonx.ai.foundationmodel.FoundationModelService;
+import dev.langchain4j.model.catalog.ModelType;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("unchecked")
+public class WatsonxModelCatalogTest {
+
+    @Mock
+    FoundationModelService mockFoundationModelService;
+
+    @Mock
+    FoundationModelService.Builder mockFoundationModelServiceBuilder;
+
+    @BeforeEach
+    void setUp() {
+        when(mockFoundationModelServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockFoundationModelServiceBuilder);
+        when(mockFoundationModelServiceBuilder.timeout(any())).thenReturn(mockFoundationModelServiceBuilder);
+        when(mockFoundationModelServiceBuilder.version(any())).thenReturn(mockFoundationModelServiceBuilder);
+        when(mockFoundationModelServiceBuilder.logRequests(any())).thenReturn(mockFoundationModelServiceBuilder);
+        when(mockFoundationModelServiceBuilder.logResponses(any())).thenReturn(mockFoundationModelServiceBuilder);
+        when(mockFoundationModelServiceBuilder.authenticator(any())).thenReturn(mockFoundationModelServiceBuilder);
+        when(mockFoundationModelServiceBuilder.apiKey(any())).thenReturn(mockFoundationModelServiceBuilder);
+        when(mockFoundationModelServiceBuilder.httpClient(any())).thenReturn(mockFoundationModelServiceBuilder);
+        when(mockFoundationModelServiceBuilder.build()).thenReturn(mockFoundationModelService);
+    }
+
+    @Test
+    void should_list_models() throws Exception {
+
+        var mockHttpClient = mock(HttpClient.class);
+        var mockHttpResponse = mock(HttpResponse.class);
+        var mockAuthenticatorProvider = mock(IBMCloudAuthenticator.class);
+        var mockHttpRequest = ArgumentCaptor.forClass(HttpRequest.class);
+
+        when(mockHttpResponse.statusCode()).thenReturn(200);
+        when(mockHttpResponse.body())
+                .thenReturn(
+                        """
+                {
+                    "total_count": 28,
+                    "limit": 100,
+                    "first": {
+                        "href": "https://us-south.ml.cloud.ibm.com/ml/v1/foundation_model_specs?version=2025-12-05"
+                    },
+                    "resources": [
+                        {
+                            "model_id": "cross-encoder/ms-marco-minilm-l-12-v2",
+                            "label": "ms-marco-minilm-l-12-v2",
+                            "provider": "cross-encoder",
+                            "source": "cross-encoder",
+                            "indemnity": "NON_IBM",
+                            "functions": [
+                                {
+                                    "id": "rerank"
+                                }
+                            ],
+                            "short_description": "Used for Information Retrieval: Encode and sort a query will all possible passages.",
+                            "long_description": "The model can be used for Information Retrieval: Given a query, encode the query will all possible passages (e.g. retrieved with ElasticSearch). Then sort the passages in a decreasing order.",
+                            "input_tier": "class_11",
+                            "output_tier": "class_11",
+                            "number_params": "33.4m",
+                            "model_limits": {
+                                "max_sequence_length": 512,
+                                "max_output_tokens": 1024
+                            },
+                            "limits": {
+                                "19e27818-79cf-4137-ae58-da279f9e9d16": {
+                                    "call_time": "10m0s",
+                                    "max_output_tokens": 1024
+                                },
+                                "3f6acf43-ede8-413a-ac69-f8af3bb0cbfe": {
+                                    "call_time": "5m0s",
+                                    "max_output_tokens": 1024
+                                },
+                                "a3d2f92f-06f9-48d0-b2e6-a7ba2b4e0577": {
+                                    "call_time": "10m0s",
+                                    "max_output_tokens": 1024
+                                },
+                                "d18d88b9-be7a-46ec-be1e-aff14904f1e9": {
+                                    "call_time": "10m0s",
+                                    "max_output_tokens": 1024
+                                }
+                            },
+                            "lifecycle": [
+                                {
+                                    "id": "available",
+                                    "start_date": "2024-09-17"
+                                }
+                            ]
+                        }
+                    ]
+                }""");
+
+        when(mockHttpClient.send(mockHttpRequest.capture(), any(BodyHandler.class)))
+                .thenReturn(mockHttpResponse);
+
+        try (MockedStatic<HttpClientProvider> httpClientProvider = mockStatic(HttpClientProvider.class)) {
+            httpClientProvider.when(HttpClientProvider::httpClient).thenReturn(mockHttpClient);
+
+            var modelCatalog = WatsonxModelCatalog.builder()
+                    .baseUrl(CloudRegion.FRANKFURT)
+                    .authenticator(mockAuthenticatorProvider)
+                    .build();
+
+            var models = modelCatalog.listModels();
+            assertEquals(1, models.size());
+            assertEquals("2024-09-17T00:00:00Z", models.get(0).createdAt().toString());
+            assertEquals(
+                    "The model can be used for Information Retrieval: Given a query, encode the query will all possible passages (e.g. retrieved with ElasticSearch). Then sort the passages in a decreasing order.",
+                    models.get(0).description());
+            assertEquals("ms-marco-minilm-l-12-v2", models.get(0).displayName());
+            assertEquals(512, models.get(0).maxInputTokens());
+            assertEquals(1024, models.get(0).maxOutputTokens());
+            assertEquals("cross-encoder/ms-marco-minilm-l-12-v2", models.get(0).name());
+            assertEquals(WATSONX, models.get(0).provider());
+            assertEquals(ModelType.SCORING, models.get(0).type());
+        }
+    }
+}

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxModerationTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxModerationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mockStatic;
@@ -62,6 +63,7 @@ public class WatsonxModerationTest {
         when(mockDetectionServiceBuilder.logResponses(any())).thenReturn(mockDetectionServiceBuilder);
         when(mockDetectionServiceBuilder.apiKey(any())).thenReturn(mockDetectionServiceBuilder);
         when(mockDetectionServiceBuilder.httpClient(any())).thenReturn(mockDetectionServiceBuilder);
+        when(mockDetectionServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockDetectionServiceBuilder);
         when(mockDetectionServiceBuilder.build()).thenReturn(mockDetectionService);
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxScoringModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxScoringModelTest.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.watsonx;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -60,6 +61,7 @@ public class WatsonxScoringModelTest {
         when(mockRerankServiceBuilder.authenticator(any())).thenReturn(mockRerankServiceBuilder);
         when(mockRerankServiceBuilder.apiKey(any())).thenReturn(mockRerankServiceBuilder);
         when(mockRerankServiceBuilder.httpClient(any())).thenReturn(mockRerankServiceBuilder);
+        when(mockRerankServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockRerankServiceBuilder);
         when(mockRerankServiceBuilder.build()).thenReturn(mockRerankService);
     }
 
@@ -86,7 +88,7 @@ public class WatsonxScoringModelTest {
                 .thenReturn(mockHttpResponse);
 
         try (MockedStatic<HttpClientProvider> httpClientProvider = mockStatic(HttpClientProvider.class)) {
-            httpClientProvider.when(HttpClientProvider::httpClient).thenReturn(mockHttpClient);
+            httpClientProvider.when(() -> HttpClientProvider.httpClient(true)).thenReturn(mockHttpClient);
 
             var scoringModel = WatsonxScoringModel.builder()
                     .baseUrl(CloudRegion.FRANKFURT)

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -86,6 +87,7 @@ public class WatsonxStreamingChatModelTest {
         when(mockChatServiceBuilder.authenticator(any())).thenReturn(mockChatServiceBuilder);
         when(mockChatServiceBuilder.apiKey(any())).thenReturn(mockChatServiceBuilder);
         when(mockChatServiceBuilder.httpClient(any())).thenReturn(mockChatServiceBuilder);
+        when(mockChatServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockChatServiceBuilder);
         when(mockChatServiceBuilder.build()).thenReturn(mockChatService);
 
         var chatUsage = new ChatUsage(10, 10, 20);
@@ -456,11 +458,11 @@ public class WatsonxStreamingChatModelTest {
 
         doAnswer(invocation -> {
                     ChatHandler handler = invocation.getArgument(1);
-                    handler.onPartialToolCall(
-                            new com.ibm.watsonx.ai.chat.model.PartialToolCall("completion-id", 0, null, "name", "{"));
-                    handler.onPartialToolCall(
-                            new com.ibm.watsonx.ai.chat.model.PartialToolCall("completion-id", 0, "id", "name", "}"));
-                    handler.onCompleteToolCall(new CompletedToolCall("completion-id", toolCall));
+                    handler.onPartialToolCall(new com.ibm.watsonx.ai.chat.model.PartialToolCall(
+                            "completion-id", 0, 0, null, "name", "{"));
+                    handler.onPartialToolCall(new com.ibm.watsonx.ai.chat.model.PartialToolCall(
+                            "completion-id", 0, 0, "id", "name", "}"));
+                    handler.onCompleteToolCall(new CompletedToolCall("completion-id", 0, toolCall));
                     handler.onCompleteResponse(chatResponse.build());
                     return CompletableFuture.completedFuture(null);
                 })

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxTokenCountEstimatorTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxTokenCountEstimatorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -72,6 +73,7 @@ public class WatsonxTokenCountEstimatorTest {
         when(mockTokenizationServiceBuilder.authenticator(any())).thenReturn(mockTokenizationServiceBuilder);
         when(mockTokenizationServiceBuilder.apiKey(any())).thenReturn(mockTokenizationServiceBuilder);
         when(mockTokenizationServiceBuilder.httpClient(any())).thenReturn(mockTokenizationServiceBuilder);
+        when(mockTokenizationServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockTokenizationServiceBuilder);
         when(mockTokenizationServiceBuilder.build()).thenReturn(mockTokenizationService);
     }
 
@@ -94,7 +96,7 @@ public class WatsonxTokenCountEstimatorTest {
                 .thenReturn(mockHttpResponse);
 
         try (MockedStatic<HttpClientProvider> httpClientProvider = mockStatic(HttpClientProvider.class)) {
-            httpClientProvider.when(HttpClientProvider::httpClient).thenReturn(mockHttpClient);
+            httpClientProvider.when(() -> HttpClientProvider.httpClient(true)).thenReturn(mockHttpClient);
             var tokenCountEstimator = WatsonxTokenCountEstimator.builder()
                     .baseUrl(CloudRegion.FRANKFURT)
                     .modelName("model-name")

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxModelCatalogIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxModelCatalogIT.java
@@ -1,0 +1,33 @@
+package dev.langchain4j.model.watsonx.it;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.langchain4j.model.catalog.ModelCatalog;
+import dev.langchain4j.model.watsonx.WatsonxModelCatalog;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+public class WatsonxModelCatalogIT {
+
+    static final String URL = System.getenv("WATSONX_URL");
+    static final ModelCatalog modelCatalog =
+            WatsonxModelCatalog.builder().logRequests(true).baseUrl(URL).build();
+
+    @Test
+    void should_list_models() {
+        var models = assertDoesNotThrow(() -> modelCatalog.listModels());
+        assertTrue(models.size() > 0);
+        assertNotNull(models.get(0).createdAt());
+        assertNotNull(models.get(0).description());
+        assertNotNull(models.get(0).displayName());
+        assertNotNull(models.get(0).maxInputTokens());
+        assertNotNull(models.get(0).maxOutputTokens());
+        assertNotNull(models.get(0).name());
+        assertNotNull(models.get(0).owner());
+        assertNotNull(models.get(0).provider());
+        assertNotNull(models.get(0).type());
+    }
+}


### PR DESCRIPTION
## Change
<!-- Please describe the changes you made. -->
- Implemented ModelCatalog support for watsonx.ai
- Updated watsonx.ai SDK dependency to version 0.18.0
- Enhanced documentation

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
