### PR TITLE
Add opt-in auto-recovery for orphaned tool messages in ChatMemory

### DIFF
--- a/docs/docs/tutorials/chat-memory.md
+++ b/docs/docs/tutorials/chat-memory.md
@@ -126,6 +126,23 @@ the following orphan `ToolExecutionResultMessage`(s) are also automatically evic
 to avoid problems with some LLM providers (such as OpenAI)
 that prohibit sending orphan `ToolExecutionResultMessage`(s) in the request.
 
+If an application restarts or fails while tool execution is in progress,
+the chat memory can contain an incomplete tool-call block. In this case, later LLM requests can fail because
+some providers require every tool call to have a matching tool result. You can enable opt-in recovery:
+
+```java
+ChatMemory chatMemory = MessageWindowChatMemory.builder()
+        .maxMessages(10)
+        .chatMemoryStore(chatMemoryStore)
+        .autoRecoverOrphanedToolMessages(true)
+        .build();
+```
+
+The same option is available on `TokenWindowChatMemory`. When enabled, orphaned tool-related messages are removed
+from the messages returned by `messages()`. Stale orphaned tool messages are also removed before adding new
+non-tool-result messages, so they do not affect window capacity. In-flight tool blocks are preserved while tool
+results are being added.
+
 ## Examples
 - With `AiServices`:
   - [Chat memory](https://github.com/langchain4j/langchain4j-examples/blob/main/other-examples/src/main/java/ServiceWithMemoryExample.java)

--- a/docs/docs/tutorials/chat-memory.md
+++ b/docs/docs/tutorials/chat-memory.md
@@ -126,9 +126,8 @@ the following orphan `ToolExecutionResultMessage`(s) are also automatically evic
 to avoid problems with some LLM providers (such as OpenAI)
 that prohibit sending orphan `ToolExecutionResultMessage`(s) in the request.
 
-If an application restarts or fails while tool execution is in progress,
-the chat memory can contain an incomplete tool-call block. In this case, later LLM requests can fail because
-some providers require every tool call to have a matching tool result. You can enable opt-in recovery:
+If tool execution is interrupted, chat memory can contain tool calls without all required results.
+Opt-in recovery removes those incomplete tool calls from later model requests:
 
 ```java
 ChatMemory chatMemory = MessageWindowChatMemory.builder()
@@ -138,10 +137,9 @@ ChatMemory chatMemory = MessageWindowChatMemory.builder()
         .build();
 ```
 
-The same option is available on `TokenWindowChatMemory`. When enabled, orphaned tool-related messages are removed
-from the messages returned by `messages()`. Stale orphaned tool messages are also removed before adding new
-non-tool-result messages, so they do not affect window capacity. In-flight tool blocks are preserved while tool
-results are being added.
+The option is disabled by default and is also available on `TokenWindowChatMemory`. Calling `messages()` returns a
+cleaned view without updating the store. A later non-result message persists the cleanup; tool result messages
+preserve in-flight tool executions.
 
 ## Examples
 - With `AiServices`:

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/ChatMemoryUtils.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/ChatMemoryUtils.java
@@ -1,0 +1,179 @@
+package dev.langchain4j.memory.chat;
+
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+
+import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+
+/**
+ * Utility methods for cleaning up orphaned tool-related messages in chat memory.
+ *
+ * @since 1.15.0
+ */
+@Internal
+class ChatMemoryUtils {
+
+    private ChatMemoryUtils() {}
+
+    /**
+     * Removes orphaned tool-related messages from the given list (mutates in place).
+     *
+     * <p>A valid tool block is defined as an {@link AiMessage} with
+     * {@code hasToolExecutionRequests() == true}, immediately followed by enough
+     * consecutive {@link ToolExecutionResultMessage}(s) to match the
+     * {@link ToolExecutionRequest}(s).
+     * When tool call IDs are available, completeness is determined by matching each
+     * {@link ToolExecutionResultMessage#id()} to a corresponding
+     * {@link ToolExecutionRequest#id()}. When IDs are unavailable, completeness falls
+     * back to the existing contiguous-count behavior. Excess or non-matching results
+     * are removed.
+     *
+     * <p>Any tool-related messages that do not belong to a valid tool block are removed:
+     * <ul>
+     *   <li>An {@link AiMessage} with tool requests followed by fewer than the expected number of
+     *       contiguous {@link ToolExecutionResultMessage}(s)
+     *       (the {@code AiMessage} and any partial results are removed)</li>
+     *   <li>An {@link AiMessage} with tool requests followed by
+     *       {@link ToolExecutionResultMessage}(s) whose IDs do not match the requested tool call IDs</li>
+     *   <li>A standalone {@link ToolExecutionResultMessage} not preceded by an
+     *       {@link AiMessage} with tool requests</li>
+     *   <li>Excess {@link ToolExecutionResultMessage}(s) beyond the expected count</li>
+     * </ul>
+     *
+     * <p>This mirrors the existing forward-direction orphan cleanup in
+     * {@code ensureCapacity()}, which removes orphan {@code ToolExecutionResultMessage}(s)
+     * when the preceding {@code AiMessage} is evicted due to window overflow.
+     *
+     * @param messages the mutable list of messages to clean up
+     */
+    static void removeOrphanedToolMessages(List<ChatMessage> messages) {
+        if (messages.isEmpty()) {
+            return;
+        }
+
+        List<ChatMessage> cleaned = new LinkedList<>();
+        ListIterator<ChatMessage> cursor = messages.listIterator();
+
+        while (cursor.hasNext()) {
+            ChatMessage current = cursor.next();
+
+            // Standalone ToolExecutionResultMessage without a preceding AiMessage: orphan
+            if (current instanceof ToolExecutionResultMessage) {
+                continue; // skip (remove)
+            }
+
+            // AiMessage with tool execution requests: parse as a tool block
+            if (current instanceof AiMessage aiMessage && aiMessage.hasToolExecutionRequests()) {
+                List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
+                int expectedResults = toolExecutionRequests.size();
+                List<ToolExecutionResultMessage> contiguousResults = new LinkedList<>();
+
+                // Collect consecutive ToolExecutionResultMessages following this AiMessage
+                while (cursor.hasNext()) {
+                    ChatMessage next = cursor.next();
+                    if (next instanceof ToolExecutionResultMessage resultMessage) {
+                        contiguousResults.add(resultMessage);
+                    } else {
+                        // Not a ToolExecutionResultMessage, push back for the outer loop
+                        cursor.previous();
+                        break;
+                    }
+                }
+
+                if (contiguousResults.size() < expectedResults) {
+                    // Incomplete block: skip the AiMessage and all partial results (remove)
+                    continue;
+                }
+
+                List<ToolExecutionResultMessage> resultsToKeep =
+                        resultsMatchingRequests(toolExecutionRequests, contiguousResults);
+                if (resultsToKeep.isEmpty()) {
+                    // Mismatched block: skip the AiMessage and all contiguous results (remove)
+                    continue;
+                }
+
+                // Complete block (or more): keep AiMessage + matching results
+                cleaned.add(aiMessage);
+                cleaned.addAll(resultsToKeep);
+                // Any excess or non-matching results are silently dropped
+                continue;
+            }
+
+            // All other messages (SystemMessage, UserMessage, AiMessage without tools): keep
+            cleaned.add(current);
+        }
+
+        messages.clear();
+        messages.addAll(cleaned);
+    }
+
+    private static List<ToolExecutionResultMessage> resultsMatchingRequests(
+            List<ToolExecutionRequest> requests, List<ToolExecutionResultMessage> results) {
+        RequestIdStatus requestIdStatus = requestIdStatus(requests);
+        if (requestIdStatus == RequestIdStatus.UNAVAILABLE) {
+            return results.subList(0, requests.size());
+        }
+        if (requestIdStatus == RequestIdStatus.INVALID) {
+            return List.of();
+        }
+
+        List<ToolExecutionResultMessage> matchingResults = new ArrayList<>();
+        for (ToolExecutionRequest request : requests) {
+            ToolExecutionResultMessage matchingResult = firstResultWithId(request.id(), results);
+            if (matchingResult == null) {
+                return List.of();
+            }
+            matchingResults.add(matchingResult);
+        }
+
+        return matchingResults;
+    }
+
+    private static RequestIdStatus requestIdStatus(List<ToolExecutionRequest> requests) {
+        Set<String> requestIds = new LinkedHashSet<>();
+        int requestIdsAvailable = 0;
+        for (ToolExecutionRequest request : requests) {
+            String id = request.id();
+            if (!isNullOrBlank(id)) {
+                requestIdsAvailable++;
+                if (!requestIds.add(id)) {
+                    return RequestIdStatus.INVALID;
+                }
+            }
+        }
+
+        if (requestIdsAvailable == 0) {
+            return RequestIdStatus.UNAVAILABLE;
+        }
+        if (requestIdsAvailable == requests.size()) {
+            return RequestIdStatus.AVAILABLE;
+        }
+
+        return RequestIdStatus.INVALID;
+    }
+
+    private static ToolExecutionResultMessage firstResultWithId(String id, List<ToolExecutionResultMessage> results) {
+        for (ToolExecutionResultMessage result : results) {
+            if (id.equals(result.id())) {
+                return result;
+            }
+        }
+
+        return null;
+    }
+
+    private enum RequestIdStatus {
+        AVAILABLE,
+        UNAVAILABLE,
+        INVALID
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/ChatMemoryUtils.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/ChatMemoryUtils.java
@@ -7,173 +7,75 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
 
-/**
- * Utility methods for cleaning up orphaned tool-related messages in chat memory.
- *
- * @since 1.20.0
- */
+/** Utilities for recovering interrupted tool executions in chat memory. */
 @Internal
 class ChatMemoryUtils {
 
     private ChatMemoryUtils() {}
 
     /**
-     * Removes orphaned tool-related messages from the given list (mutates in place).
+     * Removes incomplete tool execution blocks from the entire message history.
      *
-     * <p>A valid tool block is defined as an {@link AiMessage} with
-     * {@code hasToolExecutionRequests() == true}, immediately followed by enough
-     * consecutive {@link ToolExecutionResultMessage}(s) to match the
-     * {@link ToolExecutionRequest}(s).
-     * When tool call IDs are available, completeness is determined by matching each
-     * {@link ToolExecutionResultMessage#id()} to a corresponding
-     * {@link ToolExecutionRequest#id()}. When IDs are unavailable, completeness falls
-     * back to the existing contiguous-count behavior. Excess or non-matching results
-     * are removed.
-     *
-     * <p>Any tool-related messages that do not belong to a valid tool block are removed:
-     * <ul>
-     *   <li>An {@link AiMessage} with tool requests followed by fewer than the expected number of
-     *       contiguous {@link ToolExecutionResultMessage}(s)
-     *       (the {@code AiMessage} and any partial results are removed)</li>
-     *   <li>An {@link AiMessage} with tool requests followed by
-     *       {@link ToolExecutionResultMessage}(s) whose IDs do not match the requested tool call IDs</li>
-     *   <li>A standalone {@link ToolExecutionResultMessage} not preceded by an
-     *       {@link AiMessage} with tool requests</li>
-     *   <li>Excess {@link ToolExecutionResultMessage}(s) beyond the expected count</li>
-     * </ul>
-     *
-     * <p>This mirrors the existing forward-direction orphan cleanup in
-     * {@code ensureCapacity()}, which removes orphan {@code ToolExecutionResultMessage}(s)
-     * when the preceding {@code AiMessage} is evicted due to window overflow.
-     *
-     * @param messages the mutable list of messages to clean up
+     * <p>A block is incomplete when an {@link AiMessage} with tool requests is followed by too few
+     * consecutive {@link ToolExecutionResultMessage}s, or when equally sized request and result
+     * lists have complete, unique IDs that do not match.
      */
-    static void removeOrphanedToolMessages(List<ChatMessage> messages) {
-        if (messages.isEmpty()) {
-            return;
-        }
-
-        List<ChatMessage> cleaned = new LinkedList<>();
+    static void removeInterruptedToolExecutions(List<ChatMessage> messages) {
         ListIterator<ChatMessage> cursor = messages.listIterator();
 
         while (cursor.hasNext()) {
             ChatMessage current = cursor.next();
-
-            // Standalone ToolExecutionResultMessage without a preceding AiMessage: orphan
-            if (current instanceof ToolExecutionResultMessage) {
-                continue; // skip (remove)
-            }
-
-            // AiMessage with tool execution requests: parse as a tool block
-            if (current instanceof AiMessage aiMessage && aiMessage.hasToolExecutionRequests()) {
-                List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
-                int expectedResults = toolExecutionRequests.size();
-                List<ToolExecutionResultMessage> contiguousResults = new LinkedList<>();
-
-                // Collect consecutive ToolExecutionResultMessages following this AiMessage
-                while (cursor.hasNext()) {
-                    ChatMessage next = cursor.next();
-                    if (next instanceof ToolExecutionResultMessage resultMessage) {
-                        contiguousResults.add(resultMessage);
-                    } else {
-                        // Not a ToolExecutionResultMessage, push back for the outer loop
-                        cursor.previous();
-                        break;
-                    }
-                }
-
-                if (contiguousResults.size() < expectedResults) {
-                    // Incomplete block: skip the AiMessage and all partial results (remove)
-                    continue;
-                }
-
-                List<ToolExecutionResultMessage> resultsToKeep =
-                        resultsMatchingRequests(toolExecutionRequests, contiguousResults);
-                if (resultsToKeep.isEmpty()) {
-                    // Mismatched block: skip the AiMessage and all contiguous results (remove)
-                    continue;
-                }
-
-                // Complete block (or more): keep AiMessage + matching results
-                cleaned.add(aiMessage);
-                cleaned.addAll(resultsToKeep);
-                // Any excess or non-matching results are silently dropped
+            if (!(current instanceof AiMessage aiMessage) || !aiMessage.hasToolExecutionRequests()) {
                 continue;
             }
 
-            // All other messages (SystemMessage, UserMessage, AiMessage without tools): keep
-            cleaned.add(current);
-        }
+            List<ToolExecutionRequest> requests = aiMessage.toolExecutionRequests();
+            Set<String> resultIds = new HashSet<>();
+            boolean resultIdsReliable = true;
+            int resultCount = 0;
 
-        messages.clear();
-        messages.addAll(cleaned);
-    }
-
-    private static List<ToolExecutionResultMessage> resultsMatchingRequests(
-            List<ToolExecutionRequest> requests, List<ToolExecutionResultMessage> results) {
-        RequestIdStatus requestIdStatus = requestIdStatus(requests);
-        if (requestIdStatus == RequestIdStatus.UNAVAILABLE) {
-            return results.subList(0, requests.size());
-        }
-        if (requestIdStatus == RequestIdStatus.INVALID) {
-            return List.of();
-        }
-
-        List<ToolExecutionResultMessage> matchingResults = new ArrayList<>();
-        for (ToolExecutionRequest request : requests) {
-            ToolExecutionResultMessage matchingResult = firstResultWithId(request.id(), results);
-            if (matchingResult == null) {
-                return List.of();
+            while (cursor.hasNext()) {
+                ChatMessage next = cursor.next();
+                if (next instanceof ToolExecutionResultMessage resultMessage) {
+                    resultCount++;
+                    if (isNullOrBlank(resultMessage.id()) || !resultIds.add(resultMessage.id())) {
+                        resultIdsReliable = false;
+                    }
+                } else {
+                    cursor.previous();
+                    break;
+                }
             }
-            matchingResults.add(matchingResult);
-        }
 
-        return matchingResults;
-    }
-
-    private static RequestIdStatus requestIdStatus(List<ToolExecutionRequest> requests) {
-        Set<String> requestIds = new LinkedHashSet<>();
-        int requestIdsAvailable = 0;
-        for (ToolExecutionRequest request : requests) {
-            String id = request.id();
-            if (!isNullOrBlank(id)) {
-                requestIdsAvailable++;
-                if (!requestIds.add(id)) {
-                    return RequestIdStatus.INVALID;
+            if (isInterrupted(requests, resultCount, resultIds, resultIdsReliable)) {
+                for (int i = 0; i <= resultCount; i++) {
+                    cursor.previous();
+                    cursor.remove();
                 }
             }
         }
-
-        if (requestIdsAvailable == 0) {
-            return RequestIdStatus.UNAVAILABLE;
-        }
-        if (requestIdsAvailable == requests.size()) {
-            return RequestIdStatus.AVAILABLE;
-        }
-
-        return RequestIdStatus.INVALID;
     }
 
-    private static ToolExecutionResultMessage firstResultWithId(String id, List<ToolExecutionResultMessage> results) {
-        for (ToolExecutionResultMessage result : results) {
-            if (id.equals(result.id())) {
-                return result;
+    private static boolean isInterrupted(
+            List<ToolExecutionRequest> requests, int resultCount, Set<String> resultIds, boolean resultIdsReliable) {
+        if (resultCount < requests.size()) {
+            return true;
+        }
+        if (resultCount > requests.size() || !resultIdsReliable) {
+            return false;
+        }
+
+        Set<String> requestIds = new HashSet<>();
+        for (ToolExecutionRequest request : requests) {
+            if (isNullOrBlank(request.id()) || !requestIds.add(request.id())) {
+                return false;
             }
         }
-
-        return null;
-    }
-
-    private enum RequestIdStatus {
-        AVAILABLE,
-        UNAVAILABLE,
-        INVALID
+        return !requestIds.equals(resultIds);
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/ChatMemoryUtils.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/ChatMemoryUtils.java
@@ -1,0 +1,179 @@
+package dev.langchain4j.memory.chat;
+
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+
+import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+
+/**
+ * Utility methods for cleaning up orphaned tool-related messages in chat memory.
+ *
+ * @since 1.20.0
+ */
+@Internal
+class ChatMemoryUtils {
+
+    private ChatMemoryUtils() {}
+
+    /**
+     * Removes orphaned tool-related messages from the given list (mutates in place).
+     *
+     * <p>A valid tool block is defined as an {@link AiMessage} with
+     * {@code hasToolExecutionRequests() == true}, immediately followed by enough
+     * consecutive {@link ToolExecutionResultMessage}(s) to match the
+     * {@link ToolExecutionRequest}(s).
+     * When tool call IDs are available, completeness is determined by matching each
+     * {@link ToolExecutionResultMessage#id()} to a corresponding
+     * {@link ToolExecutionRequest#id()}. When IDs are unavailable, completeness falls
+     * back to the existing contiguous-count behavior. Excess or non-matching results
+     * are removed.
+     *
+     * <p>Any tool-related messages that do not belong to a valid tool block are removed:
+     * <ul>
+     *   <li>An {@link AiMessage} with tool requests followed by fewer than the expected number of
+     *       contiguous {@link ToolExecutionResultMessage}(s)
+     *       (the {@code AiMessage} and any partial results are removed)</li>
+     *   <li>An {@link AiMessage} with tool requests followed by
+     *       {@link ToolExecutionResultMessage}(s) whose IDs do not match the requested tool call IDs</li>
+     *   <li>A standalone {@link ToolExecutionResultMessage} not preceded by an
+     *       {@link AiMessage} with tool requests</li>
+     *   <li>Excess {@link ToolExecutionResultMessage}(s) beyond the expected count</li>
+     * </ul>
+     *
+     * <p>This mirrors the existing forward-direction orphan cleanup in
+     * {@code ensureCapacity()}, which removes orphan {@code ToolExecutionResultMessage}(s)
+     * when the preceding {@code AiMessage} is evicted due to window overflow.
+     *
+     * @param messages the mutable list of messages to clean up
+     */
+    static void removeOrphanedToolMessages(List<ChatMessage> messages) {
+        if (messages.isEmpty()) {
+            return;
+        }
+
+        List<ChatMessage> cleaned = new LinkedList<>();
+        ListIterator<ChatMessage> cursor = messages.listIterator();
+
+        while (cursor.hasNext()) {
+            ChatMessage current = cursor.next();
+
+            // Standalone ToolExecutionResultMessage without a preceding AiMessage: orphan
+            if (current instanceof ToolExecutionResultMessage) {
+                continue; // skip (remove)
+            }
+
+            // AiMessage with tool execution requests: parse as a tool block
+            if (current instanceof AiMessage aiMessage && aiMessage.hasToolExecutionRequests()) {
+                List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
+                int expectedResults = toolExecutionRequests.size();
+                List<ToolExecutionResultMessage> contiguousResults = new LinkedList<>();
+
+                // Collect consecutive ToolExecutionResultMessages following this AiMessage
+                while (cursor.hasNext()) {
+                    ChatMessage next = cursor.next();
+                    if (next instanceof ToolExecutionResultMessage resultMessage) {
+                        contiguousResults.add(resultMessage);
+                    } else {
+                        // Not a ToolExecutionResultMessage, push back for the outer loop
+                        cursor.previous();
+                        break;
+                    }
+                }
+
+                if (contiguousResults.size() < expectedResults) {
+                    // Incomplete block: skip the AiMessage and all partial results (remove)
+                    continue;
+                }
+
+                List<ToolExecutionResultMessage> resultsToKeep =
+                        resultsMatchingRequests(toolExecutionRequests, contiguousResults);
+                if (resultsToKeep.isEmpty()) {
+                    // Mismatched block: skip the AiMessage and all contiguous results (remove)
+                    continue;
+                }
+
+                // Complete block (or more): keep AiMessage + matching results
+                cleaned.add(aiMessage);
+                cleaned.addAll(resultsToKeep);
+                // Any excess or non-matching results are silently dropped
+                continue;
+            }
+
+            // All other messages (SystemMessage, UserMessage, AiMessage without tools): keep
+            cleaned.add(current);
+        }
+
+        messages.clear();
+        messages.addAll(cleaned);
+    }
+
+    private static List<ToolExecutionResultMessage> resultsMatchingRequests(
+            List<ToolExecutionRequest> requests, List<ToolExecutionResultMessage> results) {
+        RequestIdStatus requestIdStatus = requestIdStatus(requests);
+        if (requestIdStatus == RequestIdStatus.UNAVAILABLE) {
+            return results.subList(0, requests.size());
+        }
+        if (requestIdStatus == RequestIdStatus.INVALID) {
+            return List.of();
+        }
+
+        List<ToolExecutionResultMessage> matchingResults = new ArrayList<>();
+        for (ToolExecutionRequest request : requests) {
+            ToolExecutionResultMessage matchingResult = firstResultWithId(request.id(), results);
+            if (matchingResult == null) {
+                return List.of();
+            }
+            matchingResults.add(matchingResult);
+        }
+
+        return matchingResults;
+    }
+
+    private static RequestIdStatus requestIdStatus(List<ToolExecutionRequest> requests) {
+        Set<String> requestIds = new LinkedHashSet<>();
+        int requestIdsAvailable = 0;
+        for (ToolExecutionRequest request : requests) {
+            String id = request.id();
+            if (!isNullOrBlank(id)) {
+                requestIdsAvailable++;
+                if (!requestIds.add(id)) {
+                    return RequestIdStatus.INVALID;
+                }
+            }
+        }
+
+        if (requestIdsAvailable == 0) {
+            return RequestIdStatus.UNAVAILABLE;
+        }
+        if (requestIdsAvailable == requests.size()) {
+            return RequestIdStatus.AVAILABLE;
+        }
+
+        return RequestIdStatus.INVALID;
+    }
+
+    private static ToolExecutionResultMessage firstResultWithId(String id, List<ToolExecutionResultMessage> results) {
+        for (ToolExecutionResultMessage result : results) {
+            if (id.equals(result.id())) {
+                return result;
+            }
+        }
+
+        return null;
+    }
+
+    private enum RequestIdStatus {
+        AVAILABLE,
+        UNAVAILABLE,
+        INVALID
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -13,7 +13,6 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -51,6 +50,7 @@ public class MessageWindowChatMemory implements ChatMemory {
     private final Function<Object, Integer> maxMessagesProvider;
     private final ChatMemoryStore store;
     private final boolean alwaysKeepSystemMessageFirst;
+    private final boolean autoRecoverOrphanedToolMessages;
 
     private MessageWindowChatMemory(Builder builder) {
         this.id = ensureNotNull(builder.id, "id");
@@ -58,6 +58,7 @@ public class MessageWindowChatMemory implements ChatMemory {
         ensureGreaterThanZero(this.maxMessagesProvider.apply(this.id), "maxMessages");
         this.store = ensureNotNull(builder.store(), "store");
         this.alwaysKeepSystemMessageFirst = getOrDefault(builder.alwaysKeepSystemMessageFirst, false);
+        this.autoRecoverOrphanedToolMessages = getOrDefault(builder.autoRecoverOrphanedToolMessages, false);
     }
 
     @Override
@@ -67,7 +68,7 @@ public class MessageWindowChatMemory implements ChatMemory {
 
     @Override
     public void add(ChatMessage message) {
-        List<ChatMessage> messages = messages();
+        List<ChatMessage> messages = messagesForAdd(message);
 
         if (message instanceof SystemMessage) {
             Optional<SystemMessage> systemMessage = SystemMessage.findFirst(messages);
@@ -93,6 +94,17 @@ public class MessageWindowChatMemory implements ChatMemory {
         store.updateMessages(id, messages);
     }
 
+    private List<ChatMessage> messagesForAdd(ChatMessage message) {
+        if (autoRecoverOrphanedToolMessages) {
+            List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
+            if (!(message instanceof ToolExecutionResultMessage)) {
+                ChatMemoryUtils.removeOrphanedToolMessages(messages);
+            }
+            return messages;
+        }
+        return messages();
+    }
+
     @Override
     public void set(Iterable<ChatMessage> iter) {
         if (iter instanceof List) {
@@ -116,6 +128,9 @@ public class MessageWindowChatMemory implements ChatMemory {
         Integer maxMessages = this.maxMessagesProvider.apply(this.id);
         ensureGreaterThanZero(maxMessages, "maxMessages");
         List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
+        if (autoRecoverOrphanedToolMessages) {
+            ChatMemoryUtils.removeOrphanedToolMessages(messages);
+        }
         ensureCapacity(messages, maxMessages);
         return messages;
     }
@@ -155,6 +170,7 @@ public class MessageWindowChatMemory implements ChatMemory {
         private Function<Object, Integer> maxMessagesProvider;
         private ChatMemoryStore store;
         private Boolean alwaysKeepSystemMessageFirst;
+        private Boolean autoRecoverOrphanedToolMessages;
 
         /**
          * @param id The ID of the {@link ChatMemory}.
@@ -207,6 +223,34 @@ public class MessageWindowChatMemory implements ChatMemory {
          */
         public Builder alwaysKeepSystemMessageFirst(Boolean alwaysKeepSystemMessageFirst) {
             this.alwaysKeepSystemMessageFirst = alwaysKeepSystemMessageFirst;
+            return this;
+        }
+
+        /**
+         * When enabled, orphaned tool-related messages are automatically removed
+         * when {@link ChatMemory#messages()} is called. Stale orphaned tool messages
+         * are also removed before adding new non-tool-result messages, so they do not
+         * affect window capacity. In-flight tool blocks are preserved while adding
+         * {@link ToolExecutionResultMessage}(s).
+         * <p>
+         * An {@link AiMessage} with {@link ToolExecutionRequest}(s) is considered orphaned
+         * if it is not immediately followed by the expected number of contiguous
+         * {@link ToolExecutionResultMessage}(s), or when the available tool call IDs do not match.
+         * Standalone {@link ToolExecutionResultMessage}(s) that are not part of a complete tool block
+         * are also removed.
+         * <p>
+         * This typically happens when the application restarts or an error occurs during
+         * tool execution, leaving the chat memory in an inconsistent state that causes
+         * LLM providers (such as OpenAI) to reject subsequent requests.
+         * <p>
+         * Disabled by default for backward compatibility.
+         *
+         * @param autoRecoverOrphanedToolMessages whether to automatically remove orphaned tool messages
+         * @return builder
+         * @since 1.15.0
+         */
+        public Builder autoRecoverOrphanedToolMessages(Boolean autoRecoverOrphanedToolMessages) {
+            this.autoRecoverOrphanedToolMessages = autoRecoverOrphanedToolMessages;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -50,6 +50,7 @@ public class MessageWindowChatMemory implements ChatMemory {
     private final Function<Object, Integer> maxMessagesProvider;
     private final ChatMemoryStore store;
     private final boolean alwaysKeepSystemMessageFirst;
+    private final boolean autoRecoverOrphanedToolMessages;
 
     private MessageWindowChatMemory(Builder builder) {
         this.id = ensureNotNull(builder.id, "id");
@@ -57,6 +58,7 @@ public class MessageWindowChatMemory implements ChatMemory {
         ensureGreaterThanZero(this.maxMessagesProvider.apply(this.id), "maxMessages");
         this.store = ensureNotNull(builder.store(), "store");
         this.alwaysKeepSystemMessageFirst = getOrDefault(builder.alwaysKeepSystemMessageFirst, false);
+        this.autoRecoverOrphanedToolMessages = getOrDefault(builder.autoRecoverOrphanedToolMessages, false);
     }
 
     @Override
@@ -66,7 +68,7 @@ public class MessageWindowChatMemory implements ChatMemory {
 
     @Override
     public void add(ChatMessage message) {
-        List<ChatMessage> messages = messages();
+        List<ChatMessage> messages = messagesForAdd(message);
 
         if (message instanceof SystemMessage) {
             Optional<SystemMessage> systemMessage = SystemMessage.findFirst(messages);
@@ -90,6 +92,17 @@ public class MessageWindowChatMemory implements ChatMemory {
         ensureCapacity(messages, maxMessages);
 
         store.updateMessages(id, messages);
+    }
+
+    private List<ChatMessage> messagesForAdd(ChatMessage message) {
+        if (autoRecoverOrphanedToolMessages) {
+            List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
+            if (!(message instanceof ToolExecutionResultMessage)) {
+                ChatMemoryUtils.removeOrphanedToolMessages(messages);
+            }
+            return messages;
+        }
+        return messages();
     }
 
     @Override
@@ -116,6 +129,9 @@ public class MessageWindowChatMemory implements ChatMemory {
         Integer maxMessages = this.maxMessagesProvider.apply(this.id);
         ensureGreaterThanZero(maxMessages, "maxMessages");
         List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
+        if (autoRecoverOrphanedToolMessages) {
+            ChatMemoryUtils.removeOrphanedToolMessages(messages);
+        }
         ensureCapacity(messages, maxMessages);
         return messages;
     }
@@ -155,6 +171,7 @@ public class MessageWindowChatMemory implements ChatMemory {
         private Function<Object, Integer> maxMessagesProvider;
         private ChatMemoryStore store;
         private Boolean alwaysKeepSystemMessageFirst;
+        private Boolean autoRecoverOrphanedToolMessages;
 
         /**
          * @param id The ID of the {@link ChatMemory}.
@@ -207,6 +224,34 @@ public class MessageWindowChatMemory implements ChatMemory {
          */
         public Builder alwaysKeepSystemMessageFirst(Boolean alwaysKeepSystemMessageFirst) {
             this.alwaysKeepSystemMessageFirst = alwaysKeepSystemMessageFirst;
+            return this;
+        }
+
+        /**
+         * When enabled, orphaned tool-related messages are automatically removed
+         * when {@link ChatMemory#messages()} is called. Stale orphaned tool messages
+         * are also removed before adding new non-tool-result messages, so they do not
+         * affect window capacity. In-flight tool blocks are preserved while adding
+         * {@link ToolExecutionResultMessage}(s).
+         * <p>
+         * An {@link AiMessage} with {@link ToolExecutionRequest}(s) is considered orphaned
+         * if it is not immediately followed by the expected number of contiguous
+         * {@link ToolExecutionResultMessage}(s), or when the available tool call IDs do not match.
+         * Standalone {@link ToolExecutionResultMessage}(s) that are not part of a complete tool block
+         * are also removed.
+         * <p>
+         * This typically happens when the application restarts or an error occurs during
+         * tool execution, leaving the chat memory in an inconsistent state that causes
+         * LLM providers (such as OpenAI) to reject subsequent requests.
+         * <p>
+         * Disabled by default for backward compatibility.
+         *
+         * @param autoRecoverOrphanedToolMessages whether to automatically remove orphaned tool messages
+         * @return builder
+         * @since 1.20.0
+         */
+        public Builder autoRecoverOrphanedToolMessages(Boolean autoRecoverOrphanedToolMessages) {
+            this.autoRecoverOrphanedToolMessages = autoRecoverOrphanedToolMessages;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -68,7 +68,9 @@ public class MessageWindowChatMemory implements ChatMemory {
 
     @Override
     public void add(ChatMessage message) {
-        List<ChatMessage> messages = messagesForAdd(message);
+        List<ChatMessage> messages = autoRecoverOrphanedToolMessages && message instanceof ToolExecutionResultMessage
+                ? new LinkedList<>(store.getMessages(id))
+                : messages();
 
         if (message instanceof SystemMessage) {
             Optional<SystemMessage> systemMessage = SystemMessage.findFirst(messages);
@@ -92,17 +94,6 @@ public class MessageWindowChatMemory implements ChatMemory {
         ensureCapacity(messages, maxMessages);
 
         store.updateMessages(id, messages);
-    }
-
-    private List<ChatMessage> messagesForAdd(ChatMessage message) {
-        if (autoRecoverOrphanedToolMessages) {
-            List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
-            if (!(message instanceof ToolExecutionResultMessage)) {
-                ChatMemoryUtils.removeOrphanedToolMessages(messages);
-            }
-            return messages;
-        }
-        return messages();
     }
 
     @Override
@@ -130,7 +121,7 @@ public class MessageWindowChatMemory implements ChatMemory {
         ensureGreaterThanZero(maxMessages, "maxMessages");
         List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
         if (autoRecoverOrphanedToolMessages) {
-            ChatMemoryUtils.removeOrphanedToolMessages(messages);
+            ChatMemoryUtils.removeInterruptedToolExecutions(messages);
         }
         ensureCapacity(messages, maxMessages);
         return messages;
@@ -228,25 +219,11 @@ public class MessageWindowChatMemory implements ChatMemory {
         }
 
         /**
-         * When enabled, orphaned tool-related messages are automatically removed
-         * when {@link ChatMemory#messages()} is called. Stale orphaned tool messages
-         * are also removed before adding new non-tool-result messages, so they do not
-         * affect window capacity. In-flight tool blocks are preserved while adding
-         * {@link ToolExecutionResultMessage}(s).
-         * <p>
-         * An {@link AiMessage} with {@link ToolExecutionRequest}(s) is considered orphaned
-         * if it is not immediately followed by the expected number of contiguous
-         * {@link ToolExecutionResultMessage}(s), or when the available tool call IDs do not match.
-         * Standalone {@link ToolExecutionResultMessage}(s) that are not part of a complete tool block
-         * are also removed.
-         * <p>
-         * This typically happens when the application restarts or an error occurs during
-         * tool execution, leaving the chat memory in an inconsistent state that causes
-         * LLM providers (such as OpenAI) to reject subsequent requests.
-         * <p>
-         * Disabled by default for backward compatibility.
+         * Removes interrupted tool calls from the messages returned by {@link ChatMemory#messages()}.
+         * A later non-result message persists the cleanup, while tool result messages preserve an
+         * in-flight tool execution. Disabled by default.
          *
-         * @param autoRecoverOrphanedToolMessages whether to automatically remove orphaned tool messages
+         * @param autoRecoverOrphanedToolMessages whether to remove interrupted tool calls
          * @return builder
          * @since 1.20.0
          */

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
@@ -14,7 +14,6 @@ import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -54,6 +53,7 @@ public class TokenWindowChatMemory implements ChatMemory {
     private final TokenCountEstimator tokenCountEstimator;
     private final ChatMemoryStore store;
     private final boolean alwaysKeepSystemMessageFirst;
+    private final boolean autoRecoverOrphanedToolMessages;
 
     private TokenWindowChatMemory(Builder builder) {
         this.id = ensureNotNull(builder.id, "id");
@@ -62,6 +62,7 @@ public class TokenWindowChatMemory implements ChatMemory {
         this.tokenCountEstimator = ensureNotNull(builder.tokenCountEstimator, "tokenCountEstimator");
         this.store = ensureNotNull(builder.store(), "store");
         this.alwaysKeepSystemMessageFirst = getOrDefault(builder.alwaysKeepSystemMessageFirst, false);
+        this.autoRecoverOrphanedToolMessages = getOrDefault(builder.autoRecoverOrphanedToolMessages, false);
     }
 
     @Override
@@ -71,7 +72,7 @@ public class TokenWindowChatMemory implements ChatMemory {
 
     @Override
     public void add(ChatMessage message) {
-        List<ChatMessage> messages = messages();
+        List<ChatMessage> messages = messagesForAdd(message);
 
         if (message instanceof SystemMessage) {
             Optional<SystemMessage> maybeSystemMessage = SystemMessage.findFirst(messages);
@@ -97,6 +98,17 @@ public class TokenWindowChatMemory implements ChatMemory {
         store.updateMessages(id, messages);
     }
 
+    private List<ChatMessage> messagesForAdd(ChatMessage message) {
+        if (autoRecoverOrphanedToolMessages) {
+            List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
+            if (!(message instanceof ToolExecutionResultMessage)) {
+                ChatMemoryUtils.removeOrphanedToolMessages(messages);
+            }
+            return messages;
+        }
+        return messages();
+    }
+
     @Override
     public void set(Iterable<ChatMessage> iter) {
         if (iter instanceof List) {
@@ -120,6 +132,9 @@ public class TokenWindowChatMemory implements ChatMemory {
         Integer maxTokens = maxTokensProvider.apply(id);
         ensureGreaterThanZero(maxTokens, "maxTokens");
         List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
+        if (autoRecoverOrphanedToolMessages) {
+            ChatMemoryUtils.removeOrphanedToolMessages(messages);
+        }
         ensureCapacity(messages, maxTokens, tokenCountEstimator);
         return messages;
     }
@@ -173,6 +188,7 @@ public class TokenWindowChatMemory implements ChatMemory {
         private TokenCountEstimator tokenCountEstimator;
         private ChatMemoryStore store;
         private Boolean alwaysKeepSystemMessageFirst;
+        private Boolean autoRecoverOrphanedToolMessages;
 
         /**
          * @param id The ID of the {@link ChatMemory}.
@@ -232,6 +248,34 @@ public class TokenWindowChatMemory implements ChatMemory {
          */
         public Builder alwaysKeepSystemMessageFirst(Boolean alwaysKeepSystemMessageFirst) {
             this.alwaysKeepSystemMessageFirst = alwaysKeepSystemMessageFirst;
+            return this;
+        }
+
+        /**
+         * When enabled, orphaned tool-related messages are automatically removed
+         * when {@link ChatMemory#messages()} is called. Stale orphaned tool messages
+         * are also removed before adding new non-tool-result messages, so they do not
+         * affect window capacity. In-flight tool blocks are preserved while adding
+         * {@link ToolExecutionResultMessage}(s).
+         * <p>
+         * An {@link AiMessage} with {@link ToolExecutionRequest}(s) is considered orphaned
+         * if it is not immediately followed by the expected number of contiguous
+         * {@link ToolExecutionResultMessage}(s), or when the available tool call IDs do not match.
+         * Standalone {@link ToolExecutionResultMessage}(s) that are not part of a complete tool block
+         * are also removed.
+         * <p>
+         * This typically happens when the application restarts or an error occurs during
+         * tool execution, leaving the chat memory in an inconsistent state that causes
+         * LLM providers (such as OpenAI) to reject subsequent requests.
+         * <p>
+         * Disabled by default for backward compatibility.
+         *
+         * @param autoRecoverOrphanedToolMessages whether to automatically remove orphaned tool messages
+         * @return builder
+         * @since 1.15.0
+         */
+        public Builder autoRecoverOrphanedToolMessages(Boolean autoRecoverOrphanedToolMessages) {
+            this.autoRecoverOrphanedToolMessages = autoRecoverOrphanedToolMessages;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
@@ -72,7 +72,9 @@ public class TokenWindowChatMemory implements ChatMemory {
 
     @Override
     public void add(ChatMessage message) {
-        List<ChatMessage> messages = messagesForAdd(message);
+        List<ChatMessage> messages = autoRecoverOrphanedToolMessages && message instanceof ToolExecutionResultMessage
+                ? new LinkedList<>(store.getMessages(id))
+                : messages();
 
         if (message instanceof SystemMessage) {
             Optional<SystemMessage> maybeSystemMessage = SystemMessage.findFirst(messages);
@@ -96,17 +98,6 @@ public class TokenWindowChatMemory implements ChatMemory {
         ensureCapacity(messages, maxTokens, tokenCountEstimator);
 
         store.updateMessages(id, messages);
-    }
-
-    private List<ChatMessage> messagesForAdd(ChatMessage message) {
-        if (autoRecoverOrphanedToolMessages) {
-            List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
-            if (!(message instanceof ToolExecutionResultMessage)) {
-                ChatMemoryUtils.removeOrphanedToolMessages(messages);
-            }
-            return messages;
-        }
-        return messages();
     }
 
     @Override
@@ -134,7 +125,7 @@ public class TokenWindowChatMemory implements ChatMemory {
         ensureGreaterThanZero(maxTokens, "maxTokens");
         List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
         if (autoRecoverOrphanedToolMessages) {
-            ChatMemoryUtils.removeOrphanedToolMessages(messages);
+            ChatMemoryUtils.removeInterruptedToolExecutions(messages);
         }
         ensureCapacity(messages, maxTokens, tokenCountEstimator);
         return messages;
@@ -253,25 +244,11 @@ public class TokenWindowChatMemory implements ChatMemory {
         }
 
         /**
-         * When enabled, orphaned tool-related messages are automatically removed
-         * when {@link ChatMemory#messages()} is called. Stale orphaned tool messages
-         * are also removed before adding new non-tool-result messages, so they do not
-         * affect window capacity. In-flight tool blocks are preserved while adding
-         * {@link ToolExecutionResultMessage}(s).
-         * <p>
-         * An {@link AiMessage} with {@link ToolExecutionRequest}(s) is considered orphaned
-         * if it is not immediately followed by the expected number of contiguous
-         * {@link ToolExecutionResultMessage}(s), or when the available tool call IDs do not match.
-         * Standalone {@link ToolExecutionResultMessage}(s) that are not part of a complete tool block
-         * are also removed.
-         * <p>
-         * This typically happens when the application restarts or an error occurs during
-         * tool execution, leaving the chat memory in an inconsistent state that causes
-         * LLM providers (such as OpenAI) to reject subsequent requests.
-         * <p>
-         * Disabled by default for backward compatibility.
+         * Removes interrupted tool calls from the messages returned by {@link ChatMemory#messages()}.
+         * A later non-result message persists the cleanup, while tool result messages preserve an
+         * in-flight tool execution. Disabled by default.
          *
-         * @param autoRecoverOrphanedToolMessages whether to automatically remove orphaned tool messages
+         * @param autoRecoverOrphanedToolMessages whether to remove interrupted tool calls
          * @return builder
          * @since 1.20.0
          */

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
@@ -53,6 +53,7 @@ public class TokenWindowChatMemory implements ChatMemory {
     private final TokenCountEstimator tokenCountEstimator;
     private final ChatMemoryStore store;
     private final boolean alwaysKeepSystemMessageFirst;
+    private final boolean autoRecoverOrphanedToolMessages;
 
     private TokenWindowChatMemory(Builder builder) {
         this.id = ensureNotNull(builder.id, "id");
@@ -61,6 +62,7 @@ public class TokenWindowChatMemory implements ChatMemory {
         this.tokenCountEstimator = ensureNotNull(builder.tokenCountEstimator, "tokenCountEstimator");
         this.store = ensureNotNull(builder.store(), "store");
         this.alwaysKeepSystemMessageFirst = getOrDefault(builder.alwaysKeepSystemMessageFirst, false);
+        this.autoRecoverOrphanedToolMessages = getOrDefault(builder.autoRecoverOrphanedToolMessages, false);
     }
 
     @Override
@@ -70,7 +72,7 @@ public class TokenWindowChatMemory implements ChatMemory {
 
     @Override
     public void add(ChatMessage message) {
-        List<ChatMessage> messages = messages();
+        List<ChatMessage> messages = messagesForAdd(message);
 
         if (message instanceof SystemMessage) {
             Optional<SystemMessage> maybeSystemMessage = SystemMessage.findFirst(messages);
@@ -94,6 +96,17 @@ public class TokenWindowChatMemory implements ChatMemory {
         ensureCapacity(messages, maxTokens, tokenCountEstimator);
 
         store.updateMessages(id, messages);
+    }
+
+    private List<ChatMessage> messagesForAdd(ChatMessage message) {
+        if (autoRecoverOrphanedToolMessages) {
+            List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
+            if (!(message instanceof ToolExecutionResultMessage)) {
+                ChatMemoryUtils.removeOrphanedToolMessages(messages);
+            }
+            return messages;
+        }
+        return messages();
     }
 
     @Override
@@ -120,6 +133,9 @@ public class TokenWindowChatMemory implements ChatMemory {
         Integer maxTokens = maxTokensProvider.apply(id);
         ensureGreaterThanZero(maxTokens, "maxTokens");
         List<ChatMessage> messages = new LinkedList<>(store.getMessages(id));
+        if (autoRecoverOrphanedToolMessages) {
+            ChatMemoryUtils.removeOrphanedToolMessages(messages);
+        }
         ensureCapacity(messages, maxTokens, tokenCountEstimator);
         return messages;
     }
@@ -173,6 +189,7 @@ public class TokenWindowChatMemory implements ChatMemory {
         private TokenCountEstimator tokenCountEstimator;
         private ChatMemoryStore store;
         private Boolean alwaysKeepSystemMessageFirst;
+        private Boolean autoRecoverOrphanedToolMessages;
 
         /**
          * @param id The ID of the {@link ChatMemory}.
@@ -232,6 +249,34 @@ public class TokenWindowChatMemory implements ChatMemory {
          */
         public Builder alwaysKeepSystemMessageFirst(Boolean alwaysKeepSystemMessageFirst) {
             this.alwaysKeepSystemMessageFirst = alwaysKeepSystemMessageFirst;
+            return this;
+        }
+
+        /**
+         * When enabled, orphaned tool-related messages are automatically removed
+         * when {@link ChatMemory#messages()} is called. Stale orphaned tool messages
+         * are also removed before adding new non-tool-result messages, so they do not
+         * affect window capacity. In-flight tool blocks are preserved while adding
+         * {@link ToolExecutionResultMessage}(s).
+         * <p>
+         * An {@link AiMessage} with {@link ToolExecutionRequest}(s) is considered orphaned
+         * if it is not immediately followed by the expected number of contiguous
+         * {@link ToolExecutionResultMessage}(s), or when the available tool call IDs do not match.
+         * Standalone {@link ToolExecutionResultMessage}(s) that are not part of a complete tool block
+         * are also removed.
+         * <p>
+         * This typically happens when the application restarts or an error occurs during
+         * tool execution, leaving the chat memory in an inconsistent state that causes
+         * LLM providers (such as OpenAI) to reject subsequent requests.
+         * <p>
+         * Disabled by default for backward compatibility.
+         *
+         * @param autoRecoverOrphanedToolMessages whether to automatically remove orphaned tool messages
+         * @return builder
+         * @since 1.20.0
+         */
+        public Builder autoRecoverOrphanedToolMessages(Boolean autoRecoverOrphanedToolMessages) {
+            this.autoRecoverOrphanedToolMessages = autoRecoverOrphanedToolMessages;
             return this;
         }
 

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/ChatMemoryUtilsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/ChatMemoryUtilsTest.java
@@ -1,0 +1,240 @@
+package dev.langchain4j.memory.chat;
+
+import static dev.langchain4j.data.message.UserMessage.userMessage;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import java.util.LinkedList;
+import java.util.List;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+class ChatMemoryUtilsTest implements WithAssertions {
+
+    private static final ToolExecutionRequest TOOL_REQUEST_A =
+            ToolExecutionRequest.builder().id("1").name("toolA").arguments("{}").build();
+
+    private static final ToolExecutionRequest TOOL_REQUEST_B =
+            ToolExecutionRequest.builder().id("2").name("toolB").arguments("{}").build();
+
+    private static final ToolExecutionRequest TOOL_REQUEST_C =
+            ToolExecutionRequest.builder().id("3").name("toolC").arguments("{}").build();
+
+    private static final ToolExecutionRequest TOOL_REQUEST_WITHOUT_ID =
+            ToolExecutionRequest.builder().name("toolWithoutId").arguments("{}").build();
+
+    private static final ToolExecutionResultMessage RESULT_A =
+            ToolExecutionResultMessage.from(TOOL_REQUEST_A, "resultA");
+    private static final ToolExecutionResultMessage RESULT_B =
+            ToolExecutionResultMessage.from(TOOL_REQUEST_B, "resultB");
+    private static final ToolExecutionResultMessage RESULT_C =
+            ToolExecutionResultMessage.from(TOOL_REQUEST_C, "resultC");
+    private static final ToolExecutionResultMessage RESULT_WITHOUT_ID =
+            ToolExecutionResultMessage.from(TOOL_REQUEST_WITHOUT_ID, "resultWithoutId");
+
+    private static List<ChatMessage> mutableListOf(ChatMessage... messages) {
+        List<ChatMessage> list = new LinkedList<>();
+        for (ChatMessage message : messages) {
+            list.add(message);
+        }
+        return list;
+    }
+
+    @Test
+    void should_do_nothing_for_empty_list() {
+        List<ChatMessage> messages = mutableListOf();
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+        assertThat(messages).isEmpty();
+    }
+
+    @Test
+    void should_keep_non_tool_messages_unchanged() {
+        // given
+        SystemMessage systemMessage = SystemMessage.from("system");
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from("hi");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(systemMessage, userMessage, aiMessage);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(systemMessage, userMessage, aiMessage);
+    }
+
+    @Test
+    void should_remove_trailing_AiMessage_with_tool_calls_and_no_results() {
+        // given: app restarts after AiMessage(tool_calls) is committed
+        // but before any ToolExecutionResultMessage is written
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A);
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage);
+    }
+
+    @Test
+    void should_remove_trailing_AiMessage_with_partial_tool_results() {
+        // given: parallel tool calls, app restarts after some results are written but not all
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B, TOOL_REQUEST_C);
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage);
+    }
+
+    @Test
+    void should_keep_complete_tool_block() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A);
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A);
+    }
+
+    @Test
+    void should_keep_complete_multi_tool_block() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
+    }
+
+    @Test
+    void should_remove_tool_block_when_result_ids_do_not_match_requests() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_C, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, answer);
+    }
+
+    @Test
+    void should_remove_excess_tool_results() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_B, RESULT_C, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
+    }
+
+    @Test
+    void should_ignore_result_without_id_when_matching_by_request_ids() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages =
+                mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_WITHOUT_ID, RESULT_B, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
+    }
+
+    @Test
+    void should_keep_tool_results_in_request_order() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_B, RESULT_A, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
+    }
+
+    @Test
+    void should_remove_tool_block_when_request_ids_are_partially_available() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_WITHOUT_ID);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_WITHOUT_ID, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, answer);
+    }
+
+    @Test
+    void should_use_count_matching_when_request_ids_are_unavailable() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        ToolExecutionRequest toolRequestWithoutId1 =
+                ToolExecutionRequest.builder().name("tool1").arguments("{}").build();
+        ToolExecutionRequest toolRequestWithoutId2 =
+                ToolExecutionRequest.builder().name("tool2").arguments("{}").build();
+        AiMessage aiMessage = AiMessage.from(toolRequestWithoutId1, toolRequestWithoutId2);
+        ToolExecutionResultMessage resultWithoutId1 = ToolExecutionResultMessage.from(toolRequestWithoutId1, "result1");
+        ToolExecutionResultMessage resultWithoutId2 = ToolExecutionResultMessage.from(toolRequestWithoutId2, "result2");
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, resultWithoutId1, resultWithoutId2, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, aiMessage, resultWithoutId1, resultWithoutId2, answer);
+    }
+
+    @Test
+    void should_remove_incomplete_middle_block_followed_by_user_message() {
+        // given: multi-round conversation, one tool call round was interrupted,
+        // user sent a new message afterward
+        UserMessage userMessage1 = userMessage("question 1");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        UserMessage userMessage2 = userMessage("question 2");
+        AiMessage answer = AiMessage.from("answer");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage1, aiMessage, RESULT_A, userMessage2, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage1, userMessage2, answer);
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/ChatMemoryUtilsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/ChatMemoryUtilsTest.java
@@ -1,0 +1,203 @@
+package dev.langchain4j.memory.chat;
+
+import static dev.langchain4j.data.message.UserMessage.userMessage;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import java.util.LinkedList;
+import java.util.List;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+class ChatMemoryUtilsTest implements WithAssertions {
+
+    private static final ToolExecutionRequest TOOL_REQUEST_A =
+            ToolExecutionRequest.builder().id("1").name("toolA").arguments("{}").build();
+
+    private static final ToolExecutionRequest TOOL_REQUEST_B =
+            ToolExecutionRequest.builder().id("2").name("toolB").arguments("{}").build();
+
+    private static final ToolExecutionRequest TOOL_REQUEST_C =
+            ToolExecutionRequest.builder().id("3").name("toolC").arguments("{}").build();
+
+    private static final ToolExecutionRequest TOOL_REQUEST_WITHOUT_ID =
+            ToolExecutionRequest.builder().name("toolWithoutId").arguments("{}").build();
+
+    private static final ToolExecutionResultMessage RESULT_A =
+            ToolExecutionResultMessage.from(TOOL_REQUEST_A, "resultA");
+    private static final ToolExecutionResultMessage RESULT_B =
+            ToolExecutionResultMessage.from(TOOL_REQUEST_B, "resultB");
+    private static final ToolExecutionResultMessage RESULT_C =
+            ToolExecutionResultMessage.from(TOOL_REQUEST_C, "resultC");
+    private static final ToolExecutionResultMessage RESULT_WITHOUT_ID =
+            ToolExecutionResultMessage.from(TOOL_REQUEST_WITHOUT_ID, "resultWithoutId");
+
+    private static List<ChatMessage> mutableListOf(ChatMessage... messages) {
+        List<ChatMessage> list = new LinkedList<>();
+        for (ChatMessage message : messages) {
+            list.add(message);
+        }
+        return list;
+    }
+
+    @Test
+    void should_remove_trailing_AiMessage_with_tool_calls_and_no_results() {
+        // given: app restarts after AiMessage(tool_calls) is committed
+        // but before any ToolExecutionResultMessage is written
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A);
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage);
+    }
+
+    @Test
+    void should_remove_trailing_AiMessage_with_partial_tool_results() {
+        // given: parallel tool calls, app restarts after some results are written but not all
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B, TOOL_REQUEST_C);
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage);
+    }
+
+    @Test
+    void should_keep_complete_multi_tool_block() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
+    }
+
+    @Test
+    void should_remove_tool_block_when_result_ids_do_not_match_requests() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_C, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, answer);
+    }
+
+    @Test
+    void should_remove_excess_tool_results() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_B, RESULT_C, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
+    }
+
+    @Test
+    void should_ignore_result_without_id_when_matching_by_request_ids() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages =
+                mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_WITHOUT_ID, RESULT_B, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
+    }
+
+    @Test
+    void should_keep_tool_results_in_request_order() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_B, RESULT_A, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
+    }
+
+    @Test
+    void should_remove_tool_block_when_request_ids_are_partially_available() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_WITHOUT_ID);
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_WITHOUT_ID, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, answer);
+    }
+
+    @Test
+    void should_use_count_matching_when_request_ids_are_unavailable() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        ToolExecutionRequest toolRequestWithoutId1 =
+                ToolExecutionRequest.builder().name("tool1").arguments("{}").build();
+        ToolExecutionRequest toolRequestWithoutId2 =
+                ToolExecutionRequest.builder().name("tool2").arguments("{}").build();
+        AiMessage aiMessage = AiMessage.from(toolRequestWithoutId1, toolRequestWithoutId2);
+        ToolExecutionResultMessage resultWithoutId1 = ToolExecutionResultMessage.from(toolRequestWithoutId1, "result1");
+        ToolExecutionResultMessage resultWithoutId2 = ToolExecutionResultMessage.from(toolRequestWithoutId2, "result2");
+        AiMessage answer = AiMessage.from("done");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, resultWithoutId1, resultWithoutId2, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, aiMessage, resultWithoutId1, resultWithoutId2, answer);
+    }
+
+    @Test
+    void should_remove_incomplete_middle_block_followed_by_user_message() {
+        // given: multi-round conversation, one tool call round was interrupted,
+        // user sent a new message afterward
+        UserMessage userMessage1 = userMessage("question 1");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        UserMessage userMessage2 = userMessage("question 2");
+        AiMessage answer = AiMessage.from("answer");
+
+        // when
+        List<ChatMessage> messages = mutableListOf(userMessage1, aiMessage, RESULT_A, userMessage2, answer);
+        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage1, userMessage2, answer);
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/ChatMemoryUtilsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/ChatMemoryUtilsTest.java
@@ -23,181 +23,106 @@ class ChatMemoryUtilsTest implements WithAssertions {
     private static final ToolExecutionRequest TOOL_REQUEST_C =
             ToolExecutionRequest.builder().id("3").name("toolC").arguments("{}").build();
 
-    private static final ToolExecutionRequest TOOL_REQUEST_WITHOUT_ID =
-            ToolExecutionRequest.builder().name("toolWithoutId").arguments("{}").build();
-
     private static final ToolExecutionResultMessage RESULT_A =
             ToolExecutionResultMessage.from(TOOL_REQUEST_A, "resultA");
     private static final ToolExecutionResultMessage RESULT_B =
             ToolExecutionResultMessage.from(TOOL_REQUEST_B, "resultB");
     private static final ToolExecutionResultMessage RESULT_C =
             ToolExecutionResultMessage.from(TOOL_REQUEST_C, "resultC");
-    private static final ToolExecutionResultMessage RESULT_WITHOUT_ID =
-            ToolExecutionResultMessage.from(TOOL_REQUEST_WITHOUT_ID, "resultWithoutId");
 
     private static List<ChatMessage> mutableListOf(ChatMessage... messages) {
-        List<ChatMessage> list = new LinkedList<>();
-        for (ChatMessage message : messages) {
-            list.add(message);
-        }
-        return list;
+        return new LinkedList<>(List.of(messages));
     }
 
     @Test
-    void should_remove_trailing_AiMessage_with_tool_calls_and_no_results() {
-        // given: app restarts after AiMessage(tool_calls) is committed
-        // but before any ToolExecutionResultMessage is written
-        UserMessage userMessage = userMessage("hello");
-        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A);
-
-        // when
-        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage);
-        ChatMemoryUtils.removeOrphanedToolMessages(messages);
-
-        // then
-        assertThat(messages).containsExactly(userMessage);
-    }
-
-    @Test
-    void should_remove_trailing_AiMessage_with_partial_tool_results() {
-        // given: parallel tool calls, app restarts after some results are written but not all
-        UserMessage userMessage = userMessage("hello");
-        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B, TOOL_REQUEST_C);
-
-        // when
-        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A);
-        ChatMemoryUtils.removeOrphanedToolMessages(messages);
-
-        // then
-        assertThat(messages).containsExactly(userMessage);
-    }
-
-    @Test
-    void should_keep_complete_multi_tool_block() {
-        // given
-        UserMessage userMessage = userMessage("hello");
-        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
-        AiMessage answer = AiMessage.from("done");
-
-        // when
-        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
-        ChatMemoryUtils.removeOrphanedToolMessages(messages);
-
-        // then
-        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
-    }
-
-    @Test
-    void should_remove_tool_block_when_result_ids_do_not_match_requests() {
-        // given
-        UserMessage userMessage = userMessage("hello");
-        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
-        AiMessage answer = AiMessage.from("done");
-
-        // when
-        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_C, answer);
-        ChatMemoryUtils.removeOrphanedToolMessages(messages);
-
-        // then
-        assertThat(messages).containsExactly(userMessage, answer);
-    }
-
-    @Test
-    void should_remove_excess_tool_results() {
-        // given
-        UserMessage userMessage = userMessage("hello");
-        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
-        AiMessage answer = AiMessage.from("done");
-
-        // when
-        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_B, RESULT_C, answer);
-        ChatMemoryUtils.removeOrphanedToolMessages(messages);
-
-        // then
-        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
-    }
-
-    @Test
-    void should_ignore_result_without_id_when_matching_by_request_ids() {
-        // given
-        UserMessage userMessage = userMessage("hello");
-        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
-        AiMessage answer = AiMessage.from("done");
-
-        // when
-        List<ChatMessage> messages =
-                mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_WITHOUT_ID, RESULT_B, answer);
-        ChatMemoryUtils.removeOrphanedToolMessages(messages);
-
-        // then
-        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
-    }
-
-    @Test
-    void should_keep_tool_results_in_request_order() {
-        // given
-        UserMessage userMessage = userMessage("hello");
-        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
-        AiMessage answer = AiMessage.from("done");
-
-        // when
-        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_B, RESULT_A, answer);
-        ChatMemoryUtils.removeOrphanedToolMessages(messages);
-
-        // then
-        assertThat(messages).containsExactly(userMessage, aiMessage, RESULT_A, RESULT_B, answer);
-    }
-
-    @Test
-    void should_remove_tool_block_when_request_ids_are_partially_available() {
-        // given
-        UserMessage userMessage = userMessage("hello");
-        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_WITHOUT_ID);
-        AiMessage answer = AiMessage.from("done");
-
-        // when
-        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_WITHOUT_ID, answer);
-        ChatMemoryUtils.removeOrphanedToolMessages(messages);
-
-        // then
-        assertThat(messages).containsExactly(userMessage, answer);
-    }
-
-    @Test
-    void should_use_count_matching_when_request_ids_are_unavailable() {
-        // given
-        UserMessage userMessage = userMessage("hello");
-        ToolExecutionRequest toolRequestWithoutId1 =
-                ToolExecutionRequest.builder().name("tool1").arguments("{}").build();
-        ToolExecutionRequest toolRequestWithoutId2 =
-                ToolExecutionRequest.builder().name("tool2").arguments("{}").build();
-        AiMessage aiMessage = AiMessage.from(toolRequestWithoutId1, toolRequestWithoutId2);
-        ToolExecutionResultMessage resultWithoutId1 = ToolExecutionResultMessage.from(toolRequestWithoutId1, "result1");
-        ToolExecutionResultMessage resultWithoutId2 = ToolExecutionResultMessage.from(toolRequestWithoutId2, "result2");
-        AiMessage answer = AiMessage.from("done");
-
-        // when
-        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, resultWithoutId1, resultWithoutId2, answer);
-        ChatMemoryUtils.removeOrphanedToolMessages(messages);
-
-        // then
-        assertThat(messages).containsExactly(userMessage, aiMessage, resultWithoutId1, resultWithoutId2, answer);
-    }
-
-    @Test
-    void should_remove_incomplete_middle_block_followed_by_user_message() {
-        // given: multi-round conversation, one tool call round was interrupted,
-        // user sent a new message afterward
-        UserMessage userMessage1 = userMessage("question 1");
-        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
-        UserMessage userMessage2 = userMessage("question 2");
+    void should_remove_interrupted_tool_execution_from_middle_of_history() {
+        // given: a parallel tool execution was interrupted before any result
+        UserMessage firstUserMessage = userMessage("question 1");
+        AiMessage interruptedAiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        UserMessage secondUserMessage = userMessage("question 2");
         AiMessage answer = AiMessage.from("answer");
+        List<ChatMessage> messages = mutableListOf(firstUserMessage, interruptedAiMessage, secondUserMessage, answer);
 
         // when
-        List<ChatMessage> messages = mutableListOf(userMessage1, aiMessage, RESULT_A, userMessage2, answer);
-        ChatMemoryUtils.removeOrphanedToolMessages(messages);
+        ChatMemoryUtils.removeInterruptedToolExecutions(messages);
 
         // then
-        assertThat(messages).containsExactly(userMessage1, userMessage2, answer);
+        assertThat(messages).containsExactly(firstUserMessage, secondUserMessage, answer);
+    }
+
+    @Test
+    void should_preserve_non_interrupted_tool_messages_in_original_order() {
+        // given: standalone and excess results are outside interrupted-execution recovery
+        ToolExecutionResultMessage standaloneResult = ToolExecutionResultMessage.from(TOOL_REQUEST_C, "standalone");
+        ToolExecutionResultMessage excessResult = ToolExecutionResultMessage.from(TOOL_REQUEST_C, "excess");
+        UserMessage firstUserMessage = userMessage("hello");
+        AiMessage completeAiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        UserMessage secondUserMessage = userMessage("next");
+        AiMessage aiMessageWithExcessResult = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+        List<ChatMessage> messages = mutableListOf(
+                standaloneResult,
+                firstUserMessage,
+                completeAiMessage,
+                RESULT_B,
+                RESULT_A,
+                secondUserMessage,
+                aiMessageWithExcessResult,
+                RESULT_A,
+                RESULT_B,
+                excessResult,
+                answer);
+
+        // when
+        ChatMemoryUtils.removeInterruptedToolExecutions(messages);
+
+        // then
+        assertThat(messages)
+                .containsExactly(
+                        standaloneResult,
+                        firstUserMessage,
+                        completeAiMessage,
+                        RESULT_B,
+                        RESULT_A,
+                        secondUserMessage,
+                        aiMessageWithExcessResult,
+                        RESULT_A,
+                        RESULT_B,
+                        excessResult,
+                        answer);
+    }
+
+    @Test
+    void should_remove_tool_execution_when_result_ids_do_not_match_requests() {
+        // given
+        UserMessage userMessage = userMessage("hello");
+        AiMessage aiMessage = AiMessage.from(TOOL_REQUEST_A, TOOL_REQUEST_B);
+        AiMessage answer = AiMessage.from("done");
+        List<ChatMessage> messages = mutableListOf(userMessage, aiMessage, RESULT_A, RESULT_C, answer);
+
+        // when
+        ChatMemoryUtils.removeInterruptedToolExecutions(messages);
+
+        // then
+        assertThat(messages).containsExactly(userMessage, answer);
+    }
+
+    @Test
+    void should_use_result_count_when_ids_are_unavailable() {
+        // given
+        ToolExecutionRequest firstRequest =
+                ToolExecutionRequest.builder().name("tool1").arguments("{}").build();
+        ToolExecutionRequest secondRequest =
+                ToolExecutionRequest.builder().name("tool2").arguments("{}").build();
+        AiMessage aiMessage = AiMessage.from(firstRequest, secondRequest);
+        ToolExecutionResultMessage firstResult = ToolExecutionResultMessage.from(firstRequest, "result1");
+        ToolExecutionResultMessage secondResult = ToolExecutionResultMessage.from(secondRequest, "result2");
+        List<ChatMessage> messages = mutableListOf(aiMessage, firstResult, secondResult);
+
+        // when
+        ChatMemoryUtils.removeInterruptedToolExecutions(messages);
+
+        // then
+        assertThat(messages).containsExactly(aiMessage, firstResult, secondResult);
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
@@ -11,6 +11,7 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.HitCountChatMemoryStore.HitCounts;
+import java.util.List;
 import java.util.function.Function;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
@@ -634,5 +635,203 @@ class MessageWindowChatMemoryTest implements WithAssertions {
             chatMemory.set(userMessage("world"), aiMessage("hi"));
         });
         assertThat(counts).isEqualTo(new HitCounts(0, 1, 0));
+    }
+
+    @Test
+    void should_not_modify_messages_when_auto_recover_is_disabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+
+        // Pre-populate store with an incomplete tool block
+        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+
+        // Default: autoRecoverOrphanedToolMessages is false
+        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+                .maxMessages(10)
+                .chatMemoryStore(store)
+                .build();
+
+        // messages() should NOT clean up the incomplete block
+        assertThat(chatMemory.messages()).containsExactly(userMessage("hello"), aiMessageWithTools);
+    }
+
+    @Test
+    void should_remove_orphaned_tool_messages_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+
+        // Pre-populate store with an incomplete tool block
+        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+
+        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+                .maxMessages(10)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        // messages() should clean up the incomplete block
+        assertThat(chatMemory.messages()).containsExactly(userMessage("hello"));
+    }
+
+    @Test
+    void should_remove_tool_messages_with_mismatched_ids_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest1 = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool1")
+                .arguments("{}")
+                .build();
+        ToolExecutionRequest toolRequest2 = ToolExecutionRequest.builder()
+                .id("2")
+                .name("tool2")
+                .arguments("{}")
+                .build();
+        ToolExecutionRequest toolRequest3 = ToolExecutionRequest.builder()
+                .id("3")
+                .name("tool3")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest1, toolRequest2);
+        ToolExecutionResultMessage resultMessage1 = ToolExecutionResultMessage.from(toolRequest1, "result1");
+        ToolExecutionResultMessage resultMessage3 = ToolExecutionResultMessage.from(toolRequest3, "result3");
+        AiMessage answer = AiMessage.from("done");
+
+        store.updateMessages(
+                "default", List.of(userMessage("hello"), aiMessageWithTools, resultMessage1, resultMessage3, answer));
+
+        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+                .maxMessages(10)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        assertThat(chatMemory.messages()).containsExactly(userMessage("hello"), answer);
+    }
+
+    @Test
+    void messages_should_not_write_back_to_store_when_auto_recover_cleans_up() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+
+        // Pre-populate store with an incomplete tool block
+        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+
+        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+                .maxMessages(10)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        // messages() should only read, not write back
+        var counts = store.measureHitCounts(chatMemory::messages);
+        assertThat(counts).isEqualTo(new HitCounts(1, 0, 0));
+
+        // Store still contains the dirty data
+        assertThat(store.getMessages("default")).containsExactly(userMessage("hello"), aiMessageWithTools);
+    }
+
+    @Test
+    void add_should_persist_cleaned_messages_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+
+        // Pre-populate store with an incomplete tool block
+        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+
+        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+                .maxMessages(10)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        chatMemory.add(userMessage("world"));
+
+        assertThat(store.getMessages("default")).containsExactly(userMessage("hello"), userMessage("world"));
+    }
+
+    @Test
+    void add_should_recover_stale_tool_messages_before_enforcing_capacity_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        UserMessage firstUserMessage = userMessage("hello");
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+        UserMessage secondUserMessage = userMessage("world");
+
+        store.updateMessages("default", List.of(firstUserMessage, aiMessageWithTools));
+
+        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+                .maxMessages(2)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        chatMemory.add(secondUserMessage);
+
+        assertThat(store.getMessages("default")).containsExactly(firstUserMessage, secondUserMessage);
+        assertThat(chatMemory.messages()).containsExactly(firstUserMessage, secondUserMessage);
+    }
+
+    @Test
+    void should_not_remove_in_flight_tool_block_during_add_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+        ToolExecutionResultMessage resultMessage = ToolExecutionResultMessage.from(toolRequest, "result");
+
+        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+                .maxMessages(10)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        chatMemory.add(userMessage("hello"));
+        chatMemory.add(aiMessageWithTools);
+        chatMemory.add(resultMessage);
+
+        assertThat(store.getMessages("default"))
+                .containsExactly(userMessage("hello"), aiMessageWithTools, resultMessage);
+        assertThat(chatMemory.messages()).containsExactly(userMessage("hello"), aiMessageWithTools, resultMessage);
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
@@ -670,4 +670,90 @@ class MessageWindowChatMemoryTest implements WithAssertions {
         callerList.add(userMessage("a4-injected"));
         assertThat(chatMemory.messages()).containsExactly(userMessage("a2"), userMessage("a3"));
     }
+
+    @Test
+    void messages_should_not_write_back_to_store_when_auto_recover_cleans_up() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+
+        // Pre-populate store with an incomplete tool block
+        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+
+        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+                .maxMessages(10)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        // messages() should return the cleaned view without writing it back
+        var counts =
+                store.measureHitCounts(() -> assertThat(chatMemory.messages()).containsExactly(userMessage("hello")));
+        assertThat(counts).isEqualTo(new HitCounts(1, 0, 0));
+
+        // Store still contains the dirty data
+        assertThat(store.getMessages("default")).containsExactly(userMessage("hello"), aiMessageWithTools);
+    }
+
+    @Test
+    void add_should_recover_stale_tool_messages_before_enforcing_capacity_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        UserMessage firstUserMessage = userMessage("hello");
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+        UserMessage secondUserMessage = userMessage("world");
+
+        store.updateMessages("default", List.of(firstUserMessage, aiMessageWithTools));
+
+        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+                .maxMessages(2)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        chatMemory.add(secondUserMessage);
+
+        assertThat(store.getMessages("default")).containsExactly(firstUserMessage, secondUserMessage);
+        assertThat(chatMemory.messages()).containsExactly(firstUserMessage, secondUserMessage);
+    }
+
+    @Test
+    void should_not_remove_in_flight_tool_block_during_add_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+        ToolExecutionResultMessage resultMessage = ToolExecutionResultMessage.from(toolRequest, "result");
+
+        ChatMemory chatMemory = MessageWindowChatMemory.builder()
+                .maxMessages(10)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        chatMemory.add(userMessage("hello"));
+        chatMemory.add(aiMessageWithTools);
+        chatMemory.add(resultMessage);
+
+        assertThat(store.getMessages("default"))
+                .containsExactly(userMessage("hello"), aiMessageWithTools, resultMessage);
+        assertThat(chatMemory.messages()).containsExactly(userMessage("hello"), aiMessageWithTools, resultMessage);
+    }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
@@ -672,19 +672,34 @@ class MessageWindowChatMemoryTest implements WithAssertions {
     }
 
     @Test
-    void messages_should_not_write_back_to_store_when_auto_recover_cleans_up() {
+    void should_recover_interrupted_tool_execution_when_enabled() {
 
+        // given
         var store = new HitCountChatMemoryStore();
-
-        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+        ToolExecutionRequest firstRequest = ToolExecutionRequest.builder()
                 .id("1")
-                .name("tool")
+                .name("tool1")
                 .arguments("{}")
                 .build();
-        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+        ToolExecutionRequest secondRequest = ToolExecutionRequest.builder()
+                .id("2")
+                .name("tool2")
+                .arguments("{}")
+                .build();
+        UserMessage firstUserMessage = userMessage("hello");
+        AiMessage interruptedAiMessage = AiMessage.from(firstRequest, secondRequest);
+        ToolExecutionResultMessage partialResult = ToolExecutionResultMessage.from(firstRequest, "result");
+        UserMessage secondUserMessage = userMessage("world");
+        List<dev.langchain4j.data.message.ChatMessage> interruptedHistory =
+                List.of(firstUserMessage, interruptedAiMessage, partialResult);
+        store.updateMessages("default", interruptedHistory);
 
-        // Pre-populate store with an incomplete tool block
-        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+        // disabled by default
+        ChatMemory defaultChatMemory = MessageWindowChatMemory.builder()
+                .maxMessages(10)
+                .chatMemoryStore(store)
+                .build();
+        assertThat(defaultChatMemory.messages()).containsExactlyElementsOf(interruptedHistory);
 
         ChatMemory chatMemory = MessageWindowChatMemory.builder()
                 .maxMessages(10)
@@ -692,41 +707,14 @@ class MessageWindowChatMemoryTest implements WithAssertions {
                 .autoRecoverOrphanedToolMessages(true)
                 .build();
 
-        // messages() should return the cleaned view without writing it back
-        var counts =
-                store.measureHitCounts(() -> assertThat(chatMemory.messages()).containsExactly(userMessage("hello")));
-        assertThat(counts).isEqualTo(new HitCounts(1, 0, 0));
+        // when-then: reading returns a cleaned view without changing the store
+        assertThat(chatMemory.messages()).containsExactly(firstUserMessage);
+        assertThat(store.getMessages("default")).containsExactlyElementsOf(interruptedHistory);
 
-        // Store still contains the dirty data
-        assertThat(store.getMessages("default")).containsExactly(userMessage("hello"), aiMessageWithTools);
-    }
-
-    @Test
-    void add_should_recover_stale_tool_messages_before_enforcing_capacity_when_auto_recover_is_enabled() {
-
-        var store = new HitCountChatMemoryStore();
-
-        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
-                .id("1")
-                .name("tool")
-                .arguments("{}")
-                .build();
-        UserMessage firstUserMessage = userMessage("hello");
-        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
-        UserMessage secondUserMessage = userMessage("world");
-
-        store.updateMessages("default", List.of(firstUserMessage, aiMessageWithTools));
-
-        ChatMemory chatMemory = MessageWindowChatMemory.builder()
-                .maxMessages(2)
-                .chatMemoryStore(store)
-                .autoRecoverOrphanedToolMessages(true)
-                .build();
-
+        // when-then: a later user message persists the cleanup
         chatMemory.add(secondUserMessage);
-
-        assertThat(store.getMessages("default")).containsExactly(firstUserMessage, secondUserMessage);
         assertThat(chatMemory.messages()).containsExactly(firstUserMessage, secondUserMessage);
+        assertThat(store.getMessages("default")).containsExactly(firstUserMessage, secondUserMessage);
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
@@ -19,6 +19,7 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.model.openai.OpenAiChatModelName;
 import dev.langchain4j.model.openai.OpenAiTokenCountEstimator;
+import java.util.List;
 import java.util.function.Function;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
@@ -839,5 +840,197 @@ class TokenWindowChatMemoryTest implements WithAssertions {
             chatMemory.set(userMessage("world"), aiMessage("hi"));
         });
         assertThat(counts).isEqualTo(new HitCountChatMemoryStore.HitCounts(0, 1, 0));
+    }
+
+    @Test
+    void should_not_modify_messages_when_auto_recover_is_disabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+
+        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+
+        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+                .maxTokens(1000, TOKEN_COUNT_ESTIMATOR)
+                .chatMemoryStore(store)
+                .build();
+
+        assertThat(chatMemory.messages()).containsExactly(userMessage("hello"), aiMessageWithTools);
+    }
+
+    @Test
+    void should_remove_orphaned_tool_messages_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+
+        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+
+        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+                .maxTokens(1000, TOKEN_COUNT_ESTIMATOR)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        assertThat(chatMemory.messages()).containsExactly(userMessage("hello"));
+    }
+
+    @Test
+    void should_remove_tool_messages_with_mismatched_ids_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest1 = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool1")
+                .arguments("{}")
+                .build();
+        ToolExecutionRequest toolRequest2 = ToolExecutionRequest.builder()
+                .id("2")
+                .name("tool2")
+                .arguments("{}")
+                .build();
+        ToolExecutionRequest toolRequest3 = ToolExecutionRequest.builder()
+                .id("3")
+                .name("tool3")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest1, toolRequest2);
+        ToolExecutionResultMessage resultMessage1 = ToolExecutionResultMessage.from(toolRequest1, "result1");
+        ToolExecutionResultMessage resultMessage3 = ToolExecutionResultMessage.from(toolRequest3, "result3");
+        AiMessage answer = AiMessage.from("done");
+
+        store.updateMessages(
+                "default", List.of(userMessage("hello"), aiMessageWithTools, resultMessage1, resultMessage3, answer));
+
+        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+                .maxTokens(1000, TOKEN_COUNT_ESTIMATOR)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        assertThat(chatMemory.messages()).containsExactly(userMessage("hello"), answer);
+    }
+
+    @Test
+    void messages_should_not_write_back_to_store_when_auto_recover_cleans_up() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+
+        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+
+        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+                .maxTokens(1000, TOKEN_COUNT_ESTIMATOR)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        var counts = store.measureHitCounts(chatMemory::messages);
+        assertThat(counts).isEqualTo(new HitCountChatMemoryStore.HitCounts(1, 0, 0));
+
+        assertThat(store.getMessages("default")).containsExactly(userMessage("hello"), aiMessageWithTools);
+    }
+
+    @Test
+    void add_should_persist_cleaned_messages_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+
+        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+
+        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+                .maxTokens(1000, TOKEN_COUNT_ESTIMATOR)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        chatMemory.add(userMessage("world"));
+
+        assertThat(store.getMessages("default")).containsExactly(userMessage("hello"), userMessage("world"));
+    }
+
+    @Test
+    void add_should_recover_stale_tool_messages_before_enforcing_capacity_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        UserMessage firstUserMessage = userMessage("hello");
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+        UserMessage secondUserMessage = userMessage("world");
+
+        store.updateMessages("default", List.of(firstUserMessage, aiMessageWithTools));
+
+        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+                .maxTokens(
+                        TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessages(
+                                List.of(firstUserMessage, secondUserMessage)),
+                        TOKEN_COUNT_ESTIMATOR)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        chatMemory.add(secondUserMessage);
+
+        assertThat(store.getMessages("default")).containsExactly(firstUserMessage, secondUserMessage);
+        assertThat(chatMemory.messages()).containsExactly(firstUserMessage, secondUserMessage);
+    }
+
+    @Test
+    void should_not_remove_in_flight_tool_block_during_add_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+        ToolExecutionResultMessage resultMessage = ToolExecutionResultMessage.from(toolRequest, "result");
+
+        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+                .maxTokens(1000, TOKEN_COUNT_ESTIMATOR)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        chatMemory.add(userMessage("hello"));
+        chatMemory.add(aiMessageWithTools);
+        chatMemory.add(resultMessage);
+
+        assertThat(store.getMessages("default"))
+                .containsExactly(userMessage("hello"), aiMessageWithTools, resultMessage);
+        assertThat(chatMemory.messages()).containsExactly(userMessage("hello"), aiMessageWithTools, resultMessage);
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
@@ -880,4 +880,62 @@ class TokenWindowChatMemoryTest implements WithAssertions {
         callerList.add(userMessageWithTokens(10));
         assertThat(chatMemory.messages()).containsExactly(m2, m3);
     }
