### PR TITLE
Add durable long-lived task execution layer (experimental)

### DIFF
--- a/experimental/langchain4j-experimental-durable-tasks/README.md
+++ b/experimental/langchain4j-experimental-durable-tasks/README.md
@@ -1,0 +1,103 @@
+# LangChain4j Experimental: Durable Long-Lived Tasks
+
+An experimental module that adds durable lifecycle management to langchain4j agentic workflows.
+
+## Features
+
+- **Start / Monitor / Cancel** — submit agent workflows as managed tasks with unique identifiers
+- **Pause / Resume** — human-in-the-loop and external-input scenarios; tasks persist their state and resume from the last checkpoint
+- **Automatic Retry** — configurable exponential-backoff retry for transient failures
+- **Crash Recovery** — recover tasks that were running when the process stopped
+- **Event Journal** — full audit trail of every agent invocation, pause, retry, and completion
+- **Checkpointing** — scope-aware snapshots enable fast resume without re-executing completed steps
+- **Replay** — `ReplayingPlanner` replays completed invocations from the journal on resume
+
+## Quick Start
+
+```java
+// 1. Create a store (in-memory for dev, file-based for production)
+TaskExecutionStore store = new InMemoryTaskExecutionStore();
+
+// 2. Build the service
+LongLivedTaskService service = LongLivedTaskService.builder()
+        .store(store)
+        .build();
+
+// 3. Start a task
+TaskHandle handle = service.start(
+        TaskConfiguration.builder().agentName("myWorkflow").build(),
+        () -> myAgent.run(inputs));
+
+// 4. Wait for the result
+Object result = handle.awaitResult().get(5, TimeUnit.MINUTES);
+```
+
+## Pause and Resume (Human-in-the-Loop)
+
+```java
+// Use DurableHumanInTheLoop as an agent in your topology
+DurableHumanInTheLoop approval = DurableHumanInTheLoop.builder()
+        .outputKey("managerApproval")
+        .reason("Waiting for manager approval")
+        .build();
+
+// When the agent runs and no input is available, the task pauses automatically.
+// Later, provide the input and resume:
+service.provideInput(taskId, "managerApproval", "approved");
+TaskHandle resumed = service.resume(taskId, () -> myAgent.run(inputs));
+```
+
+## Automatic Retry
+
+```java
+RetryPolicy retry = RetryPolicy.builder()
+        .maxRetries(3)
+        .initialDelay(Duration.ofSeconds(2))
+        .retryableException(IOException.class)
+        .build();
+
+TaskConfiguration config = TaskConfiguration.builder()
+        .agentName("apiCaller")
+        .retryPolicy(retry)
+        .build();
+
+TaskHandle handle = service.start(config, () -> callExternalApi());
+```
+
+## Crash Recovery
+
+```java
+// On application startup:
+Set<TaskId> interrupted = service.recoverInterruptedTasks();
+for (TaskId id : interrupted) {
+    service.resume(id, () -> rebuildWorkflow(id));
+}
+```
+
+## Persistence
+
+Two built-in store implementations:
+
+| Store | Use case |
+|-------|----------|
+| `InMemoryTaskExecutionStore` | Testing and development |
+| `FileTaskExecutionStore` | Single-node production (file-per-task with atomic writes) |
+
+Custom stores (e.g., database-backed) can be created by implementing `TaskExecutionStore`.
+
+## Module Structure
+
+| Package | Description |
+|---------|-------------|
+| `durable` | `LongLivedTaskService` — the central service |
+| `durable.task` | Task API: `TaskId`, `TaskHandle`, `TaskStatus`, `TaskConfiguration`, `RetryPolicy` |
+| `durable.store` | `TaskExecutionStore` SPI and implementations |
+| `durable.store.event` | Event journal types (sealed hierarchy) |
+| `durable.hitl` | `DurableHumanInTheLoop` agent |
+| `durable.replay` | `ReplayingPlanner` for resume replay |
+| `durable.journal` | `JournalingAgentListener` for event recording |
+
+## Status
+
+This module is **experimental**. All public types are annotated with `@Experimental` and
+the API may change without notice in future releases.

