### PR TITLE
Fix NPE when toolCall.index() is null in OpenAI streaming (#4573)

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -213,7 +213,18 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
         if (toolCalls != null) {
             for (ToolCall toolCall : toolCalls) {
 
-                int index = toolCall.index() != null ? toolCall.index() : 0;
+                int index;
+                if (toolCall.index() != null) {
+                    index = toolCall.index();
+                } else {
+                    index = toolCallBuilder.index();
+                    // When index is null and a different tool call id appears, increment the index
+                    if (toolCall.id() != null
+                            && toolCallBuilder.id() != null
+                            && !toolCallBuilder.id().equals(toolCall.id())) {
+                        index = toolCallBuilder.index() + 1;
+                    }
+                }
                 if (toolCallBuilder.index() != index) {
                     onCompleteToolCall(handler, toolCallBuilder.buildAndReset());
                     toolCallBuilder.updateIndex(index);

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -145,13 +145,14 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
 
         ChatCompletionRequest openAiRequest =
                 toOpenAiChatRequest(
-                        chatRequest, parameters, sendThinking, thinkingFieldName, strictTools, strictJsonSchema)
+                                chatRequest, parameters, sendThinking, thinkingFieldName, strictTools, strictJsonSchema)
                         .stream(true)
                         .streamOptions(
                                 StreamOptions.builder().includeUsage(true).build())
                         .build();
 
-        OpenAiStreamingResponseBuilder openAiResponseBuilder = new OpenAiStreamingResponseBuilder(returnThinking, accumulateToolCallId);
+        OpenAiStreamingResponseBuilder openAiResponseBuilder =
+                new OpenAiStreamingResponseBuilder(returnThinking, accumulateToolCallId);
         ToolCallBuilder toolCallBuilder = new ToolCallBuilder();
 
         client.chatCompletion(openAiRequest)
@@ -212,7 +213,7 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
         if (toolCalls != null) {
             for (ToolCall toolCall : toolCalls) {
 
-                int index = toolCall.index();
+                int index = toolCall.index() != null ? toolCall.index() : 0;
                 if (toolCallBuilder.index() != index) {
                     onCompleteToolCall(handler, toolCallBuilder.buildAndReset());
                     toolCallBuilder.updateIndex(index);

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
@@ -162,9 +162,10 @@ public class OpenAiStreamingResponseBuilder {
 
         if (delta.toolCalls() != null && !delta.toolCalls().isEmpty()) {
             ToolCall toolCall = delta.toolCalls().get(0);
+            Integer toolCallIndex = toolCall.index() != null ? toolCall.index() : 0;
 
             ToolExecutionRequestBuilder builder = this.indexToToolExecutionRequestBuilder.computeIfAbsent(
-                    toolCall.index(), idx -> new ToolExecutionRequestBuilder());
+                    toolCallIndex, idx -> new ToolExecutionRequestBuilder());
 
             if (toolCall.id() != null) {
                 if (accumulateToolCallId) {

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
@@ -1,0 +1,90 @@
+package dev.langchain4j.model.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openai.internal.chat.*;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OpenAiStreamingResponseBuilderTest {
+
+    @Test
+    void should_handle_null_tool_call_index() {
+        // Given: a tool call with null index (as Gemini's OpenAI-compatible API returns)
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+
+        FunctionCall functionCall = FunctionCall.builder()
+                .name("getWeather")
+                .arguments("{\"city\": \"Berlin\"}")
+                .build();
+
+        ToolCall toolCall = ToolCall.builder()
+                .id("call_123")
+                .index(null) // Gemini returns null index
+                .type(ToolType.FUNCTION)
+                .function(functionCall)
+                .build();
+
+        Delta delta = Delta.builder().toolCalls(List.of(toolCall)).build();
+
+        ChatCompletionChoice choice =
+                ChatCompletionChoice.builder().index(0).delta(delta).build();
+
+        ChatCompletionResponse response = ChatCompletionResponse.builder()
+                .id("resp_1")
+                .model("gemini-2.0-flash")
+                .choices(List.of(choice))
+                .build();
+
+        // When: appending the response (should not throw NPE)
+        builder.append(response);
+
+        // Then: the tool execution request is built correctly
+        ChatResponse chatResponse = builder.build();
+        assertThat(chatResponse.aiMessage().toolExecutionRequests()).hasSize(1);
+        assertThat(chatResponse.aiMessage().toolExecutionRequests().get(0).name())
+                .isEqualTo("getWeather");
+        assertThat(chatResponse.aiMessage().toolExecutionRequests().get(0).arguments())
+                .isEqualTo("{\"city\": \"Berlin\"}");
+        assertThat(chatResponse.aiMessage().toolExecutionRequests().get(0).id()).isEqualTo("call_123");
+    }
+
+    @Test
+    void should_handle_non_null_tool_call_index() {
+        // Given: a standard tool call with non-null index
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+
+        FunctionCall functionCall = FunctionCall.builder()
+                .name("getTemperature")
+                .arguments("{\"city\": \"Paris\"}")
+                .build();
+
+        ToolCall toolCall = ToolCall.builder()
+                .id("call_456")
+                .index(0)
+                .type(ToolType.FUNCTION)
+                .function(functionCall)
+                .build();
+
+        Delta delta = Delta.builder().toolCalls(List.of(toolCall)).build();
+
+        ChatCompletionChoice choice =
+                ChatCompletionChoice.builder().index(0).delta(delta).build();
+
+        ChatCompletionResponse response = ChatCompletionResponse.builder()
+                .id("resp_2")
+                .model("gpt-4o")
+                .choices(List.of(choice))
+                .build();
+
+        // When
+        builder.append(response);
+
+        // Then
+        ChatResponse chatResponse = builder.build();
+        assertThat(chatResponse.aiMessage().toolExecutionRequests()).hasSize(1);
+        assertThat(chatResponse.aiMessage().toolExecutionRequests().get(0).name())
+                .isEqualTo("getTemperature");
+    }
+}


### PR DESCRIPTION
Gemini's OpenAI-compatible streaming API returns null for toolCall.index(), causing NullPointerException in ConcurrentHashMap.computeIfAbsent() and auto-unboxing. Default null index to 0, matching ToolCallBuilder's default.

## Issue
Closes #4573

## Change
When using Gemini's OpenAI-compatible API (`https://generativelanguage.googleapis.com/v1beta/openai/`) with `StreamingChatModel` and tools enabled, `toolCall.index()` returns `null` during streaming. This causes `NullPointerException` in two places:

1. **OpenAiStreamingResponseBuilder.java** — `ConcurrentHashMap.computeIfAbsent()` does not allow null keys
2. **OpenAiStreamingChatModel.java** — Auto-unboxing `null` `Integer` to `int` throws NPE

The fix defaults `toolCall.index()` to `0` when null, which is semantically correct since a null index indicates no parallel tool calls (single tool call at a time). This is consistent with the `ToolCallBuilder` no-arg constructor default.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)