### PR TITLE
Add User-Agent header for Anthropic API calls

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
@@ -122,6 +122,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
     private static final String CONTENT_BLOCK_THINKING = "thinking";
     private static final String CONTENT_BLOCK_REDACTED_THINKING = "redacted_thinking";
     private static final String CONTENT_BLOCK_TOOL_USE = "tool_use";
+    private static final String DEFAULT_USER_AGENT = "langchain4j";
 
     private final HttpClient httpClient;
     private final String baseUrl;
@@ -612,6 +613,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
                 .url(baseUrl, "models")
                 .addHeader("x-api-key", apiKey)
                 .addHeader("anthropic-version", version)
+                .addHeader("User-Agent", DEFAULT_USER_AGENT)
                 .build();
         SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
         return fromJson(successfulHttpResponse.body(), AnthropicModelsListResponse.class);
@@ -653,6 +655,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("x-api-key", apiKey)
                 .addHeader("anthropic-version", version)
+                .addHeader("User-Agent", DEFAULT_USER_AGENT)
                 .body(jsonRequest);
 
         if (this.beta != null) {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClientTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClientTest.java
@@ -112,6 +112,7 @@ class DefaultAnthropicClientTest {
             assertThat(sentRequest.headers().get("Content-Type")).containsExactly("application/json");
             assertThat(sentRequest.headers().get("x-api-key")).containsExactly(TEST_API_KEY);
             assertThat(sentRequest.headers().get("anthropic-version")).containsExactly(TEST_VERSION);
+            assertThat(sentRequest.headers().get("User-Agent")).containsExactly("langchain4j");
             assertThat(sentRequest.body()).isEqualTo(Json.toJson(request));
         }
 
@@ -214,6 +215,7 @@ class DefaultAnthropicClientTest {
             assertThat(sentRequest.url()).isEqualTo(TEST_BASE_URL + "/messages/count_tokens");
             assertThat(sentRequest.headers().get("x-api-key")).containsExactly(TEST_API_KEY);
             assertThat(sentRequest.headers().get("anthropic-version")).containsExactly(TEST_VERSION);
+            assertThat(sentRequest.headers().get("User-Agent")).containsExactly("langchain4j");
         }
     }
 
@@ -260,6 +262,7 @@ class DefaultAnthropicClientTest {
             assertThat(sentRequest.url()).isEqualTo(TEST_BASE_URL + "/models");
             assertThat(sentRequest.headers().get("x-api-key")).containsExactly(TEST_API_KEY);
             assertThat(sentRequest.headers().get("anthropic-version")).containsExactly(TEST_VERSION);
+            assertThat(sentRequest.headers().get("User-Agent")).containsExactly("langchain4j");
         }
     }
 
@@ -344,6 +347,7 @@ class DefaultAnthropicClientTest {
             assertThat(sentRequest.headers().get("Content-Type")).containsExactly("application/json");
             assertThat(sentRequest.headers().get("x-api-key")).containsExactly(TEST_API_KEY);
             assertThat(sentRequest.headers().get("anthropic-version")).containsExactly(TEST_VERSION);
+            assertThat(sentRequest.headers().get("User-Agent")).containsExactly("langchain4j");
         }
 
         @Test


### PR DESCRIPTION
## Issue

No open github issue, just a small tweak here. Matches what was done in https://github.com/langchain-ai/langchain/pull/35268

## Change

Passes User-Agent: langchain4j to the Anthropic API so Anthropic can identify traffic from LangChain4j.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