+
+    @Test
+    void messages_should_not_write_back_to_store_when_auto_recover_cleans_up() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+
+        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+
+        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+                .maxTokens(1000, TOKEN_COUNT_ESTIMATOR)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        var counts =
+                store.measureHitCounts(() -> assertThat(chatMemory.messages()).containsExactly(userMessage("hello")));
+        assertThat(counts).isEqualTo(new HitCountChatMemoryStore.HitCounts(1, 0, 0));
+
+        assertThat(store.getMessages("default")).containsExactly(userMessage("hello"), aiMessageWithTools);
+    }
+
+    @Test
+    void add_should_recover_stale_tool_messages_before_enforcing_capacity_when_auto_recover_is_enabled() {
+
+        var store = new HitCountChatMemoryStore();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("tool")
+                .arguments("{}")
+                .build();
+        UserMessage firstUserMessage = userMessage("hello");
+        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+        UserMessage secondUserMessage = userMessage("world");
+
+        store.updateMessages("default", List.of(firstUserMessage, aiMessageWithTools));
+
+        ChatMemory chatMemory = TokenWindowChatMemory.builder()
+                .maxTokens(
+                        TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessages(
+                                List.of(firstUserMessage, secondUserMessage)),
+                        TOKEN_COUNT_ESTIMATOR)
+                .chatMemoryStore(store)
+                .autoRecoverOrphanedToolMessages(true)
+                .build();
+
+        chatMemory.add(secondUserMessage);
+
+        assertThat(store.getMessages("default")).containsExactly(firstUserMessage, secondUserMessage);
+        assertThat(chatMemory.messages()).containsExactly(firstUserMessage, secondUserMessage);
+    }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
@@ -882,18 +882,33 @@ class TokenWindowChatMemoryTest implements WithAssertions {
     }
 
     @Test
