### PR TITLE
fix(vertexai-gemini): support anyOf and null schema elements in tool mapping

### DIFF
--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/SchemaHelper.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/SchemaHelper.java
@@ -4,15 +4,16 @@ import com.google.cloud.vertexai.api.Schema;
 import com.google.cloud.vertexai.api.Type;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
 import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
 import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNullSchema;
 import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,12 +41,12 @@ public class SchemaHelper {
             // but it seems the Gemini SDK mandates uppercase types
             // as exposed in <code>com.google.cloud.vertexai.api.Type</code>
             String schemaJsonString = jsonSchemaString
-                .replace("\"object\"", "\"OBJECT\"")
-                .replace("\"integer\"", "\"INTEGER\"")
-                .replace("\"string\"", "\"STRING\"")
-                .replace("\"number\"", "\"NUMBER\"")
-                .replace("\"array\"", "\"ARRAY\"")
-                .replace("\"boolean\"", "\"BOOLEAN\"");
+                    .replace("\"object\"", "\"OBJECT\"")
+                    .replace("\"integer\"", "\"INTEGER\"")
+                    .replace("\"string\"", "\"STRING\"")
+                    .replace("\"number\"", "\"NUMBER\"")
+                    .replace("\"array\"", "\"ARRAY\"")
+                    .replace("\"boolean\"", "\"BOOLEAN\"");
 
             Schema.Builder builder = Schema.newBuilder();
             JsonFormat.parser().merge(schemaJsonString, builder);
@@ -61,28 +62,28 @@ public class SchemaHelper {
      * @return a fully built schema
      */
     public static Schema fromClass(Class<?> theClass) {
-        if (CharSequence.class.isAssignableFrom(theClass) ||
-            Character.class.isAssignableFrom(theClass) ||
-            char.class.isAssignableFrom(theClass)) {
+        if (CharSequence.class.isAssignableFrom(theClass)
+                || Character.class.isAssignableFrom(theClass)
+                || char.class.isAssignableFrom(theClass)) {
             return Schema.newBuilder().setType(Type.STRING).build();
-        } else if (Boolean.class.isAssignableFrom(theClass) ||
-            boolean.class.isAssignableFrom(theClass)) {
+        } else if (Boolean.class.isAssignableFrom(theClass) || boolean.class.isAssignableFrom(theClass)) {
             return Schema.newBuilder().setType(Type.BOOLEAN).build();
-        } else if (Integer.class.isAssignableFrom(theClass) ||
-            int.class.isAssignableFrom(theClass) ||
-            Long.class.isAssignableFrom(theClass) ||
-            long.class.isAssignableFrom(theClass)) {
+        } else if (Integer.class.isAssignableFrom(theClass)
+                || int.class.isAssignableFrom(theClass)
+                || Long.class.isAssignableFrom(theClass)
+                || long.class.isAssignableFrom(theClass)) {
             return Schema.newBuilder().setType(Type.INTEGER).build();
-        } else if (Double.class.isAssignableFrom(theClass) ||
-            double.class.isAssignableFrom(theClass) ||
-            Float.class.isAssignableFrom(theClass) ||
-            float.class.isAssignableFrom(theClass)) {
+        } else if (Double.class.isAssignableFrom(theClass)
+                || double.class.isAssignableFrom(theClass)
+                || Float.class.isAssignableFrom(theClass)
+                || float.class.isAssignableFrom(theClass)) {
             return Schema.newBuilder().setType(Type.NUMBER).build();
         } else if (theClass.isArray()) {
             Class<?> componentType = theClass.getComponentType();
-            return Schema.newBuilder().setType(Type.ARRAY).setItems(
-                fromClass(componentType)
-            ).build();
+            return Schema.newBuilder()
+                    .setType(Type.ARRAY)
+                    .setItems(fromClass(componentType))
+                    .build();
         } else if (Collection.class.isAssignableFrom(theClass)) {
             // Because of type erasure, we can't easily know the type of the items in the collection
             return Schema.newBuilder().setType(Type.ARRAY).build();
@@ -91,22 +92,22 @@ public class SchemaHelper {
                     .map(e -> ((Enum<?>) e).name())
                     .toList();
             return Schema.newBuilder()
-                .setType(Type.STRING)
-                .addAllEnum(enumConstantNames)
-                .build();
+                    .setType(Type.STRING)
+                    .addAllEnum(enumConstantNames)
+                    .build();
         } else {
             // This is some kind of object, let's go through its fields
             Schema.Builder schemaBuilder = Schema.newBuilder().setType(Type.OBJECT);
             List<String> propertyNames = new ArrayList<>();
-            Stream.concat(
-                Arrays.stream(theClass.getDeclaredFields()),
-                Arrays.stream(theClass.getFields()))
-                .filter(field -> !field.getName().startsWith("this$"))
-                .collect(Collectors.toSet())
-                .forEach(field -> {
-                    schemaBuilder.putProperties(field.getName(), fromClass(field.getType())).build();
-                    propertyNames.add(field.getName());
-            });
+            Stream.concat(Arrays.stream(theClass.getDeclaredFields()), Arrays.stream(theClass.getFields()))
+                    .filter(field -> !field.getName().startsWith("this$"))
+                    .collect(Collectors.toSet())
+                    .forEach(field -> {
+                        schemaBuilder
+                                .putProperties(field.getName(), fromClass(field.getType()))
+                                .build();
+                        propertyNames.add(field.getName());
+                    });
             schemaBuilder.addAllRequired(propertyNames);
             return schemaBuilder.build();
         }
@@ -115,59 +116,62 @@ public class SchemaHelper {
     public static Schema from(JsonSchemaElement jsonSchemaElement) {
         if (jsonSchemaElement instanceof JsonStringSchema) {
             JsonStringSchema jsonStringSchema = (JsonStringSchema) jsonSchemaElement;
-            Schema.Builder builder = Schema.newBuilder()
-                    .setType(Type.STRING);
+            Schema.Builder builder = Schema.newBuilder().setType(Type.STRING);
             if (jsonStringSchema.description() != null) {
                 builder.setDescription(jsonStringSchema.description());
             }
             return builder.build();
         } else if (jsonSchemaElement instanceof JsonBooleanSchema) {
             JsonBooleanSchema jsonBooleanSchema = (JsonBooleanSchema) jsonSchemaElement;
-            Schema.Builder builder = Schema.newBuilder()
-                    .setType(Type.BOOLEAN);
+            Schema.Builder builder = Schema.newBuilder().setType(Type.BOOLEAN);
             if (jsonBooleanSchema.description() != null) {
                 builder.setDescription(jsonBooleanSchema.description());
             }
             return builder.build();
         } else if (jsonSchemaElement instanceof JsonIntegerSchema) {
             JsonIntegerSchema jsonIntegerSchema = (JsonIntegerSchema) jsonSchemaElement;
-            Schema.Builder builder = Schema.newBuilder()
-                    .setType(Type.INTEGER);
+            Schema.Builder builder = Schema.newBuilder().setType(Type.INTEGER);
             if (jsonIntegerSchema.description() != null) {
                 builder.setDescription(jsonIntegerSchema.description());
             }
             return builder.build();
         } else if (jsonSchemaElement instanceof JsonNumberSchema) {
             JsonNumberSchema jsonNumberSchema = (JsonNumberSchema) jsonSchemaElement;
-            Schema.Builder builder = Schema.newBuilder()
-                    .setType(Type.NUMBER);
+            Schema.Builder builder = Schema.newBuilder().setType(Type.NUMBER);
             if (jsonNumberSchema.description() != null) {
                 builder.setDescription(jsonNumberSchema.description());
             }
             return builder.build();
         } else if (jsonSchemaElement instanceof JsonEnumSchema) {
             JsonEnumSchema jsonEnumSchema = (JsonEnumSchema) jsonSchemaElement;
-            Schema.Builder builder = Schema.newBuilder()
-                    .setType(Type.STRING)
-                    .addAllEnum(jsonEnumSchema.enumValues());
+            Schema.Builder builder = Schema.newBuilder().setType(Type.STRING).addAllEnum(jsonEnumSchema.enumValues());
             if (jsonEnumSchema.description() != null) {
                 builder.setDescription(jsonEnumSchema.description());
             }
             return builder.build();
         } else if (jsonSchemaElement instanceof JsonArraySchema) {
             JsonArraySchema jsonArraySchema = (JsonArraySchema) jsonSchemaElement;
-            Schema.Builder builder = Schema.newBuilder()
-                    .setType(Type.ARRAY)
-                    .setItems(from(jsonArraySchema.items()));
+            Schema.Builder builder = Schema.newBuilder().setType(Type.ARRAY).setItems(from(jsonArraySchema.items()));
             if (jsonArraySchema.description() != null) {
                 builder.setDescription(jsonArraySchema.description());
             }
             return builder.build();
+        } else if (jsonSchemaElement instanceof JsonAnyOfSchema) {
+            JsonAnyOfSchema jsonAnyOfSchema = (JsonAnyOfSchema) jsonSchemaElement;
+            Schema.Builder builder = Schema.newBuilder()
+                    .addAllAnyOf(jsonAnyOfSchema.anyOf().stream()
+                            .map(SchemaHelper::from)
+                            .toList());
+            if (jsonAnyOfSchema.description() != null) {
+                builder.setDescription(jsonAnyOfSchema.description());
+            }
+            return builder.build();
+        } else if (jsonSchemaElement instanceof JsonNullSchema) {
+            return Schema.newBuilder().setNullable(true).build();
         } else if (jsonSchemaElement instanceof JsonObjectSchema) {
             JsonObjectSchema jsonObjectSchema = (JsonObjectSchema) jsonSchemaElement;
             Map<String, Schema> properties = new LinkedHashMap<>();
-            jsonObjectSchema.properties()
-                    .forEach((property, value) -> properties.put(property, from(value)));
+            jsonObjectSchema.properties().forEach((property, value) -> properties.put(property, from(value)));
             Schema.Builder builder = Schema.newBuilder()
                     .setType(Type.OBJECT)
                     .putAllProperties(properties)


### PR DESCRIPTION
## Summary
This fixes `SchemaHelper.from(JsonSchemaElement)` in the Vertex AI Gemini integration to handle schema variants that are already supported in Google AI Gemini mapping but currently fail in Vertex AI mapping.

Fixes #4617

## What changed
- Added handling for `JsonAnyOfSchema` in `SchemaHelper.from(...)` by mapping nested variants into Vertex AI `Schema.anyOf`.
- Added handling for `JsonNullSchema` in `SchemaHelper.from(...)` by mapping it to `Schema.nullable=true`.
- Added regression tests in `SchemaHelperTest` covering:
  - `anyOf` + `null` composition
  - direct `null` schema mapping
  - `anyOf` without description
  - object path after null-check branch

## Why this is safe
- Change is scoped to schema conversion for Vertex AI Gemini tool/response schema mapping.
- Existing behavior for other schema types is unchanged.

## Local verification
- `./mvnw -pl langchain4j-vertex-ai-gemini spotless:check -Dtest=SchemaHelperTest -Dsurefire.failIfNoSpecifiedTests=false test jacoco:report`
- `Tests run: 8, Failures: 0, Errors: 0`

Coverage note:
- The newly added anyOf/null conversion paths are exercised by dedicated regression tests.

## AI usage disclosure
AI assistance was limited to unit test drafting, code review support, and formatting/check command validation.
