### PR TITLE
Bugfix/toolid repeat:  add docs

### DIFF
--- a/docs/docs/integrations/language-models/openai-compatible.md
+++ b/docs/docs/integrations/language-models/openai-compatible.md
@@ -22,6 +22,29 @@ Many services and tools expose OpenAI-compatible APIs. The general approach to u
             .logResponses(true)
             .build();
     ```
+
+### Configuration for Specific OpenAI-Compatible APIs
+
+Some OpenAI-compatible APIs may have different behaviors in streaming responses, particularly for tool calling. LangChain4j provides configuration options to handle these differences:
+
+#### `accumulateToolCallId` (for `OpenAiStreamingChatModel`)
+
+Controls how tool call IDs are handled in streaming responses. Default is `true`.
+
+- **Enabled (`true`)**: Tool call IDs are accumulated across streaming chunks (standard OpenAI behavior)
+    - Example: Chunk 1 sends "abc", Chunk 2 sends "def" → Final ID: "abcdef"
+- **Disabled (`false`)**: Each chunk's tool call ID replaces the previous one
+    - Example: Chunk 1 sends "abc", Chunk 2 sends "abc" → Final ID: "abc"
+    - Use this for APIs like DeepSeek or Qwen that send the complete tool call ID in every chunk
+
+```java
+StreamingChatModel model = OpenAiStreamingChatModel.builder()
+        .baseUrl("https://api.deepseek.com/v1") // or other provider
+        .apiKey("YOUR_API_KEY")
+        .modelName("deepseek-chat")
+        .accumulateToolCallId(false) // Set to false for DeepSeek, Qwen, etc.
+        .build();
+```
 Below we provide specific examples for popular OpenAI-compatible APIs, including Groq, Docker Model Runner, GPT4All, Ollama, and LM Studio.
 
 ### Contents:

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
@@ -59,13 +59,19 @@ public class OpenAiStreamingResponseBuilder {
     private final Queue<ServerSentEvent> rawServerSentEvents = new ConcurrentLinkedQueue<>();
 
     private final boolean returnThinking;
+    private final boolean accumulateToolCallId;
 
     public OpenAiStreamingResponseBuilder() {
-        this(false);
+        this(false, true);
     }
 
     public OpenAiStreamingResponseBuilder(boolean returnThinking) {
+        this(returnThinking, true);
+    }
+
+    public OpenAiStreamingResponseBuilder(boolean returnThinking, boolean accumulateToolCallId) {
         this.returnThinking = returnThinking;
+        this.accumulateToolCallId = accumulateToolCallId;
         if (returnThinking) {
             this.reasoningContentBuilder = new StringBuffer();
         } else {
@@ -161,7 +167,12 @@ public class OpenAiStreamingResponseBuilder {
                     toolCall.index(), idx -> new ToolExecutionRequestBuilder());
 
             if (toolCall.id() != null) {
-                builder.idBuilder.append(toolCall.id());
+                if (accumulateToolCallId) {
+                    builder.idBuilder.append(toolCall.id());
+                } else {
+                    builder.idBuilder.setLength(0);
+                    builder.idBuilder.append(toolCall.id());
+                }
             }
 
             FunctionCall functionCall = toolCall.function();


### PR DESCRIPTION
Problem Description

Fix an issue where tool call IDs are duplicated when using OpenAI-compatible APIs (such as DeepSeek and Qwen) with streaming responses.

Some OpenAI-compatible APIs behave differently from the official OpenAI API when streaming tool calls:

OpenAI standard behavior:
The tool call ID is sent incrementally across chunks
(e.g. chunk1 = "abc", chunk2 = "abc" → final ID = "abcabc")

Some compatible APIs behavior:
The full tool call ID is repeated in every chunk
(e.g. chunk1 = "abc", chunk2 = "abc" → expected ID = "abc", not "abcabc")

This causes tool call IDs to be incorrectly accumulated and duplicated when using APIs such as DeepSeek and Qwen.

Solution

Introduce a new configuration option accumulateToolCallId in OpenAiStreamingChatModel to control how tool call IDs are handled during streaming:

Default value: true
Preserves compatibility with the official OpenAI streaming behavior

Set to false:
Suitable for APIs like DeepSeek and Qwen, where each chunk sends the full tool call ID
In this mode, the ID from each chunk replaces the previous value instead of being accumulated

Code Example
StreamingChatModel model = OpenAiStreamingChatModel.builder()
        .baseUrl("https://api.deepseek.com/v1")
        .apiKey(apiKey)
        .modelName("deepseek-chat")
        .accumulateToolCallId(false) // Disable ID accumulation
        .build();

Changes

Added the accumulateToolCallId configuration field to OpenAiStreamingChatModel

Implemented corresponding handling logic in OpenAiStreamingResponseBuilder

Updated official documentation to explain the purpose and usage scenarios of this option

Related Issue

Fixes #4528

Documentation

Documentation has been updated:
docs/docs/integrations/language-models/openai-compatible.md