### PR TITLE
Bump com.azure:azure-sdk-bom from 1.3.3 to 1.3.4

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-azure-acads/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-azure-acads/pom.xml
@@ -17,6 +17,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.130.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
                 <version>5.17.0</version>

--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
@@ -15,6 +15,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.130.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
                 <version>5.17.0</version>

--- a/langchain4j-azure-cosmos-nosql/pom.xml
+++ b/langchain4j-azure-cosmos-nosql/pom.xml
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.127.Final</version>
+                <version>4.1.130.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-core</artifactId>
-                <version>3.7.11</version>
+                <version>3.7.14</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>

--- a/langchain4j-azure-open-ai/pom.xml
+++ b/langchain4j-azure-open-ai/pom.xml
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.128.Final</version>
+                <version>4.1.130.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -59,11 +59,10 @@
             </exclusions>
         </dependency>
 
-        <!-- fixes CVE-2025-55163 -->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>4.1.128.Final</version>
+            <version>4.1.130.Final</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-github-models/pom.xml
+++ b/langchain4j-github-models/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.127.Final</version>
+                <version>4.1.130.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -53,7 +53,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-core</artifactId>
-                <version>3.7.11</version>
+                <version>3.7.14</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -53,7 +53,7 @@
         <assertk.version>0.28.1</assertk.version>
         <awaitility.version>4.2.2</awaitility.version>
         <aws.java.sdk.version>2.33.5</aws.java.sdk.version>
-        <azure-sdk.version>1.3.3</azure-sdk.version>
+        <azure-sdk.version>1.3.4</azure-sdk.version>
         <jackson.version>2.20.1</jackson.version>
         <jspecify.version>1.0.0</jspecify.version>
         <jtokkit.version>1.1.0</jtokkit.version>


### PR DESCRIPTION
This dependency update is also updating several transitive dependencies, and fixing a some security issues.