### PR TITLE
Add stream-based persistence API for InMemoryEmbeddingStore

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
+++ b/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
@@ -47,9 +47,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * <p>
  * Uses a brute force approach by iterating over all embeddings to find the best matches.
  * <p>
- * This store can be persisted using the {@link #serializeToJson()} and {@link #serializeToFile(Path)} methods.
+ * This store can be persisted using the {@link #serializeToJson()}, {@link #serializeToFile(Path)},
+ * and {@link #serializeToStream(OutputStream)} methods.
  * <p>
- * It can also be recreated from JSON or a file using the {@link #fromJson(String)} and {@link #fromFile(Path)} methods.
+ * It can also be recreated from JSON, a file, or an {@link InputStream} using the {@link #fromJson(String)},
+ * {@link #fromFile(Path)}, and {@link #fromStream(InputStream)} methods.
  *
  * @param <Embedded> The class of the object that has been embedded.
  *                   Typically, it is {@link dev.langchain4j.data.segment.TextSegment}.
@@ -216,6 +218,25 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
         serializeToFile(Paths.get(filePath));
     }
 
+    /**
+     * Serializes this store to the given {@link OutputStream} in JSON format.
+     *
+     * <p>With the default Jackson codec, this uses streaming serialization to avoid holding
+     * the entire JSON document in memory.
+     * It can be used to persist the store to any stream-based backend (e.g., network, S3, database).
+     *
+     * <p>The caller is responsible for closing the provided {@link OutputStream}.
+     *
+     * @param outputStream the {@link OutputStream} to write to
+     */
+    public void serializeToStream(OutputStream outputStream) {
+        try {
+            loadCodec().toJson(outputStream, this);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static InMemoryEmbeddingStore<TextSegment> fromJson(String json) {
         return loadCodec().fromJson(json);
     }
@@ -239,6 +260,26 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
      */
     public static InMemoryEmbeddingStore<TextSegment> fromFile(String filePath) {
         return fromFile(Paths.get(filePath));
+    }
+
+    /**
+     * Deserializes an embedding store from the given {@link InputStream} containing JSON.
+     *
+     * <p>With the default Jackson codec, this uses streaming deserialization to avoid loading
+     * the entire JSON document into memory.
+     * It can be used to load the store from any stream-based backend (e.g., network, S3, database).
+     *
+     * <p>The caller is responsible for closing the provided {@link InputStream}.
+     *
+     * @param inputStream the {@link InputStream} to read from
+     * @return a deserialized {@link InMemoryEmbeddingStore}
+     */
+    public static InMemoryEmbeddingStore<TextSegment> fromStream(InputStream inputStream) {
+        try {
+            return loadCodec().fromJson(inputStream);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/JacksonInMemoryEmbeddingStoreJsonCodec.java
+++ b/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/JacksonInMemoryEmbeddingStoreJsonCodec.java
@@ -6,6 +6,8 @@ import static com.fasterxml.jackson.annotation.PropertyAccessor.FIELD;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.StreamWriteFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -25,6 +27,8 @@ class JacksonInMemoryEmbeddingStoreJsonCodec implements InMemoryEmbeddingStoreJs
             .addMixIn(InMemoryEmbeddingStore.Entry.class, EntryMixIn.class)
             .addMixIn(Embedding.class, EmbeddingMixIn.class)
             .addMixIn(TextSegment.class, TextSegmentMixin.class)
+            .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+            .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
             .build();
 
     private static final TypeReference<InMemoryEmbeddingStore<TextSegment>> TYPE_REFERENCE = new TypeReference<>() {};

--- a/langchain4j/src/test/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStoreIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStoreIT.java
@@ -12,6 +12,13 @@ import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreWithFilteringIT;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.List;
@@ -76,6 +83,81 @@ class InMemoryEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
                     .isEqualTo(originalEmbeddingStore.entries)
                     .isInstanceOf(CopyOnWriteArrayList.class);
         }
+    }
+
+    @Test
+    void should_serialize_to_and_deserialize_from_stream() {
+
+        InMemoryEmbeddingStore<TextSegment> originalEmbeddingStore = createEmbeddingStore();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        originalEmbeddingStore.serializeToStream(outputStream);
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+        InMemoryEmbeddingStore<TextSegment> deserializedEmbeddingStore = InMemoryEmbeddingStore.fromStream(inputStream);
+
+        assertThat(deserializedEmbeddingStore.entries)
+                .isEqualTo(originalEmbeddingStore.entries)
+                .isInstanceOf(CopyOnWriteArrayList.class);
+    }
+
+    @Test
+    void should_not_close_provided_streams() {
+
+        InMemoryEmbeddingStore<TextSegment> store = createEmbeddingStore();
+
+        // verify OutputStream is not closed
+        boolean[] outputClosed = {false};
+        OutputStream trackingOutputStream = new FilterOutputStream(new ByteArrayOutputStream()) {
+            @Override
+            public void close() throws IOException {
+                outputClosed[0] = true;
+                super.close();
+            }
+        };
+        store.serializeToStream(trackingOutputStream);
+        assertThat(outputClosed[0]).isFalse();
+
+        // verify InputStream is not closed
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        store.serializeToStream(baos);
+
+        boolean[] inputClosed = {false};
+        InputStream trackingInputStream = new FilterInputStream(new ByteArrayInputStream(baos.toByteArray())) {
+            @Override
+            public void close() throws IOException {
+                inputClosed[0] = true;
+                super.close();
+            }
+        };
+        InMemoryEmbeddingStore.fromStream(trackingInputStream);
+        assertThat(inputClosed[0]).isFalse();
+    }
+
+    @Test
+    void should_wrap_io_exception_from_streams() {
+
+        InMemoryEmbeddingStore<TextSegment> store = createEmbeddingStore();
+
+        OutputStream failingOutputStream = new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                throw new IOException("write failed");
+            }
+        };
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> store.serializeToStream(failingOutputStream))
+                .withCauseInstanceOf(IOException.class);
+
+        InputStream failingInputStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException("read failed");
+            }
+        };
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> InMemoryEmbeddingStore.fromStream(failingInputStream))
+                .withCauseInstanceOf(IOException.class);
     }
 
     @Test


### PR DESCRIPTION
## Issue

Closes #4466

## Change

Add two public methods to `InMemoryEmbeddingStore` for stream-based persistence, allowing users to serialize/deserialize without file involvement:

- `serializeToStream(OutputStream)` — delegates to the codec's stream-based serialization
- `fromStream(InputStream)` — static factory method, delegates to the codec's stream-based deserialization

Both methods follow the same pattern as the existing `serializeToFile`/`fromFile` API. The caller is responsible for closing the provided stream.

Additionally, disabled Jackson's `AUTO_CLOSE_TARGET` and `AUTO_CLOSE_SOURCE` on the internal `ObjectMapper` to prevent it from closing caller-provided streams, which would violate the "caller is responsible for closing" contract documented in the Javadoc.

### Files changed

- `InMemoryEmbeddingStore.java` — 2 new public methods + updated class-level Javadoc
- `JacksonInMemoryEmbeddingStoreJsonCodec.java` — disabled auto-close features
- `InMemoryEmbeddingStoreTest.java` — 3 new tests (round-trip, stream-not-closed, IO error wrapping)

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)