### PR TITLE
docs(mcp): add Java stdio server guide (community MCP server)

### DIFF
--- a/docs/docs/tutorials/mcp-stdio-server.md
+++ b/docs/docs/tutorials/mcp-stdio-server.md
@@ -20,14 +20,14 @@ Add BOMs (recommended):
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-bom</artifactId>
-            <version>${langchain4j.version}</version>
+            <version>YOUR_LANGCHAIN4J_VERSION</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-community-bom</artifactId>
-            <version>${langchain4j.community.version}</version>
+            <version>YOUR_LANGCHAIN4J_COMMUNITY_VERSION</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -119,11 +119,3 @@ Use absolute paths; on Windows, escape backslashes.
 See the `mcp-stdio-server-example` in the examples repository for an end-to-end runnable project (including packaging and client config):
 
 - https://github.com/langchain4j/langchain4j-examples/tree/main/mcp-stdio-server-example
-
-<details>
-<summary>Using SNAPSHOT builds (development only)</summary>
-
-If you need to test unreleased changes, see the SNAPSHOT instructions in the [Get Started](/get-started) guide.
-
-</details>
-

--- a/docs/docs/tutorials/mcp-stdio-server.md
+++ b/docs/docs/tutorials/mcp-stdio-server.md
@@ -20,14 +20,14 @@ Add BOMs (recommended):
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-bom</artifactId>
-            <version>YOUR_LANGCHAIN4J_VERSION</version>
+            <version>${latest version here}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-community-bom</artifactId>
-            <version>YOUR_LANGCHAIN4J_COMMUNITY_VERSION</version>
+            <version>${latest version here}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/docs/docs/tutorials/mcp-stdio-server.md
+++ b/docs/docs/tutorials/mcp-stdio-server.md
@@ -118,4 +118,4 @@ Use absolute paths; on Windows, escape backslashes.
 
 See the `mcp-stdio-server-example` in the examples repository for an end-to-end runnable project (including packaging and client config):
 
-- https://github.com/langchain4j/langchain4j-examples/tree/main/mcp-stdio-server-example
+- https://github.com/langchain4j/langchain4j-examples (directory: `mcp-stdio-server-example`)

--- a/docs/docs/tutorials/mcp-stdio-server.md
+++ b/docs/docs/tutorials/mcp-stdio-server.md
@@ -1,0 +1,129 @@
+---
+sidebar_position: 17
+---
+
+# Building a Java MCP stdio server
+
+LangChain4j provides an MCP **client** (`langchain4j-mcp`) for connecting to MCP servers.
+If you want to build a Java-based MCP **stdio server** (a local subprocess launched by an MCP client),
+use the community module: `langchain4j-community-mcp-server`.
+
+This guide shows the minimal setup for exposing existing `@Tool`-annotated methods over MCP (JSON-RPC) via stdio.
+
+## Add dependency
+
+Add BOMs (recommended):
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-bom</artifactId>
+            <version>${langchain4j.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-community-bom</artifactId>
+            <version>${langchain4j.community.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+Then add the community MCP server dependency:
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-community-mcp-server</artifactId>
+</dependency>
+```
+
+## Implement tools
+
+Expose your functionality using `@Tool`:
+
+```java
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+
+class Calculator {
+
+    @Tool
+    long add(@P("a") long a, @P("b") long b) {
+        return a + b;
+    }
+}
+```
+
+## Start the stdio server
+
+```java
+import dev.langchain4j.community.mcp.server.McpServer;
+import dev.langchain4j.community.mcp.server.transport.StdioMcpServerTransport;
+import dev.langchain4j.mcp.protocol.McpImplementation;
+import java.util.List;
+
+public class McpServerMain {
+
+    public static void main(String[] args) throws Exception {
+        McpImplementation serverInfo = new McpImplementation();
+        serverInfo.setName("my-java-mcp-server");
+        serverInfo.setVersion("1.0.0");
+
+        McpServer server = new McpServer(List.of(new Calculator()), serverInfo);
+        new StdioMcpServerTransport(System.in, System.out, server);
+
+        // Keep the process alive while stdio is open
+        Thread.currentThread().join();
+    }
+}
+```
+
+:::caution
+`StdioMcpServerTransport` writes the JSON-RPC protocol to `System.out`.
+Make sure your logging is configured to write to `System.err` (otherwise you will corrupt the protocol stream and the client will disconnect).
+:::
+
+## Package as a runnable JAR
+
+MCP clients (like Claude Desktop) typically expect to start a local server process.
+Packaging your server as a runnable (fat) JAR is a common approach, but any runnable process works.
+
+## Configure an MCP client
+
+### Claude Desktop
+
+Add a server entry in `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "my-java-tool": {
+      "command": "java",
+      "args": ["-jar", "/absolute/path/to/my-java-mcp-server.jar"]
+    }
+  }
+}
+```
+
+Use absolute paths; on Windows, escape backslashes.
+
+## Complete runnable example
+
+See the `mcp-stdio-server-example` in the examples repository for an end-to-end runnable project (including packaging and client config):
+
+- https://github.com/langchain4j/langchain4j-examples/tree/main/mcp-stdio-server-example
+
+<details>
+<summary>Using SNAPSHOT builds (development only)</summary>
+
+If you need to test unreleased changes, see the SNAPSHOT instructions in the [Get Started](/get-started) guide.
+
+</details>
+

--- a/docs/docs/tutorials/mcp.md
+++ b/docs/docs/tutorials/mcp.md
@@ -5,6 +5,11 @@ MCP compliant servers that can provide and execute tools. General
 information about the protocol can be found at the [MCP
 website](https://modelcontextprotocol.io/).
 
+:::note
+Looking to build an MCP **stdio server** in Java?
+The server implementation lives in LangChain4j Community. See [Building a Java MCP stdio server](./mcp-stdio-server).
+:::
+
 The protocol specifies two types of transport, both of these are supported:
 
 - [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http):


### PR DESCRIPTION
## Issue
Closes #4517

## Change
- Add a focused tutorial page: `tutorials/mcp-stdio-server` (how to build a Java MCP stdio server using `langchain4j-community-mcp-server`).
- Add a short note + link from the existing MCP tutorial (`tutorials/mcp`).

## How to verify (end-to-end)
- Build the example server from langchain4j/langchain4j-examples#181.
- Configure it in Claude Desktop using the JSON snippet from `docs/docs/tutorials/mcp-stdio-server.md`.
- Ask Claude: "Please calculate 1234 + 5678 using the calculator tool."

## Notes
- Docs-only change (no code changes / no tests).
- Context: #4371 and langchain4j/langchain4j-community#527