### PR TITLE
Make MCP stdio transport's operations fail immediately when the subprocess exits

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
@@ -60,6 +60,9 @@ public class StdioMcpTransport implements McpTransport {
             process = processBuilder.start();
             log.debug("PID of the started process: {}", process.pid());
             process.onExit().thenRun(() -> {
+                if (messageHandler != null) {
+                    messageHandler.cancelAllPendingOperations("Process has exited");
+                }
                 log.debug("Subprocess has exited with code: {}", process.exitValue());
             });
         } catch (Exception e) {


### PR DESCRIPTION
See https://github.com/quarkiverse/quarkus-langchain4j/issues/2111