### PR TITLE
fix: materialize content arguments before input guardrails

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -214,10 +214,12 @@ class DefaultAiServices<T> extends AiServices<T> {
                                 .variables(variables)
                                 .build();
 
-                        UserMessage userMessage = invokeInputGuardrails(
-                                context.guardrailService(), method, userMessageForAugmentation, commonGuardrailParam);
+                        UserMessage userMessage = addContentsToUserMessage(method, args, userMessageForAugmentation);
+                        userMessage = invokeInputGuardrails(
+                                context.guardrailService(), method, userMessage, commonGuardrailParam);
 
-                        Type returnType = context.returnType != null ? context.returnType : method.getGenericReturnType();
+                        Type returnType =
+                                context.returnType != null ? context.returnType : method.getGenericReturnType();
                         boolean streaming = returnType == TokenStream.class || canAdaptTokenStreamTo(returnType);
 
                         // TODO should it be called when returnType==String?
@@ -231,8 +233,6 @@ class DefaultAiServices<T> extends AiServices<T> {
                         if ((!supportsJsonSchema || jsonSchema.isEmpty()) && !streaming && !returnsImage) {
                             userMessage = appendOutputFormatInstructions(returnType, userMessage);
                         }
-
-                        userMessage = addContentsToUserMessage(method, args, userMessage);
 
                         List<ChatMessage> messages = new ArrayList<>();
                         if (context.hasChatMemory()) {
@@ -607,8 +607,10 @@ class DefaultAiServices<T> extends AiServices<T> {
             return "";
         }
 
-        return context.userMessageProvider.apply(memoryId)
-                .orElseThrow(() -> illegalConfiguration("Error: The method '%s' does not have a user message defined.", method.getName()));
+        return context.userMessageProvider
+                .apply(memoryId)
+                .orElseThrow(() -> illegalConfiguration(
+                        "Error: The method '%s' does not have a user message defined.", method.getName()));
     }
 
     private static boolean hasContentArgument(Method method, Object[] args) {
@@ -728,12 +730,14 @@ class DefaultAiServices<T> extends AiServices<T> {
             prependTextContentsToUserMessage(userMessage, contents);
         }
 
-        return userMessage.contents().size() == contents.size() ? userMessage : userMessage.toBuilder().contents(contents).build();
+        return userMessage.contents().size() == contents.size()
+                ? userMessage
+                : userMessage.toBuilder().contents(contents).build();
     }
 
     private static void prependTextContentsToUserMessage(UserMessage userMessage, List<Content> contents) {
         List<Content> originalContent = userMessage.contents();
-        for (int i = originalContent.size()-1; i >= 0; i--) {
+        for (int i = originalContent.size() - 1; i >= 0; i--) {
             if (originalContent.get(i) instanceof TextContent textContent) {
                 contents.add(0, textContent);
             }
@@ -741,7 +745,7 @@ class DefaultAiServices<T> extends AiServices<T> {
     }
 
     private static boolean isMapOfContents(Object o) {
-        return o instanceof Map<?,?> map && map.values().stream().allMatch(Content.class::isInstance);
+        return o instanceof Map<?, ?> map && map.values().stream().allMatch(Content.class::isInstance);
     }
 
     private static boolean isListOfContents(Object o) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/guardrail/AiServiceGuardrailTests.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/guardrail/AiServiceGuardrailTests.java
@@ -3,18 +3,26 @@ package dev.langchain4j.service.guardrail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessageType;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.guardrail.GuardrailException;
 import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.InputGuardrailRequest;
 import dev.langchain4j.guardrail.InputGuardrailResult;
 import dev.langchain4j.guardrail.OutputGuardrail;
 import dev.langchain4j.guardrail.OutputGuardrailResult;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.rag.AugmentationRequest;
+import dev.langchain4j.rag.AugmentationResult;
+import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.service.AiServices;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,6 +30,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class AiServiceGuardrailTests {
+    private static final ImageContent IMAGE_CONTENT = ImageContent.from(
+            Image.builder().url("https://example.com/image.png").build());
+
     @Test
     void noGuardrails() {
         var noGuardrails = Assistant.create();
@@ -97,6 +108,66 @@ class AiServiceGuardrailTests {
                         InputGuardrailSuccess.class.getSimpleName(), OutputGuardrailSuccess.class.getSimpleName());
     }
 
+    @Test
+    void input_guardrail_should_receive_materialized_multimodal_user_message() {
+        RecordingInputGuardrail inputGuardrail = new RecordingInputGuardrail();
+        AtomicReference<UserMessage> userMessageSeenByChatModel = new AtomicReference<>();
+
+        VisionAssistant assistant = AiServices.builder(VisionAssistant.class)
+                .chatModel(new RecordingChatModel(userMessageSeenByChatModel))
+                .inputGuardrails(inputGuardrail)
+                .build();
+
+        assistant.describe(IMAGE_CONTENT);
+
+        assertThat(inputGuardrail.observedUserMessage()).isNotNull();
+        assertThat(inputGuardrail.observedUserMessage().contents())
+                .containsExactly(TextContent.from("Describe this image"), IMAGE_CONTENT);
+        assertThat(inputGuardrail.observedUserMessage().hasSingleText()).isFalse();
+        assertThat(userMessageSeenByChatModel.get()).isEqualTo(inputGuardrail.observedUserMessage());
+    }
+
+    @Test
+    void input_guardrail_should_observe_augmented_user_message_after_rag_and_before_chat_request() {
+        RecordingInputGuardrail inputGuardrail = new RecordingInputGuardrail();
+        AtomicReference<UserMessage> userMessageSeenByAugmentor = new AtomicReference<>();
+        AtomicReference<UserMessage> userMessageSeenByChatModel = new AtomicReference<>();
+
+        RetrievalAugmentor retrievalAugmentor = (AugmentationRequest request) -> {
+            userMessageSeenByAugmentor.set((UserMessage) request.chatMessage());
+            return new AugmentationResult(UserMessage.from("Augmented prompt"), null);
+        };
+
+        VisionAssistant assistant = AiServices.builder(VisionAssistant.class)
+                .chatModel(new RecordingChatModel(userMessageSeenByChatModel))
+                .inputGuardrails(inputGuardrail)
+                .retrievalAugmentor(retrievalAugmentor)
+                .build();
+
+        assistant.describe(IMAGE_CONTENT);
+
+        assertThat(userMessageSeenByAugmentor.get().contents())
+                .containsExactly(TextContent.from("Describe this image"));
+        assertThat(inputGuardrail.observedUserMessage().contents())
+                .containsExactly(TextContent.from("Augmented prompt"), IMAGE_CONTENT);
+        assertThat(userMessageSeenByChatModel.get()).isEqualTo(inputGuardrail.observedUserMessage());
+    }
+
+    @Test
+    void input_guardrail_rewrite_should_still_work_for_plain_text_requests() {
+        AtomicReference<UserMessage> userMessageSeenByChatModel = new AtomicReference<>();
+
+        PlainTextAssistant assistant = AiServices.builder(PlainTextAssistant.class)
+                .chatModel(new RecordingChatModel(userMessageSeenByChatModel))
+                .inputGuardrails(new RewritingInputGuardrail())
+                .build();
+
+        assistant.chat("Original prompt");
+
+        assertThat(userMessageSeenByChatModel.get().contents()).containsExactly(TextContent.from("Rewritten prompt"));
+        assertThat(userMessageSeenByChatModel.get().hasSingleText()).isTrue();
+    }
+
     static Stream<Arguments> classLevelAssistants() {
         return Stream.of(
                 Arguments.of("assistant with class-level annotations", ClassLevelAssistant.create()),
@@ -127,6 +198,15 @@ class AiServiceGuardrailTests {
         static Assistant create() {
             return create(Assistant.class);
         }
+    }
+
+    interface VisionAssistant {
+        @dev.langchain4j.service.UserMessage("Describe this image")
+        String describe(@dev.langchain4j.service.UserMessage ImageContent image);
+    }
+
+    interface PlainTextAssistant {
+        String chat(String message);
     }
 
     @InputGuardrails(InputGuardrailSuccess.class)
@@ -236,6 +316,29 @@ class AiServiceGuardrailTests {
         }
     }
 
+    static class RecordingInputGuardrail implements InputGuardrail {
+
+        private final AtomicReference<UserMessage> observedUserMessage = new AtomicReference<>();
+
+        @Override
+        public InputGuardrailResult validate(InputGuardrailRequest request) {
+            observedUserMessage.set(request.userMessage());
+            return success();
+        }
+
+        UserMessage observedUserMessage() {
+            return observedUserMessage.get();
+        }
+    }
+
+    static class RewritingInputGuardrail implements InputGuardrail {
+
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            return successWith("Rewritten prompt");
+        }
+    }
+
     public static class InputGuardrailFail implements InputGuardrail {
         @Override
         public InputGuardrailResult validate(UserMessage userMessage) {
@@ -274,6 +377,25 @@ class AiServiceGuardrailTests {
             return ChatResponse.builder()
                     .aiMessage(AiMessage.from("Request: %s; Response: Hi!".formatted(getUserMessage(chatRequest))))
                     .build();
+        }
+    }
+
+    static class RecordingChatModel implements ChatModel {
+
+        private final AtomicReference<UserMessage> observedUserMessage;
+
+        RecordingChatModel(AtomicReference<UserMessage> observedUserMessage) {
+            this.observedUserMessage = observedUserMessage;
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            observedUserMessage.set(chatRequest.messages().stream()
+                    .filter(message -> message.type() == ChatMessageType.USER)
+                    .map(UserMessage.class::cast)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("No user message found")));
+            return ChatResponse.builder().aiMessage(AiMessage.from("ok")).build();
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix `AiServices` input guardrail ordering for method-level `Content` / `ImageContent` arguments
- keep RAG augmentation before input guardrails
- add regression coverage for multimodal and augmented user messages seen by input guardrails

Closes #4678.

## Problem
`InputGuardrail` currently runs against an intermediate `UserMessage`.

In `DefaultAiServices`, method-level content arguments are merged into the `UserMessage` only **after** input guardrails run. As a result, an input guardrail can observe a single-text message even though the actual request sent to the model is multimodal.

That affects any guardrail that depends on the real message shape, for example:
- distinguishing plain-text vs multimodal input
- inspecting `contents()` directly
- rewriting text only for single-text requests

## Change
This PR moves `addContentsToUserMessage(...)` to happen after RAG augmentation but before input guardrail execution.

The resulting order is:
1. build the initial user message
2. run RAG augmentation, if configured
3. merge method-level content arguments into the user message
4. execute input guardrails
5. append output format instructions / continue normal request flow

This keeps the existing RAG invariant while ensuring input guardrails see the materialized user input instead of a partially built message.

## Tests
Added regression coverage in `AiServiceGuardrailTests` for:
- input guardrails receiving a materialized multimodal user message
- input guardrails seeing the augmented message after RAG and before the chat request is sent
- plain-text input guardrail rewrite behavior remaining intact

Also re-ran related service-layer tests:
- `AiServiceGuardrailTests`
- `AiServicesUserMessageConfigTest`
- `AiServicesWithCustomContentInjectorTest`
- `AiServicesRagChatMemoryBehaviorTest`
- `AiServicesObservabilityTests`
- `spotless:check`

## Notes
A downstream community feature exposed this bug, but the fix here is framework-level and not specific to that feature.