### PR TITLE
Add ModerationModel listener support and ModerationRequest/ModerationResponse API

### DIFF
--- a/docs/docs/tutorials/observability.md
+++ b/docs/docs/tutorials/observability.md
@@ -271,6 +271,97 @@ The `attributes` map allows passing information between the `onRequest`, `onResp
   `StreamingChatResponseHandler.onCompleteResponse()` is called. The `ChatModelListener.onError()` is called
   before the `StreamingChatResponseHandler.onError()` is called.
 
+## Moderation Model Observability
+
+Implementations of `ModerationModel` that support listeners (such as `OpenAiModerationModel`, `MistralAiModerationModel`,
+and `WatsonxModerationModel`) allow configuring `ModerationModelListener`(s) to listen for events such as:
+- Requests to the moderation API
+- Responses from the moderation API
+- Errors
+
+Here is an example of using `ModerationModelListener`:
+```java
+ModerationModelListener listener = new ModerationModelListener() {
+
+    @Override
+    public void onRequest(ModerationModelRequestContext requestContext) {
+        ModerationRequest moderationRequest = requestContext.moderationRequest();
+
+        // Access messages being moderated
+        System.out.println("Moderating messages: " + moderationRequest.texts());
+
+        System.out.println(requestContext.modelProvider());
+        System.out.println(moderationRequest.modelName());
+
+        Map<Object, Object> attributes = requestContext.attributes();
+        attributes.put("startTime", System.currentTimeMillis());
+    }
+
+    @Override
+    public void onResponse(ModerationModelResponseContext responseContext) {
+        ModerationResponse moderationResponse = responseContext.moderationResponse();
+
+        Moderation moderation = moderationResponse.moderation();
+        System.out.println("Flagged: " + moderation.flagged());
+        if (moderation.flagged()) {
+            System.out.println("Flagged text: " + moderation.flaggedText());
+        }
+
+        ModerationRequest moderationRequest = responseContext.moderationRequest();
+        System.out.println(moderationRequest);
+
+        System.out.println(responseContext.modelProvider());
+        System.out.println(moderationRequest.modelName());
+
+        Map<Object, Object> attributes = responseContext.attributes();
+        Long startTime = (Long) attributes.get("startTime");
+        if (startTime != null) {
+            System.out.println("Duration: " + (System.currentTimeMillis() - startTime) + "ms");
+        }
+    }
+
+    @Override
+    public void onError(ModerationModelErrorContext errorContext) {
+        Throwable error = errorContext.error();
+        error.printStackTrace();
+
+        ModerationRequest moderationRequest = errorContext.moderationRequest();
+        System.out.println(moderationRequest);
+
+        System.out.println(errorContext.modelProvider());
+        System.out.println(moderationRequest.modelName());
+
+        Map<Object, Object> attributes = errorContext.attributes();
+        System.out.println(attributes.get("startTime"));
+    }
+};
+
+ModerationModel model = OpenAiModerationModel.builder()
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .listeners(List.of(listener))
+        .build();
+
+model.moderate("Text to check for policy violations");
+```
+
+The `attributes` map allows passing information between the `onRequest`, `onResponse`, and `onError` methods of the same
+`ModerationModelListener`, as well as between multiple `ModerationModelListener`s.
+
+### How listeners work
+
+- Listeners are specified as a `List<ModerationModelListener>` and are called in the order of iteration.
+- Listeners are called synchronously and in the same thread.
+- The `ModerationModelListener.onRequest()` method is called right before calling the moderation API.
+- The `ModerationModelListener.onRequest()` method is called only once per request.
+  If an error occurs while calling the moderation API and a retry happens,
+  `ModerationModelListener.onRequest()` will **_not_** be called for every retry.
+- The `ModerationModelListener.onResponse()` method is called only once,
+  immediately after receiving a successful response.
+- The `ModerationModelListener.onError()` method is called only once.
+  If an error occurs while calling the moderation API and a retry happens,
+  `ModerationModelListener.onError()` will **_not_** be called for every retry.
+- If an exception is thrown from one of the `ModerationModelListener` methods,
+  it will be logged at the `WARN` level. The execution of subsequent listeners will continue as usual.
 
 ## RAG Observability (EmbeddingModel, EmbeddingStore and ContentRetriever)
 

--- a/langchain4j-core/pom.xml
+++ b/langchain4j-core/pom.xml
@@ -165,6 +165,8 @@
                                         <exclude>dev.langchain4j.model.chat.request.json</exclude>
                                         <exclude>dev.langchain4j.model.chat.response</exclude>
                                         <exclude>dev.langchain4j.model.listener</exclude>
+                                        <exclude>dev.langchain4j.model.moderation</exclude>
+                                        <exclude>dev.langchain4j.model.moderation.listener</exclude>
                                         <exclude>dev.langchain4j.spi</exclude>
                                         <exclude>dev.langchain4j.store.embedding</exclude>
                                         <exclude>dev.langchain4j.store.embedding.filter</exclude>

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/DisabledModerationModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/DisabledModerationModel.java
@@ -5,7 +5,6 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.ModelDisabledException;
 import dev.langchain4j.model.input.Prompt;
 import dev.langchain4j.model.output.Response;
-
 import java.util.List;
 
 /**
@@ -37,6 +36,11 @@ public class DisabledModerationModel implements ModerationModel {
 
     @Override
     public Response<Moderation> moderate(TextSegment textSegment) {
+        throw new ModelDisabledException("ModerationModel is disabled");
+    }
+
+    @Override
+    public ModerationResponse doModerate(ModerationRequest moderationRequest) {
         throw new ModelDisabledException("ModerationModel is disabled");
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
@@ -1,10 +1,12 @@
 package dev.langchain4j.model.moderation;
 
+import static dev.langchain4j.model.ModelProvider.OTHER;
+
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.input.Prompt;
 import dev.langchain4j.model.output.Response;
-
 import java.util.List;
 
 /**
@@ -13,23 +15,68 @@ import java.util.List;
 public interface ModerationModel {
 
     /**
+     * Returns the model provider for this moderation model.
+     *
+     * @return the model provider.
+     */
+    default ModelProvider provider() {
+        return OTHER;
+    }
+
+    /**
+     * Returns the model name for this moderation model.
+     *
+     * @return the model name, or {@code null} if not available.
+     */
+    default String modelName() {
+        return null;
+    }
+
+    /**
+     * This is the main API to interact with the moderation model.
+     *
+     * @param moderationRequest a {@link ModerationRequest}, containing all the inputs to the moderation model
+     * @return a {@link ModerationResponse}, containing all the outputs from the moderation model
+     */
+    default ModerationResponse moderate(ModerationRequest moderationRequest) {
+        return doModerate(moderationRequest);
+    }
+
+    /**
+     * Performs the actual moderation. This method should be overridden by implementations.
+     *
+     * @param moderationRequest the moderation request.
+     * @return the moderation response.
+     */
+    default ModerationResponse doModerate(ModerationRequest moderationRequest) {
+        throw new RuntimeException("Not implemented");
+    }
+
+    /**
      * Moderates the given text.
+     *
      * @param text the text to moderate.
      * @return the moderation {@code Response}.
      */
-    Response<Moderation> moderate(String text);
+    default Response<Moderation> moderate(String text) {
+        ModerationRequest request = ModerationRequest.builder().text(text).build();
+        ModerationResponse response = moderate(request);
+        return Response.from(response.moderation(), response.tokenUsage(), null, response.metadata());
+    }
 
     /**
      * Moderates the given prompt.
+     *
      * @param prompt the prompt to moderate.
      * @return the moderation {@code Response}.
      */
     default Response<Moderation> moderate(Prompt prompt) {
         return moderate(prompt.text());
     }
-  
+
     /**
      * Moderates the given chat message.
+     *
      * @param message the chat message to moderate.
      * @return the moderation {@code Response}.
      */
@@ -39,13 +86,20 @@ public interface ModerationModel {
 
     /**
      * Moderates the given list of chat messages.
+     *
      * @param messages the list of chat messages to moderate.
      * @return the moderation {@code Response}.
      */
-    Response<Moderation> moderate(List<ChatMessage> messages);
+    default Response<Moderation> moderate(List<ChatMessage> messages) {
+        ModerationRequest request =
+                ModerationRequest.builder().messages(messages).build();
+        ModerationResponse response = moderate(request);
+        return Response.from(response.moderation(), response.tokenUsage(), null, response.metadata());
+    }
 
     /**
      * Moderates the given text segment.
+     *
      * @param textSegment the text segment to moderate.
      * @return the moderation {@code Response}.
      */

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
@@ -15,7 +15,6 @@ import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.input.Prompt;
 import dev.langchain4j.model.moderation.listener.ModerationModelListener;
 import dev.langchain4j.model.output.Response;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -63,7 +62,8 @@ public interface ModerationModel {
      * @return the moderation {@code Response}.
      */
     default Response<Moderation> moderate(String text) {
-        ModerationRequest request = ModerationRequest.builder().text(text).build();
+        ModerationRequest request =
+                ModerationRequest.builder().messages(List.of(text)).build();
         ModerationResponse response = moderate(request);
         return Response.from(response.moderation(), null, null, response.metadata());
     }
@@ -95,8 +95,8 @@ public interface ModerationModel {
      * @return the moderation {@code Response}.
      */
     default Response<Moderation> moderate(List<ChatMessage> messages) {
-        ModerationRequest request =
-                ModerationRequest.builder().messages(messages).build();
+        List<String> texts = messages.stream().map(ModerationModel::toText).toList();
+        ModerationRequest request = ModerationRequest.builder().messages(texts).build();
         ModerationResponse response = moderate(request);
         return Response.from(response.moderation(), null, null, response.metadata());
     }
@@ -119,14 +119,7 @@ public interface ModerationModel {
      * @return a list of text inputs extracted from the request
      */
     static List<String> toInputs(ModerationRequest moderationRequest) {
-        List<String> inputs = new ArrayList<>();
-        if (moderationRequest.hasText()) {
-            inputs.add(moderationRequest.text());
-        }
-        if (moderationRequest.hasMessages()) {
-            moderationRequest.messages().stream().map(ModerationModel::toText).forEach(inputs::add);
-        }
-        return inputs;
+        return moderationRequest.messages();
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
@@ -92,7 +92,7 @@ public interface ModerationModel {
     default Response<Moderation> moderate(String text) {
         ModerationRequest request = ModerationRequest.builder().text(text).build();
         ModerationResponse response = moderate(request);
-        return Response.from(response.moderation(), response.tokenUsage(), null, response.metadata());
+        return Response.from(response.moderation(), null, null, response.metadata());
     }
 
     /**
@@ -125,7 +125,7 @@ public interface ModerationModel {
         ModerationRequest request =
                 ModerationRequest.builder().messages(messages).build();
         ModerationResponse response = moderate(request);
-        return Response.from(response.moderation(), response.tokenUsage(), null, response.metadata());
+        return Response.from(response.moderation(), null, null, response.metadata());
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
@@ -49,7 +49,7 @@ public interface ModerationModel {
      * @return the model name, or {@code null} if not available.
      */
     default String modelName() {
-        return null;
+        return "unknown";
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
@@ -26,33 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public interface ModerationModel {
 
     /**
-     * Returns the list of listeners for this moderation model.
-     *
-     * @return the list of listeners, or an empty list if none are registered.
-     */
-    default List<ModerationModelListener> listeners() {
-        return List.of();
-    }
-
-    /**
-     * Returns the model provider for this moderation model.
-     *
-     * @return the model provider.
-     */
-    default ModelProvider provider() {
-        return OTHER;
-    }
-
-    /**
-     * Returns the model name for this moderation model.
-     *
-     * @return the model name, or {@code null} if not available.
-     */
-    default String modelName() {
-        return "unknown";
-    }
-
-    /**
      * This is the main API to interact with the moderation model.
      *
      * @param moderationRequest a {@link ModerationRequest}, containing all the inputs to the moderation model
@@ -176,5 +149,32 @@ public interface ModerationModel {
         } else {
             throw new IllegalArgumentException("Unsupported message type: " + chatMessage.type());
         }
+    }
+
+    /**
+     * Returns the list of listeners for this moderation model.
+     *
+     * @return the list of listeners, or an empty list if none are registered.
+     */
+    default List<ModerationModelListener> listeners() {
+        return List.of();
+    }
+
+    /**
+     * Returns the model provider for this moderation model.
+     *
+     * @return the model provider.
+     */
+    default ModelProvider provider() {
+        return OTHER;
+    }
+
+    /**
+     * Returns the model name for this moderation model.
+     *
+     * @return the model name, or {@code null} if not available.
+     */
+    default String modelName() {
+        return "unknown";
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
@@ -63,7 +63,7 @@ public interface ModerationModel {
      */
     default Response<Moderation> moderate(String text) {
         ModerationRequest request =
-                ModerationRequest.builder().messages(List.of(text)).build();
+                ModerationRequest.builder().texts(List.of(text)).build();
         ModerationResponse response = moderate(request);
         return Response.from(response.moderation(), null, null, response.metadata());
     }
@@ -96,7 +96,7 @@ public interface ModerationModel {
      */
     default Response<Moderation> moderate(List<ChatMessage> messages) {
         List<String> texts = messages.stream().map(ModerationModel::toText).toList();
-        ModerationRequest request = ModerationRequest.builder().messages(texts).build();
+        ModerationRequest request = ModerationRequest.builder().texts(texts).build();
         ModerationResponse response = moderate(request);
         return Response.from(response.moderation(), null, null, response.metadata());
     }
@@ -119,7 +119,7 @@ public interface ModerationModel {
      * @return a list of text inputs extracted from the request
      */
     static List<String> toInputs(ModerationRequest moderationRequest) {
-        return moderationRequest.messages();
+        return moderationRequest.texts();
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
@@ -31,16 +31,21 @@ public interface ModerationModel {
      * @return a {@link ModerationResponse}, containing all the outputs from the moderation model
      */
     default ModerationResponse moderate(ModerationRequest moderationRequest) {
+        ModerationRequest finalRequest = moderationRequest.toBuilder()
+                .modelName(moderationRequest.modelName() != null ? moderationRequest.modelName() : modelName())
+                .build();
+
+        ModelProvider modelProvider = provider();
         List<ModerationModelListener> listeners = listeners();
         Map<Object, Object> attributes = new ConcurrentHashMap<>();
 
-        onRequest(moderationRequest, provider(), modelName(), attributes, listeners);
+        onRequest(finalRequest, modelProvider, attributes, listeners);
         try {
-            ModerationResponse moderationResponse = doModerate(moderationRequest);
-            onResponse(moderationResponse, moderationRequest, provider(), modelName(), attributes, listeners);
+            ModerationResponse moderationResponse = doModerate(finalRequest);
+            onResponse(moderationResponse, finalRequest, modelProvider, attributes, listeners);
             return moderationResponse;
         } catch (Exception error) {
-            onError(error, moderationRequest, provider(), modelName(), attributes, listeners);
+            onError(error, finalRequest, modelProvider, attributes, listeners);
             throw error;
         }
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModelListenerUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModelListenerUtils.java
@@ -1,0 +1,96 @@
+package dev.langchain4j.model.moderation;
+
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+
+import dev.langchain4j.Internal;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.moderation.listener.ModerationModelErrorContext;
+import dev.langchain4j.model.moderation.listener.ModerationModelListener;
+import dev.langchain4j.model.moderation.listener.ModerationModelRequestContext;
+import dev.langchain4j.model.moderation.listener.ModerationModelResponseContext;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Internal
+class ModerationModelListenerUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ModerationModelListenerUtils.class);
+
+    private ModerationModelListenerUtils() {}
+
+    static void onRequest(
+            ModerationRequest moderationRequest,
+            ModelProvider modelProvider,
+            String modelName,
+            Map<Object, Object> attributes,
+            List<ModerationModelListener> listeners) {
+        if (isNullOrEmpty(listeners)) {
+            return;
+        }
+        ModerationModelRequestContext requestContext =
+                new ModerationModelRequestContext(moderationRequest, modelProvider, modelName, attributes);
+        listeners.forEach(listener -> {
+            try {
+                listener.onRequest(requestContext);
+            } catch (Exception e) {
+                LOG.warn(
+                        "An exception occurred during the invocation of the moderation model listener '{}'. "
+                                + "This exception has been ignored.",
+                        listener.getClass().getName(),
+                        e);
+            }
+        });
+    }
+
+    static void onResponse(
+            ModerationResponse moderationResponse,
+            ModerationRequest moderationRequest,
+            ModelProvider modelProvider,
+            String modelName,
+            Map<Object, Object> attributes,
+            List<ModerationModelListener> listeners) {
+        if (isNullOrEmpty(listeners)) {
+            return;
+        }
+        ModerationModelResponseContext responseContext = new ModerationModelResponseContext(
+                moderationResponse, moderationRequest, modelProvider, modelName, attributes);
+        listeners.forEach(listener -> {
+            try {
+                listener.onResponse(responseContext);
+            } catch (Exception e) {
+                LOG.warn(
+                        "An exception occurred during the invocation of the moderation model listener '{}'. "
+                                + "This exception has been ignored.",
+                        listener.getClass().getName(),
+                        e);
+            }
+        });
+    }
+
+    static void onError(
+            Throwable error,
+            ModerationRequest moderationRequest,
+            ModelProvider modelProvider,
+            String modelName,
+            Map<Object, Object> attributes,
+            List<ModerationModelListener> listeners) {
+        if (isNullOrEmpty(listeners)) {
+            return;
+        }
+        ModerationModelErrorContext errorContext =
+                new ModerationModelErrorContext(error, moderationRequest, modelProvider, modelName, attributes);
+        listeners.forEach(listener -> {
+            try {
+                listener.onError(errorContext);
+            } catch (Exception e) {
+                LOG.warn(
+                        "An exception occurred during the invocation of the moderation model listener '{}'. "
+                                + "This exception has been ignored.",
+                        listener.getClass().getName(),
+                        e);
+            }
+        });
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModelListenerUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModelListenerUtils.java
@@ -23,14 +23,13 @@ class ModerationModelListenerUtils {
     static void onRequest(
             ModerationRequest moderationRequest,
             ModelProvider modelProvider,
-            String modelName,
             Map<Object, Object> attributes,
             List<ModerationModelListener> listeners) {
         if (isNullOrEmpty(listeners)) {
             return;
         }
         ModerationModelRequestContext requestContext =
-                new ModerationModelRequestContext(moderationRequest, modelProvider, modelName, attributes);
+                new ModerationModelRequestContext(moderationRequest, modelProvider, attributes);
         listeners.forEach(listener -> {
             try {
                 listener.onRequest(requestContext);
@@ -48,14 +47,13 @@ class ModerationModelListenerUtils {
             ModerationResponse moderationResponse,
             ModerationRequest moderationRequest,
             ModelProvider modelProvider,
-            String modelName,
             Map<Object, Object> attributes,
             List<ModerationModelListener> listeners) {
         if (isNullOrEmpty(listeners)) {
             return;
         }
-        ModerationModelResponseContext responseContext = new ModerationModelResponseContext(
-                moderationResponse, moderationRequest, modelProvider, modelName, attributes);
+        ModerationModelResponseContext responseContext =
+                new ModerationModelResponseContext(moderationResponse, moderationRequest, modelProvider, attributes);
         listeners.forEach(listener -> {
             try {
                 listener.onResponse(responseContext);
@@ -73,14 +71,13 @@ class ModerationModelListenerUtils {
             Throwable error,
             ModerationRequest moderationRequest,
             ModelProvider modelProvider,
-            String modelName,
             Map<Object, Object> attributes,
             List<ModerationModelListener> listeners) {
         if (isNullOrEmpty(listeners)) {
             return;
         }
         ModerationModelErrorContext errorContext =
-                new ModerationModelErrorContext(error, moderationRequest, modelProvider, modelName, attributes);
+                new ModerationModelErrorContext(error, moderationRequest, modelProvider, attributes);
         listeners.forEach(listener -> {
             try {
                 listener.onError(errorContext);

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationRequest.java
@@ -1,0 +1,151 @@
+package dev.langchain4j.model.moderation;
+
+import static dev.langchain4j.internal.Utils.copyIfNotNull;
+
+import dev.langchain4j.data.message.ChatMessage;
+import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents a moderation request.
+ */
+public class ModerationRequest {
+
+    @Nullable
+    private final String text;
+
+    @Nullable
+    private final List<ChatMessage> messages;
+
+    private ModerationRequest(Builder builder) {
+        this.text = builder.text;
+        this.messages = copyIfNotNull(builder.messages);
+    }
+
+    /**
+     * Returns the text to moderate.
+     *
+     * @return the text to moderate, or {@code null} if not set.
+     */
+    @Nullable
+    public String text() {
+        return text;
+    }
+
+    /**
+     * Returns the list of chat messages to moderate.
+     *
+     * @return the list of chat messages to moderate, or {@code null} if not set.
+     */
+    @Nullable
+    public List<ChatMessage> messages() {
+        return messages;
+    }
+
+    /**
+     * Returns {@code true} if text is set.
+     *
+     * @return {@code true} if text is set.
+     */
+    public boolean hasText() {
+        return text != null;
+    }
+
+    /**
+     * Returns {@code true} if messages are set.
+     *
+     * @return {@code true} if messages are set.
+     */
+    public boolean hasMessages() {
+        return messages != null && !messages.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ModerationRequest that = (ModerationRequest) o;
+        return Objects.equals(text, that.text) && Objects.equals(messages, that.messages);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(text, messages);
+    }
+
+    @Override
+    public String toString() {
+        return "ModerationRequest{" + "text=" + text + ", messages=" + messages + '}';
+    }
+
+    /**
+     * Converts this instance to a {@link Builder} with all of the same field values,
+     * allowing modifications to the current object's fields.
+     *
+     * @return a new {@link Builder} instance initialized with the current state of this {@code ModerationRequest}.
+     */
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    /**
+     * Creates a new builder.
+     *
+     * @return a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link ModerationRequest}.
+     */
+    public static class Builder {
+
+        private String text;
+        private List<ChatMessage> messages;
+
+        private Builder() {}
+
+        private Builder(ModerationRequest request) {
+            this.text = request.text;
+            this.messages = request.messages;
+        }
+
+        /**
+         * Sets the text to moderate.
+         *
+         * @param text the text to moderate.
+         * @return this builder.
+         */
+        public Builder text(String text) {
+            this.text = text;
+            return this;
+        }
+
+        /**
+         * Sets the list of chat messages to moderate.
+         *
+         * @param messages the list of chat messages to moderate.
+         * @return this builder.
+         */
+        public Builder messages(List<ChatMessage> messages) {
+            this.messages = messages;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link ModerationRequest}.
+         *
+         * @return a new {@link ModerationRequest}.
+         * @throws IllegalArgumentException if neither text nor messages are set.
+         */
+        public ModerationRequest build() {
+            if (text == null && (messages == null || messages.isEmpty())) {
+                throw new IllegalArgumentException("Either text or messages must be set");
+            }
+            return new ModerationRequest(this);
+        }
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationRequest.java
@@ -142,8 +142,13 @@ public class ModerationRequest {
          * @throws IllegalArgumentException if neither text nor messages are set.
          */
         public ModerationRequest build() {
-            if (text == null && (messages == null || messages.isEmpty())) {
+            boolean hasText = text != null;
+            boolean hasMessages = messages != null && !messages.isEmpty();
+            if (!hasText && !hasMessages) {
                 throw new IllegalArgumentException("Either text or messages must be set");
+            }
+            if (hasText && hasMessages) {
+                throw new IllegalArgumentException("Only one of text or messages can be set, not both");
             }
             return new ModerationRequest(this);
         }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationRequest.java
@@ -1,64 +1,29 @@
 package dev.langchain4j.model.moderation;
 
 import static dev.langchain4j.internal.Utils.copyIfNotNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 
-import dev.langchain4j.data.message.ChatMessage;
 import java.util.List;
 import java.util.Objects;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a moderation request.
  */
 public class ModerationRequest {
 
-    @Nullable
-    private final String text;
-
-    @Nullable
-    private final List<ChatMessage> messages;
+    private final List<String> messages;
 
     private ModerationRequest(Builder builder) {
-        this.text = builder.text;
         this.messages = copyIfNotNull(builder.messages);
     }
 
     /**
-     * Returns the text to moderate.
+     * Returns the list of text messages to moderate.
      *
-     * @return the text to moderate, or {@code null} if not set.
+     * @return the list of text messages to moderate.
      */
-    @Nullable
-    public String text() {
-        return text;
-    }
-
-    /**
-     * Returns the list of chat messages to moderate.
-     *
-     * @return the list of chat messages to moderate, or {@code null} if not set.
-     */
-    @Nullable
-    public List<ChatMessage> messages() {
+    public List<String> messages() {
         return messages;
-    }
-
-    /**
-     * Returns {@code true} if text is set.
-     *
-     * @return {@code true} if text is set.
-     */
-    public boolean hasText() {
-        return text != null;
-    }
-
-    /**
-     * Returns {@code true} if messages are set.
-     *
-     * @return {@code true} if messages are set.
-     */
-    public boolean hasMessages() {
-        return messages != null && !messages.isEmpty();
     }
 
     @Override
@@ -66,17 +31,17 @@ public class ModerationRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ModerationRequest that = (ModerationRequest) o;
-        return Objects.equals(text, that.text) && Objects.equals(messages, that.messages);
+        return Objects.equals(messages, that.messages);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(text, messages);
+        return Objects.hash(messages);
     }
 
     @Override
     public String toString() {
-        return "ModerationRequest{" + "text=" + text + ", messages=" + messages + '}';
+        return "ModerationRequest{" + "messages=" + messages + '}';
     }
 
     /**
@@ -103,34 +68,21 @@ public class ModerationRequest {
      */
     public static class Builder {
 
-        private String text;
-        private List<ChatMessage> messages;
+        private List<String> messages;
 
         private Builder() {}
 
         private Builder(ModerationRequest request) {
-            this.text = request.text;
             this.messages = request.messages;
         }
 
         /**
-         * Sets the text to moderate.
+         * Sets the list of text messages to moderate.
          *
-         * @param text the text to moderate.
+         * @param messages the list of text messages to moderate.
          * @return this builder.
          */
-        public Builder text(String text) {
-            this.text = text;
-            return this;
-        }
-
-        /**
-         * Sets the list of chat messages to moderate.
-         *
-         * @param messages the list of chat messages to moderate.
-         * @return this builder.
-         */
-        public Builder messages(List<ChatMessage> messages) {
+        public Builder messages(List<String> messages) {
             this.messages = messages;
             return this;
         }
@@ -139,17 +91,10 @@ public class ModerationRequest {
          * Builds a new {@link ModerationRequest}.
          *
          * @return a new {@link ModerationRequest}.
-         * @throws IllegalArgumentException if neither text nor messages are set.
+         * @throws IllegalArgumentException if messages is null or empty.
          */
         public ModerationRequest build() {
-            boolean hasText = text != null;
-            boolean hasMessages = messages != null && !messages.isEmpty();
-            if (!hasText && !hasMessages) {
-                throw new IllegalArgumentException("Either text or messages must be set");
-            }
-            if (hasText && hasMessages) {
-                throw new IllegalArgumentException("Only one of text or messages can be set, not both");
-            }
+            ensureNotEmpty(messages, "messages");
             return new ModerationRequest(this);
         }
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationRequest.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 
 import java.util.List;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a moderation request.
@@ -13,8 +14,12 @@ public class ModerationRequest {
 
     private final List<String> texts;
 
+    @Nullable
+    private final String modelName;
+
     private ModerationRequest(Builder builder) {
         this.texts = copyIfNotNull(builder.texts);
+        this.modelName = builder.modelName;
     }
 
     /**
@@ -26,22 +31,33 @@ public class ModerationRequest {
         return texts;
     }
 
+    /**
+     * Returns the model name to use for this request.
+     * When set, this overrides the model name configured when the {@link ModerationModel} was created.
+     *
+     * @return the model name, or {@code null} if not specified.
+     */
+    @Nullable
+    public String modelName() {
+        return modelName;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ModerationRequest that = (ModerationRequest) o;
-        return Objects.equals(texts, that.texts);
+        return Objects.equals(texts, that.texts) && Objects.equals(modelName, that.modelName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(texts);
+        return Objects.hash(texts, modelName);
     }
 
     @Override
     public String toString() {
-        return "ModerationRequest{" + "texts=" + texts + '}';
+        return "ModerationRequest{" + "texts=" + texts + ", modelName='" + modelName + '\'' + '}';
     }
 
     /**
@@ -69,11 +85,13 @@ public class ModerationRequest {
     public static class Builder {
 
         private List<String> texts;
+        private String modelName;
 
         private Builder() {}
 
         private Builder(ModerationRequest request) {
             this.texts = request.texts;
+            this.modelName = request.modelName;
         }
 
         /**
@@ -84,6 +102,18 @@ public class ModerationRequest {
          */
         public Builder texts(List<String> texts) {
             this.texts = texts;
+            return this;
+        }
+
+        /**
+         * Sets the model name to use for this request.
+         * When set, this overrides the model name configured when the {@link ModerationModel} was created.
+         *
+         * @param modelName the model name.
+         * @return this builder.
+         */
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
             return this;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationRequest.java
@@ -11,19 +11,19 @@ import java.util.Objects;
  */
 public class ModerationRequest {
 
-    private final List<String> messages;
+    private final List<String> texts;
 
     private ModerationRequest(Builder builder) {
-        this.messages = copyIfNotNull(builder.messages);
+        this.texts = copyIfNotNull(builder.texts);
     }
 
     /**
-     * Returns the list of text messages to moderate.
+     * Returns the list of texts to moderate.
      *
-     * @return the list of text messages to moderate.
+     * @return the list of texts to moderate.
      */
-    public List<String> messages() {
-        return messages;
+    public List<String> texts() {
+        return texts;
     }
 
     @Override
@@ -31,17 +31,17 @@ public class ModerationRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ModerationRequest that = (ModerationRequest) o;
-        return Objects.equals(messages, that.messages);
+        return Objects.equals(texts, that.texts);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(messages);
+        return Objects.hash(texts);
     }
 
     @Override
     public String toString() {
-        return "ModerationRequest{" + "messages=" + messages + '}';
+        return "ModerationRequest{" + "texts=" + texts + '}';
     }
 
     /**
@@ -68,22 +68,22 @@ public class ModerationRequest {
      */
     public static class Builder {
 
-        private List<String> messages;
+        private List<String> texts;
 
         private Builder() {}
 
         private Builder(ModerationRequest request) {
-            this.messages = request.messages;
+            this.texts = request.texts;
         }
 
         /**
-         * Sets the list of text messages to moderate.
+         * Sets the list of texts to moderate.
          *
-         * @param messages the list of text messages to moderate.
+         * @param texts the list of texts to moderate.
          * @return this builder.
          */
-        public Builder messages(List<String> messages) {
-            this.messages = messages;
+        public Builder texts(List<String> texts) {
+            this.texts = texts;
             return this;
         }
 
@@ -91,10 +91,10 @@ public class ModerationRequest {
          * Builds a new {@link ModerationRequest}.
          *
          * @return a new {@link ModerationRequest}.
-         * @throws IllegalArgumentException if messages is null or empty.
+         * @throws IllegalArgumentException if texts is null or empty.
          */
         public ModerationRequest build() {
-            ensureNotEmpty(messages, "messages");
+            ensureNotEmpty(texts, "texts");
             return new ModerationRequest(this);
         }
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationResponse.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationResponse.java
@@ -3,7 +3,6 @@ package dev.langchain4j.model.moderation;
 import static dev.langchain4j.internal.Utils.copyIfNotNull;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
-import dev.langchain4j.model.output.TokenUsage;
 import java.util.Map;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
@@ -16,14 +15,10 @@ public class ModerationResponse {
     private final Moderation moderation;
 
     @Nullable
-    private final TokenUsage tokenUsage;
-
-    @Nullable
     private final Map<String, Object> metadata;
 
     private ModerationResponse(Builder builder) {
         this.moderation = ensureNotNull(builder.moderation, "moderation");
-        this.tokenUsage = builder.tokenUsage;
         this.metadata = copyIfNotNull(builder.metadata);
     }
 
@@ -34,16 +29,6 @@ public class ModerationResponse {
      */
     public Moderation moderation() {
         return moderation;
-    }
-
-    /**
-     * Returns the token usage, if available.
-     *
-     * @return the token usage, or {@code null} if not available.
-     */
-    @Nullable
-    public TokenUsage tokenUsage() {
-        return tokenUsage;
     }
 
     /**
@@ -61,22 +46,17 @@ public class ModerationResponse {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ModerationResponse that = (ModerationResponse) o;
-        return Objects.equals(moderation, that.moderation)
-                && Objects.equals(tokenUsage, that.tokenUsage)
-                && Objects.equals(metadata, that.metadata);
+        return Objects.equals(moderation, that.moderation) && Objects.equals(metadata, that.metadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(moderation, tokenUsage, metadata);
+        return Objects.hash(moderation, metadata);
     }
 
     @Override
     public String toString() {
-        return "ModerationResponse{" + "moderation="
-                + moderation + ", tokenUsage="
-                + tokenUsage + ", metadata="
-                + metadata + '}';
+        return "ModerationResponse{" + "moderation=" + moderation + ", metadata=" + metadata + '}';
     }
 
     /**
@@ -104,14 +84,12 @@ public class ModerationResponse {
     public static class Builder {
 
         private Moderation moderation;
-        private TokenUsage tokenUsage;
         private Map<String, Object> metadata;
 
         private Builder() {}
 
         private Builder(ModerationResponse response) {
             this.moderation = response.moderation;
-            this.tokenUsage = response.tokenUsage;
             this.metadata = response.metadata;
         }
 
@@ -123,17 +101,6 @@ public class ModerationResponse {
          */
         public Builder moderation(Moderation moderation) {
             this.moderation = moderation;
-            return this;
-        }
-
-        /**
-         * Sets the token usage.
-         *
-         * @param tokenUsage the token usage.
-         * @return this builder.
-         */
-        public Builder tokenUsage(TokenUsage tokenUsage) {
-            this.tokenUsage = tokenUsage;
             return this;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationResponse.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationResponse.java
@@ -1,0 +1,160 @@
+package dev.langchain4j.model.moderation;
+
+import static dev.langchain4j.internal.Utils.copyIfNotNull;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.model.output.TokenUsage;
+import java.util.Map;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents a moderation response.
+ */
+public class ModerationResponse {
+
+    private final Moderation moderation;
+
+    @Nullable
+    private final TokenUsage tokenUsage;
+
+    @Nullable
+    private final Map<String, Object> metadata;
+
+    private ModerationResponse(Builder builder) {
+        this.moderation = ensureNotNull(builder.moderation, "moderation");
+        this.tokenUsage = builder.tokenUsage;
+        this.metadata = copyIfNotNull(builder.metadata);
+    }
+
+    /**
+     * Returns the moderation result.
+     *
+     * @return the moderation result.
+     */
+    public Moderation moderation() {
+        return moderation;
+    }
+
+    /**
+     * Returns the token usage, if available.
+     *
+     * @return the token usage, or {@code null} if not available.
+     */
+    @Nullable
+    public TokenUsage tokenUsage() {
+        return tokenUsage;
+    }
+
+    /**
+     * Returns the metadata, if available.
+     *
+     * @return the metadata, or {@code null} if not available.
+     */
+    @Nullable
+    public Map<String, Object> metadata() {
+        return metadata;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ModerationResponse that = (ModerationResponse) o;
+        return Objects.equals(moderation, that.moderation)
+                && Objects.equals(tokenUsage, that.tokenUsage)
+                && Objects.equals(metadata, that.metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(moderation, tokenUsage, metadata);
+    }
+
+    @Override
+    public String toString() {
+        return "ModerationResponse{" + "moderation="
+                + moderation + ", tokenUsage="
+                + tokenUsage + ", metadata="
+                + metadata + '}';
+    }
+
+    /**
+     * Converts this instance to a {@link Builder} with all of the same field values,
+     * allowing modifications to the current object's fields.
+     *
+     * @return a new {@link Builder} instance initialized with the current state of this {@code ModerationResponse}.
+     */
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    /**
+     * Creates a new builder.
+     *
+     * @return a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link ModerationResponse}.
+     */
+    public static class Builder {
+
+        private Moderation moderation;
+        private TokenUsage tokenUsage;
+        private Map<String, Object> metadata;
+
+        private Builder() {}
+
+        private Builder(ModerationResponse response) {
+            this.moderation = response.moderation;
+            this.tokenUsage = response.tokenUsage;
+            this.metadata = response.metadata;
+        }
+
+        /**
+         * Sets the moderation result.
+         *
+         * @param moderation the moderation result.
+         * @return this builder.
+         */
+        public Builder moderation(Moderation moderation) {
+            this.moderation = moderation;
+            return this;
+        }
+
+        /**
+         * Sets the token usage.
+         *
+         * @param tokenUsage the token usage.
+         * @return this builder.
+         */
+        public Builder tokenUsage(TokenUsage tokenUsage) {
+            this.tokenUsage = tokenUsage;
+            return this;
+        }
+
+        /**
+         * Sets the metadata.
+         *
+         * @param metadata the metadata.
+         * @return this builder.
+         */
+        public Builder metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link ModerationResponse}.
+         *
+         * @return a new {@link ModerationResponse}.
+         */
+        public ModerationResponse build() {
+            return new ModerationResponse(this);
+        }
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationResponse.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationResponse.java
@@ -1,11 +1,10 @@
 package dev.langchain4j.model.moderation;
 
-import static dev.langchain4j.internal.Utils.copyIfNotNull;
+import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import java.util.Map;
 import java.util.Objects;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a moderation response.
@@ -14,12 +13,11 @@ public class ModerationResponse {
 
     private final Moderation moderation;
 
-    @Nullable
     private final Map<String, Object> metadata;
 
     private ModerationResponse(Builder builder) {
         this.moderation = ensureNotNull(builder.moderation, "moderation");
-        this.metadata = copyIfNotNull(builder.metadata);
+        this.metadata = copy(builder.metadata);
     }
 
     /**
@@ -32,11 +30,10 @@ public class ModerationResponse {
     }
 
     /**
-     * Returns the metadata, if available.
+     * Returns the metadata.
      *
-     * @return the metadata, or {@code null} if not available.
+     * @return the metadata.
      */
-    @Nullable
     public Map<String, Object> metadata() {
         return metadata;
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelErrorContext.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelErrorContext.java
@@ -1,0 +1,100 @@
+package dev.langchain4j.model.moderation.listener;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.moderation.ModerationRequest;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The moderation model error context.
+ * It contains the error, corresponding {@link ModerationRequest}, {@link ModelProvider}, model name and attributes.
+ * The attributes can be used to pass data between methods of a {@link ModerationModelListener}
+ * or between multiple {@link ModerationModelListener}s.
+ */
+public class ModerationModelErrorContext {
+
+    private final Throwable error;
+    private final ModerationRequest moderationRequest;
+
+    @Nullable
+    private final ModelProvider modelProvider;
+
+    @Nullable
+    private final String modelName;
+
+    private final Map<Object, Object> attributes;
+
+    /**
+     * Creates a new {@link ModerationModelErrorContext}.
+     *
+     * @param error              the error that occurred.
+     * @param moderationRequest  the moderation request.
+     * @param modelProvider      the model provider, or {@code null} if not available.
+     * @param modelName          the model name, or {@code null} if not available.
+     * @param attributes         the attributes map.
+     */
+    public ModerationModelErrorContext(
+            Throwable error,
+            ModerationRequest moderationRequest,
+            @Nullable ModelProvider modelProvider,
+            @Nullable String modelName,
+            Map<Object, Object> attributes) {
+        this.error = ensureNotNull(error, "error");
+        this.moderationRequest = ensureNotNull(moderationRequest, "moderationRequest");
+        this.modelProvider = modelProvider;
+        this.modelName = modelName;
+        this.attributes = ensureNotNull(attributes, "attributes");
+    }
+
+    /**
+     * @return The error that occurred.
+     */
+    public Throwable error() {
+        return error;
+    }
+
+    /**
+     * @return The moderation request.
+     */
+    public ModerationRequest moderationRequest() {
+        return moderationRequest;
+    }
+
+    /**
+     * @return The model provider, or {@code null} if not available.
+     */
+    @Nullable
+    public ModelProvider modelProvider() {
+        return modelProvider;
+    }
+
+    /**
+     * Returns the model name.
+     *
+     * @return the model name, or {@code null} if not available.
+     */
+    @Nullable
+    public String modelName() {
+        return modelName;
+    }
+
+    /**
+     * @return The attributes map. It can be used to pass data between methods of a {@link ModerationModelListener}
+     * or between multiple {@link ModerationModelListener}s.
+     */
+    public Map<Object, Object> attributes() {
+        return attributes;
+    }
+
+    @Override
+    public String toString() {
+        return "ModerationModelErrorContext{" + "error="
+                + error + ", moderationRequest="
+                + moderationRequest + ", modelProvider="
+                + modelProvider + ", modelName='"
+                + modelName + '\'' + ", attributes="
+                + attributes + '}';
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelErrorContext.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelErrorContext.java
@@ -9,7 +9,7 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * The moderation model error context.
- * It contains the error, corresponding {@link ModerationRequest}, {@link ModelProvider}, model name and attributes.
+ * It contains the error, corresponding {@link ModerationRequest}, {@link ModelProvider} and attributes.
  * The attributes can be used to pass data between methods of a {@link ModerationModelListener}
  * or between multiple {@link ModerationModelListener}s.
  */
@@ -21,9 +21,6 @@ public class ModerationModelErrorContext {
     @Nullable
     private final ModelProvider modelProvider;
 
-    @Nullable
-    private final String modelName;
-
     private final Map<Object, Object> attributes;
 
     /**
@@ -32,19 +29,16 @@ public class ModerationModelErrorContext {
      * @param error              the error that occurred.
      * @param moderationRequest  the moderation request.
      * @param modelProvider      the model provider, or {@code null} if not available.
-     * @param modelName          the model name, or {@code null} if not available.
      * @param attributes         the attributes map.
      */
     public ModerationModelErrorContext(
             Throwable error,
             ModerationRequest moderationRequest,
             @Nullable ModelProvider modelProvider,
-            @Nullable String modelName,
             Map<Object, Object> attributes) {
         this.error = ensureNotNull(error, "error");
         this.moderationRequest = ensureNotNull(moderationRequest, "moderationRequest");
         this.modelProvider = modelProvider;
-        this.modelName = modelName;
         this.attributes = ensureNotNull(attributes, "attributes");
     }
 
@@ -71,16 +65,6 @@ public class ModerationModelErrorContext {
     }
 
     /**
-     * Returns the model name.
-     *
-     * @return the model name, or {@code null} if not available.
-     */
-    @Nullable
-    public String modelName() {
-        return modelName;
-    }
-
-    /**
      * @return The attributes map. It can be used to pass data between methods of a {@link ModerationModelListener}
      * or between multiple {@link ModerationModelListener}s.
      */
@@ -93,8 +77,7 @@ public class ModerationModelErrorContext {
         return "ModerationModelErrorContext{" + "error="
                 + error + ", moderationRequest="
                 + moderationRequest + ", modelProvider="
-                + modelProvider + ", modelName='"
-                + modelName + '\'' + ", attributes="
+                + modelProvider + ", attributes="
                 + attributes + '}';
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelListener.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelListener.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.model.moderation.listener;
+
+import dev.langchain4j.model.moderation.ModerationModel;
+import dev.langchain4j.model.moderation.ModerationRequest;
+import dev.langchain4j.model.moderation.ModerationResponse;
+
+/**
+ * A {@link ModerationModel} listener that listens for requests, responses and errors.
+ */
+public interface ModerationModelListener {
+
+    /**
+     * This method is called before the request is sent to the moderation model.
+     *
+     * @param requestContext The request context. It contains the {@link ModerationRequest} and attributes.
+     *                       The attributes can be used to pass data between methods of this listener
+     *                       or between multiple listeners.
+     */
+    default void onRequest(ModerationModelRequestContext requestContext) {}
+
+    /**
+     * This method is called after the response is received from the model.
+     *
+     * @param responseContext The response context.
+     *                        It contains {@link ModerationResponse}, corresponding {@link ModerationRequest} and attributes.
+     *                        The attributes can be used to pass data between methods of this listener
+     *                        or between multiple listeners.
+     */
+    default void onResponse(ModerationModelResponseContext responseContext) {}
+
+    /**
+     * This method is called when an error occurs during interaction with the model.
+     *
+     * @param errorContext The error context.
+     *                     It contains the error, corresponding {@link ModerationRequest} and attributes.
+     *                     The attributes can be used to pass data between methods of this listener
+     *                     or between multiple listeners.
+     */
+    default void onError(ModerationModelErrorContext errorContext) {}
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelRequestContext.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelRequestContext.java
@@ -1,0 +1,88 @@
+package dev.langchain4j.model.moderation.listener;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.moderation.ModerationRequest;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The moderation model request context.
+ * It contains the {@link ModerationRequest}, {@link ModelProvider}, model name and attributes.
+ * The attributes can be used to pass data between methods of a {@link ModerationModelListener}
+ * or between multiple {@link ModerationModelListener}s.
+ */
+public class ModerationModelRequestContext {
+
+    private final ModerationRequest moderationRequest;
+
+    @Nullable
+    private final ModelProvider modelProvider;
+
+    @Nullable
+    private final String modelName;
+
+    private final Map<Object, Object> attributes;
+
+    /**
+     * Creates a new {@link ModerationModelRequestContext}.
+     *
+     * @param moderationRequest the moderation request.
+     * @param modelProvider     the model provider, or {@code null} if not available.
+     * @param modelName         the model name, or {@code null} if not available.
+     * @param attributes        the attributes map.
+     */
+    public ModerationModelRequestContext(
+            ModerationRequest moderationRequest,
+            @Nullable ModelProvider modelProvider,
+            @Nullable String modelName,
+            Map<Object, Object> attributes) {
+        this.moderationRequest = ensureNotNull(moderationRequest, "moderationRequest");
+        this.modelProvider = modelProvider;
+        this.modelName = modelName;
+        this.attributes = ensureNotNull(attributes, "attributes");
+    }
+
+    /**
+     * @return The moderation request.
+     */
+    public ModerationRequest moderationRequest() {
+        return moderationRequest;
+    }
+
+    /**
+     * @return The model provider, or {@code null} if not available.
+     */
+    @Nullable
+    public ModelProvider modelProvider() {
+        return modelProvider;
+    }
+
+    /**
+     * Returns the model name.
+     *
+     * @return the model name, or {@code null} if not available.
+     */
+    @Nullable
+    public String modelName() {
+        return modelName;
+    }
+
+    /**
+     * @return The attributes map. It can be used to pass data between methods of a {@link ModerationModelListener}
+     * or between multiple {@link ModerationModelListener}s.
+     */
+    public Map<Object, Object> attributes() {
+        return attributes;
+    }
+
+    @Override
+    public String toString() {
+        return "ModerationModelRequestContext{" + "moderationRequest="
+                + moderationRequest + ", modelProvider="
+                + modelProvider + ", modelName='"
+                + modelName + '\'' + ", attributes="
+                + attributes + '}';
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelRequestContext.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelRequestContext.java
@@ -9,7 +9,7 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * The moderation model request context.
- * It contains the {@link ModerationRequest}, {@link ModelProvider}, model name and attributes.
+ * It contains the {@link ModerationRequest}, {@link ModelProvider} and attributes.
  * The attributes can be used to pass data between methods of a {@link ModerationModelListener}
  * or between multiple {@link ModerationModelListener}s.
  */
@@ -20,9 +20,6 @@ public class ModerationModelRequestContext {
     @Nullable
     private final ModelProvider modelProvider;
 
-    @Nullable
-    private final String modelName;
-
     private final Map<Object, Object> attributes;
 
     /**
@@ -30,17 +27,14 @@ public class ModerationModelRequestContext {
      *
      * @param moderationRequest the moderation request.
      * @param modelProvider     the model provider, or {@code null} if not available.
-     * @param modelName         the model name, or {@code null} if not available.
      * @param attributes        the attributes map.
      */
     public ModerationModelRequestContext(
             ModerationRequest moderationRequest,
             @Nullable ModelProvider modelProvider,
-            @Nullable String modelName,
             Map<Object, Object> attributes) {
         this.moderationRequest = ensureNotNull(moderationRequest, "moderationRequest");
         this.modelProvider = modelProvider;
-        this.modelName = modelName;
         this.attributes = ensureNotNull(attributes, "attributes");
     }
 
@@ -60,16 +54,6 @@ public class ModerationModelRequestContext {
     }
 
     /**
-     * Returns the model name.
-     *
-     * @return the model name, or {@code null} if not available.
-     */
-    @Nullable
-    public String modelName() {
-        return modelName;
-    }
-
-    /**
      * @return The attributes map. It can be used to pass data between methods of a {@link ModerationModelListener}
      * or between multiple {@link ModerationModelListener}s.
      */
@@ -81,8 +65,7 @@ public class ModerationModelRequestContext {
     public String toString() {
         return "ModerationModelRequestContext{" + "moderationRequest="
                 + moderationRequest + ", modelProvider="
-                + modelProvider + ", modelName='"
-                + modelName + '\'' + ", attributes="
+                + modelProvider + ", attributes="
                 + attributes + '}';
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelResponseContext.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelResponseContext.java
@@ -1,0 +1,101 @@
+package dev.langchain4j.model.moderation.listener;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.moderation.ModerationRequest;
+import dev.langchain4j.model.moderation.ModerationResponse;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The moderation model response context.
+ * It contains {@link ModerationResponse}, corresponding {@link ModerationRequest}, {@link ModelProvider}, model name and attributes.
+ * The attributes can be used to pass data between methods of a {@link ModerationModelListener}
+ * or between multiple {@link ModerationModelListener}s.
+ */
+public class ModerationModelResponseContext {
+
+    private final ModerationResponse moderationResponse;
+    private final ModerationRequest moderationRequest;
+
+    @Nullable
+    private final ModelProvider modelProvider;
+
+    @Nullable
+    private final String modelName;
+
+    private final Map<Object, Object> attributes;
+
+    /**
+     * Creates a new {@link ModerationModelResponseContext}.
+     *
+     * @param moderationResponse the moderation response.
+     * @param moderationRequest  the moderation request.
+     * @param modelProvider      the model provider, or {@code null} if not available.
+     * @param modelName          the model name, or {@code null} if not available.
+     * @param attributes         the attributes map.
+     */
+    public ModerationModelResponseContext(
+            ModerationResponse moderationResponse,
+            ModerationRequest moderationRequest,
+            @Nullable ModelProvider modelProvider,
+            @Nullable String modelName,
+            Map<Object, Object> attributes) {
+        this.moderationResponse = ensureNotNull(moderationResponse, "moderationResponse");
+        this.moderationRequest = ensureNotNull(moderationRequest, "moderationRequest");
+        this.modelProvider = modelProvider;
+        this.modelName = modelName;
+        this.attributes = ensureNotNull(attributes, "attributes");
+    }
+
+    /**
+     * @return The moderation response.
+     */
+    public ModerationResponse moderationResponse() {
+        return moderationResponse;
+    }
+
+    /**
+     * @return The moderation request.
+     */
+    public ModerationRequest moderationRequest() {
+        return moderationRequest;
+    }
+
+    /**
+     * @return The model provider, or {@code null} if not available.
+     */
+    @Nullable
+    public ModelProvider modelProvider() {
+        return modelProvider;
+    }
+
+    /**
+     * Returns the model name.
+     *
+     * @return the model name, or {@code null} if not available.
+     */
+    @Nullable
+    public String modelName() {
+        return modelName;
+    }
+
+    /**
+     * @return The attributes map. It can be used to pass data between methods of a {@link ModerationModelListener}
+     * or between multiple {@link ModerationModelListener}s.
+     */
+    public Map<Object, Object> attributes() {
+        return attributes;
+    }
+
+    @Override
+    public String toString() {
+        return "ModerationModelResponseContext{" + "moderationResponse="
+                + moderationResponse + ", moderationRequest="
+                + moderationRequest + ", modelProvider="
+                + modelProvider + ", modelName='"
+                + modelName + '\'' + ", attributes="
+                + attributes + '}';
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelResponseContext.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/listener/ModerationModelResponseContext.java
@@ -10,7 +10,7 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * The moderation model response context.
- * It contains {@link ModerationResponse}, corresponding {@link ModerationRequest}, {@link ModelProvider}, model name and attributes.
+ * It contains {@link ModerationResponse}, corresponding {@link ModerationRequest}, {@link ModelProvider} and attributes.
  * The attributes can be used to pass data between methods of a {@link ModerationModelListener}
  * or between multiple {@link ModerationModelListener}s.
  */
@@ -22,9 +22,6 @@ public class ModerationModelResponseContext {
     @Nullable
     private final ModelProvider modelProvider;
 
-    @Nullable
-    private final String modelName;
-
     private final Map<Object, Object> attributes;
 
     /**
@@ -33,19 +30,16 @@ public class ModerationModelResponseContext {
      * @param moderationResponse the moderation response.
      * @param moderationRequest  the moderation request.
      * @param modelProvider      the model provider, or {@code null} if not available.
-     * @param modelName          the model name, or {@code null} if not available.
      * @param attributes         the attributes map.
      */
     public ModerationModelResponseContext(
             ModerationResponse moderationResponse,
             ModerationRequest moderationRequest,
             @Nullable ModelProvider modelProvider,
-            @Nullable String modelName,
             Map<Object, Object> attributes) {
         this.moderationResponse = ensureNotNull(moderationResponse, "moderationResponse");
         this.moderationRequest = ensureNotNull(moderationRequest, "moderationRequest");
         this.modelProvider = modelProvider;
-        this.modelName = modelName;
         this.attributes = ensureNotNull(attributes, "attributes");
     }
 
@@ -72,16 +66,6 @@ public class ModerationModelResponseContext {
     }
 
     /**
-     * Returns the model name.
-     *
-     * @return the model name, or {@code null} if not available.
-     */
-    @Nullable
-    public String modelName() {
-        return modelName;
-    }
-
-    /**
      * @return The attributes map. It can be used to pass data between methods of a {@link ModerationModelListener}
      * or between multiple {@link ModerationModelListener}s.
      */
@@ -94,8 +78,7 @@ public class ModerationModelResponseContext {
         return "ModerationModelResponseContext{" + "moderationResponse="
                 + moderationResponse + ", moderationRequest="
                 + moderationRequest + ", modelProvider="
-                + modelProvider + ", modelName='"
-                + modelName + '\'' + ", attributes="
+                + modelProvider + ", attributes="
                 + attributes + '}';
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationModelTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationModelTest.java
@@ -1,27 +1,28 @@
 package dev.langchain4j.model.moderation;
 
-import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.input.Prompt;
 import dev.langchain4j.model.output.Response;
+import java.util.List;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 class ModerationModelTest implements WithAssertions {
 
     public static class FlagEverythingModel implements ModerationModel {
 
         @Override
-        public Response<Moderation> moderate(String text) {
-            return Response.from(Moderation.flagged(text));
-        }
-
-        @Override
-        public Response<Moderation> moderate(List<ChatMessage> messages) {
-            return Response.from(Moderation.flagged(((UserMessage) messages.get(0)).singleText()));
+        public ModerationResponse doModerate(ModerationRequest moderationRequest) {
+            String flaggedText;
+            if (moderationRequest.hasText()) {
+                flaggedText = moderationRequest.text();
+            } else {
+                flaggedText = ((UserMessage) moderationRequest.messages().get(0)).singleText();
+            }
+            return ModerationResponse.builder()
+                    .moderation(Moderation.flagged(flaggedText))
+                    .build();
         }
     }
 
@@ -44,5 +45,23 @@ class ModerationModelTest implements WithAssertions {
         ModerationModel model = new FlagEverythingModel();
         Response<Moderation> response = model.moderate(TextSegment.from("Hello, world!"));
         assertThat(response).isEqualTo(Response.from(Moderation.flagged("Hello, world!")));
+    }
+
+    @Test
+    void moderate_moderation_request_with_text() {
+        ModerationModel model = new FlagEverythingModel();
+        ModerationRequest request = ModerationRequest.builder().text("hello").build();
+        ModerationResponse response = model.moderate(request);
+        assertThat(response.moderation()).isEqualTo(Moderation.flagged("hello"));
+    }
+
+    @Test
+    void moderate_moderation_request_with_messages() {
+        ModerationModel model = new FlagEverythingModel();
+        ModerationRequest request = ModerationRequest.builder()
+                .messages(List.of(UserMessage.from("user msg")))
+                .build();
+        ModerationResponse response = model.moderate(request);
+        assertThat(response.moderation()).isEqualTo(Moderation.flagged("user msg"));
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationModelTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationModelTest.java
@@ -14,12 +14,7 @@ class ModerationModelTest implements WithAssertions {
 
         @Override
         public ModerationResponse doModerate(ModerationRequest moderationRequest) {
-            String flaggedText;
-            if (moderationRequest.hasText()) {
-                flaggedText = moderationRequest.text();
-            } else {
-                flaggedText = ((UserMessage) moderationRequest.messages().get(0)).singleText();
-            }
+            String flaggedText = moderationRequest.messages().get(0);
             return ModerationResponse.builder()
                     .moderation(Moderation.flagged(flaggedText))
                     .build();
@@ -50,7 +45,8 @@ class ModerationModelTest implements WithAssertions {
     @Test
     void moderate_moderation_request_with_text() {
         ModerationModel model = new FlagEverythingModel();
-        ModerationRequest request = ModerationRequest.builder().text("hello").build();
+        ModerationRequest request =
+                ModerationRequest.builder().messages(List.of("hello")).build();
         ModerationResponse response = model.moderate(request);
         assertThat(response.moderation()).isEqualTo(Moderation.flagged("hello"));
     }
@@ -58,9 +54,8 @@ class ModerationModelTest implements WithAssertions {
     @Test
     void moderate_moderation_request_with_messages() {
         ModerationModel model = new FlagEverythingModel();
-        ModerationRequest request = ModerationRequest.builder()
-                .messages(List.of(UserMessage.from("user msg")))
-                .build();
+        ModerationRequest request =
+                ModerationRequest.builder().messages(List.of("user msg")).build();
         ModerationResponse response = model.moderate(request);
         assertThat(response.moderation()).isEqualTo(Moderation.flagged("user msg"));
     }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationModelTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationModelTest.java
@@ -14,7 +14,7 @@ class ModerationModelTest implements WithAssertions {
 
         @Override
         public ModerationResponse doModerate(ModerationRequest moderationRequest) {
-            String flaggedText = moderationRequest.messages().get(0);
+            String flaggedText = moderationRequest.texts().get(0);
             return ModerationResponse.builder()
                     .moderation(Moderation.flagged(flaggedText))
                     .build();
@@ -46,7 +46,7 @@ class ModerationModelTest implements WithAssertions {
     void moderate_moderation_request_with_text() {
         ModerationModel model = new FlagEverythingModel();
         ModerationRequest request =
-                ModerationRequest.builder().messages(List.of("hello")).build();
+                ModerationRequest.builder().texts(List.of("hello")).build();
         ModerationResponse response = model.moderate(request);
         assertThat(response.moderation()).isEqualTo(Moderation.flagged("hello"));
     }
@@ -55,7 +55,7 @@ class ModerationModelTest implements WithAssertions {
     void moderate_moderation_request_with_messages() {
         ModerationModel model = new FlagEverythingModel();
         ModerationRequest request =
-                ModerationRequest.builder().messages(List.of("user msg")).build();
+                ModerationRequest.builder().texts(List.of("user msg")).build();
         ModerationResponse response = model.moderate(request);
         assertThat(response.moderation()).isEqualTo(Moderation.flagged("user msg"));
     }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationRequestTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationRequestTest.java
@@ -3,98 +3,69 @@ package dev.langchain4j.model.moderation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import dev.langchain4j.data.message.UserMessage;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ModerationRequestTest {
 
     @Test
-    void should_throw_when_neither_text_nor_messages_set() {
-        assertThatThrownBy(() -> ModerationRequest.builder().build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Either text or messages must be set");
+    void should_throw_when_messages_not_set() {
+        assertThatThrownBy(() -> ModerationRequest.builder().build()).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void should_throw_when_messages_is_empty_list() {
         assertThatThrownBy(() -> ModerationRequest.builder().messages(List.of()).build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Either text or messages must be set");
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void should_throw_when_messages_is_null() {
         assertThatThrownBy(() -> ModerationRequest.builder().messages(null).build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Either text or messages must be set");
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void should_create_request_with_text() {
+    void should_create_request_with_single_message() {
         // when
         ModerationRequest request =
-                ModerationRequest.builder().text("some text").build();
+                ModerationRequest.builder().messages(List.of("some text")).build();
 
         // then
-        assertThat(request.text()).isEqualTo("some text");
-        assertThat(request.messages()).isNull();
-        assertThat(request.hasText()).isTrue();
-        assertThat(request.hasMessages()).isFalse();
+        assertThat(request.messages()).containsExactly("some text");
     }
 
     @Test
-    void should_create_request_with_messages() {
-        // given
-        UserMessage message = UserMessage.from("hello");
-
+    void should_create_request_with_multiple_messages() {
         // when
-        ModerationRequest request =
-                ModerationRequest.builder().messages(List.of(message)).build();
+        ModerationRequest request = ModerationRequest.builder()
+                .messages(List.of("first", "second", "third"))
+                .build();
 
         // then
-        assertThat(request.text()).isNull();
-        assertThat(request.messages()).containsExactly(message);
-        assertThat(request.hasText()).isFalse();
-        assertThat(request.hasMessages()).isTrue();
-    }
-
-    @Test
-    void should_throw_when_both_text_and_messages_set() {
-        // given
-        UserMessage message = UserMessage.from("hello");
-
-        // when-then
-        assertThatThrownBy(() -> ModerationRequest.builder()
-                        .text("some text")
-                        .messages(List.of(message))
-                        .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Only one of text or messages can be set, not both");
+        assertThat(request.messages()).containsExactly("first", "second", "third");
     }
 
     @Test
     void should_preserve_order_of_messages() {
-        // given
-        UserMessage first = UserMessage.from("first");
-        UserMessage second = UserMessage.from("second");
-        UserMessage third = UserMessage.from("third");
-
         // when
         ModerationRequest request = ModerationRequest.builder()
-                .messages(List.of(first, second, third))
+                .messages(List.of("first", "second", "third"))
                 .build();
 
         // then
-        assertThat(request.messages()).containsExactly(first, second, third);
+        assertThat(request.messages()).containsExactly("first", "second", "third");
     }
 
     @Test
     void should_have_correct_equals_and_hashCode() {
         // given
-        ModerationRequest request1 = ModerationRequest.builder().text("text").build();
-        ModerationRequest request2 = ModerationRequest.builder().text("text").build();
-        ModerationRequest request3 = ModerationRequest.builder().text("other").build();
+        ModerationRequest request1 =
+                ModerationRequest.builder().messages(List.of("text")).build();
+        ModerationRequest request2 =
+                ModerationRequest.builder().messages(List.of("text")).build();
+        ModerationRequest request3 =
+                ModerationRequest.builder().messages(List.of("other")).build();
 
         // then
         assertThat(request1).isEqualTo(request2);
@@ -106,27 +77,14 @@ class ModerationRequestTest {
     void should_create_copy_with_toBuilder() {
         // given
         ModerationRequest original =
-                ModerationRequest.builder().text("original").build();
+                ModerationRequest.builder().messages(List.of("original")).build();
 
         // when
-        ModerationRequest copy = original.toBuilder().text("modified").build();
+        ModerationRequest copy =
+                original.toBuilder().messages(List.of("modified")).build();
 
         // then
-        assertThat(original.text()).isEqualTo("original");
-        assertThat(copy.text()).isEqualTo("modified");
-    }
-
-    @Test
-    void should_create_request_with_multiple_messages() {
-        // given
-        UserMessage first = UserMessage.from("hello");
-        UserMessage second = UserMessage.from("world");
-
-        // when
-        ModerationRequest request =
-                ModerationRequest.builder().messages(List.of(first, second)).build();
-
-        // then
-        assertThat(request.messages()).containsExactly(first, second);
+        assertThat(original.messages()).containsExactly("original");
+        assertThat(copy.messages()).containsExactly("modified");
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationRequestTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationRequestTest.java
@@ -60,21 +60,17 @@ class ModerationRequestTest {
     }
 
     @Test
-    void should_create_request_with_both_text_and_messages() {
+    void should_throw_when_both_text_and_messages_set() {
         // given
         UserMessage message = UserMessage.from("hello");
 
-        // when
-        ModerationRequest request = ModerationRequest.builder()
-                .text("some text")
-                .messages(List.of(message))
-                .build();
-
-        // then
-        assertThat(request.text()).isEqualTo("some text");
-        assertThat(request.messages()).containsExactly(message);
-        assertThat(request.hasText()).isTrue();
-        assertThat(request.hasMessages()).isTrue();
+        // when-then
+        assertThatThrownBy(() -> ModerationRequest.builder()
+                        .text("some text")
+                        .messages(List.of(message))
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Only one of text or messages can be set, not both");
     }
 
     @Test

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationRequestTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationRequestTest.java
@@ -1,0 +1,136 @@
+package dev.langchain4j.model.moderation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.message.UserMessage;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ModerationRequestTest {
+
+    @Test
+    void should_throw_when_neither_text_nor_messages_set() {
+        assertThatThrownBy(() -> ModerationRequest.builder().build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Either text or messages must be set");
+    }
+
+    @Test
+    void should_throw_when_messages_is_empty_list() {
+        assertThatThrownBy(() -> ModerationRequest.builder().messages(List.of()).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Either text or messages must be set");
+    }
+
+    @Test
+    void should_throw_when_messages_is_null() {
+        assertThatThrownBy(() -> ModerationRequest.builder().messages(null).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Either text or messages must be set");
+    }
+
+    @Test
+    void should_create_request_with_text() {
+        // when
+        ModerationRequest request =
+                ModerationRequest.builder().text("some text").build();
+
+        // then
+        assertThat(request.text()).isEqualTo("some text");
+        assertThat(request.messages()).isNull();
+        assertThat(request.hasText()).isTrue();
+        assertThat(request.hasMessages()).isFalse();
+    }
+
+    @Test
+    void should_create_request_with_messages() {
+        // given
+        UserMessage message = UserMessage.from("hello");
+
+        // when
+        ModerationRequest request =
+                ModerationRequest.builder().messages(List.of(message)).build();
+
+        // then
+        assertThat(request.text()).isNull();
+        assertThat(request.messages()).containsExactly(message);
+        assertThat(request.hasText()).isFalse();
+        assertThat(request.hasMessages()).isTrue();
+    }
+
+    @Test
+    void should_create_request_with_both_text_and_messages() {
+        // given
+        UserMessage message = UserMessage.from("hello");
+
+        // when
+        ModerationRequest request = ModerationRequest.builder()
+                .text("some text")
+                .messages(List.of(message))
+                .build();
+
+        // then
+        assertThat(request.text()).isEqualTo("some text");
+        assertThat(request.messages()).containsExactly(message);
+        assertThat(request.hasText()).isTrue();
+        assertThat(request.hasMessages()).isTrue();
+    }
+
+    @Test
+    void should_preserve_order_of_messages() {
+        // given
+        UserMessage first = UserMessage.from("first");
+        UserMessage second = UserMessage.from("second");
+        UserMessage third = UserMessage.from("third");
+
+        // when
+        ModerationRequest request = ModerationRequest.builder()
+                .messages(List.of(first, second, third))
+                .build();
+
+        // then
+        assertThat(request.messages()).containsExactly(first, second, third);
+    }
+
+    @Test
+    void should_have_correct_equals_and_hashCode() {
+        // given
+        ModerationRequest request1 = ModerationRequest.builder().text("text").build();
+        ModerationRequest request2 = ModerationRequest.builder().text("text").build();
+        ModerationRequest request3 = ModerationRequest.builder().text("other").build();
+
+        // then
+        assertThat(request1).isEqualTo(request2);
+        assertThat(request1.hashCode()).isEqualTo(request2.hashCode());
+        assertThat(request1).isNotEqualTo(request3);
+    }
+
+    @Test
+    void should_create_copy_with_toBuilder() {
+        // given
+        ModerationRequest original =
+                ModerationRequest.builder().text("original").build();
+
+        // when
+        ModerationRequest copy = original.toBuilder().text("modified").build();
+
+        // then
+        assertThat(original.text()).isEqualTo("original");
+        assertThat(copy.text()).isEqualTo("modified");
+    }
+
+    @Test
+    void should_create_request_with_multiple_messages() {
+        // given
+        UserMessage first = UserMessage.from("hello");
+        UserMessage second = UserMessage.from("world");
+
+        // when
+        ModerationRequest request =
+                ModerationRequest.builder().messages(List.of(first, second)).build();
+
+        // then
+        assertThat(request.messages()).containsExactly(first, second);
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationRequestTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationRequestTest.java
@@ -15,13 +15,13 @@ class ModerationRequestTest {
 
     @Test
     void should_throw_when_messages_is_empty_list() {
-        assertThatThrownBy(() -> ModerationRequest.builder().messages(List.of()).build())
+        assertThatThrownBy(() -> ModerationRequest.builder().texts(List.of()).build())
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void should_throw_when_messages_is_null() {
-        assertThatThrownBy(() -> ModerationRequest.builder().messages(null).build())
+        assertThatThrownBy(() -> ModerationRequest.builder().texts(null).build())
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -29,43 +29,43 @@ class ModerationRequestTest {
     void should_create_request_with_single_message() {
         // when
         ModerationRequest request =
-                ModerationRequest.builder().messages(List.of("some text")).build();
+                ModerationRequest.builder().texts(List.of("some text")).build();
 
         // then
-        assertThat(request.messages()).containsExactly("some text");
+        assertThat(request.texts()).containsExactly("some text");
     }
 
     @Test
     void should_create_request_with_multiple_messages() {
         // when
         ModerationRequest request = ModerationRequest.builder()
-                .messages(List.of("first", "second", "third"))
+                .texts(List.of("first", "second", "third"))
                 .build();
 
         // then
-        assertThat(request.messages()).containsExactly("first", "second", "third");
+        assertThat(request.texts()).containsExactly("first", "second", "third");
     }
 
     @Test
     void should_preserve_order_of_messages() {
         // when
         ModerationRequest request = ModerationRequest.builder()
-                .messages(List.of("first", "second", "third"))
+                .texts(List.of("first", "second", "third"))
                 .build();
 
         // then
-        assertThat(request.messages()).containsExactly("first", "second", "third");
+        assertThat(request.texts()).containsExactly("first", "second", "third");
     }
 
     @Test
     void should_have_correct_equals_and_hashCode() {
         // given
         ModerationRequest request1 =
-                ModerationRequest.builder().messages(List.of("text")).build();
+                ModerationRequest.builder().texts(List.of("text")).build();
         ModerationRequest request2 =
-                ModerationRequest.builder().messages(List.of("text")).build();
+                ModerationRequest.builder().texts(List.of("text")).build();
         ModerationRequest request3 =
-                ModerationRequest.builder().messages(List.of("other")).build();
+                ModerationRequest.builder().texts(List.of("other")).build();
 
         // then
         assertThat(request1).isEqualTo(request2);
@@ -77,14 +77,13 @@ class ModerationRequestTest {
     void should_create_copy_with_toBuilder() {
         // given
         ModerationRequest original =
-                ModerationRequest.builder().messages(List.of("original")).build();
+                ModerationRequest.builder().texts(List.of("original")).build();
 
         // when
-        ModerationRequest copy =
-                original.toBuilder().messages(List.of("modified")).build();
+        ModerationRequest copy = original.toBuilder().texts(List.of("modified")).build();
 
         // then
-        assertThat(original.messages()).containsExactly("original");
-        assertThat(copy.messages()).containsExactly("modified");
+        assertThat(original.texts()).containsExactly("original");
+        assertThat(copy.texts()).containsExactly("modified");
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationRequestTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationRequestTest.java
@@ -33,21 +33,11 @@ class ModerationRequestTest {
 
         // then
         assertThat(request.texts()).containsExactly("some text");
+        assertThat(request.modelName()).isNull();
     }
 
     @Test
     void should_create_request_with_multiple_messages() {
-        // when
-        ModerationRequest request = ModerationRequest.builder()
-                .texts(List.of("first", "second", "third"))
-                .build();
-
-        // then
-        assertThat(request.texts()).containsExactly("first", "second", "third");
-    }
-
-    @Test
-    void should_preserve_order_of_messages() {
         // when
         ModerationRequest request = ModerationRequest.builder()
                 .texts(List.of("first", "second", "third"))
@@ -66,24 +56,56 @@ class ModerationRequestTest {
                 ModerationRequest.builder().texts(List.of("text")).build();
         ModerationRequest request3 =
                 ModerationRequest.builder().texts(List.of("other")).build();
+        ModerationRequest request4 = ModerationRequest.builder()
+                .texts(List.of("text"))
+                .modelName("model-a")
+                .build();
+        ModerationRequest request5 = ModerationRequest.builder()
+                .texts(List.of("text"))
+                .modelName("model-a")
+                .build();
 
         // then
         assertThat(request1).isEqualTo(request2);
         assertThat(request1.hashCode()).isEqualTo(request2.hashCode());
         assertThat(request1).isNotEqualTo(request3);
+        assertThat(request4).isEqualTo(request5);
+        assertThat(request4.hashCode()).isEqualTo(request5.hashCode());
+        assertThat(request1).isNotEqualTo(request4);
     }
 
     @Test
     void should_create_copy_with_toBuilder() {
         // given
-        ModerationRequest original =
-                ModerationRequest.builder().texts(List.of("original")).build();
+        ModerationRequest original = ModerationRequest.builder()
+                .texts(List.of("original"))
+                .modelName("original-model")
+                .build();
 
         // when
-        ModerationRequest copy = original.toBuilder().texts(List.of("modified")).build();
+        ModerationRequest copy = original.toBuilder().build();
+        ModerationRequest modified = original.toBuilder()
+                .texts(List.of("modified"))
+                .modelName("modified-model")
+                .build();
 
         // then
-        assertThat(original.texts()).containsExactly("original");
-        assertThat(copy.texts()).containsExactly("modified");
+        assertThat(copy.texts()).containsExactly("original");
+        assertThat(copy.modelName()).isEqualTo("original-model");
+        assertThat(modified.texts()).containsExactly("modified");
+        assertThat(modified.modelName()).isEqualTo("modified-model");
+    }
+
+    @Test
+    void should_create_request_with_modelName() {
+        // when
+        ModerationRequest request = ModerationRequest.builder()
+                .texts(List.of("some text"))
+                .modelName("custom-model")
+                .build();
+
+        // then
+        assertThat(request.texts()).containsExactly("some text");
+        assertThat(request.modelName()).isEqualTo("custom-model");
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationResponseTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationResponseTest.java
@@ -1,0 +1,146 @@
+package dev.langchain4j.model.moderation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.model.output.TokenUsage;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ModerationResponseTest {
+
+    @Test
+    void should_throw_when_moderation_is_not_set() {
+        assertThatThrownBy(() -> ModerationResponse.builder().build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("moderation cannot be null");
+    }
+
+    @Test
+    void should_throw_when_moderation_is_null() {
+        assertThatThrownBy(() -> ModerationResponse.builder().moderation(null).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("moderation cannot be null");
+    }
+
+    @Test
+    void should_create_response_with_moderation_only() {
+        // given
+        Moderation moderation = Moderation.notFlagged();
+
+        // when
+        ModerationResponse response =
+                ModerationResponse.builder().moderation(moderation).build();
+
+        // then
+        assertThat(response.moderation()).isEqualTo(moderation);
+        assertThat(response.tokenUsage()).isNull();
+        assertThat(response.metadata()).isNull();
+    }
+
+    @Test
+    void should_create_response_with_all_fields() {
+        // given
+        Moderation moderation = Moderation.flagged("bad content");
+        TokenUsage tokenUsage = new TokenUsage(10, 20, 30);
+        Map<String, Object> metadata = Map.of("key", "value");
+
+        // when
+        ModerationResponse response = ModerationResponse.builder()
+                .moderation(moderation)
+                .tokenUsage(tokenUsage)
+                .metadata(metadata)
+                .build();
+
+        // then
+        assertThat(response.moderation()).isEqualTo(moderation);
+        assertThat(response.tokenUsage()).isEqualTo(tokenUsage);
+        assertThat(response.metadata()).containsEntry("key", "value");
+    }
+
+    @Test
+    void should_create_response_with_flagged_moderation() {
+        // given
+        Moderation moderation = Moderation.flagged("offensive text");
+
+        // when
+        ModerationResponse response =
+                ModerationResponse.builder().moderation(moderation).build();
+
+        // then
+        assertThat(response.moderation().flagged()).isTrue();
+        assertThat(response.moderation().flaggedText()).isEqualTo("offensive text");
+    }
+
+    @Test
+    void should_create_response_with_not_flagged_moderation() {
+        // given
+        Moderation moderation = Moderation.notFlagged();
+
+        // when
+        ModerationResponse response =
+                ModerationResponse.builder().moderation(moderation).build();
+
+        // then
+        assertThat(response.moderation().flagged()).isFalse();
+        assertThat(response.moderation().flaggedText()).isNull();
+    }
+
+    @Test
+    void should_have_correct_equals_and_hashCode() {
+        // given
+        Moderation moderation = Moderation.notFlagged();
+        TokenUsage tokenUsage = new TokenUsage(1, 2, 3);
+
+        ModerationResponse response1 = ModerationResponse.builder()
+                .moderation(moderation)
+                .tokenUsage(tokenUsage)
+                .build();
+        ModerationResponse response2 = ModerationResponse.builder()
+                .moderation(moderation)
+                .tokenUsage(tokenUsage)
+                .build();
+        ModerationResponse response3 = ModerationResponse.builder()
+                .moderation(Moderation.flagged("bad"))
+                .build();
+
+        // then
+        assertThat(response1).isEqualTo(response2);
+        assertThat(response1.hashCode()).isEqualTo(response2.hashCode());
+        assertThat(response1).isNotEqualTo(response3);
+    }
+
+    @Test
+    void should_create_copy_with_toBuilder() {
+        // given
+        Moderation original = Moderation.notFlagged();
+        Moderation updated = Moderation.flagged("bad");
+        ModerationResponse originalResponse =
+                ModerationResponse.builder().moderation(original).build();
+
+        // when
+        ModerationResponse copy =
+                originalResponse.toBuilder().moderation(updated).build();
+
+        // then
+        assertThat(originalResponse.moderation()).isEqualTo(original);
+        assertThat(copy.moderation()).isEqualTo(updated);
+    }
+
+    @Test
+    void should_create_response_with_token_usage() {
+        // given
+        Moderation moderation = Moderation.notFlagged();
+        TokenUsage tokenUsage = new TokenUsage(5, 10, 15);
+
+        // when
+        ModerationResponse response = ModerationResponse.builder()
+                .moderation(moderation)
+                .tokenUsage(tokenUsage)
+                .build();
+
+        // then
+        assertThat(response.tokenUsage()).isEqualTo(tokenUsage);
+        assertThat(response.metadata()).isNull();
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationResponseTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationResponseTest.java
@@ -3,7 +3,6 @@ package dev.langchain4j.model.moderation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import dev.langchain4j.model.output.TokenUsage;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,6 @@ class ModerationResponseTest {
 
         // then
         assertThat(response.moderation()).isEqualTo(moderation);
-        assertThat(response.tokenUsage()).isNull();
         assertThat(response.metadata()).isNull();
     }
 
@@ -42,19 +40,16 @@ class ModerationResponseTest {
     void should_create_response_with_all_fields() {
         // given
         Moderation moderation = Moderation.flagged("bad content");
-        TokenUsage tokenUsage = new TokenUsage(10, 20, 30);
         Map<String, Object> metadata = Map.of("key", "value");
 
         // when
         ModerationResponse response = ModerationResponse.builder()
                 .moderation(moderation)
-                .tokenUsage(tokenUsage)
                 .metadata(metadata)
                 .build();
 
         // then
         assertThat(response.moderation()).isEqualTo(moderation);
-        assertThat(response.tokenUsage()).isEqualTo(tokenUsage);
         assertThat(response.metadata()).containsEntry("key", "value");
     }
 
@@ -90,16 +85,11 @@ class ModerationResponseTest {
     void should_have_correct_equals_and_hashCode() {
         // given
         Moderation moderation = Moderation.notFlagged();
-        TokenUsage tokenUsage = new TokenUsage(1, 2, 3);
 
-        ModerationResponse response1 = ModerationResponse.builder()
-                .moderation(moderation)
-                .tokenUsage(tokenUsage)
-                .build();
-        ModerationResponse response2 = ModerationResponse.builder()
-                .moderation(moderation)
-                .tokenUsage(tokenUsage)
-                .build();
+        ModerationResponse response1 =
+                ModerationResponse.builder().moderation(moderation).build();
+        ModerationResponse response2 =
+                ModerationResponse.builder().moderation(moderation).build();
         ModerationResponse response3 = ModerationResponse.builder()
                 .moderation(Moderation.flagged("bad"))
                 .build();
@@ -128,19 +118,18 @@ class ModerationResponseTest {
     }
 
     @Test
-    void should_create_response_with_token_usage() {
+    void should_create_response_with_metadata() {
         // given
         Moderation moderation = Moderation.notFlagged();
-        TokenUsage tokenUsage = new TokenUsage(5, 10, 15);
+        Map<String, Object> metadata = Map.of("key", "value");
 
         // when
         ModerationResponse response = ModerationResponse.builder()
                 .moderation(moderation)
-                .tokenUsage(tokenUsage)
+                .metadata(metadata)
                 .build();
 
         // then
-        assertThat(response.tokenUsage()).isEqualTo(tokenUsage);
-        assertThat(response.metadata()).isNull();
+        assertThat(response.metadata()).containsEntry("key", "value");
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationResponseTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/ModerationResponseTest.java
@@ -33,7 +33,7 @@ class ModerationResponseTest {
 
         // then
         assertThat(response.moderation()).isEqualTo(moderation);
-        assertThat(response.metadata()).isNull();
+        assertThat(response.metadata()).isEmpty();
     }
 
     @Test

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/common/AbstractModerationModelListenerIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/common/AbstractModerationModelListenerIT.java
@@ -1,0 +1,300 @@
+package dev.langchain4j.model.moderation.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.fail;
+
+import dev.langchain4j.model.moderation.ModerationModel;
+import dev.langchain4j.model.moderation.ModerationRequest;
+import dev.langchain4j.model.moderation.ModerationResponse;
+import dev.langchain4j.model.moderation.listener.ModerationModelErrorContext;
+import dev.langchain4j.model.moderation.listener.ModerationModelListener;
+import dev.langchain4j.model.moderation.listener.ModerationModelRequestContext;
+import dev.langchain4j.model.moderation.listener.ModerationModelResponseContext;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Make sure these dependencies are present in the module where this test class is extended:
+ * <pre>
+ *
+ * <dependency>
+ *     <groupId>dev.langchain4j</groupId>
+ *     <artifactId>langchain4j-core</artifactId>
+ *     <classifier>tests</classifier>
+ *     <type>test-jar</type>
+ *     <scope>test</scope>
+ * </dependency>
+ *
+ * </pre>
+ */
+public abstract class AbstractModerationModelListenerIT {
+
+    protected abstract ModerationModel createModel(List<ModerationModelListener> listeners);
+
+    protected ModerationModel createModel(ModerationModelListener listener) {
+        return createModel(List.of(listener));
+    }
+
+    protected abstract ModerationModel createFailingModel(List<ModerationModelListener> listeners);
+
+    protected ModerationModel createFailingModel(ModerationModelListener listener) {
+        return createFailingModel(List.of(listener));
+    }
+
+    protected abstract Class<? extends Exception> expectedExceptionClass();
+
+    @Test
+    void should_listen_request_and_response() {
+
+        // given
+        AtomicReference<ModerationRequest> moderationRequestReference = new AtomicReference<>();
+        AtomicInteger onRequestInvocations = new AtomicInteger();
+
+        AtomicReference<ModerationResponse> moderationResponseReference = new AtomicReference<>();
+        AtomicInteger onResponseInvocations = new AtomicInteger();
+        AtomicReference<ModerationModel> modelReference = new AtomicReference<>();
+
+        ModerationModelListener listener = new ModerationModelListener() {
+
+            @Override
+            public void onRequest(ModerationModelRequestContext requestContext) {
+                moderationRequestReference.set(requestContext.moderationRequest());
+                onRequestInvocations.incrementAndGet();
+
+                assertThat(requestContext.modelProvider())
+                        .isNotNull()
+                        .isEqualTo(modelReference.get().provider());
+
+                assertThat(requestContext.modelName())
+                        .isEqualTo(modelReference.get().modelName());
+
+                requestContext.attributes().put("id", "12345");
+            }
+
+            @Override
+            public void onResponse(ModerationModelResponseContext responseContext) {
+                moderationResponseReference.set(responseContext.moderationResponse());
+                onResponseInvocations.incrementAndGet();
+
+                assertThat(responseContext.moderationRequest()).isEqualTo(moderationRequestReference.get());
+
+                assertThat(responseContext.modelProvider())
+                        .isNotNull()
+                        .isEqualTo(modelReference.get().provider());
+
+                assertThat(responseContext.modelName())
+                        .isEqualTo(modelReference.get().modelName());
+
+                assertThat(responseContext.attributes()).containsEntry("id", "12345");
+            }
+
+            @Override
+            public void onError(ModerationModelErrorContext errorContext) {
+                fail("onError() must not be called. Exception: "
+                        + errorContext.error().getMessage());
+            }
+        };
+
+        ModerationModel model = createModel(listener);
+        modelReference.set(model);
+
+        String textToModerate = "hello";
+        ModerationRequest moderationRequest =
+                ModerationRequest.builder().text(textToModerate).build();
+
+        // when
+        ModerationResponse moderationResponse = model.moderate(moderationRequest);
+
+        // then
+        ModerationRequest observedModerationRequest = moderationRequestReference.get();
+        assertThat(observedModerationRequest.text()).isEqualTo(textToModerate);
+
+        assertThat(onRequestInvocations).hasValue(1);
+
+        ModerationResponse observedResponse = moderationResponseReference.get();
+        assertThat(observedResponse).isNotNull();
+        assertThat(observedResponse.moderation()).isEqualTo(moderationResponse.moderation());
+
+        assertThat(onResponseInvocations).hasValue(1);
+    }
+
+    @Test
+    void should_listen_error() {
+
+        // given
+        AtomicReference<ModerationRequest> moderationRequestReference = new AtomicReference<>();
+        AtomicInteger onRequestInvocations = new AtomicInteger();
+
+        AtomicReference<Throwable> errorReference = new AtomicReference<>();
+        AtomicInteger onErrorInvocations = new AtomicInteger();
+        AtomicReference<ModerationModel> modelReference = new AtomicReference<>();
+
+        ModerationModelListener listener = new ModerationModelListener() {
+
+            @Override
+            public void onRequest(ModerationModelRequestContext requestContext) {
+                moderationRequestReference.set(requestContext.moderationRequest());
+                onRequestInvocations.incrementAndGet();
+
+                assertThat(requestContext.modelProvider())
+                        .isNotNull()
+                        .isEqualTo(modelReference.get().provider());
+
+                assertThat(requestContext.modelName())
+                        .isEqualTo(modelReference.get().modelName());
+
+                requestContext.attributes().put("id", "12345");
+            }
+
+            @Override
+            public void onResponse(ModerationModelResponseContext responseContext) {
+                fail("onResponse() must not be called");
+            }
+
+            @Override
+            public void onError(ModerationModelErrorContext errorContext) {
+                errorReference.set(errorContext.error());
+                onErrorInvocations.incrementAndGet();
+
+                assertThat(errorContext.moderationRequest()).isEqualTo(moderationRequestReference.get());
+
+                assertThat(errorContext.modelProvider())
+                        .isNotNull()
+                        .isEqualTo(modelReference.get().provider());
+
+                assertThat(errorContext.modelName())
+                        .isEqualTo(modelReference.get().modelName());
+
+                assertThat(errorContext.attributes()).containsEntry("id", "12345");
+            }
+        };
+
+        ModerationModel model = createFailingModel(listener);
+        modelReference.set(model);
+
+        String textToModerate = "this message will fail";
+
+        ModerationRequest moderationRequest =
+                ModerationRequest.builder().text(textToModerate).build();
+
+        // when
+        Throwable thrown = catchThrowable(() -> model.moderate(moderationRequest));
+
+        // then
+        Throwable error = errorReference.get();
+        assertThat(error).isExactlyInstanceOf(expectedExceptionClass());
+
+        assertThat(thrown).isNotNull();
+        assertThat(error).isIn(thrown, thrown.getCause());
+
+        assertThat(onRequestInvocations).hasValue(1);
+        assertThat(onErrorInvocations).hasValue(1);
+    }
+
+    @Test
+    void should_continue_executing_other_listeners_when_one_throws_exception() {
+
+        // given
+        AtomicInteger firstListenerOnRequestInvocations = new AtomicInteger();
+        AtomicInteger firstListenerOnResponseInvocations = new AtomicInteger();
+
+        AtomicInteger secondListenerOnRequestInvocations = new AtomicInteger();
+        AtomicInteger secondListenerOnResponseInvocations = new AtomicInteger();
+
+        ModerationModelListener failingListener = new ModerationModelListener() {
+
+            @Override
+            public void onRequest(ModerationModelRequestContext requestContext) {
+                firstListenerOnRequestInvocations.incrementAndGet();
+                throw new RuntimeException("Simulated failure in onRequest");
+            }
+
+            @Override
+            public void onResponse(ModerationModelResponseContext responseContext) {
+                firstListenerOnResponseInvocations.incrementAndGet();
+                throw new RuntimeException("Simulated failure in onResponse");
+            }
+
+            @Override
+            public void onError(ModerationModelErrorContext errorContext) {
+                throw new RuntimeException("Simulated failure in onError");
+            }
+        };
+
+        ModerationModelListener successfulListener = new ModerationModelListener() {
+
+            @Override
+            public void onRequest(ModerationModelRequestContext requestContext) {
+                secondListenerOnRequestInvocations.incrementAndGet();
+            }
+
+            @Override
+            public void onResponse(ModerationModelResponseContext responseContext) {
+                secondListenerOnResponseInvocations.incrementAndGet();
+            }
+        };
+
+        ModerationModel model = createModel(List.of(failingListener, successfulListener));
+
+        String textToModerate = "hello";
+        ModerationRequest moderationRequest =
+                ModerationRequest.builder().text(textToModerate).build();
+
+        // when
+        ModerationResponse response = model.moderate(moderationRequest);
+
+        // then - both listeners should have been invoked despite the first one throwing exceptions
+        assertThat(response).isNotNull();
+        assertThat(response.moderation()).isNotNull();
+
+        assertThat(firstListenerOnRequestInvocations).hasValue(1);
+        assertThat(firstListenerOnResponseInvocations).hasValue(1);
+
+        assertThat(secondListenerOnRequestInvocations).hasValue(1);
+        assertThat(secondListenerOnResponseInvocations).hasValue(1);
+    }
+
+    @Test
+    void should_continue_executing_other_listeners_when_one_throws_exception_in_onError() {
+
+        // given
+        AtomicInteger firstListenerOnErrorInvocations = new AtomicInteger();
+        AtomicInteger secondListenerOnErrorInvocations = new AtomicInteger();
+
+        ModerationModelListener failingListener = new ModerationModelListener() {
+
+            @Override
+            public void onError(ModerationModelErrorContext errorContext) {
+                firstListenerOnErrorInvocations.incrementAndGet();
+                throw new RuntimeException("Simulated failure in onError");
+            }
+        };
+
+        ModerationModelListener successfulListener = new ModerationModelListener() {
+
+            @Override
+            public void onError(ModerationModelErrorContext errorContext) {
+                secondListenerOnErrorInvocations.incrementAndGet();
+            }
+        };
+
+        ModerationModel model = createFailingModel(List.of(failingListener, successfulListener));
+
+        ModerationRequest moderationRequest =
+                ModerationRequest.builder().text("this message will fail").build();
+
+        // when
+        try {
+            model.moderate(moderationRequest);
+        } catch (Exception e) {
+            // expected
+        }
+
+        // then - both listeners should have been invoked despite the first one throwing an exception
+        assertThat(firstListenerOnErrorInvocations).hasValue(1);
+        assertThat(secondListenerOnErrorInvocations).hasValue(1);
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/common/AbstractModerationModelListenerIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/common/AbstractModerationModelListenerIT.java
@@ -103,14 +103,14 @@ public abstract class AbstractModerationModelListenerIT {
 
         String textToModerate = "hello";
         ModerationRequest moderationRequest =
-                ModerationRequest.builder().text(textToModerate).build();
+                ModerationRequest.builder().messages(List.of(textToModerate)).build();
 
         // when
         ModerationResponse moderationResponse = model.moderate(moderationRequest);
 
         // then
         ModerationRequest observedModerationRequest = moderationRequestReference.get();
-        assertThat(observedModerationRequest.text()).isEqualTo(textToModerate);
+        assertThat(observedModerationRequest.messages()).containsExactly(textToModerate);
 
         assertThat(onRequestInvocations).hasValue(1);
 
@@ -178,7 +178,7 @@ public abstract class AbstractModerationModelListenerIT {
         String textToModerate = "this message will fail";
 
         ModerationRequest moderationRequest =
-                ModerationRequest.builder().text(textToModerate).build();
+                ModerationRequest.builder().messages(List.of(textToModerate)).build();
 
         // when
         Throwable thrown = catchThrowable(() -> model.moderate(moderationRequest));
@@ -241,7 +241,7 @@ public abstract class AbstractModerationModelListenerIT {
 
         String textToModerate = "hello";
         ModerationRequest moderationRequest =
-                ModerationRequest.builder().text(textToModerate).build();
+                ModerationRequest.builder().messages(List.of(textToModerate)).build();
 
         // when
         ModerationResponse response = model.moderate(moderationRequest);
@@ -283,8 +283,9 @@ public abstract class AbstractModerationModelListenerIT {
 
         ModerationModel model = createFailingModel(List.of(failingListener, successfulListener));
 
-        ModerationRequest moderationRequest =
-                ModerationRequest.builder().text("this message will fail").build();
+        ModerationRequest moderationRequest = ModerationRequest.builder()
+                .messages(List.of("this message will fail"))
+                .build();
 
         // when
         try {

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/common/AbstractModerationModelListenerIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/common/AbstractModerationModelListenerIT.java
@@ -68,7 +68,7 @@ public abstract class AbstractModerationModelListenerIT {
                         .isNotNull()
                         .isEqualTo(modelReference.get().provider());
 
-                assertThat(requestContext.modelName())
+                assertThat(requestContext.moderationRequest().modelName())
                         .isEqualTo(modelReference.get().modelName());
 
                 requestContext.attributes().put("id", "12345");
@@ -85,7 +85,7 @@ public abstract class AbstractModerationModelListenerIT {
                         .isNotNull()
                         .isEqualTo(modelReference.get().provider());
 
-                assertThat(responseContext.modelName())
+                assertThat(responseContext.moderationRequest().modelName())
                         .isEqualTo(modelReference.get().modelName());
 
                 assertThat(responseContext.attributes()).containsEntry("id", "12345");
@@ -143,7 +143,7 @@ public abstract class AbstractModerationModelListenerIT {
                         .isNotNull()
                         .isEqualTo(modelReference.get().provider());
 
-                assertThat(requestContext.modelName())
+                assertThat(requestContext.moderationRequest().modelName())
                         .isEqualTo(modelReference.get().modelName());
 
                 requestContext.attributes().put("id", "12345");
@@ -165,7 +165,7 @@ public abstract class AbstractModerationModelListenerIT {
                         .isNotNull()
                         .isEqualTo(modelReference.get().provider());
 
-                assertThat(errorContext.modelName())
+                assertThat(errorContext.moderationRequest().modelName())
                         .isEqualTo(modelReference.get().modelName());
 
                 assertThat(errorContext.attributes()).containsEntry("id", "12345");

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/common/AbstractModerationModelListenerIT.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/moderation/common/AbstractModerationModelListenerIT.java
@@ -103,14 +103,14 @@ public abstract class AbstractModerationModelListenerIT {
 
         String textToModerate = "hello";
         ModerationRequest moderationRequest =
-                ModerationRequest.builder().messages(List.of(textToModerate)).build();
+                ModerationRequest.builder().texts(List.of(textToModerate)).build();
 
         // when
         ModerationResponse moderationResponse = model.moderate(moderationRequest);
 
         // then
         ModerationRequest observedModerationRequest = moderationRequestReference.get();
-        assertThat(observedModerationRequest.messages()).containsExactly(textToModerate);
+        assertThat(observedModerationRequest.texts()).containsExactly(textToModerate);
 
         assertThat(onRequestInvocations).hasValue(1);
 
@@ -178,7 +178,7 @@ public abstract class AbstractModerationModelListenerIT {
         String textToModerate = "this message will fail";
 
         ModerationRequest moderationRequest =
-                ModerationRequest.builder().messages(List.of(textToModerate)).build();
+                ModerationRequest.builder().texts(List.of(textToModerate)).build();
 
         // when
         Throwable thrown = catchThrowable(() -> model.moderate(moderationRequest));
@@ -241,7 +241,7 @@ public abstract class AbstractModerationModelListenerIT {
 
         String textToModerate = "hello";
         ModerationRequest moderationRequest =
-                ModerationRequest.builder().messages(List.of(textToModerate)).build();
+                ModerationRequest.builder().texts(List.of(textToModerate)).build();
 
         // when
         ModerationResponse response = model.moderate(moderationRequest);
@@ -284,7 +284,7 @@ public abstract class AbstractModerationModelListenerIT {
         ModerationModel model = createFailingModel(List.of(failingListener, successfulListener));
 
         ModerationRequest moderationRequest = ModerationRequest.builder()
-                .messages(List.of("this message will fail"))
+                .texts(List.of("this message will fail"))
                 .build();
 
         // when

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
@@ -45,7 +45,7 @@ public class MistralAiModerationModel implements ModerationModel {
 
     @Override
     public List<ModerationModelListener> listeners() {
-        return listeners != null ? listeners : List.of();
+        return listeners;
     }
 
     @Override

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
@@ -5,11 +5,6 @@ import static dev.langchain4j.internal.Utils.copyIfNotNull;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.SystemMessage;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiCategories;
@@ -23,7 +18,6 @@ import dev.langchain4j.model.moderation.ModerationRequest;
 import dev.langchain4j.model.moderation.ModerationResponse;
 import dev.langchain4j.model.moderation.listener.ModerationModelListener;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 
@@ -66,35 +60,8 @@ public class MistralAiModerationModel implements ModerationModel {
 
     @Override
     public ModerationResponse doModerate(ModerationRequest moderationRequest) {
-        List<String> inputs = toInputs(moderationRequest);
+        List<String> inputs = ModerationModel.toInputs(moderationRequest);
         return moderateInternal(inputs);
-    }
-
-    private List<String> toInputs(ModerationRequest moderationRequest) {
-        List<String> inputs = new ArrayList<>();
-        if (moderationRequest.hasText()) {
-            inputs.add(moderationRequest.text());
-        }
-        if (moderationRequest.hasMessages()) {
-            moderationRequest.messages().stream()
-                    .map(MistralAiModerationModel::toText)
-                    .forEach(inputs::add);
-        }
-        return inputs;
-    }
-
-    private static String toText(ChatMessage chatMessage) {
-        if (chatMessage instanceof SystemMessage systemMessage) {
-            return systemMessage.text();
-        } else if (chatMessage instanceof UserMessage userMessage) {
-            return userMessage.singleText();
-        } else if (chatMessage instanceof AiMessage aiMessage) {
-            return aiMessage.text();
-        } else if (chatMessage instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
-            return toolExecutionResultMessage.text();
-        } else {
-            throw new IllegalArgumentException("Unsupported message type: " + chatMessage.type());
-        }
     }
 
     private ModerationResponse moderateInternal(List<String> inputs) {

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.model.mistralai;
 
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
+import static dev.langchain4j.internal.Utils.copyIfNotNull;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 
@@ -20,6 +21,7 @@ import dev.langchain4j.model.moderation.Moderation;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.moderation.ModerationRequest;
 import dev.langchain4j.model.moderation.ModerationResponse;
+import dev.langchain4j.model.moderation.listener.ModerationModelListener;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +32,7 @@ public class MistralAiModerationModel implements ModerationModel {
     private final MistralAiClient client;
     private final String modelName;
     private final Integer maxRetries;
+    private final List<ModerationModelListener> listeners;
 
     public MistralAiModerationModel(Builder builder) {
         this.client = MistralAiClient.builder()
@@ -43,6 +46,12 @@ public class MistralAiModerationModel implements ModerationModel {
                 .build();
         this.modelName = ensureNotBlank(builder.modelName, "modelName");
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
+        this.listeners = copyIfNotNull(builder.listeners);
+    }
+
+    @Override
+    public List<ModerationModelListener> listeners() {
+        return listeners != null ? listeners : List.of();
     }
 
     @Override
@@ -137,6 +146,7 @@ public class MistralAiModerationModel implements ModerationModel {
         private Logger logger;
         private String modelName;
         private Integer maxRetries;
+        private List<ModerationModelListener> listeners;
 
         /**
          * @param httpClientBuilder the HTTP client builder to use for creating the HTTP client
@@ -188,6 +198,17 @@ public class MistralAiModerationModel implements ModerationModel {
 
         public Builder maxRetries(int maxRetries) {
             this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /**
+         * Sets the listeners for this moderation model.
+         *
+         * @param listeners the listeners.
+         * @return {@code this}.
+         */
+        public Builder listeners(List<ModerationModelListener> listeners) {
+            this.listeners = listeners;
             return this;
         }
 

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
@@ -61,14 +61,13 @@ public class MistralAiModerationModel implements ModerationModel {
     @Override
     public ModerationResponse doModerate(ModerationRequest moderationRequest) {
         List<String> inputs = ModerationModel.toInputs(moderationRequest);
-        String effectiveModelName = getOrDefault(moderationRequest.modelName(), modelName);
-        return moderateInternal(inputs, effectiveModelName);
+        return moderateInternal(inputs, moderationRequest.modelName());
     }
 
-    private ModerationResponse moderateInternal(List<String> inputs, String effectiveModelName) {
+    private ModerationResponse moderateInternal(List<String> inputs, String modelName) {
 
         MistralAiModerationRequest request = MistralAiModerationRequest.builder()
-                .model(effectiveModelName)
+                .model(modelName)
                 .input(inputs)
                 .build();
 

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
@@ -61,13 +61,14 @@ public class MistralAiModerationModel implements ModerationModel {
     @Override
     public ModerationResponse doModerate(ModerationRequest moderationRequest) {
         List<String> inputs = ModerationModel.toInputs(moderationRequest);
-        return moderateInternal(inputs);
+        String effectiveModelName = getOrDefault(moderationRequest.modelName(), modelName);
+        return moderateInternal(inputs, effectiveModelName);
     }
 
-    private ModerationResponse moderateInternal(List<String> inputs) {
+    private ModerationResponse moderateInternal(List<String> inputs, String effectiveModelName) {
 
         MistralAiModerationRequest request = MistralAiModerationRequest.builder()
-                .model(modelName)
+                .model(effectiveModelName)
                 .input(inputs)
                 .build();
 

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiModerationModelIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiModerationModelIT.java
@@ -1,21 +1,24 @@
 package dev.langchain4j.model.mistralai;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.model.moderation.Moderation;
 import dev.langchain4j.model.moderation.ModerationModel;
+import dev.langchain4j.model.moderation.ModerationRequest;
+import dev.langchain4j.model.moderation.ModerationResponse;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+")
 class MistralAiModerationModelIT {
 
     ModerationModel model = new MistralAiModerationModel.Builder()
-        .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
-        .modelName("mistral-moderation-latest")
-        .logRequests(true)
-        .logResponses(true)
-        .build();
+            .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+            .modelName("mistral-moderation-latest")
+            .logRequests(true)
+            .logResponses(true)
+            .build();
 
     @Test
     void should_flag() {
@@ -31,5 +34,25 @@ class MistralAiModerationModelIT {
         assertThat(moderation.flagged()).isFalse();
     }
 
+    @Test
+    void should_use_model_name_from_request_overriding_default() {
 
+        // given - model configured with a non-existent default model name
+        ModerationModel model = new MistralAiModerationModel.Builder()
+                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .modelName("non-existent-model")
+                .build();
+
+        // request overrides with a valid model name
+        ModerationRequest request = ModerationRequest.builder()
+                .texts(List.of("I want to hug them."))
+                .modelName("mistral-moderation-latest")
+                .build();
+
+        // when - should succeed because request model name overrides the invalid default
+        ModerationResponse response = model.moderate(request);
+
+        // then
+        assertThat(response.moderation().flagged()).isFalse();
+    }
 }

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiModerationModelListenerIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiModerationModelListenerIT.java
@@ -1,0 +1,38 @@
+package dev.langchain4j.model.mistralai;
+
+import dev.langchain4j.exception.AuthenticationException;
+import dev.langchain4j.model.moderation.ModerationModel;
+import dev.langchain4j.model.moderation.common.AbstractModerationModelListenerIT;
+import dev.langchain4j.model.moderation.listener.ModerationModelListener;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+")
+class MistralAiModerationModelListenerIT extends AbstractModerationModelListenerIT {
+
+    @Override
+    protected ModerationModel createModel(List<ModerationModelListener> listeners) {
+        return MistralAiModerationModel.builder()
+                .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+                .modelName("mistral-moderation-latest")
+                .logRequests(true)
+                .logResponses(true)
+                .listeners(listeners)
+                .build();
+    }
+
+    @Override
+    protected ModerationModel createFailingModel(List<ModerationModelListener> listeners) {
+        return MistralAiModerationModel.builder()
+                .apiKey("banana")
+                .modelName("mistral-moderation-latest")
+                .maxRetries(0)
+                .listeners(listeners)
+                .build();
+    }
+
+    @Override
+    protected Class<? extends Exception> expectedExceptionClass() {
+        return AuthenticationException.class;
+    }
+}

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
@@ -8,11 +8,6 @@ import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_USER_AGE
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.time.Duration.ofSeconds;
 
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.SystemMessage;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.moderation.Moderation;
@@ -24,7 +19,6 @@ import dev.langchain4j.model.openai.internal.OpenAiClient;
 import dev.langchain4j.model.openai.internal.moderation.ModerationResult;
 import dev.langchain4j.model.openai.spi.OpenAiModerationModelBuilderFactory;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -79,35 +73,8 @@ public class OpenAiModerationModel implements ModerationModel {
 
     @Override
     public ModerationResponse doModerate(ModerationRequest moderationRequest) {
-        List<String> inputs = toInputs(moderationRequest);
+        List<String> inputs = ModerationModel.toInputs(moderationRequest);
         return moderateInternal(inputs);
-    }
-
-    private List<String> toInputs(ModerationRequest moderationRequest) {
-        List<String> inputs = new ArrayList<>();
-        if (moderationRequest.hasText()) {
-            inputs.add(moderationRequest.text());
-        }
-        if (moderationRequest.hasMessages()) {
-            moderationRequest.messages().stream()
-                    .map(OpenAiModerationModel::toText)
-                    .forEach(inputs::add);
-        }
-        return inputs;
-    }
-
-    private static String toText(ChatMessage chatMessage) {
-        if (chatMessage instanceof SystemMessage systemMessage) {
-            return systemMessage.text();
-        } else if (chatMessage instanceof UserMessage userMessage) {
-            return userMessage.singleText();
-        } else if (chatMessage instanceof AiMessage aiMessage) {
-            return aiMessage.text();
-        } else if (chatMessage instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
-            return toolExecutionResultMessage.text();
-        } else {
-            throw new IllegalArgumentException("Unsupported message type: " + chatMessage.type());
-        }
     }
 
     private ModerationResponse moderateInternal(List<String> inputs) {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
@@ -53,7 +53,7 @@ public class OpenAiModerationModel implements ModerationModel {
                 .build();
         this.modelName = builder.modelName;
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
-        this.listeners = copyIfNotNull(builder.listeners);
+        this.listeners = copy(builder.listeners);
     }
 
     @Override

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
@@ -1,7 +1,7 @@
 package dev.langchain4j.model.openai;
 
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
-import static dev.langchain4j.internal.Utils.copyIfNotNull;
+import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_OPENAI_URL;
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_USER_AGENT;

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
@@ -63,7 +63,7 @@ public class OpenAiModerationModel implements ModerationModel {
 
     @Override
     public List<ModerationModelListener> listeners() {
-        return listeners != null ? listeners : List.of();
+        return listeners;
     }
 
     @Override

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
@@ -74,15 +74,14 @@ public class OpenAiModerationModel implements ModerationModel {
     @Override
     public ModerationResponse doModerate(ModerationRequest moderationRequest) {
         List<String> inputs = ModerationModel.toInputs(moderationRequest);
-        String effectiveModelName = getOrDefault(moderationRequest.modelName(), modelName);
-        return moderateInternal(inputs, effectiveModelName);
+        return moderateInternal(inputs, moderationRequest.modelName());
     }
 
-    private ModerationResponse moderateInternal(List<String> inputs, String effectiveModelName) {
+    private ModerationResponse moderateInternal(List<String> inputs, String modelName) {
 
         dev.langchain4j.model.openai.internal.moderation.ModerationRequest request =
                 dev.langchain4j.model.openai.internal.moderation.ModerationRequest.builder()
-                        .model(effectiveModelName)
+                        .model(modelName)
                         .input(inputs)
                         .build();
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiModerationModel.java
@@ -74,14 +74,15 @@ public class OpenAiModerationModel implements ModerationModel {
     @Override
     public ModerationResponse doModerate(ModerationRequest moderationRequest) {
         List<String> inputs = ModerationModel.toInputs(moderationRequest);
-        return moderateInternal(inputs);
+        String effectiveModelName = getOrDefault(moderationRequest.modelName(), modelName);
+        return moderateInternal(inputs, effectiveModelName);
     }
 
-    private ModerationResponse moderateInternal(List<String> inputs) {
+    private ModerationResponse moderateInternal(List<String> inputs, String effectiveModelName) {
 
         dev.langchain4j.model.openai.internal.moderation.ModerationRequest request =
                 dev.langchain4j.model.openai.internal.moderation.ModerationRequest.builder()
-                        .model(modelName)
+                        .model(effectiveModelName)
                         .input(inputs)
                         .build();
 

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiModerationModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiModerationModelIT.java
@@ -1,12 +1,15 @@
 package dev.langchain4j.model.openai;
 
-import dev.langchain4j.model.moderation.Moderation;
-import dev.langchain4j.model.moderation.ModerationModel;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-
 import static dev.langchain4j.model.openai.OpenAiModerationModelName.OMNI_MODERATION_LATEST;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.moderation.Moderation;
+import dev.langchain4j.model.moderation.ModerationModel;
+import dev.langchain4j.model.moderation.ModerationRequest;
+import dev.langchain4j.model.moderation.ModerationResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class OpenAiModerationModelIT {
@@ -47,5 +50,29 @@ class OpenAiModerationModelIT {
 
         // then
         assertThat(moderation.flagged()).isFalse();
+    }
+
+    @Test
+    void should_use_model_name_from_request_overriding_default() {
+
+        // given - model configured with a non-existent default model name
+        ModerationModel model = OpenAiModerationModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName("non-existent-model")
+                .build();
+
+        // request overrides with a valid model name
+        ModerationRequest request = ModerationRequest.builder()
+                .texts(List.of("I want to hug them."))
+                .modelName("omni-moderation-latest")
+                .build();
+
+        // when - should succeed because request model name overrides the invalid default
+        ModerationResponse response = model.moderate(request);
+
+        // then
+        assertThat(response.moderation().flagged()).isFalse();
     }
 }

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiModerationModelListenerIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiModerationModelListenerIT.java
@@ -1,0 +1,39 @@
+package dev.langchain4j.model.openai;
+
+import dev.langchain4j.exception.AuthenticationException;
+import dev.langchain4j.model.moderation.ModerationModel;
+import dev.langchain4j.model.moderation.common.AbstractModerationModelListenerIT;
+import dev.langchain4j.model.moderation.listener.ModerationModelListener;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class OpenAiModerationModelListenerIT extends AbstractModerationModelListenerIT {
+
+    @Override
+    protected ModerationModel createModel(List<ModerationModelListener> listeners) {
+        return OpenAiModerationModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .logRequests(true)
+                .logResponses(true)
+                .listeners(listeners)
+                .build();
+    }
+
+    @Override
+    protected ModerationModel createFailingModel(List<ModerationModelListener> listeners) {
+        return OpenAiModerationModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey("banana")
+                .maxRetries(0)
+                .listeners(listeners)
+                .build();
+    }
+
+    @Override
+    protected Class<? extends Exception> expectedExceptionClass() {
+        return AuthenticationException.class;
+    }
+}

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
@@ -64,7 +64,7 @@ public class WatsonxModerationModel implements ModerationModel {
                 .verifySsl(builder.verifySsl)
                 .build();
 
-        this.listeners = copyIfNotNull(builder.listeners);
+        this.listeners = copy(builder.listeners);
     }
 
     @Override

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.watsonx;
 
-import static dev.langchain4j.internal.Utils.copyIfNotNull;
+import static dev.langchain4j.internal.Utils.copy;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.watsonx;
 
+import static dev.langchain4j.internal.Utils.copyIfNotNull;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
@@ -19,6 +20,7 @@ import dev.langchain4j.model.moderation.Moderation;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.moderation.ModerationRequest;
 import dev.langchain4j.model.moderation.ModerationResponse;
+import dev.langchain4j.model.moderation.listener.ModerationModelListener;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +45,7 @@ import java.util.concurrent.CompletionException;
 public class WatsonxModerationModel implements ModerationModel {
     private final List<BaseDetector> detectors;
     private final DetectionService detectionService;
+    private final List<ModerationModelListener> listeners;
 
     public WatsonxModerationModel(Builder builder) {
 
@@ -66,6 +69,13 @@ public class WatsonxModerationModel implements ModerationModel {
                 .httpClient(builder.httpClient)
                 .verifySsl(builder.verifySsl)
                 .build();
+
+        this.listeners = copyIfNotNull(builder.listeners);
+    }
+
+    @Override
+    public List<ModerationModelListener> listeners() {
+        return listeners != null ? listeners : List.of();
     }
 
     @Override
@@ -180,6 +190,7 @@ public class WatsonxModerationModel implements ModerationModel {
      */
     public static class Builder extends WatsonxBuilder<Builder> {
         private List<BaseDetector> detectors;
+        private List<ModerationModelListener> listeners;
 
         private Builder() {}
 
@@ -200,6 +211,17 @@ public class WatsonxModerationModel implements ModerationModel {
          */
         public Builder detectors(BaseDetector... detectors) {
             return detectors(List.of(detectors));
+        }
+
+        /**
+         * Sets the listeners for this moderation model.
+         *
+         * @param listeners the listeners.
+         * @return {@code this}.
+         */
+        public Builder listeners(List<ModerationModelListener> listeners) {
+            this.listeners = listeners;
+            return this;
         }
 
         public WatsonxModerationModel build() {

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
@@ -69,7 +69,7 @@ public class WatsonxModerationModel implements ModerationModel {
 
     @Override
     public List<ModerationModelListener> listeners() {
-        return listeners != null ? listeners : List.of();
+        return listeners;
     }
 
     @Override

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxModerationModel.java
@@ -8,11 +8,6 @@ import com.ibm.watsonx.ai.detection.DetectionService;
 import com.ibm.watsonx.ai.detection.DetectionTextRequest;
 import com.ibm.watsonx.ai.detection.DetectionTextResponse;
 import com.ibm.watsonx.ai.detection.detector.BaseDetector;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.SystemMessage;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.exception.LangChain4jException;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.model.ModelProvider;
@@ -21,7 +16,6 @@ import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.moderation.ModerationRequest;
 import dev.langchain4j.model.moderation.ModerationResponse;
 import dev.langchain4j.model.moderation.listener.ModerationModelListener;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -85,35 +79,8 @@ public class WatsonxModerationModel implements ModerationModel {
 
     @Override
     public ModerationResponse doModerate(ModerationRequest moderationRequest) {
-        List<String> inputs = toInputs(moderationRequest);
+        List<String> inputs = ModerationModel.toInputs(moderationRequest);
         return moderateInternal(inputs);
-    }
-
-    private List<String> toInputs(ModerationRequest moderationRequest) {
-        List<String> inputs = new ArrayList<>();
-        if (moderationRequest.hasText()) {
-            inputs.add(moderationRequest.text());
-        }
-        if (moderationRequest.hasMessages()) {
-            moderationRequest.messages().stream()
-                    .map(WatsonxModerationModel::toText)
-                    .forEach(inputs::add);
-        }
-        return inputs;
-    }
-
-    private static String toText(ChatMessage chatMessage) {
-        if (chatMessage instanceof SystemMessage systemMessage) {
-            return systemMessage.text();
-        } else if (chatMessage instanceof UserMessage userMessage) {
-            return userMessage.singleText();
-        } else if (chatMessage instanceof AiMessage aiMessage) {
-            return aiMessage.text();
-        } else if (chatMessage instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
-            return toolExecutionResultMessage.text();
-        } else {
-            throw new IllegalArgumentException("Unsupported message type: " + chatMessage.type());
-        }
     }
 
     private ModerationResponse moderateInternal(List<String> inputs) {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxModerationModelListenerIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxModerationModelListenerIT.java
@@ -1,0 +1,47 @@
+package dev.langchain4j.model.watsonx.it;
+
+import com.ibm.watsonx.ai.detection.detector.Hap;
+import dev.langchain4j.exception.AuthenticationException;
+import dev.langchain4j.model.moderation.ModerationModel;
+import dev.langchain4j.model.moderation.common.AbstractModerationModelListenerIT;
+import dev.langchain4j.model.moderation.listener.ModerationModelListener;
+import dev.langchain4j.model.watsonx.WatsonxModerationModel;
+import java.util.List;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+public class WatsonxModerationModelListenerIT extends AbstractModerationModelListenerIT {
+
+    static final String API_KEY = System.getenv("WATSONX_API_KEY");
+    static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
+    static final String URL = System.getenv("WATSONX_URL");
+
+    @Override
+    protected ModerationModel createModel(List<ModerationModelListener> listeners) {
+        return WatsonxModerationModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .projectId(PROJECT_ID)
+                .detectors(Hap.ofDefaults())
+                .listeners(listeners)
+                .build();
+    }
+
+    @Override
+    protected ModerationModel createFailingModel(List<ModerationModelListener> listeners) {
+        return WatsonxModerationModel.builder()
+                .baseUrl(URL)
+                .apiKey("invalid-api-key")
+                .projectId(PROJECT_ID)
+                .detectors(Hap.ofDefaults())
+                .listeners(listeners)
+                .build();
+    }
+
+    @Override
+    protected Class<? extends Exception> expectedExceptionClass() {
+        return AuthenticationException.class;
+    }
+}


### PR DESCRIPTION
## Issue

This PR adds observability support for `ModerationModel` implementations, following the same patterns established for `ChatModel` listeners. It introduces a new request/response API for moderation operations and provides listener callbacks for monitoring moderation requests, responses, and errors.

## Change

Commits:

1) [f025c0f61](https://github.com/jeanbisutti/langchain4j/commit/f025c0f61) - **Add ModerationRequest/ModerationResponse API to ModerationModel**
   - Introduce `ModerationRequest` with builder pattern supporting both text and messages
   - Introduce `ModerationResponse` with metadata (model name, token usage, finish reason)
   - Add `moderate(ModerationRequest)` method to `ModerationModel` interface
   - Update all implementations (OpenAI, MistralAI, Watsonx) to support the new API
   - Add unit tests for request/response classes

2) [aed77bf60](https://github.com/jeanbisutti/langchain4j/commit/aed77bf60) - **Add moderation model listener support**
   - Add `ModerationModelListener` interface with `onRequest`, `onResponse`, `onError` callbacks
   - Add context classes: `ModerationModelRequestContext`, `ModerationModelResponseContext`, `ModerationModelErrorContext`
   - Add `ModerationModelListenerUtils` for consistent listener invocation across implementations
   - Implement listener support in OpenAI, MistralAI, and Watsonx moderation models
   - Add `AbstractModerationModelListenerIT` base test class for consistent testing
   - Add documentation in observability tutorial

3) [2c600cd90](https://github.com/jeanbisutti/langchain4j/commit/2c600cd90) - **Refactoring - Add toInputs and toText utility methods to ModerationModel**
   - Extract common `toInputs()` and `toText()` utility methods to `ModerationModel` interface
   - Remove duplicate code from OpenAI, MistralAI, and Watsonx implementations

**Backward Compatibility:** The existing `moderate(String text)` and `moderate(ChatMessage... messages)` methods remain unchanged. The new `moderate(ModerationRequest)` API is additive. Listener support is opt-in via builder configuration.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)