### PR TITLE
Subsidiary SSE channel for Streamable HTTP

### DIFF
--- a/docs/docs/tutorials/mcp.md
+++ b/docs/docs/tutorials/mcp.md
@@ -60,10 +60,11 @@ McpTransport transport = StreamableHttpMcpTransport.builder()
         .build();
 ```
 
-**_NOTE:_** The Streamable HTTP transport currently does not create a global SSE stream
-(as described in the [spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#listening-for-messages-from-the-server)).
-Depending on the MCP server implementation, this may mean features that require server-initiated requests and notifications may or may not work.
-If the server piggybacks requests and notifications over SSE streams created for client-initiated operations, these will work.
+**_NOTE:_** The Streamable HTTP transport can optionally open a subsidiary
+[GET-based SSE stream](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server)
+for receiving server-initiated notifications and requests. Enable it with `.subsidiaryChannel(true)` on the builder.
+It is disabled by default. If the server does not support it, the transport logs a warning and continues without it.
+If the stream breaks after being established, the transport reconnects automatically (respecting the server's `retry` value, defaulting to 5 seconds).
 
 For the WebSocket transport:
 ```java

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseSubscriber.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/SseSubscriber.java
@@ -5,15 +5,32 @@ import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 
 class SseSubscriber implements Flow.Subscriber<String> {
+
+    /**
+     * Future for the result of the operation that this SSE subscriber was created for.
+     * If this is a subsidiary SSE subscriber for the long-lived GET channel (therefore, no operation), this will be null.
+     */
     private final CompletableFuture<JsonNode> future;
+
     private final Logger logger;
     private final boolean logResponses;
     private final McpOperationHandler operationHandler;
     private Flow.Subscription subscription;
+    private final boolean subsidiary;
+    private final AtomicReference<String> lastEventId;
+    private final AtomicLong retryMs;
+    private final Runnable onStreamEnd;
+    private final AtomicBoolean transportClosed;
 
+    /**
+     * Constructor for a regular (non-subsidiary) SSE subscriber, used for POST response streams.
+     */
     SseSubscriber(
             CompletableFuture<JsonNode> future,
             boolean logResponses,
@@ -23,6 +40,34 @@ class SseSubscriber implements Flow.Subscriber<String> {
         this.logResponses = logResponses;
         this.operationHandler = operationHandler;
         this.logger = logger;
+        this.subsidiary = false;
+        this.lastEventId = null;
+        this.retryMs = null;
+        this.onStreamEnd = null;
+        // in a regular subscriber, we don't really need this information that the transport is closed
+        this.transportClosed = new AtomicBoolean(false);
+    }
+
+    /**
+     * Constructor for a subsidiary SSE subscriber, used for the long-lived GET SSE channel.
+     */
+    SseSubscriber(
+            boolean logResponses,
+            McpOperationHandler operationHandler,
+            Logger logger,
+            AtomicReference<String> lastEventId,
+            AtomicLong retryMs,
+            Runnable onStreamEnd,
+            AtomicBoolean transportClosed) {
+        this.future = null;
+        this.logResponses = logResponses;
+        this.operationHandler = operationHandler;
+        this.logger = logger;
+        this.subsidiary = true;
+        this.lastEventId = lastEventId;
+        this.retryMs = retryMs;
+        this.onStreamEnd = onStreamEnd;
+        this.transportClosed = transportClosed;
     }
 
     @Override
@@ -33,7 +78,7 @@ class SseSubscriber implements Flow.Subscriber<String> {
 
     @Override
     public void onNext(String item) {
-        if (logResponses) {
+        if (logResponses && !item.trim().isEmpty()) {
             logger.info("SSE event received: " + item);
         }
         subscription.request(1);
@@ -43,16 +88,38 @@ class SseSubscriber implements Flow.Subscriber<String> {
             } catch (JsonProcessingException e) {
                 logger.warn("Failed to parse SSE event: " + item, e);
             }
+        } else if (item.startsWith("id:") && lastEventId != null) {
+            lastEventId.set(item.substring(3).trim());
+        } else if (item.startsWith("retry:") && retryMs != null) {
+            try {
+                retryMs.set(Long.parseLong(item.substring(6).trim()));
+            } catch (NumberFormatException e) {
+                logger.warn("Failed to parse SSE retry value: " + item, e);
+            }
         }
     }
 
     @Override
     public void onError(Throwable throwable) {
-        future.completeExceptionally(throwable);
+        if (subsidiary && !transportClosed.get()) {
+            logger.debug("Subsidiary SSE channel error", throwable);
+            if (onStreamEnd != null) {
+                onStreamEnd.run();
+            }
+        } else {
+            future.completeExceptionally(throwable);
+        }
     }
 
     @Override
     public void onComplete() {
-        logger.debug("SSE channel closed");
+        if (subsidiary) {
+            logger.debug("Subsidiary SSE channel closed");
+            if (onStreamEnd != null && !transportClosed.get()) {
+                onStreamEnd.run();
+            }
+        } else {
+            logger.debug("SSE channel closed");
+        }
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.mcp.client.McpCallContext;
 import dev.langchain4j.mcp.client.McpHeadersSupplier;
 import dev.langchain4j.mcp.client.logging.McpLoggers;
@@ -27,6 +28,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import javax.net.ssl.SSLContext;
@@ -35,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 public class StreamableHttpMcpTransport implements McpTransport {
     private static final Logger LOG = LoggerFactory.getLogger(StreamableHttpMcpTransport.class);
+    private static final long DEFAULT_SUBSIDIARY_RETRY_MS = 5000;
     private final String url;
     private final McpHeadersSupplier customHeadersSupplier;
     private final boolean logResponses;
@@ -49,6 +54,15 @@ public class StreamableHttpMcpTransport implements McpTransport {
     private McpInitializeRequest initializeRequest;
     private final AtomicReference<String> mcpSessionId = new AtomicReference<>();
 
+    // Subsidiary SSE channel fields
+    private final boolean subsidiaryChannelEnabled;
+    private volatile Runnable onFailureCallback;
+    private volatile boolean subsidiaryChannelEstablished;
+    private final AtomicReference<String> subsidiaryLastEventId = new AtomicReference<>();
+    private final AtomicLong subsidiaryRetryMs = new AtomicLong(DEFAULT_SUBSIDIARY_RETRY_MS);
+    private final Executor executor;
+    private AtomicBoolean closed = new AtomicBoolean(false);
+
     public StreamableHttpMcpTransport(StreamableHttpMcpTransport.Builder builder) {
         url = ensureNotNull(builder.url, "Missing server endpoint URL");
         logRequests = builder.logRequests;
@@ -58,6 +72,8 @@ public class StreamableHttpMcpTransport implements McpTransport {
         customHeadersSupplier = getOrDefault(builder.customHeadersSupplier, (i) -> Map.of());
         sslContext = builder.sslContext;
         httpVersion = builder.forceHttpVersion1_1 ? HttpClient.Version.HTTP_1_1 : HttpClient.Version.HTTP_2;
+        subsidiaryChannelEnabled = builder.subsidiaryChannelEnabled;
+        executor = getOrDefault(builder.executor, DefaultExecutorProvider.getDefaultExecutorService());
         HttpClient.Builder clientBuilder =
                 HttpClient.newBuilder().connectTimeout(timeout).version(httpVersion);
         if (builder.executor != null) {
@@ -86,7 +102,14 @@ public class StreamableHttpMcpTransport implements McpTransport {
                 })
                 .thenCompose(originalResponse -> execute(
                                 new McpCallContext(null, new McpInitializationNotification()), false)
-                        .thenCompose(nullNode -> CompletableFuture.completedFuture(originalResponse)));
+                        .thenCompose(nullNode -> CompletableFuture.completedFuture(originalResponse)))
+                .thenCompose(originalResponse -> {
+                    if (subsidiaryChannelEnabled) {
+                        return startSubsidiaryChannel(true)
+                                .thenCompose(v -> CompletableFuture.completedFuture(originalResponse));
+                    }
+                    return CompletableFuture.completedFuture(originalResponse);
+                });
     }
 
     private HttpRequest createRequest(McpJsonRpcMessage message, McpCallContext callContext)
@@ -139,7 +162,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
 
     @Override
     public void onFailure(Runnable actionOnFailure) {
-        // nothing to do here, we don't maintain a long-running SSE channel (yet)
+        this.onFailureCallback = actionOnFailure;
     }
 
     private CompletableFuture<JsonNode> execute(McpCallContext context, boolean isRetry) {
@@ -228,12 +251,114 @@ public class StreamableHttpMcpTransport implements McpTransport {
         return future;
     }
 
+    /**
+     * Opens the subsidiary SSE channel by issuing an HTTP GET to the MCP endpoint.
+     * This allows the server to send notifications and requests to the client
+     * without the client first sending data via HTTP POST.
+     *
+     * @param firstAttempt if true, failures will not trigger reconnection
+     * @return a future that completes when the channel setup attempt finishes
+     */
+    private CompletableFuture<Void> startSubsidiaryChannel(boolean firstAttempt) {
+        if (closed.get()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Accept", "text/event-stream")
+                .GET();
+        String sessionId = mcpSessionId.get();
+        if (sessionId != null) {
+            requestBuilder.header("Mcp-Session-Id", sessionId);
+        }
+        String lastId = subsidiaryLastEventId.get();
+        if (lastId != null) {
+            requestBuilder.header("Last-Event-ID", lastId);
+        }
+        Map<String, String> headers = customHeadersSupplier.apply(null);
+        if (headers != null) {
+            headers.forEach(requestBuilder::header);
+        }
+        HttpRequest request = requestBuilder.build();
+
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        SseSubscriber subscriber = new SseSubscriber(
+                logResponses,
+                operationHandler,
+                trafficLog,
+                subsidiaryLastEventId,
+                subsidiaryRetryMs,
+                this::scheduleSubsidiaryReconnect,
+                closed);
+
+        httpClient
+                .sendAsync(request, responseInfo -> {
+                    int statusCode = responseInfo.statusCode();
+                    Optional<String> contentType = responseInfo.headers().firstValue("Content-Type");
+                    if (isExpectedStatusCode(statusCode)
+                            && contentType.isPresent()
+                            && contentType.get().contains("text/event-stream")) {
+                        subsidiaryChannelEstablished = true;
+                        LOG.debug("Subsidiary SSE channel established");
+                        result.complete(null);
+                        return HttpResponse.BodySubscribers.fromLineSubscriber(subscriber);
+                    } else {
+                        if (firstAttempt) {
+                            LOG.warn(
+                                    "Failed to open subsidiary SSE channel (status={}, contentType={}), will not re-attempt",
+                                    statusCode,
+                                    contentType.orElse("absent"));
+                        } else {
+                            LOG.debug(
+                                    "Failed to reconnect subsidiary SSE channel (status={}, contentType={}), scheduling retry",
+                                    statusCode,
+                                    contentType.orElse("absent"));
+                            if (!closed.get()) {
+                                scheduleSubsidiaryReconnect();
+                            }
+                        }
+                        result.complete(null);
+                        return HttpResponse.BodySubscribers.discarding();
+                    }
+                })
+                .exceptionally(t -> {
+                    if (!closed.get()) {
+                        if (firstAttempt) {
+                            LOG.warn("Failed to open subsidiary SSE channel", t);
+                        } else {
+                            LOG.debug("Subsidiary SSE channel connection failed, scheduling retry", t);
+                            scheduleSubsidiaryReconnect();
+                        }
+                    }
+                    result.complete(null);
+                    return null;
+                });
+        return result;
+    }
+
+    private void scheduleSubsidiaryReconnect() {
+        if (closed.get() || !subsidiaryChannelEstablished) {
+            return;
+        }
+        long delayMs = subsidiaryRetryMs.get();
+        LOG.debug("Scheduling subsidiary SSE channel reconnect in {} ms", delayMs);
+        Executor delayedExecutor = CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS, executor);
+        CompletableFuture.runAsync(
+                () -> {
+                    if (!closed.get()) {
+                        startSubsidiaryChannel(false);
+                    }
+                },
+                delayedExecutor);
+    }
+
     private boolean isExpectedStatusCode(int statusCode) {
         return statusCode >= 200 && statusCode < 300;
     }
 
     @Override
     public void close() throws IOException {
+        closed.set(true);
         // The httpClient.close() method only exists on JDK 21+, so invoke it only if we can.
         // Replace this with a normal method call when switching the base to JDK 21+.
         try {
@@ -257,6 +382,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
         private Logger logger;
         private SSLContext sslContext;
         private boolean forceHttpVersion1_1;
+        private boolean subsidiaryChannelEnabled = false;
 
         /**
          * The URL of the MCP server.
@@ -332,6 +458,8 @@ public class StreamableHttpMcpTransport implements McpTransport {
 
         /**
          * An optional {@link Executor} that will be used for executing requests and handling responses.
+         * It will also be used for scheduling auto-reconnect attempts of the subsidiary SSE channel if that is enabled.
+         * If not provided, a default shared executor will be used.
          */
         public StreamableHttpMcpTransport.Builder executor(Executor executor) {
             this.executor = executor;
@@ -352,6 +480,21 @@ public class StreamableHttpMcpTransport implements McpTransport {
          */
         public StreamableHttpMcpTransport.Builder setHttpVersion1_1() {
             this.forceHttpVersion1_1 = true;
+            return this;
+        }
+
+        /**
+         * Enables or disables the subsidiary SSE channel. When enabled, the transport
+         * will open an HTTP GET-based SSE stream after initialization, allowing the
+         * server to send notifications and requests to the client without the client
+         * first sending data via HTTP POST. If the server does not support the
+         * subsidiary channel (returns 405), the transport will log a warning and
+         * continue without it. If the stream breaks after being successfully
+         * established, the transport will automatically attempt to reconnect.
+         * Defaults to {@code false}.
+         */
+        public StreamableHttpMcpTransport.Builder subsidiaryChannel(boolean subsidiaryChannelEnabled) {
+            this.subsidiaryChannelEnabled = subsidiaryChannelEnabled;
             return this;
         }
 

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolUpdatesStreamableHttpTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpToolUpdatesStreamableHttpTransportIT.java
@@ -12,11 +12,9 @@ import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Disabled("Tool list updates not working over streamable-http transport yet - opening a global SSE stream is necessary")
 class McpToolUpdatesStreamableHttpTransportIT extends McpToolUpdatesTestBase {
 
     private static final Logger log = LoggerFactory.getLogger(McpToolUpdatesStreamableHttpTransportIT.class);
@@ -30,6 +28,7 @@ class McpToolUpdatesStreamableHttpTransportIT extends McpToolUpdatesTestBase {
                 .url("http://localhost:8080/mcp")
                 .logRequests(true)
                 .logResponses(true)
+                .subsidiaryChannel(true)
                 .build();
         mcpClient = new DefaultMcpClient.Builder()
                 .transport(transport)


### PR DESCRIPTION
Adds support for the subsidiary SSE channel as desribed in https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server

`quarkus-mcp-server` calls it "subsidiary", the spec doesn't have any name for it, so I went with subsidiary too.

I went with it being disabled by default because I don't think it is something that will be used very often, and it's somewhat experimental, so better stay on the safe side.

FYI @mkouba