### PR TITLE
feat: propagate isError from ToolExecutionResultMessage to Anthropic

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -115,7 +115,8 @@ public class AnthropicMapper {
     }
 
     private static AnthropicToolResultContent toAnthropicToolResultContent(ToolExecutionResultMessage message) {
-        return new AnthropicToolResultContent(message.id(), message.text(), message.isError() ? true : null);
+        return new AnthropicToolResultContent(
+                message.id(), message.text(), Boolean.TRUE.equals(message.isError()) ? true : null);
     }
 
     private static List<AnthropicMessageContent> toAnthropicMessageContents(UserMessage message) {

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -115,7 +115,7 @@ public class AnthropicMapper {
     }
 
     private static AnthropicToolResultContent toAnthropicToolResultContent(ToolExecutionResultMessage message) {
-        return new AnthropicToolResultContent(message.id(), message.text(), null); // TODO propagate isError
+        return new AnthropicToolResultContent(message.id(), message.text(), message.isError() ? true : null);
     }
 
     private static List<AnthropicMessageContent> toAnthropicMessageContents(UserMessage message) {

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/JacksonChatMessageJsonCodec.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/JacksonChatMessageJsonCodec.java
@@ -133,14 +133,8 @@ public class JacksonChatMessageJsonCodec implements ChatMessageJsonCodec {
     private abstract static class ToolExecutionRequestMixin {}
 
     @JsonInclude(NON_NULL)
+    @JsonDeserialize(builder = ToolExecutionResultMessage.Builder.class)
     private abstract static class ToolExecutionResultMessageMixin {
-
-        @JsonCreator
-        public ToolExecutionResultMessageMixin(
-                @JsonProperty("id") String id,
-                @JsonProperty("toolName") String toolName,
-                @JsonProperty("text") String text,
-                @JsonProperty("isError") boolean isError) {}
 
         @JsonProperty("isError")
         abstract boolean isError();

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/JacksonChatMessageJsonCodec.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/JacksonChatMessageJsonCodec.java
@@ -137,7 +137,7 @@ public class JacksonChatMessageJsonCodec implements ChatMessageJsonCodec {
     private abstract static class ToolExecutionResultMessageMixin {
 
         @JsonProperty("isError")
-        abstract boolean isError();
+        abstract Boolean isError();
     }
 
     @JsonInclude(NON_NULL)

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/JacksonChatMessageJsonCodec.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/JacksonChatMessageJsonCodec.java
@@ -133,13 +133,17 @@ public class JacksonChatMessageJsonCodec implements ChatMessageJsonCodec {
     private abstract static class ToolExecutionRequestMixin {}
 
     @JsonInclude(NON_NULL)
-    private static class ToolExecutionResultMessageMixin {
+    private abstract static class ToolExecutionResultMessageMixin {
 
         @JsonCreator
         public ToolExecutionResultMessageMixin(
                 @JsonProperty("id") String id,
                 @JsonProperty("toolName") String toolName,
-                @JsonProperty("text") String text) {}
+                @JsonProperty("text") String text,
+                @JsonProperty("isError") boolean isError) {}
+
+        @JsonProperty("isError")
+        abstract boolean isError();
     }
 
     @JsonInclude(NON_NULL)

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
@@ -16,6 +16,7 @@ public class ToolExecutionResultMessage implements ChatMessage {
     private final String id;
     private final String toolName;
     private final String text;
+    private final boolean isError;
 
     /**
      * Creates a {@link ToolExecutionResultMessage}.
@@ -24,9 +25,21 @@ public class ToolExecutionResultMessage implements ChatMessage {
      * @param text the result of the tool execution.
      */
     public ToolExecutionResultMessage(String id, String toolName, String text) {
+        this(id, toolName, text, false);
+    }
+
+    /**
+     * Creates a {@link ToolExecutionResultMessage}.
+     * @param id the id of the tool.
+     * @param toolName the name of the tool.
+     * @param text the result of the tool execution.
+     * @param isError whether the tool execution resulted in an error.
+     */
+    public ToolExecutionResultMessage(String id, String toolName, String text, boolean isError) {
         this.id = id;
         this.toolName = toolName;
         this.text = ensureNotNull(text, "text");
+        this.isError = isError;
     }
 
     /**
@@ -53,6 +66,14 @@ public class ToolExecutionResultMessage implements ChatMessage {
         return text;
     }
 
+    /**
+     * Returns whether the tool execution resulted in an error.
+     * @return true if the tool execution resulted in an error, false otherwise.
+     */
+    public boolean isError() {
+        return isError;
+    }
+
     @Override
     public ChatMessageType type() {
         return TOOL_EXECUTION_RESULT;
@@ -65,12 +86,13 @@ public class ToolExecutionResultMessage implements ChatMessage {
         ToolExecutionResultMessage that = (ToolExecutionResultMessage) o;
         return Objects.equals(this.id, that.id)
                 && Objects.equals(this.toolName, that.toolName)
-                && Objects.equals(this.text, that.text);
+                && Objects.equals(this.text, that.text)
+                && this.isError == that.isError;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, toolName, text);
+        return Objects.hash(id, toolName, text, isError);
     }
 
     @Override
@@ -78,7 +100,8 @@ public class ToolExecutionResultMessage implements ChatMessage {
         return "ToolExecutionResultMessage {" + " id = "
                 + quoted(id) + " toolName = "
                 + quoted(toolName) + " text = "
-                + quoted(text) + " }";
+                + quoted(text) + " isError = "
+                + isError + " }";
     }
 
     /**
@@ -93,6 +116,18 @@ public class ToolExecutionResultMessage implements ChatMessage {
 
     /**
      * Creates a {@link ToolExecutionResultMessage} from a {@link ToolExecutionRequest} and the result of the tool execution.
+     * @param request the request.
+     * @param toolExecutionResult the result of the tool execution.
+     * @param isError whether the tool execution resulted in an error.
+     * @return the {@link ToolExecutionResultMessage}.
+     */
+    public static ToolExecutionResultMessage from(
+            ToolExecutionRequest request, String toolExecutionResult, boolean isError) {
+        return new ToolExecutionResultMessage(request.id(), request.name(), toolExecutionResult, isError);
+    }
+
+    /**
+     * Creates a {@link ToolExecutionResultMessage} from a {@link ToolExecutionRequest} and the result of the tool execution.
      * @param id the id of the tool.
      * @param toolName the name of the tool.
      * @param toolExecutionResult the result of the tool execution.
@@ -100,6 +135,19 @@ public class ToolExecutionResultMessage implements ChatMessage {
      */
     public static ToolExecutionResultMessage from(String id, String toolName, String toolExecutionResult) {
         return new ToolExecutionResultMessage(id, toolName, toolExecutionResult);
+    }
+
+    /**
+     * Creates a {@link ToolExecutionResultMessage} from a {@link ToolExecutionRequest} and the result of the tool execution.
+     * @param id the id of the tool.
+     * @param toolName the name of the tool.
+     * @param toolExecutionResult the result of the tool execution.
+     * @param isError whether the tool execution resulted in an error.
+     * @return the {@link ToolExecutionResultMessage}.
+     */
+    public static ToolExecutionResultMessage from(
+            String id, String toolName, String toolExecutionResult, boolean isError) {
+        return new ToolExecutionResultMessage(id, toolName, toolExecutionResult, isError);
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
@@ -17,7 +17,7 @@ public class ToolExecutionResultMessage implements ChatMessage {
     private final String id;
     private final String toolName;
     private final String text;
-    private final boolean isError;
+    private final Boolean isError;
 
     /**
      * Creates a {@link ToolExecutionResultMessage} from a builder.
@@ -39,7 +39,7 @@ public class ToolExecutionResultMessage implements ChatMessage {
         this.id = id;
         this.toolName = toolName;
         this.text = ensureNotNull(text, "text");
-        this.isError = false;
+        this.isError = null;
     }
 
     /**
@@ -68,9 +68,9 @@ public class ToolExecutionResultMessage implements ChatMessage {
 
     /**
      * Returns whether the tool execution resulted in an error.
-     * @return true if the tool execution resulted in an error, false otherwise.
+     * @return true if the tool execution resulted in an error, false if it did not, null if unknown.
      */
-    public boolean isError() {
+    public Boolean isError() {
         return isError;
     }
 
@@ -87,7 +87,7 @@ public class ToolExecutionResultMessage implements ChatMessage {
         return Objects.equals(this.id, that.id)
                 && Objects.equals(this.toolName, that.toolName)
                 && Objects.equals(this.text, that.text)
-                && this.isError == that.isError;
+                && Objects.equals(this.isError, that.isError);
     }
 
     @Override
@@ -117,7 +117,7 @@ public class ToolExecutionResultMessage implements ChatMessage {
         private String id;
         private String toolName;
         private String text;
-        private boolean isError;
+        private Boolean isError;
 
         /**
          * Sets the id of the tool.
@@ -158,7 +158,7 @@ public class ToolExecutionResultMessage implements ChatMessage {
          * @return the builder.
          */
         @JsonProperty("isError")
-        public Builder isError(boolean isError) {
+        public Builder isError(Boolean isError) {
             this.isError = isError;
             return this;
         }

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT
 import static dev.langchain4j.internal.Utils.quoted;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import java.util.Objects;
 
@@ -19,13 +20,13 @@ public class ToolExecutionResultMessage implements ChatMessage {
     private final boolean isError;
 
     /**
-     * Creates a {@link ToolExecutionResultMessage}.
-     * @param id the id of the tool.
-     * @param toolName the name of the tool.
-     * @param text the result of the tool execution.
+     * Creates a {@link ToolExecutionResultMessage} from a builder.
      */
-    public ToolExecutionResultMessage(String id, String toolName, String text) {
-        this(id, toolName, text, false);
+    public ToolExecutionResultMessage(Builder builder) {
+        this.id = builder.id;
+        this.toolName = builder.toolName;
+        this.text = ensureNotNull(builder.text, "text");
+        this.isError = builder.isError;
     }
 
     /**
@@ -33,13 +34,12 @@ public class ToolExecutionResultMessage implements ChatMessage {
      * @param id the id of the tool.
      * @param toolName the name of the tool.
      * @param text the result of the tool execution.
-     * @param isError whether the tool execution resulted in an error.
      */
-    public ToolExecutionResultMessage(String id, String toolName, String text, boolean isError) {
+    public ToolExecutionResultMessage(String id, String toolName, String text) {
         this.id = id;
         this.toolName = toolName;
         this.text = ensureNotNull(text, "text");
-        this.isError = isError;
+        this.isError = false;
     }
 
     /**
@@ -105,6 +105,74 @@ public class ToolExecutionResultMessage implements ChatMessage {
     }
 
     /**
+     * Creates a builder for {@link ToolExecutionResultMessage}.
+     * @return the builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String id;
+        private String toolName;
+        private String text;
+        private boolean isError;
+
+        /**
+         * Sets the id of the tool.
+         * @param id the id of the tool.
+         * @return the builder.
+         */
+        @JsonProperty("id")
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * Sets the name of the tool.
+         * @param toolName the name of the tool.
+         * @return the builder.
+         */
+        @JsonProperty("toolName")
+        public Builder toolName(String toolName) {
+            this.toolName = toolName;
+            return this;
+        }
+
+        /**
+         * Sets the result text of the tool execution.
+         * @param text the result of the tool execution.
+         * @return the builder.
+         */
+        @JsonProperty("text")
+        public Builder text(String text) {
+            this.text = text;
+            return this;
+        }
+
+        /**
+         * Sets whether the tool execution resulted in an error.
+         * @param isError whether the tool execution resulted in an error.
+         * @return the builder.
+         */
+        @JsonProperty("isError")
+        public Builder isError(boolean isError) {
+            this.isError = isError;
+            return this;
+        }
+
+        /**
+         * Builds the {@link ToolExecutionResultMessage}.
+         * @return the {@link ToolExecutionResultMessage}.
+         */
+        public ToolExecutionResultMessage build() {
+            return new ToolExecutionResultMessage(this);
+        }
+    }
+
+    /**
      * Creates a {@link ToolExecutionResultMessage} from a {@link ToolExecutionRequest} and the result of the tool execution.
      * @param request the request.
      * @param toolExecutionResult the result of the tool execution.
@@ -116,18 +184,6 @@ public class ToolExecutionResultMessage implements ChatMessage {
 
     /**
      * Creates a {@link ToolExecutionResultMessage} from a {@link ToolExecutionRequest} and the result of the tool execution.
-     * @param request the request.
-     * @param toolExecutionResult the result of the tool execution.
-     * @param isError whether the tool execution resulted in an error.
-     * @return the {@link ToolExecutionResultMessage}.
-     */
-    public static ToolExecutionResultMessage from(
-            ToolExecutionRequest request, String toolExecutionResult, boolean isError) {
-        return new ToolExecutionResultMessage(request.id(), request.name(), toolExecutionResult, isError);
-    }
-
-    /**
-     * Creates a {@link ToolExecutionResultMessage} from a {@link ToolExecutionRequest} and the result of the tool execution.
      * @param id the id of the tool.
      * @param toolName the name of the tool.
      * @param toolExecutionResult the result of the tool execution.
@@ -135,19 +191,6 @@ public class ToolExecutionResultMessage implements ChatMessage {
      */
     public static ToolExecutionResultMessage from(String id, String toolName, String toolExecutionResult) {
         return new ToolExecutionResultMessage(id, toolName, toolExecutionResult);
-    }
-
-    /**
-     * Creates a {@link ToolExecutionResultMessage} from a {@link ToolExecutionRequest} and the result of the tool execution.
-     * @param id the id of the tool.
-     * @param toolName the name of the tool.
-     * @param toolExecutionResult the result of the tool execution.
-     * @param isError whether the tool execution resulted in an error.
-     * @return the {@link ToolExecutionResultMessage}.
-     */
-    public static ToolExecutionResultMessage from(
-            String id, String toolName, String toolExecutionResult, boolean isError) {
-        return new ToolExecutionResultMessage(id, toolName, toolExecutionResult, isError);
     }
 
     /**

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/ChatMessageSerializerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/ChatMessageSerializerTest.java
@@ -8,11 +8,11 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -95,7 +95,10 @@ class ChatMessageSerializerTest {
                         "{\"text\":\"test-text\",\"thinking\":\"test-thinking\",\"toolExecutionRequests\":[{\"name\":\"weather\",\"arguments\":\"{\\\"city\\\": \\\"Munich\\\"}\"}],\"attributes\":{\"name\":\"Klaus\",\"age\":42,\"extra\":[\"one\",\"two\"]},\"type\":\"AI\"}"),
                 Arguments.of(
                         ToolExecutionResultMessage.from("12345", "weather", "sunny"),
-                        "{\"id\":\"12345\",\"toolName\":\"weather\",\"text\":\"sunny\",\"type\":\"TOOL_EXECUTION_RESULT\"}"),
+                        "{\"id\":\"12345\",\"toolName\":\"weather\",\"text\":\"sunny\",\"isError\":false,\"type\":\"TOOL_EXECUTION_RESULT\"}"),
+                Arguments.of(
+                        ToolExecutionResultMessage.from("12345", "weather", "error occurred", true),
+                        "{\"id\":\"12345\",\"toolName\":\"weather\",\"text\":\"error occurred\",\"isError\":true,\"type\":\"TOOL_EXECUTION_RESULT\"}"),
                 Arguments.of(
                         CustomMessage.from(new LinkedHashMap<>() {
                             {
@@ -137,7 +140,8 @@ class ChatMessageSerializerTest {
     @Test
     void should_deserialize_UserMessage_without_attributes() {
 
-        UserMessage deserialized = (UserMessage) messageFromJson("{\"contents\":[{\"text\":\"hello\",\"type\":\"TEXT\"}],\"type\":\"USER\"}");
+        UserMessage deserialized = (UserMessage)
+                messageFromJson("{\"contents\":[{\"text\":\"hello\",\"type\":\"TEXT\"}],\"type\":\"USER\"}");
 
         assertThat(deserialized.name()).isNull();
         assertThat(deserialized.contents()).containsExactly(TextContent.from("hello"));

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/ChatMessageSerializerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/ChatMessageSerializerTest.java
@@ -97,7 +97,12 @@ class ChatMessageSerializerTest {
                         ToolExecutionResultMessage.from("12345", "weather", "sunny"),
                         "{\"id\":\"12345\",\"toolName\":\"weather\",\"text\":\"sunny\",\"isError\":false,\"type\":\"TOOL_EXECUTION_RESULT\"}"),
                 Arguments.of(
-                        ToolExecutionResultMessage.from("12345", "weather", "error occurred", true),
+                        ToolExecutionResultMessage.builder()
+                                .id("12345")
+                                .toolName("weather")
+                                .text("error occurred")
+                                .isError(true)
+                                .build(),
                         "{\"id\":\"12345\",\"toolName\":\"weather\",\"text\":\"error occurred\",\"isError\":true,\"type\":\"TOOL_EXECUTION_RESULT\"}"),
                 Arguments.of(
                         CustomMessage.from(new LinkedHashMap<>() {
@@ -160,5 +165,17 @@ class ChatMessageSerializerTest {
         assertThat(deserialized.thinking()).isNull();
         assertThat(deserialized.toolExecutionRequests()).isEmpty();
         assertThat(deserialized.attributes()).isEmpty();
+    }
+
+    @Test
+    void should_deserialize_ToolExecutionResultMessage_without_isError() {
+
+        ToolExecutionResultMessage deserialized = (ToolExecutionResultMessage) messageFromJson(
+                "{\"id\":\"12345\",\"toolName\":\"weather\",\"text\":\"sunny\",\"type\":\"TOOL_EXECUTION_RESULT\"}");
+
+        assertThat(deserialized.id()).isEqualTo("12345");
+        assertThat(deserialized.toolName()).isEqualTo("weather");
+        assertThat(deserialized.text()).isEqualTo("sunny");
+        assertThat(deserialized.isError()).isFalse();
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/ChatMessageSerializerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/ChatMessageSerializerTest.java
@@ -95,7 +95,7 @@ class ChatMessageSerializerTest {
                         "{\"text\":\"test-text\",\"thinking\":\"test-thinking\",\"toolExecutionRequests\":[{\"name\":\"weather\",\"arguments\":\"{\\\"city\\\": \\\"Munich\\\"}\"}],\"attributes\":{\"name\":\"Klaus\",\"age\":42,\"extra\":[\"one\",\"two\"]},\"type\":\"AI\"}"),
                 Arguments.of(
                         ToolExecutionResultMessage.from("12345", "weather", "sunny"),
-                        "{\"id\":\"12345\",\"toolName\":\"weather\",\"text\":\"sunny\",\"isError\":false,\"type\":\"TOOL_EXECUTION_RESULT\"}"),
+                        "{\"id\":\"12345\",\"toolName\":\"weather\",\"text\":\"sunny\",\"type\":\"TOOL_EXECUTION_RESULT\"}"),
                 Arguments.of(
                         ToolExecutionResultMessage.builder()
                                 .id("12345")
@@ -176,6 +176,6 @@ class ChatMessageSerializerTest {
         assertThat(deserialized.id()).isEqualTo("12345");
         assertThat(deserialized.toolName()).isEqualTo("weather");
         assertThat(deserialized.text()).isEqualTo("sunny");
-        assertThat(deserialized.isError()).isFalse();
+        assertThat(deserialized.isError()).isNull();
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/ToolExecutionResultMessageTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/ToolExecutionResultMessageTest.java
@@ -11,12 +11,12 @@ class ToolExecutionResultMessageTest implements WithAssertions {
         assertThat(tm.id()).isEqualTo("id");
         assertThat(tm.toolName()).isEqualTo("toolName");
         assertThat(tm.text()).isEqualTo("text");
-        assertThat(tm.isError()).isFalse();
+        assertThat(tm.isError()).isNull();
         assertThat(tm.type()).isEqualTo(ChatMessageType.TOOL_EXECUTION_RESULT);
 
         assertThat(tm)
                 .hasToString(
-                        "ToolExecutionResultMessage { id = \"id\" toolName = \"toolName\" text = \"text\" isError = false }");
+                        "ToolExecutionResultMessage { id = \"id\" toolName = \"toolName\" text = \"text\" isError = null }");
     }
 
     @Test

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/ToolExecutionResultMessageTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/ToolExecutionResultMessageTest.java
@@ -21,7 +21,12 @@ class ToolExecutionResultMessageTest implements WithAssertions {
 
     @Test
     void methods_with_isError() {
-        ToolExecutionResultMessage tm = new ToolExecutionResultMessage("id", "toolName", "error message", true);
+        ToolExecutionResultMessage tm = ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("toolName")
+                .text("error message")
+                .isError(true)
+                .build();
         assertThat(tm.id()).isEqualTo("id");
         assertThat(tm.toolName()).isEqualTo("toolName");
         assertThat(tm.text()).isEqualTo("error message");
@@ -50,7 +55,12 @@ class ToolExecutionResultMessageTest implements WithAssertions {
                 .isNotEqualTo(ToolExecutionResultMessage.from("changed", "toolName", "text"))
                 .isNotEqualTo(ToolExecutionResultMessage.from("id", "changed", "text"))
                 .isNotEqualTo(ToolExecutionResultMessage.from("id", "toolName", "changed"))
-                .isNotEqualTo(ToolExecutionResultMessage.from("id", "toolName", "text", true))
+                .isNotEqualTo(ToolExecutionResultMessage.builder()
+                        .id("id")
+                        .toolName("toolName")
+                        .text("text")
+                        .isError(true)
+                        .build())
                 .isNotEqualTo(t3)
                 .doesNotHaveSameHashCodeAs(t3);
 
@@ -69,7 +79,12 @@ class ToolExecutionResultMessageTest implements WithAssertions {
                 .isEqualTo(ToolExecutionResultMessage.from("id", "toolName", "text"))
                 .isEqualTo(ToolExecutionResultMessage.from(request, "text"))
                 .isEqualTo(ToolExecutionResultMessage.toolExecutionResultMessage("id", "toolName", "text"))
-                .isEqualTo(ToolExecutionResultMessage.toolExecutionResultMessage(request, "text"));
+                .isEqualTo(ToolExecutionResultMessage.toolExecutionResultMessage(request, "text"))
+                .isEqualTo(ToolExecutionResultMessage.builder()
+                        .id("id")
+                        .toolName("toolName")
+                        .text("text")
+                        .build());
     }
 
     @Test

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/ToolExecutionResultMessageTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/ToolExecutionResultMessageTest.java
@@ -11,10 +11,26 @@ class ToolExecutionResultMessageTest implements WithAssertions {
         assertThat(tm.id()).isEqualTo("id");
         assertThat(tm.toolName()).isEqualTo("toolName");
         assertThat(tm.text()).isEqualTo("text");
+        assertThat(tm.isError()).isFalse();
         assertThat(tm.type()).isEqualTo(ChatMessageType.TOOL_EXECUTION_RESULT);
 
         assertThat(tm)
-                .hasToString("ToolExecutionResultMessage " + "{ id = \"id\" toolName = \"toolName\" text = \"text\" }");
+                .hasToString(
+                        "ToolExecutionResultMessage { id = \"id\" toolName = \"toolName\" text = \"text\" isError = false }");
+    }
+
+    @Test
+    void methods_with_isError() {
+        ToolExecutionResultMessage tm = new ToolExecutionResultMessage("id", "toolName", "error message", true);
+        assertThat(tm.id()).isEqualTo("id");
+        assertThat(tm.toolName()).isEqualTo("toolName");
+        assertThat(tm.text()).isEqualTo("error message");
+        assertThat(tm.isError()).isTrue();
+        assertThat(tm.type()).isEqualTo(ChatMessageType.TOOL_EXECUTION_RESULT);
+
+        assertThat(tm)
+                .hasToString(
+                        "ToolExecutionResultMessage { id = \"id\" toolName = \"toolName\" text = \"error message\" isError = true }");
     }
 
     @Test
@@ -34,6 +50,7 @@ class ToolExecutionResultMessageTest implements WithAssertions {
                 .isNotEqualTo(ToolExecutionResultMessage.from("changed", "toolName", "text"))
                 .isNotEqualTo(ToolExecutionResultMessage.from("id", "changed", "text"))
                 .isNotEqualTo(ToolExecutionResultMessage.from("id", "toolName", "changed"))
+                .isNotEqualTo(ToolExecutionResultMessage.from("id", "toolName", "text", true))
                 .isNotEqualTo(t3)
                 .doesNotHaveSameHashCodeAs(t3);
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -304,8 +304,12 @@ public class ToolService {
             for (Map.Entry<ToolExecutionRequest, ToolExecutionResult> entry : toolResults.entrySet()) {
                 ToolExecutionRequest request = entry.getKey();
                 ToolExecutionResult result = entry.getValue();
-                ToolExecutionResultMessage resultMessage =
-                        ToolExecutionResultMessage.from(request, result.resultText(), result.isError());
+                ToolExecutionResultMessage resultMessage = ToolExecutionResultMessage.builder()
+                        .id(request.id())
+                        .toolName(request.name())
+                        .text(result.resultText())
+                        .isError(result.isError())
+                        .build();
 
                 ToolExecution toolExecution =
                         ToolExecution.builder().request(request).result(result).build();

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -305,7 +305,7 @@ public class ToolService {
                 ToolExecutionRequest request = entry.getKey();
                 ToolExecutionResult result = entry.getValue();
                 ToolExecutionResultMessage resultMessage =
-                        ToolExecutionResultMessage.from(request, result.resultText());
+                        ToolExecutionResultMessage.from(request, result.resultText(), result.isError());
 
                 ToolExecution toolExecution =
                         ToolExecution.builder().request(request).result(result).build();


### PR DESCRIPTION
## Issue
Closes #4481

## Change
Add `isError` field to `ToolExecutionResultMessage` (backward compatible with default `false`) and propagate it to Anthropic's `is_error` field in `tool_result`.

Per [Anthropic documentation](https://docs.anthropic.com/en/docs/build-with-claude/tool-use#tool-result), `is_error` tells the model that the tool execution failed, allowing it to retry or adjust its approach.

### Changes:
- **ToolExecutionResultMessage.java**: Added `isError` field (primitive `boolean`, default `false`), new constructors/factory methods, updated `equals`/`hashCode`/`toString`
- **ToolService.java**: Pass `result.isError()` when creating `ToolExecutionResultMessage`
- **AnthropicMapper.java**: Propagate `message.isError() ? true : null` to Anthropic API (only sends `is_error: true` when error occurred)
- **ToolExecutionResultMessageTest.java**: Updated tests for new `isError` field

cc @dliubarskyi

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
