### PR TITLE
Fix/mcp executor proper lifecycle

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
@@ -45,9 +45,9 @@ public class StdioMcpTransport implements McpTransport {
         this.logger = builder.logger;
         this.executorService =
                 getOrDefault(builder.executorService, DefaultExecutorProvider::getDefaultExecutorService);
-        // FIXME: are there actually any cases where we should shut down the executor service?
-        // the DefaultExecutorProvider always returns a single shared instance, so we can't shut it down
-        this.shouldShutdownExecutorService = false;
+        // Only shutdown executor if user explicitly provided one, never shutdown the shared default executor
+        this.shouldShutdownExecutorService = builder.executorService != null
+                && builder.executorService != DefaultExecutorProvider.getDefaultExecutorService();
     }
 
     @Override

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpMultipleTransportInstancesIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpMultipleTransportInstancesIT.java
@@ -1,0 +1,73 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getJBangCommand;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getPathToScript;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.skipTestsIfJbangNotAvailable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.McpResource;
+import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test that validates multiple StdioMcpTransport instances can coexist
+ * without ExecutorService conflicts. This test specifically addresses the issue
+ * that was causing CI failures in PR #4486 and led to revert #4522.
+ *
+ * The root cause was that multiple transport instances sharing the same
+ * DefaultExecutorProvider.getDefaultExecutorService() singleton would fail
+ * when the first instance shutdown the shared executor during close().
+ */
+class McpMultipleTransportInstancesIT {
+
+    @BeforeAll
+    static void setup() {
+        skipTestsIfJbangNotAvailable();
+    }
+
+    @Test
+    void shouldHandleMultipleTransportInstancesWithoutExecutorConflicts() throws Exception {
+        // Create first transport instance
+        StdioMcpTransport transport1 = new StdioMcpTransport.Builder()
+                .command(List.of(
+                        getJBangCommand(), "--quiet", "--fresh", "run", getPathToScript("resources_mcp_server.java")))
+                .build();
+
+        McpClient client1 = new DefaultMcpClient.Builder()
+                .transport(transport1)
+                .toolExecutionTimeout(Duration.ofSeconds(4))
+                .build();
+
+        // Initialize and use first client
+        List<McpResource> result1 = client1.listResources();
+        assertNotNull(result1);
+        assertEquals(2, result1.size());
+
+        // Create second transport instance (this would fail with RejectedExecutionException
+        // if the shared executor was improperly shutdown by the first instance)
+        StdioMcpTransport transport2 = new StdioMcpTransport.Builder()
+                .command(List.of(
+                        getJBangCommand(), "--quiet", "--fresh", "run", getPathToScript("resources_mcp_server.java")))
+                .build();
+
+        McpClient client2 = new DefaultMcpClient.Builder()
+                .transport(transport2)
+                .toolExecutionTimeout(Duration.ofSeconds(4))
+                .build();
+
+        // Initialize and use second client - this validates the executor is still functional
+        List<McpResource> result2 = client2.listResources();
+        assertNotNull(result2);
+        assertEquals(2, result2.size());
+
+        // Close both clients - should not cause executor conflicts
+        client1.close();
+        client2.close();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #4485

## Change
Fix ExecutorService lifecycle management in `StdioMcpTransport` to resolve integration test failures that caused revert in PR #4522.

### Problem
The FIXME comment left after revert #4522 used a blanket `shouldShutdownExecutorService = false` approach, which addressed CI failures but wasn't the proper solution. The root cause was multiple transport instances sharing the same `DefaultExecutorProvider.getDefaultExecutorService()` singleton, and the first instance shutting it down caused subsequent instances to fail with `RejectedExecutionException`.

### Solution
Replace the blanket approach with smart logic:
```java
// Only shutdown executor if user explicitly provided one, never shutdown the shared default executor
this.shouldShutdownExecutorService = builder.executorService != null && 
        builder.executorService != DefaultExecutorProvider.getDefaultExecutorService();