-    void messages_should_not_write_back_to_store_when_auto_recover_cleans_up() {
+    void should_recover_interrupted_tool_execution_when_enabled() {
 
+        // given
         var store = new HitCountChatMemoryStore();
-
-        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+        ToolExecutionRequest firstRequest = ToolExecutionRequest.builder()
                 .id("1")
-                .name("tool")
+                .name("tool1")
                 .arguments("{}")
                 .build();
-        AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
+        ToolExecutionRequest secondRequest = ToolExecutionRequest.builder()
+                .id("2")
+                .name("tool2")
+                .arguments("{}")
+                .build();
+        UserMessage firstUserMessage = userMessage("hello");
+        AiMessage interruptedAiMessage = AiMessage.from(firstRequest, secondRequest);
+        ToolExecutionResultMessage partialResult = ToolExecutionResultMessage.from(firstRequest, "result");
+        UserMessage secondUserMessage = userMessage("world");
+        List<ChatMessage> interruptedHistory = List.of(firstUserMessage, interruptedAiMessage, partialResult);
+        store.updateMessages("default", interruptedHistory);
 
-        store.updateMessages("default", List.of(userMessage("hello"), aiMessageWithTools));
+        // disabled by default
+        ChatMemory defaultChatMemory = TokenWindowChatMemory.builder()
+                .maxTokens(1000, TOKEN_COUNT_ESTIMATOR)
+                .chatMemoryStore(store)
+                .build();
+        assertThat(defaultChatMemory.messages()).containsExactlyElementsOf(interruptedHistory);
 
         ChatMemory chatMemory = TokenWindowChatMemory.builder()
                 .maxTokens(1000, TOKEN_COUNT_ESTIMATOR)
@@ -901,41 +916,42 @@ class TokenWindowChatMemoryTest implements WithAssertions {
                 .autoRecoverOrphanedToolMessages(true)
                 .build();
 
-        var counts =
-                store.measureHitCounts(() -> assertThat(chatMemory.messages()).containsExactly(userMessage("hello")));
-        assertThat(counts).isEqualTo(new HitCountChatMemoryStore.HitCounts(1, 0, 0));
+        // when-then: reading returns a cleaned view without changing the store
+        assertThat(chatMemory.messages()).containsExactly(firstUserMessage);
+        assertThat(store.getMessages("default")).containsExactlyElementsOf(interruptedHistory);
 
-        assertThat(store.getMessages("default")).containsExactly(userMessage("hello"), aiMessageWithTools);
+        // when-then: a later user message persists the cleanup
+        chatMemory.add(secondUserMessage);
+        assertThat(chatMemory.messages()).containsExactly(firstUserMessage, secondUserMessage);
+        assertThat(store.getMessages("default")).containsExactly(firstUserMessage, secondUserMessage);
     }
 
     @Test
-    void add_should_recover_stale_tool_messages_before_enforcing_capacity_when_auto_recover_is_enabled() {
+    void should_not_remove_in_flight_tool_block_during_add_when_auto_recover_is_enabled() {
 
+        // given
         var store = new HitCountChatMemoryStore();
-
         ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
                 .id("1")
                 .name("tool")
                 .arguments("{}")
                 .build();
-        UserMessage firstUserMessage = userMessage("hello");
         AiMessage aiMessageWithTools = AiMessage.from(toolRequest);
-        UserMessage secondUserMessage = userMessage("world");
-
-        store.updateMessages("default", List.of(firstUserMessage, aiMessageWithTools));
-
+        ToolExecutionResultMessage resultMessage = ToolExecutionResultMessage.from(toolRequest, "result");
         ChatMemory chatMemory = TokenWindowChatMemory.builder()
-                .maxTokens(
-                        TOKEN_COUNT_ESTIMATOR.estimateTokenCountInMessages(
-                                List.of(firstUserMessage, secondUserMessage)),
-                        TOKEN_COUNT_ESTIMATOR)
+                .maxTokens(1000, TOKEN_COUNT_ESTIMATOR)
                 .chatMemoryStore(store)
                 .autoRecoverOrphanedToolMessages(true)
                 .build();
 
-        chatMemory.add(secondUserMessage);
+        // when
+        chatMemory.add(userMessage("hello"));
+        chatMemory.add(aiMessageWithTools);
+        chatMemory.add(resultMessage);
 
-        assertThat(store.getMessages("default")).containsExactly(firstUserMessage, secondUserMessage);
-        assertThat(chatMemory.messages()).containsExactly(firstUserMessage, secondUserMessage);
+        // then
+        assertThat(store.getMessages("default"))
+                .containsExactly(userMessage("hello"), aiMessageWithTools, resultMessage);
+        assertThat(chatMemory.messages()).containsExactly(userMessage("hello"), aiMessageWithTools, resultMessage);
     }
 }


### PR DESCRIPTION
## Issue
Fixes #3806

## Change
Adds opt-in orphaned tool-message recovery to MessageWindowChatMemory and TokenWindowChatMemory.

When enabled, messages() returns a cleaned view without rewriting the store. Adding a later non-tool-result message persists the cleanup before capacity is enforced; adding a ToolExecutionResultMessage preserves an in-flight tool block. Tool results are matched by call ID when IDs are complete and unique, with count-based fallback when IDs are unavailable or unreliable.

The option remains disabled by default for 1.x compatibility.

## Testing
- ChatMemoryUtilsTest, MessageWindowChatMemoryTest, TokenWindowChatMemoryTest: 48 tests passed
- git diff --check