### PR TITLE
feat: propagate isError from ToolExecutionResultMessage to Anthropic

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -115,7 +115,7 @@ public class AnthropicMapper {
     }
 
     private static AnthropicToolResultContent toAnthropicToolResultContent(ToolExecutionResultMessage message) {
-        return new AnthropicToolResultContent(message.id(), message.text(), null); // TODO propagate isError
+        return new AnthropicToolResultContent(message.id(), message.text(), message.isError() ? true : null);
     }
 
     private static List<AnthropicMessageContent> toAnthropicMessageContents(UserMessage message) {

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
@@ -16,6 +16,7 @@ public class ToolExecutionResultMessage implements ChatMessage {
     private final String id;
     private final String toolName;
     private final String text;
+    private final boolean isError;
 
     /**
      * Creates a {@link ToolExecutionResultMessage}.
@@ -24,9 +25,21 @@ public class ToolExecutionResultMessage implements ChatMessage {
      * @param text the result of the tool execution.
      */
     public ToolExecutionResultMessage(String id, String toolName, String text) {
+        this(id, toolName, text, false);
+    }
+
+    /**
+     * Creates a {@link ToolExecutionResultMessage}.
+     * @param id the id of the tool.
+     * @param toolName the name of the tool.
+     * @param text the result of the tool execution.
+     * @param isError whether the tool execution resulted in an error.
+     */
+    public ToolExecutionResultMessage(String id, String toolName, String text, boolean isError) {
         this.id = id;
         this.toolName = toolName;
         this.text = ensureNotNull(text, "text");
+        this.isError = isError;
     }
 
     /**
@@ -53,6 +66,14 @@ public class ToolExecutionResultMessage implements ChatMessage {
         return text;
     }
 
+    /**
+     * Returns whether the tool execution resulted in an error.
+     * @return true if the tool execution resulted in an error, false otherwise.
+     */
+    public boolean isError() {
+        return isError;
+    }
+
     @Override
     public ChatMessageType type() {
         return TOOL_EXECUTION_RESULT;
@@ -65,12 +86,13 @@ public class ToolExecutionResultMessage implements ChatMessage {
         ToolExecutionResultMessage that = (ToolExecutionResultMessage) o;
         return Objects.equals(this.id, that.id)
                 && Objects.equals(this.toolName, that.toolName)
-                && Objects.equals(this.text, that.text);
+                && Objects.equals(this.text, that.text)
+                && this.isError == that.isError;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, toolName, text);
+        return Objects.hash(id, toolName, text, isError);
     }
 
     @Override
@@ -78,7 +100,8 @@ public class ToolExecutionResultMessage implements ChatMessage {
         return "ToolExecutionResultMessage {" + " id = "
                 + quoted(id) + " toolName = "
                 + quoted(toolName) + " text = "
-                + quoted(text) + " }";
+                + quoted(text) + " isError = "
+                + isError + " }";
     }
 
     /**
@@ -93,6 +116,18 @@ public class ToolExecutionResultMessage implements ChatMessage {
 
     /**
      * Creates a {@link ToolExecutionResultMessage} from a {@link ToolExecutionRequest} and the result of the tool execution.
+     * @param request the request.
+     * @param toolExecutionResult the result of the tool execution.
+     * @param isError whether the tool execution resulted in an error.
+     * @return the {@link ToolExecutionResultMessage}.
+     */
+    public static ToolExecutionResultMessage from(
+            ToolExecutionRequest request, String toolExecutionResult, boolean isError) {
+        return new ToolExecutionResultMessage(request.id(), request.name(), toolExecutionResult, isError);
+    }
+
+    /**
+     * Creates a {@link ToolExecutionResultMessage} from a {@link ToolExecutionRequest} and the result of the tool execution.
      * @param id the id of the tool.
      * @param toolName the name of the tool.
      * @param toolExecutionResult the result of the tool execution.
@@ -100,6 +135,19 @@ public class ToolExecutionResultMessage implements ChatMessage {
      */
     public static ToolExecutionResultMessage from(String id, String toolName, String toolExecutionResult) {
         return new ToolExecutionResultMessage(id, toolName, toolExecutionResult);
+    }
+
+    /**
+     * Creates a {@link ToolExecutionResultMessage} from a {@link ToolExecutionRequest} and the result of the tool execution.
+     * @param id the id of the tool.
+     * @param toolName the name of the tool.
+     * @param toolExecutionResult the result of the tool execution.
+     * @param isError whether the tool execution resulted in an error.
+     * @return the {@link ToolExecutionResultMessage}.
+     */
+    public static ToolExecutionResultMessage from(
+            String id, String toolName, String toolExecutionResult, boolean isError) {
+        return new ToolExecutionResultMessage(id, toolName, toolExecutionResult, isError);
     }
 
     /**

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/ToolExecutionResultMessageTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/ToolExecutionResultMessageTest.java
@@ -11,10 +11,26 @@ class ToolExecutionResultMessageTest implements WithAssertions {
         assertThat(tm.id()).isEqualTo("id");
         assertThat(tm.toolName()).isEqualTo("toolName");
         assertThat(tm.text()).isEqualTo("text");
+        assertThat(tm.isError()).isFalse();
         assertThat(tm.type()).isEqualTo(ChatMessageType.TOOL_EXECUTION_RESULT);
 
         assertThat(tm)
-                .hasToString("ToolExecutionResultMessage " + "{ id = \"id\" toolName = \"toolName\" text = \"text\" }");
+                .hasToString(
+                        "ToolExecutionResultMessage { id = \"id\" toolName = \"toolName\" text = \"text\" isError = false }");
+    }
+
+    @Test
+    void methods_with_isError() {
+        ToolExecutionResultMessage tm = new ToolExecutionResultMessage("id", "toolName", "error message", true);
+        assertThat(tm.id()).isEqualTo("id");
+        assertThat(tm.toolName()).isEqualTo("toolName");
+        assertThat(tm.text()).isEqualTo("error message");
+        assertThat(tm.isError()).isTrue();
+        assertThat(tm.type()).isEqualTo(ChatMessageType.TOOL_EXECUTION_RESULT);
+
+        assertThat(tm)
+                .hasToString(
+                        "ToolExecutionResultMessage { id = \"id\" toolName = \"toolName\" text = \"error message\" isError = true }");
     }
 
     @Test
@@ -34,6 +50,7 @@ class ToolExecutionResultMessageTest implements WithAssertions {
                 .isNotEqualTo(ToolExecutionResultMessage.from("changed", "toolName", "text"))
                 .isNotEqualTo(ToolExecutionResultMessage.from("id", "changed", "text"))
                 .isNotEqualTo(ToolExecutionResultMessage.from("id", "toolName", "changed"))
+                .isNotEqualTo(ToolExecutionResultMessage.from("id", "toolName", "text", true))
                 .isNotEqualTo(t3)
                 .doesNotHaveSameHashCodeAs(t3);
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -305,7 +305,7 @@ public class ToolService {
                 ToolExecutionRequest request = entry.getKey();
                 ToolExecutionResult result = entry.getValue();
                 ToolExecutionResultMessage resultMessage =
-                        ToolExecutionResultMessage.from(request, result.resultText());
+                        ToolExecutionResultMessage.from(request, result.resultText(), result.isError());
 
                 ToolExecution toolExecution =
                         ToolExecution.builder().request(request).result(result).build();


### PR DESCRIPTION
## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #4481

## Change
<!-- Please describe the changes you made. -->
Add `isError` field to `ToolExecutionResultMessage` (backward compatible with default `false`) and propagate it to Anthropic's `is_error` field in `tool_result`.

Per [Anthropic documentation](https://docs.anthropic.com/en/docs/build-with-claude/tool-use#tool-result), `is_error` tells the model that the tool execution failed, allowing it to retry or adjust its approach.

### Changes:
- **ToolExecutionResultMessage.java**: Added `isError` field (primitive `boolean`, default `false`), new constructors/factory methods, updated `equals`/`hashCode`/`toString`
- **ToolService.java**: Pass `result.isError()` when creating `ToolExecutionResultMessage`
- **AnthropicMapper.java**: Propagate `message.isError() ? true : null` to Anthropic API (only sends `is_error: true` when error occurred)

cc @dliubarskyi

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
