### PR TITLE
Fix ModerationModel Javadoc

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/moderation/ModerationModel.java
@@ -160,7 +160,7 @@ public interface ModerationModel {
     /**
      * Returns the model name for this moderation model.
      *
-     * @return the model name, or {@code null} if not available.
+     * @return the model name, or {@code "unknown"} if not available.
      */
     default String modelName() {
         return "unknown";


### PR DESCRIPTION
The return Javadoc tag for ModerationModel#modelName() incorrectly states the method returns null when the model name is not available, but the default implementation actually returns "unknown".