### PR TITLE
Fix unsafe generic cast in InvocationContext.Builder

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/invocation/InvocationContext.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/invocation/InvocationContext.java
@@ -173,7 +173,8 @@ public interface InvocationContext {
         /**
          * Sets the LC4j managed parameters for the builder.
          */
-        public Builder managedParameters(Map<Class<? extends LangChain4jManaged>, LangChain4jManaged> managedParameters) {
+        public Builder managedParameters(
+                Map<Class<? extends LangChain4jManaged>, LangChain4jManaged> managedParameters) {
             this.managedParameters = managedParameters;
             return this;
         }
@@ -198,8 +199,8 @@ public interface InvocationContext {
         /**
          * Constructs an instance of {@link InvocationContext} using the current state of the builder.
          */
-        public <T extends InvocationContext> T build() {
-            return (T) new DefaultInvocationContext(this);
+        public InvocationContext build() {
+            return new DefaultInvocationContext(this);
         }
 
         public UUID invocationId() {


### PR DESCRIPTION
## Problem

`InvocationContext.Builder#build()` was declared as a generic method:

``` java
public <T extends InvocationContext> T build() {
    return (T) new DefaultInvocationContext(this);
}
```

The method claims it can return *any* subtype of `InvocationContext`, but it **always** returns a `DefaultInvocationContext`. This creates a false sense of type safety for callers.

As a result,  code compiles but fails at runtime in the following scenari

``` java
   /**
     * Dummy subtype used only for testing.
     */
    interface CustomInvocationContext extends InvocationContext {
    }
   CustomInvocationContext ctx = InvocationContext.builder().build();
```

This causes a **`ClassCastException`** because
`DefaultInvocationContext` is not a `CustomInvocationContext`.

------------------------------------------------------------------------

## Solution

The builder now returns the concrete type it actually constructs:

``` java
public InvocationContext build() {
    return new DefaultInvocationContext(this);
}
```
