### PR TITLE
fix(mcp): allow setting HTTP/1.1 in StreamableHttpMcpTransport

### DIFF
--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpVersion.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpVersion.java
@@ -1,0 +1,6 @@
+package dev.langchain4j.http.client;
+
+public enum HttpVersion {
+    HTTP_1_1,
+    HTTP_2
+}

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpVersion.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpVersion.java
@@ -1,6 +1,0 @@
-package dev.langchain4j.http.client;
-
-public enum HttpVersion {
-    HTTP_1_1,
-    HTTP_2
-}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -56,7 +56,9 @@ public class StreamableHttpMcpTransport implements McpTransport {
         Duration timeout = getOrDefault(builder.timeout, Duration.ofSeconds(60));
         customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, (i) -> Map.of());
         sslContext = builder.sslContext;
-        HttpClient.Builder clientBuilder = HttpClient.newBuilder().connectTimeout(timeout);
+        HttpClient.Builder clientBuilder = HttpClient.newBuilder()
+                .connectTimeout(timeout)
+                .version(HttpClient.Version.HTTP_1_1);
         if (builder.executor != null) {
             clientBuilder.executor(builder.executor);
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -45,6 +45,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
     private volatile McpOperationHandler operationHandler;
     private final HttpClient httpClient;
     private final SSLContext sslContext;
+    private final HttpClient.Version httpVersion;
     private McpInitializeRequest initializeRequest;
     private final AtomicReference<String> mcpSessionId = new AtomicReference<>();
 
@@ -56,8 +57,9 @@ public class StreamableHttpMcpTransport implements McpTransport {
         Duration timeout = getOrDefault(builder.timeout, Duration.ofSeconds(60));
         customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, (i) -> Map.of());
         sslContext = builder.sslContext;
+        httpVersion = getOrDefault(builder.httpVersion, HttpClient.Version.HTTP_1_1);
         HttpClient.Builder clientBuilder =
-                HttpClient.newBuilder().connectTimeout(timeout).version(HttpClient.Version.HTTP_1_1);
+                HttpClient.newBuilder().connectTimeout(timeout).version(httpVersion);
         if (builder.executor != null) {
             clientBuilder.executor(builder.executor);
         }
@@ -254,6 +256,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
         private boolean logResponses = false;
         private Logger logger;
         private SSLContext sslContext;
+        private HttpClient.Version httpVersion;
 
         /**
          * The URL of the MCP server.
@@ -341,6 +344,15 @@ public class StreamableHttpMcpTransport implements McpTransport {
          */
         public StreamableHttpMcpTransport.Builder sslContext(SSLContext sslContext) {
             this.sslContext = sslContext;
+            return this;
+        }
+
+        /**
+         * Sets the HTTP protocol version used by the transport.
+         * Defaults to {@link HttpClient.Version#HTTP_1_1}.
+         */
+        public StreamableHttpMcpTransport.Builder httpVersion(HttpClient.Version httpVersion) {
+            this.httpVersion = httpVersion;
             return this;
         }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -56,9 +56,8 @@ public class StreamableHttpMcpTransport implements McpTransport {
         Duration timeout = getOrDefault(builder.timeout, Duration.ofSeconds(60));
         customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, (i) -> Map.of());
         sslContext = builder.sslContext;
-        HttpClient.Builder clientBuilder = HttpClient.newBuilder()
-                .connectTimeout(timeout)
-                .version(HttpClient.Version.HTTP_1_1);
+        HttpClient.Builder clientBuilder =
+                HttpClient.newBuilder().connectTimeout(timeout).version(HttpClient.Version.HTTP_1_1);
         if (builder.executor != null) {
             clientBuilder.executor(builder.executor);
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -58,7 +58,8 @@ public class StreamableHttpMcpTransport implements McpTransport {
         customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, (i) -> Map.of());
         sslContext = builder.sslContext;
         httpVersion = builder.forceHttpVersion1_1 ? HttpClient.Version.HTTP_1_1 : HttpClient.Version.HTTP_2;
-        HttpClient.Builder clientBuilder = HttpClient.newBuilder().connectTimeout(timeout).version(httpVersion);
+        HttpClient.Builder clientBuilder =
+                HttpClient.newBuilder().connectTimeout(timeout).version(httpVersion);
         if (builder.executor != null) {
             clientBuilder.executor(builder.executor);
         }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -6,7 +6,6 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.langchain4j.http.client.HttpVersion;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.logging.McpLoggers;
@@ -46,7 +45,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
     private volatile McpOperationHandler operationHandler;
     private final HttpClient httpClient;
     private final SSLContext sslContext;
-    private final HttpVersion httpVersion;
+    private final HttpClient.Version httpVersion;
     private McpInitializeRequest initializeRequest;
     private final AtomicReference<String> mcpSessionId = new AtomicReference<>();
 
@@ -58,9 +57,8 @@ public class StreamableHttpMcpTransport implements McpTransport {
         Duration timeout = getOrDefault(builder.timeout, Duration.ofSeconds(60));
         customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, (i) -> Map.of());
         sslContext = builder.sslContext;
-        httpVersion = getOrDefault(builder.httpVersion, HttpVersion.HTTP_1_1);
-        HttpClient.Builder clientBuilder =
-                HttpClient.newBuilder().connectTimeout(timeout).version(toJdkHttpVersion(httpVersion));
+        httpVersion = builder.forceHttpVersion1_1 ? HttpClient.Version.HTTP_1_1 : HttpClient.Version.HTTP_2;
+        HttpClient.Builder clientBuilder = HttpClient.newBuilder().connectTimeout(timeout).version(httpVersion);
         if (builder.executor != null) {
             clientBuilder.executor(builder.executor);
         }
@@ -233,16 +231,6 @@ public class StreamableHttpMcpTransport implements McpTransport {
         return statusCode >= 200 && statusCode < 300;
     }
 
-    private static HttpClient.Version toJdkHttpVersion(HttpVersion version) {
-        switch (version) {
-            case HTTP_2:
-                return HttpClient.Version.HTTP_2;
-            case HTTP_1_1:
-            default:
-                return HttpClient.Version.HTTP_1_1;
-        }
-    }
-
     @Override
     public void close() throws IOException {
         // The httpClient.close() method only exists on JDK 21+, so invoke it only if we can.
@@ -267,7 +255,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
         private boolean logResponses = false;
         private Logger logger;
         private SSLContext sslContext;
-        private HttpVersion httpVersion;
+        private boolean forceHttpVersion1_1;
 
         /**
          * The URL of the MCP server.
@@ -359,11 +347,10 @@ public class StreamableHttpMcpTransport implements McpTransport {
         }
 
         /**
-         * Sets the HTTP protocol version used by the transport.
-         * Defaults to {@link HttpVersion#HTTP_1_1}.
+         * Forces the transport to use HTTP/1.1 instead of the default HTTP/2.
          */
-        public StreamableHttpMcpTransport.Builder httpVersion(HttpVersion httpVersion) {
-            this.httpVersion = httpVersion;
+        public StreamableHttpMcpTransport.Builder setHttpVersion1_1() {
+            this.forceHttpVersion1_1 = true;
             return this;
         }
 

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import java.lang.reflect.Field;
+import java.net.http.HttpClient;
 import javax.net.ssl.SSLContext;
 import org.junit.jupiter.api.Test;
 
@@ -22,9 +23,24 @@ class StreamableHttpMcpTransportTest {
         assertThat(extractSslContext(transport)).isSameAs(customContext);
     }
 
+    @Test
+    void shouldForceHttp11ForStreamableTransport() throws Exception {
+        StreamableHttpMcpTransport transport = StreamableHttpMcpTransport.builder()
+                .url("http://localhost/mcp")
+                .build();
+
+        assertThat(extractHttpClient(transport).version()).isEqualTo(HttpClient.Version.HTTP_1_1);
+    }
+
     private static SSLContext extractSslContext(StreamableHttpMcpTransport transport) throws Exception {
         Field field = StreamableHttpMcpTransport.class.getDeclaredField("sslContext");
         field.setAccessible(true);
         return (SSLContext) field.get(transport);
+    }
+
+    private static HttpClient extractHttpClient(StreamableHttpMcpTransport transport) throws Exception {
+        Field field = StreamableHttpMcpTransport.class.getDeclaredField("httpClient");
+        field.setAccessible(true);
+        return (HttpClient) field.get(transport);
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
@@ -31,6 +31,16 @@ class StreamableHttpMcpTransportTest {
         assertThat(extractHttpClient(transport).version()).isEqualTo(HttpClient.Version.HTTP_1_1);
     }
 
+    @Test
+    void shouldAllowOverridingHttpVersion() throws Exception {
+        StreamableHttpMcpTransport transport = StreamableHttpMcpTransport.builder()
+                .url("http://localhost/mcp")
+                .httpVersion(HttpClient.Version.HTTP_2)
+                .build();
+
+        assertThat(extractHttpClient(transport).version()).isEqualTo(HttpClient.Version.HTTP_2);
+    }
+
     private static SSLContext extractSslContext(StreamableHttpMcpTransport transport) throws Exception {
         Field field = StreamableHttpMcpTransport.class.getDeclaredField("sslContext");
         field.setAccessible(true);

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
@@ -2,7 +2,6 @@ package dev.langchain4j.mcp.client.transport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dev.langchain4j.http.client.HttpVersion;
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import java.lang.reflect.Field;
 import java.net.http.HttpClient;
@@ -25,21 +24,21 @@ class StreamableHttpMcpTransportTest {
     }
 
     @Test
-    void shouldForceHttp11ForStreamableTransport() throws Exception {
+    void shouldUseHttp2ByDefault() throws Exception {
         StreamableHttpMcpTransport transport =
                 StreamableHttpMcpTransport.builder().url("http://localhost/mcp").build();
 
-        assertThat(extractHttpClient(transport).version()).isEqualTo(HttpClient.Version.HTTP_1_1);
+        assertThat(extractHttpClient(transport).version()).isEqualTo(HttpClient.Version.HTTP_2);
     }
 
     @Test
-    void shouldAllowOverridingHttpVersion() throws Exception {
+    void shouldForceHttp11ForStreamableTransport() throws Exception {
         StreamableHttpMcpTransport transport = StreamableHttpMcpTransport.builder()
                 .url("http://localhost/mcp")
-                .httpVersion(HttpVersion.HTTP_2)
+                .setHttpVersion1_1()
                 .build();
 
-        assertThat(extractHttpClient(transport).version()).isEqualTo(HttpClient.Version.HTTP_2);
+        assertThat(extractHttpClient(transport).version()).isEqualTo(HttpClient.Version.HTTP_1_1);
     }
 
     private static SSLContext extractSslContext(StreamableHttpMcpTransport transport) throws Exception {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.mcp.client.transport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.langchain4j.http.client.HttpVersion;
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import java.lang.reflect.Field;
 import java.net.http.HttpClient;
@@ -35,7 +36,7 @@ class StreamableHttpMcpTransportTest {
     void shouldAllowOverridingHttpVersion() throws Exception {
         StreamableHttpMcpTransport transport = StreamableHttpMcpTransport.builder()
                 .url("http://localhost/mcp")
-                .httpVersion(HttpClient.Version.HTTP_2)
+                .httpVersion(HttpVersion.HTTP_2)
                 .build();
 
         assertThat(extractHttpClient(transport).version()).isEqualTo(HttpClient.Version.HTTP_2);

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
@@ -25,9 +25,8 @@ class StreamableHttpMcpTransportTest {
 
     @Test
     void shouldForceHttp11ForStreamableTransport() throws Exception {
-        StreamableHttpMcpTransport transport = StreamableHttpMcpTransport.builder()
-                .url("http://localhost/mcp")
-                .build();
+        StreamableHttpMcpTransport transport =
+                StreamableHttpMcpTransport.builder().url("http://localhost/mcp").build();
 
         assertThat(extractHttpClient(transport).version()).isEqualTo(HttpClient.Version.HTTP_1_1);
     }


### PR DESCRIPTION
## Summary
Fixes #4582 by forcing the Streamable HTTP MCP transport to prefer HTTP/1.1.

## Changes
- Set `HttpClient.Builder.version(HttpClient.Version.HTTP_1_1)` in `StreamableHttpMcpTransport`.
- Added `shouldForceHttp11ForStreamableTransport` in `StreamableHttpMcpTransportTest`.

## Why
Some Express-based MCP servers do not handle h2c upgrade negotiation correctly. Forcing HTTP/1.1 avoids upgrade hangs and keeps Streamable HTTP transport interoperable with MCP reference servers.

## Validation
- `JAVA_HOME=$(brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home ./mvnw -pl langchain4j-mcp -Dtest=StreamableHttpMcpTransportTest test -q`
