### PR TITLE
Mcp listeners error handling

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -361,6 +361,11 @@ public class DefaultMcpClient implements McpClient {
         } catch (InterruptedException e) {
             Thread.interrupted();
             throw new RuntimeException(e);
+        } catch (McpException e) {
+            if (listener != null) {
+                listener.onResourceGetError(context, e);
+            }
+            throw e;
         } finally {
             pendingOperations.remove(operationId);
         }
@@ -405,6 +410,11 @@ public class DefaultMcpClient implements McpClient {
         } catch (InterruptedException e) {
             Thread.interrupted();
             throw new RuntimeException(e);
+        } catch (McpException e) {
+            if (listener != null) {
+                listener.onPromptGetError(context, e);
+            }
+            throw e;
         } finally {
             pendingOperations.remove(operationId);
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClientListener.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClientListener.java
@@ -3,24 +3,55 @@ package dev.langchain4j.mcp.client;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import java.util.Map;
 
+/**
+ * Listener interface for monitoring MCP client operations.
+ */
 public interface McpClientListener {
 
+    /**
+     * Called before executing a tool.
+     */
     default void beforeExecuteTool(McpCallContext context) {}
 
+    /**
+     * Called after executing a tool if the execution was successful, or if it resulted in an application-level error
+     * (but not a protocol-level or communication error).
+     */
     default void afterExecuteTool(McpCallContext context, ToolExecutionResult result, Map<String, Object> rawResult) {}
 
+    /**
+     * Called when a tool execution fails due to a protocol-level or communication error.
+     */
     default void onExecuteToolError(McpCallContext context, Throwable error) {}
 
+    /**
+     * Called before getting a resource.
+     */
     default void beforeResourceGet(McpCallContext context) {}
 
+    /**
+     * Called after getting a resource.
+     */
     default void afterResourceGet(
             McpCallContext context, McpReadResourceResult result, Map<String, Object> rawResult) {}
 
+    /**
+     * Called when getting a resource fails.
+     */
     default void onResourceGetError(McpCallContext context, Throwable error) {}
 
+    /**
+     * Called before getting a prompt.
+     */
     default void beforePromptGet(McpCallContext context) {}
 
+    /**
+     * Called after getting a prompt.
+     */
     default void afterPromptGet(McpCallContext context, McpGetPromptResult result, Map<String, Object> rawResult) {}
 
+    /**
+     * Called when getting a prompt fails.
+     */
     default void onPromptGetError(McpCallContext context, Throwable error) {}
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolExecutionHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolExecutionHelper.java
@@ -21,25 +21,29 @@ class ToolExecutionHelper {
      * If the response contains both 'content' and 'structuredContent' elements, the
      * structured content is given precedence.
      */
-    static ToolExecutionResult extractResult(JsonNode result) {
+    static ToolExecutionResult extractResult(JsonNode result, boolean ignoreApplicationLevelErrors) {
         if (result.has("result")) {
             JsonNode resultNode = result.get("result");
             if (resultNode.has("structuredContent")
                     && !resultNode.get("structuredContent").isNull()) {
                 JsonNode content = resultNode.get("structuredContent");
-                if (isError(resultNode)) {
+                if (isError(resultNode) && !ignoreApplicationLevelErrors) {
                     throw new ToolExecutionException(content.toString());
                 }
                 return ToolExecutionResult.builder()
                         .result(toObject(content))
                         .resultText(content.toString())
+                        .isError(isError(resultNode))
                         .build();
             } else if (resultNode.has("content")) {
                 String content = extractSuccessfulResult((ArrayNode) resultNode.get("content"));
-                if (isError(resultNode)) {
+                if (isError(resultNode) && !ignoreApplicationLevelErrors) {
                     throw new ToolExecutionException(content);
                 }
-                return ToolExecutionResult.builder().resultText(content).build();
+                return ToolExecutionResult.builder()
+                        .isError(isError(resultNode))
+                        .resultText(content)
+                        .build();
             } else {
                 throw new RuntimeException("Result does not contain 'content' element: " + result);
             }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/StructuredContentParsingTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/StructuredContentParsingTest.java
@@ -36,7 +36,7 @@ public class StructuredContentParsingTest {
                 }
                 """;
         JsonNode responseNode = objectMapper.readTree(response);
-        ToolExecutionResult toolExecutionResult = ToolExecutionHelper.extractResult(responseNode);
+        ToolExecutionResult toolExecutionResult = ToolExecutionHelper.extractResult(responseNode, false);
         assertThat(toolExecutionResult.result()).isInstanceOf(Map.class);
         Map<String, Object> map = (Map<String, Object>) toolExecutionResult.result();
         assertThat(map).hasSize(4);

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpClientListenerIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpClientListenerIT.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class McpClientListenerTest {
+public class McpClientListenerIT {
 
     static McpClient mcpClient;
     static TestListener testListener;
@@ -76,8 +76,28 @@ public class McpClientListenerTest {
     @Test
     public void toolCallWithApplicationLevelError() {
         try {
+            ToolExecutionResult result = mcpClient.executeTool(ToolExecutionRequest.builder()
+                    .name("withApplicationLevelError")
+                    .build());
+            Assertions.fail("Should have thrown an exception");
+        } catch (Exception e) {
+            assertThat(testListener.toolContext).isNotNull();
+            assertThat(testListener.toolContext.message().method).isEqualTo(McpClientMethod.TOOLS_CALL);
+            assertThat(testListener.toolContext.message().getId()).isNotNull();
+            assertThat(testListener.toolResultContext).isNotNull();
+            assertThat(testListener.toolResultContext).isSameAs(testListener.toolContext);
+            assertThat(testListener.toolResult).isNotNull();
+            assertThat(testListener.toolResult.isError()).isTrue();
+            assertThat(testListener.toolResult.resultText()).isEqualTo("Application-level error");
+            assertThat(testListener.toolError).isNull();
+        }
+    }
+
+    @Test
+    public void toolCallWithProtocolError() {
+        try {
             ToolExecutionResult result = mcpClient.executeTool(
-                    ToolExecutionRequest.builder().name("withError").build());
+                    ToolExecutionRequest.builder().name("withProtocolError").build());
             Assertions.fail("Should have thrown an exception");
         } catch (Exception e) {
             assertThat(testListener.toolContext).isNotNull();

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpClientListenerIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpClientListenerIT.java
@@ -145,6 +145,23 @@ public class McpClientListenerIT {
     }
 
     @Test
+    public void resourceGetError() {
+        try {
+            mcpClient.readResource("file:///test-resource-failing");
+            Assertions.fail("Should have thrown an exception");
+        } catch (Exception e) {
+            // check that the beforeResourceGet callback was invoked
+            assertThat(testListener.resourceContext).isNotNull();
+            assertThat(testListener.resourceContext.message().method).isEqualTo(McpClientMethod.RESOURCES_READ);
+            assertThat(testListener.resourceContext.message().getId()).isNotNull();
+
+            // check that the onResourceGetError callback was invoked
+            assertThat(testListener.resourceResult).isNull();
+            assertThat(testListener.resourceError).isNotNull();
+        }
+    }
+
+    @Test
     public void promptGet() {
         McpGetPromptResult result = mcpClient.getPrompt("testPrompt", Map.of());
         assertThat(result).isNotNull();
@@ -157,6 +174,23 @@ public class McpClientListenerIT {
         // check that the afterPromptGet callback was invoked
         assertThat(testListener.promptResult).isNotNull();
         assertThat(testListener.promptResultContext).isSameAs(testListener.prompt);
+    }
+
+    @Test
+    public void promptGetError() {
+        try {
+            mcpClient.getPrompt("testPromptFailing", Map.of());
+            Assertions.fail("Should have thrown an exception");
+        } catch (Exception e) {
+            // check that the beforePromptGet callback was invoked
+            assertThat(testListener.prompt).isNotNull();
+            assertThat(testListener.prompt.message().method).isEqualTo(McpClientMethod.PROMPTS_GET);
+            assertThat(testListener.prompt.message().getId()).isNotNull();
+
+            // check that the onPromptGetError callback was invoked
+            assertThat(testListener.promptResult).isNull();
+            assertThat(testListener.promptError).isNotNull();
+        }
     }
 
     static class TestListener implements McpClientListener {

--- a/langchain4j-mcp/src/test/resources/listener_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/listener_mcp_server.java
@@ -48,9 +48,19 @@ public class listener_mcp_server {
         return TextResourceContents.create("file:///test-resource", "Test resource content");
     }
 
-    @Prompt(description = "Test prompt for listener")
+    @Resource(uri = "file:///test-resource-failing", mimeType = "text/plain")
+    TextResourceContents testResourceFailing() {
+        throw new RuntimeException("Can't read this resource!");
+    }
+
+    @Prompt
     public PromptMessage testPrompt() {
         return PromptMessage.withUserRole(new TextContent("Test prompt message"));
+    }
+
+    @Prompt
+    public PromptMessage testPromptFailing() {
+        throw new RuntimeException("Can't read this prompt!");
     }
 
 }

--- a/langchain4j-mcp/src/test/resources/listener_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/listener_mcp_server.java
@@ -28,8 +28,13 @@ public class listener_mcp_server {
     }
 
     @Tool
-    public ToolResponse withError() {
-        return ToolResponse.error("Something went wrong");
+    public ToolResponse withApplicationLevelError() {
+        return ToolResponse.error("Application-level error");
+    }
+
+    @Tool
+    public ToolResponse withProtocolError() {
+        throw new RuntimeException("Protocol error");
     }
 
     @Tool


### PR DESCRIPTION
More proper error handling for MCP listeners

- Call `onPromptGetError` when prompt retrieval fails
- Call `onResourceGetError` when resource retrieval fails
- Call `afterExecuteTool` instead of `onExecuteToolError` when a tool fails with an application-level error
- Rename `McpClientListenerTest` to `McpClientListenerIT` for consistency
- Javadoc for `McpClientListener`