### PR TITLE
feat(open-ai-official): add reasoning summaries to Responses streaming

### DIFF
--- a/docs/docs/integrations/language-models/open-ai-official.md
+++ b/docs/docs/integrations/language-models/open-ai-official.md
@@ -272,3 +272,8 @@ StreamingChatModel model = OpenAiOfficialResponsesStreamingChatModel.builder()
 - **Cancellation**: Supports `StreamingHandle.cancel()` to stop responses
 - **Same features**: Full support for tools, listeners, and all standard parameters
 
+### Reasoning summaries
+If the selected model supports reasoning summaries, you can request them using the
+`reasoningSummary` parameter. When provided, the summary is surfaced in the final
+`AiMessage.thinking` field. Summaries are optional and model-dependent, so `thinking`
+may be `null` when the model does not return a summary.

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
@@ -880,7 +880,8 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             }
         }
 
-        private void handleReasoningSummaryTextDelta(com.openai.models.responses.ResponseReasoningSummaryTextDeltaEvent event) {
+        private void handleReasoningSummaryTextDelta(
+                com.openai.models.responses.ResponseReasoningSummaryTextDeltaEvent event) {
             String delta = event.delta();
             if (delta != null && !delta.isEmpty()) {
                 reasoningSummaryBuilder.append(delta);

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
@@ -971,9 +971,7 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             });
 
             // Build final AI message (include reasoning summary if present)
-            String text = !textBuilder.isEmpty()
-                    ? textBuilder.toString()
-                    : (completedToolCalls.isEmpty() ? "" : null);
+            String text = !textBuilder.isEmpty() ? textBuilder.toString() : (completedToolCalls.isEmpty() ? "" : null);
             String reasoning = extractReasoningSummary(response);
 
             AiMessage.Builder aiMessageBuilder = AiMessage.builder()

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/InternalOpenAiOfficialTestHelper.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/InternalOpenAiOfficialTestHelper.java
@@ -8,6 +8,7 @@ import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatModel;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialEmbeddingModel;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialStreamingChatModel;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,7 @@ public class InternalOpenAiOfficialTestHelper {
     static final OpenAiOfficialChatModel OPEN_AI_CHAT_MODEL_JSON_WITHOUT_STRICT_SCHEMA;
     static final OpenAiOfficialChatModel OPEN_AI_CHAT_MODEL_JSON_WITH_STRICT_SCHEMA;
     static final OpenAiOfficialStreamingChatModel OPEN_AI_STREAMING_CHAT_MODEL;
+    static final OpenAiOfficialResponsesStreamingChatModel OPEN_AI_RESPONSES_STREAMING_CHAT_MODEL;
 
     // Embedding models
     static final OpenAiOfficialEmbeddingModel OPEN_AI_EMBEDDING_MODEL;
@@ -81,6 +83,11 @@ public class InternalOpenAiOfficialTestHelper {
                     .modelName(CHAT_MODEL_NAME)
                     .build();
 
+            OPEN_AI_RESPONSES_STREAMING_CHAT_MODEL = OpenAiOfficialResponsesStreamingChatModel.builder()
+                    .apiKey(System.getenv("OPENAI_API_KEY"))
+                    .modelName(CHAT_MODEL_NAME)
+                    .build();
+
             OPEN_AI_EMBEDDING_MODEL = OpenAiOfficialEmbeddingModel.builder()
                     .apiKey(System.getenv("OPENAI_API_KEY"))
                     .modelName(EMBEDDING_MODEL_NAME)
@@ -97,6 +104,7 @@ public class InternalOpenAiOfficialTestHelper {
             OPEN_AI_CHAT_MODEL_JSON_WITHOUT_STRICT_SCHEMA = null;
             OPEN_AI_CHAT_MODEL_JSON_WITH_STRICT_SCHEMA = null;
             OPEN_AI_STREAMING_CHAT_MODEL = null;
+            OPEN_AI_RESPONSES_STREAMING_CHAT_MODEL = null;
             OPEN_AI_EMBEDDING_MODEL = null;
             OPEN_AI_IMAGE_MODEL = null;
         }
@@ -156,6 +164,21 @@ public class InternalOpenAiOfficialTestHelper {
             log.error("Testing streaming models: skipping tests as OpenAI API keys are not set");
         }
         return models;
+    }
+
+    static List<StreamingChatModel> chatModelsResponsesStreaming() {
+        List<StreamingChatModel> models = new ArrayList<>();
+        if (OPEN_AI_RESPONSES_STREAMING_CHAT_MODEL != null) {
+            models.add(OPEN_AI_RESPONSES_STREAMING_CHAT_MODEL);
+        }
+        if (models.isEmpty()) {
+            log.error("Testing responses streaming models: skipping tests as OpenAI API keys are not set");
+        }
+        return models;
+    }
+
+    static OpenAiOfficialResponsesStreamingChatModel.Builder responsesStreamingChatModelBuilder() {
+        return OpenAiOfficialResponsesStreamingChatModel.builder().apiKey(System.getenv("OPENAI_API_KEY"));
     }
 
     static List<dev.langchain4j.model.embedding.EmbeddingModel> embeddingModels() {

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialResponsesStreamingAiServiceIT.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialResponsesStreamingAiServiceIT.java
@@ -1,10 +1,8 @@
 package dev.langchain4j.model.openaiofficial.openai;
 
-import com.openai.client.okhttp.OpenAIOkHttpClient;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatResponseMetadata;
-import dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialTokenUsage;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.service.common.AbstractStreamingAiServiceIT;
@@ -16,13 +14,8 @@ class OpenAiOfficialResponsesStreamingAiServiceIT extends AbstractStreamingAiSer
 
     @Override
     protected List<StreamingChatModel> models() {
-        var client = OpenAIOkHttpClient.builder()
-                .apiKey(System.getenv("OPENAI_API_KEY"))
-                .build();
-
-        StreamingChatModel model = OpenAiOfficialResponsesStreamingChatModel.builder()
-                .client(client)
-                .modelName(InternalOpenAiOfficialTestHelper.CHAT_MODEL_NAME.toString())
+        StreamingChatModel model = InternalOpenAiOfficialTestHelper.responsesStreamingChatModelBuilder()
+                .modelName(InternalOpenAiOfficialTestHelper.CHAT_MODEL_NAME)
                 .build();
 
         return List.of(model);

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialResponsesStreamingChatModelIT.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialResponsesStreamingChatModelIT.java
@@ -393,6 +393,28 @@ class OpenAiOfficialResponsesStreamingChatModelIT extends AbstractStreamingChatM
     }
 
     @Test
+    void should_not_return_reasoning_summary_when_not_requested() {
+
+        // given
+        var client = OpenAIOkHttpClient.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .build();
+
+        StreamingChatModel model = OpenAiOfficialResponsesStreamingChatModel.builder()
+                .client(client)
+                .modelName(InternalOpenAiOfficialTestHelper.CHAT_MODEL_NAME.toString())
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        model.chat("What is 2+2?", handler);
+
+        // then
+        assertThat(handler.get().aiMessage().text()).isNotBlank();
+        assertThat(handler.get().aiMessage().thinking()).isNull();
+    }
+
+    @Test
     void should_support_max_tool_calls() {
 
         // given

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialResponsesStreamingChatModelIT.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialResponsesStreamingChatModelIT.java
@@ -24,8 +24,8 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatRequestParameters;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatResponseMetadata;
@@ -131,16 +131,13 @@ class OpenAiOfficialResponsesStreamingChatModelIT extends AbstractStreamingChatM
 
         ToolSpecification weatherTool = ToolSpecification.builder()
                 .name("getWeather")
-                .parameters(JsonObjectSchema.builder()
-                        .addStringProperty("city")
-                        .build())
+                .parameters(JsonObjectSchema.builder().addStringProperty("city").build())
                 .build();
 
         ToolSpecification timeTool = ToolSpecification.builder()
                 .name("getTime")
-                .parameters(JsonObjectSchema.builder()
-                        .addStringProperty("country")
-                        .build())
+                .parameters(
+                        JsonObjectSchema.builder().addStringProperty("country").build())
                 .build();
 
         ChatRequest chatRequest = ChatRequest.builder()
@@ -173,9 +170,7 @@ class OpenAiOfficialResponsesStreamingChatModelIT extends AbstractStreamingChatM
 
         if (assertToolId(model)) {
             assertThat(weatherToolExecutionRequest.id()).isNotBlank();
-            assertThat(timeToolExecutionRequest.id())
-                    .isNotBlank()
-                    .isNotEqualTo(weatherToolExecutionRequest.id());
+            assertThat(timeToolExecutionRequest.id()).isNotBlank().isNotEqualTo(weatherToolExecutionRequest.id());
         }
 
         if (assertTokenUsage()) {
@@ -215,7 +210,10 @@ class OpenAiOfficialResponsesStreamingChatModelIT extends AbstractStreamingChatM
                 .isEqualToIgnoringWhitespace("{\"country\":\"France\"}");
 
         if (assertToolId(model)) {
-            assertThat(completeWeatherToolCall.orElseThrow().toolExecutionRequest().id())
+            assertThat(completeWeatherToolCall
+                            .orElseThrow()
+                            .toolExecutionRequest()
+                            .id())
                     .isEqualTo(weatherToolExecutionRequest.id());
             assertThat(completeTimeToolCall.orElseThrow().toolExecutionRequest().id())
                     .isEqualTo(timeToolExecutionRequest.id());

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialResponsesStreamingChatModelIT.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialResponsesStreamingChatModelIT.java
@@ -368,6 +368,31 @@ class OpenAiOfficialResponsesStreamingChatModelIT extends AbstractStreamingChatM
     }
 
     @Test
+    void should_support_reasoning_summary() {
+
+        // given
+        var client = OpenAIOkHttpClient.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .build();
+
+        StreamingChatModel model = OpenAiOfficialResponsesStreamingChatModel.builder()
+                .client(client)
+                .modelName("o4-mini")
+                .reasoningEffort("medium")
+                .reasoningSummary("auto")
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        model.chat(
+                "Do 2 plus 12, then 14 divided by 2, then multiply those results by 3. Think step by step.", handler);
+
+        // then
+        assertThat(handler.get().aiMessage().text()).isNotBlank();
+        assertThat(handler.get().aiMessage().thinking()).isNotBlank();
+    }
+
+    @Test
     void should_support_max_tool_calls() {
 
         // given
@@ -443,6 +468,5 @@ class OpenAiOfficialResponsesStreamingChatModelIT extends AbstractStreamingChatM
 
     @Override
     @Disabled("Can't do it reliably")
-    protected void should_execute_multiple_tools_in_parallel_then_answer(StreamingChatModel model) {
-    }
+    protected void should_execute_multiple_tools_in_parallel_then_answer(StreamingChatModel model) {}
 }

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialResponsesStreamingChatModelListenerIT.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialResponsesStreamingChatModelListenerIT.java
@@ -1,11 +1,9 @@
 package dev.langchain4j.model.openaiofficial.openai;
 
-import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.models.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.common.AbstractStreamingChatModelListenerIT;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
-import dev.langchain4j.model.openaiofficial.OpenAiOfficialResponsesStreamingChatModel;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
@@ -13,12 +11,7 @@ class OpenAiOfficialResponsesStreamingChatModelListenerIT extends AbstractStream
 
     @Override
     protected StreamingChatModel createModel(ChatModelListener listener) {
-        var client = OpenAIOkHttpClient.builder()
-                .apiKey(System.getenv("OPENAI_API_KEY"))
-                .build();
-
-        return OpenAiOfficialResponsesStreamingChatModel.builder()
-                .client(client)
+        return InternalOpenAiOfficialTestHelper.responsesStreamingChatModelBuilder()
                 .modelName(modelName())
                 .temperature(temperature())
                 .topP(topP())
@@ -34,10 +27,8 @@ class OpenAiOfficialResponsesStreamingChatModelListenerIT extends AbstractStream
 
     @Override
     protected StreamingChatModel createFailingModel(ChatModelListener listener) {
-        var client = OpenAIOkHttpClient.builder().apiKey("banana").build();
-
-        return OpenAiOfficialResponsesStreamingChatModel.builder()
-                .client(client)
+        return InternalOpenAiOfficialTestHelper.responsesStreamingChatModelBuilder()
+                .apiKey("banana")
                 .modelName(modelName())
                 .listeners(listener)
                 .build();


### PR DESCRIPTION
## Issue
Related to #3252, #3637, and the closed PR #4489 (this PR follows the official OpenAI SDK path instead of Azure OpenAI SDK).

## Change
- Add reasoning summary support to the OpenAI Official Responses streaming model.
- Surface summary content in `AiMessage.thinking`.
- Add integration tests for reasoning summaries (positive and negative cases, gated by `OPENAI_API_KEY`).
- Document reasoning summaries in the OpenAI Official SDK docs.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [X] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
