### PR TITLE
修复流式响应时，tool call id重复的问题

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -64,6 +64,7 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
     private final boolean returnThinking;
     private final boolean sendThinking;
     private final String thinkingFieldName;
+    private final boolean accumulateToolCallId;
     private final List<ChatModelListener> listeners;
 
     public OpenAiStreamingChatModel(OpenAiStreamingChatModelBuilder builder) {
@@ -127,6 +128,7 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
         this.returnThinking = getOrDefault(builder.returnThinking, false);
         this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.thinkingFieldName = getOrDefault(builder.thinkingFieldName, "reasoning_content");
+        this.accumulateToolCallId = getOrDefault(builder.accumulateToolCallId, true);
         this.listeners = copy(builder.listeners);
     }
 
@@ -143,13 +145,13 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
 
         ChatCompletionRequest openAiRequest =
                 toOpenAiChatRequest(
-                                chatRequest, parameters, sendThinking, thinkingFieldName, strictTools, strictJsonSchema)
+                        chatRequest, parameters, sendThinking, thinkingFieldName, strictTools, strictJsonSchema)
                         .stream(true)
                         .streamOptions(
                                 StreamOptions.builder().includeUsage(true).build())
                         .build();
 
-        OpenAiStreamingResponseBuilder openAiResponseBuilder = new OpenAiStreamingResponseBuilder(returnThinking);
+        OpenAiStreamingResponseBuilder openAiResponseBuilder = new OpenAiStreamingResponseBuilder(returnThinking, accumulateToolCallId);
         ToolCallBuilder toolCallBuilder = new ToolCallBuilder();
 
         client.chatCompletion(openAiRequest)
@@ -284,6 +286,7 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
         private Boolean returnThinking;
         private Boolean sendThinking;
         private String thinkingFieldName;
+        private Boolean accumulateToolCallId;
         private Duration timeout;
         private Boolean logRequests;
         private Boolean logResponses;
@@ -497,6 +500,26 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
         public OpenAiStreamingChatModelBuilder sendThinking(Boolean sendThinking) {
             this.sendThinking = sendThinking;
             this.thinkingFieldName = "reasoning_content";
+            return this;
+        }
+
+        /**
+         * Controls whether to accumulate tool call IDs in streaming responses.
+         * <p>
+         * This setting is useful when using OpenAI-compatible APIs (like DeepSeek or Qwen) that send
+         * the complete tool call ID in every streaming chunk, rather than sending it incrementally.
+         * <p>
+         * Enabled by default (true) for standard OpenAI behavior.
+         * Set to false for APIs like DeepSeek/Qwen that repeat the full ID in each chunk.
+         * <p>
+         * When enabled (true): IDs are accumulated across chunks (e.g., "abc" + "def" = "abcdef")
+         * When disabled (false): Each chunk's ID replaces the previous one (e.g., "abc" -> "abc")
+         *
+         * @param accumulateToolCallId whether to accumulate tool call IDs
+         * @return {@code this}
+         */
+        public OpenAiStreamingChatModelBuilder accumulateToolCallId(Boolean accumulateToolCallId) {
+            this.accumulateToolCallId = accumulateToolCallId;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
@@ -59,13 +59,19 @@ public class OpenAiStreamingResponseBuilder {
     private final Queue<ServerSentEvent> rawServerSentEvents = new ConcurrentLinkedQueue<>();
 
     private final boolean returnThinking;
+    private final boolean accumulateToolCallId;
 
     public OpenAiStreamingResponseBuilder() {
-        this(false);
+        this(false, true);
     }
 
     public OpenAiStreamingResponseBuilder(boolean returnThinking) {
+        this(returnThinking, true);
+    }
+
+    public OpenAiStreamingResponseBuilder(boolean returnThinking, boolean accumulateToolCallId) {
         this.returnThinking = returnThinking;
+        this.accumulateToolCallId = accumulateToolCallId;
         if (returnThinking) {
             this.reasoningContentBuilder = new StringBuffer();
         } else {
@@ -161,7 +167,12 @@ public class OpenAiStreamingResponseBuilder {
                     toolCall.index(), idx -> new ToolExecutionRequestBuilder());
 
             if (toolCall.id() != null) {
-                builder.idBuilder.append(toolCall.id());
+                if (accumulateToolCallId) {
+                    builder.idBuilder.append(toolCall.id());
+                } else {
+                    builder.idBuilder.setLength(0);
+                    builder.idBuilder.append(toolCall.id());
+                }
             }
 
             FunctionCall functionCall = toolCall.function();


### PR DESCRIPTION
Closes https://github.com/langchain4j/langchain4j/issues/4528

修改的文件

  1. langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
    - 在类中添加了 accumulateToolCallId 字段 (第 67 行)
    - 在构造函数中初始化该字段,默认值为 true (第 131 行)
    - 将该标志传递给 OpenAiStreamingResponseBuilder (第 154 行)
    - 在 OpenAiStreamingChatModelBuilder 中添加了 accumulateToolCallId 字段 
    - 添加了 accumulateToolCallId() 设置方法,
    - 
  2. langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
    - 添加了 accumulateToolCallId 字段  
    - 添加了新的构造函数以支持该参数 
    - 修改了 tool call ID 的处理逻辑 
        - 当 accumulateToolCallId=true 时: 累积 ID 片段  
      - 当 accumulateToolCallId=false 时: 每次用新的 ID 替换旧的 