### PR TITLE
Revert "[BUG] FileSystemDocumentLoaderExtensions.loadDocuments() does not skip failed documents"

### DIFF
--- a/langchain4j-kotlin/src/main/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensions.kt
+++ b/langchain4j-kotlin/src/main/kotlin/dev/langchain4j/kotlin/data/document/loader/FileSystemDocumentLoaderExtensions.kt
@@ -1,6 +1,5 @@
 package dev.langchain4j.kotlin.data.document.loader
 
-import dev.langchain4j.data.document.BlankDocumentException
 import dev.langchain4j.data.document.Document
 import dev.langchain4j.data.document.DocumentParser
 import dev.langchain4j.data.document.loader.FileSystemDocumentLoader
@@ -68,22 +67,12 @@ public suspend fun loadDocuments(
         matchedFiles
             .map { file ->
                 async(context) {
-                    try {
-                        documentParser.parseAsync(
-                            FileSystemSource(file),
-                            context
-                        )
-                    } catch (e: BlankDocumentException) {
-                        // blank/empty documents are ignored
-                        null
-                    } catch (e: Exception) {
-                        val message = e.cause?.message ?: e.message
-                        logger.warn("Failed to load '{}': {}", file, message)
-                        null
-                    }
+                    documentParser.parseAsync(
+                        FileSystemSource(file),
+                        context
+                    )
                 }
             }.awaitAll()
-            .filterNotNull()  // Remove failed documents (null)
             .map { document ->
                 val metadata = document.metadata()
                 logger.info(


### PR DESCRIPTION
Reverts langchain4j/langchain4j#4348