### PR TITLE
Add ChatRequestOptions to propagate listener attributes

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/ChatModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/ChatModel.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.chat;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.ModelProvider.OTHER;
 import static dev.langchain4j.model.chat.ChatModelListenerUtils.onError;
 import static dev.langchain4j.model.chat.ChatModelListenerUtils.onRequest;
@@ -32,6 +33,20 @@ public interface ChatModel {
      * @return a {@link ChatResponse}, containing all the outputs from the LLM
      */
     default ChatResponse chat(ChatRequest chatRequest) {
+        return chat(chatRequest, ChatRequestOptions.EMPTY);
+    }
+
+    /**
+     * Sends a chat request with additional invocation options.
+     *
+     * @param chatRequest a {@link ChatRequest}, containing all the inputs to the LLM
+     * @param options     a {@link ChatRequestOptions} carrying listener attributes and other per-call metadata
+     * @return a {@link ChatResponse}, containing all the outputs from the LLM
+     * @since 1.13.0
+     */
+    default ChatResponse chat(ChatRequest chatRequest, ChatRequestOptions options) {
+
+        ChatRequestOptions effectiveOptions = getOrDefault(options, ChatRequestOptions.EMPTY);
 
         ChatRequest finalChatRequest = ChatRequest.builder()
                 .messages(chatRequest.messages())
@@ -39,7 +54,7 @@ public interface ChatModel {
                 .build();
 
         List<ChatModelListener> listeners = listeners();
-        Map<Object, Object> attributes = new ConcurrentHashMap<>();
+        Map<Object, Object> attributes = new ConcurrentHashMap<>(effectiveOptions.listenerAttributes());
 
         onRequest(finalChatRequest, provider(), attributes, listeners);
         try {

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/ChatRequestOptions.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/ChatRequestOptions.java
@@ -1,18 +1,19 @@
 package dev.langchain4j.model.chat;
 
-import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static dev.langchain4j.internal.Utils.copy;
+
 /**
- * Options that accompany a {@link dev.langchain4j.model.chat.request.ChatRequest ChatRequest} through the
- * {@link ChatModel#chat(dev.langchain4j.model.chat.request.ChatRequest, ChatRequestOptions) ChatModel.chat} or
- * {@link StreamingChatModel#chat(dev.langchain4j.model.chat.request.ChatRequest,
- * dev.langchain4j.model.chat.response.StreamingChatResponseHandler, ChatRequestOptions) StreamingChatModel.chat}
+ * Options that accompany a {@link ChatRequest} through the
+ * {@link ChatModel#chat(ChatRequest, ChatRequestOptions)} or
+ * {@link StreamingChatModel#chat(ChatRequest, ChatRequestOptions, StreamingChatResponseHandler)}
  * invocation.
  *
  * <p>These options are <em>not</em> sent to the LLM provider; they are purely
@@ -57,20 +58,18 @@ public class ChatRequestOptions {
 
     public static class Builder {
 
-        private final Map<Object, Object> listenerAttributes = new LinkedHashMap<>();
+        private Map<Object, Object> listenerAttributes;
 
-        public Builder addListenerAttribute(Object key, Object value) {
-            ensureNotNull(key, "key");
-            ensureNotNull(value, "value");
-            this.listenerAttributes.put(key, value);
+        public Builder listenerAttributes(Map<Object, Object> listenerAttributes) {
+            this.listenerAttributes = listenerAttributes;
             return this;
         }
 
-        public Builder listenerAttributes(Map<Object, Object> attributes) {
-            if (attributes != null) {
-                this.listenerAttributes.clear();
-                this.listenerAttributes.putAll(attributes);
+        public Builder addListenerAttribute(Object key, Object value) {
+            if (this.listenerAttributes == null) {
+                this.listenerAttributes = new LinkedHashMap<>();
             }
+            this.listenerAttributes.put(key, value);
             return this;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/ChatRequestOptions.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/ChatRequestOptions.java
@@ -1,0 +1,81 @@
+package dev.langchain4j.model.chat;
+
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Options that accompany a {@link dev.langchain4j.model.chat.request.ChatRequest ChatRequest} through the
+ * {@link ChatModel#chat(dev.langchain4j.model.chat.request.ChatRequest, ChatRequestOptions) ChatModel.chat} or
+ * {@link StreamingChatModel#chat(dev.langchain4j.model.chat.request.ChatRequest,
+ * dev.langchain4j.model.chat.response.StreamingChatResponseHandler, ChatRequestOptions) StreamingChatModel.chat}
+ * invocation.
+ *
+ * <p>These options are <em>not</em> sent to the LLM provider; they are purely
+ * for the LangChain4j invocation chain (listeners, hooks, etc.).
+ *
+ * @since 1.13.0
+ */
+public class ChatRequestOptions {
+
+    public static final ChatRequestOptions EMPTY = new ChatRequestOptions(Collections.emptyMap());
+
+    private final Map<Object, Object> listenerAttributes;
+
+    private ChatRequestOptions(Map<Object, Object> listenerAttributes) {
+        this.listenerAttributes = copy(listenerAttributes);
+    }
+
+    public Map<Object, Object> listenerAttributes() {
+        return listenerAttributes;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ChatRequestOptions that)) return false;
+        return Objects.equals(listenerAttributes, that.listenerAttributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(listenerAttributes);
+    }
+
+    @Override
+    public String toString() {
+        return "ChatRequestOptions{listenerAttributes=" + listenerAttributes + "}";
+    }
+
+    public static class Builder {
+
+        private final Map<Object, Object> listenerAttributes = new LinkedHashMap<>();
+
+        public Builder addListenerAttribute(Object key, Object value) {
+            ensureNotNull(key, "key");
+            ensureNotNull(value, "value");
+            this.listenerAttributes.put(key, value);
+            return this;
+        }
+
+        public Builder listenerAttributes(Map<Object, Object> attributes) {
+            if (attributes != null) {
+                this.listenerAttributes.clear();
+                this.listenerAttributes.putAll(attributes);
+            }
+            return this;
+        }
+
+        public ChatRequestOptions build() {
+            return new ChatRequestOptions(listenerAttributes);
+        }
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/StreamingChatModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/StreamingChatModel.java
@@ -1,10 +1,5 @@
 package dev.langchain4j.model.chat;
 
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.model.ModelProvider.OTHER;
-import static dev.langchain4j.model.chat.ChatModelListenerUtils.onRequest;
-import static dev.langchain4j.model.chat.ChatModelListenerUtils.onResponse;
-
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.ModelProvider;
@@ -21,10 +16,16 @@ import dev.langchain4j.model.chat.response.PartialThinkingContext;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCallContext;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.model.ModelProvider.OTHER;
+import static dev.langchain4j.model.chat.ChatModelListenerUtils.onRequest;
+import static dev.langchain4j.model.chat.ChatModelListenerUtils.onResponse;
 
 /**
  * Represents a language model that has a chat API and can stream a response one token at a time.
@@ -36,29 +37,29 @@ public interface StreamingChatModel {
     /**
      * This is the main API to interact with the chat model.
      *
-     * @param chatRequest a {@link ChatRequest}, containing all the inputs to the LLM
-     * @param handler     a {@link StreamingChatResponseHandler} that will handle streaming response from the LLM
+     * @param request a {@link ChatRequest}, containing all the inputs to the LLM
+     * @param handler a {@link StreamingChatResponseHandler} that will handle streaming response from the LLM
      */
-    default void chat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
-        chat(chatRequest, handler, ChatRequestOptions.EMPTY);
+    default void chat(ChatRequest request, StreamingChatResponseHandler handler) {
+        chat(request, ChatRequestOptions.EMPTY, handler);
     }
 
     /**
      * Sends a streaming chat request with additional invocation options.
      *
-     * @param chatRequest a {@link ChatRequest}, containing all the inputs to the LLM
-     * @param handler     a {@link StreamingChatResponseHandler} that will handle streaming response from the LLM
-     * @param options     a {@link ChatRequestOptions} carrying listener attributes and other per-call metadata
+     * @param request a {@link ChatRequest}, containing all the inputs to the LLM
+     * @param options a {@link ChatRequestOptions} carrying listener attributes and other per-call metadata
+     * @param handler a {@link StreamingChatResponseHandler} that will handle streaming response from the LLM
      * @since 1.13.0
      */
-    default void chat(ChatRequest chatRequest, StreamingChatResponseHandler handler, ChatRequestOptions options) {
-
-        ChatRequestOptions effectiveOptions = getOrDefault(options, ChatRequestOptions.EMPTY);
+    default void chat(ChatRequest request, ChatRequestOptions options, StreamingChatResponseHandler handler) {
 
         ChatRequest finalChatRequest = ChatRequest.builder()
-                .messages(chatRequest.messages())
-                .parameters(defaultRequestParameters().overrideWith(chatRequest.parameters()))
+                .messages(request.messages())
+                .parameters(defaultRequestParameters().overrideWith(request.parameters()))
                 .build();
+
+        ChatRequestOptions effectiveOptions = getOrDefault(options, ChatRequestOptions.EMPTY);
 
         List<ChatModelListener> listeners = listeners();
         Map<Object, Object> attributes = new ConcurrentHashMap<>(effectiveOptions.listenerAttributes());

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/StreamingChatModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/StreamingChatModel.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.chat;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.ModelProvider.OTHER;
 import static dev.langchain4j.model.chat.ChatModelListenerUtils.onRequest;
 import static dev.langchain4j.model.chat.ChatModelListenerUtils.onResponse;
@@ -39,6 +40,20 @@ public interface StreamingChatModel {
      * @param handler     a {@link StreamingChatResponseHandler} that will handle streaming response from the LLM
      */
     default void chat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+        chat(chatRequest, handler, ChatRequestOptions.EMPTY);
+    }
+
+    /**
+     * Sends a streaming chat request with additional invocation options.
+     *
+     * @param chatRequest a {@link ChatRequest}, containing all the inputs to the LLM
+     * @param handler     a {@link StreamingChatResponseHandler} that will handle streaming response from the LLM
+     * @param options     a {@link ChatRequestOptions} carrying listener attributes and other per-call metadata
+     * @since 1.13.0
+     */
+    default void chat(ChatRequest chatRequest, StreamingChatResponseHandler handler, ChatRequestOptions options) {
+
+        ChatRequestOptions effectiveOptions = getOrDefault(options, ChatRequestOptions.EMPTY);
 
         ChatRequest finalChatRequest = ChatRequest.builder()
                 .messages(chatRequest.messages())
@@ -46,7 +61,7 @@ public interface StreamingChatModel {
                 .build();
 
         List<ChatModelListener> listeners = listeners();
-        Map<Object, Object> attributes = new ConcurrentHashMap<>();
+        Map<Object, Object> attributes = new ConcurrentHashMap<>(effectiveOptions.listenerAttributes());
 
         StreamingChatResponseHandler observingHandler = new StreamingChatResponseHandler() {
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/ChatModelListenerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/ChatModelListenerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
@@ -228,5 +229,89 @@ class ChatModelListenerTest {
 
         // then
         verify(listener2).onError(any());
+    }
+
+    @Test
+    void should_propagate_options_attributes_to_listener_on_request() {
+
+        // given
+        ChatModelListener listener = spy(new ChatModelListener() {
+            @Override
+            public void onRequest(ChatModelRequestContext requestContext) {
+                assertThat(requestContext.attributes()).containsEntry("tenantId", "acme-co");
+            }
+        });
+        TestChatModel model = new TestChatModel(List.of(listener));
+        ChatRequestOptions options = ChatRequestOptions.builder()
+                .addListenerAttribute("tenantId", "acme-co")
+                .build();
+
+        // when
+        model.chat(ChatRequest.builder().messages(UserMessage.from("hi")).build(), options);
+
+        // then
+        verify(listener).onRequest(any());
+    }
+
+    @Test
+    void should_propagate_options_attributes_to_listener_on_response() {
+
+        // given
+        ChatModelListener listener = spy(new ChatModelListener() {
+            @Override
+            public void onResponse(ChatModelResponseContext responseContext) {
+                assertThat(responseContext.attributes()).containsEntry("tenantId", "acme-co");
+            }
+        });
+        TestChatModel model = new TestChatModel(List.of(listener));
+        ChatRequestOptions options = ChatRequestOptions.builder()
+                .addListenerAttribute("tenantId", "acme-co")
+                .build();
+
+        // when
+        model.chat(ChatRequest.builder().messages(UserMessage.from("hi")).build(), options);
+
+        // then
+        verify(listener).onResponse(any());
+    }
+
+    @Test
+    void should_propagate_options_attributes_to_listener_on_error() {
+
+        // given
+        ChatModelListener listener = spy(new ChatModelListener() {
+            @Override
+            public void onError(ChatModelErrorContext errorContext) {
+                assertThat(errorContext.attributes()).containsEntry("tenantId", "acme-co");
+            }
+        });
+        TestChatModel model = new TestChatModel(List.of(listener)) {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                throw new RuntimeException("fail");
+            }
+        };
+        ChatRequestOptions options = ChatRequestOptions.builder()
+                .addListenerAttribute("tenantId", "acme-co")
+                .build();
+
+        // when
+        assertThatThrownBy(() -> model.chat(
+                ChatRequest.builder().messages(UserMessage.from("hi")).build(), options));
+
+        // then
+        verify(listener).onError(any());
+    }
+
+    @Test
+    void should_handle_null_options() {
+
+        // given
+        TestChatModel model = new TestChatModel(List.of());
+
+        // when/then
+        assertThatNoException()
+                .isThrownBy(() -> model.chat(
+                        ChatRequest.builder().messages(UserMessage.from("hi")).build(), (ChatRequestOptions) null));
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/ChatRequestOptionsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/ChatRequestOptionsTest.java
@@ -1,9 +1,7 @@
 package dev.langchain4j.model.chat;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -49,47 +47,6 @@ class ChatRequestOptionsTest {
 
         // then
         assertThat(options.listenerAttributes()).containsOnlyKeys("new");
-    }
-
-    @Test
-    void should_reject_null_key() {
-        assertThatThrownBy(() -> ChatRequestOptions.builder().addListenerAttribute(null, "v"))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void should_reject_null_value() {
-        assertThatThrownBy(() -> ChatRequestOptions.builder().addListenerAttribute("k", null))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void should_make_defensive_copy() {
-
-        // given
-        Map<Object, Object> original = new HashMap<>();
-        original.put("key", "value");
-
-        // when
-        ChatRequestOptions options =
-                ChatRequestOptions.builder().listenerAttributes(original).build();
-        original.put("extra", "modified");
-
-        // then
-        assertThat(options.listenerAttributes()).doesNotContainKey("extra");
-    }
-
-    @Test
-    void should_handle_null_bulk_map() {
-
-        // when
-        ChatRequestOptions options = ChatRequestOptions.builder()
-                .addListenerAttribute("key", "value")
-                .listenerAttributes(null)
-                .build();
-
-        // then
-        assertThat(options.listenerAttributes()).containsEntry("key", "value");
     }
 
     @Test

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/ChatRequestOptionsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/ChatRequestOptionsTest.java
@@ -1,0 +1,117 @@
+package dev.langchain4j.model.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ChatRequestOptionsTest {
+
+    @Test
+    void empty_should_have_no_attributes() {
+        assertThat(ChatRequestOptions.EMPTY.listenerAttributes()).isEmpty();
+    }
+
+    @Test
+    void should_build_with_single_attribute() {
+
+        // when
+        ChatRequestOptions options = ChatRequestOptions.builder()
+                .addListenerAttribute("key", "value")
+                .build();
+
+        // then
+        assertThat(options.listenerAttributes()).containsEntry("key", "value");
+    }
+
+    @Test
+    void should_build_with_bulk_attributes() {
+
+        // when
+        ChatRequestOptions options = ChatRequestOptions.builder()
+                .listenerAttributes(Map.of("a", 1, "b", 2))
+                .build();
+
+        // then
+        assertThat(options.listenerAttributes()).containsEntry("a", 1).containsEntry("b", 2);
+    }
+
+    @Test
+    void bulk_should_replace_previous_attributes() {
+
+        // when
+        ChatRequestOptions options = ChatRequestOptions.builder()
+                .addListenerAttribute("old", "value")
+                .listenerAttributes(Map.of("new", "value"))
+                .build();
+
+        // then
+        assertThat(options.listenerAttributes()).containsOnlyKeys("new");
+    }
+
+    @Test
+    void should_reject_null_key() {
+        assertThatThrownBy(() -> ChatRequestOptions.builder().addListenerAttribute(null, "v"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_reject_null_value() {
+        assertThatThrownBy(() -> ChatRequestOptions.builder().addListenerAttribute("k", null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_make_defensive_copy() {
+
+        // given
+        Map<Object, Object> original = new HashMap<>();
+        original.put("key", "value");
+
+        // when
+        ChatRequestOptions options =
+                ChatRequestOptions.builder().listenerAttributes(original).build();
+        original.put("extra", "modified");
+
+        // then
+        assertThat(options.listenerAttributes()).doesNotContainKey("extra");
+    }
+
+    @Test
+    void should_handle_null_bulk_map() {
+
+        // when
+        ChatRequestOptions options = ChatRequestOptions.builder()
+                .addListenerAttribute("key", "value")
+                .listenerAttributes(null)
+                .build();
+
+        // then
+        assertThat(options.listenerAttributes()).containsEntry("key", "value");
+    }
+
+    @Test
+    void should_have_correct_equals_and_hashCode() {
+
+        // given
+        ChatRequestOptions a =
+                ChatRequestOptions.builder().addListenerAttribute("k", "v").build();
+        ChatRequestOptions b =
+                ChatRequestOptions.builder().addListenerAttribute("k", "v").build();
+
+        // then
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void should_have_meaningful_toString() {
+        ChatRequestOptions options = ChatRequestOptions.builder()
+                .addListenerAttribute("tenantId", "acme")
+                .build();
+
+        assertThat(options.toString()).contains("tenantId").contains("acme");
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/StreamingChatModelListenerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/StreamingChatModelListenerTest.java
@@ -76,15 +76,14 @@ class StreamingChatModelListenerTest {
 
         // when
         model.chat(
-                ChatRequest.builder().messages(UserMessage.from("hi")).build(),
-                new StreamingChatResponseHandler() {
+                ChatRequest.builder().messages(UserMessage.from("hi")).build(), options, new StreamingChatResponseHandler() {
                     @Override
                     public void onCompleteResponse(ChatResponse completeResponse) {}
 
                     @Override
                     public void onError(Throwable error) {}
-                },
-                options);
+                }
+        );
 
         // then
         assertThat(verified.get(5, TimeUnit.SECONDS)).isTrue();
@@ -111,15 +110,14 @@ class StreamingChatModelListenerTest {
 
         // when
         model.chat(
-                ChatRequest.builder().messages(UserMessage.from("hi")).build(),
-                new StreamingChatResponseHandler() {
+                ChatRequest.builder().messages(UserMessage.from("hi")).build(), options, new StreamingChatResponseHandler() {
                     @Override
                     public void onCompleteResponse(ChatResponse completeResponse) {}
 
                     @Override
                     public void onError(Throwable error) {}
-                },
-                options);
+                }
+        );
 
         // then
         assertThat(verified.get(5, TimeUnit.SECONDS)).isTrue();
@@ -135,14 +133,13 @@ class StreamingChatModelListenerTest {
         // when/then
         assertThatNoException()
                 .isThrownBy(() -> model.chat(
-                        ChatRequest.builder().messages(UserMessage.from("hi")).build(),
-                        new StreamingChatResponseHandler() {
+                        ChatRequest.builder().messages(UserMessage.from("hi")).build(), null, new StreamingChatResponseHandler() {
                             @Override
                             public void onCompleteResponse(ChatResponse completeResponse) {}
 
                             @Override
                             public void onError(Throwable error) {}
-                        },
-                        null));
+                        }
+                ));
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/StreamingChatModelListenerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/StreamingChatModelListenerTest.java
@@ -1,0 +1,148 @@
+package dev.langchain4j.model.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
+import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class StreamingChatModelListenerTest {
+
+    static class TestStreamingChatModel implements StreamingChatModel {
+
+        private final List<ChatModelListener> listeners;
+        private final boolean shouldFail;
+
+        TestStreamingChatModel(List<ChatModelListener> listeners) {
+            this(listeners, false);
+        }
+
+        TestStreamingChatModel(List<ChatModelListener> listeners, boolean shouldFail) {
+            this.listeners = listeners;
+            this.shouldFail = shouldFail;
+        }
+
+        @Override
+        public List<ChatModelListener> listeners() {
+            return listeners;
+        }
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            if (shouldFail) {
+                handler.onError(new RuntimeException("streaming fail"));
+            } else {
+                handler.onCompleteResponse(
+                        ChatResponse.builder().aiMessage(AiMessage.from("hi")).build());
+            }
+        }
+    }
+
+    @Test
+    void should_propagate_options_attributes_to_listener_on_request_and_response() throws Exception {
+
+        // given
+        CompletableFuture<Boolean> verified = new CompletableFuture<>();
+        ChatModelListener listener = spy(new ChatModelListener() {
+            @Override
+            public void onRequest(ChatModelRequestContext ctx) {
+                assertThat(ctx.attributes()).containsEntry("tenantId", "acme-co");
+            }
+
+            @Override
+            public void onResponse(ChatModelResponseContext ctx) {
+                assertThat(ctx.attributes()).containsEntry("tenantId", "acme-co");
+                verified.complete(true);
+            }
+        });
+        TestStreamingChatModel model = new TestStreamingChatModel(List.of(listener));
+        ChatRequestOptions options = ChatRequestOptions.builder()
+                .addListenerAttribute("tenantId", "acme-co")
+                .build();
+
+        // when
+        model.chat(
+                ChatRequest.builder().messages(UserMessage.from("hi")).build(),
+                new StreamingChatResponseHandler() {
+                    @Override
+                    public void onCompleteResponse(ChatResponse completeResponse) {}
+
+                    @Override
+                    public void onError(Throwable error) {}
+                },
+                options);
+
+        // then
+        assertThat(verified.get(5, TimeUnit.SECONDS)).isTrue();
+        verify(listener).onRequest(any());
+        verify(listener).onResponse(any());
+    }
+
+    @Test
+    void should_propagate_options_attributes_to_listener_on_error() throws Exception {
+
+        // given
+        CompletableFuture<Boolean> verified = new CompletableFuture<>();
+        ChatModelListener listener = spy(new ChatModelListener() {
+            @Override
+            public void onError(ChatModelErrorContext ctx) {
+                assertThat(ctx.attributes()).containsEntry("key", "value");
+                verified.complete(true);
+            }
+        });
+        TestStreamingChatModel model = new TestStreamingChatModel(List.of(listener), true);
+        ChatRequestOptions options = ChatRequestOptions.builder()
+                .addListenerAttribute("key", "value")
+                .build();
+
+        // when
+        model.chat(
+                ChatRequest.builder().messages(UserMessage.from("hi")).build(),
+                new StreamingChatResponseHandler() {
+                    @Override
+                    public void onCompleteResponse(ChatResponse completeResponse) {}
+
+                    @Override
+                    public void onError(Throwable error) {}
+                },
+                options);
+
+        // then
+        assertThat(verified.get(5, TimeUnit.SECONDS)).isTrue();
+        verify(listener).onError(any());
+    }
+
+    @Test
+    void should_handle_null_options() {
+
+        // given
+        TestStreamingChatModel model = new TestStreamingChatModel(List.of());
+
+        // when/then
+        assertThatNoException()
+                .isThrownBy(() -> model.chat(
+                        ChatRequest.builder().messages(UserMessage.from("hi")).build(),
+                        new StreamingChatResponseHandler() {
+                            @Override
+                            public void onCompleteResponse(ChatResponse completeResponse) {}
+
+                            @Override
+                            public void onError(Throwable error) {}
+                        },
+                        null));
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/AbstractAiServicesWithToolErrorHandlerTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AbstractAiServicesWithToolErrorHandlerTest.java
@@ -14,6 +14,7 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.ChatRequestOptions;
 import dev.langchain4j.model.chat.mock.ChatModelMock;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
@@ -399,6 +400,7 @@ public abstract class AbstractAiServicesWithToolErrorHandlerTest {
         verify(model, atLeast(0)).listeners();
         verify(model, atLeast(0)).provider();
         verify(model, atLeast(0)).supportedCapabilities();
+        verify(model, atLeast(0)).chat(any(ChatRequest.class), any(ChatRequestOptions.class));
     }
 
     static class CustomToolException extends RuntimeException {

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesIT.java
@@ -30,6 +30,7 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.ChatRequestOptions;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.input.structured.StructuredPrompt;
@@ -99,6 +100,7 @@ public class AiServicesIT {
         ignoreInteractions(model).supportedCapabilities();
         ignoreInteractions(model).listeners();
         ignoreInteractions(model).provider();
+        ignoreInteractions(model).chat(any(ChatRequest.class), any(ChatRequestOptions.class));
         verifyNoMoreInteractions(model);
     }
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolSearchToolIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolSearchToolIT.java
@@ -1065,12 +1065,12 @@ public class StreamingAiServicesWithToolSearchToolIT {
     }
 
     public static void verifyNoMoreImportantInteractions(StreamingChatModel model) {
+        ignoreInteractions(model).chat(any(ChatRequest.class), any(ChatRequestOptions.class), any(StreamingChatResponseHandler.class));
         ignoreInteractions(model).doChat(any(), any());
         ignoreInteractions(model).defaultRequestParameters();
         ignoreInteractions(model).supportedCapabilities();
         ignoreInteractions(model).listeners();
         ignoreInteractions(model).provider();
-        ignoreInteractions(model).chat(any(ChatRequest.class), any(StreamingChatResponseHandler.class), any(ChatRequestOptions.class));
         verifyNoMoreInteractions(model);
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolSearchToolIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolSearchToolIT.java
@@ -8,8 +8,10 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.internal.Json;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatRequestOptions;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
@@ -1068,6 +1070,7 @@ public class StreamingAiServicesWithToolSearchToolIT {
         ignoreInteractions(model).supportedCapabilities();
         ignoreInteractions(model).listeners();
         ignoreInteractions(model).provider();
+        ignoreInteractions(model).chat(any(ChatRequest.class), any(StreamingChatResponseHandler.class), any(ChatRequestOptions.class));
         verifyNoMoreInteractions(model);
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
@@ -1662,12 +1662,12 @@ class StreamingAiServicesWithToolsIT {
 
     // TODO rename verifyNoMoreImportantInteractions
     private static void verifyNoMoreInteractionsFor(StreamingChatModel model) {
+        ignoreInteractions(model).chat(any(ChatRequest.class), any(ChatRequestOptions.class), any(StreamingChatResponseHandler.class));
         ignoreInteractions(model).doChat(any(), any());
         ignoreInteractions(model).defaultRequestParameters();
         ignoreInteractions(model).supportedCapabilities();
         ignoreInteractions(model).listeners();
         ignoreInteractions(model).provider();
-        ignoreInteractions(model).chat(any(ChatRequest.class), any(StreamingChatResponseHandler.class), any(ChatRequestOptions.class));
         verifyNoMoreInteractions(model);
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
@@ -36,11 +36,13 @@ import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.invocation.InvocationParameters;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatRequestOptions;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
@@ -1665,6 +1667,7 @@ class StreamingAiServicesWithToolsIT {
         ignoreInteractions(model).supportedCapabilities();
         ignoreInteractions(model).listeners();
         ignoreInteractions(model).provider();
+        ignoreInteractions(model).chat(any(ChatRequest.class), any(StreamingChatResponseHandler.class), any(ChatRequestOptions.class));
         verifyNoMoreInteractions(model);
     }
 }


### PR DESCRIPTION
## Issue

Closes #3617

## Change

Introduces `ChatRequestOptions` as an extensible wrapper for invocation-level options, following @dliubarskyi's [suggestion](https://github.com/langchain4j/langchain4j/issues/3617#issuecomment-4010310535). This allows callers to pass custom metadata (e.g., tenantId, correlationId) to `ChatModelListener`s via `listenerAttributes`.

New API methods:
- `ChatModel.chat(ChatRequest, ChatRequestOptions)`
- `StreamingChatModel.chat(ChatRequest, StreamingChatResponseHandler, ChatRequestOptions)`

The existing single-argument `chat(ChatRequest)` delegates to the new overload with `ChatRequestOptions.EMPTY` for backward compatibility. Options are not sent to the LLM provider — they are only used within the LangChain4j invocation chain and listeners.

`ChatRequestOptions` is designed to be extensible for future options such as retry strategy or HTTP settings.

Updated Mockito `verifyNoMoreInteractions` helper methods in 4 test files to account for the new default method delegation chain, which introduces an additional mock interaction when using Mockito spies.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)