### PR TITLE
Centralize MCP traffic logger configuration

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/McpLoggers.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/McpLoggers.java
@@ -1,0 +1,22 @@
+package dev.langchain4j.mcp.client.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Central place for MCP-related loggers.
+ */
+public final class McpLoggers {
+
+    public static final String DEFAULT_TRAFFIC_LOGGER_NAME = "MCP";
+
+    private static final Logger DEFAULT_TRAFFIC_LOGGER =
+            LoggerFactory.getLogger(DEFAULT_TRAFFIC_LOGGER_NAME);
+
+    private McpLoggers() {
+    }
+
+    public static Logger traffic() {
+        return DEFAULT_TRAFFIC_LOGGER;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/McpLoggers.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/logging/McpLoggers.java
@@ -10,11 +10,9 @@ public final class McpLoggers {
 
     public static final String DEFAULT_TRAFFIC_LOGGER_NAME = "MCP";
 
-    private static final Logger DEFAULT_TRAFFIC_LOGGER =
-            LoggerFactory.getLogger(DEFAULT_TRAFFIC_LOGGER_NAME);
+    private static final Logger DEFAULT_TRAFFIC_LOGGER = LoggerFactory.getLogger(DEFAULT_TRAFFIC_LOGGER_NAME);
 
-    private McpLoggers() {
-    }
+    private McpLoggers() {}
 
     public static Logger traffic() {
         return DEFAULT_TRAFFIC_LOGGER;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/McpRequestLoggingInterceptor.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/McpRequestLoggingInterceptor.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.mcp.client.transport.http;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+
+import dev.langchain4j.mcp.client.logging.McpLoggers;
 import java.io.IOException;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -11,14 +14,10 @@ import okio.Buffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import dev.langchain4j.mcp.client.logging.McpLoggers;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-
 class McpRequestLoggingInterceptor implements Interceptor {
 
     private static final Logger log = LoggerFactory.getLogger(McpRequestLoggingInterceptor.class);
-   
+
     private final Logger trafficLog;
 
     McpRequestLoggingInterceptor(Logger logger) {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/McpRequestLoggingInterceptor.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/McpRequestLoggingInterceptor.java
@@ -11,17 +11,18 @@ import okio.Buffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dev.langchain4j.mcp.client.logging.McpLoggers;
+
 import static dev.langchain4j.internal.Utils.getOrDefault;
 
 class McpRequestLoggingInterceptor implements Interceptor {
 
     private static final Logger log = LoggerFactory.getLogger(McpRequestLoggingInterceptor.class);
-    private static final Logger DEFAULT_TRAFFIC_LOG = LoggerFactory.getLogger("MCP");
-
+   
     private final Logger trafficLog;
 
     McpRequestLoggingInterceptor(Logger logger) {
-        this.trafficLog = getOrDefault(logger, DEFAULT_TRAFFIC_LOG);
+        this.trafficLog = getOrDefault(logger, McpLoggers.traffic());
     }
 
     @Override

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseEventListener.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseEventListener.java
@@ -3,6 +3,8 @@ package dev.langchain4j.mcp.client.transport.http;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.mcp.client.logging.McpLoggers;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import java.util.concurrent.CompletableFuture;
 import okhttp3.Response;
@@ -15,7 +17,7 @@ public class SseEventListener extends EventSourceListener {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger log = LoggerFactory.getLogger(SseEventListener.class);
-    private static final Logger trafficLog = LoggerFactory.getLogger("MCP");
+    private static final Logger trafficLog = McpLoggers.traffic();
     private final boolean logEvents;
     // this will contain the POST url for sending commands to the server
     private final CompletableFuture<String> initializationFinished;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseEventListener.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseEventListener.java
@@ -3,7 +3,6 @@ package dev.langchain4j.mcp.client.transport.http;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import dev.langchain4j.mcp.client.logging.McpLoggers;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import java.util.concurrent.CompletableFuture;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
+import dev.langchain4j.mcp.client.logging.McpLoggers;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
@@ -33,8 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class StreamableHttpMcpTransport implements McpTransport {
-
-    private static final Logger DEFAULT_TRAFFIC_LOG = LoggerFactory.getLogger("MCP");
     private static final Logger LOG = LoggerFactory.getLogger(StreamableHttpMcpTransport.class);
     private final String url;
     private final McpHeadersSupplier customHeadersSupplier;
@@ -53,7 +52,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
         url = ensureNotNull(builder.url, "Missing server endpoint URL");
         logRequests = builder.logRequests;
         logResponses = builder.logResponses;
-        trafficLog = getOrDefault(builder.logger, DEFAULT_TRAFFIC_LOG);
+        trafficLog = getOrDefault(builder.logger, McpLoggers.traffic());
         Duration timeout = getOrDefault(builder.timeout, Duration.ofSeconds(60));
         customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, (i) -> Map.of());
         sslContext = builder.sslContext;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/websocket/WebSocketMcpTransport.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
+import dev.langchain4j.mcp.client.logging.McpLoggers;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpClientMessage;
@@ -31,8 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class WebSocketMcpTransport implements McpTransport {
-
-    private static final Logger DEFAULT_TRAFFIC_LOG = LoggerFactory.getLogger("MCP");
     private static final Logger LOG = LoggerFactory.getLogger(WebSocketMcpTransport.class);
     private final String url;
     private final McpHeadersSupplier headersSupplier;
@@ -54,7 +53,7 @@ public class WebSocketMcpTransport implements McpTransport {
         this.url = ensureNotNull(builder.url, "Missing server endpoint URL");
         this.logResponses = builder.logResponses;
         this.logRequests = builder.logRequests;
-        this.trafficLog = getOrDefault(builder.logger, DEFAULT_TRAFFIC_LOG);
+        this.trafficLog = getOrDefault(builder.logger, McpLoggers.traffic());
         this.connectTimeout = getOrDefault(builder.timeout, Duration.ofSeconds(60));
         this.headersSupplier = getOrDefault(builder.headersSupplier, (i) -> Map.of());
         this.executor = builder.executor;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
@@ -5,9 +5,7 @@ import static dev.langchain4j.internal.Utils.getOrDefault;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import dev.langchain4j.mcp.client.logging.McpLoggers;
-
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/transport/stdio/JsonRpcIoHandler.java
@@ -5,6 +5,9 @@ import static dev.langchain4j.internal.Utils.getOrDefault;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.langchain4j.mcp.client.logging.McpLoggers;
+
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
@@ -20,7 +23,6 @@ public class JsonRpcIoHandler implements Runnable, Closeable {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger log = LoggerFactory.getLogger(JsonRpcIoHandler.class);
-    private static final Logger DEFAULT_TRAFFIC_LOG = LoggerFactory.getLogger("MCP");
 
     private final InputStream input;
     private final PrintStream out;
@@ -44,7 +46,7 @@ public class JsonRpcIoHandler implements Runnable, Closeable {
         this.logEvents = logEvents;
         this.messageHandler = messageHandler;
         this.out = new PrintStream(output, true);
-        this.trafficLog = getOrDefault(logger, DEFAULT_TRAFFIC_LOG);
+        this.trafficLog = getOrDefault(logger, McpLoggers.traffic());
     }
 
     @Override


### PR DESCRIPTION
### Summary

This PR centralizes the MCP traffic logger definition into a single utility class to avoid duplication and ensure consistent logging across MCP components.

### What changed

- Introduced `McpLoggers` as the single source of truth for MCP-related loggers  
- Centralized the `"MCP"` traffic logger creation  
- Removed repeated `LoggerFactory.getLogger("MCP")` declarations across classes  
- Improved clarity and maintainability of MCP traffic logging  