### PR TITLE
Raw response documenmtation for MistralAi and Anthropic

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -525,6 +525,23 @@ Map<String, Object> customParameters = Map.of(
 );
 ```
 
+## Accessing raw HTTP responses and Server-Sent Events (SSE)
+
+When using `AnthropicChatModel`, you can access the raw HTTP response:
+```java
+SuccessfulHttpResponse rawHttpResponse = ((AnthropicChatResponseMetadata) chatResponse.metadata()).rawHttpResponse();
+System.out.println(rawHttpResponse.body());
+System.out.println(rawHttpResponse.headers());
+System.out.println(rawHttpResponse.statusCode());
+```
+
+When using `AnthropicStreamingChatModel`, you can access the raw HTTP response (see above) and raw Server-Sent Events:
+```java
+List<ServerSentEvent> rawServerSentEvents = ((AnthropicChatResponseMetadata) chatResponse.metadata()).rawServerSentEvents();
+System.out.println(rawServerSentEvents.get(0).data());
+System.out.println(rawServerSentEvents.get(0).event());
+```
+
 ## AnthropicTokenCountEstimator
 
 ```java

--- a/docs/docs/integrations/language-models/mistral-ai.md
+++ b/docs/docs/integrations/language-models/mistral-ai.md
@@ -577,7 +577,7 @@ System.out.println(rawHttpResponse.headers());
 System.out.println(rawHttpResponse.statusCode());
 ```
 
-When using `OpenAiStreamingChatModel`, you can access the raw HTTP response (see above) and raw Server-Sent Events:
+When using `MistralAiStreamingChatModel`, you can access the raw HTTP response (see above) and raw Server-Sent Events:
 ```java
 List<ServerSentEvent> rawServerSentEvents = ((MistralAiChatResponseMetadata) chatResponse.metadata()).rawServerSentEvents();
 System.out.println(rawServerSentEvents.get(0).data());

--- a/docs/docs/integrations/language-models/mistral-ai.md
+++ b/docs/docs/integrations/language-models/mistral-ai.md
@@ -567,6 +567,22 @@ public static void main(String[] args) {
 }
 ``` 
 
+## Accessing raw HTTP responses and Server-Sent Events (SSE)
+
+When using `MistralAiChatModel`, you can access the raw HTTP response:
+```java
+SuccessfulHttpResponse rawHttpResponse = ((MistralAiChatResponseMetadata) chatResponse.metadata()).rawHttpResponse();
+System.out.println(rawHttpResponse.body());
+System.out.println(rawHttpResponse.headers());
+System.out.println(rawHttpResponse.statusCode());
+```
+
+When using `OpenAiStreamingChatModel`, you can access the raw HTTP response (see above) and raw Server-Sent Events:
+```java
+List<ServerSentEvent> rawServerSentEvents = ((MistralAiChatResponseMetadata) chatResponse.metadata()).rawServerSentEvents();
+System.out.println(rawServerSentEvents.get(0).data());
+System.out.println(rawServerSentEvents.get(0).event());
+```
 
 ## Examples
 - [Mistral AI Examples](https://github.com/langchain4j/langchain4j-examples/tree/main/mistral-ai-examples/src/main/java)


### PR DESCRIPTION
Followup of #4405 / #4222

## Changes
Documents MistralAiChatResponseMetadata and AnthropicChatResponseMetadata and their raw response capabilities.


## General checklist
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)