### PR TITLE
Some more MCP client fixes

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
@@ -45,7 +45,9 @@ public class StdioMcpTransport implements McpTransport {
         this.logger = builder.logger;
         this.executorService =
                 getOrDefault(builder.executorService, DefaultExecutorProvider::getDefaultExecutorService);
-        this.shouldShutdownExecutorService = builder.executorService == null;
+        // FIXME: are there actually any cases where we should shut down the executor service?
+        // the DefaultExecutorProvider always returns a single shared instance, so we can't shut it down
+        this.shouldShutdownExecutorService = false;
     }
 
     @Override


### PR DESCRIPTION
- Don't shut down the executor from DefaultExecutorProvider: The problem is that the `DefaultExecutorProvider` returns a single shared instance so if we close it, it breaks any other stuff in the app that might want to use it
- In the WebSocket MCP transport, we erroneously treat some operations as "wait for response"  when they don't expect any response. This causes a resource leak, and it potentially breaks client-initiated operations that happen to have the same ID as something that was a server-initiated operation but a response to it was registered here.