### PR TITLE
Add Azure OpenAI Responses API models and reasoning summaries

### DIFF
--- a/docs/docs/integrations/language-models/azure-open-ai.md
+++ b/docs/docs/integrations/language-models/azure-open-ai.md
@@ -118,6 +118,42 @@ class ChatModelController {
 }
 ```
 
+## Responses API (Reasoning Summaries)
+
+Azure OpenAI reasoning summaries are available via the **Responses API**. These summaries are returned as a
+*reasoning output item*; if the service does not emit that item, {@code AiMessage.thinking()} will be {@code null}.
+This behavior is service-dependent and can vary by prompt.
+
+### Plain Java
+
+```java
+import com.azure.ai.openai.responses.models.ResponsesReasoningConfigurationEffort;
+import dev.langchain4j.model.azure.AzureOpenAiResponsesChatModel;
+
+ChatModel model = AzureOpenAiResponsesChatModel.builder()
+        .endpoint(System.getenv("AZURE_OPENAI_URL"))
+        .apiKey(System.getenv("AZURE_OPENAI_KEY"))
+        .deploymentName("gpt-5.2-chat")
+        .reasoningSummary("auto") // or "detailed"
+        .reasoningEffort(ResponsesReasoningConfigurationEffort.MEDIUM)
+        .build();
+```
+
+### Streaming
+
+```java
+import com.azure.ai.openai.responses.models.ResponsesReasoningConfigurationEffort;
+import dev.langchain4j.model.azure.AzureOpenAiResponsesStreamingChatModel;
+
+StreamingChatModel model = AzureOpenAiResponsesStreamingChatModel.builder()
+        .endpoint(System.getenv("AZURE_OPENAI_URL"))
+        .apiKey(System.getenv("AZURE_OPENAI_KEY"))
+        .deploymentName("gpt-5.2-chat")
+        .reasoningSummary("auto")
+        .reasoningEffort(ResponsesReasoningConfigurationEffort.MEDIUM)
+        .build();
+```
+
 ## Creating `AzureOpenAiChatModel` with Azure Credentials
 
 API key can have a few security issues (can be committed, can be passed around, etc.).

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiResponsesChatModel.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiResponsesChatModel.java
@@ -1,0 +1,463 @@
+package dev.langchain4j.model.azure;
+
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.model.ModelProvider.AZURE_OPEN_AI;
+import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.validate;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+
+import com.azure.ai.openai.responses.ResponsesClient;
+import com.azure.ai.openai.responses.models.CreateResponsesRequest;
+import com.azure.ai.openai.responses.models.ResponsesReasoningConfiguration;
+import com.azure.ai.openai.responses.models.ResponsesReasoningConfigurationEffort;
+import com.azure.ai.openai.responses.models.ResponsesReasoningConfigurationGenerateSummary;
+import com.azure.core.credential.KeyCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.HttpClientProvider;
+import com.azure.core.http.ProxyOptions;
+import com.azure.core.http.policy.RetryOptions;
+import com.azure.core.util.BinaryData;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.azure.spi.AzureOpenAiResponsesChatModelBuilderFactory;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.output.Response;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents an OpenAI model, hosted on Azure, that uses the Responses API.
+ * The model's response is returned in a single call.
+ * Reasoning summaries are only available when the service emits a reasoning output item;
+ * otherwise {@link dev.langchain4j.data.message.AiMessage#thinking()} will be {@code null}.
+ */
+public class AzureOpenAiResponsesChatModel implements ChatModel {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureOpenAiResponsesChatModel.class);
+
+    private final ResponsesClient client;
+    private final ChatRequestParameters defaultRequestParameters;
+
+    private final String user;
+    private final boolean strictJsonSchema;
+    private final ResponsesReasoningConfigurationEffort reasoningEffort;
+    private final String reasoningSummary;
+    private final boolean logRequestsAndResponses;
+
+    private final List<ChatModelListener> listeners;
+    private final Set<Capability> supportedCapabilities;
+
+    public AzureOpenAiResponsesChatModel(Builder builder) {
+        if (builder.responsesClient == null) {
+            if (builder.tokenCredential != null) {
+                this.client = InternalAzureOpenAiResponsesHelper.setupSyncClient(
+                        builder.endpoint,
+                        builder.serviceVersion,
+                        builder.tokenCredential,
+                        builder.timeout,
+                        builder.maxRetries,
+                        builder.retryOptions,
+                        builder.httpClientProvider,
+                        builder.proxyOptions,
+                        builder.logRequestsAndResponses,
+                        builder.userAgentSuffix,
+                        builder.customHeaders);
+            } else if (builder.keyCredential != null) {
+                this.client = InternalAzureOpenAiResponsesHelper.setupSyncClient(
+                        builder.endpoint,
+                        builder.serviceVersion,
+                        builder.keyCredential,
+                        builder.timeout,
+                        builder.maxRetries,
+                        builder.retryOptions,
+                        builder.httpClientProvider,
+                        builder.proxyOptions,
+                        builder.logRequestsAndResponses,
+                        builder.userAgentSuffix,
+                        builder.customHeaders);
+            } else {
+                this.client = InternalAzureOpenAiResponsesHelper.setupSyncClient(
+                        builder.endpoint,
+                        builder.serviceVersion,
+                        builder.apiKey,
+                        builder.timeout,
+                        builder.maxRetries,
+                        builder.retryOptions,
+                        builder.httpClientProvider,
+                        builder.proxyOptions,
+                        builder.logRequestsAndResponses,
+                        builder.userAgentSuffix,
+                        builder.customHeaders);
+            }
+        } else {
+            this.client = ensureNotNull(builder.responsesClient, "responsesClient");
+        }
+
+        ChatRequestParameters parameters;
+        if (builder.defaultRequestParameters != null) {
+            validate(builder.defaultRequestParameters);
+            parameters = builder.defaultRequestParameters;
+        } else {
+            parameters = DefaultChatRequestParameters.EMPTY;
+        }
+
+        this.defaultRequestParameters = ChatRequestParameters.builder()
+                .modelName(getOrDefault(builder.deploymentName, parameters.modelName()))
+                .temperature(getOrDefault(builder.temperature, parameters.temperature()))
+                .topP(getOrDefault(builder.topP, parameters.topP()))
+                .maxOutputTokens(getOrDefault(builder.maxTokens, parameters.maxOutputTokens()))
+                .toolSpecifications(parameters.toolSpecifications())
+                .toolChoice(parameters.toolChoice())
+                .responseFormat(getOrDefault(builder.responseFormat, parameters.responseFormat()))
+                .build();
+
+        this.user = builder.user;
+        this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
+        this.reasoningEffort = builder.reasoningEffort;
+        this.reasoningSummary = builder.reasoningSummary;
+        this.logRequestsAndResponses = builder.logRequestsAndResponses;
+
+        this.listeners = copy(builder.listeners);
+        this.supportedCapabilities = copy(builder.supportedCapabilities);
+    }
+
+    @Override
+    public ChatRequestParameters defaultRequestParameters() {
+        return defaultRequestParameters;
+    }
+
+    @Override
+    public Set<Capability> supportedCapabilities() {
+        return supportedCapabilities;
+    }
+
+    @Override
+    public ChatResponse doChat(ChatRequest request) {
+        ChatRequestParameters parameters = request.parameters();
+        validate(parameters);
+
+        List<com.azure.ai.openai.responses.models.ResponsesMessage> messages =
+                InternalAzureOpenAiResponsesHelper.toResponsesMessages(request.messages());
+
+        ResponseFormat responseFormat = parameters.responseFormat();
+        com.azure.ai.openai.responses.models.ResponseTextOptions textOptions = null;
+        if (responseFormat != null) {
+            textOptions = InternalAzureOpenAiResponsesHelper.toResponseTextOptions(responseFormat, strictJsonSchema);
+        }
+
+        List<com.azure.ai.openai.responses.models.ResponsesTool> tools =
+                parameters.toolSpecifications().isEmpty()
+                        ? List.of()
+                        : InternalAzureOpenAiResponsesHelper.toResponsesTools(
+                                parameters.toolSpecifications(), strictJsonSchema);
+
+        com.azure.ai.openai.responses.models.ResponsesResponse response;
+        if (reasoningSummary != null) {
+            BinaryData requestBody = InternalAzureOpenAiResponsesHelper.buildRequestBody(
+                    parameters.modelName(),
+                    messages,
+                    parameters.temperature(),
+                    parameters.topP(),
+                    parameters.maxOutputTokens(),
+                    user,
+                    textOptions,
+                    reasoningEffort,
+                    reasoningSummary,
+                    tools,
+                    parameters.toolChoice(),
+                    false);
+            response = AzureOpenAiExceptionMapper.INSTANCE.withExceptionMapper(
+                    () -> InternalAzureOpenAiResponsesHelper.createResponseWithRawRequest(client, requestBody));
+        } else {
+            CreateResponsesRequest createRequest = new CreateResponsesRequest(
+                    InternalAzureOpenAiResponsesHelper.toModel(parameters.modelName()), messages);
+            createRequest.setTemperature(parameters.temperature());
+            createRequest.setTopP(parameters.topP());
+            createRequest.setMaxOutputTokens(parameters.maxOutputTokens());
+            createRequest.setUser(user);
+            if (textOptions != null) {
+                createRequest.setText(textOptions);
+            }
+            if (reasoningEffort != null) {
+                ResponsesReasoningConfiguration reasoning = new ResponsesReasoningConfiguration(reasoningEffort);
+                createRequest.setReasoning(reasoning);
+            }
+            if (!tools.isEmpty()) {
+                createRequest.setTools(tools);
+            }
+            if (parameters.toolChoice() != null) {
+                createRequest.setToolChoice(
+                        InternalAzureOpenAiResponsesHelper.toToolChoiceBinaryData(parameters.toolChoice()));
+            }
+            response =
+                    AzureOpenAiExceptionMapper.INSTANCE.withExceptionMapper(() -> client.createResponse(createRequest));
+        }
+
+        Response<AiMessage> parsed = InternalAzureOpenAiResponsesHelper.toResponse(response, null);
+        if (logRequestsAndResponses) {
+            Integer reasoningTokens = InternalAzureOpenAiResponsesHelper.extractReasoningTokens(response);
+            if (parsed.content().thinking() == null && reasoningTokens != null && reasoningTokens > 0) {
+                LOGGER.info(
+                        "Reasoning tokens were reported ({}), but no reasoning summary text was returned. "
+                                + "This can happen depending on the model/service.",
+                        reasoningTokens);
+            }
+        }
+
+        return ChatResponse.builder()
+                .aiMessage(parsed.content())
+                .metadata(ChatResponseMetadata.builder()
+                        .id(response.getId())
+                        .modelName(response.getModel())
+                        .tokenUsage(parsed.tokenUsage())
+                        .finishReason(parsed.finishReason())
+                        .build())
+                .build();
+    }
+
+    @Override
+    public List<ChatModelListener> listeners() {
+        return listeners;
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return AZURE_OPEN_AI;
+    }
+
+    public static Builder builder() {
+        for (AzureOpenAiResponsesChatModelBuilderFactory factory :
+                loadFactories(AzureOpenAiResponsesChatModelBuilderFactory.class)) {
+            return factory.get();
+        }
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private ChatRequestParameters defaultRequestParameters;
+
+        private String endpoint;
+        private String serviceVersion;
+        private String apiKey;
+        private KeyCredential keyCredential;
+        private TokenCredential tokenCredential;
+        private HttpClientProvider httpClientProvider;
+        private String deploymentName;
+        private Integer maxTokens;
+        private Double temperature;
+        private Double topP;
+        private String user;
+        private ResponseFormat responseFormat;
+        private Boolean strictJsonSchema;
+        private Duration timeout;
+        private Integer maxRetries;
+        private RetryOptions retryOptions;
+        private ProxyOptions proxyOptions;
+        private boolean logRequestsAndResponses;
+        private ResponsesClient responsesClient;
+        private String userAgentSuffix;
+        private List<ChatModelListener> listeners;
+        private Map<String, String> customHeaders;
+        private Set<Capability> supportedCapabilities;
+        private ResponsesReasoningConfigurationEffort reasoningEffort;
+        private String reasoningSummary;
+
+        public Builder defaultRequestParameters(ChatRequestParameters parameters) {
+            this.defaultRequestParameters = parameters;
+            return this;
+        }
+
+        /**
+         * Sets the Azure OpenAI endpoint. This is a mandatory parameter.
+         *
+         * @param endpoint The Azure OpenAI endpoint in the format: https://{resource}.openai.azure.com/
+         * @return builder
+         */
+        public Builder endpoint(String endpoint) {
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        /**
+         * Sets the Azure OpenAI API service version. This is optional; if not set, the latest is used.
+         *
+         * @param serviceVersion The Azure OpenAI API service version in the format: 2024-10-21
+         * @return builder
+         */
+        public Builder serviceVersion(String serviceVersion) {
+            this.serviceVersion = serviceVersion;
+            return this;
+        }
+
+        /**
+         * Sets the Azure OpenAI API key.
+         *
+         * @param apiKey The Azure OpenAI API key.
+         * @return builder
+         */
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * Used to authenticate with the OpenAI service, instead of Azure OpenAI.
+         * This automatically sets the endpoint to https://api.openai.com/v1.
+         *
+         * @param nonAzureApiKey The non-Azure OpenAI API key
+         * @return builder
+         */
+        public Builder nonAzureApiKey(String nonAzureApiKey) {
+            this.keyCredential = new KeyCredential(nonAzureApiKey);
+            this.endpoint = "https://api.openai.com/v1";
+            return this;
+        }
+
+        public Builder keyCredential(KeyCredential keyCredential) {
+            this.keyCredential = keyCredential;
+            return this;
+        }
+
+        public Builder tokenCredential(TokenCredential tokenCredential) {
+            this.tokenCredential = tokenCredential;
+            return this;
+        }
+
+        public Builder httpClientProvider(HttpClientProvider httpClientProvider) {
+            this.httpClientProvider = httpClientProvider;
+            return this;
+        }
+
+        /**
+         * Sets the Azure OpenAI deployment name (model). This is a mandatory parameter.
+         *
+         * @param deploymentName The Azure OpenAI deployment name.
+         * @return builder
+         */
+        public Builder deploymentName(String deploymentName) {
+            this.deploymentName = deploymentName;
+            return this;
+        }
+
+        public Builder maxTokens(Integer maxTokens) {
+            this.maxTokens = maxTokens;
+            return this;
+        }
+
+        public Builder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        public Builder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        public Builder user(String user) {
+            this.user = user;
+            return this;
+        }
+
+        public Builder responseFormat(ResponseFormat responseFormat) {
+            this.responseFormat = responseFormat;
+            return this;
+        }
+
+        public Builder strictJsonSchema(Boolean strictJsonSchema) {
+            this.strictJsonSchema = strictJsonSchema;
+            return this;
+        }
+
+        public Builder reasoningEffort(ResponsesReasoningConfigurationEffort reasoningEffort) {
+            this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
+        public Builder reasoningSummary(ResponsesReasoningConfigurationGenerateSummary reasoningSummary) {
+            this.reasoningSummary = reasoningSummary != null ? reasoningSummary.toString() : null;
+            return this;
+        }
+
+        /**
+         * Sets the reasoning summary mode. Accepts values like "auto", "concise", or "detailed".
+         */
+        public Builder reasoningSummary(String reasoningSummary) {
+            this.reasoningSummary = reasoningSummary;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Builder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder retryOptions(RetryOptions retryOptions) {
+            this.retryOptions = retryOptions;
+            return this;
+        }
+
+        public Builder proxyOptions(ProxyOptions proxyOptions) {
+            this.proxyOptions = proxyOptions;
+            return this;
+        }
+
+        public Builder logRequestsAndResponses(boolean logRequestsAndResponses) {
+            this.logRequestsAndResponses = logRequestsAndResponses;
+            return this;
+        }
+
+        public Builder responsesClient(ResponsesClient responsesClient) {
+            this.responsesClient = responsesClient;
+            return this;
+        }
+
+        public Builder userAgentSuffix(String userAgentSuffix) {
+            this.userAgentSuffix = userAgentSuffix;
+            return this;
+        }
+
+        public Builder listeners(List<ChatModelListener> listeners) {
+            this.listeners = listeners;
+            return this;
+        }
+
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeaders = customHeaders;
+            return this;
+        }
+
+        public Builder supportedCapabilities(Set<Capability> supportedCapabilities) {
+            this.supportedCapabilities = supportedCapabilities;
+            return this;
+        }
+
+        public Builder supportedCapabilities(Capability... supportedCapabilities) {
+            return supportedCapabilities(new HashSet<>(List.of(supportedCapabilities)));
+        }
+
+        public AzureOpenAiResponsesChatModel build() {
+            return new AzureOpenAiResponsesChatModel(this);
+        }
+    }
+}

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiResponsesStreamingChatModel.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiResponsesStreamingChatModel.java
@@ -1,0 +1,601 @@
+package dev.langchain4j.model.azure;
+
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteResponse;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteToolCall;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialResponse;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.model.ModelProvider.AZURE_OPEN_AI;
+import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.validate;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+
+import com.azure.ai.openai.responses.ResponsesAsyncClient;
+import com.azure.ai.openai.responses.models.CreateResponsesRequest;
+import com.azure.ai.openai.responses.models.ResponsesReasoningConfiguration;
+import com.azure.ai.openai.responses.models.ResponsesReasoningConfigurationEffort;
+import com.azure.ai.openai.responses.models.ResponsesReasoningConfigurationGenerateSummary;
+import com.azure.ai.openai.responses.models.ResponsesResponse;
+import com.azure.ai.openai.responses.models.ResponsesStreamEvent;
+import com.azure.ai.openai.responses.models.ResponsesStreamEventCompleted;
+import com.azure.ai.openai.responses.models.ResponsesStreamEventCreated;
+import com.azure.ai.openai.responses.models.ResponsesStreamEventError;
+import com.azure.ai.openai.responses.models.ResponsesStreamEventFailed;
+import com.azure.ai.openai.responses.models.ResponsesStreamEventIncomplete;
+import com.azure.ai.openai.responses.models.ResponsesStreamEventOutputTextDelta;
+import com.azure.core.credential.KeyCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.HttpClientProvider;
+import com.azure.core.http.ProxyOptions;
+import com.azure.core.http.policy.RetryOptions;
+import com.azure.core.util.BinaryData;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.azure.spi.AzureOpenAiResponsesStreamingChatModelBuilderFactory;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.StreamingHandle;
+import dev.langchain4j.model.output.Response;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+/**
+ * Represents an OpenAI model, hosted on Azure, that uses the Responses API.
+ * The model's response is streamed token by token and should be handled with {@link StreamingChatResponseHandler}.
+ * Reasoning summaries are only available when the service emits a reasoning output item;
+ * otherwise {@link dev.langchain4j.data.message.AiMessage#thinking()} will be {@code null}.
+ */
+public class AzureOpenAiResponsesStreamingChatModel implements StreamingChatModel {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureOpenAiResponsesStreamingChatModel.class);
+
+    private final ResponsesAsyncClient client;
+    private final ChatRequestParameters defaultRequestParameters;
+
+    private final String user;
+    private final boolean strictJsonSchema;
+    private final ResponsesReasoningConfigurationEffort reasoningEffort;
+    private final String reasoningSummary;
+    private final boolean logRequestsAndResponses;
+
+    private final List<ChatModelListener> listeners;
+    private final Set<Capability> supportedCapabilities;
+
+    public AzureOpenAiResponsesStreamingChatModel(Builder builder) {
+        if (builder.responsesAsyncClient == null) {
+            if (builder.tokenCredential != null) {
+                this.client = InternalAzureOpenAiResponsesHelper.setupAsyncClient(
+                        builder.endpoint,
+                        builder.serviceVersion,
+                        builder.tokenCredential,
+                        builder.timeout,
+                        builder.maxRetries,
+                        builder.retryOptions,
+                        builder.httpClientProvider,
+                        builder.proxyOptions,
+                        builder.logRequestsAndResponses,
+                        builder.userAgentSuffix,
+                        builder.customHeaders);
+            } else if (builder.keyCredential != null) {
+                this.client = InternalAzureOpenAiResponsesHelper.setupAsyncClient(
+                        builder.endpoint,
+                        builder.serviceVersion,
+                        builder.keyCredential,
+                        builder.timeout,
+                        builder.maxRetries,
+                        builder.retryOptions,
+                        builder.httpClientProvider,
+                        builder.proxyOptions,
+                        builder.logRequestsAndResponses,
+                        builder.userAgentSuffix,
+                        builder.customHeaders);
+            } else {
+                this.client = InternalAzureOpenAiResponsesHelper.setupAsyncClient(
+                        builder.endpoint,
+                        builder.serviceVersion,
+                        builder.apiKey,
+                        builder.timeout,
+                        builder.maxRetries,
+                        builder.retryOptions,
+                        builder.httpClientProvider,
+                        builder.proxyOptions,
+                        builder.logRequestsAndResponses,
+                        builder.userAgentSuffix,
+                        builder.customHeaders);
+            }
+        } else {
+            this.client = ensureNotNull(builder.responsesAsyncClient, "responsesAsyncClient");
+        }
+
+        ChatRequestParameters parameters;
+        if (builder.defaultRequestParameters != null) {
+            validate(builder.defaultRequestParameters);
+            parameters = builder.defaultRequestParameters;
+        } else {
+            parameters = DefaultChatRequestParameters.EMPTY;
+        }
+
+        this.defaultRequestParameters = ChatRequestParameters.builder()
+                .modelName(getOrDefault(builder.deploymentName, parameters.modelName()))
+                .temperature(getOrDefault(builder.temperature, parameters.temperature()))
+                .topP(getOrDefault(builder.topP, parameters.topP()))
+                .maxOutputTokens(getOrDefault(builder.maxTokens, parameters.maxOutputTokens()))
+                .toolSpecifications(parameters.toolSpecifications())
+                .toolChoice(parameters.toolChoice())
+                .responseFormat(getOrDefault(builder.responseFormat, parameters.responseFormat()))
+                .build();
+
+        this.user = builder.user;
+        this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
+        this.reasoningEffort = builder.reasoningEffort;
+        this.reasoningSummary = builder.reasoningSummary;
+        this.logRequestsAndResponses = builder.logRequestsAndResponses;
+
+        this.listeners = copy(builder.listeners);
+        this.supportedCapabilities = copy(builder.supportedCapabilities);
+    }
+
+    @Override
+    public ChatRequestParameters defaultRequestParameters() {
+        return defaultRequestParameters;
+    }
+
+    @Override
+    public Set<Capability> supportedCapabilities() {
+        return supportedCapabilities;
+    }
+
+    @Override
+    public void doChat(ChatRequest request, StreamingChatResponseHandler handler) {
+        ChatRequestParameters parameters = request.parameters();
+        validate(parameters);
+
+        List<com.azure.ai.openai.responses.models.ResponsesMessage> messages =
+                InternalAzureOpenAiResponsesHelper.toResponsesMessages(request.messages());
+
+        ResponseFormat responseFormat = parameters.responseFormat();
+        com.azure.ai.openai.responses.models.ResponseTextOptions textOptions = null;
+        if (responseFormat != null) {
+            textOptions = InternalAzureOpenAiResponsesHelper.toResponseTextOptions(responseFormat, strictJsonSchema);
+        }
+
+        List<com.azure.ai.openai.responses.models.ResponsesTool> tools =
+                parameters.toolSpecifications().isEmpty()
+                        ? List.of()
+                        : InternalAzureOpenAiResponsesHelper.toResponsesTools(
+                                parameters.toolSpecifications(), strictJsonSchema);
+
+        Flux<ResponsesStreamEvent> stream;
+        if (reasoningSummary != null) {
+            BinaryData requestBody = InternalAzureOpenAiResponsesHelper.buildRequestBody(
+                    parameters.modelName(),
+                    messages,
+                    parameters.temperature(),
+                    parameters.topP(),
+                    parameters.maxOutputTokens(),
+                    user,
+                    textOptions,
+                    reasoningEffort,
+                    reasoningSummary,
+                    tools,
+                    parameters.toolChoice(),
+                    true);
+            stream = InternalAzureOpenAiResponsesHelper.createResponseStreamWithRawRequest(client, requestBody);
+        } else {
+            CreateResponsesRequest createRequest = new CreateResponsesRequest(
+                    InternalAzureOpenAiResponsesHelper.toModel(parameters.modelName()), messages);
+            createRequest.setTemperature(parameters.temperature());
+            createRequest.setTopP(parameters.topP());
+            createRequest.setMaxOutputTokens(parameters.maxOutputTokens());
+            createRequest.setUser(user);
+            if (textOptions != null) {
+                createRequest.setText(textOptions);
+            }
+            if (reasoningEffort != null) {
+                ResponsesReasoningConfiguration reasoning = new ResponsesReasoningConfiguration(reasoningEffort);
+                createRequest.setReasoning(reasoning);
+            }
+            if (!tools.isEmpty()) {
+                createRequest.setTools(tools);
+            }
+            if (parameters.toolChoice() != null) {
+                createRequest.setToolChoice(
+                        InternalAzureOpenAiResponsesHelper.toToolChoiceBinaryData(parameters.toolChoice()));
+            }
+            stream = client.createResponseStream(createRequest);
+        }
+
+        AtomicReference<ResponsesResponse> completedResponse = new AtomicReference<>();
+        AtomicReference<String> responseId = new AtomicReference<>();
+        AtomicReference<String> responseModelName = new AtomicReference<>();
+        AtomicReference<StreamingHandle> streamingHandle = new AtomicReference<>();
+        AtomicBoolean errorReported = new AtomicBoolean(false);
+        StringBuilder textBuilder = new StringBuilder();
+
+        Disposable disposable = stream.subscribe(
+                event -> handleEvent(
+                        event,
+                        handler,
+                        streamingHandle.get(),
+                        textBuilder,
+                        completedResponse,
+                        responseId,
+                        responseModelName,
+                        errorReported),
+                error -> {
+                    RuntimeException mappedError = AzureOpenAiExceptionMapper.INSTANCE.mapException(error);
+                    errorReported.set(true);
+                    withLoggingExceptions(() -> handler.onError(mappedError));
+                },
+                () -> {
+                    if (errorReported.get()) {
+                        return;
+                    }
+                    ResponsesResponse response = completedResponse.get();
+                    Response<dev.langchain4j.data.message.AiMessage> parsed =
+                            InternalAzureOpenAiResponsesHelper.toResponse(response, textBuilder.toString());
+                    if (logRequestsAndResponses) {
+                        Integer reasoningTokens = InternalAzureOpenAiResponsesHelper.extractReasoningTokens(response);
+                        if (parsed.content().thinking() == null && reasoningTokens != null && reasoningTokens > 0) {
+                            LOGGER.info(
+                                    "Reasoning tokens were reported ({}), but no reasoning summary text was returned. "
+                                            + "This can happen depending on the model/service.",
+                                    reasoningTokens);
+                        }
+                    }
+
+                    List<ToolExecutionRequest> toolCalls = parsed.content().toolExecutionRequests();
+                    for (int i = 0; i < toolCalls.size(); i++) {
+                        onCompleteToolCall(handler, new CompleteToolCall(i, toolCalls.get(i)));
+                    }
+
+                    ChatResponse chatResponse = ChatResponse.builder()
+                            .aiMessage(parsed.content())
+                            .metadata(ChatResponseMetadata.builder()
+                                    .id(responseId.get())
+                                    .modelName(responseModelName.get())
+                                    .tokenUsage(parsed.tokenUsage())
+                                    .finishReason(parsed.finishReason())
+                                    .build())
+                            .build();
+
+                    onCompleteResponse(handler, chatResponse);
+                });
+
+        streamingHandle.set(new AzureOpenAiStreamingHandle(disposable));
+    }
+
+    private static void handleEvent(
+            ResponsesStreamEvent event,
+            StreamingChatResponseHandler handler,
+            StreamingHandle streamingHandle,
+            StringBuilder textBuilder,
+            AtomicReference<ResponsesResponse> completedResponse,
+            AtomicReference<String> responseId,
+            AtomicReference<String> responseModelName,
+            AtomicBoolean errorReported) {
+        if (event == null) {
+            return;
+        }
+
+        if (event instanceof ResponsesStreamEventOutputTextDelta textDelta) {
+            String delta = textDelta.getDelta();
+            if (!isNullOrBlank(delta)) {
+                textBuilder.append(delta);
+                onPartialResponse(handler, delta, streamingHandle);
+            }
+            return;
+        }
+
+        if (event instanceof ResponsesStreamEventCreated created) {
+            ResponsesResponse response = created.getResponse();
+            if (response != null) {
+                if (!isNullOrBlank(response.getId())) {
+                    responseId.set(response.getId());
+                }
+                if (!isNullOrBlank(response.getModel())) {
+                    responseModelName.set(response.getModel());
+                }
+            }
+            return;
+        }
+
+        if (event instanceof ResponsesStreamEventCompleted completed) {
+            ResponsesResponse response = completed.getResponse();
+            if (response != null) {
+                completedResponse.set(response);
+                if (!isNullOrBlank(response.getId())) {
+                    responseId.set(response.getId());
+                }
+                if (!isNullOrBlank(response.getModel())) {
+                    responseModelName.set(response.getModel());
+                }
+            }
+            return;
+        }
+
+        if (event instanceof ResponsesStreamEventIncomplete incomplete) {
+            ResponsesResponse response = incomplete.getResponse();
+            if (response != null) {
+                completedResponse.set(response);
+                if (!isNullOrBlank(response.getId())) {
+                    responseId.set(response.getId());
+                }
+                if (!isNullOrBlank(response.getModel())) {
+                    responseModelName.set(response.getModel());
+                }
+            }
+            return;
+        }
+
+        if (event instanceof ResponsesStreamEventFailed failed) {
+            errorReported.set(true);
+            ResponsesResponse response = failed.getResponse();
+            String message = response != null
+                    ? response.getError() != null ? response.getError().getMessage() : "Responses stream failed"
+                    : "Responses stream failed";
+            withLoggingExceptions(() -> handler.onError(new RuntimeException(message)));
+            return;
+        }
+
+        if (event instanceof ResponsesStreamEventError errorEvent) {
+            errorReported.set(true);
+            String message = errorEvent.getMessage() != null
+                    ? "Responses stream error: " + errorEvent.getMessage()
+                    : "Responses stream error";
+            withLoggingExceptions(() -> handler.onError(new RuntimeException(message)));
+        }
+    }
+
+    @Override
+    public List<ChatModelListener> listeners() {
+        return listeners;
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return AZURE_OPEN_AI;
+    }
+
+    public static Builder builder() {
+        for (AzureOpenAiResponsesStreamingChatModelBuilderFactory factory :
+                loadFactories(AzureOpenAiResponsesStreamingChatModelBuilderFactory.class)) {
+            return factory.get();
+        }
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private ChatRequestParameters defaultRequestParameters;
+
+        private String endpoint;
+        private String serviceVersion;
+        private String apiKey;
+        private KeyCredential keyCredential;
+        private TokenCredential tokenCredential;
+        private HttpClientProvider httpClientProvider;
+        private String deploymentName;
+        private Integer maxTokens;
+        private Double temperature;
+        private Double topP;
+        private String user;
+        private ResponseFormat responseFormat;
+        private Boolean strictJsonSchema;
+        private Duration timeout;
+        private Integer maxRetries;
+        private RetryOptions retryOptions;
+        private ProxyOptions proxyOptions;
+        private boolean logRequestsAndResponses;
+        private ResponsesAsyncClient responsesAsyncClient;
+        private String userAgentSuffix;
+        private List<ChatModelListener> listeners;
+        private Map<String, String> customHeaders;
+        private Set<Capability> supportedCapabilities;
+        private ResponsesReasoningConfigurationEffort reasoningEffort;
+        private String reasoningSummary;
+
+        public Builder defaultRequestParameters(ChatRequestParameters parameters) {
+            this.defaultRequestParameters = parameters;
+            return this;
+        }
+
+        /**
+         * Sets the Azure OpenAI endpoint. This is a mandatory parameter.
+         *
+         * @param endpoint The Azure OpenAI endpoint in the format: https://{resource}.openai.azure.com/
+         * @return builder
+         */
+        public Builder endpoint(String endpoint) {
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        /**
+         * Sets the Azure OpenAI API service version. This is optional; if not set, the latest is used.
+         *
+         * @param serviceVersion The Azure OpenAI API service version in the format: 2024-10-21
+         * @return builder
+         */
+        public Builder serviceVersion(String serviceVersion) {
+            this.serviceVersion = serviceVersion;
+            return this;
+        }
+
+        /**
+         * Sets the Azure OpenAI API key.
+         *
+         * @param apiKey The Azure OpenAI API key.
+         * @return builder
+         */
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * Used to authenticate with the OpenAI service, instead of Azure OpenAI.
+         * This automatically sets the endpoint to https://api.openai.com/v1.
+         *
+         * @param nonAzureApiKey The non-Azure OpenAI API key
+         * @return builder
+         */
+        public Builder nonAzureApiKey(String nonAzureApiKey) {
+            this.keyCredential = new KeyCredential(nonAzureApiKey);
+            this.endpoint = "https://api.openai.com/v1";
+            return this;
+        }
+
+        public Builder keyCredential(KeyCredential keyCredential) {
+            this.keyCredential = keyCredential;
+            return this;
+        }
+
+        public Builder tokenCredential(TokenCredential tokenCredential) {
+            this.tokenCredential = tokenCredential;
+            return this;
+        }
+
+        public Builder httpClientProvider(HttpClientProvider httpClientProvider) {
+            this.httpClientProvider = httpClientProvider;
+            return this;
+        }
+
+        /**
+         * Sets the Azure OpenAI deployment name (model). This is a mandatory parameter.
+         *
+         * @param deploymentName The Azure OpenAI deployment name.
+         * @return builder
+         */
+        public Builder deploymentName(String deploymentName) {
+            this.deploymentName = deploymentName;
+            return this;
+        }
+
+        public Builder maxTokens(Integer maxTokens) {
+            this.maxTokens = maxTokens;
+            return this;
+        }
+
+        public Builder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        public Builder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        public Builder user(String user) {
+            this.user = user;
+            return this;
+        }
+
+        public Builder responseFormat(ResponseFormat responseFormat) {
+            this.responseFormat = responseFormat;
+            return this;
+        }
+
+        public Builder strictJsonSchema(Boolean strictJsonSchema) {
+            this.strictJsonSchema = strictJsonSchema;
+            return this;
+        }
+
+        public Builder reasoningEffort(ResponsesReasoningConfigurationEffort reasoningEffort) {
+            this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
+        public Builder reasoningSummary(ResponsesReasoningConfigurationGenerateSummary reasoningSummary) {
+            this.reasoningSummary = reasoningSummary != null ? reasoningSummary.toString() : null;
+            return this;
+        }
+
+        /**
+         * Sets the reasoning summary mode. Accepts values like "auto", "concise", or "detailed".
+         */
+        public Builder reasoningSummary(String reasoningSummary) {
+            this.reasoningSummary = reasoningSummary;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Builder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder retryOptions(RetryOptions retryOptions) {
+            this.retryOptions = retryOptions;
+            return this;
+        }
+
+        public Builder proxyOptions(ProxyOptions proxyOptions) {
+            this.proxyOptions = proxyOptions;
+            return this;
+        }
+
+        public Builder logRequestsAndResponses(boolean logRequestsAndResponses) {
+            this.logRequestsAndResponses = logRequestsAndResponses;
+            return this;
+        }
+
+        public Builder responsesAsyncClient(ResponsesAsyncClient responsesAsyncClient) {
+            this.responsesAsyncClient = responsesAsyncClient;
+            return this;
+        }
+
+        public Builder userAgentSuffix(String userAgentSuffix) {
+            this.userAgentSuffix = userAgentSuffix;
+            return this;
+        }
+
+        public Builder listeners(List<ChatModelListener> listeners) {
+            this.listeners = listeners;
+            return this;
+        }
+
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeaders = customHeaders;
+            return this;
+        }
+
+        public Builder supportedCapabilities(Set<Capability> supportedCapabilities) {
+            this.supportedCapabilities = supportedCapabilities;
+            return this;
+        }
+
+        public Builder supportedCapabilities(Capability... supportedCapabilities) {
+            return supportedCapabilities(new HashSet<>(List.of(supportedCapabilities)));
+        }
+
+        public AzureOpenAiResponsesStreamingChatModel build() {
+            return new AzureOpenAiResponsesStreamingChatModel(this);
+        }
+    }
+}

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiResponsesHelper.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiResponsesHelper.java
@@ -1,0 +1,682 @@
+package dev.langchain4j.model.azure;
+
+import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.model.output.FinishReason.CONTENT_FILTER;
+import static dev.langchain4j.model.output.FinishReason.LENGTH;
+import static dev.langchain4j.model.output.FinishReason.OTHER;
+import static dev.langchain4j.model.output.FinishReason.STOP;
+import static dev.langchain4j.model.output.FinishReason.TOOL_EXECUTION;
+import static java.time.Duration.ofSeconds;
+import static java.util.stream.Collectors.toList;
+
+import com.azure.ai.openai.implementation.OpenAIUtils;
+import com.azure.ai.openai.responses.AzureResponsesServiceVersion;
+import com.azure.ai.openai.responses.ResponsesAsyncClient;
+import com.azure.ai.openai.responses.ResponsesClient;
+import com.azure.ai.openai.responses.ResponsesClientBuilder;
+import com.azure.ai.openai.responses.implementation.NonAzureResponsesClientImpl;
+import com.azure.ai.openai.responses.implementation.OpenAIServerSentEvents;
+import com.azure.ai.openai.responses.implementation.ResponsesClientImpl;
+import com.azure.ai.openai.responses.models.CreateResponsesRequestModel;
+import com.azure.ai.openai.responses.models.ResponseTextOptions;
+import com.azure.ai.openai.responses.models.ResponsesAssistantMessage;
+import com.azure.ai.openai.responses.models.ResponsesContent;
+import com.azure.ai.openai.responses.models.ResponsesFunctionCallItem;
+import com.azure.ai.openai.responses.models.ResponsesFunctionTool;
+import com.azure.ai.openai.responses.models.ResponsesInputContentImage;
+import com.azure.ai.openai.responses.models.ResponsesInputContentImageDetail;
+import com.azure.ai.openai.responses.models.ResponsesInputContentText;
+import com.azure.ai.openai.responses.models.ResponsesItem;
+import com.azure.ai.openai.responses.models.ResponsesMessage;
+import com.azure.ai.openai.responses.models.ResponsesMessageRole;
+import com.azure.ai.openai.responses.models.ResponsesOutputContentText;
+import com.azure.ai.openai.responses.models.ResponsesReasoningConfigurationEffort;
+import com.azure.ai.openai.responses.models.ResponsesReasoningItem;
+import com.azure.ai.openai.responses.models.ResponsesReasoningItemSummaryElement;
+import com.azure.ai.openai.responses.models.ResponsesReasoningItemSummaryElementSummaryText;
+import com.azure.ai.openai.responses.models.ResponsesResponse;
+import com.azure.ai.openai.responses.models.ResponsesResponseIncompleteDetails;
+import com.azure.ai.openai.responses.models.ResponsesResponseIncompleteDetailsReason;
+import com.azure.ai.openai.responses.models.ResponsesResponseStatus;
+import com.azure.ai.openai.responses.models.ResponsesResponseUsage;
+import com.azure.ai.openai.responses.models.ResponsesStreamEvent;
+import com.azure.ai.openai.responses.models.ResponsesSystemMessage;
+import com.azure.ai.openai.responses.models.ResponsesTextFormatJsonObject;
+import com.azure.ai.openai.responses.models.ResponsesTextFormatJsonSchema;
+import com.azure.ai.openai.responses.models.ResponsesTextFormatText;
+import com.azure.ai.openai.responses.models.ResponsesTool;
+import com.azure.ai.openai.responses.models.ResponsesToolChoiceOption;
+import com.azure.ai.openai.responses.models.ResponsesUserMessage;
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.credential.KeyCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpClientProvider;
+import com.azure.core.http.ProxyOptions;
+import com.azure.core.http.netty.NettyAsyncHttpClientProvider;
+import com.azure.core.http.policy.HttpLogDetailLevel;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.core.http.policy.RetryOptions;
+import com.azure.core.http.rest.RequestOptions;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.ClientOptions;
+import com.azure.core.util.Header;
+import com.azure.core.util.HttpClientOptions;
+import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ResponseFormatType;
+import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonRawSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Internal
+class InternalAzureOpenAiResponsesHelper {
+
+    static final String DEFAULT_USER_AGENT = InternalAzureOpenAiHelper.DEFAULT_USER_AGENT;
+
+    static ResponsesClient setupSyncClient(
+            String endpoint,
+            String serviceVersion,
+            Object credential,
+            Duration timeout,
+            Integer maxRetries,
+            RetryOptions retryOptions,
+            HttpClientProvider httpClientProvider,
+            ProxyOptions proxyOptions,
+            boolean logRequestsAndResponses,
+            String userAgentSuffix,
+            Map<String, String> customHeaders) {
+        ResponsesClientBuilder builder = setupResponsesClientBuilder(
+                endpoint,
+                serviceVersion,
+                credential,
+                timeout,
+                maxRetries,
+                retryOptions,
+                httpClientProvider,
+                proxyOptions,
+                logRequestsAndResponses,
+                userAgentSuffix,
+                customHeaders);
+        return builder.buildClient();
+    }
+
+    static ResponsesAsyncClient setupAsyncClient(
+            String endpoint,
+            String serviceVersion,
+            Object credential,
+            Duration timeout,
+            Integer maxRetries,
+            RetryOptions retryOptions,
+            HttpClientProvider httpClientProvider,
+            ProxyOptions proxyOptions,
+            boolean logRequestsAndResponses,
+            String userAgentSuffix,
+            Map<String, String> customHeaders) {
+        ResponsesClientBuilder builder = setupResponsesClientBuilder(
+                endpoint,
+                serviceVersion,
+                credential,
+                timeout,
+                maxRetries,
+                retryOptions,
+                httpClientProvider,
+                proxyOptions,
+                logRequestsAndResponses,
+                userAgentSuffix,
+                customHeaders);
+        return builder.buildAsyncClient();
+    }
+
+    private static ResponsesClientBuilder setupResponsesClientBuilder(
+            String endpoint,
+            String serviceVersion,
+            Object credential,
+            Duration timeout,
+            Integer maxRetries,
+            RetryOptions retryOptions,
+            HttpClientProvider httpClientProvider,
+            ProxyOptions proxyOptions,
+            boolean logRequestsAndResponses,
+            String userAgentSuffix,
+            Map<String, String> customHeaders) {
+        timeout = getOrDefault(timeout, ofSeconds(60));
+        HttpClientOptions clientOptions = new HttpClientOptions();
+        clientOptions.setConnectTimeout(timeout);
+        clientOptions.setResponseTimeout(timeout);
+        clientOptions.setReadTimeout(timeout);
+        clientOptions.setWriteTimeout(timeout);
+        clientOptions.setProxyOptions(proxyOptions);
+
+        String userAgent = DEFAULT_USER_AGENT;
+        if (userAgentSuffix != null && !userAgentSuffix.isEmpty()) {
+            userAgent = DEFAULT_USER_AGENT + "-" + userAgentSuffix;
+        }
+        List<Header> headers = new ArrayList<>();
+        headers.add(new Header("User-Agent", userAgent));
+        if (customHeaders != null) {
+            customHeaders.forEach((name, value) -> headers.add(new Header(name, value)));
+        }
+        clientOptions.setHeaders(headers);
+
+        httpClientProvider = getOrDefault(httpClientProvider, NettyAsyncHttpClientProvider::new);
+        HttpClient httpClient = httpClientProvider.createInstance(clientOptions);
+
+        HttpLogOptions httpLogOptions = new HttpLogOptions();
+        if (logRequestsAndResponses) {
+            httpLogOptions.setLogLevel(HttpLogDetailLevel.BODY_AND_HEADERS);
+        }
+
+        retryOptions = InternalAzureOpenAiHelper.resolveRetryOptions(maxRetries, retryOptions);
+
+        ClientOptions responsesClientOptions = new ClientOptions().setHeaders(headers);
+
+        ResponsesClientBuilder builder = new ResponsesClientBuilder()
+                .endpoint(ensureNotBlank(endpoint, "endpoint"))
+                .serviceVersion(getResponsesServiceVersion(serviceVersion))
+                .httpClient(httpClient)
+                .httpLogOptions(httpLogOptions)
+                .clientOptions(responsesClientOptions)
+                .retryOptions(retryOptions);
+
+        if (credential instanceof String) {
+            builder.credential(new AzureKeyCredential((String) credential));
+        } else if (credential instanceof KeyCredential) {
+            builder.credential((KeyCredential) credential);
+        } else if (credential instanceof TokenCredential) {
+            builder.credential((TokenCredential) credential);
+        } else {
+            throw new IllegalArgumentException("Unsupported credential type: " + credential.getClass());
+        }
+
+        return builder;
+    }
+
+    static AzureResponsesServiceVersion getResponsesServiceVersion(String serviceVersion) {
+        if (serviceVersion != null) {
+            for (AzureResponsesServiceVersion version : AzureResponsesServiceVersion.values()) {
+                if (version.getVersion().equals(serviceVersion)) {
+                    return version;
+                }
+            }
+        }
+        return AzureResponsesServiceVersion.getLatest();
+    }
+
+    static List<ResponsesMessage> toResponsesMessages(List<ChatMessage> messages) {
+        return messages.stream()
+                .map(InternalAzureOpenAiResponsesHelper::toResponsesMessage)
+                .collect(toList());
+    }
+
+    private static ResponsesMessage toResponsesMessage(ChatMessage message) {
+        if (message instanceof SystemMessage systemMessage) {
+            return new ResponsesSystemMessage(List.of(new ResponsesInputContentText(systemMessage.text())));
+        } else if (message instanceof UserMessage userMessage) {
+            return toUserMessage(userMessage);
+        } else if (message instanceof AiMessage aiMessage) {
+            return toAssistantMessage(aiMessage);
+        } else if (message instanceof ToolExecutionResultMessage) {
+            throw new UnsupportedFeatureException(
+                    "Tool execution result messages are not supported by Azure Responses API in this SDK version");
+        } else {
+            throw new IllegalArgumentException("Unsupported message type: " + message.type());
+        }
+    }
+
+    private static ResponsesMessage toAssistantMessage(AiMessage aiMessage) {
+        if (aiMessage.hasToolExecutionRequests()) {
+            throw new UnsupportedFeatureException(
+                    "Tool execution requests in assistant messages are not supported by Azure Responses API in this SDK version");
+        }
+        if (isNullOrBlank(aiMessage.text())) {
+            throw new UnsupportedFeatureException(
+                    "Assistant messages without text are not supported by Azure Responses API in this SDK version");
+        }
+        return new ResponsesAssistantMessage(List.of(new ResponsesInputContentText(aiMessage.text())));
+    }
+
+    private static ResponsesMessage toUserMessage(UserMessage userMessage) {
+        if (userMessage.hasSingleText()) {
+            return new ResponsesUserMessage(List.of(new ResponsesInputContentText(
+                    ((TextContent) userMessage.contents().get(0)).text())));
+        }
+        List<ResponsesContent> contents = userMessage.contents().stream()
+                .map(content -> {
+                    if (content instanceof TextContent) {
+                        return new ResponsesInputContentText(((TextContent) content).text());
+                    } else if (content instanceof ImageContent imageContent) {
+                        ResponsesInputContentImage image = new ResponsesInputContentImage()
+                                .setImageUrl(toImageUrl(imageContent.image()))
+                                .setDetail(toImageDetail(imageContent.detailLevel()));
+                        return image;
+                    } else {
+                        throw new IllegalArgumentException("Unsupported content type: " + content.type());
+                    }
+                })
+                .collect(toList());
+        return new ResponsesUserMessage(contents);
+    }
+
+    private static String toImageUrl(Image image) {
+        if (image.url() != null) {
+            return image.url().toString();
+        }
+        return String.format("data:%s;base64,%s", image.mimeType(), image.base64Data());
+    }
+
+    private static ResponsesInputContentImageDetail toImageDetail(ImageContent.DetailLevel detailLevel) {
+        if (detailLevel == null) {
+            return null;
+        }
+        return switch (detailLevel) {
+            case LOW -> ResponsesInputContentImageDetail.LOW;
+            case HIGH -> ResponsesInputContentImageDetail.HIGH;
+            case AUTO -> ResponsesInputContentImageDetail.AUTO;
+        };
+    }
+
+    static ResponseTextOptions toResponseTextOptions(ResponseFormat responseFormat, boolean strict) {
+        if (responseFormat == null) {
+            return null;
+        }
+
+        ResponseTextOptions options = new ResponseTextOptions();
+        if (responseFormat.type() == ResponseFormatType.TEXT) {
+            options.setFormat(new ResponsesTextFormatText());
+        } else if (responseFormat.type() == ResponseFormatType.JSON) {
+            JsonSchema jsonSchema = responseFormat.jsonSchema();
+            if (jsonSchema == null) {
+                options.setFormat(new ResponsesTextFormatJsonObject());
+            } else {
+                if (!(jsonSchema.rootElement() instanceof JsonObjectSchema
+                        || jsonSchema.rootElement() instanceof JsonRawSchema)) {
+                    throw new IllegalArgumentException(
+                            "For Azure OpenAI Responses API, the root element of the JSON Schema must be either a JsonObjectSchema or a JsonRawSchema, but it was: "
+                                    + jsonSchema.rootElement().getClass());
+                }
+                Map<String, Object> schemaMap = toMap(jsonSchema.rootElement(), strict);
+                ResponsesTextFormatJsonSchema schema =
+                        new ResponsesTextFormatJsonSchema(jsonSchema.name(), BinaryData.fromObject(schemaMap));
+                schema.setStrict(strict);
+                options.setFormat(schema);
+            }
+        }
+
+        return options;
+    }
+
+    static List<ResponsesTool> toResponsesTools(Collection<ToolSpecification> toolSpecifications, boolean strict) {
+        return toolSpecifications.stream()
+                .map(toolSpecification -> new ResponsesFunctionTool(
+                        toolSpecification.name(),
+                        toolSpecification.description(),
+                        getParameters(toolSpecification),
+                        strict))
+                .collect(toList());
+    }
+
+    static BinaryData toToolChoiceBinaryData(ToolChoice toolChoice) {
+        ResponsesToolChoiceOption option =
+                switch (toolChoice) {
+                    case AUTO -> ResponsesToolChoiceOption.AUTO;
+                    case REQUIRED -> ResponsesToolChoiceOption.REQUIRED;
+                    case NONE -> ResponsesToolChoiceOption.NONE;
+                };
+        return BinaryData.fromObject(option);
+    }
+
+    static ResponsesToolChoiceOption toToolChoiceOption(ToolChoice toolChoice) {
+        return switch (toolChoice) {
+            case AUTO -> ResponsesToolChoiceOption.AUTO;
+            case REQUIRED -> ResponsesToolChoiceOption.REQUIRED;
+            case NONE -> ResponsesToolChoiceOption.NONE;
+        };
+    }
+
+    static BinaryData buildRequestBody(
+            String modelName,
+            List<ResponsesMessage> messages,
+            Double temperature,
+            Double topP,
+            Integer maxOutputTokens,
+            String user,
+            ResponseTextOptions textOptions,
+            ResponsesReasoningConfigurationEffort reasoningEffort,
+            String reasoningSummary,
+            List<ResponsesTool> tools,
+            ToolChoice toolChoice,
+            boolean stream) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("model", modelName);
+        payload.put("input", messages);
+
+        if (temperature != null) {
+            payload.put("temperature", temperature);
+        }
+        if (topP != null) {
+            payload.put("top_p", topP);
+        }
+        if (maxOutputTokens != null) {
+            payload.put("max_output_tokens", maxOutputTokens);
+        }
+        if (!isNullOrBlank(user)) {
+            payload.put("user", user);
+        }
+        if (textOptions != null) {
+            payload.put("text", textOptions);
+        }
+        if (!isNullOrEmpty(tools)) {
+            payload.put("tools", tools);
+        }
+        if (toolChoice != null) {
+            payload.put("tool_choice", toToolChoiceOption(toolChoice));
+        }
+
+        if (reasoningEffort != null || reasoningSummary != null) {
+            Map<String, Object> reasoning = new HashMap<>();
+            if (reasoningEffort != null) {
+                reasoning.put("effort", reasoningEffort.toString());
+            }
+            if (reasoningSummary != null) {
+                reasoning.put("summary", reasoningSummary);
+            }
+            payload.put("reasoning", reasoning);
+        }
+
+        if (stream) {
+            payload.put("stream", true);
+        }
+
+        return BinaryData.fromObject(payload);
+    }
+
+    static ResponsesResponse createResponseWithRawRequest(ResponsesClient client, BinaryData requestBody) {
+        ResponsesClientImpl serviceClient = getServiceClient(client);
+        NonAzureResponsesClientImpl nonAzureServiceClient = getNonAzureServiceClient(client);
+        RequestOptions requestOptions = new RequestOptions();
+        if (serviceClient != null) {
+            OpenAIUtils.addAzureVersionToRequestOptions(
+                    serviceClient.getEndpoint(), requestOptions, serviceClient.getServiceVersion());
+            com.azure.core.http.rest.Response<BinaryData> response =
+                    serviceClient.createResponseWithResponse("application/json", requestBody, requestOptions);
+            return response.getValue().toObject(ResponsesResponse.class);
+        }
+        if (nonAzureServiceClient != null) {
+            com.azure.core.http.rest.Response<BinaryData> response =
+                    nonAzureServiceClient.createResponseWithResponse("application/json", requestBody, requestOptions);
+            return response.getValue().toObject(ResponsesResponse.class);
+        }
+        throw new IllegalStateException("Unable to access Responses client implementation");
+    }
+
+    static Flux<ResponsesStreamEvent> createResponseStreamWithRawRequest(
+            ResponsesAsyncClient client, BinaryData requestBody) {
+        ResponsesClientImpl serviceClient = getServiceClient(client);
+        NonAzureResponsesClientImpl nonAzureServiceClient = getNonAzureServiceClient(client);
+        RequestOptions requestOptions = new RequestOptions();
+        if (serviceClient != null) {
+            OpenAIUtils.addAzureVersionToRequestOptions(
+                    serviceClient.getEndpoint(), requestOptions, serviceClient.getServiceVersion());
+            Mono<com.azure.core.http.rest.Response<BinaryData>> responseMono =
+                    serviceClient.createResponseWithResponseAsync("text/event-stream", requestBody, requestOptions);
+            Flux<ByteBuffer> events =
+                    responseMono.flatMapMany(response -> response.getValue().toFluxByteBuffer());
+            return new OpenAIServerSentEvents(events).getEvents();
+        }
+        if (nonAzureServiceClient != null) {
+            Mono<com.azure.core.http.rest.Response<BinaryData>> responseMono =
+                    nonAzureServiceClient.createResponseWithResponseAsync(
+                            "text/event-stream", requestBody, requestOptions);
+            Flux<ByteBuffer> events =
+                    responseMono.flatMapMany(response -> response.getValue().toFluxByteBuffer());
+            return new OpenAIServerSentEvents(events).getEvents();
+        }
+        throw new IllegalStateException("Unable to access Responses client implementation");
+    }
+
+    private static ResponsesClientImpl getServiceClient(Object client) {
+        return getField(client, "serviceClient", ResponsesClientImpl.class);
+    }
+
+    private static NonAzureResponsesClientImpl getNonAzureServiceClient(Object client) {
+        return getField(client, "nonAzureServiceClient", NonAzureResponsesClientImpl.class);
+    }
+
+    private static <T> T getField(Object target, String fieldName, Class<T> type) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Object value = field.get(target);
+            if (type.isInstance(value)) {
+                return type.cast(value);
+            }
+            return null;
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalStateException(
+                    "Unable to access field '" + fieldName + "' on "
+                            + target.getClass().getName(),
+                    e);
+        }
+    }
+
+    private static BinaryData getParameters(ToolSpecification toolSpecification) {
+        return toOpenAiParameters(toolSpecification.parameters());
+    }
+
+    private static final Map<String, Object> NO_PARAMETER_DATA = new HashMap<>();
+
+    static {
+        NO_PARAMETER_DATA.put("type", "object");
+        NO_PARAMETER_DATA.put("properties", new HashMap<>());
+    }
+
+    private static BinaryData toOpenAiParameters(JsonObjectSchema toolParameters) {
+        Parameters parameters = new Parameters();
+        if (toolParameters == null) {
+            return BinaryData.fromObject(NO_PARAMETER_DATA);
+        }
+        parameters.setProperties(toMap(toolParameters.properties()));
+        parameters.setRequired(toolParameters.required());
+        return BinaryData.fromObject(parameters);
+    }
+
+    private static class Parameters {
+
+        private final String type = "object";
+
+        private Map<String, Map<String, Object>> properties = new HashMap<>();
+
+        private List<String> required = new ArrayList<>();
+
+        public String getType() {
+            return this.type;
+        }
+
+        public Map<String, Map<String, Object>> getProperties() {
+            return properties;
+        }
+
+        public void setProperties(Map<String, Map<String, Object>> properties) {
+            this.properties = properties;
+        }
+
+        public List<String> getRequired() {
+            return required;
+        }
+
+        public void setRequired(List<String> required) {
+            this.required = required;
+        }
+    }
+
+    static Response<AiMessage> toResponse(ResponsesResponse response, String fallbackText) {
+        String text = extractOutputText(response);
+        if (isNullOrBlank(text)) {
+            text = fallbackText;
+        }
+        String summary = extractReasoningSummary(response);
+        List<ToolExecutionRequest> toolExecutionRequests = extractToolExecutionRequests(response);
+
+        AiMessage aiMessage = AiMessage.builder()
+                .text(isNullOrBlank(text) ? null : text)
+                .thinking(isNullOrBlank(summary) ? null : summary)
+                .toolExecutionRequests(toolExecutionRequests)
+                .build();
+
+        TokenUsage tokenUsage = tokenUsageFrom(response != null ? response.getUsage() : null);
+        FinishReason finishReason = finishReasonFrom(response, toolExecutionRequests);
+
+        return Response.from(aiMessage, tokenUsage, finishReason);
+    }
+
+    private static String extractOutputText(ResponsesResponse response) {
+        if (response == null || isNullOrEmpty(response.getOutput())) {
+            return null;
+        }
+        StringBuilder builder = new StringBuilder();
+        for (ResponsesItem item : response.getOutput()) {
+            if (item instanceof ResponsesMessage message) {
+                if (message.getRole() != ResponsesMessageRole.ASSISTANT) {
+                    continue;
+                }
+                if (message instanceof ResponsesAssistantMessage assistantMessage) {
+                    List<ResponsesContent> contents = assistantMessage.getContent();
+                    if (isNullOrEmpty(contents)) {
+                        continue;
+                    }
+                    for (ResponsesContent content : contents) {
+                        if (content instanceof ResponsesOutputContentText outputText) {
+                            String text = outputText.getText();
+                            if (!isNullOrBlank(text)) {
+                                builder.append(text);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        String text = builder.toString();
+        return isNullOrBlank(text) ? null : text;
+    }
+
+    private static String extractReasoningSummary(ResponsesResponse response) {
+        if (response == null || isNullOrEmpty(response.getOutput())) {
+            return null;
+        }
+        StringBuilder builder = new StringBuilder();
+        for (ResponsesItem item : response.getOutput()) {
+            if (item instanceof ResponsesReasoningItem reasoningItem) {
+                List<ResponsesReasoningItemSummaryElement> summary = reasoningItem.getSummary();
+                if (isNullOrEmpty(summary)) {
+                    continue;
+                }
+                for (ResponsesReasoningItemSummaryElement element : summary) {
+                    if (element instanceof ResponsesReasoningItemSummaryElementSummaryText summaryText) {
+                        String text = summaryText.getText();
+                        if (isNullOrBlank(text)) {
+                            continue;
+                        }
+                        if (!builder.isEmpty()) {
+                            builder.append("\n");
+                        }
+                        builder.append(text);
+                    }
+                }
+            }
+        }
+        String summary = builder.toString();
+        return isNullOrBlank(summary) ? null : summary;
+    }
+
+    static Integer extractReasoningTokens(ResponsesResponse response) {
+        if (response == null || response.getUsage() == null) {
+            return null;
+        }
+        if (response.getUsage().getOutputTokensDetails() == null) {
+            return null;
+        }
+        return response.getUsage().getOutputTokensDetails().getReasoningTokens();
+    }
+
+    private static List<ToolExecutionRequest> extractToolExecutionRequests(ResponsesResponse response) {
+        if (response == null || isNullOrEmpty(response.getOutput())) {
+            return List.of();
+        }
+        List<ToolExecutionRequest> toolExecutionRequests = new ArrayList<>();
+        for (ResponsesItem item : response.getOutput()) {
+            if (item instanceof ResponsesFunctionCallItem functionCall) {
+                toolExecutionRequests.add(ToolExecutionRequest.builder()
+                        .id(functionCall.getCallId())
+                        .name(functionCall.getName())
+                        .arguments(functionCall.getArguments())
+                        .build());
+            }
+        }
+        return toolExecutionRequests;
+    }
+
+    static TokenUsage tokenUsageFrom(ResponsesResponseUsage usage) {
+        if (usage == null) {
+            return null;
+        }
+        return new TokenUsage(usage.getInputTokens(), usage.getOutputTokens(), usage.getTotalTokens());
+    }
+
+    static FinishReason finishReasonFrom(ResponsesResponse response, List<ToolExecutionRequest> toolCalls) {
+        if (!isNullOrEmpty(toolCalls)) {
+            return TOOL_EXECUTION;
+        }
+        if (response == null || response.getStatus() == null) {
+            return null;
+        }
+        if (response.getStatus() == ResponsesResponseStatus.COMPLETED) {
+            return STOP;
+        }
+        if (response.getStatus() == ResponsesResponseStatus.INCOMPLETE) {
+            ResponsesResponseIncompleteDetails details = response.getIncompleteDetails();
+            if (details != null && details.getReason() != null) {
+                if (details.getReason() == ResponsesResponseIncompleteDetailsReason.MAX_OUTPUT_TOKENS) {
+                    return LENGTH;
+                }
+                if (details.getReason() == ResponsesResponseIncompleteDetailsReason.CONTENT_FILTER) {
+                    return CONTENT_FILTER;
+                }
+            }
+        }
+        return OTHER;
+    }
+
+    static CreateResponsesRequestModel toModel(String modelName) {
+        return CreateResponsesRequestModel.fromString(modelName);
+    }
+}

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/spi/AzureOpenAiResponsesChatModelBuilderFactory.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/spi/AzureOpenAiResponsesChatModelBuilderFactory.java
@@ -1,0 +1,9 @@
+package dev.langchain4j.model.azure.spi;
+
+import dev.langchain4j.model.azure.AzureOpenAiResponsesChatModel;
+import java.util.function.Supplier;
+
+/**
+ * A factory for building {@link AzureOpenAiResponsesChatModel.Builder} instances.
+ */
+public interface AzureOpenAiResponsesChatModelBuilderFactory extends Supplier<AzureOpenAiResponsesChatModel.Builder> {}

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/spi/AzureOpenAiResponsesStreamingChatModelBuilderFactory.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/spi/AzureOpenAiResponsesStreamingChatModelBuilderFactory.java
@@ -1,0 +1,10 @@
+package dev.langchain4j.model.azure.spi;
+
+import dev.langchain4j.model.azure.AzureOpenAiResponsesStreamingChatModel;
+import java.util.function.Supplier;
+
+/**
+ * A factory for building {@link AzureOpenAiResponsesStreamingChatModel.Builder} instances.
+ */
+public interface AzureOpenAiResponsesStreamingChatModelBuilderFactory
+        extends Supplier<AzureOpenAiResponsesStreamingChatModel.Builder> {}

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureModelBuilders.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureModelBuilders.java
@@ -22,6 +22,10 @@ public class AzureModelBuilders {
         return System.getenv("AZURE_OPENAI_ENDPOINT");
     }
 
+    public static String getAzureOpenaiResponsesDeploymentName() {
+        return System.getenv("AZURE_OPENAI_RESPONSES_DEPLOYMENT_NAME");
+    }
+
     public static AzureOpenAiChatModel.Builder chatModelBuilder() {
         return AzureOpenAiChatModel.builder()
                 .endpoint(getAzureOpenaiEndpoint())
@@ -35,6 +39,26 @@ public class AzureModelBuilders {
     public static AzureOpenAiStreamingChatModel.Builder streamingChatModelBuilder() {
 
         return AzureOpenAiStreamingChatModel.builder()
+                .endpoint(getAzureOpenaiEndpoint())
+                .apiKey(getAzureOpenaiKey())
+                .deploymentName(DEFAULT_CHAT_MODEL)
+                .temperature(DEFAULT_TEMPERATURE)
+                .maxTokens(DEFAULT_MAX_TOKENS)
+                .logRequestsAndResponses(true);
+    }
+
+    public static AzureOpenAiResponsesChatModel.Builder responsesChatModelBuilder() {
+        return AzureOpenAiResponsesChatModel.builder()
+                .endpoint(getAzureOpenaiEndpoint())
+                .apiKey(getAzureOpenaiKey())
+                .deploymentName(DEFAULT_CHAT_MODEL)
+                .temperature(DEFAULT_TEMPERATURE)
+                .maxTokens(DEFAULT_MAX_TOKENS)
+                .logRequestsAndResponses(true);
+    }
+
+    public static AzureOpenAiResponsesStreamingChatModel.Builder responsesStreamingChatModelBuilder() {
+        return AzureOpenAiResponsesStreamingChatModel.builder()
                 .endpoint(getAzureOpenaiEndpoint())
                 .apiKey(getAzureOpenaiKey())
                 .deploymentName(DEFAULT_CHAT_MODEL)

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiResponsesChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiResponsesChatModelIT.java
@@ -1,0 +1,45 @@
+package dev.langchain4j.model.azure;
+
+import static dev.langchain4j.model.azure.AzureModelBuilders.getAzureOpenaiEndpoint;
+import static dev.langchain4j.model.azure.AzureModelBuilders.getAzureOpenaiKey;
+import static dev.langchain4j.model.azure.AzureModelBuilders.getAzureOpenaiResponsesDeploymentName;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.azure.ai.openai.responses.models.ResponsesReasoningConfigurationEffort;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_RESPONSES_DEPLOYMENT_NAME", matches = ".+")
+class AzureOpenAiResponsesChatModelIT {
+
+    @Test
+    void should_return_reasoning_summary() {
+        String deploymentName = getAzureOpenaiResponsesDeploymentName();
+
+        ChatModel model = AzureOpenAiResponsesChatModel.builder()
+                .endpoint(getAzureOpenaiEndpoint())
+                .apiKey(getAzureOpenaiKey())
+                .deploymentName(deploymentName)
+                .reasoningEffort(ResponsesReasoningConfigurationEffort.MEDIUM)
+                .reasoningSummary("detailed")
+                .temperature(null)
+                .topP(null)
+                .maxTokens(null)
+                .logRequestsAndResponses(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("Say hello in one sentence.");
+
+        ChatResponse response = model.chat(userMessage);
+
+        assertThat(response.aiMessage().text()).isNotBlank();
+        String summary = response.aiMessage().thinking();
+        Assumptions.assumeTrue(summary != null && !summary.isBlank(), "Reasoning summary not returned");
+        assertThat(summary).isNotBlank();
+    }
+}

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiResponsesResponseParserTest.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiResponsesResponseParserTest.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.model.azure;
+
+import static dev.langchain4j.model.output.FinishReason.STOP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.azure.ai.openai.responses.models.ResponsesResponse;
+import com.azure.core.util.BinaryData;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.Test;
+
+class AzureOpenAiResponsesResponseParserTest {
+
+    @Test
+    void should_extract_reasoning_summary_and_text() {
+        String json = "{"
+                + "\"id\":\"resp_1\","
+                + "\"object\":\"response\","
+                + "\"status\":\"completed\","
+                + "\"model\":\"gpt-4o-mini\","
+                + "\"output\":["
+                + "{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Reasoning summary\"}]},"
+                + "{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello\"}]}"
+                + "],"
+                + "\"usage\":{\"input_tokens\":1,\"output_tokens\":2,\"total_tokens\":3}"
+                + "}";
+
+        ResponsesResponse response = BinaryData.fromString(json).toObject(ResponsesResponse.class);
+        Response<AiMessage> parsed = InternalAzureOpenAiResponsesHelper.toResponse(response, null);
+
+        assertThat(parsed.content().text()).isEqualTo("Hello");
+        assertThat(parsed.content().thinking()).isEqualTo("Reasoning summary");
+        assertThat(parsed.tokenUsage().inputTokenCount()).isEqualTo(1);
+        assertThat(parsed.tokenUsage().outputTokenCount()).isEqualTo(2);
+        assertThat(parsed.tokenUsage().totalTokenCount()).isEqualTo(3);
+        assertThat(parsed.finishReason()).isEqualTo(STOP);
+    }
+
+    @Test
+    void should_handle_missing_reasoning_summary() {
+        String json = "{"
+                + "\"id\":\"resp_2\","
+                + "\"object\":\"response\","
+                + "\"status\":\"completed\","
+                + "\"model\":\"gpt-4o-mini\","
+                + "\"output\":["
+                + "{\"id\":\"msg_2\",\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\","
+                + "\"content\":[{\"type\":\"output_text\",\"text\":\"Hello\"}]}"
+                + "],"
+                + "\"usage\":{"
+                + "\"input_tokens\":1,"
+                + "\"output_tokens\":2,"
+                + "\"total_tokens\":3,"
+                + "\"output_tokens_details\":{\"reasoning_tokens\":42}"
+                + "}"
+                + "}";
+
+        ResponsesResponse response = BinaryData.fromString(json).toObject(ResponsesResponse.class);
+        Response<AiMessage> parsed = InternalAzureOpenAiResponsesHelper.toResponse(response, null);
+
+        assertThat(parsed.content().text()).isEqualTo("Hello");
+        assertThat(parsed.content().thinking()).isNull();
+    }
+}

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiResponsesStreamingChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiResponsesStreamingChatModelIT.java
@@ -1,0 +1,62 @@
+package dev.langchain4j.model.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.azure.ai.openai.responses.models.ResponsesReasoningConfigurationEffort;
+import dev.langchain4j.exception.InternalServerException;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_KEY", matches = ".+")
+class AzureOpenAiResponsesStreamingChatModelIT {
+
+    @Test
+    void should_return_reasoning_summary_when_enabled() {
+        String deploymentName = AzureModelBuilders.getAzureOpenaiResponsesDeploymentName();
+        Assumptions.assumeTrue(
+                deploymentName != null && !deploymentName.isBlank(),
+                "AZURE_OPENAI_RESPONSES_DEPLOYMENT_NAME must be set to run this test");
+
+        StreamingChatModel model = AzureOpenAiResponsesStreamingChatModel.builder()
+                .endpoint(AzureModelBuilders.getAzureOpenaiEndpoint())
+                .apiKey(AzureModelBuilders.getAzureOpenaiKey())
+                .deploymentName(deploymentName)
+                .maxTokens(100)
+                .reasoningEffort(ResponsesReasoningConfigurationEffort.MEDIUM)
+                .reasoningSummary("auto")
+                .logRequestsAndResponses(true)
+                .build();
+
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        try {
+            model.chat("Say hello and briefly explain your approach.", handler);
+            ChatResponse response = handler.get();
+
+            assertThat(response.aiMessage().text()).contains("Hello");
+            Assumptions.assumeTrue(
+                    response.aiMessage().thinking() != null,
+                    "Reasoning summary not returned by model, skipping assertion");
+            assertThat(response.aiMessage().thinking()).isNotBlank();
+        } catch (RuntimeException ex) {
+            if (hasCause(ex, InternalServerException.class)) {
+                Assumptions.assumeTrue(false, "Azure service unavailable, skipping test");
+            }
+            throw ex;
+        }
+    }
+
+    private static boolean hasCause(Throwable throwable, Class<? extends Throwable> type) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (type.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Issue
Closes #3637  
Related: #3252, #3816, #3817

## Change
- Added Azure OpenAI Responses API chat + streaming models to surface reasoning summaries when the service emits reasoning output items.
- Added graceful handling for missing summaries (thinking stays null).
- Added a debug log when reasoning tokens exist but summary text is absent (only if `logRequestsAndResponses=true`).
- Added unit + IT coverage and updated Azure OpenAI docs with Responses API usage and summary caveat.
- Examples PR: https://github.com/langchain4j/langchain4j-examples/pull/185

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [X] I have added/updated the documentation
- [X] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable) 

## Checklist for adding new maven module
- [ ] I have added my new module in the root pom.xml and langchain4j-bom/pom.xml — N/A (no new module)

## Checklist for adding new embedding store integration
- [ ] I have added a {NameOfIntegration}EmbeddingStoreIT ... — N/A (no embedding store changes)
- [ ] I have added a {NameOfIntegration}EmbeddingStoreRemovalIT ... — N/A (no embedding store changes)

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the {NameOfIntegration}EmbeddingStore works correctly ... — N/A (no embedding store changes)