### PR TITLE
Mention the MCP client key when logging health check failure

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -520,7 +520,7 @@ public class DefaultMcpClient implements McpClient {
             try {
                 checkHealth();
             } catch (Exception e) {
-                log.warn("mcp server health check failed. Attempting to reconnect...", e);
+                log.warn("MCP server health check (client key: " + key + ") failed. Attempting to reconnect...", e);
                 triggerReconnection();
             }
         };


### PR DESCRIPTION
With multiple clients, it's not clear which one has started failing..