### PR TITLE
Make sure the HibernateEmbeddingStore also works with Hibernate ORM 7.1

### DIFF
--- a/langchain4j-hibernate/src/main/java/dev/langchain4j/store/embedding/hibernate/Embedding.java
+++ b/langchain4j-hibernate/src/main/java/dev/langchain4j/store/embedding/hibernate/Embedding.java
@@ -27,5 +27,5 @@ import org.hibernate.type.SqlTypes;
  */
 @Target({METHOD, FIELD})
 @Retention(RUNTIME)
-@JdbcTypeCode(SqlTypes.VECTOR_FLOAT32)
+@JdbcTypeCode(SqlTypes.VECTOR)
 public @interface Embedding {}

--- a/langchain4j-hibernate/src/test/java/dev/langchain4j/store/embedding/generic/PgVectorEmbeddingIndexedStoreIT.java
+++ b/langchain4j-hibernate/src/test/java/dev/langchain4j/store/embedding/generic/PgVectorEmbeddingIndexedStoreIT.java
@@ -38,6 +38,7 @@ class PgVectorEmbeddingIndexedStoreIT extends EmbeddingStoreWithFilteringIT {
                 .createIndex(true)
                 .indexType("ivfflat")
                 .indexOptions("lists = 1")
+                .createTable(true)
                 .dropTableFirst(true)
                 .build();
     }

--- a/langchain4j-hibernate/src/test/java/dev/langchain4j/store/embedding/generic/PgVectorEmbeddingStoreConfigIT.java
+++ b/langchain4j-hibernate/src/test/java/dev/langchain4j/store/embedding/generic/PgVectorEmbeddingStoreConfigIT.java
@@ -53,6 +53,7 @@ public class PgVectorEmbeddingStoreConfigIT extends EmbeddingStoreWithFilteringI
                 .dataSource(dataSource)
                 .table(TABLE_NAME)
                 .dimension(TABLE_DIMENSION)
+                .createTable(true)
                 .dropTableFirst(true)
                 .build();
     }

--- a/langchain4j-hibernate/src/test/java/dev/langchain4j/store/embedding/generic/PgVectorEmbeddingStoreIT.java
+++ b/langchain4j-hibernate/src/test/java/dev/langchain4j/store/embedding/generic/PgVectorEmbeddingStoreIT.java
@@ -50,6 +50,7 @@ class PgVectorEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
                 .password("test")
                 .table("test" + nextInt(1000, 2000))
                 .dimension(384)
+                .createTable(true)
                 .dropTableFirst(true)
                 .build();
     }

--- a/langchain4j-hibernate/src/test/java/dev/langchain4j/store/embedding/generic/PgVectorEmbeddingStoreRemovalIT.java
+++ b/langchain4j-hibernate/src/test/java/dev/langchain4j/store/embedding/generic/PgVectorEmbeddingStoreRemovalIT.java
@@ -36,6 +36,7 @@ class PgVectorEmbeddingStoreRemovalIT extends EmbeddingStoreWithRemovalIT {
                 .password("test")
                 .table("test" + nextInt(2000, 3000))
                 .dimension(384)
+                .createTable(true)
                 .dropTableFirst(true)
                 .build();
     }


### PR DESCRIPTION
This is a quick follow-up of https://github.com/langchain4j/langchain4j/pull/4622 as I noticed that the integration didn't work with Hibernate ORM 7.1, which is part of the previous Quarkus LTS.