### PR TITLE
Fix packages and dependencies

### DIFF
--- a/langchain4j-observation/pom.xml
+++ b/langchain4j-observation/pom.xml
@@ -38,6 +38,14 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation</artifactId>
+        </dependency>
 
         <!-- For testing purposes-->
         <dependency>
@@ -55,6 +63,11 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>4.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/langchain4j-observation/src/main/java/dev/langchain4j/observation/context/ChatModelObservationContext.java
+++ b/langchain4j-observation/src/main/java/dev/langchain4j/observation/context/ChatModelObservationContext.java
@@ -1,4 +1,4 @@
-package context;
+package dev.langchain4j.observation.context;
 
 import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
 import dev.langchain4j.model.chat.listener.ChatModelRequestContext;

--- a/langchain4j-observation/src/main/java/dev/langchain4j/observation/convention/ChatModelConvention.java
+++ b/langchain4j-observation/src/main/java/dev/langchain4j/observation/convention/ChatModelConvention.java
@@ -1,6 +1,6 @@
-package convention;
+package dev.langchain4j.observation.convention;
 
-import context.ChatModelObservationContext;
+import dev.langchain4j.observation.context.ChatModelObservationContext;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
 

--- a/langchain4j-observation/src/main/java/dev/langchain4j/observation/convention/ChatModelDocumentation.java
+++ b/langchain4j-observation/src/main/java/dev/langchain4j/observation/convention/ChatModelDocumentation.java
@@ -1,4 +1,4 @@
-package convention;
+package dev.langchain4j.observation.convention;
 
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.observation.Observation;

--- a/langchain4j-observation/src/main/java/dev/langchain4j/observation/convention/DefaultChatModelConvention.java
+++ b/langchain4j-observation/src/main/java/dev/langchain4j/observation/convention/DefaultChatModelConvention.java
@@ -1,15 +1,14 @@
-package convention;
+package dev.langchain4j.observation.convention;
 
-import static convention.ChatModelDocumentation.HighCardinalityValues.INPUT_TOKENS;
-import static convention.ChatModelDocumentation.HighCardinalityValues.OUTPUT_TOKENS;
-import static convention.ChatModelDocumentation.LowCardinalityValues.OPERATION_NAME;
-import static convention.ChatModelDocumentation.LowCardinalityValues.OUTCOME;
-import static convention.ChatModelDocumentation.LowCardinalityValues.PROVIDER_NAME;
-import static convention.ChatModelDocumentation.LowCardinalityValues.REQUEST_MODEL;
-import static convention.ChatModelDocumentation.LowCardinalityValues.RESPONSE_MODEL;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.HighCardinalityValues.INPUT_TOKENS;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.HighCardinalityValues.OUTPUT_TOKENS;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.OPERATION_NAME;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.OUTCOME;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.PROVIDER_NAME;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.REQUEST_MODEL;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.RESPONSE_MODEL;
 import static java.util.Optional.ofNullable;
 
-import context.ChatModelObservationContext;
 import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
 import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
 import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
@@ -18,6 +17,7 @@ import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.observation.context.ChatModelObservationContext;
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import org.jspecify.annotations.Nullable;

--- a/langchain4j-observation/src/main/java/dev/langchain4j/observation/listener/ObservationChatModelListener.java
+++ b/langchain4j-observation/src/main/java/dev/langchain4j/observation/listener/ObservationChatModelListener.java
@@ -1,16 +1,12 @@
 package dev.langchain4j.observation.listener;
 
-import static convention.ChatModelDocumentation.LowCardinalityValues.OPERATION_NAME;
-import static convention.ChatModelDocumentation.LowCardinalityValues.PROVIDER_NAME;
-import static convention.ChatModelDocumentation.LowCardinalityValues.REQUEST_MODEL;
-import static convention.ChatModelDocumentation.LowCardinalityValues.RESPONSE_MODEL;
-import static convention.ChatModelDocumentation.LowCardinalityValues.TOKEN_TYPE;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.OPERATION_NAME;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.PROVIDER_NAME;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.REQUEST_MODEL;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.RESPONSE_MODEL;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.TOKEN_TYPE;
 import static java.util.Optional.ofNullable;
 
-import context.ChatModelObservationContext;
-import convention.ChatModelConvention;
-import convention.ChatModelDocumentation;
-import convention.DefaultChatModelConvention;
 import dev.langchain4j.Experimental;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
@@ -20,6 +16,10 @@ import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.observation.context.ChatModelObservationContext;
+import dev.langchain4j.observation.convention.ChatModelConvention;
+import dev.langchain4j.observation.convention.ChatModelDocumentation;
+import dev.langchain4j.observation.convention.DefaultChatModelConvention;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter.MeterProvider;
 import io.micrometer.core.instrument.MeterRegistry;

--- a/langchain4j-observation/src/test/java/dev/langchain4j/observation/listener/ObservationChatModelListenerIT.java
+++ b/langchain4j-observation/src/test/java/dev/langchain4j/observation/listener/ObservationChatModelListenerIT.java
@@ -1,12 +1,12 @@
 package dev.langchain4j.observation.listener;
 
-import static convention.ChatModelDocumentation.HighCardinalityValues.INPUT_TOKENS;
-import static convention.ChatModelDocumentation.HighCardinalityValues.OUTPUT_TOKENS;
-import static convention.ChatModelDocumentation.LowCardinalityValues.OPERATION_NAME;
-import static convention.ChatModelDocumentation.LowCardinalityValues.OUTCOME;
-import static convention.ChatModelDocumentation.LowCardinalityValues.REQUEST_MODEL;
-import static convention.ChatModelDocumentation.LowCardinalityValues.RESPONSE_MODEL;
-import static convention.ChatModelDocumentation.LowCardinalityValues.TOKEN_TYPE;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.HighCardinalityValues.INPUT_TOKENS;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.HighCardinalityValues.OUTPUT_TOKENS;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.OPERATION_NAME;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.OUTCOME;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.REQUEST_MODEL;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.RESPONSE_MODEL;
+import static dev.langchain4j.observation.convention.ChatModelDocumentation.LowCardinalityValues.TOKEN_TYPE;
 import static dev.langchain4j.observation.listener.ObservationChatModelListener.TOKEN_USAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;


### PR DESCRIPTION
Pakages were wrong. Sorry, I just noticed it now.
When I was running the build I got warnings about the need for explicit dependencies.
I didn't include jspecify because I can't find where the module might be using it. 


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