--- a/experimental/langchain4j-experimental-durable-tasks/pom.xml
+++ b/experimental/langchain4j-experimental-durable-tasks/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-parent</artifactId>
+        <version>1.12.0-beta20-SNAPSHOT</version>
+        <relativePath>../../langchain4j-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-experimental-durable-tasks</artifactId>
+    <name>LangChain4j :: Experimental :: Durable Tasks</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>1.12.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-agentic</artifactId>
+            <version>1.12.0-beta20-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/LongLivedTaskService.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/LongLivedTaskService.java
@@ -623,8 +623,10 @@ public class LongLivedTaskService implements AutoCloseable {
                         if (fresh == null || fresh.status().isTerminal()) {
                             return;
                         }
-                        LOG.warn("Task {} CAS to RUNNING failed twice (current: {}), aborting attempt",
-                                taskId, fresh.status());
+                        LOG.warn(
+                                "Task {} CAS to RUNNING failed twice (current: {}), aborting attempt",
+                                taskId,
+                                fresh.status());
                         return;
                     } else {
                         metadata = running.get();
@@ -714,7 +716,11 @@ public class LongLivedTaskService implements AutoCloseable {
                     }
                     future.completeExceptionally(pausedException);
                     activeHandles.remove(taskId);
-                    LOG.info("Task {} paused (unwrapped from {}): {}", taskId, e.getClass().getSimpleName(), pausedException.reason());
+                    LOG.info(
+                            "Task {} paused (unwrapped from {}): {}",
+                            taskId,
+                            e.getClass().getSimpleName(),
+                            pausedException.reason());
                     return;
                 }
 

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/LongLivedTaskService.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/LongLivedTaskService.java
@@ -1,0 +1,910 @@
+package dev.langchain4j.experimental.durable;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.internal.CheckpointManager;
+import dev.langchain4j.experimental.durable.internal.DefaultTaskHandle;
+import dev.langchain4j.experimental.durable.internal.ObjectMapperFactory;
+import dev.langchain4j.experimental.durable.journal.JournalingAgentListener;
+import dev.langchain4j.experimental.durable.replay.ReplayingPlanner;
+import dev.langchain4j.experimental.durable.store.TaskExecutionStore;
+import dev.langchain4j.experimental.durable.store.event.TaskCancelledEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskCompletedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskFailedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskPausedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskResumedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskRetryEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskStartedEvent;
+import dev.langchain4j.experimental.durable.task.CheckpointPolicy;
+import dev.langchain4j.experimental.durable.task.RetryPolicy;
+import dev.langchain4j.experimental.durable.task.TaskConfiguration;
+import dev.langchain4j.experimental.durable.task.TaskHandle;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import dev.langchain4j.experimental.durable.task.TaskPausedException;
+import dev.langchain4j.experimental.durable.task.TaskStatus;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Central service for managing durable, long-lived agent tasks.
+ *
+ * <p>This service wraps any agentic execution with a durable lifecycle:
+ * start, monitor, pause, resume, cancel, retry, and query. It is not limited
+ * to any single workflow pattern — it supports sequential, conditional,
+ * and loop-based planners equally well.
+ *
+ * <h2>Supported scenarios</h2>
+ * <ul>
+ *   <li>Long-running tool calls (APIs, web scraping, batch processing)</li>
+ *   <li>Multi-step agentic workflows (sequential / conditional / loop)</li>
+ *   <li>Crash and restart recovery</li>
+ *   <li>Automatic retry after transient failures</li>
+ *   <li>Explicit pause / resume (including human-in-the-loop)</li>
+ *   <li>Observability and replay via the event journal</li>
+ * </ul>
+ *
+ * <h2>Starting a task</h2>
+ * <pre>{@code
+ * TaskHandle handle = service.start(
+ *     TaskConfiguration.builder().agentName("myWorkflow").build(),
+ *     () -> myAgent.run(inputs));
+ * }</pre>
+ *
+ * <h2>Resuming after crash or pause</h2>
+ * <pre>{@code
+ * // Application recreates the agent topology
+ * TaskHandle handle = service.resume(taskId, () -> myAgent.run(inputs));
+ * }</pre>
+ *
+ * <h2>Automatic retry on transient failures</h2>
+ * <pre>{@code
+ * RetryPolicy retry = RetryPolicy.builder()
+ *         .maxRetries(3)
+ *         .initialDelay(Duration.ofSeconds(2))
+ *         .retryableException(IOException.class)
+ *         .build();
+ * TaskConfiguration config = TaskConfiguration.builder()
+ *         .agentName("apiCaller")
+ *         .retryPolicy(retry)
+ *         .build();
+ * TaskHandle handle = service.start(config, () -> callExternalApi());
+ * }</pre>
+ *
+ * <h2>Crash recovery on startup</h2>
+ * <pre>{@code
+ * Set<TaskId> interrupted = service.recoverInterruptedTasks();
+ * for (TaskId id : interrupted) {
+ *     service.resume(id, () -> rebuildWorkflow(id));
+ * }
+ * }</pre>
+ *
+ * <h2>Providing external input for a paused task</h2>
+ * <pre>{@code
+ * service.provideInput(taskId, "approvalKey", "approved");
+ * TaskHandle handle = service.resume(taskId, () -> myAgent.run(inputs));
+ * }</pre>
+ *
+ * <p>The service uses a {@link TaskExecutionStore} for persistence and a
+ * {@link JournalingAgentListener} to record execution events.
+ *
+ * @see TaskHandle
+ * @see TaskExecutionStore
+ * @see RetryPolicy
+ */
+@Experimental
+public class LongLivedTaskService implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LongLivedTaskService.class);
+
+    private final TaskExecutionStore store;
+    private final ExecutorService executorService;
+    private final CheckpointPolicy defaultCheckpointPolicy;
+    private final CheckpointManager checkpointManager;
+    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+    private final java.util.concurrent.ScheduledExecutorService scheduler;
+    private final ConcurrentHashMap<TaskId, DefaultTaskHandle> activeHandles = new ConcurrentHashMap<>();
+
+    private LongLivedTaskService(Builder builder) {
+        this.store = builder.store;
+        this.executorService = builder.executorService != null
+                ? builder.executorService
+                : Executors.newCachedThreadPool(r -> {
+                    Thread t = new Thread(r);
+                    t.setDaemon(true);
+                    t.setName("durable-task-" + t.getId());
+                    return t;
+                });
+        this.defaultCheckpointPolicy = builder.defaultCheckpointPolicy;
+        this.checkpointManager = new CheckpointManager(store);
+        this.objectMapper = ObjectMapperFactory.create();
+        this.scheduler = java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            t.setName("durable-task-timeout-scheduler");
+            return t;
+        });
+    }
+
+    // ---- Lifecycle operations ----
+
+    /**
+     * Starts a new durable task.
+     *
+     * <p>The task is assigned a random identifier, persisted as PENDING, then
+     * submitted for asynchronous execution. The returned {@link TaskHandle} can
+     * be used to monitor progress or cancel the task.
+     *
+     * @param configuration the task configuration (including optional retry policy)
+     * @param workflow      supplier that invokes the agent topology and returns the result
+     * @return a handle to the running task
+     */
+    public TaskHandle start(TaskConfiguration configuration, Supplier<Object> workflow) {
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, configuration.agentName(), configuration.labels());
+        store.saveMetadata(metadata);
+
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        DefaultTaskHandle handle = new DefaultTaskHandle(taskId, metadata, future);
+        handle.setCancelCallback(this::cancel);
+        activeHandles.put(taskId, handle);
+
+        CheckpointPolicy policy =
+                configuration.checkpointPolicy() != null ? configuration.checkpointPolicy() : defaultCheckpointPolicy;
+        RetryPolicy retryPolicy = configuration.retryPolicy();
+        Duration timeout = configuration.timeout();
+
+        store.appendEvent(new TaskStartedEvent(taskId, Instant.now(), Map.of()));
+
+        executorService.submit(() -> executeTask(taskId, metadata, workflow, future, policy, retryPolicy, timeout));
+
+        LOG.info("Task {} started with agent '{}'", taskId, configuration.agentName());
+        return handle;
+    }
+
+    /**
+     * Resumes a previously paused, failed, or interrupted task.
+     *
+     * <p>The application must recreate the agent topology and provide it as a
+     * {@code workflow} supplier. The caller is responsible for wiring a
+     * {@link ReplayingPlanner} into the workflow if replay of completed steps
+     * is desired — the journal events can be obtained via {@link #events(TaskId)}.
+     *
+     * <p>Failed tasks can be resumed as a manual retry mechanism. Completed and
+     * cancelled tasks cannot be resumed.
+     *
+     * <p>If the task is paused waiting for external input, call
+     * {@link #provideInput(TaskId, String, Object)} first, then resume.
+     *
+     * @param taskId   the identifier of the task to resume
+     * @param workflow supplier that invokes the (recreated) agent topology
+     * @return a handle to the resumed task
+     * @throws IllegalStateException if the task is not found, completed or cancelled
+     */
+    public TaskHandle resume(TaskId taskId, Supplier<Object> workflow) {
+        return resume(taskId, workflow, null);
+    }
+
+    /**
+     * Resumes a previously paused, failed, or interrupted task with explicit configuration.
+     *
+     * <p>Allows specifying a {@link TaskConfiguration} to override the retry policy and
+     * checkpoint policy for the resumed execution. If {@code configuration} is null,
+     * defaults are used.
+     *
+     * @param taskId        the identifier of the task to resume
+     * @param workflow      supplier that invokes the (recreated) agent topology
+     * @param configuration optional configuration override for the resumed execution
+     * @return a handle to the resumed task
+     * @throws IllegalStateException if the task is not found, completed or cancelled
+     */
+    public TaskHandle resume(TaskId taskId, Supplier<Object> workflow, TaskConfiguration configuration) {
+        TaskMetadata metadata =
+                store.loadMetadata(taskId).orElseThrow(() -> new IllegalStateException("Task not found: " + taskId));
+
+        TaskStatus current = metadata.status();
+        if (current == TaskStatus.COMPLETED || current == TaskStatus.CANCELLED) {
+            throw new IllegalStateException("Cannot resume task " + taskId + " in state: " + current);
+        }
+        if (current == TaskStatus.RUNNING || current == TaskStatus.RETRYING) {
+            throw new IllegalStateException("Cannot resume task " + taskId + " that is already " + current
+                    + "; cancel it first or wait for it to finish");
+        }
+
+        // Store-atomic CAS to activate the task. This prevents concurrent resumes
+        // from both succeeding and launching duplicate workers.
+        Optional<TaskMetadata> updated = store.compareAndSetStatus(taskId, current, TaskStatus.RUNNING);
+        if (updated.isEmpty()) {
+            throw new IllegalStateException(
+                    "Cannot resume task " + taskId + ": concurrent transition already in progress");
+        }
+        TaskMetadata activatedMetadata = updated.get();
+
+        store.appendEvent(new TaskResumedEvent(taskId, Instant.now(), Map.of()));
+
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        DefaultTaskHandle handle = new DefaultTaskHandle(taskId, activatedMetadata, future);
+        handle.setCancelCallback(this::cancel);
+
+        // Complete old handle's future so callers holding it don't hang forever
+        DefaultTaskHandle oldHandle = activeHandles.put(taskId, handle);
+        if (oldHandle != null) {
+            oldHandle
+                    .future()
+                    .completeExceptionally(
+                            new IllegalStateException("Task " + taskId + " was resumed; use the new handle"));
+        }
+
+        CheckpointPolicy policy = (configuration != null && configuration.checkpointPolicy() != null)
+                ? configuration.checkpointPolicy()
+                : defaultCheckpointPolicy;
+        RetryPolicy retryPolicy = (configuration != null) ? configuration.retryPolicy() : null;
+        Duration timeout = (configuration != null) ? configuration.timeout() : null;
+
+        executorService.submit(
+                () -> executeTask(taskId, activatedMetadata, workflow, future, policy, retryPolicy, timeout));
+
+        LOG.info("Task {} resumed", taskId);
+        return handle;
+    }
+
+    /**
+     * Writes external input into the event journal for a paused task.
+     *
+     * <p>The input is recorded as key-value data in a {@link TaskResumedEvent}.
+     * When the task is subsequently {@link #resume resumed}, the replay mechanism
+     * writes this value into the scope so agents that depend on it (e.g.,
+     * DurableHumanInTheLoop) find it immediately.
+     *
+     * <p>This is a general mechanism — not limited to human input. Any external
+     * data (API callbacks, approval signals, computed values) can be provided.
+     *
+     * @param taskId the task identifier
+     * @param key    the scope key under which the value will be stored
+     * @param value  the external value
+     * @throws IllegalStateException if the task is not found or not paused
+     */
+    public void provideInput(TaskId taskId, String key, Object value) {
+        TaskMetadata metadata =
+                store.loadMetadata(taskId).orElseThrow(() -> new IllegalStateException("Task not found: " + taskId));
+
+        if (metadata.status() != TaskStatus.PAUSED) {
+            throw new IllegalStateException(
+                    "Task " + taskId + " is not paused (current status: " + metadata.status() + ")");
+        }
+
+        store.appendEvent(new TaskResumedEvent(taskId, Instant.now(), Map.of(key, value)));
+
+        LOG.info("External input provided for task {} at key '{}'", taskId, key);
+    }
+
+    /**
+     * Cancels a task.
+     *
+     * <p>If the task is currently running, the underlying future is cancelled
+     * with an interrupt. If the task is paused or retrying, it transitions
+     * directly to {@link TaskStatus#CANCELLED}. Uses an atomic compare-and-set
+     * guard to prevent races with concurrent completion.
+     *
+     * @param taskId the task identifier
+     * @return {@code true} if the task was cancelled, {@code false} if already terminal
+     */
+    public boolean cancel(TaskId taskId) {
+        TaskMetadata metadata = store.loadMetadata(taskId).orElse(null);
+        if (metadata == null) {
+            return false;
+        }
+
+        // Store-atomic CAS: try to transition from whatever non-terminal state to CANCELLED.
+        // The store-level CAS loads the persisted metadata, checks the status, transitions,
+        // and saves atomically — preventing the race where cancel and completion operate on
+        // different in-memory instances with FileTaskExecutionStore.
+        TaskStatus current = metadata.status();
+        if (current.isTerminal()) {
+            return false;
+        }
+        Optional<TaskMetadata> cancelled = store.compareAndSetStatus(taskId, current, TaskStatus.CANCELLED);
+        if (cancelled.isEmpty()) {
+            // Status changed concurrently — re-read from store and try once more
+            metadata = store.loadMetadata(taskId).orElse(null);
+            if (metadata == null) {
+                return false;
+            }
+            current = metadata.status();
+            if (current.isTerminal()) {
+                return false;
+            }
+            cancelled = store.compareAndSetStatus(taskId, current, TaskStatus.CANCELLED);
+        }
+        if (cancelled.isEmpty()) {
+            // Both CAS attempts failed — another transition won the race
+            return false;
+        }
+
+        store.appendEvent(new TaskCancelledEvent(taskId, Instant.now()));
+
+        // Cancel the future AFTER metadata transition
+        DefaultTaskHandle handle = activeHandles.remove(taskId);
+        if (handle != null) {
+            // Sync in-memory metadata for handle.status() callers
+            handle.updateMetadata(cancelled.get());
+            handle.future()
+                    .completeExceptionally(
+                            new java.util.concurrent.CancellationException("Task " + taskId + " cancelled"));
+            handle.cancel();
+        }
+
+        LOG.info("Task {} cancelled", taskId);
+        return true;
+    }
+
+    // ---- Crash recovery ----
+
+    /**
+     * Discovers tasks that were running when the process last stopped.
+     *
+     * <p>This method finds all tasks in {@link TaskStatus#RUNNING} or
+     * {@link TaskStatus#RETRYING} status and transitions them to
+     * {@link TaskStatus#PAUSED} so they can be explicitly resumed by the
+     * application. This is the recommended first call on startup when using
+     * a persistent {@link TaskExecutionStore}.
+     *
+     * <p>The caller is responsible for resuming each returned task by calling
+     * {@link #resume(TaskId, Supplier)} with a recreated workflow.
+     *
+     * @return the set of task ids that were interrupted and are now paused
+     */
+    public Set<TaskId> recoverInterruptedTasks() {
+        Set<TaskId> running = store.getTaskIdsByStatus(TaskStatus.RUNNING);
+        Set<TaskId> retrying = store.getTaskIdsByStatus(TaskStatus.RETRYING);
+
+        List<TaskId> interrupted = new ArrayList<>();
+        interrupted.addAll(running);
+        interrupted.addAll(retrying);
+
+        List<TaskId> recovered = new ArrayList<>();
+        for (TaskId taskId : interrupted) {
+            store.loadMetadata(taskId).ifPresent(metadata -> {
+                TaskStatus current = metadata.status();
+                Optional<TaskMetadata> paused = store.compareAndSetStatus(taskId, current, TaskStatus.PAUSED);
+                if (paused.isPresent()) {
+                    store.appendEvent(
+                            new TaskPausedEvent(taskId, Instant.now(), "Recovered after process restart", null));
+                    recovered.add(taskId);
+                    LOG.info("Task {} recovered from interrupted state, now PAUSED", taskId);
+                } else {
+                    LOG.warn("Task {} could not be recovered (concurrent status transition)", taskId);
+                }
+            });
+        }
+
+        return Set.copyOf(recovered);
+    }
+
+    // ---- Query operations ----
+
+    /**
+     * Returns the current status of a task.
+     *
+     * @param taskId the task identifier
+     * @return the task status, or empty if not found
+     */
+    public Optional<TaskStatus> status(TaskId taskId) {
+        return store.loadMetadata(taskId).map(TaskMetadata::status);
+    }
+
+    /**
+     * Returns the metadata for a task.
+     *
+     * @param taskId the task identifier
+     * @return the task metadata, or empty if not found
+     */
+    public Optional<TaskMetadata> metadata(TaskId taskId) {
+        return store.loadMetadata(taskId);
+    }
+
+    /**
+     * Returns the event journal for a task. The journal provides a complete
+     * audit trail of the task's execution: starts, agent invocations,
+     * retries, pauses, failures, and completion.
+     *
+     * @param taskId the task identifier
+     * @return ordered list of events
+     */
+    public List<TaskEvent> events(TaskId taskId) {
+        return store.loadEvents(taskId);
+    }
+
+    /**
+     * Returns all known task identifiers.
+     *
+     * @return set of task ids
+     */
+    public Set<TaskId> listTasks() {
+        return store.getAllTaskIds();
+    }
+
+    /**
+     * Returns task identifiers filtered by status.
+     *
+     * @param status the status to filter by
+     * @return set of matching task ids
+     */
+    public Set<TaskId> listTasks(TaskStatus status) {
+        return store.getTaskIdsByStatus(status);
+    }
+
+    /**
+     * Deletes all data for a terminal task.
+     *
+     * @param taskId the task identifier
+     * @return {@code true} if the task was deleted
+     * @throws IllegalStateException if the task exists but is not in a terminal state
+     */
+    public boolean cleanup(TaskId taskId) {
+        TaskMetadata metadata = store.loadMetadata(taskId).orElse(null);
+        if (metadata != null && !metadata.status().isTerminal()) {
+            throw new IllegalStateException(
+                    "Cannot cleanup task " + taskId + " in non-terminal state: " + metadata.status());
+        }
+        activeHandles.remove(taskId);
+        return store.delete(taskId);
+    }
+
+    // ---- Factory helpers ----
+
+    /**
+     * Creates a {@link JournalingAgentListener} for a task. This listener should be
+     * registered with the agent topology to enable event journaling.
+     *
+     * @param taskId the task identifier
+     * @return a new journaling listener
+     */
+    public JournalingAgentListener createJournalingListener(TaskId taskId) {
+        return new JournalingAgentListener(taskId, store);
+    }
+
+    /**
+     * Creates a {@link JournalingAgentListener} for a task with checkpoint-policy
+     * awareness. When the policy is {@link CheckpointPolicy#AFTER_EACH_AGENT},
+     * a checkpoint with the current {@link dev.langchain4j.agentic.scope.AgenticScope}
+     * is taken after every successful agent invocation. When the policy is
+     * {@link CheckpointPolicy#AFTER_ROOT_CALL}, a scope-aware checkpoint is taken
+     * when the root agentic scope is destroyed (i.e., the root call completes).
+     *
+     * @param taskId the task identifier
+     * @param policy the checkpoint policy to apply
+     * @return a new journaling listener
+     */
+    public JournalingAgentListener createJournalingListener(TaskId taskId, CheckpointPolicy policy) {
+        java.util.function.Consumer<dev.langchain4j.agentic.scope.AgenticScope> afterAgentCheckpoint = null;
+        java.util.function.Consumer<dev.langchain4j.agentic.scope.AgenticScope> rootCallCheckpoint = null;
+
+        if (policy == CheckpointPolicy.AFTER_EACH_AGENT) {
+            afterAgentCheckpoint = (scope) -> {
+                store.loadMetadata(taskId).ifPresent(md -> checkpointManager.checkpoint(taskId, md, scope));
+            };
+        }
+        if (policy == CheckpointPolicy.AFTER_ROOT_CALL || policy == CheckpointPolicy.AFTER_EACH_AGENT) {
+            rootCallCheckpoint = (scope) -> {
+                store.loadMetadata(taskId).ifPresent(md -> checkpointManager.checkpoint(taskId, md, scope));
+            };
+        }
+        return new JournalingAgentListener(taskId, store, afterAgentCheckpoint, rootCallCheckpoint);
+    }
+
+    /**
+     * Returns the underlying store.
+     *
+     * @return the task execution store
+     */
+    public TaskExecutionStore store() {
+        return store;
+    }
+
+    // ---- Shutdown ----
+
+    /**
+     * Gracefully shuts down the executor service and scheduler, waiting up to the given
+     * timeout for running tasks to complete. Tasks that do not finish within the timeout
+     * are interrupted.
+     *
+     * @param timeout  the maximum time to wait
+     * @param unit     the time unit
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     */
+    public void shutdown(long timeout, TimeUnit unit) throws InterruptedException {
+        LOG.info("Shutting down LongLivedTaskService (timeout={}{})", timeout, unit);
+        scheduler.shutdown();
+        executorService.shutdown();
+        if (!executorService.awaitTermination(timeout, unit)) {
+            LOG.warn("Executor did not terminate within timeout, forcing shutdown");
+            executorService.shutdownNow();
+        }
+        if (!scheduler.awaitTermination(Math.min(timeout, 5), unit)) {
+            scheduler.shutdownNow();
+        }
+    }
+
+    /**
+     * Implements {@link AutoCloseable} for try-with-resources support.
+     * Shuts down with a default timeout of 30 seconds.
+     */
+    @Override
+    public void close() {
+        try {
+            shutdown(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted during close, forcing shutdown");
+            executorService.shutdownNow();
+            scheduler.shutdownNow();
+        }
+    }
+
+    // ---- Internal execution ----
+
+    private void executeTask(
+            TaskId taskId,
+            TaskMetadata metadata,
+            Supplier<Object> workflow,
+            CompletableFuture<Object> future,
+            CheckpointPolicy policy,
+            RetryPolicy retryPolicy,
+            Duration timeout) {
+
+        // Schedule a timeout cancellation if configured
+        java.util.concurrent.ScheduledFuture<?> timeoutFuture = null;
+        if (timeout != null && !timeout.isZero() && !timeout.isNegative()) {
+            timeoutFuture = scheduler.schedule(
+                    () -> {
+                        LOG.warn("Task {} timed out after {}", taskId, timeout);
+                        cancel(taskId);
+                    },
+                    timeout.toMillis(),
+                    java.util.concurrent.TimeUnit.MILLISECONDS);
+        }
+
+        try {
+            doExecuteTask(taskId, metadata, workflow, future, policy, retryPolicy);
+        } finally {
+            if (timeoutFuture != null) {
+                timeoutFuture.cancel(false);
+            }
+        }
+    }
+
+    private void doExecuteTask(
+            TaskId taskId,
+            TaskMetadata metadata,
+            Supplier<Object> workflow,
+            CompletableFuture<Object> future,
+            CheckpointPolicy policy,
+            RetryPolicy retryPolicy) {
+
+        int maxAttempts = (retryPolicy != null) ? retryPolicy.maxRetries() + 1 : 1;
+        Exception lastException = null;
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                // Store-atomic CAS guard: only transition to RUNNING if we're in an expected
+                // pre-run state. If cancel() won the race, the store has CANCELLED — bail out.
+                TaskStatus current = metadata.status();
+                if (current.isTerminal()) {
+                    LOG.debug("Task {} is already in terminal state {}, aborting execution", taskId, current);
+                    return;
+                }
+                Optional<TaskMetadata> running = store.compareAndSetStatus(taskId, current, TaskStatus.RUNNING);
+                if (running.isEmpty()) {
+                    // Status changed concurrently — re-check via store
+                    TaskMetadata fresh = store.loadMetadata(taskId).orElse(null);
+                    if (fresh == null || fresh.status().isTerminal()) {
+                        return;
+                    }
+                    running = store.compareAndSetStatus(taskId, fresh.status(), TaskStatus.RUNNING);
+                    if (running.isEmpty()) {
+                        // Both CAS attempts failed — bail out rather than force a stale write
+                        fresh = store.loadMetadata(taskId).orElse(null);
+                        if (fresh == null || fresh.status().isTerminal()) {
+                            return;
+                        }
+                        LOG.warn("Task {} CAS to RUNNING failed twice (current: {}), aborting attempt",
+                                taskId, fresh.status());
+                        return;
+                    } else {
+                        metadata = running.get();
+                    }
+                } else {
+                    metadata = running.get();
+                }
+                // Sync the handle's metadata view
+                DefaultTaskHandle currentHandle = activeHandles.get(taskId);
+                if (currentHandle != null) {
+                    currentHandle.updateMetadata(metadata);
+                }
+
+                Object result = workflow.get();
+
+                // Store-atomic CAS: only move to COMPLETED if the persisted status is
+                // still RUNNING. cancel() may have written CANCELLED to the store while
+                // workflow.get() was executing — without store-level CAS, the worker's
+                // stale in-memory metadata would overwrite CANCELLED with COMPLETED.
+                Optional<TaskMetadata> completed =
+                        store.compareAndSetStatus(taskId, TaskStatus.RUNNING, TaskStatus.COMPLETED);
+                if (completed.isEmpty()) {
+                    LOG.info(
+                            "Task {} finished but cannot transition to COMPLETED (current: {})",
+                            taskId,
+                            metadata.status());
+                    // The task was cancelled mid-flight — don't overwrite the cancel.
+                    // Still complete the future so callers don't hang.
+                    future.complete(result);
+                    return;
+                }
+                metadata = completed.get();
+
+                String serializedResult = serializeResult(result);
+                store.appendEvent(new TaskCompletedEvent(taskId, Instant.now(), serializedResult));
+
+                // NOTE: no service-level completion checkpoint here. The scope-aware
+                // checkpoint is already created by JournalingAgentListener.
+                // beforeAgenticScopeDestroyed (wired for both AFTER_ROOT_CALL and
+                // AFTER_EACH_AGENT) fires before workflow.get() returns. A null-scope
+                // checkpoint here would overwrite that scope data.
+
+                future.complete(result);
+                activeHandles.remove(taskId);
+                LOG.info("Task {} completed successfully", taskId);
+                return;
+
+            } catch (TaskPausedException e) {
+                Optional<TaskMetadata> paused =
+                        store.compareAndSetStatus(taskId, TaskStatus.RUNNING, TaskStatus.PAUSED);
+                if (paused.isEmpty()) {
+                    LOG.info("Task {} paused but status already changed (concurrent cancel?)", taskId);
+                    return;
+                }
+                metadata = paused.get();
+
+                store.appendEvent(new TaskPausedEvent(taskId, Instant.now(), e.reason(), e.pendingOutputKey()));
+
+                if (policy == CheckpointPolicy.AFTER_EACH_AGENT) {
+                    checkpointManager.checkpoint(taskId, metadata, null);
+                }
+
+                // Complete the future exceptionally so callers don't hang.
+                // They can detect pause via the TaskPausedException type.
+                future.completeExceptionally(e);
+                activeHandles.remove(taskId);
+                LOG.info("Task {} paused: {}", taskId, e.reason());
+                return;
+
+            } catch (Exception e) {
+                lastException = e;
+
+                // Check if the exception wraps a TaskPausedException (e.g., from CompletionException)
+                TaskPausedException pausedException = findInCauseChain(e, TaskPausedException.class);
+                if (pausedException != null) {
+                    Optional<TaskMetadata> paused =
+                            store.compareAndSetStatus(taskId, TaskStatus.RUNNING, TaskStatus.PAUSED);
+                    if (paused.isEmpty()) {
+                        LOG.info("Task {} paused (wrapped) but status already changed (concurrent cancel?)", taskId);
+                        return;
+                    }
+                    metadata = paused.get();
+                    store.appendEvent(new TaskPausedEvent(
+                            taskId, Instant.now(), pausedException.reason(), pausedException.pendingOutputKey()));
+                    if (policy == CheckpointPolicy.AFTER_EACH_AGENT) {
+                        checkpointManager.checkpoint(taskId, metadata, null);
+                    }
+                    future.completeExceptionally(pausedException);
+                    activeHandles.remove(taskId);
+                    LOG.info("Task {} paused (unwrapped from {}): {}", taskId, e.getClass().getSimpleName(), pausedException.reason());
+                    return;
+                }
+
+                // If already cancelled, don't retry or record failure.
+                // Check the store (not just in-memory metadata) to see concurrent cancel.
+                TaskStatus storedStatus =
+                        store.loadMetadata(taskId).map(TaskMetadata::status).orElse(metadata.status());
+                if (storedStatus.isTerminal()) {
+                    LOG.debug("Task {} caught exception but already terminal ({})", taskId, storedStatus);
+                    future.completeExceptionally(e);
+                    activeHandles.remove(taskId);
+                    return;
+                }
+
+                boolean canRetry = attempt < maxAttempts && retryPolicy != null && retryPolicy.isRetryable(e);
+                if (canRetry) {
+                    Duration delay = retryPolicy.delayForAttempt(attempt);
+                    store.appendEvent(new TaskRetryEvent(
+                            taskId,
+                            Instant.now(),
+                            attempt,
+                            retryPolicy.maxRetries(),
+                            e.getMessage(),
+                            delay.toMillis()));
+
+                    LOG.warn(
+                            "Task {} attempt {}/{} failed ({}), retrying in {}ms",
+                            taskId,
+                            attempt,
+                            maxAttempts,
+                            e.getMessage(),
+                            delay.toMillis());
+
+                    Optional<TaskMetadata> retrying =
+                            store.compareAndSetStatus(taskId, TaskStatus.RUNNING, TaskStatus.RETRYING);
+                    if (retrying.isPresent()) {
+                        metadata = retrying.get();
+                    }
+
+                    if (policy == CheckpointPolicy.AFTER_EACH_AGENT) {
+                        checkpointManager.checkpoint(taskId, metadata, null);
+                    }
+
+                    try {
+                        Thread.sleep(delay.toMillis());
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        if (store.compareAndSetStatus(taskId, TaskStatus.RETRYING, TaskStatus.CANCELLED)
+                                .isPresent()) {
+                            store.appendEvent(new TaskCancelledEvent(taskId, Instant.now()));
+                        }
+                        future.cancel(true);
+                        activeHandles.remove(taskId);
+                        LOG.info("Task {} interrupted during retry delay, cancelled", taskId);
+                        return;
+                    }
+                    // Continue loop for next attempt
+                } else {
+                    break; // Fall through to terminal failure
+                }
+            }
+        }
+
+        // All attempts exhausted — record terminal failure.
+        // Use RUNNING as expected because that's the state we entered the last attempt with.
+        // If cancel() already set CANCELLED, RUNNING won't match and the CAS will correctly fail.
+        if (lastException != null) {
+            Optional<TaskMetadata> failed = store.compareAndSetStatus(
+                    taskId, TaskStatus.RUNNING, TaskStatus.FAILED, lastException.getMessage());
+            if (failed.isPresent()) {
+                metadata = failed.get();
+
+                String stackTrace = formatStackTrace(lastException);
+                store.appendEvent(new TaskFailedEvent(taskId, Instant.now(), lastException.getMessage(), stackTrace));
+            }
+
+            future.completeExceptionally(lastException);
+            activeHandles.remove(taskId);
+            LOG.error("Task {} failed: {}", taskId, lastException.getMessage(), lastException);
+        }
+    }
+
+    private static String formatStackTrace(Throwable throwable) {
+        StringWriter sw = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+
+    /**
+     * Walks the exception cause chain looking for an instance of the given type.
+     *
+     * @param throwable the starting throwable
+     * @param type      the type to search for
+     * @param <T>       the exception type
+     * @return the matching exception, or {@code null} if not found
+     */
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> T findInCauseChain(Throwable throwable, Class<T> type) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (type.isInstance(current)) {
+                return (T) current;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    /**
+     * Serializes a task result using Jackson. Falls back to {@code toString()} if
+     * serialization fails.
+     */
+    private String serializeResult(Object result) {
+        if (result == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(result);
+        } catch (Exception e) {
+            LOG.warn("Failed to serialize task result, falling back to toString(): {}", e.getMessage());
+            return result.toString();
+        }
+    }
+
+    /**
+     * Creates a new builder for {@link LongLivedTaskService}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link LongLivedTaskService}.
+     */
+    public static final class Builder {
+
+        private TaskExecutionStore store;
+        private ExecutorService executorService;
+        private CheckpointPolicy defaultCheckpointPolicy = CheckpointPolicy.AFTER_EACH_AGENT;
+
+        private Builder() {}
+
+        /**
+         * Sets the task execution store. Required.
+         *
+         * @param store the store for task persistence
+         * @return this builder
+         */
+        public Builder store(TaskExecutionStore store) {
+            this.store = store;
+            return this;
+        }
+
+        /**
+         * Sets a custom executor service for running tasks.
+         * If not set, a cached thread pool with daemon threads is used.
+         *
+         * @param executorService the executor service
+         * @return this builder
+         */
+        public Builder executorService(ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
+        }
+
+        /**
+         * Sets the default checkpoint policy for tasks that don't specify one.
+         * Defaults to {@link CheckpointPolicy#AFTER_EACH_AGENT}.
+         *
+         * @param defaultCheckpointPolicy the default policy
+         * @return this builder
+         */
+        public Builder defaultCheckpointPolicy(CheckpointPolicy defaultCheckpointPolicy) {
+            this.defaultCheckpointPolicy = defaultCheckpointPolicy;
+            return this;
+        }
+
+        /**
+         * Builds the {@link LongLivedTaskService}.
+         *
+         * @return a new long-lived task service
+         * @throws IllegalArgumentException if store is null
+         */
+        public LongLivedTaskService build() {
+            if (store == null) {
+                throw new IllegalArgumentException("store must not be null");
+            }
+            return new LongLivedTaskService(this);
+        }
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/hitl/DurableHumanInTheLoop.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/hitl/DurableHumanInTheLoop.java
@@ -1,0 +1,144 @@
+package dev.langchain4j.experimental.durable.hitl;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.internal.AgentSpecsProvider;
+import dev.langchain4j.agentic.observability.AgentListener;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.experimental.durable.task.TaskPausedException;
+
+/**
+ * A durable variant of HumanInTheLoop that pauses the task when human input is needed.
+ *
+ * <p>On first invocation, this agent checks whether the scope already contains the
+ * expected output (indicating this is a resume after the human provided input). If so,
+ * it returns the value from the scope. Otherwise, it throws {@link TaskPausedException}
+ * to signal that the task should be paused and persisted.
+ *
+ * <p>The task service catches the exception, checkpoints the task in PAUSED status,
+ * and waits for the application to call {@code resume(taskId, userInput)} with the
+ * human's answer. On resume, the answer is written to the scope under the
+ * {@link #outputKey()} before re-entering the agent topology, so this agent
+ * finds it and returns it immediately.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * DurableHumanInTheLoop humanAgent = DurableHumanInTheLoop.builder()
+ *         .outputKey("userApproval")
+ *         .reason("Waiting for manager approval")
+ *         .build();
+ * }</pre>
+ *
+ * <p>No changes to the core {@code langchain4j-agentic} module are required.
+ */
+@Experimental
+public record DurableHumanInTheLoop(
+        String outputKey, String description, boolean async, String reason, AgentListener listener)
+        implements AgentSpecsProvider {
+
+    /**
+     * Agent method invoked by the planner. Returns existing human input from
+     * the scope if present (resume path), or throws {@link TaskPausedException}
+     * to pause the task and wait for input (initial path).
+     *
+     * @param scope the current agentic scope
+     * @return the human-provided input from the scope
+     * @throws TaskPausedException if human input is not yet available
+     */
+    @Agent("A durable agent that pauses the task to wait for human input")
+    public Object askUser(AgenticScope scope) {
+        if (scope.hasState(outputKey)) {
+            return scope.readState(outputKey);
+        }
+        throw new TaskPausedException(reason != null ? reason : "Waiting for human input", outputKey);
+    }
+
+    /**
+     * Creates a new builder for {@link DurableHumanInTheLoop}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link DurableHumanInTheLoop}.
+     */
+    public static final class Builder {
+
+        private String outputKey = "humanInput";
+        private String description = "A durable agent that pauses the task to wait for human input";
+        private boolean async = false;
+        private String reason;
+        private AgentListener agentListener;
+
+        private Builder() {}
+
+        /**
+         * Sets the scope key where the human input will be stored.
+         * Defaults to {@code "humanInput"}.
+         *
+         * @param outputKey the scope key
+         * @return this builder
+         */
+        public Builder outputKey(String outputKey) {
+            this.outputKey = outputKey;
+            return this;
+        }
+
+        /**
+         * Sets the description for this agent.
+         *
+         * @param description the description
+         * @return this builder
+         */
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        /**
+         * Sets whether this agent runs asynchronously.
+         *
+         * @param async true for async execution
+         * @return this builder
+         */
+        public Builder async(boolean async) {
+            this.async = async;
+            return this;
+        }
+
+        /**
+         * Sets the human-readable reason for pausing. Included in the
+         * {@link TaskPausedException} message.
+         *
+         * @param reason the reason for pausing
+         * @return this builder
+         */
+        public Builder reason(String reason) {
+            this.reason = reason;
+            return this;
+        }
+
+        /**
+         * Sets an agent listener.
+         *
+         * @param listener the listener
+         * @return this builder
+         */
+        public Builder listener(AgentListener listener) {
+            this.agentListener = listener;
+            return this;
+        }
+
+        /**
+         * Builds the {@link DurableHumanInTheLoop}.
+         *
+         * @return a new durable human-in-the-loop agent
+         */
+        public DurableHumanInTheLoop build() {
+            return new DurableHumanInTheLoop(outputKey, description, async, reason, agentListener);
+        }
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/hitl/package-info.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/hitl/package-info.java
@@ -1,0 +1,4 @@
+@Experimental
+package dev.langchain4j.experimental.durable.hitl;
+
+import dev.langchain4j.Experimental;

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/internal/CheckpointManager.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/internal/CheckpointManager.java
@@ -1,0 +1,80 @@
+package dev.langchain4j.experimental.durable.internal;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.Internal;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.experimental.durable.store.Checkpoint;
+import dev.langchain4j.experimental.durable.store.TaskExecutionStore;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Internal helper that creates and persists checkpoints for a running task.
+ *
+ * <p>Checkpoint creation never throws; failures are logged at WARN level so the
+ * running task is never disrupted by a persistence failure.
+ */
+@Internal
+public class CheckpointManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CheckpointManager.class);
+
+    private final TaskExecutionStore store;
+    private final ObjectMapper objectMapper;
+
+    public CheckpointManager(TaskExecutionStore store) {
+        this.store = store;
+        this.objectMapper = ObjectMapperFactory.create();
+    }
+
+    /**
+     * Takes a checkpoint of the current task state and persists it.
+     *
+     * @param taskId   the task identifier
+     * @param metadata the current metadata
+     * @param scope    the current agentic scope, or {@code null} if unavailable
+     */
+    public void checkpoint(TaskId taskId, TaskMetadata metadata, AgenticScope scope) {
+        try {
+            // Snapshot the metadata to guarantee checkpoint immutability
+            TaskMetadata snapshot = TaskMetadata.of(
+                    metadata.id(),
+                    metadata.agentName(),
+                    metadata.status(),
+                    metadata.createdAt(),
+                    metadata.updatedAt(),
+                    metadata.failureReason(),
+                    metadata.labels());
+            String serializedScope = serializeScope(scope);
+            List<TaskEvent> events = store.loadEvents(taskId);
+            Checkpoint cp = new Checkpoint(taskId, snapshot, serializedScope, events.size(), Instant.now());
+            store.saveCheckpoint(cp);
+            LOG.debug("Checkpoint saved for task {} with {} events", taskId, events.size());
+        } catch (Exception e) {
+            LOG.warn("Failed to save checkpoint for task {}: {}", taskId, e.getMessage(), e);
+        }
+    }
+
+    private String serializeScope(AgenticScope scope) {
+        if (scope == null) {
+            return null;
+        }
+        try {
+            Map<String, Object> state = scope.state();
+            return objectMapper.writeValueAsString(state);
+        } catch (JsonProcessingException e) {
+            LOG.warn("Failed to serialize scope state, checkpoint will have null scope: {}", e.getMessage());
+            return null;
+        } catch (Exception e) {
+            LOG.warn("Unexpected error serializing scope state: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/internal/DefaultTaskHandle.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/internal/DefaultTaskHandle.java
@@ -1,0 +1,88 @@
+package dev.langchain4j.experimental.durable.internal;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskHandle;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import dev.langchain4j.experimental.durable.task.TaskStatus;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * Default implementation of {@link TaskHandle} backed by a {@link CompletableFuture}
+ * and task metadata.
+ */
+@Experimental
+public class DefaultTaskHandle implements TaskHandle {
+
+    private final TaskId taskId;
+    private final CompletableFuture<Object> future;
+    private volatile TaskMetadata metadata;
+    private volatile Function<TaskId, Boolean> cancelCallback;
+
+    public DefaultTaskHandle(TaskId taskId, TaskMetadata metadata, CompletableFuture<Object> future) {
+        this.taskId = taskId;
+        this.metadata = metadata;
+        this.future = future;
+    }
+
+    @Override
+    public TaskId id() {
+        return taskId;
+    }
+
+    @Override
+    public TaskStatus status() {
+        return metadata.status();
+    }
+
+    @Override
+    public Optional<Object> result() {
+        if (future.isDone() && !future.isCancelled() && !future.isCompletedExceptionally()) {
+            return Optional.ofNullable(future.join());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public CompletableFuture<Object> awaitResult() {
+        return future;
+    }
+
+    @Override
+    public boolean cancel() {
+        if (cancelCallback != null) {
+            return cancelCallback.apply(taskId);
+        }
+        // Fallback: only cancel the future (should not happen when wired through service)
+        return future.cancel(true);
+    }
+
+    /**
+     * Sets the cancel callback that delegates to the service-level cancel.
+     *
+     * @param cancelCallback function that performs store-atomic cancellation
+     */
+    public void setCancelCallback(Function<TaskId, Boolean> cancelCallback) {
+        this.cancelCallback = cancelCallback;
+    }
+
+    /**
+     * Updates the metadata snapshot held by this handle.
+     *
+     * @param metadata the updated metadata
+     */
+    public void updateMetadata(TaskMetadata metadata) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * Returns the underlying future.
+     *
+     * @return the completable future
+     */
+    public CompletableFuture<Object> future() {
+        return future;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/internal/ObjectMapperFactory.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/internal/ObjectMapperFactory.java
@@ -1,0 +1,43 @@
+package dev.langchain4j.experimental.durable.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.langchain4j.Internal;
+
+/**
+ * Shared factory for creating pre-configured {@link ObjectMapper} instances
+ * used throughout the durable tasks module.
+ *
+ * <p>All mappers register the {@link JavaTimeModule} and disable
+ * {@link SerializationFeature#WRITE_DATES_AS_TIMESTAMPS} so that
+ * {@link java.time.Instant} values are serialized as ISO-8601 strings.
+ */
+@Internal
+public final class ObjectMapperFactory {
+
+    private ObjectMapperFactory() {}
+
+    /**
+     * Creates a new {@link ObjectMapper} with standard configuration.
+     *
+     * @return a configured ObjectMapper
+     */
+    public static ObjectMapper create() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+
+    /**
+     * Creates a new {@link ObjectMapper} with pretty-printing enabled.
+     *
+     * @return a configured ObjectMapper with indented output
+     */
+    public static ObjectMapper createPrettyPrinting() {
+        ObjectMapper mapper = create();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        return mapper;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/internal/package-info.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/internal/package-info.java
@@ -1,0 +1,4 @@
+@Experimental
+package dev.langchain4j.experimental.durable.internal;
+
+import dev.langchain4j.Experimental;

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/journal/JournalingAgentListener.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/journal/JournalingAgentListener.java
@@ -1,0 +1,177 @@
+package dev.langchain4j.experimental.durable.journal;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.agentic.observability.AgentInvocationError;
+import dev.langchain4j.agentic.observability.AgentListener;
+import dev.langchain4j.agentic.observability.AgentRequest;
+import dev.langchain4j.agentic.observability.AgentResponse;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.experimental.durable.store.TaskExecutionStore;
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationCompletedEvent;
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationFailedEvent;
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationStartedEvent;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An {@link AgentListener} that journals agent invocation events to a {@link TaskExecutionStore}.
+ *
+ * <p>This listener records three event types:
+ * <ul>
+ *   <li>{@link AgentInvocationStartedEvent} — before each agent invocation</li>
+ *   <li>{@link AgentInvocationCompletedEvent} — after successful completion</li>
+ *   <li>{@link AgentInvocationFailedEvent} — on invocation failure</li>
+ * </ul>
+ *
+ * <p>All event recording is best-effort: exceptions during event serialization or
+ * persistence are logged at WARN level and never propagated to the running task.
+ *
+ * <p>This listener is always inherited by sub-agents so the full invocation tree
+ * is captured in the journal.
+ */
+@Experimental
+public class JournalingAgentListener implements AgentListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JournalingAgentListener.class);
+
+    private final TaskId taskId;
+    private final TaskExecutionStore store;
+    private final ObjectMapper objectMapper;
+    private final Consumer<AgenticScope> afterAgentCheckpoint;
+    private final Consumer<AgenticScope> rootCallCheckpoint;
+
+    public JournalingAgentListener(TaskId taskId, TaskExecutionStore store) {
+        this(taskId, store, null, null);
+    }
+
+    /**
+     * Creates a journaling listener with optional checkpoint callbacks.
+     *
+     * <p>The {@code afterAgentCheckpoint} callback is invoked after each successful agent
+     * invocation with the current {@link AgenticScope}, enabling
+     * {@link dev.langchain4j.experimental.durable.task.CheckpointPolicy#AFTER_EACH_AGENT}
+     * to capture scope state. The {@code rootCallCheckpoint} callback is invoked when the
+     * root agentic scope is about to be destroyed (i.e., the root call has completed),
+     * enabling {@link dev.langchain4j.experimental.durable.task.CheckpointPolicy#AFTER_ROOT_CALL}.
+     *
+     * @param taskId                the task identifier
+     * @param store                 the event store
+     * @param afterAgentCheckpoint  if non-null, invoked after each successful agent invocation with the scope
+     * @param rootCallCheckpoint    if non-null, invoked when the root agentic scope is about to be destroyed
+     */
+    public JournalingAgentListener(
+            TaskId taskId,
+            TaskExecutionStore store,
+            Consumer<AgenticScope> afterAgentCheckpoint,
+            Consumer<AgenticScope> rootCallCheckpoint) {
+        this.taskId = taskId;
+        this.store = store;
+        this.afterAgentCheckpoint = afterAgentCheckpoint;
+        this.rootCallCheckpoint = rootCallCheckpoint;
+        this.objectMapper = dev.langchain4j.experimental.durable.internal.ObjectMapperFactory.create();
+    }
+
+    @Override
+    public void beforeAgentInvocation(AgentRequest agentRequest) {
+        try {
+            Map<String, Object> inputs = agentRequest.inputs();
+            AgentInvocationStartedEvent event = new AgentInvocationStartedEvent(
+                    taskId, Instant.now(), agentRequest.agentName(), agentRequest.agentId(), inputs);
+            store.appendEvent(event);
+        } catch (Exception e) {
+            LOG.warn("Failed to journal agent invocation start for task {}: {}", taskId, e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void afterAgentInvocation(AgentResponse agentResponse) {
+        try {
+            String serializedOutput = serializeOutput(agentResponse.output());
+            AgentInvocationCompletedEvent event = new AgentInvocationCompletedEvent(
+                    taskId, Instant.now(), agentResponse.agentName(), agentResponse.agentId(), serializedOutput);
+            store.appendEvent(event);
+        } catch (Exception e) {
+            LOG.warn("Failed to journal agent invocation completion for task {}: {}", taskId, e.getMessage(), e);
+        }
+
+        if (afterAgentCheckpoint != null) {
+            try {
+                afterAgentCheckpoint.accept(agentResponse.agenticScope());
+            } catch (Exception e) {
+                LOG.warn("Checkpoint after agent invocation failed for task {}: {}", taskId, e.getMessage(), e);
+            }
+        }
+    }
+
+    @Override
+    public void beforeAgenticScopeDestroyed(AgenticScope agenticScope) {
+        if (rootCallCheckpoint != null) {
+            try {
+                rootCallCheckpoint.accept(agenticScope);
+            } catch (Exception e) {
+                LOG.warn("Root-call checkpoint failed for task {}: {}", taskId, e.getMessage(), e);
+            }
+        }
+    }
+
+    @Override
+    public void onAgentInvocationError(AgentInvocationError invocationError) {
+        try {
+            Throwable error = invocationError.error();
+            String stackTrace = formatStackTrace(error);
+            AgentInvocationFailedEvent event = new AgentInvocationFailedEvent(
+                    taskId,
+                    Instant.now(),
+                    invocationError.agentName(),
+                    invocationError.agentId(),
+                    error.getMessage(),
+                    stackTrace);
+            store.appendEvent(event);
+        } catch (Exception e) {
+            LOG.warn("Failed to journal agent invocation error for task {}: {}", taskId, e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean inheritedBySubagents() {
+        return true;
+    }
+
+    /**
+     * Returns the task identifier this listener is journaling for.
+     *
+     * @return the task id
+     */
+    public TaskId taskId() {
+        return taskId;
+    }
+
+    private String serializeOutput(Object output) {
+        if (output == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(output);
+        } catch (JsonProcessingException e) {
+            LOG.warn("Failed to serialize agent output, falling back to toString(): {}", e.getMessage());
+            return output.toString();
+        }
+    }
+
+    private static String formatStackTrace(Throwable throwable) {
+        if (throwable == null) {
+            return null;
+        }
+        StringWriter sw = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/journal/package-info.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/journal/package-info.java
@@ -1,0 +1,4 @@
+@Experimental
+package dev.langchain4j.experimental.durable.journal;
+
+import dev.langchain4j.Experimental;

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/package-info.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/package-info.java
@@ -1,0 +1,4 @@
+@Experimental
+package dev.langchain4j.experimental.durable;
+
+import dev.langchain4j.Experimental;

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/replay/ReplayingPlanner.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/replay/ReplayingPlanner.java
@@ -1,0 +1,281 @@
+package dev.langchain4j.experimental.durable.replay;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.agentic.planner.Action;
+import dev.langchain4j.agentic.planner.AgentInstance;
+import dev.langchain4j.agentic.planner.AgenticSystemTopology;
+import dev.langchain4j.agentic.planner.InitPlanningContext;
+import dev.langchain4j.agentic.planner.Planner;
+import dev.langchain4j.agentic.planner.PlanningContext;
+import dev.langchain4j.agentic.scope.AgentInvocation;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationCompletedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskResumedEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A planner that replays previously completed agent invocations during task resume,
+ * then delegates to the original planner for live execution.
+ *
+ * <p>On resume, the application recreates the agent topology and wraps the planner
+ * with a {@code ReplayingPlanner}. During {@link #firstAction(PlanningContext)},
+ * this planner:
+ * <ol>
+ *   <li>Writes each replayed agent output back into the scope</li>
+ *   <li>Advances the delegate planner's cursor by calling its methods</li>
+ *   <li>Transitions to live execution once all replayed steps are consumed</li>
+ * </ol>
+ *
+ * <p>This avoids re-executing already-completed agent invocations while keeping
+ * the delegate planner's internal state (e.g., cursor positions) synchronized.
+ *
+ * @see Planner
+ */
+@Experimental
+public class ReplayingPlanner implements Planner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReplayingPlanner.class);
+
+    private final Planner delegate;
+    private final List<AgentInvocationCompletedEvent> completedEvents;
+    private final List<TaskResumedEvent> resumedEvents;
+    private final ObjectMapper objectMapper;
+
+    private List<AgentInstance> subagents;
+    private int replayedCount;
+    private boolean replayComplete;
+
+    private ReplayingPlanner(Builder builder) {
+        this.delegate = builder.delegate;
+        this.completedEvents = extractCompletedEvents(builder.journalEvents);
+        this.resumedEvents = extractResumedEvents(builder.journalEvents);
+        this.objectMapper = dev.langchain4j.experimental.durable.internal.ObjectMapperFactory.create();
+        this.replayedCount = 0;
+        this.replayComplete = completedEvents.isEmpty() && resumedEvents.isEmpty();
+    }
+
+    @Override
+    public void init(InitPlanningContext initPlanningContext) {
+        delegate.init(initPlanningContext);
+        this.subagents = initPlanningContext.subagents();
+    }
+
+    /**
+     * On the first action, replays all completed invocations by writing their outputs
+     * into the scope and advancing the delegate planner. Returns the first live action
+     * that requires actual agent execution.
+     */
+    @Override
+    public Action firstAction(PlanningContext planningContext) {
+        if (replayComplete) {
+            return delegate.firstAction(planningContext);
+        }
+
+        LOG.info("Replaying {} completed invocations and {} resume events from journal", completedEvents.size(), resumedEvents.size());
+
+        AgenticScope scope = planningContext.agenticScope();
+
+        // Write any user input from resume events into the scope
+        for (TaskResumedEvent event : resumedEvents) {
+            if (event.userInput() != null) {
+                for (Map.Entry<String, Object> entry : event.userInput().entrySet()) {
+                    scope.writeState(entry.getKey(), entry.getValue());
+                    LOG.debug("Wrote user input to scope key '{}'", entry.getKey());
+                }
+            }
+        }
+
+        // Get the delegate's first action to initialize its state
+        Action currentAction = delegate.firstAction(planningContext);
+
+        // Replay each completed invocation
+        while (replayedCount < completedEvents.size()) {
+            AgentInvocationCompletedEvent event = completedEvents.get(replayedCount);
+            Object output = deserializeOutput(event.serializedOutput());
+
+            // Write the replayed output to scope using the agent's output key
+            writeOutputToScope(scope, event, output);
+
+            // Create a synthetic invocation so the delegate can advance its state
+            AgentInvocation syntheticInvocation =
+                    new AgentInvocation(null, event.agentName(), event.agentId(), Map.of(), output);
+
+            replayedCount++;
+
+            // Advance the delegate to its next action
+            currentAction = delegate.nextAction(new PlanningContext(scope, syntheticInvocation));
+            LOG.debug("Replayed invocation {}/{}: agent={}", replayedCount, completedEvents.size(), event.agentName());
+
+            if (currentAction.isDone()) {
+                LOG.info("Delegate planner terminated after {} replayed invocations", replayedCount);
+                break;
+            }
+        }
+
+        replayComplete = true;
+        LOG.info("Replay complete. {} invocations replayed. Switching to live execution.", replayedCount);
+        return currentAction;
+    }
+
+    /**
+     * After replay is complete, all calls delegate directly.
+     */
+    @Override
+    public Action nextAction(PlanningContext planningContext) {
+        return delegate.nextAction(planningContext);
+    }
+
+    @Override
+    public AgenticSystemTopology topology() {
+        return delegate.topology();
+    }
+
+    @Override
+    public boolean terminated() {
+        return delegate.terminated();
+    }
+
+    /**
+     * Returns the number of invocations that were replayed from the journal.
+     *
+     * @return the replayed invocation count
+     */
+    public int replayedCount() {
+        return replayedCount;
+    }
+
+    /**
+     * Returns whether replay has completed and the planner is in live mode.
+     *
+     * @return {@code true} if replay is complete
+     */
+    public boolean isReplayComplete() {
+        return replayComplete;
+    }
+
+    private void writeOutputToScope(AgenticScope scope, AgentInvocationCompletedEvent event, Object output) {
+        if (output == null) {
+            return;
+        }
+        // Find the matching agent instance to determine its output key
+        String outputKey = findOutputKey(event.agentId(), event.agentName());
+        if (outputKey != null) {
+            scope.writeState(outputKey, output);
+            LOG.debug("Wrote replayed output to scope key '{}' for agent '{}'", outputKey, event.agentName());
+        } else {
+            LOG.debug(
+                    "No output key found for agent '{}' (id={}), skipping scope write",
+                    event.agentName(),
+                    event.agentId());
+        }
+    }
+
+    private String findOutputKey(String agentId, String agentName) {
+        if (subagents == null) {
+            return null;
+        }
+        for (AgentInstance agent : subagents) {
+            if (agentId != null && agentId.equals(agent.agentId())) {
+                return agent.outputKey();
+            }
+            if (agentName != null && agentName.equals(agent.name())) {
+                return agent.outputKey();
+            }
+        }
+        return null;
+    }
+
+    private Object deserializeOutput(String serializedOutput) {
+        if (serializedOutput == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(serializedOutput, Object.class);
+        } catch (JsonProcessingException e) {
+            LOG.warn("Failed to deserialize replayed output, returning raw string: {}", e.getMessage());
+            return serializedOutput;
+        }
+    }
+
+    private static List<AgentInvocationCompletedEvent> extractCompletedEvents(List<TaskEvent> events) {
+        List<AgentInvocationCompletedEvent> completed = new ArrayList<>();
+        for (TaskEvent event : events) {
+            if (event instanceof AgentInvocationCompletedEvent completedEvent) {
+                completed.add(completedEvent);
+            }
+        }
+        return List.copyOf(completed);
+    }
+
+    private static List<TaskResumedEvent> extractResumedEvents(List<TaskEvent> events) {
+        List<TaskResumedEvent> resumed = new ArrayList<>();
+        for (TaskEvent event : events) {
+            if (event instanceof TaskResumedEvent resumedEvent) {
+                resumed.add(resumedEvent);
+            }
+        }
+        return List.copyOf(resumed);
+    }
+
+    /**
+     * Creates a new builder for {@link ReplayingPlanner}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link ReplayingPlanner}.
+     */
+    public static final class Builder {
+
+        private Planner delegate;
+        private List<TaskEvent> journalEvents = List.of();
+
+        private Builder() {}
+
+        /**
+         * Sets the delegate planner to wrap. Required.
+         *
+         * @param delegate the original planner
+         * @return this builder
+         */
+        public Builder delegate(Planner delegate) {
+            this.delegate = delegate;
+            return this;
+        }
+
+        /**
+         * Sets the journal events from which to extract completed invocations. Required.
+         *
+         * @param journalEvents the journal events
+         * @return this builder
+         */
+        public Builder journalEvents(List<TaskEvent> journalEvents) {
+            this.journalEvents = journalEvents;
+            return this;
+        }
+
+        /**
+         * Builds the {@link ReplayingPlanner}.
+         *
+         * @return a new replaying planner
+         * @throws IllegalArgumentException if delegate is null
+         */
+        public ReplayingPlanner build() {
+            if (delegate == null) {
+                throw new IllegalArgumentException("delegate planner must not be null");
+            }
+            return new ReplayingPlanner(this);
+        }
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/replay/ReplayingPlanner.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/replay/ReplayingPlanner.java
@@ -78,7 +78,10 @@ public class ReplayingPlanner implements Planner {
             return delegate.firstAction(planningContext);
         }
 
-        LOG.info("Replaying {} completed invocations and {} resume events from journal", completedEvents.size(), resumedEvents.size());
+        LOG.info(
+                "Replaying {} completed invocations and {} resume events from journal",
+                completedEvents.size(),
+                resumedEvents.size());
 
         AgenticScope scope = planningContext.agenticScope();
 

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/replay/package-info.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/replay/package-info.java
@@ -1,0 +1,4 @@
+@Experimental
+package dev.langchain4j.experimental.durable.replay;
+
+import dev.langchain4j.Experimental;

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/Checkpoint.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/Checkpoint.java
@@ -1,0 +1,49 @@
+package dev.langchain4j.experimental.durable.store;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import java.time.Instant;
+
+/**
+ * An immutable snapshot of a task's state at a specific point in time.
+ *
+ * <p>A checkpoint captures:
+ * <ul>
+ *   <li>The task metadata (status, agent name, labels, timestamps)</li>
+ *   <li>The serialized scope state (agent invocation data as JSON)</li>
+ *   <li>The number of journal events replayed to reach this state</li>
+ *   <li>The timestamp when this checkpoint was taken</li>
+ * </ul>
+ *
+ * <p>Checkpoints are used during resume to fast-forward the agent topology to the
+ * last-known good state, avoiding re-execution of already-completed invocations.
+ *
+ * @param taskId         the identifier of the task
+ * @param metadata       the task metadata at checkpoint time
+ * @param serializedScope the scope state serialized as JSON, or {@code null} if serialization failed
+ * @param eventCount     the number of events in the journal at checkpoint time
+ * @param createdAt      the timestamp when this checkpoint was created
+ */
+@Experimental
+public record Checkpoint(
+        TaskId taskId, TaskMetadata metadata, String serializedScope, int eventCount, Instant createdAt) {
+
+    @JsonCreator
+    public Checkpoint(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("metadata") TaskMetadata metadata,
+            @JsonProperty("serializedScope") String serializedScope,
+            @JsonProperty("eventCount") int eventCount,
+            @JsonProperty("createdAt") Instant createdAt) {
+        this.taskId = ensureNotNull(taskId, "taskId");
+        this.metadata = ensureNotNull(metadata, "metadata");
+        this.serializedScope = serializedScope;
+        this.eventCount = eventCount;
+        this.createdAt = ensureNotNull(createdAt, "createdAt");
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/InMemoryTaskExecutionStore.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/InMemoryTaskExecutionStore.java
@@ -77,8 +77,8 @@ public class InMemoryTaskExecutionStore implements TaskExecutionStore {
                 cp.metadata().updatedAt(),
                 cp.metadata().failureReason(),
                 cp.metadata().labels());
-        return Optional.of(new Checkpoint(
-                cp.taskId(), metaSnapshot, cp.serializedScope(), cp.eventCount(), cp.createdAt()));
+        return Optional.of(
+                new Checkpoint(cp.taskId(), metaSnapshot, cp.serializedScope(), cp.eventCount(), cp.createdAt()));
     }
 
     @Override

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/InMemoryTaskExecutionStore.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/InMemoryTaskExecutionStore.java
@@ -1,0 +1,119 @@
+package dev.langchain4j.experimental.durable.store;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import dev.langchain4j.experimental.durable.task.TaskStatus;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * In-memory implementation of {@link TaskExecutionStore} backed by concurrent hash maps.
+ *
+ * <p>This implementation is suitable for testing and development. All data is lost when
+ * the JVM exits. For production use, consider {@code FileTaskExecutionStore} or a
+ * custom database-backed implementation.
+ *
+ * <p>All operations are thread-safe.
+ */
+@Experimental
+public class InMemoryTaskExecutionStore implements TaskExecutionStore {
+
+    private final ConcurrentHashMap<TaskId, TaskMetadata> metadataMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<TaskId, List<TaskEvent>> eventsMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<TaskId, Checkpoint> checkpointMap = new ConcurrentHashMap<>();
+
+    @Override
+    public void saveMetadata(TaskMetadata metadata) {
+        metadataMap.put(metadata.id(), metadata);
+    }
+
+    @Override
+    public Optional<TaskMetadata> loadMetadata(TaskId taskId) {
+        return Optional.ofNullable(metadataMap.get(taskId));
+    }
+
+    @Override
+    public void appendEvent(TaskEvent event) {
+        eventsMap
+                .computeIfAbsent(event.taskId(), id -> Collections.synchronizedList(new ArrayList<>()))
+                .add(event);
+    }
+
+    @Override
+    public List<TaskEvent> loadEvents(TaskId taskId) {
+        List<TaskEvent> events = eventsMap.get(taskId);
+        if (events == null) {
+            return List.of();
+        }
+        synchronized (events) {
+            return List.copyOf(events);
+        }
+    }
+
+    @Override
+    public void saveCheckpoint(Checkpoint checkpoint) {
+        checkpointMap.put(checkpoint.taskId(), checkpoint);
+    }
+
+    @Override
+    public Optional<Checkpoint> loadCheckpoint(TaskId taskId) {
+        Checkpoint cp = checkpointMap.get(taskId);
+        if (cp == null) {
+            return Optional.empty();
+        }
+        // Return a defensive copy so callers cannot mutate the stored snapshot
+        TaskMetadata metaSnapshot = TaskMetadata.of(
+                cp.metadata().id(),
+                cp.metadata().agentName(),
+                cp.metadata().status(),
+                cp.metadata().createdAt(),
+                cp.metadata().updatedAt(),
+                cp.metadata().failureReason(),
+                cp.metadata().labels());
+        return Optional.of(new Checkpoint(
+                cp.taskId(), metaSnapshot, cp.serializedScope(), cp.eventCount(), cp.createdAt()));
+    }
+
+    @Override
+    public Set<TaskId> getAllTaskIds() {
+        return Set.copyOf(metadataMap.keySet());
+    }
+
+    @Override
+    public Set<TaskId> getTaskIdsByStatus(TaskStatus status) {
+        return metadataMap.values().stream()
+                .filter(metadata -> metadata.status() == status)
+                .map(TaskMetadata::id)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    public boolean delete(TaskId taskId) {
+        boolean existed = metadataMap.remove(taskId) != null;
+        eventsMap.remove(taskId);
+        checkpointMap.remove(taskId);
+        return existed;
+    }
+
+    @Override
+    public Optional<TaskMetadata> compareAndSetStatus(
+            TaskId taskId, TaskStatus expectedStatus, TaskStatus newStatus, String failureReason) {
+        TaskMetadata metadata = metadataMap.get(taskId);
+        if (metadata == null) {
+            return Optional.empty();
+        }
+        // In-memory store shares the same object instance, so the synchronized
+        // compareAndTransition on TaskMetadata is sufficient for atomicity.
+        if (!metadata.compareAndTransition(expectedStatus, newStatus, failureReason)) {
+            return Optional.empty();
+        }
+        return Optional.of(metadata);
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/TaskExecutionStore.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/TaskExecutionStore.java
@@ -1,0 +1,157 @@
+package dev.langchain4j.experimental.durable.store;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import dev.langchain4j.experimental.durable.task.TaskStatus;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Service provider interface for durable task persistence.
+ *
+ * <p>Implementations must be safe for concurrent access from multiple threads.
+ * All mutating operations should be atomic with respect to a single task.
+ *
+ * <p>Two built-in implementations are provided:
+ * <ul>
+ *   <li>{@code InMemoryTaskExecutionStore} — for testing and development</li>
+ *   <li>{@code FileTaskExecutionStore} — for single-node production use</li>
+ * </ul>
+ */
+@Experimental
+public interface TaskExecutionStore {
+
+    /**
+     * Saves or updates the metadata for a task.
+     *
+     * @param metadata the task metadata to persist
+     * @throws TaskStoreException if the operation fails
+     */
+    void saveMetadata(TaskMetadata metadata);
+
+    /**
+     * Loads the metadata for a task.
+     *
+     * @param taskId the task identifier
+     * @return the metadata, or empty if no task with that id is known
+     * @throws TaskStoreException if the operation fails
+     */
+    Optional<TaskMetadata> loadMetadata(TaskId taskId);
+
+    /**
+     * Appends an event to a task's execution journal.
+     *
+     * <p>Events must be appended in order and are never modified or removed.
+     *
+     * @param event the event to append
+     * @throws TaskStoreException if the operation fails
+     */
+    void appendEvent(TaskEvent event);
+
+    /**
+     * Returns all events for a task, in the order they were appended.
+     *
+     * @param taskId the task identifier
+     * @return ordered list of events, empty if no events exist
+     * @throws TaskStoreException if the operation fails
+     */
+    List<TaskEvent> loadEvents(TaskId taskId);
+
+    /**
+     * Saves a checkpoint for a task, replacing any previous checkpoint.
+     *
+     * @param checkpoint the checkpoint to save
+     * @throws TaskStoreException if the operation fails
+     */
+    void saveCheckpoint(Checkpoint checkpoint);
+
+    /**
+     * Loads the most recent checkpoint for a task.
+     *
+     * @param taskId the task identifier
+     * @return the most recent checkpoint, or empty if none exists
+     * @throws TaskStoreException if the operation fails
+     */
+    Optional<Checkpoint> loadCheckpoint(TaskId taskId);
+
+    /**
+     * Returns the identifiers of all known tasks.
+     *
+     * @return set of task identifiers
+     * @throws TaskStoreException if the operation fails
+     */
+    Set<TaskId> getAllTaskIds();
+
+    /**
+     * Returns the identifiers of all tasks in the given status.
+     *
+     * @param status the status to filter by
+     * @return set of matching task identifiers
+     * @throws TaskStoreException if the operation fails
+     */
+    Set<TaskId> getTaskIdsByStatus(TaskStatus status);
+
+    /**
+     * Deletes all data (metadata, events, checkpoint) for a task.
+     *
+     * @param taskId the task identifier
+     * @return {@code true} if the task existed and was deleted, {@code false} otherwise
+     * @throws TaskStoreException if the operation fails
+     */
+    boolean delete(TaskId taskId);
+
+    /**
+     * Atomically loads the metadata from the store, verifies that the current status
+     * matches {@code expectedStatus}, transitions to {@code newStatus}, and persists
+     * the updated metadata — all as a single atomic operation with respect to the store.
+     *
+     * <p>This method is the store-level compare-and-set that prevents races between
+     * concurrent cancel and complete operations when the store deserializes metadata
+     * into new instances (e.g., {@code FileTaskExecutionStore}). Callers should use
+     * this method instead of loading metadata, calling
+     * {@link TaskMetadata#compareAndTransition}, and saving separately.
+     *
+     * <p>The default implementation is <em>not</em> atomic across load and save.
+     * Concrete implementations should override to provide true atomicity.
+     *
+     * @param taskId         the task identifier
+     * @param expectedStatus the status the task must currently be in
+     * @param newStatus      the target status
+     * @return the updated metadata if the transition succeeded, or empty if the task
+     *         was not found or its status did not match {@code expectedStatus}
+     * @throws TaskStoreException if the operation fails
+     */
+    default Optional<TaskMetadata> compareAndSetStatus(TaskId taskId, TaskStatus expectedStatus, TaskStatus newStatus) {
+        return compareAndSetStatus(taskId, expectedStatus, newStatus, null);
+    }
+
+    /**
+     * Atomically loads the metadata from the store, verifies that the current status
+     * matches {@code expectedStatus}, transitions to {@code newStatus} with the given
+     * failure reason, and persists the updated metadata.
+     *
+     * @param taskId         the task identifier
+     * @param expectedStatus the status the task must currently be in
+     * @param newStatus      the target status
+     * @param failureReason  optional failure reason (only meaningful for {@link TaskStatus#FAILED})
+     * @return the updated metadata if the transition succeeded, or empty if the task
+     *         was not found or its status did not match {@code expectedStatus}
+     * @throws TaskStoreException if the operation fails
+     */
+    default Optional<TaskMetadata> compareAndSetStatus(
+            TaskId taskId, TaskStatus expectedStatus, TaskStatus newStatus, String failureReason) {
+        Optional<TaskMetadata> loaded = loadMetadata(taskId);
+        if (loaded.isEmpty()) {
+            return Optional.empty();
+        }
+        TaskMetadata metadata = loaded.get();
+        if (!metadata.compareAndTransition(expectedStatus, newStatus, failureReason)) {
+            return Optional.empty();
+        }
+        saveMetadata(metadata);
+        return Optional.of(metadata);
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/TaskExecutionStore.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/TaskExecutionStore.java
@@ -15,11 +15,12 @@ import java.util.Set;
  * <p>Implementations must be safe for concurrent access from multiple threads.
  * All mutating operations should be atomic with respect to a single task.
  *
- * <p>Two built-in implementations are provided:
+ * <p>A built-in file-based implementation is provided:
  * <ul>
- *   <li>{@code InMemoryTaskExecutionStore} — for testing and development</li>
- *   <li>{@code FileTaskExecutionStore} — for single-node production use</li>
+ *   <li>{@code FileTaskExecutionStore} — append-only JSON journal for single-node production use</li>
  * </ul>
+ *
+ * <p>For testing, an in-memory implementation is available in the {@code test} scope.
  */
 @Experimental
 public interface TaskExecutionStore {

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/TaskStoreException.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/TaskStoreException.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.experimental.durable.store;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.exception.LangChain4jException;
+
+/**
+ * Exception thrown when a {@link TaskExecutionStore} operation fails.
+ */
+@Experimental
+public class TaskStoreException extends LangChain4jException {
+
+    public TaskStoreException(String message) {
+        super(message);
+    }
+
+    public TaskStoreException(Throwable cause) {
+        super(cause.getMessage(), cause);
+    }
+
+    public TaskStoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/AgentInvocationCompletedEvent.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/AgentInvocationCompletedEvent.java
@@ -1,0 +1,33 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+
+/**
+ * Recorded when an agent invocation completes successfully within a task.
+ *
+ * <p>The output is stored as a pre-serialized JSON string to avoid issues with
+ * non-serializable types (e.g., {@code DelayedResponse}) in the scope state.
+ */
+@Experimental
+public record AgentInvocationCompletedEvent(
+        TaskId taskId, Instant timestamp, String agentName, String agentId, String serializedOutput)
+        implements TaskEvent {
+
+    @JsonCreator
+    public AgentInvocationCompletedEvent(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("timestamp") Instant timestamp,
+            @JsonProperty("agentName") String agentName,
+            @JsonProperty("agentId") String agentId,
+            @JsonProperty("serializedOutput") String serializedOutput) {
+        this.taskId = taskId;
+        this.timestamp = timestamp;
+        this.agentName = agentName;
+        this.agentId = agentId;
+        this.serializedOutput = serializedOutput;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/AgentInvocationFailedEvent.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/AgentInvocationFailedEvent.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+
+/**
+ * Recorded when an agent invocation fails with an error within a task.
+ */
+@Experimental
+public record AgentInvocationFailedEvent(
+        TaskId taskId, Instant timestamp, String agentName, String agentId, String errorMessage, String stackTrace)
+        implements TaskEvent {
+
+    @JsonCreator
+    public AgentInvocationFailedEvent(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("timestamp") Instant timestamp,
+            @JsonProperty("agentName") String agentName,
+            @JsonProperty("agentId") String agentId,
+            @JsonProperty("errorMessage") String errorMessage,
+            @JsonProperty("stackTrace") String stackTrace) {
+        this.taskId = taskId;
+        this.timestamp = timestamp;
+        this.agentName = agentName;
+        this.agentId = agentId;
+        this.errorMessage = errorMessage;
+        this.stackTrace = stackTrace;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/AgentInvocationStartedEvent.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/AgentInvocationStartedEvent.java
@@ -1,0 +1,31 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Recorded when an agent invocation begins within a task.
+ */
+@Experimental
+public record AgentInvocationStartedEvent(
+        TaskId taskId, Instant timestamp, String agentName, String agentId, Map<String, Object> inputs)
+        implements TaskEvent {
+
+    @JsonCreator
+    public AgentInvocationStartedEvent(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("timestamp") Instant timestamp,
+            @JsonProperty("agentName") String agentName,
+            @JsonProperty("agentId") String agentId,
+            @JsonProperty("inputs") Map<String, Object> inputs) {
+        this.taskId = taskId;
+        this.timestamp = timestamp;
+        this.agentName = agentName;
+        this.agentId = agentId;
+        this.inputs = inputs != null ? Map.copyOf(inputs) : Map.of();
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskCancelledEvent.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskCancelledEvent.java
@@ -1,0 +1,20 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+
+/**
+ * Recorded when a task is explicitly cancelled.
+ */
+@Experimental
+public record TaskCancelledEvent(TaskId taskId, Instant timestamp) implements TaskEvent {
+
+    @JsonCreator
+    public TaskCancelledEvent(@JsonProperty("taskId") TaskId taskId, @JsonProperty("timestamp") Instant timestamp) {
+        this.taskId = taskId;
+        this.timestamp = timestamp;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskCompletedEvent.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskCompletedEvent.java
@@ -1,0 +1,24 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+
+/**
+ * Recorded when a task completes successfully.
+ */
+@Experimental
+public record TaskCompletedEvent(TaskId taskId, Instant timestamp, String serializedResult) implements TaskEvent {
+
+    @JsonCreator
+    public TaskCompletedEvent(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("timestamp") Instant timestamp,
+            @JsonProperty("serializedResult") String serializedResult) {
+        this.taskId = taskId;
+        this.timestamp = timestamp;
+        this.serializedResult = serializedResult;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskEvent.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskEvent.java
@@ -1,0 +1,71 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+
+/**
+ * Sealed interface for all events in a task's execution journal.
+ *
+ * <p>Events are appended to an ordered journal and enable:
+ * <ul>
+ *   <li>Reconstructing execution history for debugging and observability</li>
+ *   <li>Determining the resume point after a crash</li>
+ *   <li>Auditing all agent invocations and their outcomes</li>
+ * </ul>
+ *
+ * <p>All events carry a {@link #schemaVersion()} for forward compatibility.
+ * Consumers should tolerate unknown fields gracefully.
+ */
+@Experimental
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = TaskStartedEvent.class, name = "task_started"),
+    @JsonSubTypes.Type(value = AgentInvocationStartedEvent.class, name = "agent_invocation_started"),
+    @JsonSubTypes.Type(value = AgentInvocationCompletedEvent.class, name = "agent_invocation_completed"),
+    @JsonSubTypes.Type(value = AgentInvocationFailedEvent.class, name = "agent_invocation_failed"),
+    @JsonSubTypes.Type(value = TaskPausedEvent.class, name = "task_paused"),
+    @JsonSubTypes.Type(value = TaskResumedEvent.class, name = "task_resumed"),
+    @JsonSubTypes.Type(value = TaskCompletedEvent.class, name = "task_completed"),
+    @JsonSubTypes.Type(value = TaskFailedEvent.class, name = "task_failed"),
+    @JsonSubTypes.Type(value = TaskCancelledEvent.class, name = "task_cancelled"),
+    @JsonSubTypes.Type(value = TaskRetryEvent.class, name = "task_retry"),
+})
+public sealed interface TaskEvent
+        permits TaskStartedEvent,
+                AgentInvocationStartedEvent,
+                AgentInvocationCompletedEvent,
+                AgentInvocationFailedEvent,
+                TaskPausedEvent,
+                TaskResumedEvent,
+                TaskCompletedEvent,
+                TaskFailedEvent,
+                TaskCancelledEvent,
+                TaskRetryEvent {
+
+    /**
+     * Returns the identifier of the task this event belongs to.
+     *
+     * @return the task id
+     */
+    TaskId taskId();
+
+    /**
+     * Returns the timestamp when this event occurred.
+     *
+     * @return the event timestamp
+     */
+    Instant timestamp();
+
+    /**
+     * Returns the schema version for this event type. Starts at 1.
+     * Consumers should use this to handle format evolution.
+     *
+     * @return the schema version
+     */
+    default int schemaVersion() {
+        return 1;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskFailedEvent.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskFailedEvent.java
@@ -1,0 +1,27 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+
+/**
+ * Recorded when a task fails with an error.
+ */
+@Experimental
+public record TaskFailedEvent(TaskId taskId, Instant timestamp, String errorMessage, String stackTrace)
+        implements TaskEvent {
+
+    @JsonCreator
+    public TaskFailedEvent(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("timestamp") Instant timestamp,
+            @JsonProperty("errorMessage") String errorMessage,
+            @JsonProperty("stackTrace") String stackTrace) {
+        this.taskId = taskId;
+        this.timestamp = timestamp;
+        this.errorMessage = errorMessage;
+        this.stackTrace = stackTrace;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskPausedEvent.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskPausedEvent.java
@@ -1,0 +1,27 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+
+/**
+ * Recorded when a task is paused, typically to wait for human input.
+ */
+@Experimental
+public record TaskPausedEvent(TaskId taskId, Instant timestamp, String reason, String pendingAgentName)
+        implements TaskEvent {
+
+    @JsonCreator
+    public TaskPausedEvent(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("timestamp") Instant timestamp,
+            @JsonProperty("reason") String reason,
+            @JsonProperty("pendingAgentName") String pendingAgentName) {
+        this.taskId = taskId;
+        this.timestamp = timestamp;
+        this.reason = reason;
+        this.pendingAgentName = pendingAgentName;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskResumedEvent.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskResumedEvent.java
@@ -1,0 +1,25 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Recorded when a paused task is resumed, optionally with user-provided input.
+ */
+@Experimental
+public record TaskResumedEvent(TaskId taskId, Instant timestamp, Map<String, Object> userInput) implements TaskEvent {
+
+    @JsonCreator
+    public TaskResumedEvent(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("timestamp") Instant timestamp,
+            @JsonProperty("userInput") Map<String, Object> userInput) {
+        this.taskId = taskId;
+        this.timestamp = timestamp;
+        this.userInput = userInput != null ? Map.copyOf(userInput) : Map.of();
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskRetryEvent.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskRetryEvent.java
@@ -1,0 +1,39 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+
+/**
+ * Recorded when a failed task attempt is retried automatically.
+ *
+ * @param taskId       the task identifier
+ * @param timestamp    when the retry was scheduled
+ * @param attempt      the retry attempt number (1-based)
+ * @param maxRetries   the configured maximum retries
+ * @param errorMessage the error message from the failed attempt
+ * @param delayMillis  the delay in milliseconds before this retry
+ */
+@Experimental
+public record TaskRetryEvent(
+        TaskId taskId, Instant timestamp, int attempt, int maxRetries, String errorMessage, long delayMillis)
+        implements TaskEvent {
+
+    @JsonCreator
+    public TaskRetryEvent(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("timestamp") Instant timestamp,
+            @JsonProperty("attempt") int attempt,
+            @JsonProperty("maxRetries") int maxRetries,
+            @JsonProperty("errorMessage") String errorMessage,
+            @JsonProperty("delayMillis") long delayMillis) {
+        this.taskId = taskId;
+        this.timestamp = timestamp;
+        this.attempt = attempt;
+        this.maxRetries = maxRetries;
+        this.errorMessage = errorMessage;
+        this.delayMillis = delayMillis;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskStartedEvent.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/TaskStartedEvent.java
@@ -1,0 +1,26 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Recorded when a task begins execution.
+ */
+@Experimental
+public record TaskStartedEvent(TaskId taskId, Instant timestamp, Map<String, Object> initialInputs)
+        implements TaskEvent {
+
+    @JsonCreator
+    public TaskStartedEvent(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("timestamp") Instant timestamp,
+            @JsonProperty("initialInputs") Map<String, Object> initialInputs) {
+        this.taskId = taskId;
+        this.timestamp = timestamp;
+        this.initialInputs = initialInputs != null ? Map.copyOf(initialInputs) : Map.of();
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/package-info.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/event/package-info.java
@@ -1,0 +1,4 @@
+@Experimental
+package dev.langchain4j.experimental.durable.store.event;
+
+import dev.langchain4j.Experimental;

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/file/FileTaskExecutionStore.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/file/FileTaskExecutionStore.java
@@ -1,0 +1,397 @@
+package dev.langchain4j.experimental.durable.store.file;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.experimental.durable.internal.ObjectMapperFactory;
+import dev.langchain4j.experimental.durable.store.Checkpoint;
+import dev.langchain4j.experimental.durable.store.TaskExecutionStore;
+import dev.langchain4j.experimental.durable.store.TaskStoreException;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import dev.langchain4j.experimental.durable.task.TaskStatus;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * File-based implementation of {@link TaskExecutionStore}.
+ *
+ * <p>Persists task data to a directory structure on the local filesystem:
+ * <pre>
+ *   baseDir/
+ *     {taskId}/
+ *       metadata.json       — task metadata
+ *       journal.jsonl        — append-only event journal (one JSON line per event)
+ *       checkpoint.json      — most recent checkpoint
+ * </pre>
+ *
+ * <p>Writes to metadata and checkpoint files use atomic move (write to temp file
+ * then rename) to prevent corruption from crashes. Journal appends use
+ * {@link StandardOpenOption#SYNC} for durability.
+ *
+ * <p>A per-task {@link ReentrantLock} serializes concurrent operations on the same task.
+ */
+@Experimental
+public class FileTaskExecutionStore implements TaskExecutionStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileTaskExecutionStore.class);
+
+    private static final String METADATA_FILE = "metadata.json";
+    private static final String JOURNAL_FILE = "journal.jsonl";
+    private static final String CHECKPOINT_FILE = "checkpoint.json";
+
+    private final Path baseDir;
+    private final ObjectMapper objectMapper;
+    private final ObjectWriter compactWriter;
+    private final ConcurrentHashMap<TaskId, ReentrantLock> lockMap = new ConcurrentHashMap<>();
+
+    private FileTaskExecutionStore(Builder builder) {
+        this.baseDir = builder.baseDir;
+        this.objectMapper = builder.objectMapper != null ? builder.objectMapper : ObjectMapperFactory.createPrettyPrinting();
+        this.compactWriter = objectMapper.writer().without(SerializationFeature.INDENT_OUTPUT);
+        ensureDirectoryExists(this.baseDir);
+    }
+
+    private ReentrantLock lockFor(TaskId taskId) {
+        return lockMap.computeIfAbsent(taskId, id -> new ReentrantLock());
+    }
+
+    private Path taskDir(TaskId taskId) {
+        return baseDir.resolve(taskId.value());
+    }
+
+    // -- Metadata --
+
+    @Override
+    public void saveMetadata(TaskMetadata metadata) {
+        ReentrantLock lock = lockFor(metadata.id());
+        lock.lock();
+        try {
+            Path dir = taskDir(metadata.id());
+            ensureDirectoryExists(dir);
+            atomicWrite(dir.resolve(METADATA_FILE), objectMapper.writeValueAsBytes(metadata));
+        } catch (JsonProcessingException e) {
+            throw new TaskStoreException("Failed to serialize metadata for task " + metadata.id(), e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public Optional<TaskMetadata> loadMetadata(TaskId taskId) {
+        ReentrantLock lock = lockFor(taskId);
+        lock.lock();
+        try {
+            Path file = taskDir(taskId).resolve(METADATA_FILE);
+            if (!Files.exists(file)) {
+                return Optional.empty();
+            }
+            return Optional.of(objectMapper.readValue(file.toFile(), TaskMetadata.class));
+        } catch (IOException e) {
+            throw new TaskStoreException("Failed to load metadata for task " + taskId, e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // -- Events --
+
+    @Override
+    public void appendEvent(TaskEvent event) {
+        ReentrantLock lock = lockFor(event.taskId());
+        lock.lock();
+        try {
+            Path dir = taskDir(event.taskId());
+            ensureDirectoryExists(dir);
+            Path journalFile = dir.resolve(JOURNAL_FILE);
+            String line = compactWriter.writeValueAsString(event);
+            try (BufferedWriter writer = Files.newBufferedWriter(
+                    journalFile, StandardOpenOption.CREATE, StandardOpenOption.APPEND, StandardOpenOption.SYNC)) {
+                writer.write(line);
+                writer.newLine();
+            }
+        } catch (IOException e) {
+            throw new TaskStoreException("Failed to append event for task " + event.taskId(), e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public List<TaskEvent> loadEvents(TaskId taskId) {
+        ReentrantLock lock = lockFor(taskId);
+        lock.lock();
+        try {
+            Path journalFile = taskDir(taskId).resolve(JOURNAL_FILE);
+            if (!Files.exists(journalFile)) {
+                return List.of();
+            }
+            List<TaskEvent> events = new ArrayList<>();
+            try (BufferedReader reader = Files.newBufferedReader(journalFile)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    String trimmed = line.trim();
+                    if (!trimmed.isEmpty()) {
+                        events.add(objectMapper.readValue(trimmed, TaskEvent.class));
+                    }
+                }
+            }
+            return List.copyOf(events);
+        } catch (IOException e) {
+            throw new TaskStoreException("Failed to load events for task " + taskId, e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // -- Checkpoint --
+
+    @Override
+    public void saveCheckpoint(Checkpoint checkpoint) {
+        ReentrantLock lock = lockFor(checkpoint.taskId());
+        lock.lock();
+        try {
+            Path dir = taskDir(checkpoint.taskId());
+            ensureDirectoryExists(dir);
+            atomicWrite(dir.resolve(CHECKPOINT_FILE), objectMapper.writeValueAsBytes(checkpoint));
+        } catch (JsonProcessingException e) {
+            throw new TaskStoreException("Failed to serialize checkpoint for task " + checkpoint.taskId(), e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public Optional<Checkpoint> loadCheckpoint(TaskId taskId) {
+        ReentrantLock lock = lockFor(taskId);
+        lock.lock();
+        try {
+            Path file = taskDir(taskId).resolve(CHECKPOINT_FILE);
+            if (!Files.exists(file)) {
+                return Optional.empty();
+            }
+            return Optional.of(objectMapper.readValue(file.toFile(), Checkpoint.class));
+        } catch (IOException e) {
+            throw new TaskStoreException("Failed to load checkpoint for task " + taskId, e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // -- Query --
+
+    @Override
+    public Set<TaskId> getAllTaskIds() {
+        try {
+            if (!Files.exists(baseDir)) {
+                return Set.of();
+            }
+            Set<TaskId> taskIds = new HashSet<>();
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(baseDir, Files::isDirectory)) {
+                for (Path dir : stream) {
+                    Path metadataFile = dir.resolve(METADATA_FILE);
+                    if (Files.exists(metadataFile)) {
+                        taskIds.add(new TaskId(dir.getFileName().toString()));
+                    }
+                }
+            }
+            return Set.copyOf(taskIds);
+        } catch (IOException e) {
+            throw new TaskStoreException("Failed to list task ids", e);
+        }
+    }
+
+    @Override
+    public Set<TaskId> getTaskIdsByStatus(TaskStatus status) {
+        return getAllTaskIds().stream()
+                .filter(taskId -> {
+                    Optional<TaskMetadata> metadata = loadMetadata(taskId);
+                    return metadata.isPresent() && metadata.get().status() == status;
+                })
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    // -- Delete --
+
+    @Override
+    public boolean delete(TaskId taskId) {
+        ReentrantLock lock = lockFor(taskId);
+        lock.lock();
+        try {
+            Path dir = taskDir(taskId);
+            if (!Files.exists(dir)) {
+                return false;
+            }
+            deleteDirectoryRecursively(dir);
+            // Do NOT remove the lock entry here — removing while holding the lock
+            // allows concurrent callers to create a new lock via lockFor(), bypassing
+            // serialization. The small memory cost of a stale entry is acceptable.
+            return true;
+        } catch (IOException e) {
+            throw new TaskStoreException("Failed to delete task " + taskId, e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // -- Store-atomic CAS --
+
+    @Override
+    public Optional<TaskMetadata> compareAndSetStatus(
+            TaskId taskId, TaskStatus expectedStatus, TaskStatus newStatus, String failureReason) {
+        ReentrantLock lock = lockFor(taskId);
+        lock.lock();
+        try {
+            Path file = taskDir(taskId).resolve(METADATA_FILE);
+            if (!Files.exists(file)) {
+                return Optional.empty();
+            }
+            TaskMetadata metadata = objectMapper.readValue(file.toFile(), TaskMetadata.class);
+            if (!metadata.compareAndTransition(expectedStatus, newStatus, failureReason)) {
+                return Optional.empty();
+            }
+            atomicWrite(file, objectMapper.writeValueAsBytes(metadata));
+            return Optional.of(metadata);
+        } catch (IOException e) {
+            throw new TaskStoreException("Failed to compare-and-set status for task " + taskId, e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // -- Internal helpers --
+
+    private void atomicWrite(Path target, byte[] content) {
+        try {
+            Path tempFile = Files.createTempFile(target.getParent(), "tmp-", ".json");
+            try {
+                Files.write(tempFile, content);
+                try {
+                    Files.move(tempFile, target, StandardCopyOption.ATOMIC_MOVE);
+                } catch (AtomicMoveNotSupportedException e) {
+                    LOG.debug("Atomic move not supported, falling back to replace: {}", target);
+                    Files.move(tempFile, target, StandardCopyOption.REPLACE_EXISTING);
+                }
+            } catch (IOException e) {
+                // Clean up temp file on failure
+                try {
+                    Files.deleteIfExists(tempFile);
+                } catch (IOException suppressed) {
+                    e.addSuppressed(suppressed);
+                }
+                throw e;
+            }
+        } catch (IOException e) {
+            throw new TaskStoreException("Failed to write file: " + target, e);
+        }
+    }
+
+    private static void ensureDirectoryExists(Path dir) {
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException e) {
+            throw new TaskStoreException("Failed to create directory: " + dir, e);
+        }
+    }
+
+    private static void deleteDirectoryRecursively(Path dir) throws IOException {
+        if (!Files.exists(dir)) {
+            return;
+        }
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+            for (Path entry : stream) {
+                if (Files.isDirectory(entry)) {
+                    deleteDirectoryRecursively(entry);
+                } else {
+                    Files.delete(entry);
+                }
+            }
+        }
+        Files.delete(dir);
+    }
+
+    /**
+     * Returns the base directory used by this store.
+     *
+     * @return the base directory path
+     */
+    public Path baseDir() {
+        return baseDir;
+    }
+
+    /**
+     * Creates a new builder for {@link FileTaskExecutionStore}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link FileTaskExecutionStore}.
+     */
+    public static final class Builder {
+
+        private Path baseDir;
+        private ObjectMapper objectMapper;
+
+        private Builder() {}
+
+        /**
+         * Sets the base directory for task data. Required.
+         *
+         * @param baseDir the base directory
+         * @return this builder
+         */
+        public Builder baseDir(Path baseDir) {
+            this.baseDir = baseDir;
+            return this;
+        }
+
+        /**
+         * Sets a custom {@link ObjectMapper} for JSON serialization.
+         * If not set, a default mapper with {@code JavaTimeModule} and pretty-print is used.
+         *
+         * @param objectMapper the object mapper
+         * @return this builder
+         */
+        public Builder objectMapper(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+            return this;
+        }
+
+        /**
+         * Builds the {@link FileTaskExecutionStore}.
+         *
+         * @return a new file task execution store
+         * @throws IllegalArgumentException if {@code baseDir} is null
+         */
+        public FileTaskExecutionStore build() {
+            if (baseDir == null) {
+                throw new IllegalArgumentException("baseDir must not be null");
+            }
+            return new FileTaskExecutionStore(this);
+        }
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/file/FileTaskExecutionStore.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/file/FileTaskExecutionStore.java
@@ -67,7 +67,8 @@ public class FileTaskExecutionStore implements TaskExecutionStore {
 
     private FileTaskExecutionStore(Builder builder) {
         this.baseDir = builder.baseDir;
-        this.objectMapper = builder.objectMapper != null ? builder.objectMapper : ObjectMapperFactory.createPrettyPrinting();
+        this.objectMapper =
+                builder.objectMapper != null ? builder.objectMapper : ObjectMapperFactory.createPrettyPrinting();
         this.compactWriter = objectMapper.writer().without(SerializationFeature.INDENT_OUTPUT);
         ensureDirectoryExists(this.baseDir);
     }

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/file/package-info.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/file/package-info.java
@@ -1,0 +1,4 @@
+@Experimental
+package dev.langchain4j.experimental.durable.store.file;
+
+import dev.langchain4j.Experimental;

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/package-info.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/store/package-info.java
@@ -1,0 +1,4 @@
+@Experimental
+package dev.langchain4j.experimental.durable.store;
+
+import dev.langchain4j.Experimental;

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/CheckpointPolicy.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/CheckpointPolicy.java
@@ -1,0 +1,30 @@
+package dev.langchain4j.experimental.durable.task;
+
+import dev.langchain4j.Experimental;
+
+/**
+ * Controls when checkpoints (scope snapshots) are saved during task execution.
+ *
+ * <p>Checkpoints enable resuming a task from the last saved point after a crash or restart.
+ * More frequent checkpoints provide better resume granularity at the cost of storage I/O.
+ */
+@Experimental
+public enum CheckpointPolicy {
+
+    /** No checkpoints are saved. Resume is not possible. */
+    NONE,
+
+    /**
+     * A checkpoint is saved when the root agentic scope is about to be destroyed,
+     * capturing the final scope state. Intermediate transitions such as pause or retry
+     * do not trigger a checkpoint under this policy.
+     */
+    AFTER_ROOT_CALL,
+
+    /**
+     * A checkpoint is saved after each agent invocation completes, capturing the
+     * current scope state. This is the default and provides the finest resume
+     * granularity.
+     */
+    AFTER_EACH_AGENT
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/RetryPolicy.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/RetryPolicy.java
@@ -1,0 +1,255 @@
+package dev.langchain4j.experimental.durable.task;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.Experimental;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Configures automatic retry behaviour for failed durable tasks.
+ *
+ * <p>When a task throws a retryable exception, the service will automatically
+ * re-execute the workflow up to {@link #maxRetries()} times, applying an
+ * exponential back-off delay between attempts.
+ *
+ * <p>If no {@code retryableExceptions} are specified, <em>all</em> exceptions
+ * (except {@link TaskPausedException}) are considered retryable.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * RetryPolicy policy = RetryPolicy.builder()
+ *         .maxRetries(3)
+ *         .initialDelay(Duration.ofSeconds(1))
+ *         .backoffMultiplier(2.0)
+ *         .retryableException(IOException.class)
+ *         .build();
+ * }</pre>
+ */
+@Experimental
+public final class RetryPolicy {
+
+    /** A policy that disables retries entirely. */
+    public static final RetryPolicy NONE = new RetryPolicy(0, Duration.ZERO, 1.0, Duration.ZERO, Set.of());
+
+    private final int maxRetries;
+    private final Duration initialDelay;
+    private final double backoffMultiplier;
+    private final Duration maxDelay;
+    private final Set<Class<? extends Throwable>> retryableExceptions;
+
+    private RetryPolicy(
+            int maxRetries,
+            Duration initialDelay,
+            double backoffMultiplier,
+            Duration maxDelay,
+            Set<Class<? extends Throwable>> retryableExceptions) {
+        this.maxRetries = maxRetries;
+        this.initialDelay = ensureNotNull(initialDelay, "initialDelay");
+        this.backoffMultiplier = backoffMultiplier;
+        this.maxDelay = ensureNotNull(maxDelay, "maxDelay");
+        this.retryableExceptions = Collections.unmodifiableSet(new LinkedHashSet<>(retryableExceptions));
+    }
+
+    /**
+     * Maximum number of retry attempts after the initial execution.
+     * Zero means no retries (fail immediately).
+     *
+     * @return the maximum retry count
+     */
+    public int maxRetries() {
+        return maxRetries;
+    }
+
+    /**
+     * Delay before the first retry attempt.
+     *
+     * @return the initial delay
+     */
+    public Duration initialDelay() {
+        return initialDelay;
+    }
+
+    /**
+     * Multiplier applied to the delay after each retry attempt.
+     * For example, with an initial delay of 1 second and a multiplier of 2.0,
+     * retries happen at 1s, 2s, 4s, 8s, etc.
+     *
+     * @return the backoff multiplier
+     */
+    public double backoffMultiplier() {
+        return backoffMultiplier;
+    }
+
+    /**
+     * Upper bound for the computed delay. Prevents excessively long waits
+     * when the backoff multiplier produces large values.
+     *
+     * @return the maximum delay
+     */
+    public Duration maxDelay() {
+        return maxDelay;
+    }
+
+    /**
+     * Exception types that trigger a retry. If empty, all exceptions are retryable
+     * (except {@link TaskPausedException}).
+     *
+     * @return the set of retryable exception classes
+     */
+    public Set<Class<? extends Throwable>> retryableExceptions() {
+        return retryableExceptions;
+    }
+
+    /**
+     * Returns {@code true} if the given exception should trigger a retry.
+     *
+     * <p>When retryable exception classes are configured, the entire cause chain
+     * is checked: if any exception in the chain matches a retryable class, the
+     * exception is considered retryable.
+     *
+     * <p>{@link TaskPausedException} is never retried regardless of configuration.
+     *
+     * @param throwable the exception to test
+     * @return true if retryable
+     */
+    public boolean isRetryable(Throwable throwable) {
+        if (throwable instanceof TaskPausedException) {
+            return false;
+        }
+        // Walk cause chain for TaskPausedException
+        Throwable current = throwable.getCause();
+        while (current != null) {
+            if (current instanceof TaskPausedException) {
+                return false;
+            }
+            current = current.getCause();
+        }
+        if (retryableExceptions.isEmpty()) {
+            return true;
+        }
+        // Check entire cause chain against retryable exceptions
+        Throwable t = throwable;
+        while (t != null) {
+            for (Class<? extends Throwable> retryable : retryableExceptions) {
+                if (retryable.isInstance(t)) {
+                    return true;
+                }
+            }
+            t = t.getCause();
+        }
+        return false;
+    }
+
+    /**
+     * Computes the delay for a given attempt number (1-based).
+     *
+     * @param attempt the retry attempt number (1 for first retry, 2 for second, etc.)
+     * @return the computed delay
+     */
+    public Duration delayForAttempt(int attempt) {
+        if (attempt <= 1 || initialDelay.isZero()) {
+            return initialDelay;
+        }
+        double rawMillis = initialDelay.toMillis() * Math.pow(backoffMultiplier, attempt - 1);
+        long millis = rawMillis >= Long.MAX_VALUE ? Long.MAX_VALUE : (long) rawMillis;
+        Duration computed = Duration.ofMillis(millis);
+        return maxDelay.isZero() ? computed : computed.compareTo(maxDelay) > 0 ? maxDelay : computed;
+    }
+
+    /**
+     * Creates a new builder for {@link RetryPolicy}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link RetryPolicy}.
+     */
+    public static final class Builder {
+
+        private int maxRetries = 3;
+        private Duration initialDelay = Duration.ofSeconds(1);
+        private double backoffMultiplier = 2.0;
+        private Duration maxDelay = Duration.ofMinutes(1);
+        private final Set<Class<? extends Throwable>> retryableExceptions = new LinkedHashSet<>();
+
+        private Builder() {}
+
+        /**
+         * Sets the maximum number of retry attempts. Defaults to 3.
+         *
+         * @param maxRetries the max retry count (0 to disable retries)
+         * @return this builder
+         */
+        public Builder maxRetries(int maxRetries) {
+            if (maxRetries < 0) {
+                throw new IllegalArgumentException("maxRetries must be >= 0");
+            }
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /**
+         * Sets the initial delay before the first retry. Defaults to 1 second.
+         *
+         * @param initialDelay the initial delay
+         * @return this builder
+         */
+        public Builder initialDelay(Duration initialDelay) {
+            this.initialDelay = ensureNotNull(initialDelay, "initialDelay");
+            return this;
+        }
+
+        /**
+         * Sets the exponential backoff multiplier. Defaults to 2.0.
+         *
+         * @param backoffMultiplier the multiplier (&gt;= 1.0)
+         * @return this builder
+         */
+        public Builder backoffMultiplier(double backoffMultiplier) {
+            if (backoffMultiplier < 1.0) {
+                throw new IllegalArgumentException("backoffMultiplier must be >= 1.0");
+            }
+            this.backoffMultiplier = backoffMultiplier;
+            return this;
+        }
+
+        /**
+         * Sets the maximum delay cap. Defaults to 1 minute.
+         *
+         * @param maxDelay the maximum delay
+         * @return this builder
+         */
+        public Builder maxDelay(Duration maxDelay) {
+            this.maxDelay = ensureNotNull(maxDelay, "maxDelay");
+            return this;
+        }
+
+        /**
+         * Adds an exception type that should trigger a retry.
+         * If no retryable exceptions are added, all exceptions are retryable.
+         *
+         * @param exceptionClass the exception class
+         * @return this builder
+         */
+        public Builder retryableException(Class<? extends Throwable> exceptionClass) {
+            this.retryableExceptions.add(ensureNotNull(exceptionClass, "exceptionClass"));
+            return this;
+        }
+
+        /**
+         * Builds the {@link RetryPolicy}.
+         *
+         * @return a new retry policy
+         */
+        public RetryPolicy build() {
+            return new RetryPolicy(maxRetries, initialDelay, backoffMultiplier, maxDelay, retryableExceptions);
+        }
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskConfiguration.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskConfiguration.java
@@ -1,0 +1,119 @@
+package dev.langchain4j.experimental.durable.task;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.Experimental;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Configuration for starting a durable long-lived task.
+ *
+ * <p>Controls execution behaviour: checkpoint policy, retry policy, timeout, and
+ * user-defined labels for categorisation.
+ */
+@Experimental
+public final class TaskConfiguration {
+
+    private final String agentName;
+    private final CheckpointPolicy checkpointPolicy;
+    private final RetryPolicy retryPolicy;
+    private final Map<String, String> labels;
+    private final Duration timeout;
+
+    private TaskConfiguration(Builder builder) {
+        this.agentName = ensureNotBlank(builder.agentName, "agentName");
+        this.checkpointPolicy = builder.checkpointPolicy;
+        this.retryPolicy = builder.retryPolicy;
+        this.labels = Collections.unmodifiableMap(new LinkedHashMap<>(builder.labels));
+        this.timeout = builder.timeout;
+    }
+
+    public String agentName() {
+        return agentName;
+    }
+
+    public CheckpointPolicy checkpointPolicy() {
+        return checkpointPolicy;
+    }
+
+    /**
+     * Returns the retry policy, or {@code null} if retries are disabled.
+     *
+     * @return the retry policy, or null
+     */
+    public RetryPolicy retryPolicy() {
+        return retryPolicy;
+    }
+
+    public Map<String, String> labels() {
+        return labels;
+    }
+
+    /**
+     * Returns the optional execution timeout, or {@code null} if no timeout is configured.
+     *
+     * @return the timeout, or null
+     */
+    public Duration timeout() {
+        return timeout;
+    }
+
+    /**
+     * Creates a new builder for {@link TaskConfiguration}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private String agentName;
+        private CheckpointPolicy checkpointPolicy;
+        private RetryPolicy retryPolicy;
+        private Map<String, String> labels = Collections.emptyMap();
+        private Duration timeout;
+
+        private Builder() {}
+
+        public Builder agentName(String agentName) {
+            this.agentName = agentName;
+            return this;
+        }
+
+        public Builder checkpointPolicy(CheckpointPolicy checkpointPolicy) {
+            this.checkpointPolicy = ensureNotNull(checkpointPolicy, "checkpointPolicy");
+            return this;
+        }
+
+        /**
+         * Sets the retry policy. If not set, failed tasks are not retried.
+         *
+         * @param retryPolicy the retry policy
+         * @return this builder
+         */
+        public Builder retryPolicy(RetryPolicy retryPolicy) {
+            this.retryPolicy = retryPolicy;
+            return this;
+        }
+
+        public Builder labels(Map<String, String> labels) {
+            this.labels = ensureNotNull(labels, "labels");
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public TaskConfiguration build() {
+            return new TaskConfiguration(this);
+        }
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskHandle.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskHandle.java
@@ -1,0 +1,54 @@
+package dev.langchain4j.experimental.durable.task;
+
+import dev.langchain4j.Experimental;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A handle to a running or completed durable long-lived task.
+ *
+ * <p>Returned by {@link dev.langchain4j.experimental.durable.LongLivedTaskService#start LongLivedTaskService.start()}
+ * and {@link dev.langchain4j.experimental.durable.LongLivedTaskService#resume LongLivedTaskService.resume()}.
+ * Provides access to the task's identity, current status, result, and cancellation.
+ */
+@Experimental
+public interface TaskHandle {
+
+    /**
+     * Returns the unique identifier of this task.
+     *
+     * @return the task id
+     */
+    TaskId id();
+
+    /**
+     * Returns the current status of this task. The status is kept in sync with the
+     * execution lifecycle via the service and reflects the latest known state.
+     *
+     * @return the current status
+     */
+    TaskStatus status();
+
+    /**
+     * Returns the task result if the task has completed successfully.
+     *
+     * @return an Optional containing the result, or empty if not yet completed
+     */
+    Optional<Object> result();
+
+    /**
+     * Returns a {@link CompletableFuture} that completes when the task finishes
+     * (successfully, with failure, or with cancellation).
+     *
+     * @return a future that resolves to the task result
+     */
+    CompletableFuture<Object> awaitResult();
+
+    /**
+     * Cancels this task. If the task is currently running, an interrupt is sent
+     * to the executing thread. The task transitions to {@link TaskStatus#CANCELLED}.
+     *
+     * @return {@code true} if the task was cancelled, {@code false} if it was already in a terminal state
+     */
+    boolean cancel();
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskId.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskId.java
@@ -1,0 +1,37 @@
+package dev.langchain4j.experimental.durable.task;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import dev.langchain4j.internal.Utils;
+
+/**
+ * Unique identifier for a durable long-lived task.
+ *
+ * <p>Wraps a non-blank string value, typically a UUID. Provides type safety to prevent
+ * accidental mixing with other string identifiers such as memoryId or agentId.
+ */
+@Experimental
+public record TaskId(@JsonProperty("value") String value) {
+
+    @JsonCreator
+    public TaskId(@JsonProperty("value") String value) {
+        this.value = ensureNotBlank(value, "taskId value");
+    }
+
+    /**
+     * Creates a new TaskId with a random UUID value.
+     *
+     * @return a new unique TaskId
+     */
+    public static TaskId random() {
+        return new TaskId(Utils.randomUUID());
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskMetadata.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskMetadata.java
@@ -1,0 +1,185 @@
+package dev.langchain4j.experimental.durable.task;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Experimental;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Metadata describing a durable long-lived task: identity, status, timestamps, and optional labels.
+ *
+ * <p>This is a mutable holder intentionally — status and timestamps are updated throughout the task lifecycle.
+ * Thread safety for state transitions is provided via {@code synchronized} methods.
+ */
+@Experimental
+public final class TaskMetadata {
+
+    private final TaskId id;
+    private final String agentName;
+    private volatile TaskStatus status;
+    private final Instant createdAt;
+    private volatile Instant updatedAt;
+    private volatile String failureReason;
+    private final Map<String, String> labels;
+
+    @JsonCreator
+    private TaskMetadata(
+            @JsonProperty("id") TaskId id,
+            @JsonProperty("agentName") String agentName,
+            @JsonProperty("status") TaskStatus status,
+            @JsonProperty("createdAt") Instant createdAt,
+            @JsonProperty("updatedAt") Instant updatedAt,
+            @JsonProperty("failureReason") String failureReason,
+            @JsonProperty("labels") Map<String, String> labels) {
+        this.id = ensureNotNull(id, "id");
+        this.agentName = ensureNotBlank(agentName, "agentName");
+        this.status = ensureNotNull(status, "status");
+        this.createdAt = ensureNotNull(createdAt, "createdAt");
+        this.updatedAt = ensureNotNull(updatedAt, "updatedAt");
+        this.failureReason = failureReason;
+        this.labels = Collections.unmodifiableMap(new LinkedHashMap<>(ensureNotNull(labels, "labels")));
+    }
+
+    /**
+     * Creates a new TaskMetadata in {@link TaskStatus#PENDING} state.
+     *
+     * @param id        the unique task identifier
+     * @param agentName a human-readable name for the agent or workflow
+     * @param labels    optional key-value labels for user metadata
+     * @return a new TaskMetadata
+     */
+    public static TaskMetadata create(TaskId id, String agentName, Map<String, String> labels) {
+        Instant now = Instant.now();
+        return new TaskMetadata(id, agentName, TaskStatus.PENDING, now, now, null, labels);
+    }
+
+    /**
+     * Creates a TaskMetadata from stored values (e.g., deserialized from a file).
+     */
+    public static TaskMetadata of(
+            TaskId id,
+            String agentName,
+            TaskStatus status,
+            Instant createdAt,
+            Instant updatedAt,
+            String failureReason,
+            Map<String, String> labels) {
+        return new TaskMetadata(id, agentName, status, createdAt, updatedAt, failureReason, labels);
+    }
+
+    @JsonProperty("id")
+    public TaskId id() {
+        return id;
+    }
+
+    @JsonProperty("agentName")
+    public String agentName() {
+        return agentName;
+    }
+
+    @JsonProperty("status")
+    public TaskStatus status() {
+        return status;
+    }
+
+    @JsonProperty("createdAt")
+    public Instant createdAt() {
+        return createdAt;
+    }
+
+    @JsonProperty("updatedAt")
+    public Instant updatedAt() {
+        return updatedAt;
+    }
+
+    @JsonProperty("failureReason")
+    public String failureReason() {
+        return failureReason;
+    }
+
+    @JsonProperty("labels")
+    public Map<String, String> labels() {
+        return labels;
+    }
+
+    /**
+     * Transitions this task to the given status, updating the timestamp.
+     *
+     * @param newStatus the new status
+     */
+    public synchronized void transitionTo(TaskStatus newStatus) {
+        transitionTo(newStatus, null);
+    }
+
+    /**
+     * Transitions this task to the given status with a failure reason, updating the timestamp.
+     *
+     * @param newStatus     the new status
+     * @param failureReason optional failure reason (only meaningful for {@link TaskStatus#FAILED})
+     */
+    public synchronized void transitionTo(TaskStatus newStatus, String failureReason) {
+        if (this.status.isTerminal()) {
+            throw new IllegalStateException("Cannot transition from terminal state " + this.status);
+        }
+        this.status = ensureNotNull(newStatus, "newStatus");
+        this.failureReason = failureReason;
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Atomically transitions from {@code expectedStatus} to {@code newStatus} if and only if the
+     * current status matches the expected value. This is the compare-and-set guard that prevents
+     * race conditions between concurrent cancel and complete operations.
+     *
+     * @param expectedStatus the status expected before the transition
+     * @param newStatus      the target status
+     * @return {@code true} if the transition succeeded, {@code false} if the current status
+     *         did not match {@code expectedStatus}
+     */
+    public synchronized boolean compareAndTransition(TaskStatus expectedStatus, TaskStatus newStatus) {
+        return compareAndTransition(expectedStatus, newStatus, null);
+    }
+
+    /**
+     * Atomically transitions from {@code expectedStatus} to {@code newStatus} with a failure reason,
+     * if and only if the current status matches the expected value.
+     *
+     * @param expectedStatus the status expected before the transition
+     * @param newStatus      the target status
+     * @param failureReason  optional failure reason
+     * @return {@code true} if the transition succeeded, {@code false} if the current status
+     *         did not match {@code expectedStatus}
+     */
+    public synchronized boolean compareAndTransition(
+            TaskStatus expectedStatus, TaskStatus newStatus, String failureReason) {
+        if (this.status != expectedStatus) {
+            return false;
+        }
+        // COMPLETED and CANCELLED are hard-terminal: no further transitions allowed.
+        // FAILED is soft-terminal: allows FAILED→RUNNING for resume.
+        if (expectedStatus == TaskStatus.COMPLETED || expectedStatus == TaskStatus.CANCELLED) {
+            return false;
+        }
+        this.status = ensureNotNull(newStatus, "newStatus");
+        this.failureReason = failureReason;
+        this.updatedAt = Instant.now();
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "TaskMetadata{id=" + id
+                + ", agentName='" + agentName + '\''
+                + ", status=" + status
+                + ", createdAt=" + createdAt
+                + ", updatedAt=" + updatedAt
+                + (failureReason != null ? ", failureReason='" + failureReason + '\'' : "")
+                + '}';
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskPausedException.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskPausedException.java
@@ -1,0 +1,62 @@
+package dev.langchain4j.experimental.durable.task;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.exception.LangChain4jException;
+
+/**
+ * Thrown to signal that a task should be paused.
+ *
+ * <p>Common pause reasons include waiting for human input, waiting for an
+ * external approval, or explicitly pausing a long-running batch. The
+ * exception propagates naturally through the planner loop and is caught by
+ * {@link dev.langchain4j.experimental.durable.LongLivedTaskService}, which transitions the task to
+ * {@link TaskStatus#PAUSED} and saves a checkpoint.
+ *
+ * <p>This mechanism requires zero changes to the existing agentic runtime.
+ */
+@Experimental
+public class TaskPausedException extends LangChain4jException {
+
+    private final String reason;
+    private final String pendingOutputKey;
+
+    /**
+     * Creates a pause exception with a reason and an associated scope key.
+     *
+     * @param reason           the human-readable reason for pausing
+     * @param pendingOutputKey the scope key that is awaiting a value, or {@code null}
+     */
+    public TaskPausedException(String reason, String pendingOutputKey) {
+        super("Task paused: " + reason);
+        this.reason = reason;
+        this.pendingOutputKey = pendingOutputKey;
+    }
+
+    /**
+     * Creates a pause exception with a reason and no associated scope key.
+     *
+     * @param reason the human-readable reason for pausing
+     */
+    public TaskPausedException(String reason) {
+        this(reason, null);
+    }
+
+    /**
+     * Returns the reason for pausing.
+     *
+     * @return the pause reason
+     */
+    public String reason() {
+        return reason;
+    }
+
+    /**
+     * Returns the scope state key that is awaiting a value, or {@code null}
+     * if the pause is not tied to a specific scope key.
+     *
+     * @return the pending output key, or null
+     */
+    public String pendingOutputKey() {
+        return pendingOutputKey;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskStatus.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/TaskStatus.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.experimental.durable.task;
+
+import dev.langchain4j.Experimental;
+
+/**
+ * Lifecycle status of a durable long-lived task.
+ */
+@Experimental
+public enum TaskStatus {
+
+    /** Task has been created but not yet started. */
+    PENDING,
+
+    /** Task is currently executing. */
+    RUNNING,
+
+    /** Task is paused, awaiting external input or an explicit resume. */
+    PAUSED,
+
+    /** Task is waiting before an automatic retry after a transient failure. */
+    RETRYING,
+
+    /** Task execution failed with an error. */
+    FAILED,
+
+    /** Task completed successfully. */
+    COMPLETED,
+
+    /** Task was explicitly cancelled. */
+    CANCELLED;
+
+    /**
+     * Returns {@code true} if the task is in a terminal state ({@link #COMPLETED},
+     * {@link #FAILED}, or {@link #CANCELLED}).
+     *
+     * <p>{@link #COMPLETED} and {@link #CANCELLED} are <em>hard-terminal</em> — no further
+     * transitions are possible. {@link #FAILED} is <em>soft-terminal</em> — it can be
+     * resumed back to {@link #RUNNING} via
+     * {@link dev.langchain4j.experimental.durable.LongLivedTaskService#resume}.
+     *
+     * @return true if terminal
+     */
+    public boolean isTerminal() {
+        return this == COMPLETED || this == FAILED || this == CANCELLED;
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/package-info.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/main/java/dev/langchain4j/experimental/durable/task/package-info.java
@@ -1,0 +1,4 @@
+@Experimental
+package dev.langchain4j.experimental.durable.task;
+
+import dev.langchain4j.Experimental;

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/CodeReviewFixesTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/CodeReviewFixesTest.java
@@ -1,0 +1,830 @@
+package dev.langchain4j.experimental.durable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.experimental.durable.store.Checkpoint;
+import dev.langchain4j.experimental.durable.store.InMemoryTaskExecutionStore;
+import dev.langchain4j.experimental.durable.store.event.TaskCancelledEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskCompletedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.store.file.FileTaskExecutionStore;
+import dev.langchain4j.experimental.durable.task.CheckpointPolicy;
+import dev.langchain4j.experimental.durable.task.RetryPolicy;
+import dev.langchain4j.experimental.durable.task.TaskConfiguration;
+import dev.langchain4j.experimental.durable.task.TaskHandle;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import dev.langchain4j.experimental.durable.task.TaskPausedException;
+import dev.langchain4j.experimental.durable.task.TaskStatus;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for all P1/P2/P3 code-review fixes.
+ */
+class CodeReviewFixesTest {
+
+    private InMemoryTaskExecutionStore store;
+    private LongLivedTaskService service;
+
+    @BeforeEach
+    void setup() {
+        store = new InMemoryTaskExecutionStore();
+        service = LongLivedTaskService.builder()
+                .store(store)
+                .defaultCheckpointPolicy(CheckpointPolicy.NONE)
+                .build();
+    }
+
+    // ---- P1: Cancel race - compareAndTransition ----
+
+    @Test
+    void cancel_vs_complete_race_should_not_throw() throws Exception {
+        // Verify that when cancel() races with natural completion,
+        // no IllegalStateException is thrown and the task ends up in a terminal state.
+        CountDownLatch workflowRunning = new CountDownLatch(1);
+        CountDownLatch cancelIssued = new CountDownLatch(1);
+
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("raceAgent").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            workflowRunning.countDown();
+            try {
+                cancelIssued.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return "completed";
+        });
+
+        workflowRunning.await(5, TimeUnit.SECONDS);
+
+        // Issue cancel while workflow is about to return
+        service.cancel(handle.id());
+        cancelIssued.countDown();
+
+        // Wait for everything to settle
+        Thread.sleep(300);
+
+        // Task should be in a terminal state — either CANCELLED or COMPLETED, no crash
+        TaskStatus status = service.status(handle.id()).orElse(null);
+        assertThat(status).isNotNull();
+        assertThat(status.isTerminal()).isTrue();
+    }
+
+    @Test
+    void cancel_already_terminal_should_return_false() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("doneAgent").build();
+
+        TaskHandle handle = service.start(config, () -> "done");
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+        Thread.sleep(100);
+
+        boolean cancelled = service.cancel(handle.id());
+        assertThat(cancelled).isFalse();
+    }
+
+    @Test
+    void cancel_should_record_cancelled_event() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("cancelEventAgent").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            try {
+                Thread.sleep(10_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return null;
+        });
+
+        Thread.sleep(100);
+        service.cancel(handle.id());
+        Thread.sleep(100);
+
+        List<TaskEvent> events = service.events(handle.id());
+        assertThat(events.stream().anyMatch(e -> e instanceof TaskCancelledEvent))
+                .isTrue();
+    }
+
+    // ---- P1: executeTask CAS for COMPLETED ----
+
+    @Test
+    void concurrent_cancel_during_workflow_should_not_overwrite_cancelled_with_completed() throws Exception {
+        AtomicReference<TaskId> taskIdRef = new AtomicReference<>();
+        CountDownLatch workflowStarted = new CountDownLatch(1);
+
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("cancelDuringWork").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            taskIdRef.set(null); // just to show workflow ran
+            workflowStarted.countDown();
+            try {
+                Thread.sleep(5_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return "result after sleep";
+        });
+
+        workflowStarted.await(5, TimeUnit.SECONDS);
+        Thread.sleep(50);
+
+        // Cancel while running
+        service.cancel(handle.id());
+
+        Thread.sleep(300);
+
+        // The status should be CANCELLED, not COMPLETED
+        assertThat(service.status(handle.id())).contains(TaskStatus.CANCELLED);
+    }
+
+    // ---- P2: Resume from FAILED ----
+
+    @Test
+    void should_resume_failed_task() throws Exception {
+        AtomicBoolean shouldFail = new AtomicBoolean(true);
+
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("failThenResume").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            if (shouldFail.get()) {
+                throw new RuntimeException("first run fails");
+            }
+            return "success on retry";
+        });
+
+        assertThatThrownBy(() -> handle.awaitResult().get(5, TimeUnit.SECONDS));
+        Thread.sleep(100);
+        assertThat(service.status(handle.id())).contains(TaskStatus.FAILED);
+
+        // Now resume the failed task
+        shouldFail.set(false);
+        TaskHandle resumed = service.resume(handle.id(), () -> "success on retry");
+        Object result = resumed.awaitResult().get(5, TimeUnit.SECONDS);
+
+        assertThat(result).isEqualTo("success on retry");
+        assertThat(resumed.status()).isEqualTo(TaskStatus.COMPLETED);
+    }
+
+    @Test
+    void should_not_resume_completed_task() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("completedAgent").build();
+
+        TaskHandle handle = service.start(config, () -> "done");
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+        Thread.sleep(100);
+
+        assertThatThrownBy(() -> service.resume(handle.id(), () -> "retry"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("COMPLETED");
+    }
+
+    @Test
+    void should_not_resume_cancelled_task() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("cancelledAgent").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            try {
+                Thread.sleep(10_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return null;
+        });
+
+        Thread.sleep(100);
+        service.cancel(handle.id());
+        Thread.sleep(100);
+
+        assertThatThrownBy(() -> service.resume(handle.id(), () -> "retry"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("CANCELLED");
+    }
+
+    // ---- P2: Resume with retryPolicy ----
+
+    @Test
+    void should_resume_with_retry_policy_from_configuration() throws Exception {
+        // Start a task that pauses
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("pauseForRetry").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            throw new TaskPausedException("waiting", "key");
+        });
+
+        Thread.sleep(200);
+        assertThat(service.status(handle.id())).contains(TaskStatus.PAUSED);
+
+        // Resume with explicit retry policy
+        AtomicBoolean firstAttempt = new AtomicBoolean(true);
+        RetryPolicy retryPolicy = RetryPolicy.builder()
+                .maxRetries(2)
+                .initialDelay(Duration.ofMillis(50))
+                .build();
+
+        TaskConfiguration resumeConfig = TaskConfiguration.builder()
+                .agentName("pauseForRetry")
+                .retryPolicy(retryPolicy)
+                .build();
+
+        TaskHandle resumed = service.resume(
+                handle.id(),
+                () -> {
+                    if (firstAttempt.getAndSet(false)) {
+                        throw new RuntimeException("transient error");
+                    }
+                    return "success after retry";
+                },
+                resumeConfig);
+
+        Object result = resumed.awaitResult().get(10, TimeUnit.SECONDS);
+        assertThat(result).isEqualTo("success after retry");
+    }
+
+    // ---- P3: Timeout ----
+
+    @Test
+    void should_cancel_task_on_timeout() throws Exception {
+        TaskConfiguration config = TaskConfiguration.builder()
+                .agentName("timeoutAgent")
+                .timeout(Duration.ofMillis(200))
+                .build();
+
+        TaskHandle handle = service.start(config, () -> {
+            try {
+                Thread.sleep(10_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return "never";
+        });
+
+        Thread.sleep(500);
+
+        TaskStatus status = service.status(handle.id()).orElse(null);
+        assertThat(status).isEqualTo(TaskStatus.CANCELLED);
+    }
+
+    @Test
+    void should_not_timeout_if_completes_in_time() throws Exception {
+        TaskConfiguration config = TaskConfiguration.builder()
+                .agentName("fastAgent")
+                .timeout(Duration.ofSeconds(5))
+                .build();
+
+        TaskHandle handle = service.start(config, () -> "fast result");
+        Object result = handle.awaitResult().get(5, TimeUnit.SECONDS);
+
+        assertThat(result).isEqualTo("fast result");
+        assertThat(handle.status()).isEqualTo(TaskStatus.COMPLETED);
+    }
+
+    // ---- P1: TaskMetadata.compareAndTransition ----
+
+    @Test
+    void compare_and_transition_should_succeed_when_expected_matches() {
+        TaskMetadata metadata = TaskMetadata.create(TaskId.random(), "agent", Map.of());
+        metadata.transitionTo(TaskStatus.RUNNING);
+
+        boolean success = metadata.compareAndTransition(TaskStatus.RUNNING, TaskStatus.COMPLETED);
+
+        assertThat(success).isTrue();
+        assertThat(metadata.status()).isEqualTo(TaskStatus.COMPLETED);
+    }
+
+    @Test
+    void compare_and_transition_should_fail_when_expected_does_not_match() {
+        TaskMetadata metadata = TaskMetadata.create(TaskId.random(), "agent", Map.of());
+        metadata.transitionTo(TaskStatus.RUNNING);
+
+        boolean success = metadata.compareAndTransition(TaskStatus.PAUSED, TaskStatus.COMPLETED);
+
+        assertThat(success).isFalse();
+        assertThat(metadata.status()).isEqualTo(TaskStatus.RUNNING);
+    }
+
+    @Test
+    void compare_and_transition_should_set_failure_reason() {
+        TaskMetadata metadata = TaskMetadata.create(TaskId.random(), "agent", Map.of());
+        metadata.transitionTo(TaskStatus.RUNNING);
+
+        boolean success = metadata.compareAndTransition(TaskStatus.RUNNING, TaskStatus.FAILED, "error occurred");
+
+        assertThat(success).isTrue();
+        assertThat(metadata.status()).isEqualTo(TaskStatus.FAILED);
+        assertThat(metadata.failureReason()).isEqualTo("error occurred");
+    }
+
+    @Test
+    void compare_and_transition_from_terminal_should_fail() {
+        TaskMetadata metadata = TaskMetadata.create(TaskId.random(), "agent", Map.of());
+        metadata.transitionTo(TaskStatus.COMPLETED);
+
+        // COMPLETED is hard-terminal: CAS must return false even if expected matches
+        boolean success = metadata.compareAndTransition(TaskStatus.COMPLETED, TaskStatus.RUNNING);
+
+        assertThat(success).isFalse();
+        assertThat(metadata.status()).isEqualTo(TaskStatus.COMPLETED);
+    }
+
+    @Test
+    void compare_and_transition_from_cancelled_should_fail() {
+        TaskMetadata metadata = TaskMetadata.create(TaskId.random(), "agent", Map.of());
+        metadata.transitionTo(TaskStatus.RUNNING);
+        metadata.compareAndTransition(TaskStatus.RUNNING, TaskStatus.CANCELLED);
+
+        boolean success = metadata.compareAndTransition(TaskStatus.CANCELLED, TaskStatus.RUNNING);
+
+        assertThat(success).isFalse();
+        assertThat(metadata.status()).isEqualTo(TaskStatus.CANCELLED);
+    }
+
+    @Test
+    void compare_and_transition_from_failed_to_running_should_succeed() {
+        // FAILED is soft-terminal: FAILED→RUNNING allowed for resume
+        TaskMetadata metadata = TaskMetadata.create(TaskId.random(), "agent", Map.of());
+        metadata.transitionTo(TaskStatus.RUNNING);
+        metadata.compareAndTransition(TaskStatus.RUNNING, TaskStatus.FAILED, "error");
+
+        boolean success = metadata.compareAndTransition(TaskStatus.FAILED, TaskStatus.RUNNING);
+
+        assertThat(success).isTrue();
+        assertThat(metadata.status()).isEqualTo(TaskStatus.RUNNING);
+    }
+
+    // ---- P1: Paused handle should not hang ----
+
+    @Test
+    void paused_task_handle_future_should_complete_exceptionally() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("pauseAgent").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            throw new TaskPausedException("needs input", "key");
+        });
+
+        // The future should complete with TaskPausedException, not hang
+        assertThatThrownBy(() -> handle.awaitResult().get(5, TimeUnit.SECONDS))
+                .hasCauseInstanceOf(TaskPausedException.class);
+    }
+
+    @Test
+    void resumed_task_should_complete_old_handle_future() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("resumeOldHandle").build();
+
+        TaskHandle handle1 = service.start(config, () -> {
+            throw new TaskPausedException("paused", "key");
+        });
+
+        // Wait for pause
+        assertThatThrownBy(() -> handle1.awaitResult().get(5, TimeUnit.SECONDS))
+                .hasCauseInstanceOf(TaskPausedException.class);
+        Thread.sleep(100);
+
+        // Resume — creates handle2
+        TaskHandle handle2 = service.resume(handle1.id(), () -> "resumed result");
+        Object result = handle2.awaitResult().get(5, TimeUnit.SECONDS);
+
+        assertThat(result).isEqualTo("resumed result");
+        assertThat(handle2.status()).isEqualTo(TaskStatus.COMPLETED);
+    }
+
+    // ---- P2: cancel double-CAS ----
+
+    @Test
+    void cancel_should_not_report_success_if_already_completed() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("quickAgent").build();
+
+        TaskHandle handle = service.start(config, () -> "done");
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+        Thread.sleep(100);
+
+        // Task is COMPLETED — cancel must return false
+        boolean cancelled = service.cancel(handle.id());
+        assertThat(cancelled).isFalse();
+
+        // No TaskCancelledEvent should be recorded
+        List<TaskEvent> events = service.events(handle.id());
+        assertThat(events.stream().anyMatch(e -> e instanceof TaskCancelledEvent))
+                .isFalse();
+    }
+
+    // ---- P2: activeHandles leak ----
+
+    @Test
+    void active_handles_should_not_leak_on_completion() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("leakTest").build();
+
+        TaskHandle handle = service.start(config, () -> "done");
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+        Thread.sleep(100);
+
+        // After completion, the handle should be removed from internal tracking
+        // We verify indirectly: cancelling a completed task returns false
+        boolean cancelled = service.cancel(handle.id());
+        assertThat(cancelled).isFalse();
+        assertThat(handle.status()).isEqualTo(TaskStatus.COMPLETED);
+    }
+
+    @Test
+    void active_handles_should_not_leak_on_failure() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("failLeakTest").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            throw new RuntimeException("boom");
+        });
+
+        assertThatThrownBy(() -> handle.awaitResult().get(5, TimeUnit.SECONDS));
+        Thread.sleep(100);
+
+        assertThat(handle.status()).isEqualTo(TaskStatus.FAILED);
+    }
+
+    @Test
+    void active_handles_should_not_leak_on_pause() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("pauseLeakTest").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            throw new TaskPausedException("paused", "key");
+        });
+
+        assertThatThrownBy(() -> handle.awaitResult().get(5, TimeUnit.SECONDS))
+                .hasCauseInstanceOf(TaskPausedException.class);
+        Thread.sleep(100);
+
+        assertThat(handle.status()).isEqualTo(TaskStatus.PAUSED);
+    }
+
+    // ---- P1 (third review): Resume of RUNNING/RETRYING blocked ----
+
+    @Test
+    void resume_running_task_should_throw() throws Exception {
+        CountDownLatch workflowRunning = new CountDownLatch(1);
+        CountDownLatch canFinish = new CountDownLatch(1);
+
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("longRunner").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            workflowRunning.countDown();
+            try {
+                canFinish.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return "done";
+        });
+
+        workflowRunning.await(5, TimeUnit.SECONDS);
+
+        // Task is RUNNING — resume must throw
+        assertThatThrownBy(() -> service.resume(handle.id(), () -> "retry"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already RUNNING");
+
+        canFinish.countDown();
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+    }
+
+    // ---- P2 (third review): AFTER_ROOT_CALL should not checkpoint on pause ----
+
+    @Test
+    void after_root_call_should_not_checkpoint_on_pause() throws Exception {
+        LongLivedTaskService svcWithRootCall = LongLivedTaskService.builder()
+                .store(store)
+                .defaultCheckpointPolicy(CheckpointPolicy.AFTER_ROOT_CALL)
+                .build();
+
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("pauseNoChk").build();
+
+        TaskHandle handle = svcWithRootCall.start(config, () -> {
+            throw new TaskPausedException("paused", "key");
+        });
+
+        assertThatThrownBy(() -> handle.awaitResult().get(5, TimeUnit.SECONDS))
+                .hasCauseInstanceOf(TaskPausedException.class);
+        Thread.sleep(100);
+
+        // Under AFTER_ROOT_CALL, a pause must NOT produce service-level checkpoints
+        assertThat(store.loadCheckpoint(handle.id())).isEmpty();
+    }
+
+    @Test
+    void after_root_call_should_not_checkpoint_on_retry() throws Exception {
+        LongLivedTaskService svcWithRootCall = LongLivedTaskService.builder()
+                .store(store)
+                .defaultCheckpointPolicy(CheckpointPolicy.AFTER_ROOT_CALL)
+                .build();
+
+        AtomicBoolean firstAttempt = new AtomicBoolean(true);
+        RetryPolicy retryPolicy = RetryPolicy.builder()
+                .maxRetries(1)
+                .initialDelay(Duration.ofMillis(10))
+                .build();
+        TaskConfiguration config = TaskConfiguration.builder()
+                .agentName("retryNoChk")
+                .retryPolicy(retryPolicy)
+                .build();
+
+        TaskHandle handle = svcWithRootCall.start(config, () -> {
+            if (firstAttempt.getAndSet(false)) {
+                throw new RuntimeException("transient");
+            }
+            return "ok";
+        });
+
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+        Thread.sleep(100);
+
+        // Under AFTER_ROOT_CALL, service-level checkpoint creation was removed
+        // to prevent overwriting scope-aware checkpoints from
+        // JournalingAgentListener.beforeAgenticScopeDestroyed. Without real
+        // agents producing scope callbacks, no checkpoint should exist.
+        Checkpoint cp = store.loadCheckpoint(handle.id()).orElse(null);
+        assertThat(cp).isNull();
+    }
+
+    @Test
+    void after_each_agent_should_checkpoint_on_pause() throws Exception {
+        LongLivedTaskService svcWithEach = LongLivedTaskService.builder()
+                .store(store)
+                .defaultCheckpointPolicy(CheckpointPolicy.AFTER_EACH_AGENT)
+                .build();
+
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("pauseWithChk").build();
+
+        TaskHandle handle = svcWithEach.start(config, () -> {
+            throw new TaskPausedException("paused", "key");
+        });
+
+        assertThatThrownBy(() -> handle.awaitResult().get(5, TimeUnit.SECONDS))
+                .hasCauseInstanceOf(TaskPausedException.class);
+        Thread.sleep(100);
+
+        // Under AFTER_EACH_AGENT, the pause SHOULD produce a checkpoint
+        Checkpoint cp = store.loadCheckpoint(handle.id()).orElse(null);
+        assertThat(cp).isNotNull();
+        assertThat(cp.metadata().status()).isEqualTo(TaskStatus.PAUSED);
+    }
+
+    // ---- Completion events are recorded properly ----
+
+    @Test
+    void completed_task_should_have_completion_event() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("completeEventAgent").build();
+
+        TaskHandle handle = service.start(config, () -> "the result");
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+        Thread.sleep(100);
+
+        List<TaskEvent> events = service.events(handle.id());
+        boolean hasCompleted = events.stream().anyMatch(e -> e instanceof TaskCompletedEvent);
+        assertThat(hasCompleted).isTrue();
+    }
+
+    // ---- P1 (fourth review): Store-atomic CAS — cancel vs complete with FileStore ----
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void cancel_vs_complete_with_file_store_should_respect_cancel() throws Exception {
+        FileTaskExecutionStore fileStore = FileTaskExecutionStore.builder()
+                .baseDir(tempDir.resolve("cancel-race"))
+                .build();
+        LongLivedTaskService fileService = LongLivedTaskService.builder()
+                .store(fileStore)
+                .defaultCheckpointPolicy(CheckpointPolicy.NONE)
+                .build();
+
+        CountDownLatch workflowRunning = new CountDownLatch(1);
+        CountDownLatch cancelDone = new CountDownLatch(1);
+
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("fileCancelRace").build();
+
+        TaskHandle handle = fileService.start(config, () -> {
+            workflowRunning.countDown();
+            try {
+                // Wait for cancel to happen, then return normally
+                cancelDone.await(5, TimeUnit.SECONDS);
+                Thread.sleep(50); // Small delay to let cancel persist first
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return "completed after cancel";
+        });
+
+        workflowRunning.await(5, TimeUnit.SECONDS);
+        Thread.sleep(50);
+
+        // Cancel while workflow is running
+        boolean cancelled = fileService.cancel(handle.id());
+        cancelDone.countDown();
+        assertThat(cancelled).isTrue();
+
+        // Wait for worker to finish
+        Thread.sleep(500);
+
+        // With store-atomic CAS, cancel must win — the worker's completion CAS
+        // should fail because the persisted status is now CANCELLED.
+        TaskStatus finalStatus =
+                fileStore.loadMetadata(handle.id()).map(TaskMetadata::status).orElse(null);
+        assertThat(finalStatus).isEqualTo(TaskStatus.CANCELLED);
+    }
+
+    @Test
+    void store_compare_and_set_should_succeed_when_expected_matches() {
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, "agent", Map.of());
+        metadata.transitionTo(TaskStatus.RUNNING);
+        store.saveMetadata(metadata);
+
+        Optional<TaskMetadata> updated = store.compareAndSetStatus(taskId, TaskStatus.RUNNING, TaskStatus.COMPLETED);
+
+        assertThat(updated).isPresent();
+        assertThat(updated.get().status()).isEqualTo(TaskStatus.COMPLETED);
+        // Verify persisted:
+        assertThat(store.loadMetadata(taskId).get().status()).isEqualTo(TaskStatus.COMPLETED);
+    }
+
+    @Test
+    void store_compare_and_set_should_fail_when_expected_does_not_match() {
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, "agent", Map.of());
+        metadata.transitionTo(TaskStatus.RUNNING);
+        store.saveMetadata(metadata);
+
+        // Expected is PAUSED but actual is RUNNING — should fail
+        Optional<TaskMetadata> updated = store.compareAndSetStatus(taskId, TaskStatus.PAUSED, TaskStatus.COMPLETED);
+
+        assertThat(updated).isEmpty();
+        // Status unchanged:
+        assertThat(store.loadMetadata(taskId).get().status()).isEqualTo(TaskStatus.RUNNING);
+    }
+
+    @Test
+    void store_compare_and_set_should_return_empty_for_unknown_task() {
+        Optional<TaskMetadata> updated =
+                store.compareAndSetStatus(new TaskId("doesNotExist"), TaskStatus.RUNNING, TaskStatus.COMPLETED);
+        assertThat(updated).isEmpty();
+    }
+
+    @Test
+    void file_store_compare_and_set_should_be_atomic() throws IOException {
+        FileTaskExecutionStore fileStore = FileTaskExecutionStore.builder()
+                .baseDir(tempDir.resolve("cas-atomic"))
+                .build();
+
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, "agent", Map.of());
+        metadata.transitionTo(TaskStatus.RUNNING);
+        fileStore.saveMetadata(metadata);
+
+        // First CAS: RUNNING → CANCELLED should succeed
+        Optional<TaskMetadata> cancelled =
+                fileStore.compareAndSetStatus(taskId, TaskStatus.RUNNING, TaskStatus.CANCELLED);
+        assertThat(cancelled).isPresent();
+        assertThat(cancelled.get().status()).isEqualTo(TaskStatus.CANCELLED);
+
+        // Second CAS: RUNNING → COMPLETED should fail (store has CANCELLED)
+        Optional<TaskMetadata> completed =
+                fileStore.compareAndSetStatus(taskId, TaskStatus.RUNNING, TaskStatus.COMPLETED);
+        assertThat(completed).isEmpty();
+
+        // Store still has CANCELLED:
+        assertThat(fileStore.loadMetadata(taskId).get().status()).isEqualTo(TaskStatus.CANCELLED);
+    }
+
+    @Test
+    void store_compare_and_set_with_failure_reason() {
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, "agent", Map.of());
+        metadata.transitionTo(TaskStatus.RUNNING);
+        store.saveMetadata(metadata);
+
+        Optional<TaskMetadata> failed =
+                store.compareAndSetStatus(taskId, TaskStatus.RUNNING, TaskStatus.FAILED, "out of memory");
+
+        assertThat(failed).isPresent();
+        assertThat(failed.get().status()).isEqualTo(TaskStatus.FAILED);
+        assertThat(failed.get().failureReason()).isEqualTo("out of memory");
+    }
+
+    // ---- P2 (fourth review): Resume CAS check ----
+
+    @Test
+    void concurrent_resume_of_failed_task_should_reject_second_caller() throws Exception {
+        // Start a task that fails
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("concurrentResume").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            throw new RuntimeException("initial failure");
+        });
+
+        assertThatThrownBy(() -> handle.awaitResult().get(5, TimeUnit.SECONDS));
+        Thread.sleep(100);
+        assertThat(service.status(handle.id())).contains(TaskStatus.FAILED);
+
+        // First resume succeeds
+        CountDownLatch resumeRunning = new CountDownLatch(1);
+        CountDownLatch canFinish = new CountDownLatch(1);
+        TaskHandle resumed1 = service.resume(handle.id(), () -> {
+            resumeRunning.countDown();
+            try {
+                canFinish.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return "ok";
+        });
+
+        resumeRunning.await(5, TimeUnit.SECONDS);
+
+        // Second resume should throw because status is now RUNNING, not FAILED
+        assertThatThrownBy(() -> service.resume(handle.id(), () -> "should not run"))
+                .isInstanceOf(IllegalStateException.class);
+
+        canFinish.countDown();
+        resumed1.awaitResult().get(5, TimeUnit.SECONDS);
+    }
+
+    // ---- P1 (fourth review): Completion checkpoint should NOT overwrite scope ----
+
+    @Test
+    void after_root_call_completion_should_not_overwrite_scope_checkpoint() throws Exception {
+        // Under AFTER_ROOT_CALL, the completion path must NOT write a null-scope
+        // checkpoint that overwrites the scope-aware checkpoint from
+        // beforeAgenticScopeDestroyed. After completion, if there is a checkpoint,
+        // it should NOT have null serializedScope (unless the agent produced no scope
+        // events at all).
+        LongLivedTaskService svcWithRootCall = LongLivedTaskService.builder()
+                .store(store)
+                .defaultCheckpointPolicy(CheckpointPolicy.AFTER_ROOT_CALL)
+                .build();
+
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("scopePreservation").build();
+
+        // Note: this test verifies the service-level behavior. The service should NOT
+        // produce a null-scope completion checkpoint. The JournalingAgentListener
+        // would produce the scope-aware checkpoint via beforeAgenticScopeDestroyed,
+        // but in this unit test without actual agentic scope events, we verify that
+        // the service at least does NOT overwrite any existing checkpoint.
+
+        // Pre-populate a mock checkpoint with non-null scope to prove the service
+        // does not overwrite it on completion.
+        TaskHandle handle = svcWithRootCall.start(config, () -> "result");
+        Thread.sleep(50); // let task start
+        TaskId taskId = handle.id();
+
+        // Wait for completion
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+        Thread.sleep(100);
+
+        // The service should NOT have written a null-scope checkpoint on completion.
+        // Either no checkpoint exists (if no agent callbacks fired), or the existing
+        // one has scope data. We verify there's no checkpoint with null scope AND
+        // COMPLETED metadata:
+        Optional<Checkpoint> cp = store.loadCheckpoint(taskId);
+        if (cp.isPresent()) {
+            // If a checkpoint was created by the service, its serializedScope should
+            // not be the null produced by the old completion path.
+            // (In this minimal test without real agents, the service should simply
+            // not create any completion checkpoint at all.)
+            assertThat(cp.get().metadata().status())
+                    .as("Completion checkpoint should not exist from service-level code")
+                    .isNotEqualTo(TaskStatus.COMPLETED);
+        }
+        // If empty — correct: no service-level completion checkpoint was created.
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/LongLivedTaskServiceTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/LongLivedTaskServiceTest.java
@@ -1,0 +1,325 @@
+package dev.langchain4j.experimental.durable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.experimental.durable.store.InMemoryTaskExecutionStore;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskRetryEvent;
+import dev.langchain4j.experimental.durable.task.CheckpointPolicy;
+import dev.langchain4j.experimental.durable.task.RetryPolicy;
+import dev.langchain4j.experimental.durable.task.TaskConfiguration;
+import dev.langchain4j.experimental.durable.task.TaskHandle;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import dev.langchain4j.experimental.durable.task.TaskPausedException;
+import dev.langchain4j.experimental.durable.task.TaskStatus;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LongLivedTaskServiceTest {
+
+    private InMemoryTaskExecutionStore store;
+    private LongLivedTaskService service;
+
+    @BeforeEach
+    void setup() {
+        store = new InMemoryTaskExecutionStore();
+        service = LongLivedTaskService.builder()
+                .store(store)
+                .defaultCheckpointPolicy(CheckpointPolicy.NONE)
+                .build();
+    }
+
+    @Test
+    void should_start_and_complete_task() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("testAgent").build();
+
+        TaskHandle handle = service.start(config, () -> "result");
+
+        Object result = handle.awaitResult().get(5, TimeUnit.SECONDS);
+        assertThat(result).isEqualTo("result");
+        assertThat(handle.status()).isEqualTo(TaskStatus.COMPLETED);
+    }
+
+    @Test
+    void should_record_task_as_failed_on_exception() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("failAgent").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            throw new RuntimeException("boom");
+        });
+
+        assertThatThrownBy(() -> handle.awaitResult().get(5, TimeUnit.SECONDS))
+                .hasCauseInstanceOf(RuntimeException.class);
+
+        // Wait briefly for async status update
+        Thread.sleep(100);
+        assertThat(handle.status()).isEqualTo(TaskStatus.FAILED);
+    }
+
+    @Test
+    void should_pause_task_on_task_paused_exception() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("pauseAgent").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            throw new TaskPausedException("Need approval", "approvalKey");
+        });
+
+        // Wait for async processing
+        Thread.sleep(200);
+        assertThat(handle.status()).isEqualTo(TaskStatus.PAUSED);
+    }
+
+    @Test
+    void should_cancel_task() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("cancelAgent").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            try {
+                Thread.sleep(10_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return "never";
+        });
+
+        // Wait for task to start
+        Thread.sleep(100);
+        boolean cancelled = service.cancel(handle.id());
+
+        assertThat(cancelled).isTrue();
+    }
+
+    @Test
+    void should_list_tasks() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("listAgent").build();
+
+        TaskHandle handle = service.start(config, () -> "done");
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+
+        assertThat(service.listTasks()).contains(handle.id());
+    }
+
+    @Test
+    void should_get_task_events() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("eventAgent").build();
+
+        TaskHandle handle = service.start(config, () -> "ok");
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+
+        assertThat(service.events(handle.id())).isNotEmpty();
+    }
+
+    @Test
+    void should_cleanup_completed_task() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("cleanupAgent").build();
+
+        TaskHandle handle = service.start(config, () -> "done");
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+
+        // Wait for status update
+        Thread.sleep(100);
+        boolean cleaned = service.cleanup(handle.id());
+
+        assertThat(cleaned).isTrue();
+        assertThat(service.metadata(handle.id())).isEmpty();
+    }
+
+    @Test
+    void should_not_cleanup_running_task() {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("runningAgent").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            try {
+                Thread.sleep(10_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return null;
+        });
+
+        // Wait for task to start
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        assertThatThrownBy(() -> service.cleanup(handle.id())).isInstanceOf(IllegalStateException.class);
+
+        service.cancel(handle.id());
+    }
+
+    @Test
+    void should_require_store_in_builder() {
+        assertThatThrownBy(() -> LongLivedTaskService.builder().build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("store");
+    }
+
+    // ---- Retry tests ----
+
+    @Test
+    void should_retry_on_transient_failure_then_succeed() throws Exception {
+        AtomicInteger attempts = new AtomicInteger(0);
+
+        RetryPolicy retryPolicy = RetryPolicy.builder()
+                .maxRetries(3)
+                .initialDelay(Duration.ofMillis(50))
+                .retryableException(IOException.class)
+                .build();
+
+        TaskConfiguration config = TaskConfiguration.builder()
+                .agentName("retryAgent")
+                .retryPolicy(retryPolicy)
+                .build();
+
+        TaskHandle handle = service.start(config, () -> {
+            int attempt = attempts.incrementAndGet();
+            if (attempt < 3) {
+                throw new RuntimeException(new IOException("Connection refused"));
+            }
+            return "success after retries";
+        });
+
+        Object result = handle.awaitResult().get(10, TimeUnit.SECONDS);
+        assertThat(result).isEqualTo("success after retries");
+        assertThat(handle.status()).isEqualTo(TaskStatus.COMPLETED);
+        assertThat(attempts.get()).isEqualTo(3);
+    }
+
+    @Test
+    void should_exhaust_retries_then_fail() throws Exception {
+        RetryPolicy retryPolicy = RetryPolicy.builder()
+                .maxRetries(2)
+                .initialDelay(Duration.ofMillis(50))
+                .build();
+
+        TaskConfiguration config = TaskConfiguration.builder()
+                .agentName("failRetryAgent")
+                .retryPolicy(retryPolicy)
+                .build();
+
+        TaskHandle handle = service.start(config, () -> {
+            throw new RuntimeException("always fails");
+        });
+
+        assertThatThrownBy(() -> handle.awaitResult().get(10, TimeUnit.SECONDS))
+                .hasCauseInstanceOf(RuntimeException.class);
+
+        Thread.sleep(100);
+        assertThat(handle.status()).isEqualTo(TaskStatus.FAILED);
+
+        // Verify retry events were recorded
+        List<TaskEvent> events = service.events(handle.id());
+        long retryEventCount =
+                events.stream().filter(e -> e instanceof TaskRetryEvent).count();
+        assertThat(retryEventCount).isEqualTo(2);
+    }
+
+    @Test
+    void should_not_retry_task_paused_exception() throws Exception {
+        RetryPolicy retryPolicy = RetryPolicy.builder()
+                .maxRetries(3)
+                .initialDelay(Duration.ofMillis(50))
+                .build();
+
+        TaskConfiguration config = TaskConfiguration.builder()
+                .agentName("pauseRetryAgent")
+                .retryPolicy(retryPolicy)
+                .build();
+
+        TaskHandle handle = service.start(config, () -> {
+            throw new TaskPausedException("Need input", "inputKey");
+        });
+
+        Thread.sleep(200);
+        assertThat(handle.status()).isEqualTo(TaskStatus.PAUSED);
+    }
+
+    // ---- Crash recovery tests ----
+
+    @Test
+    void should_recover_interrupted_tasks() {
+        // Simulate tasks that were RUNNING when process crashed
+        TaskId task1 = TaskId.random();
+        TaskId task2 = TaskId.random();
+        TaskMetadata meta1 = TaskMetadata.create(task1, "agent1", java.util.Map.of());
+        TaskMetadata meta2 = TaskMetadata.create(task2, "agent2", java.util.Map.of());
+        meta1.transitionTo(TaskStatus.RUNNING);
+        meta2.transitionTo(TaskStatus.RUNNING);
+        store.saveMetadata(meta1);
+        store.saveMetadata(meta2);
+
+        Set<TaskId> recovered = service.recoverInterruptedTasks();
+
+        assertThat(recovered).containsExactlyInAnyOrder(task1, task2);
+        assertThat(service.status(task1)).contains(TaskStatus.PAUSED);
+        assertThat(service.status(task2)).contains(TaskStatus.PAUSED);
+    }
+
+    @Test
+    void should_recover_retrying_tasks() {
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, "retryingAgent", java.util.Map.of());
+        metadata.transitionTo(TaskStatus.RETRYING);
+        store.saveMetadata(metadata);
+
+        Set<TaskId> recovered = service.recoverInterruptedTasks();
+
+        assertThat(recovered).contains(taskId);
+        assertThat(service.status(taskId)).contains(TaskStatus.PAUSED);
+    }
+
+    // ---- provideInput tests ----
+
+    @Test
+    void should_provide_input_for_paused_task() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("inputAgent").build();
+
+        TaskHandle handle = service.start(config, () -> {
+            throw new TaskPausedException("Need approval", "approvalKey");
+        });
+
+        Thread.sleep(200);
+        assertThat(handle.status()).isEqualTo(TaskStatus.PAUSED);
+
+        // Should not throw
+        service.provideInput(handle.id(), "approvalKey", "approved");
+
+        // Verify event was recorded
+        List<TaskEvent> events = service.events(handle.id());
+        assertThat(events).isNotEmpty();
+    }
+
+    @Test
+    void should_reject_input_for_non_paused_task() throws Exception {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("doneAgent").build();
+
+        TaskHandle handle = service.start(config, () -> "done");
+        handle.awaitResult().get(5, TimeUnit.SECONDS);
+
+        Thread.sleep(100);
+
+        assertThatThrownBy(() -> service.provideInput(handle.id(), "key", "value"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not paused");
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/hitl/DurableHumanInTheLoopTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/hitl/DurableHumanInTheLoopTest.java
@@ -1,0 +1,76 @@
+package dev.langchain4j.experimental.durable.hitl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.experimental.durable.task.TaskPausedException;
+import org.junit.jupiter.api.Test;
+
+class DurableHumanInTheLoopTest {
+
+    @Test
+    void should_throw_task_paused_when_no_input_in_scope() {
+        AgenticScope scope = mock(AgenticScope.class);
+        when(scope.hasState("approval")).thenReturn(false);
+
+        DurableHumanInTheLoop hitl = DurableHumanInTheLoop.builder()
+                .outputKey("approval")
+                .reason("Waiting for manager")
+                .build();
+
+        assertThatThrownBy(() -> hitl.askUser(scope))
+                .isInstanceOf(TaskPausedException.class)
+                .hasMessageContaining("Waiting for manager");
+    }
+
+    @Test
+    void should_return_value_from_scope_on_resume() {
+        AgenticScope scope = mock(AgenticScope.class);
+        when(scope.hasState("approval")).thenReturn(true);
+        when(scope.readState("approval")).thenReturn("approved");
+
+        DurableHumanInTheLoop hitl = DurableHumanInTheLoop.builder()
+                .outputKey("approval")
+                .reason("Waiting for manager")
+                .build();
+
+        Object result = hitl.askUser(scope);
+        assertThat(result).isEqualTo("approved");
+    }
+
+    @Test
+    void should_use_default_output_key() {
+        DurableHumanInTheLoop hitl = DurableHumanInTheLoop.builder().build();
+        assertThat(hitl.outputKey()).isEqualTo("humanInput");
+    }
+
+    @Test
+    void should_use_default_reason_when_not_set() {
+        AgenticScope scope = mock(AgenticScope.class);
+        when(scope.hasState("humanInput")).thenReturn(false);
+
+        DurableHumanInTheLoop hitl = DurableHumanInTheLoop.builder().build();
+
+        assertThatThrownBy(() -> hitl.askUser(scope))
+                .isInstanceOf(TaskPausedException.class)
+                .hasMessageContaining("Waiting for human input");
+    }
+
+    @Test
+    void should_set_builder_properties() {
+        DurableHumanInTheLoop hitl = DurableHumanInTheLoop.builder()
+                .outputKey("customKey")
+                .description("Custom description")
+                .async(true)
+                .reason("Custom reason")
+                .build();
+
+        assertThat(hitl.outputKey()).isEqualTo("customKey");
+        assertThat(hitl.description()).isEqualTo("Custom description");
+        assertThat(hitl.async()).isTrue();
+        assertThat(hitl.reason()).isEqualTo("Custom reason");
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/internal/DefaultTaskHandleTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/internal/DefaultTaskHandleTest.java
@@ -1,0 +1,108 @@
+package dev.langchain4j.experimental.durable.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import dev.langchain4j.experimental.durable.task.TaskStatus;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DefaultTaskHandleTest {
+
+    private TaskId taskId;
+    private TaskMetadata metadata;
+    private CompletableFuture<Object> future;
+    private DefaultTaskHandle handle;
+
+    @BeforeEach
+    void setup() {
+        taskId = TaskId.random();
+        metadata = TaskMetadata.create(taskId, "testAgent", Map.of());
+        future = new CompletableFuture<>();
+        handle = new DefaultTaskHandle(taskId, metadata, future);
+    }
+
+    @Test
+    void should_return_task_id() {
+        assertThat(handle.id()).isEqualTo(taskId);
+    }
+
+    @Test
+    void should_reflect_metadata_status() {
+        assertThat(handle.status()).isEqualTo(TaskStatus.PENDING);
+
+        metadata.transitionTo(TaskStatus.RUNNING);
+        assertThat(handle.status()).isEqualTo(TaskStatus.RUNNING);
+    }
+
+    @Test
+    void should_return_empty_result_when_not_completed() {
+        assertThat(handle.result()).isEmpty();
+    }
+
+    @Test
+    void should_return_result_when_future_completed() {
+        future.complete("the result");
+
+        assertThat(handle.result()).contains("the result");
+    }
+
+    @Test
+    void should_return_empty_result_when_future_completed_exceptionally() {
+        future.completeExceptionally(new RuntimeException("fail"));
+
+        assertThat(handle.result()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_result_when_future_cancelled() {
+        future.cancel(true);
+
+        assertThat(handle.result()).isEmpty();
+    }
+
+    @Test
+    void should_return_the_future_from_await_result() {
+        assertThat(handle.awaitResult()).isSameAs(future);
+    }
+
+    @Test
+    void should_cancel_future_and_return_true() {
+        metadata.transitionTo(TaskStatus.RUNNING);
+
+        boolean cancelled = handle.cancel();
+
+        assertThat(cancelled).isTrue();
+        assertThat(future.isCancelled()).isTrue();
+        // Note: metadata transitions are managed by LongLivedTaskService, not the handle.
+        // The handle.cancel() only cancels the underlying future.
+    }
+
+    @Test
+    void should_return_false_when_future_already_completed() {
+        future.complete("done");
+
+        boolean cancelled = handle.cancel();
+
+        assertThat(cancelled).isFalse();
+        assertThat(future.isCancelled()).isFalse();
+    }
+
+    @Test
+    void should_update_status_after_update_metadata() {
+        TaskMetadata updatedMetadata = TaskMetadata.create(taskId, "testAgent", Map.of());
+        updatedMetadata.transitionTo(TaskStatus.PAUSED);
+
+        handle.updateMetadata(updatedMetadata);
+
+        assertThat(handle.status()).isEqualTo(TaskStatus.PAUSED);
+    }
+
+    @Test
+    void should_expose_underlying_future() {
+        assertThat(handle.future()).isSameAs(future);
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/journal/JournalingAgentListenerTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/journal/JournalingAgentListenerTest.java
@@ -1,0 +1,198 @@
+package dev.langchain4j.experimental.durable.journal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agentic.observability.AgentInvocationError;
+import dev.langchain4j.agentic.observability.AgentRequest;
+import dev.langchain4j.agentic.observability.AgentResponse;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.experimental.durable.store.InMemoryTaskExecutionStore;
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationCompletedEvent;
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationFailedEvent;
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationStartedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JournalingAgentListenerTest {
+
+    private InMemoryTaskExecutionStore store;
+    private TaskId taskId;
+    private JournalingAgentListener listener;
+
+    @BeforeEach
+    void setup() {
+        store = new InMemoryTaskExecutionStore();
+        taskId = new TaskId("journal-task-1");
+        listener = new JournalingAgentListener(taskId, store);
+    }
+
+    @Test
+    void should_return_task_id() {
+        assertThat(listener.taskId()).isEqualTo(taskId);
+    }
+
+    @Test
+    void should_be_inherited_by_subagents() {
+        assertThat(listener.inheritedBySubagents()).isTrue();
+    }
+
+    @Test
+    void should_record_agent_invocation_started_event() {
+        AgentRequest request = mock(AgentRequest.class);
+        when(request.agentName()).thenReturn("summarizer");
+        when(request.agentId()).thenReturn("sum-1");
+        when(request.inputs()).thenReturn(Map.of("text", "hello world"));
+
+        listener.beforeAgentInvocation(request);
+
+        List<TaskEvent> events = store.loadEvents(taskId);
+        assertThat(events).hasSize(1);
+        assertThat(events.get(0)).isInstanceOf(AgentInvocationStartedEvent.class);
+
+        AgentInvocationStartedEvent started = (AgentInvocationStartedEvent) events.get(0);
+        assertThat(started.taskId()).isEqualTo(taskId);
+        assertThat(started.agentName()).isEqualTo("summarizer");
+        assertThat(started.agentId()).isEqualTo("sum-1");
+        assertThat(started.inputs()).containsEntry("text", "hello world");
+    }
+
+    @Test
+    void should_record_agent_invocation_completed_event() {
+        AgentResponse response = mock(AgentResponse.class);
+        when(response.agentName()).thenReturn("classifier");
+        when(response.agentId()).thenReturn("cls-1");
+        when(response.output()).thenReturn("positive");
+
+        listener.afterAgentInvocation(response);
+
+        List<TaskEvent> events = store.loadEvents(taskId);
+        assertThat(events).hasSize(1);
+        assertThat(events.get(0)).isInstanceOf(AgentInvocationCompletedEvent.class);
+
+        AgentInvocationCompletedEvent completed = (AgentInvocationCompletedEvent) events.get(0);
+        assertThat(completed.taskId()).isEqualTo(taskId);
+        assertThat(completed.agentName()).isEqualTo("classifier");
+        assertThat(completed.agentId()).isEqualTo("cls-1");
+        assertThat(completed.serializedOutput()).isNotNull();
+    }
+
+    @Test
+    void should_record_agent_invocation_failed_event() {
+        RuntimeException error = new RuntimeException("connection timeout");
+        AgentInvocationError invocationError = mock(AgentInvocationError.class);
+        when(invocationError.agentName()).thenReturn("fetcher");
+        when(invocationError.agentId()).thenReturn("fetch-1");
+        when(invocationError.error()).thenReturn(error);
+
+        listener.onAgentInvocationError(invocationError);
+
+        List<TaskEvent> events = store.loadEvents(taskId);
+        assertThat(events).hasSize(1);
+        assertThat(events.get(0)).isInstanceOf(AgentInvocationFailedEvent.class);
+
+        AgentInvocationFailedEvent failed = (AgentInvocationFailedEvent) events.get(0);
+        assertThat(failed.taskId()).isEqualTo(taskId);
+        assertThat(failed.agentName()).isEqualTo("fetcher");
+        assertThat(failed.errorMessage()).isEqualTo("connection timeout");
+        assertThat(failed.stackTrace()).contains("RuntimeException");
+    }
+
+    @Test
+    void should_record_events_in_order() {
+        AgentRequest request = mock(AgentRequest.class);
+        when(request.agentName()).thenReturn("agent");
+        when(request.agentId()).thenReturn("a-1");
+        when(request.inputs()).thenReturn(Map.of());
+
+        AgentResponse response = mock(AgentResponse.class);
+        when(response.agentName()).thenReturn("agent");
+        when(response.agentId()).thenReturn("a-1");
+        when(response.output()).thenReturn("output");
+
+        listener.beforeAgentInvocation(request);
+        listener.afterAgentInvocation(response);
+
+        List<TaskEvent> events = store.loadEvents(taskId);
+        assertThat(events).hasSize(2);
+        assertThat(events.get(0)).isInstanceOf(AgentInvocationStartedEvent.class);
+        assertThat(events.get(1)).isInstanceOf(AgentInvocationCompletedEvent.class);
+    }
+
+    @Test
+    void should_handle_null_output_gracefully() {
+        AgentResponse response = mock(AgentResponse.class);
+        when(response.agentName()).thenReturn("nullOutputAgent");
+        when(response.agentId()).thenReturn("null-1");
+        when(response.output()).thenReturn(null);
+
+        // Should not throw
+        listener.afterAgentInvocation(response);
+
+        List<TaskEvent> events = store.loadEvents(taskId);
+        assertThat(events).hasSize(1);
+        AgentInvocationCompletedEvent completed = (AgentInvocationCompletedEvent) events.get(0);
+        assertThat(completed.serializedOutput()).isNull();
+    }
+
+    // ---- Scope-aware checkpoint callbacks ----
+
+    @Test
+    void should_call_after_agent_checkpoint_with_scope() {
+        AtomicReference<AgenticScope> receivedScope = new AtomicReference<>();
+        AgenticScope mockScope = mock(AgenticScope.class);
+
+        JournalingAgentListener listenerWithCallback =
+                new JournalingAgentListener(taskId, store, receivedScope::set, null);
+
+        AgentResponse response = mock(AgentResponse.class);
+        when(response.agentName()).thenReturn("agent");
+        when(response.agentId()).thenReturn("a-1");
+        when(response.output()).thenReturn("result");
+        when(response.agenticScope()).thenReturn(mockScope);
+
+        listenerWithCallback.afterAgentInvocation(response);
+
+        assertThat(receivedScope.get()).isSameAs(mockScope);
+    }
+
+    @Test
+    void should_not_call_after_agent_checkpoint_when_null() {
+        // The 2-arg constructor sets afterAgentCheckpoint to null — no NPE expected
+        AgentResponse response = mock(AgentResponse.class);
+        when(response.agentName()).thenReturn("agent");
+        when(response.agentId()).thenReturn("a-1");
+        when(response.output()).thenReturn("result");
+
+        listener.afterAgentInvocation(response);
+
+        // No exception means success — only event should be the completion event
+        assertThat(store.loadEvents(taskId)).hasSize(1);
+    }
+
+    @Test
+    void should_call_root_call_checkpoint_on_scope_destroyed() {
+        AtomicReference<AgenticScope> receivedScope = new AtomicReference<>();
+        AgenticScope mockScope = mock(AgenticScope.class);
+
+        JournalingAgentListener listenerWithRootCallback =
+                new JournalingAgentListener(taskId, store, null, receivedScope::set);
+
+        listenerWithRootCallback.beforeAgenticScopeDestroyed(mockScope);
+
+        assertThat(receivedScope.get()).isSameAs(mockScope);
+    }
+
+    @Test
+    void should_not_call_root_call_checkpoint_when_null() {
+        // The 2-arg constructor sets rootCallCheckpoint to null — no NPE expected
+        listener.beforeAgenticScopeDestroyed(mock(AgenticScope.class));
+        // If we get here without exception, pass
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/replay/ReplayingPlannerTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/replay/ReplayingPlannerTest.java
@@ -1,0 +1,174 @@
+package dev.langchain4j.experimental.durable.replay;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agentic.planner.Action;
+import dev.langchain4j.agentic.planner.AgenticSystemTopology;
+import dev.langchain4j.agentic.planner.InitPlanningContext;
+import dev.langchain4j.agentic.planner.Planner;
+import dev.langchain4j.agentic.planner.PlanningContext;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationCompletedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskResumedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskStartedEvent;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ReplayingPlannerTest {
+
+    @Test
+    void should_delegate_directly_when_no_journal_events() {
+        Planner delegate = new TestSequentialPlanner(3);
+        AgenticScope scope = Mockito.mock(AgenticScope.class);
+
+        ReplayingPlanner planner = ReplayingPlanner.builder()
+                .delegate(delegate)
+                .journalEvents(List.of())
+                .build();
+
+        planner.init(new InitPlanningContext(scope, null, List.of()));
+        assertThat(planner.isReplayComplete()).isTrue();
+        assertThat(planner.replayedCount()).isEqualTo(0);
+    }
+
+    @Test
+    void should_replay_completed_invocations() {
+        TaskId taskId = new TaskId("t1");
+        Instant now = Instant.now();
+
+        List<TaskEvent> events = List.of(
+                new TaskStartedEvent(taskId, now, Map.of()),
+                new AgentInvocationCompletedEvent(taskId, now, "agent1", "a1", "\"result1\""),
+                new AgentInvocationCompletedEvent(taskId, now, "agent2", "a2", "\"result2\""));
+
+        TestSequentialPlanner delegate = new TestSequentialPlanner(3);
+        AgenticScope scope = Mockito.mock(AgenticScope.class);
+
+        ReplayingPlanner planner = ReplayingPlanner.builder()
+                .delegate(delegate)
+                .journalEvents(events)
+                .build();
+
+        planner.init(new InitPlanningContext(scope, null, List.of()));
+
+        // firstAction should replay 2 completed invocations and return the 3rd (live) action
+        Action action = planner.firstAction(new PlanningContext(scope, null));
+
+        assertThat(planner.isReplayComplete()).isTrue();
+        assertThat(planner.replayedCount()).isEqualTo(2);
+        // The delegate has been advanced past 2 steps, so the next action should be for step 3
+        assertThat(action.isDone()).isFalse();
+    }
+
+    @Test
+    void should_return_done_when_all_steps_were_completed() {
+        TaskId taskId = new TaskId("t1");
+        Instant now = Instant.now();
+
+        List<TaskEvent> events = List.of(
+                new TaskStartedEvent(taskId, now, Map.of()),
+                new AgentInvocationCompletedEvent(taskId, now, "agent1", "a1", "\"r1\""),
+                new AgentInvocationCompletedEvent(taskId, now, "agent2", "a2", "\"r2\""));
+
+        // Delegate only has 2 steps — replay covers all
+        TestSequentialPlanner delegate = new TestSequentialPlanner(2);
+        AgenticScope scope = Mockito.mock(AgenticScope.class);
+
+        ReplayingPlanner planner = ReplayingPlanner.builder()
+                .delegate(delegate)
+                .journalEvents(events)
+                .build();
+
+        planner.init(new InitPlanningContext(scope, null, List.of()));
+        Action action = planner.firstAction(new PlanningContext(scope, null));
+
+        assertThat(action.isDone()).isTrue();
+        assertThat(planner.replayedCount()).isEqualTo(2);
+    }
+
+    @Test
+    void should_report_topology_from_delegate() {
+        Planner delegate = new TestSequentialPlanner(1);
+        ReplayingPlanner planner = ReplayingPlanner.builder()
+                .delegate(delegate)
+                .journalEvents(List.of())
+                .build();
+
+        assertThat(planner.topology()).isEqualTo(AgenticSystemTopology.SEQUENCE);
+    }
+
+    @Test
+    void should_write_user_input_from_resumed_events_to_scope() {
+        TaskId taskId = new TaskId("t1");
+        Instant now = Instant.now();
+
+        List<TaskEvent> events = List.of(
+                new TaskStartedEvent(taskId, now, Map.of()),
+                new TaskResumedEvent(taskId, now, Map.of("approvalKey", "approved")),
+                new TaskResumedEvent(taskId, now, Map.of("otherKey", 42))
+        );
+
+        TestSequentialPlanner delegate = new TestSequentialPlanner(1);
+        AgenticScope scope = Mockito.mock(AgenticScope.class);
+
+        ReplayingPlanner planner = ReplayingPlanner.builder()
+                .delegate(delegate)
+                .journalEvents(events)
+                .build();
+
+        planner.init(new InitPlanningContext(scope, null, List.of()));
+        planner.firstAction(new PlanningContext(scope, null));
+
+        Mockito.verify(scope).writeState("approvalKey", "approved");
+        Mockito.verify(scope).writeState("otherKey", 42);
+    }
+
+    /**
+     * A simple test planner that simulates a sequential execution of N steps.
+     */
+    private static class TestSequentialPlanner implements Planner {
+
+        private final int totalSteps;
+        private int cursor = 0;
+
+        TestSequentialPlanner(int totalSteps) {
+            this.totalSteps = totalSteps;
+        }
+
+        @Override
+        public void init(InitPlanningContext initPlanningContext) {
+            // no-op for test
+        }
+
+        @Override
+        public Action firstAction(PlanningContext planningContext) {
+            return nextAction(planningContext);
+        }
+
+        @Override
+        public Action nextAction(PlanningContext planningContext) {
+            if (cursor >= totalSteps) {
+                return done();
+            }
+            cursor++;
+            // Return a simple AgentCallAction with an empty agent list
+            // (we won't actually execute agents in these tests)
+            return new Action.AgentCallAction(List.of());
+        }
+
+        @Override
+        public AgenticSystemTopology topology() {
+            return AgenticSystemTopology.SEQUENCE;
+        }
+
+        @Override
+        public boolean terminated() {
+            return cursor >= totalSteps;
+        }
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/replay/ReplayingPlannerTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/replay/ReplayingPlannerTest.java
@@ -110,8 +110,7 @@ class ReplayingPlannerTest {
         List<TaskEvent> events = List.of(
                 new TaskStartedEvent(taskId, now, Map.of()),
                 new TaskResumedEvent(taskId, now, Map.of("approvalKey", "approved")),
-                new TaskResumedEvent(taskId, now, Map.of("otherKey", 42))
-        );
+                new TaskResumedEvent(taskId, now, Map.of("otherKey", 42)));
 
         TestSequentialPlanner delegate = new TestSequentialPlanner(1);
         AgenticScope scope = Mockito.mock(AgenticScope.class);

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/store/InMemoryTaskExecutionStore.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/store/InMemoryTaskExecutionStore.java
@@ -1,6 +1,5 @@
 package dev.langchain4j.experimental.durable.store;
 
-import dev.langchain4j.Experimental;
 import dev.langchain4j.experimental.durable.store.event.TaskEvent;
 import dev.langchain4j.experimental.durable.task.TaskId;
 import dev.langchain4j.experimental.durable.task.TaskMetadata;
@@ -14,15 +13,15 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
- * In-memory implementation of {@link TaskExecutionStore} backed by concurrent hash maps.
+ * Test-only in-memory implementation of {@link TaskExecutionStore}.
  *
- * <p>This implementation is suitable for testing and development. All data is lost when
- * the JVM exits. For production use, consider {@code FileTaskExecutionStore} or a
- * custom database-backed implementation.
+ * <p><strong>Not suitable for production use.</strong> All data is lost when the JVM exits.
+ * This class exists solely as a test helper and is not part of the module's public API.
+ * For production use, see {@link dev.langchain4j.experimental.durable.store.file.FileTaskExecutionStore}
+ * or provide a custom database-backed implementation of {@link TaskExecutionStore}.
  *
  * <p>All operations are thread-safe.
  */
-@Experimental
 public class InMemoryTaskExecutionStore implements TaskExecutionStore {
 
     private final ConcurrentHashMap<TaskId, TaskMetadata> metadataMap = new ConcurrentHashMap<>();

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/store/InMemoryTaskExecutionStoreTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/store/InMemoryTaskExecutionStoreTest.java
@@ -1,0 +1,159 @@
+package dev.langchain4j.experimental.durable.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationCompletedEvent;
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationStartedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskCompletedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskStartedEvent;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import dev.langchain4j.experimental.durable.task.TaskStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InMemoryTaskExecutionStoreTest {
+
+    private InMemoryTaskExecutionStore store;
+
+    @BeforeEach
+    void setup() {
+        store = new InMemoryTaskExecutionStore();
+    }
+
+    @Test
+    void should_save_and_load_metadata() {
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, "testAgent", Map.of());
+
+        store.saveMetadata(metadata);
+        Optional<TaskMetadata> loaded = store.loadMetadata(taskId);
+
+        assertThat(loaded).isPresent();
+        assertThat(loaded.get().id()).isEqualTo(taskId);
+        assertThat(loaded.get().agentName()).isEqualTo("testAgent");
+    }
+
+    @Test
+    void should_return_empty_for_unknown_task() {
+        assertThat(store.loadMetadata(TaskId.random())).isEmpty();
+    }
+
+    @Test
+    void should_append_and_load_events() {
+        TaskId taskId = TaskId.random();
+        TaskEvent event1 = new TaskStartedEvent(taskId, Instant.now(), Map.of());
+        TaskEvent event2 = new AgentInvocationStartedEvent(taskId, Instant.now(), "agent1", "id1", Map.of());
+        TaskEvent event3 = new AgentInvocationCompletedEvent(taskId, Instant.now(), "agent1", "id1", "\"result\"");
+
+        store.appendEvent(event1);
+        store.appendEvent(event2);
+        store.appendEvent(event3);
+
+        List<TaskEvent> events = store.loadEvents(taskId);
+        assertThat(events).hasSize(3);
+        assertThat(events.get(0)).isInstanceOf(TaskStartedEvent.class);
+        assertThat(events.get(1)).isInstanceOf(AgentInvocationStartedEvent.class);
+        assertThat(events.get(2)).isInstanceOf(AgentInvocationCompletedEvent.class);
+    }
+
+    @Test
+    void should_return_empty_events_for_unknown_task() {
+        assertThat(store.loadEvents(TaskId.random())).isEmpty();
+    }
+
+    @Test
+    void should_save_and_load_checkpoint() {
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, "agent", Map.of());
+        Checkpoint checkpoint = new Checkpoint(taskId, metadata, "{}", 5, Instant.now());
+
+        store.saveCheckpoint(checkpoint);
+        Optional<Checkpoint> loaded = store.loadCheckpoint(taskId);
+
+        assertThat(loaded).isPresent();
+        assertThat(loaded.get().taskId()).isEqualTo(taskId);
+        assertThat(loaded.get().eventCount()).isEqualTo(5);
+    }
+
+    @Test
+    void should_get_all_task_ids() {
+        TaskId id1 = TaskId.random();
+        TaskId id2 = TaskId.random();
+        store.saveMetadata(TaskMetadata.create(id1, "agent1", Map.of()));
+        store.saveMetadata(TaskMetadata.create(id2, "agent2", Map.of()));
+
+        Set<TaskId> ids = store.getAllTaskIds();
+        assertThat(ids).containsExactlyInAnyOrder(id1, id2);
+    }
+
+    @Test
+    void should_get_task_ids_by_status() {
+        TaskId runningId = TaskId.random();
+        TaskId pausedId = TaskId.random();
+
+        TaskMetadata running = TaskMetadata.create(runningId, "agent", Map.of());
+        running.transitionTo(TaskStatus.RUNNING);
+
+        TaskMetadata paused = TaskMetadata.create(pausedId, "agent", Map.of());
+        paused.transitionTo(TaskStatus.PAUSED);
+
+        store.saveMetadata(running);
+        store.saveMetadata(paused);
+
+        assertThat(store.getTaskIdsByStatus(TaskStatus.RUNNING)).containsExactly(runningId);
+        assertThat(store.getTaskIdsByStatus(TaskStatus.PAUSED)).containsExactly(pausedId);
+    }
+
+    @Test
+    void should_delete_task_data() {
+        TaskId taskId = TaskId.random();
+        store.saveMetadata(TaskMetadata.create(taskId, "agent", Map.of()));
+        store.appendEvent(new TaskStartedEvent(taskId, Instant.now(), Map.of()));
+        store.saveCheckpoint(
+                new Checkpoint(taskId, TaskMetadata.create(taskId, "agent", Map.of()), "{}", 1, Instant.now()));
+
+        boolean deleted = store.delete(taskId);
+
+        assertThat(deleted).isTrue();
+        assertThat(store.loadMetadata(taskId)).isEmpty();
+        assertThat(store.loadEvents(taskId)).isEmpty();
+        assertThat(store.loadCheckpoint(taskId)).isEmpty();
+    }
+
+    @Test
+    void should_return_false_when_deleting_nonexistent_task() {
+        assertThat(store.delete(TaskId.random())).isFalse();
+    }
+
+    @Test
+    void should_replace_checkpoint_on_save() {
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, "agent", Map.of());
+
+        store.saveCheckpoint(new Checkpoint(taskId, metadata, "{}", 3, Instant.now()));
+        store.saveCheckpoint(new Checkpoint(taskId, metadata, "{}", 7, Instant.now()));
+
+        Optional<Checkpoint> loaded = store.loadCheckpoint(taskId);
+        assertThat(loaded).isPresent();
+        assertThat(loaded.get().eventCount()).isEqualTo(7);
+    }
+
+    @Test
+    void should_handle_completed_event_in_journal() {
+        TaskId taskId = TaskId.random();
+        store.appendEvent(new TaskStartedEvent(taskId, Instant.now(), Map.of()));
+        store.appendEvent(new TaskCompletedEvent(taskId, Instant.now(), "\"done\""));
+
+        List<TaskEvent> events = store.loadEvents(taskId);
+        assertThat(events).hasSize(2);
+        assertThat(events.get(1)).isInstanceOf(TaskCompletedEvent.class);
+        assertThat(((TaskCompletedEvent) events.get(1)).serializedResult()).isEqualTo("\"done\"");
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/store/event/TaskEventSerializationTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/store/event/TaskEventSerializationTest.java
@@ -1,0 +1,162 @@
+package dev.langchain4j.experimental.durable.store.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TaskEventSerializationTest {
+
+    private ObjectMapper objectMapper;
+    private TaskId taskId;
+    private Instant now;
+
+    @BeforeEach
+    void setup() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        taskId = new TaskId("test-task-1");
+        now = Instant.now();
+    }
+
+    @Test
+    void should_round_trip_task_started_event() throws Exception {
+        TaskEvent event = new TaskStartedEvent(taskId, now, Map.of("input", "hello"));
+        String json = objectMapper.writeValueAsString(event);
+        TaskEvent deserialized = objectMapper.readValue(json, TaskEvent.class);
+
+        assertThat(deserialized).isInstanceOf(TaskStartedEvent.class);
+        TaskStartedEvent typed = (TaskStartedEvent) deserialized;
+        assertThat(typed.taskId()).isEqualTo(taskId);
+        assertThat(typed.initialInputs()).containsEntry("input", "hello");
+    }
+
+    @Test
+    void should_round_trip_agent_invocation_started_event() throws Exception {
+        TaskEvent event =
+                new AgentInvocationStartedEvent(taskId, now, "summarizer", "sum-1", Map.of("text", "content"));
+        String json = objectMapper.writeValueAsString(event);
+        TaskEvent deserialized = objectMapper.readValue(json, TaskEvent.class);
+
+        assertThat(deserialized).isInstanceOf(AgentInvocationStartedEvent.class);
+        AgentInvocationStartedEvent typed = (AgentInvocationStartedEvent) deserialized;
+        assertThat(typed.agentName()).isEqualTo("summarizer");
+        assertThat(typed.agentId()).isEqualTo("sum-1");
+    }
+
+    @Test
+    void should_round_trip_agent_invocation_completed_event() throws Exception {
+        TaskEvent event = new AgentInvocationCompletedEvent(taskId, now, "summarizer", "sum-1", "\"summary text\"");
+        String json = objectMapper.writeValueAsString(event);
+        TaskEvent deserialized = objectMapper.readValue(json, TaskEvent.class);
+
+        assertThat(deserialized).isInstanceOf(AgentInvocationCompletedEvent.class);
+        AgentInvocationCompletedEvent typed = (AgentInvocationCompletedEvent) deserialized;
+        assertThat(typed.serializedOutput()).isEqualTo("\"summary text\"");
+    }
+
+    @Test
+    void should_round_trip_agent_invocation_failed_event() throws Exception {
+        TaskEvent event =
+                new AgentInvocationFailedEvent(taskId, now, "agent1", "a1", "NullPointerException", "stack trace here");
+        String json = objectMapper.writeValueAsString(event);
+        TaskEvent deserialized = objectMapper.readValue(json, TaskEvent.class);
+
+        assertThat(deserialized).isInstanceOf(AgentInvocationFailedEvent.class);
+        AgentInvocationFailedEvent typed = (AgentInvocationFailedEvent) deserialized;
+        assertThat(typed.errorMessage()).isEqualTo("NullPointerException");
+    }
+
+    @Test
+    void should_round_trip_task_paused_event() throws Exception {
+        TaskEvent event = new TaskPausedEvent(taskId, now, "Waiting for approval", "approvalKey");
+        String json = objectMapper.writeValueAsString(event);
+        TaskEvent deserialized = objectMapper.readValue(json, TaskEvent.class);
+
+        assertThat(deserialized).isInstanceOf(TaskPausedEvent.class);
+        TaskPausedEvent typed = (TaskPausedEvent) deserialized;
+        assertThat(typed.reason()).isEqualTo("Waiting for approval");
+        assertThat(typed.pendingAgentName()).isEqualTo("approvalKey");
+    }
+
+    @Test
+    void should_round_trip_task_resumed_event() throws Exception {
+        TaskEvent event = new TaskResumedEvent(taskId, now, Map.of("approval", "yes"));
+        String json = objectMapper.writeValueAsString(event);
+        TaskEvent deserialized = objectMapper.readValue(json, TaskEvent.class);
+
+        assertThat(deserialized).isInstanceOf(TaskResumedEvent.class);
+        TaskResumedEvent typed = (TaskResumedEvent) deserialized;
+        assertThat(typed.userInput()).containsEntry("approval", "yes");
+    }
+
+    @Test
+    void should_round_trip_task_completed_event() throws Exception {
+        TaskEvent event = new TaskCompletedEvent(taskId, now, "\"final result\"");
+        String json = objectMapper.writeValueAsString(event);
+        TaskEvent deserialized = objectMapper.readValue(json, TaskEvent.class);
+
+        assertThat(deserialized).isInstanceOf(TaskCompletedEvent.class);
+        TaskCompletedEvent typed = (TaskCompletedEvent) deserialized;
+        assertThat(typed.serializedResult()).isEqualTo("\"final result\"");
+    }
+
+    @Test
+    void should_round_trip_task_failed_event() throws Exception {
+        TaskEvent event = new TaskFailedEvent(taskId, now, "Out of memory", "java.lang.OOM...");
+        String json = objectMapper.writeValueAsString(event);
+        TaskEvent deserialized = objectMapper.readValue(json, TaskEvent.class);
+
+        assertThat(deserialized).isInstanceOf(TaskFailedEvent.class);
+        TaskFailedEvent typed = (TaskFailedEvent) deserialized;
+        assertThat(typed.errorMessage()).isEqualTo("Out of memory");
+    }
+
+    @Test
+    void should_round_trip_task_cancelled_event() throws Exception {
+        TaskEvent event = new TaskCancelledEvent(taskId, now);
+        String json = objectMapper.writeValueAsString(event);
+        TaskEvent deserialized = objectMapper.readValue(json, TaskEvent.class);
+
+        assertThat(deserialized).isInstanceOf(TaskCancelledEvent.class);
+        TaskCancelledEvent typed = (TaskCancelledEvent) deserialized;
+        assertThat(typed.taskId()).isEqualTo(taskId);
+    }
+
+    @Test
+    void should_include_type_discriminator_in_json() throws Exception {
+        TaskEvent event = new TaskStartedEvent(taskId, now, Map.of());
+        String json = objectMapper.writeValueAsString(event);
+
+        assertThat(json).contains("\"type\":");
+        assertThat(json).contains("\"task_started\"");
+    }
+
+    @Test
+    void should_have_default_schema_version() {
+        TaskEvent event = new TaskStartedEvent(taskId, now, Map.of());
+        assertThat(event.schemaVersion()).isEqualTo(1);
+    }
+
+    @Test
+    void should_round_trip_task_retry_event() throws Exception {
+        TaskEvent event = new TaskRetryEvent(taskId, now, 2, 5, "Connection refused", 4000L);
+        String json = objectMapper.writeValueAsString(event);
+        TaskEvent deserialized = objectMapper.readValue(json, TaskEvent.class);
+
+        assertThat(deserialized).isInstanceOf(TaskRetryEvent.class);
+        TaskRetryEvent typed = (TaskRetryEvent) deserialized;
+        assertThat(typed.taskId()).isEqualTo(taskId);
+        assertThat(typed.attempt()).isEqualTo(2);
+        assertThat(typed.maxRetries()).isEqualTo(5);
+        assertThat(typed.errorMessage()).isEqualTo("Connection refused");
+        assertThat(typed.delayMillis()).isEqualTo(4000L);
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/store/file/FileTaskExecutionStoreTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/store/file/FileTaskExecutionStoreTest.java
@@ -1,0 +1,161 @@
+package dev.langchain4j.experimental.durable.store.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.experimental.durable.store.Checkpoint;
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationCompletedEvent;
+import dev.langchain4j.experimental.durable.store.event.AgentInvocationStartedEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskEvent;
+import dev.langchain4j.experimental.durable.store.event.TaskStartedEvent;
+import dev.langchain4j.experimental.durable.task.TaskId;
+import dev.langchain4j.experimental.durable.task.TaskMetadata;
+import dev.langchain4j.experimental.durable.task.TaskStatus;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileTaskExecutionStoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    private FileTaskExecutionStore store;
+
+    @BeforeEach
+    void setup() {
+        store = FileTaskExecutionStore.builder()
+                .baseDir(tempDir.resolve("tasks"))
+                .build();
+    }
+
+    @Test
+    void should_save_and_load_metadata() {
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, "agent1", Map.of("env", "test"));
+
+        store.saveMetadata(metadata);
+        Optional<TaskMetadata> loaded = store.loadMetadata(taskId);
+
+        assertThat(loaded).isPresent();
+        assertThat(loaded.get().id()).isEqualTo(taskId);
+        assertThat(loaded.get().agentName()).isEqualTo("agent1");
+    }
+
+    @Test
+    void should_return_empty_for_unknown_task() {
+        assertThat(store.loadMetadata(new TaskId("nonexistent"))).isEmpty();
+    }
+
+    @Test
+    void should_append_and_load_events() {
+        TaskId taskId = TaskId.random();
+        Instant now = Instant.now();
+
+        store.appendEvent(new TaskStartedEvent(taskId, now, Map.of()));
+        store.appendEvent(new AgentInvocationStartedEvent(taskId, now, "agent1", "id1", Map.of()));
+        store.appendEvent(new AgentInvocationCompletedEvent(taskId, now, "agent1", "id1", "\"done\""));
+
+        List<TaskEvent> events = store.loadEvents(taskId);
+        assertThat(events).hasSize(3);
+        assertThat(events.get(0)).isInstanceOf(TaskStartedEvent.class);
+        assertThat(events.get(2)).isInstanceOf(AgentInvocationCompletedEvent.class);
+    }
+
+    @Test
+    void should_persist_events_as_jsonl() {
+        TaskId taskId = TaskId.random();
+        store.appendEvent(new TaskStartedEvent(taskId, Instant.now(), Map.of()));
+        store.appendEvent(new AgentInvocationStartedEvent(taskId, Instant.now(), "agent1", "id1", Map.of()));
+
+        Path journalFile = tempDir.resolve("tasks").resolve(taskId.value()).resolve("journal.jsonl");
+        assertThat(journalFile).exists();
+    }
+
+    @Test
+    void should_save_and_load_checkpoint() {
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, "agent", Map.of());
+        Checkpoint checkpoint = new Checkpoint(taskId, metadata, "{\"state\": 1}", 5, Instant.now());
+
+        store.saveCheckpoint(checkpoint);
+        Optional<Checkpoint> loaded = store.loadCheckpoint(taskId);
+
+        assertThat(loaded).isPresent();
+        assertThat(loaded.get().eventCount()).isEqualTo(5);
+        assertThat(loaded.get().serializedScope()).isEqualTo("{\"state\": 1}");
+    }
+
+    @Test
+    void should_get_all_task_ids() {
+        TaskId id1 = TaskId.random();
+        TaskId id2 = TaskId.random();
+        store.saveMetadata(TaskMetadata.create(id1, "a1", Map.of()));
+        store.saveMetadata(TaskMetadata.create(id2, "a2", Map.of()));
+
+        Set<TaskId> ids = store.getAllTaskIds();
+        assertThat(ids).containsExactlyInAnyOrder(id1, id2);
+    }
+
+    @Test
+    void should_get_task_ids_by_status() {
+        TaskId runningId = TaskId.random();
+        TaskId pausedId = TaskId.random();
+
+        TaskMetadata running = TaskMetadata.create(runningId, "a", Map.of());
+        running.transitionTo(TaskStatus.RUNNING);
+
+        TaskMetadata paused = TaskMetadata.create(pausedId, "a", Map.of());
+        paused.transitionTo(TaskStatus.PAUSED);
+
+        store.saveMetadata(running);
+        store.saveMetadata(paused);
+
+        assertThat(store.getTaskIdsByStatus(TaskStatus.RUNNING)).containsExactly(runningId);
+        assertThat(store.getTaskIdsByStatus(TaskStatus.PAUSED)).containsExactly(pausedId);
+    }
+
+    @Test
+    void should_delete_task_data() {
+        TaskId taskId = TaskId.random();
+        store.saveMetadata(TaskMetadata.create(taskId, "a", Map.of()));
+        store.appendEvent(new TaskStartedEvent(taskId, Instant.now(), Map.of()));
+        store.saveCheckpoint(
+                new Checkpoint(taskId, TaskMetadata.create(taskId, "a", Map.of()), "{}", 1, Instant.now()));
+
+        boolean deleted = store.delete(taskId);
+
+        assertThat(deleted).isTrue();
+        assertThat(store.loadMetadata(taskId)).isEmpty();
+        assertThat(store.loadEvents(taskId)).isEmpty();
+        assertThat(store.loadCheckpoint(taskId)).isEmpty();
+
+        Path taskDir = tempDir.resolve("tasks").resolve(taskId.value());
+        assertThat(taskDir).doesNotExist();
+    }
+
+    @Test
+    void should_return_false_when_deleting_nonexistent_task() {
+        assertThat(store.delete(new TaskId("no-such-task"))).isFalse();
+    }
+
+    @Test
+    void should_survive_round_trip_across_store_instances() {
+        TaskId taskId = TaskId.random();
+        store.saveMetadata(TaskMetadata.create(taskId, "agent", Map.of()));
+        store.appendEvent(new TaskStartedEvent(taskId, Instant.now(), Map.of()));
+
+        // Create a new store instance pointing to same directory
+        FileTaskExecutionStore store2 = FileTaskExecutionStore.builder()
+                .baseDir(tempDir.resolve("tasks"))
+                .build();
+
+        assertThat(store2.loadMetadata(taskId)).isPresent();
+        assertThat(store2.loadEvents(taskId)).hasSize(1);
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/RetryPolicyTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/RetryPolicyTest.java
@@ -1,0 +1,116 @@
+package dev.langchain4j.experimental.durable.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class RetryPolicyTest {
+
+    @Test
+    void should_build_with_defaults() {
+        RetryPolicy policy = RetryPolicy.builder().build();
+
+        assertThat(policy.maxRetries()).isEqualTo(3);
+        assertThat(policy.initialDelay()).isEqualTo(Duration.ofSeconds(1));
+        assertThat(policy.backoffMultiplier()).isEqualTo(2.0);
+        assertThat(policy.maxDelay()).isEqualTo(Duration.ofMinutes(1));
+        assertThat(policy.retryableExceptions()).isEmpty();
+    }
+
+    @Test
+    void should_build_with_custom_values() {
+        RetryPolicy policy = RetryPolicy.builder()
+                .maxRetries(5)
+                .initialDelay(Duration.ofMillis(500))
+                .backoffMultiplier(1.5)
+                .maxDelay(Duration.ofSeconds(30))
+                .retryableException(IOException.class)
+                .retryableException(IllegalStateException.class)
+                .build();
+
+        assertThat(policy.maxRetries()).isEqualTo(5);
+        assertThat(policy.initialDelay()).isEqualTo(Duration.ofMillis(500));
+        assertThat(policy.backoffMultiplier()).isEqualTo(1.5);
+        assertThat(policy.maxDelay()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(policy.retryableExceptions())
+                .containsExactlyInAnyOrder(IOException.class, IllegalStateException.class);
+    }
+
+    @Test
+    void should_compute_exponential_delay() {
+        RetryPolicy policy = RetryPolicy.builder()
+                .initialDelay(Duration.ofSeconds(1))
+                .backoffMultiplier(2.0)
+                .maxDelay(Duration.ofMinutes(1))
+                .build();
+
+        assertThat(policy.delayForAttempt(1)).isEqualTo(Duration.ofSeconds(1));
+        assertThat(policy.delayForAttempt(2)).isEqualTo(Duration.ofSeconds(2));
+        assertThat(policy.delayForAttempt(3)).isEqualTo(Duration.ofSeconds(4));
+        assertThat(policy.delayForAttempt(4)).isEqualTo(Duration.ofSeconds(8));
+    }
+
+    @Test
+    void should_cap_delay_at_max() {
+        RetryPolicy policy = RetryPolicy.builder()
+                .initialDelay(Duration.ofSeconds(10))
+                .backoffMultiplier(3.0)
+                .maxDelay(Duration.ofSeconds(30))
+                .build();
+
+        // attempt 1: 10s, attempt 2: 30s (capped), attempt 3: 30s (capped)
+        assertThat(policy.delayForAttempt(1)).isEqualTo(Duration.ofSeconds(10));
+        assertThat(policy.delayForAttempt(2)).isEqualTo(Duration.ofSeconds(30));
+        assertThat(policy.delayForAttempt(3)).isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void should_be_retryable_when_no_exceptions_configured() {
+        RetryPolicy policy = RetryPolicy.builder().build();
+
+        assertThat(policy.isRetryable(new RuntimeException("boom"))).isTrue();
+        assertThat(policy.isRetryable(new IOException("io"))).isTrue();
+    }
+
+    @Test
+    void should_filter_by_retryable_exceptions() {
+        RetryPolicy policy =
+                RetryPolicy.builder().retryableException(IOException.class).build();
+
+        assertThat(policy.isRetryable(new IOException("io"))).isTrue();
+        assertThat(policy.isRetryable(new RuntimeException("runtime"))).isFalse();
+    }
+
+    @Test
+    void should_match_cause_chain() {
+        RetryPolicy policy =
+                RetryPolicy.builder().retryableException(IOException.class).build();
+
+        Exception wrappedException = new RuntimeException("wrapped", new IOException("cause"));
+        assertThat(policy.isRetryable(wrappedException)).isTrue();
+    }
+
+    @Test
+    void should_never_retry_task_paused_exception() {
+        RetryPolicy policy = RetryPolicy.builder().build();
+
+        assertThat(policy.isRetryable(new TaskPausedException("paused", "key"))).isFalse();
+    }
+
+    @Test
+    void none_should_never_retry() {
+        RetryPolicy none = RetryPolicy.NONE;
+
+        assertThat(none.maxRetries()).isZero();
+        assertThat(none.isRetryable(new RuntimeException("boom"))).isTrue();
+    }
+
+    @Test
+    void should_reject_negative_max_retries() {
+        assertThatThrownBy(() -> RetryPolicy.builder().maxRetries(-1).build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/TaskConfigurationTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/TaskConfigurationTest.java
@@ -1,0 +1,63 @@
+package dev.langchain4j.experimental.durable.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class TaskConfigurationTest {
+
+    @Test
+    void should_build_with_defaults() {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("myAgent").build();
+
+        assertThat(config.agentName()).isEqualTo("myAgent");
+        assertThat(config.checkpointPolicy()).isNull(); // null = defers to service default
+        assertThat(config.labels()).isEmpty();
+        assertThat(config.timeout()).isNull();
+    }
+
+    @Test
+    void should_build_with_custom_values() {
+        java.time.Duration timeout = java.time.Duration.ofMinutes(30);
+        java.util.Map<String, String> labels = java.util.Map.of("team", "ml");
+
+        TaskConfiguration config = TaskConfiguration.builder()
+                .agentName("customAgent")
+                .checkpointPolicy(CheckpointPolicy.AFTER_ROOT_CALL)
+                .labels(labels)
+                .timeout(timeout)
+                .build();
+
+        assertThat(config.agentName()).isEqualTo("customAgent");
+        assertThat(config.checkpointPolicy()).isEqualTo(CheckpointPolicy.AFTER_ROOT_CALL);
+        assertThat(config.labels()).containsEntry("team", "ml");
+        assertThat(config.timeout()).isEqualTo(timeout);
+    }
+
+    @Test
+    void should_build_with_retry_policy() {
+        RetryPolicy retryPolicy = RetryPolicy.builder()
+                .maxRetries(5)
+                .initialDelay(Duration.ofSeconds(2))
+                .build();
+
+        TaskConfiguration config = TaskConfiguration.builder()
+                .agentName("retryAgent")
+                .retryPolicy(retryPolicy)
+                .build();
+
+        assertThat(config.retryPolicy()).isNotNull();
+        assertThat(config.retryPolicy().maxRetries()).isEqualTo(5);
+        assertThat(config.retryPolicy().initialDelay()).isEqualTo(Duration.ofSeconds(2));
+    }
+
+    @Test
+    void should_have_null_retry_policy_by_default() {
+        TaskConfiguration config =
+                TaskConfiguration.builder().agentName("defaultAgent").build();
+
+        assertThat(config.retryPolicy()).isNull();
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/TaskIdTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/TaskIdTest.java
@@ -1,0 +1,52 @@
+package dev.langchain4j.experimental.durable.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class TaskIdTest {
+
+    @Test
+    void should_create_task_id_with_value() {
+        TaskId taskId = new TaskId("test-123");
+        assertThat(taskId.value()).isEqualTo("test-123");
+    }
+
+    @Test
+    void should_create_random_task_id() {
+        TaskId taskId = TaskId.random();
+        assertThat(taskId.value()).isNotBlank();
+    }
+
+    @Test
+    void should_generate_unique_random_ids() {
+        TaskId id1 = TaskId.random();
+        TaskId id2 = TaskId.random();
+        assertThat(id1).isNotEqualTo(id2);
+    }
+
+    @Test
+    void should_throw_when_value_is_null() {
+        assertThatThrownBy(() -> new TaskId(null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_throw_when_value_is_blank() {
+        assertThatThrownBy(() -> new TaskId("  ")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_have_meaningful_to_string() {
+        TaskId taskId = new TaskId("abc");
+        assertThat(taskId.toString()).contains("abc");
+    }
+
+    @Test
+    void should_be_equal_for_same_value() {
+        TaskId id1 = new TaskId("same");
+        TaskId id2 = new TaskId("same");
+        assertThat(id1).isEqualTo(id2);
+        assertThat(id1.hashCode()).isEqualTo(id2.hashCode());
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/TaskMetadataTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/TaskMetadataTest.java
@@ -1,0 +1,70 @@
+package dev.langchain4j.experimental.durable.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TaskMetadataTest {
+
+    @Test
+    void should_create_metadata_with_factory_method() {
+        TaskId taskId = TaskId.random();
+        TaskMetadata metadata = TaskMetadata.create(taskId, "testAgent", Map.of("env", "test"));
+
+        assertThat(metadata.id()).isEqualTo(taskId);
+        assertThat(metadata.agentName()).isEqualTo("testAgent");
+        assertThat(metadata.status()).isEqualTo(TaskStatus.PENDING);
+        assertThat(metadata.labels()).containsEntry("env", "test");
+        assertThat(metadata.createdAt()).isNotNull();
+        assertThat(metadata.updatedAt()).isNotNull();
+        assertThat(metadata.failureReason()).isNull();
+    }
+
+    @Test
+    void should_transition_to_running() {
+        TaskMetadata metadata = TaskMetadata.create(TaskId.random(), "agent", Map.of());
+        metadata.transitionTo(TaskStatus.RUNNING);
+        assertThat(metadata.status()).isEqualTo(TaskStatus.RUNNING);
+    }
+
+    @Test
+    void should_transition_to_failed_with_reason() {
+        TaskMetadata metadata = TaskMetadata.create(TaskId.random(), "agent", Map.of());
+        metadata.transitionTo(TaskStatus.RUNNING);
+        metadata.transitionTo(TaskStatus.FAILED, "Connection timeout");
+
+        assertThat(metadata.status()).isEqualTo(TaskStatus.FAILED);
+        assertThat(metadata.failureReason()).isEqualTo("Connection timeout");
+    }
+
+    @Test
+    void should_not_transition_from_terminal_state() {
+        TaskMetadata metadata = TaskMetadata.create(TaskId.random(), "agent", Map.of());
+        metadata.transitionTo(TaskStatus.COMPLETED);
+
+        assertThatThrownBy(() -> metadata.transitionTo(TaskStatus.RUNNING))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("terminal");
+    }
+
+    @Test
+    void should_update_timestamp_on_transition() {
+        TaskMetadata metadata = TaskMetadata.create(TaskId.random(), "agent", Map.of());
+        java.time.Instant before = metadata.updatedAt();
+
+        // Small delay to ensure timestamp changes
+        metadata.transitionTo(TaskStatus.RUNNING);
+
+        assertThat(metadata.updatedAt()).isAfterOrEqualTo(before);
+    }
+
+    @Test
+    void should_have_unmodifiable_labels() {
+        TaskMetadata metadata = TaskMetadata.create(TaskId.random(), "agent", Map.of("key", "value"));
+
+        assertThatThrownBy(() -> metadata.labels().put("new", "value"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/TaskPausedExceptionTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/TaskPausedExceptionTest.java
@@ -1,0 +1,55 @@
+package dev.langchain4j.experimental.durable.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TaskPausedExceptionTest {
+
+    @Test
+    void should_create_with_reason_and_pending_key() {
+        TaskPausedException ex = new TaskPausedException("Need approval", "approvalKey");
+
+        assertThat(ex.reason()).isEqualTo("Need approval");
+        assertThat(ex.pendingOutputKey()).isEqualTo("approvalKey");
+        assertThat(ex.getMessage()).contains("Need approval");
+    }
+
+    @Test
+    void should_create_with_reason_only() {
+        TaskPausedException ex = new TaskPausedException("Waiting for data");
+
+        assertThat(ex.reason()).isEqualTo("Waiting for data");
+        assertThat(ex.pendingOutputKey()).isNull();
+    }
+
+    @Test
+    void should_include_reason_in_message() {
+        TaskPausedException ex = new TaskPausedException("External callback pending", "callbackResult");
+
+        assertThat(ex.getMessage()).isEqualTo("Task paused: External callback pending");
+    }
+
+    @Test
+    void should_be_instance_of_lang_chain4j_exception() {
+        TaskPausedException ex = new TaskPausedException("paused");
+
+        assertThat(ex).isInstanceOf(dev.langchain4j.exception.LangChain4jException.class);
+    }
+
+    @Test
+    void should_have_null_pending_key_when_single_arg_constructor_used() {
+        TaskPausedException ex = new TaskPausedException("batch job paused");
+
+        assertThat(ex.pendingOutputKey()).isNull();
+        assertThat(ex.reason()).isEqualTo("batch job paused");
+    }
+
+    @Test
+    void not_retryable_by_default_retry_policy() {
+        TaskPausedException ex = new TaskPausedException("paused");
+        RetryPolicy policy = RetryPolicy.builder().build();
+
+        assertThat(policy.isRetryable(ex)).isFalse();
+    }
+}

--- a/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/TaskStatusTest.java
+++ b/experimental/langchain4j-experimental-durable-tasks/src/test/java/dev/langchain4j/experimental/durable/task/TaskStatusTest.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.experimental.durable.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TaskStatusTest {
+
+    @Test
+    void should_identify_terminal_states() {
+        assertThat(TaskStatus.COMPLETED.isTerminal()).isTrue();
+        assertThat(TaskStatus.FAILED.isTerminal()).isTrue();
+        assertThat(TaskStatus.CANCELLED.isTerminal()).isTrue();
+    }
+
+    @Test
+    void should_identify_non_terminal_states() {
+        assertThat(TaskStatus.PENDING.isTerminal()).isFalse();
+        assertThat(TaskStatus.RUNNING.isTerminal()).isFalse();
+        assertThat(TaskStatus.PAUSED.isTerminal()).isFalse();
+        assertThat(TaskStatus.RETRYING.isTerminal()).isFalse();
+    }
+}

--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -575,6 +575,11 @@
             </dependency>
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-experimental-durable-tasks</artifactId>
+                <version>${langchain4j.beta.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-agentic</artifactId>
                 <version>${langchain4j.beta.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
 
         <!-- experimental -->
         <module>experimental/langchain4j-experimental-sql</module>
+        <module>experimental/langchain4j-experimental-durable-tasks</module>
         <module>langchain4j-agentic</module>
         <module>langchain4j-agentic-a2a</module>
         <module>langchain4j-agentic-patterns</module>


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

After working on this for a while, this is the first PR that delivers a fully working implementation of a durable long-lived task execution layer. I hope to continue contributing more improvements and refinements in the near future.

CC @dliubarskyi — would love your feedback on the design and API surface.
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #4637

## Change
<!-- Please describe the changes you made. -->

This PR introduces a new **experimental** module — `langchain4j-experimental-durable-tasks` — that adds a durable, resumable, long-lived task execution layer for agentic workflows.

### New module: `experimental/langchain4j-experimental-durable-tasks`

| Package | Key Classes | Purpose |
|---------|-------------|---------|
| `task` | `TaskHandle`, `TaskId`, `TaskStatus`, `TaskMetadata`, `TaskConfiguration`, `CheckpointPolicy`, `RetryPolicy` | Public API & value objects |
| `store` | `TaskExecutionStore`, `InMemoryTaskExecutionStore`, `Checkpoint` | Pluggable persistence with store-atomic CAS |
| `store.file` | `FileTaskExecutionStore` | File-system backed store |
| `store.event` | `TaskEvent` hierarchy (10 event types) | Full event sourcing |
| `journal` | `JournalingAgentListener` | Records tool calls & LLM responses during execution |
| `replay` | `ReplayingPlanner` | Replays journaled decisions on resume |
| `hitl` | `DurableHumanInTheLoop` | Human-in-the-loop with pause/resume support |
| `internal` | `CheckpointManager`, `DefaultTaskHandle`, `ObjectMapperFactory` | Internal wiring |
| (root) | `LongLivedTaskService` | Main orchestrator — submit, pause, resume, cancel, retry |

### Key design decisions

- **Store-atomic CAS** — All status transitions use `compareAndSetStatus()` at the store level, eliminating race windows between read and write.
- **Checkpoint + journal replay** — On resume, the last checkpoint is loaded and the journal is replayed through `ReplayingPlanner`, so the agent fast-forwards past already-completed steps.
- **Event sourcing** — Every lifecycle transition emits a typed `TaskEvent`, enabling audit trails and external integrations.
- **No external dependencies** — Only depends on `langchain4j-core` + Jackson (already in the dependency tree).

### Task lifecycle

```
PENDING → RUNNING → COMPLETED
              ↓          ↑
           PAUSED → RUNNING
              ↓
          CANCELLED

RUNNING → FAILED → RUNNING (retry)
                  → CANCELLED
```

### Stats

- **40** main source files, **15** test files
- **6,219** lines of code
- **151** tests — all passing

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`
