### PR TITLE
Add langchain4j-skills-validator module for validating skills references

### DIFF
--- a/langchain4j-skills-validator/README.md
+++ b/langchain4j-skills-validator/README.md
@@ -16,7 +16,7 @@ A Java implementation of the Agent Skills reference library. This utility provid
 
 ```bash
 cd langchain4j-skills-validator
-mvn -Dmaven.javadoc.skip=true clean package
+mvn clean package
 ```
 
 This creates an executable JAR at `target/langchain4j-skills-validator-{version}.jar`.

--- a/langchain4j-skills-validator/README.md
+++ b/langchain4j-skills-validator/README.md
@@ -1,0 +1,119 @@
+# langchain4j-skills-validator
+
+A Java implementation of the Agent Skills reference library. This utility provides tools for validating, parsing, and working with Agent Skills metadata defined in `SKILL.md` files.
+
+
+## Features
+
+- **Validate Skills**: Check that skill directories have valid `SKILL.md` files with proper frontmatter, correct naming conventions, and required fields
+- **Parse Properties**: Extract skill metadata from YAML frontmatter in `SKILL.md` files
+- **Generate Prompts**: Create `<available_skills>` XML blocks for inclusion in agent system prompts (Anthropic's recommended format)
+- **CLI Tool**: Command-line interface for all major operations
+
+## Installation & Setup
+
+### Build from Source
+
+```bash
+cd langchain4j-skills-validator
+mvn -Dmaven.javadoc.skip=true clean package
+```
+
+This creates an executable JAR at `target/langchain4j-skills-validator-{version}.jar`.
+
+### Running the CLI
+
+```bash
+java -jar skills-validator.jar --help
+```
+
+## Usage
+
+### Command Line Interface
+
+#### Validate a Skill
+
+```bash
+java -jar skills-validator.jar validate /path/to/skill-directory
+```
+
+Validates that a skill directory has:
+- A `SKILL.md` file (uppercase or lowercase)
+- Valid YAML frontmatter with required fields
+- Proper naming conventions (lowercase, hyphens allowed, no leading/trailing hyphens)
+- Directory name matching the skill name
+
+#### Read Skill Properties
+
+```bash
+java -jar skills-validator.jar read-properties /path/to/skill-directory
+```
+
+Outputs skill properties as JSON:
+
+```json
+{
+  "name": "my-skill",
+  "description": "What this skill does",
+  "license": "Apache 2.0",
+  "compatibility": "Java 17+",
+  "allowed-tools": "file:read, file:write",
+  "metadata": {
+    "category": "file-operations"
+  }
+}
+```
+
+#### Generate Agent Prompt XML
+
+```bash
+java -jar skills-validator.jar to-prompt /path/to/skill-a /path/to/skill-b
+```
+
+Generates `<available_skills>` XML for agent prompts:
+
+```xml
+<available_skills>
+<skill>
+<name>
+my-skill
+</name>
+<description>
+What this skill does
+</description>
+<location>
+/path/to/skill/SKILL.md
+</location>
+</skill>
+</available_skills>
+```
+
+### Java API
+
+Use the library directly in your Java applications:
+
+```java
+public class Example {
+    public static void main(String[] args) throws Exception {
+        Path skillDir = Path.of("path/to/skill");
+
+        // Validate a skill
+        SkillValidator validator = new SkillValidator();
+        List<String> errors = validator.validate(skillDir);
+        if (!errors.isEmpty()) {
+            errors.forEach(System.err::println);
+        }
+
+        // Read skill properties
+        FrontmatterParser parser = new FrontmatterParser();
+        SkillProperties props = parser.readProperties(skillDir);
+        System.out.println("Skill: " + props.getName());
+        System.out.println("Description: " + props.getDescription());
+
+        // Generate prompt XML
+        PromptGenerator generator = new PromptGenerator();
+        String prompt = generator.toPrompt(List.of(skillDir));
+        System.out.println(prompt);
+    }
+}
+```

--- a/langchain4j-skills-validator/pom.xml
+++ b/langchain4j-skills-validator/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-parent</artifactId>
+        <version>1.13.0-beta22-SNAPSHOT</version>
+        <relativePath>../langchain4j-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-skills-validator</artifactId>
+    <name>LangChain4j :: Skills Validator</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>1.13.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-skills</artifactId>
+            <version>1.13.0-beta22-SNAPSHOT</version>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>1.13.0-SNAPSHOT</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>1.13.0-SNAPSHOT</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Source:
+		https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.13.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.2</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <!-- Compile Java -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+
+            <!-- Run tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+
+                        <configuration>
+                            <finalName>skills-validator</finalName>
+
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>dev.langchain4j.skills.validator.SkillsRefCli</mainClass>
+                                </transformer>
+                            </transformers>
+
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/SkillValidator.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/SkillValidator.java
@@ -1,0 +1,245 @@
+package dev.langchain4j.skills.validator;
+
+import dev.langchain4j.skills.validator.error.ParseError;
+import dev.langchain4j.skills.validator.parser.FrontmatterParser;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Skill validation logic.
+ */
+public class SkillValidator {
+    private static final int MAX_SKILL_NAME_LENGTH = 64;
+    private static final int MAX_DESCRIPTION_LENGTH = 1024;
+    private static final int MAX_COMPATIBILITY_LENGTH = 500;
+
+    private static final Set<String> ALLOWED_FIELDS =
+            Set.of("name", "description", "license", "allowed-tools", "metadata", "compatibility");
+
+    private final FrontmatterParser parser = new FrontmatterParser();
+
+    /**
+     * Validate a skill directory.
+     *
+     * @param skillDir Path to the skill directory
+     * @return List of validation error messages. Empty list means valid.
+     */
+    public List<String> validate(Path skillDir) {
+        skillDir = Objects.requireNonNull(skillDir, "skillDir cannot be null").toAbsolutePath();
+
+        if (!Files.exists(skillDir)) {
+            return List.of("Path does not exist: " + skillDir);
+        }
+
+        if (!Files.isDirectory(skillDir)) {
+            return List.of("Not a directory: " + skillDir);
+        }
+
+        Path skillMd = parser.findSkillMd(skillDir);
+        if (skillMd == null) {
+            return List.of("Missing required file: SKILL.md");
+        }
+
+        try {
+            String content = Files.readString(skillMd);
+            FrontmatterParser.FrontmatterResult result = parser.parseFrontmatter(content);
+            return validateMetadata(result.getMetadata(), skillDir);
+        } catch (ParseError e) {
+            return List.of(e.getMessage());
+        } catch (Exception e) {
+            return List.of("Error reading or parsing SKILL.md: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Validate parsed skill metadata.
+     *
+     * @param metadata Parsed YAML frontmatter dictionary
+     * @param skillDir Optional path to skill directory (for name-directory match check)
+     * @return List of validation error messages. Empty list means valid.
+     */
+    public List<String> validateMetadata(Map<String, Object> metadata, Path skillDir) {
+        List<String> errors = new ArrayList<>();
+
+        // Check for unknown fields
+        errors.addAll(validateMetadataFields(metadata));
+
+        // Validate name
+        if (!metadata.containsKey("name")) {
+            errors.add("Missing required field in frontmatter: name");
+        } else {
+            errors.addAll(validateName(metadata.get("name"), skillDir));
+        }
+
+        // Validate description
+        if (!metadata.containsKey("description")) {
+            errors.add("Missing required field in frontmatter: description");
+        } else {
+            errors.addAll(validateDescription(metadata.get("description")));
+        }
+
+        // Validate compatibility if present
+        if (metadata.containsKey("compatibility")) {
+            errors.addAll(validateCompatibility(metadata.get("compatibility")));
+        }
+
+        return errors;
+    }
+
+    /**
+     * Validate that only allowed fields are present.
+     */
+    private List<String> validateMetadataFields(Map<String, Object> metadata) {
+        List<String> errors = new ArrayList<>();
+
+        Set<String> extraFields = new HashSet<>(metadata.keySet());
+        extraFields.removeAll(ALLOWED_FIELDS);
+
+        if (!extraFields.isEmpty()) {
+            List<String> sortedExtra = new ArrayList<>(extraFields);
+            sortedExtra.sort(String::compareTo);
+            errors.add("Unexpected fields in frontmatter: "
+                    + sortedExtra
+                    + ". Only "
+                    + new ArrayList<>(ALLOWED_FIELDS)
+                    + " are allowed.");
+        }
+
+        return errors;
+    }
+
+    /**
+     * Validate skill name format and directory match.
+     *
+     * <p>Skill names support i18n characters (Unicode letters) plus hyphens. Names must be
+     * lowercase and cannot start/end with hyphens.
+     */
+    private List<String> validateName(Object nameObj, Path skillDir) {
+        List<String> errors = new ArrayList<>();
+
+        if (!(nameObj instanceof String)) {
+            errors.add("Field 'name' must be a non-empty string");
+            return errors;
+        }
+
+        String name = (String) nameObj;
+        if (name.isBlank()) {
+            errors.add("Field 'name' must be a non-empty string");
+            return errors;
+        }
+
+        // Normalize to NFKC form
+        name = Normalizer.normalize(name.strip(), Normalizer.Form.NFKC);
+
+        // Check length
+        if (name.length() > MAX_SKILL_NAME_LENGTH) {
+            errors.add("Skill name '"
+                    + name
+                    + "' exceeds "
+                    + MAX_SKILL_NAME_LENGTH
+                    + " character limit ("
+                    + name.length()
+                    + " chars)");
+        }
+
+        // Check lowercase
+        if (!name.equals(name.toLowerCase())) {
+            errors.add("Skill name '" + name + "' must be lowercase");
+        }
+
+        // Check start/end hyphens
+        if (name.startsWith("-") || name.endsWith("-")) {
+            errors.add("Skill name cannot start or end with a hyphen");
+        }
+
+        // Check consecutive hyphens
+        if (name.contains("--")) {
+            errors.add("Skill name cannot contain consecutive hyphens");
+        }
+
+        // Check valid characters
+        if (!isValidSkillName(name)) {
+            errors.add("Skill name '"
+                    + name
+                    + "' contains invalid characters. "
+                    + "Only letters, digits, and hyphens are allowed.");
+        }
+
+        // Check directory match
+        if (skillDir != null) {
+            String dirName = Normalizer.normalize(skillDir.getFileName().toString(), Normalizer.Form.NFKC);
+            if (!dirName.equals(name)) {
+                errors.add("Directory name '" + skillDir.getFileName() + "' must match skill name '" + name + "'");
+            }
+        }
+
+        return errors;
+    }
+
+    /**
+     * Check if name contains only valid characters.
+     */
+    private boolean isValidSkillName(String name) {
+        Pattern pattern = Pattern.compile("^[\\p{L}\\p{N}-]+$");
+        return pattern.matcher(name).matches();
+    }
+
+    /**
+     * Validate description format.
+     */
+    private List<String> validateDescription(Object descObj) {
+        List<String> errors = new ArrayList<>();
+
+        if (!(descObj instanceof String)) {
+            errors.add("Field 'description' must be a non-empty string");
+            return errors;
+        }
+
+        String description = (String) descObj;
+        if (description.isBlank()) {
+            errors.add("Field 'description' must be a non-empty string");
+            return errors;
+        }
+
+        if (description.length() > MAX_DESCRIPTION_LENGTH) {
+            errors.add("Description exceeds "
+                    + MAX_DESCRIPTION_LENGTH
+                    + " character limit ("
+                    + description.length()
+                    + " chars)");
+        }
+
+        return errors;
+    }
+
+    /**
+     * Validate compatibility format.
+     */
+    private List<String> validateCompatibility(Object compatObj) {
+        List<String> errors = new ArrayList<>();
+
+        if (!(compatObj instanceof String)) {
+            errors.add("Field 'compatibility' must be a string");
+            return errors;
+        }
+
+        String compatibility = (String) compatObj;
+        if (compatibility.length() > MAX_COMPATIBILITY_LENGTH) {
+            errors.add("Compatibility exceeds "
+                    + MAX_COMPATIBILITY_LENGTH
+                    + " character limit ("
+                    + compatibility.length()
+                    + " chars)");
+        }
+
+        return errors;
+    }
+}

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/SkillValidator.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/SkillValidator.java
@@ -90,14 +90,14 @@ public class SkillValidator {
         if (metadata.containsKey("compatibility")) {
             errors.addAll(validateCompatibility(metadata.get("compatibility")));
         }
-        
+
         if (metadata.containsKey("allowed-tools")) {
             errors.addAll(validateAllowedTools(metadata.get("allowed-tools")));
         }
 
         return errors;
     }
-    
+
     /**
      * Validate the {@code allowed-tools} field from SKILL.md frontmatter.
      *
@@ -137,7 +137,6 @@ public class SkillValidator {
 
         return errors;
     }
-
 
     /**
      * Validate that only allowed fields are present.

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/SkillValidator.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/SkillValidator.java
@@ -90,9 +90,54 @@ public class SkillValidator {
         if (metadata.containsKey("compatibility")) {
             errors.addAll(validateCompatibility(metadata.get("compatibility")));
         }
+        
+        if (metadata.containsKey("allowed-tools")) {
+            errors.addAll(validateAllowedTools(metadata.get("allowed-tools")));
+        }
 
         return errors;
     }
+    
+    /**
+     * Validate the {@code allowed-tools} field from SKILL.md frontmatter.
+     *
+     * <p>The {@code allowed-tools} field specifies which external tools a skill
+     * requires to function correctly. The value must be a whitespace-separated
+     * list of tool identifiers.
+     *
+     * <p>Each entry may optionally include a constraint in parentheses.
+     *
+     * <p>Examples of valid values:
+     * <pre>
+     * allowed-tools: Bash(git:*) Bash(jq:*) Read
+     * allowed-tools: Bash(python3:*) Read
+     * allowed-tools: Read
+     * </pre>
+     *
+     *
+     * <p>If any token does not match the expected format, a validation error
+     * is returned for that entry.
+     *
+     * @param allowedToolsObj the raw {@code allowed-tools} value parsed from the YAML frontmatter
+     * @return a list of validation error messages. An empty list indicates the value is valid.
+     */
+    private List<String> validateAllowedTools(Object allowedToolsObj) {
+        List<String> errors = new ArrayList<>();
+
+        if (!(allowedToolsObj instanceof String)) {
+            errors.add("Field 'allowed-tools' must be a string");
+            return errors;
+        }
+
+        String allowedTools = ((String) allowedToolsObj).trim();
+
+        if (allowedTools.isEmpty()) {
+            errors.add("Field 'allowed-tools' cannot be empty");
+        }
+
+        return errors;
+    }
+
 
     /**
      * Validate that only allowed fields are present.

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/SkillsRefCli.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/SkillsRefCli.java
@@ -1,0 +1,151 @@
+package dev.langchain4j.skills.validator;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import dev.langchain4j.skills.validator.error.SkillError;
+import dev.langchain4j.skills.validator.model.SkillProperties;
+import dev.langchain4j.skills.validator.parser.FrontmatterParser;
+import dev.langchain4j.skills.validator.prompt.PromptGenerator;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Main CLI entry point for skills-ref.
+ */
+public class SkillsRefCli {
+    private static final String VERSION = "1.0-SNAPSHOT";
+    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private static final SkillValidator validator = new SkillValidator();
+    private static final FrontmatterParser parser = new FrontmatterParser();
+    private static final PromptGenerator generator = new PromptGenerator();
+
+    public static void main(String[] args) {
+        if (args.length == 0) {
+            printHelp();
+            System.exit(0);
+        }
+
+        String command = args[0];
+
+        try {
+            switch (command) {
+                case "validate":
+                    validateCommand(args);
+                    break;
+                case "read-properties":
+                    readPropertiesCommand(args);
+                    break;
+                case "to-prompt":
+                    toPromptCommand(args);
+                    break;
+                case "--version":
+                case "-v":
+                    System.out.println(VERSION);
+                    break;
+                case "--help":
+                case "-h":
+                    printHelp();
+                    break;
+                default:
+                    System.err.println("Unknown command: " + command);
+                    printHelp();
+                    System.exit(1);
+            }
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            System.exit(1);
+        }
+    }
+
+    private static void validateCommand(String[] args) throws SkillError {
+        if (args.length < 2) {
+            System.err.println("Usage: skills-ref validate <skill-path>");
+            System.exit(1);
+        }
+
+        Path skillPath = Paths.get(args[1]).toAbsolutePath();
+
+        // If a SKILL.md file is provided, use its parent directory
+        if (Files.isRegularFile(skillPath) && skillPath.getFileName().toString().equalsIgnoreCase("skill.md")) {
+            skillPath = skillPath.getParent();
+        }
+
+        List<String> errors = validator.validate(skillPath);
+
+        if (!errors.isEmpty()) {
+            System.err.println("Validation failed for " + skillPath + ":");
+            for (String error : errors) {
+                System.err.println("  - " + error);
+            }
+            System.exit(1);
+        } else {
+            System.out.println("Valid skill: " + skillPath);
+        }
+    }
+
+    private static void readPropertiesCommand(String[] args) throws SkillError {
+        if (args.length < 2) {
+            System.err.println("Usage: skills-ref read-properties <skill-path>");
+            System.exit(1);
+        }
+
+        Path skillPath = Paths.get(args[1]).toAbsolutePath();
+
+        // If a SKILL.md file is provided, use its parent directory
+        if (Files.isRegularFile(skillPath) && skillPath.getFileName().toString().equalsIgnoreCase("skill.md")) {
+            skillPath = skillPath.getParent();
+        }
+
+        SkillProperties props = parser.readProperties(skillPath);
+        String json = gson.toJson(props.toMap());
+        System.out.println(json);
+    }
+
+    private static void toPromptCommand(String[] args) throws SkillError {
+        if (args.length < 2) {
+            System.err.println("Usage: skills-ref to-prompt <skill-path> [skill-path...]");
+            System.exit(1);
+        }
+
+        List<Path> skillPaths = new ArrayList<>();
+        for (int i = 1; i < args.length; i++) {
+            Path skillPath = Paths.get(args[i]).toAbsolutePath();
+
+            // If a SKILL.md file is provided, use its parent directory
+            if (Files.isRegularFile(skillPath)
+                    && skillPath.getFileName().toString().equalsIgnoreCase("skill.md")) {
+                skillPath = skillPath.getParent();
+            }
+
+            skillPaths.add(skillPath);
+        }
+
+        String output = generator.toPrompt(skillPaths);
+        System.out.println(output);
+    }
+
+    private static void printHelp() {
+        System.out.println("Usage: skills-ref [command] [options]");
+        System.out.println();
+        System.out.println("Commands:");
+        System.out.println(
+                "  validate <skill-path>          Validate a skill directory. Checks that the skill has a valid");
+        System.out.println(
+                "                                 SKILL.md with proper frontmatter, correct naming conventions,");
+        System.out.println("                                 and required fields.");
+        System.out.println();
+        System.out.println("  read-properties <skill-path>  Read and print skill properties as JSON. Parses the YAML");
+        System.out.println("                                 frontmatter from SKILL.md and outputs the properties");
+        System.out.println("                                 as JSON.");
+        System.out.println();
+        System.out.println("  to-prompt <skill-path>...     Generate <available_skills> XML for agent prompts.");
+        System.out.println("                                 Accepts one or more skill directories.");
+        System.out.println();
+        System.out.println("Options:");
+        System.out.println("  --version, -v                 Show version");
+        System.out.println("  --help, -h                    Show this help message");
+    }
+}

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/error/ParseError.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/error/ParseError.java
@@ -1,0 +1,14 @@
+package dev.langchain4j.skills.validator.error;
+
+/**
+ * Raised when SKILL.md parsing fails.
+ */
+public class ParseError extends SkillError {
+    public ParseError(String message) {
+        super(message);
+    }
+
+    public ParseError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/error/SkillError.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/error/SkillError.java
@@ -1,0 +1,14 @@
+package dev.langchain4j.skills.validator.error;
+
+/**
+ * Base exception for all skill-related errors.
+ */
+public class SkillError extends Exception {
+    public SkillError(String message) {
+        super(message);
+    }
+
+    public SkillError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/error/ValidationError.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/error/ValidationError.java
@@ -1,0 +1,24 @@
+package dev.langchain4j.skills.validator.error;
+
+import java.util.List;
+
+/**
+ * Raised when skill properties are invalid.
+ */
+public class ValidationError extends SkillError {
+    private final List<String> errors;
+
+    public ValidationError(String message) {
+        super(message);
+        this.errors = List.of(message);
+    }
+
+    public ValidationError(String message, List<String> errors) {
+        super(message);
+        this.errors = errors != null ? List.copyOf(errors) : List.of(message);
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+}

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/model/SkillProperties.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/model/SkillProperties.java
@@ -1,0 +1,218 @@
+package dev.langchain4j.skills.validator.model;
+
+import com.google.gson.JsonObject;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Properties parsed from a skill's SKILL.md frontmatter.
+ *
+ * <p>Attributes:
+ * <ul>
+ *   <li>name: Skill name in kebab-case (required)
+ *   <li>description: What the skill does and when the model should use it (required)
+ *   <li>license: License for the skill (optional)
+ *   <li>compatibility: Compatibility information for the skill (optional)
+ *   <li>allowedTools: Tool patterns the skill requires (optional, experimental)
+ *   <li>metadata: Key-value pairs for client-specific properties (defaults to empty map)
+ * </ul>
+ */
+public class SkillProperties {
+    private final String name;
+    private final String description;
+    private final String license;
+    private final String compatibility;
+    private final String allowedTools;
+    private final Map<String, String> metadata;
+
+    public SkillProperties(
+            String name,
+            String description,
+            String license,
+            String compatibility,
+            String allowedTools,
+            Map<String, String> metadata) {
+        this.name = Objects.requireNonNull(name, "name cannot be null");
+        this.description = Objects.requireNonNull(description, "description cannot be null");
+        this.license = license;
+        this.compatibility = compatibility;
+        this.allowedTools = allowedTools;
+        this.metadata = metadata != null ? new HashMap<>(metadata) : new HashMap<>();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getLicense() {
+        return license;
+    }
+
+    public String getCompatibility() {
+        return compatibility;
+    }
+
+    public String getAllowedTools() {
+        return allowedTools;
+    }
+
+    public Map<String, String> getMetadata() {
+        return Collections.unmodifiableMap(metadata);
+    }
+
+    /**
+     * Convert to map, excluding null values and empty metadata.
+     *
+     * @return Map representation of the skill properties
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("name", name);
+        result.put("description", description);
+
+        if (license != null) {
+            result.put("license", license);
+        }
+        if (compatibility != null) {
+            result.put("compatibility", compatibility);
+        }
+        if (allowedTools != null) {
+            result.put("allowed-tools", allowedTools);
+        }
+        if (!metadata.isEmpty()) {
+            result.put("metadata", new HashMap<>(metadata));
+        }
+
+        return result;
+    }
+
+    /**
+     * Convert to JSON object suitable for JSON serialization.
+     *
+     * @return JsonObject representation
+     */
+    public JsonObject toJsonObject() {
+        JsonObject json = new JsonObject();
+        json.addProperty("name", name);
+        json.addProperty("description", description);
+
+        if (license != null) {
+            json.addProperty("license", license);
+        }
+        if (compatibility != null) {
+            json.addProperty("compatibility", compatibility);
+        }
+        if (allowedTools != null) {
+            json.addProperty("allowed-tools", allowedTools);
+        }
+        if (!metadata.isEmpty()) {
+            JsonObject metadataObj = new JsonObject();
+            metadata.forEach(metadataObj::addProperty);
+            json.add("metadata", metadataObj);
+        }
+
+        return json;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SkillProperties that = (SkillProperties) o;
+        return Objects.equals(name, that.name)
+                && Objects.equals(description, that.description)
+                && Objects.equals(license, that.license)
+                && Objects.equals(compatibility, that.compatibility)
+                && Objects.equals(allowedTools, that.allowedTools)
+                && Objects.equals(metadata, that.metadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, license, compatibility, allowedTools, metadata);
+    }
+
+    @Override
+    public String toString() {
+        return "SkillProperties{"
+                + "name='"
+                + name
+                + '\''
+                + ", description='"
+                + description
+                + '\''
+                + ", license='"
+                + license
+                + '\''
+                + ", compatibility='"
+                + compatibility
+                + '\''
+                + ", allowedTools='"
+                + allowedTools
+                + '\''
+                + ", metadata="
+                + metadata
+                + '}';
+    }
+
+    /**
+     * Builder for SkillProperties.
+     */
+    public static class Builder {
+        private String name;
+        private String description;
+        private String license;
+        private String compatibility;
+        private String allowedTools;
+        private Map<String, String> metadata = new HashMap<>();
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder license(String license) {
+            this.license = license;
+            return this;
+        }
+
+        public Builder compatibility(String compatibility) {
+            this.compatibility = compatibility;
+            return this;
+        }
+
+        public Builder allowedTools(String allowedTools) {
+            this.allowedTools = allowedTools;
+            return this;
+        }
+
+        public Builder metadata(Map<String, String> metadata) {
+            this.metadata = metadata != null ? new HashMap<>(metadata) : new HashMap<>();
+            return this;
+        }
+
+        public Builder putMetadata(String key, String value) {
+            this.metadata.put(key, value);
+            return this;
+        }
+
+        public SkillProperties build() {
+            return new SkillProperties(name, description, license, compatibility, allowedTools, metadata);
+        }
+    }
+}

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/package-info.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/package-info.java
@@ -1,0 +1,5 @@
+package dev.langchain4j.skills.validator;
+
+/**
+ * Main package for skills validation functionality.
+ */

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/parser/FrontmatterParser.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/parser/FrontmatterParser.java
@@ -1,0 +1,193 @@
+package dev.langchain4j.skills.validator.parser;
+
+import dev.langchain4j.skills.validator.error.ParseError;
+import dev.langchain4j.skills.validator.error.ValidationError;
+import dev.langchain4j.skills.validator.model.SkillProperties;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.error.YAMLException;
+
+/**
+ * YAML frontmatter parsing for SKILL.md files.
+ */
+public class FrontmatterParser {
+    private final Yaml yaml = new Yaml();
+
+    /**
+     * Find the SKILL.md file in a skill directory.
+     *
+     * <p>Prefers SKILL.md (uppercase) but accepts skill.md (lowercase).
+     *
+     * @param skillDir Path to the skill directory
+     * @return Path to the SKILL.md file, or null if not found
+     */
+    public Path findSkillMd(Path skillDir) {
+        Path upperCase = skillDir.resolve("SKILL.md");
+        if (Files.exists(upperCase)) {
+            return upperCase;
+        }
+
+        Path lowerCase = skillDir.resolve("skill.md");
+        if (Files.exists(lowerCase)) {
+            return lowerCase;
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse YAML frontmatter from SKILL.md content.
+     *
+     * @param content Raw content of SKILL.md file
+     * @return Tuple of (metadata map, markdown body)
+     * @throws ParseError If frontmatter is missing or invalid
+     */
+    public FrontmatterResult parseFrontmatter(String content) throws ParseError {
+        if (!content.startsWith("---")) {
+            throw new ParseError("SKILL.md must start with YAML frontmatter (---)");
+        }
+
+        String[] parts = content.split("---", 3);
+        if (parts.length < 3) {
+            throw new ParseError("SKILL.md frontmatter not properly closed with ---");
+        }
+
+        String frontmatterStr = parts[1];
+        String body = parts[2].strip();
+
+        Map<String, Object> metadata;
+        try {
+            Object parsed = yaml.load(frontmatterStr);
+            if (!(parsed instanceof Map)) {
+                throw new ParseError("SKILL.md frontmatter must be a YAML mapping");
+            }
+            metadata = (Map<String, Object>) parsed;
+        } catch (YAMLException e) {
+            throw new ParseError("Invalid YAML in frontmatter: " + e.getMessage(), e);
+        }
+
+        // Normalize metadata map - ensure string keys and values
+        Map<String, Object> normalizedMetadata = new HashMap<>();
+        for (Map.Entry<?, ?> entry : metadata.entrySet()) {
+            String key = entry.getKey().toString();
+            if ("metadata".equals(key) && entry.getValue() instanceof Map) {
+                Map<String, String> nestedMetadata = new HashMap<>();
+                Map<?, ?> nestedMap = (Map<?, ?>) entry.getValue();
+                nestedMap.forEach((k, v) -> nestedMetadata.put(String.valueOf(k), String.valueOf(v)));
+                normalizedMetadata.put(key, nestedMetadata);
+            } else {
+                normalizedMetadata.put(key, entry.getValue());
+            }
+        }
+
+        return new FrontmatterResult(normalizedMetadata, body);
+    }
+
+    /**
+     * Read skill properties from SKILL.md frontmatter.
+     *
+     * <p>This function parses the frontmatter and returns properties. It does NOT perform full
+     * validation. Use {@link com.agentskills.skillsref.validator.SkillValidator#validate(Path)} for that.
+     *
+     * @param skillDir Path to the skill directory
+     * @return SkillProperties with parsed metadata
+     * @throws ParseError If SKILL.md is missing or has invalid YAML
+     * @throws ValidationError If required fields (name, description) are missing
+     */
+    public SkillProperties readProperties(Path skillDir) throws ParseError, ValidationError {
+        skillDir = Objects.requireNonNull(skillDir, "skillDir cannot be null").toAbsolutePath();
+
+        Path skillMd = findSkillMd(skillDir);
+        if (skillMd == null) {
+            throw new ParseError("SKILL.md not found in " + skillDir);
+        }
+
+        String content;
+        try {
+            content = Files.readString(skillMd);
+        } catch (Exception e) {
+            throw new ParseError("Failed to read SKILL.md: " + e.getMessage(), e);
+        }
+
+        FrontmatterResult result = parseFrontmatter(content);
+        Map<String, Object> metadata = result.getMetadata();
+
+        // Validate required fields
+        if (!metadata.containsKey("name")) {
+            throw new ValidationError("Missing required field in frontmatter: name");
+        }
+        if (!metadata.containsKey("description")) {
+            throw new ValidationError("Missing required field in frontmatter: description");
+        }
+
+        Object nameObj = metadata.get("name");
+        Object descObj = metadata.get("description");
+
+        if (!(nameObj instanceof String) || ((String) nameObj).isBlank()) {
+            throw new ValidationError("Field 'name' must be a non-empty string");
+        }
+        if (!(descObj instanceof String) || ((String) descObj).isBlank()) {
+            throw new ValidationError("Field 'description' must be a non-empty string");
+        }
+
+        String name = ((String) nameObj).strip();
+        String description = ((String) descObj).strip();
+
+        String license = getStringValue(metadata, "license");
+        String compatibility = getStringValue(metadata, "compatibility");
+        String allowedTools = getStringValue(metadata, "allowed-tools");
+        Map<String, String> metadataMap = null;
+
+        if (metadata.containsKey("metadata") && metadata.get("metadata") instanceof Map) {
+            metadataMap = (Map<String, String>) metadata.get("metadata");
+        }
+
+        return SkillProperties.builder()
+                .name(name)
+                .description(description)
+                .license(license)
+                .compatibility(compatibility)
+                .allowedTools(allowedTools)
+                .metadata(metadataMap)
+                .build();
+    }
+
+    /**
+     * Helper to get string value from metadata map, handling null and type safety.
+     */
+    private String getStringValue(Map<String, Object> metadata, String key) {
+        Object value = metadata.get(key);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String) {
+            return (String) value;
+        }
+        return value.toString();
+    }
+
+    /**
+     * Result wrapper for parsed frontmatter.
+     */
+    public static class FrontmatterResult {
+        private final Map<String, Object> metadata;
+        private final String body;
+
+        public FrontmatterResult(Map<String, Object> metadata, String body) {
+            this.metadata = Objects.requireNonNull(metadata, "metadata cannot be null");
+            this.body = Objects.requireNonNull(body, "body cannot be null");
+        }
+
+        public Map<String, Object> getMetadata() {
+            return metadata;
+        }
+
+        public String getBody() {
+            return body;
+        }
+    }
+}

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/parser/FrontmatterParser.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/parser/FrontmatterParser.java
@@ -91,7 +91,7 @@ public class FrontmatterParser {
      * Read skill properties from SKILL.md frontmatter.
      *
      * <p>This function parses the frontmatter and returns properties. It does NOT perform full
-     * validation. Use {@link com.agentskills.skillsref.validator.SkillValidator#validate(Path)} for that.
+     * validation. Use {@link dev.langchain4j.skills.validator.SkillValidator#validate(Path)} for that.
      *
      * @param skillDir Path to the skill directory
      * @return SkillProperties with parsed metadata

--- a/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/prompt/PromptGenerator.java
+++ b/langchain4j-skills-validator/src/main/java/dev/langchain4j/skills/validator/prompt/PromptGenerator.java
@@ -1,0 +1,89 @@
+package dev.langchain4j.skills.validator.prompt;
+
+import dev.langchain4j.skills.validator.error.SkillError;
+import dev.langchain4j.skills.validator.model.SkillProperties;
+import dev.langchain4j.skills.validator.parser.FrontmatterParser;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Generate &lt;available_skills&gt; XML prompt block for agent system prompts.
+ */
+public class PromptGenerator {
+    private final FrontmatterParser parser = new FrontmatterParser();
+
+    /**
+     * Generate the &lt;available_skills&gt; XML block for inclusion in agent prompts.
+     *
+     * <p>This XML format is what Anthropic uses and recommends for Claude models. Skill Clients
+     * may format skill information differently to suit their models or preferences.
+     *
+     * @param skillDirs List of paths to skill directories
+     * @return XML string with &lt;available_skills&gt; block containing each skill's name,
+     *     description, and location.
+     * @throws SkillError If any skill cannot be processed
+     *     <p>Example output:
+     *     <pre>
+     * &lt;available_skills&gt;
+     * &lt;skill&gt;
+     * &lt;name&gt;pdf-reader&lt;/name&gt;
+     * &lt;description&gt;Read and extract text from PDF files&lt;/description&gt;
+     * &lt;location&gt;/path/to/pdf-reader/SKILL.md&lt;/location&gt;
+     * &lt;/skill&gt;
+     * &lt;/available_skills&gt;
+     *     </pre>
+     */
+    public String toPrompt(List<Path> skillDirs) throws SkillError {
+        Objects.requireNonNull(skillDirs, "skillDirs cannot be null");
+
+        if (skillDirs.isEmpty()) {
+            return "<available_skills>\n</available_skills>";
+        }
+
+        List<String> lines = new ArrayList<>();
+        lines.add("<available_skills>");
+
+        for (Path skillDir : skillDirs) {
+            Path resolvedDir = skillDir.toAbsolutePath();
+            SkillProperties props = parser.readProperties(resolvedDir);
+
+            lines.add("<skill>");
+            lines.add("<name>");
+            lines.add(escapeXml(props.getName()));
+            lines.add("</name>");
+            lines.add("<description>");
+            lines.add(escapeXml(props.getDescription()));
+            lines.add("</description>");
+
+            Path skillMd = parser.findSkillMd(resolvedDir);
+            lines.add("<location>");
+            lines.add(skillMd.toString());
+            lines.add("</location>");
+
+            lines.add("</skill>");
+        }
+
+        lines.add("</available_skills>");
+
+        return String.join("\n", lines);
+    }
+
+    /**
+     * Escape special XML characters.
+     *
+     * @param text Text to escape
+     * @return XML-escaped text
+     */
+    private String escapeXml(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+}

--- a/langchain4j-skills-validator/src/test/java/dev/langchain4j/skills/validator/SkillValidatorIntegrationTest.java
+++ b/langchain4j-skills-validator/src/test/java/dev/langchain4j/skills/validator/SkillValidatorIntegrationTest.java
@@ -1,0 +1,205 @@
+package dev.langchain4j.skills.validator;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests using real skill files from test/resources directory.
+ * Tests both valid and invalid skills according to the agentskills.io specification.
+ */
+class SkillValidatorIntegrationTest {
+    private static final SkillValidator validator = new SkillValidator();
+    private static Path skillsBasePath;
+
+    @BeforeAll
+    static void setup() {
+        URL resource = SkillValidatorIntegrationTest.class.getResource("/skills");
+        assertThat(resource)
+                .withFailMessage("Test resources directory not found")
+                .isNotNull();
+        skillsBasePath = Paths.get(resource.getPath());
+    }
+
+    @Nested
+    @DisplayName("Valid Skills")
+    class ValidSkillsTests {
+
+        @Test
+        @DisplayName("should validate minimal valid skill with only required fields")
+        void shouldValidateMinimalSkill() {
+            Path skillPath = skillsBasePath.resolve("valid-skill");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should validate skill with all optional fields")
+        void shouldValidateSkillWithAllFields() {
+            Path skillPath = skillsBasePath.resolve("pdf-processing");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should validate skill with metadata")
+        void shouldValidateSkillWithMetadata() {
+            Path skillPath = skillsBasePath.resolve("data-analysis");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Invalid Skills - Name Validation")
+    class InvalidNameTests {
+
+        @Test
+        @DisplayName("should reject uppercase letters in name")
+        void shouldRejectUppercaseName() {
+            Path skillPath = skillsBasePath.resolve("invalid-uppercase");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isNotEmpty().anyMatch(e -> e.toLowerCase().contains("lowercase"));
+        }
+
+        @Test
+        @DisplayName("should reject name starting with hyphen")
+        void shouldRejectNameStartingWithHyphen() {
+            Path skillPath = skillsBasePath.resolve("invalid-starts-hyphen");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isNotEmpty().anyMatch(e -> e.contains("cannot start or end with a hyphen"));
+        }
+
+        @Test
+        @DisplayName("should reject consecutive hyphens in name")
+        void shouldRejectConsecutiveHyphens() {
+            Path skillPath = skillsBasePath.resolve("invalid-consecutive-hyphens");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isNotEmpty().anyMatch(e -> e.contains("consecutive hyphens"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Invalid Skills - Required Fields")
+    class RequiredFieldsTests {
+
+        @Test
+        @DisplayName("should reject skill without name field")
+        void shouldRejectMissingName() {
+            Path skillPath = skillsBasePath.resolve("invalid-missing-name");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isNotEmpty().anyMatch(e -> e.contains("Missing required field") && e.contains("name"));
+        }
+
+        @Test
+        @DisplayName("should reject directory without SKILL.md file")
+        void shouldRejectMissingSkillMd() {
+            Path skillPath = skillsBasePath.resolve("empty-dir");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isNotEmpty().anyMatch(e -> e.contains("SKILL.md"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Invalid Skills - Length Limits")
+    class LengthLimitTests {
+
+        @Test
+        @DisplayName("should reject description exceeding 1024 characters")
+        void shouldRejectLongDescription() {
+            Path skillPath = skillsBasePath.resolve("invalid-long-description");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isNotEmpty().anyMatch(e -> e.contains("Description exceeds") && e.contains("1024"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Directory Name Validation")
+    class DirectoryNameTests {
+
+        @Test
+        @DisplayName("should pass when directory name matches skill name")
+        void shouldPassMatchingDirectoryName() {
+            Path skillPath = skillsBasePath.resolve("valid-skill");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should fail when directory name doesn't match skill name")
+        void shouldFailMismatchedDirectoryName() {
+            Path skillPath = skillsBasePath.resolve("invalid-uppercase");
+            List<String> errors = validator.validate(skillPath);
+
+            // This should fail both for uppercase AND directory mismatch
+            assertThat(errors).isNotEmpty().anyMatch(e -> e.contains("Directory name") || e.contains("lowercase"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases and Boundary Tests")
+    class EdgeCaseTests {
+
+        @Test
+        @DisplayName("should handle skills with numbers in name")
+        void shouldAllowNumbersInName() {
+            // The pdf-processing and data-analysis don't have numbers,
+            // but valid-skill could be extended with v2, etc.
+            // This tests the general case
+            Path skillPath = skillsBasePath.resolve("valid-skill");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should handle skills with hyphens correctly")
+        void shouldAllowHyphensInName() {
+            Path skillPath = skillsBasePath.resolve("pdf-processing");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should validate all optional fields are actually optional")
+        void shouldAcceptMinimalSkillWithoutOptionalFields() {
+            Path skillPath = skillsBasePath.resolve("valid-skill");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Multiple Validation Errors")
+    class MultipleErrorTests {
+
+        @Test
+        @DisplayName("should report multiple errors for badly formed skills")
+        void shouldReportMultipleErrors() {
+            // invalid-uppercase has both uppercase and directory mismatch issues
+            Path skillPath = skillsBasePath.resolve("invalid-uppercase");
+            List<String> errors = validator.validate(skillPath);
+
+            assertThat(errors.size()).isGreaterThanOrEqualTo(1);
+        }
+    }
+}

--- a/langchain4j-skills-validator/src/test/java/dev/langchain4j/skills/validator/SkillValidatorTest.java
+++ b/langchain4j-skills-validator/src/test/java/dev/langchain4j/skills/validator/SkillValidatorTest.java
@@ -1,0 +1,190 @@
+package dev.langchain4j.skills.validator;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SkillValidatorTest {
+    private final SkillValidator validator = new SkillValidator();
+
+    @Test
+    void shouldValidateCorrectSkill() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("name", "test-skill");
+        metadata.put("description", "A test skill");
+
+        List<String> errors = validator.validateMetadata(metadata, null);
+
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void shouldReturnErrorIfPathDoesNotExist() {
+        List<String> errors = validator.validate(Path.of("/nonexistent/path"));
+
+        assertThat(errors).isNotEmpty().anyMatch(e -> e.contains("does not exist"));
+    }
+
+    @Test
+    void shouldReturnErrorIfPathIsNotDirectory(@TempDir Path tempDir) throws Exception {
+        Path file = Files.createFile(tempDir.resolve("file.txt"));
+
+        List<String> errors = validator.validate(file);
+
+        assertThat(errors).isNotEmpty().anyMatch(e -> e.contains("Not a directory"));
+    }
+
+    @Test
+    void shouldReturnErrorIfSkillMdMissing(@TempDir Path tempDir) {
+        List<String> errors = validator.validate(tempDir);
+
+        assertThat(errors).isNotEmpty().anyMatch(e -> e.contains("SKILL.md"));
+    }
+
+    @Test
+    void shouldReturnErrorIfNameMissing(@TempDir Path tempDir) throws Exception {
+        String content = "---\ndescription: A test skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        List<String> errors = validator.validate(tempDir);
+
+        assertThat(errors).anyMatch(e -> e.contains("Missing required field"));
+        assertThat(errors).anyMatch(e -> e.contains("name"));
+    }
+
+    @Test
+    void shouldReturnErrorIfDescriptionMissing(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: test-skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        List<String> errors = validator.validate(tempDir);
+
+        assertThat(errors).anyMatch(e -> e.contains("Missing required field"));
+        assertThat(errors).anyMatch(e -> e.contains("description"));
+    }
+
+    @Test
+    void shouldReturnErrorIfNameIsNotLowercase(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: TestSkill\ndescription: A test skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        List<String> errors = validator.validate(tempDir);
+
+        assertThat(errors).anySatisfy(e -> assertThat(e).contains("lowercase"));
+    }
+
+    @Test
+    void shouldReturnErrorIfNameStartsWithHyphen(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: -test-skill\ndescription: A test skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        List<String> errors = validator.validate(tempDir);
+
+        assertThat(errors).anySatisfy(e -> assertThat(e).contains("cannot start or end with a hyphen"));
+    }
+
+    @Test
+    void shouldReturnErrorIfNameEndsWithHyphen(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: test-skill-\ndescription: A test skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        List<String> errors = validator.validate(tempDir);
+
+        assertThat(errors).anySatisfy(e -> assertThat(e).contains("cannot start or end with a hyphen"));
+    }
+
+    @Test
+    void shouldReturnErrorIfNameHasConsecutiveHyphens(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: test--skill\ndescription: A test skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        List<String> errors = validator.validate(tempDir);
+
+        assertThat(errors).anySatisfy(e -> assertThat(e).contains("consecutive hyphens"));
+    }
+
+    @Test
+    void shouldReturnErrorIfNameTooLong(@TempDir Path tempDir) throws Exception {
+        String longName = "a".repeat(100);
+        String content = "---\nname: " + longName + "\ndescription: A test skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        List<String> errors = validator.validate(tempDir);
+
+        assertThat(errors).anySatisfy(e -> assertThat(e).contains("exceeds"));
+    }
+
+    @Test
+    void shouldReturnErrorIfDescriptionTooLong(@TempDir Path tempDir) throws Exception {
+        String longDesc = "a".repeat(2000);
+        String content = "---\nname: test-skill\ndescription: " + longDesc + "\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        List<String> errors = validator.validate(tempDir);
+
+        assertThat(errors).anySatisfy(e -> assertThat(e).contains("exceeds"));
+    }
+
+    @Test
+    void shouldReturnErrorIfDirectoryNameDoesntMatchSkillName(@TempDir Path tempDir) throws Exception {
+        Path skillDir = tempDir.resolve("wrong-name");
+        Files.createDirectory(skillDir);
+        String content = "---\nname: test-skill\ndescription: A test skill\n---\nBody";
+        Files.writeString(skillDir.resolve("SKILL.md"), content);
+
+        List<String> errors = validator.validate(skillDir);
+
+        assertThat(errors).anySatisfy(e -> assertThat(e).contains("Directory name"));
+    }
+
+    @Test
+    void shouldReturnErrorForUnexpectedFields(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: test-skill\ndescription: A test skill\nunknown-field: value\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        List<String> errors = validator.validate(tempDir);
+
+        assertThat(errors).anySatisfy(e -> assertThat(e).contains("Unexpected fields"));
+    }
+
+    @Test
+    void shouldValidateMetadataWithValidFields(@TempDir Path tempDir) throws Exception {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("name", "test-skill");
+        metadata.put("description", "A test skill");
+        metadata.put("license", "Apache 2.0");
+        metadata.put("compatibility", "Java 17+");
+
+        List<String> errors = validator.validateMetadata(metadata, null);
+
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void shouldAllowHyphensInSkillName() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("name", "my-test-skill");
+        metadata.put("description", "A test skill");
+
+        List<String> errors = validator.validateMetadata(metadata, null);
+
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void shouldAllowNumbersInSkillName() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("name", "skill-v2");
+        metadata.put("description", "A test skill");
+
+        List<String> errors = validator.validateMetadata(metadata, null);
+
+        assertThat(errors).isEmpty();
+    }
+}

--- a/langchain4j-skills-validator/src/test/java/dev/langchain4j/skills/validator/model/SkillPropertiesTest.java
+++ b/langchain4j-skills-validator/src/test/java/dev/langchain4j/skills/validator/model/SkillPropertiesTest.java
@@ -1,0 +1,169 @@
+package dev.langchain4j.skills.validator.model;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SkillPropertiesTest {
+
+    @Test
+    void shouldCreateSkillPropertiesWithRequiredFields() {
+        SkillProperties props = SkillProperties.builder()
+                .name("my-skill")
+                .description("A test skill")
+                .build();
+
+        assertThat(props.getName()).isEqualTo("my-skill");
+        assertThat(props.getDescription()).isEqualTo("A test skill");
+        assertThat(props.getLicense()).isNull();
+        assertThat(props.getMetadata()).isEmpty();
+    }
+
+    @Test
+    void shouldCreateSkillPropertiesWithAllFields() {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("key1", "value1");
+
+        SkillProperties props = SkillProperties.builder()
+                .name("my-skill")
+                .description("A test skill")
+                .license("Apache 2.0")
+                .compatibility("Java 17+")
+                .allowedTools("tool1, tool2")
+                .metadata(metadata)
+                .build();
+
+        assertThat(props.getName()).isEqualTo("my-skill");
+        assertThat(props.getDescription()).isEqualTo("A test skill");
+        assertThat(props.getLicense()).isEqualTo("Apache 2.0");
+        assertThat(props.getCompatibility()).isEqualTo("Java 17+");
+        assertThat(props.getAllowedTools()).isEqualTo("tool1, tool2");
+        assertThat(props.getMetadata()).containsEntry("key1", "value1");
+    }
+
+    @Test
+    void shouldConvertToMapExcludingNullValues() {
+        SkillProperties props = SkillProperties.builder()
+                .name("my-skill")
+                .description("A test skill")
+                .license("Apache 2.0")
+                .build();
+
+        Map<String, Object> map = props.toMap();
+
+        assertThat(map).containsKeys("name", "description", "license");
+        assertThat(map).doesNotContainKeys("compatibility", "allowed-tools");
+    }
+
+    @Test
+    void shouldConvertToMapExcludingEmptyMetadata() {
+        SkillProperties props = SkillProperties.builder()
+                .name("my-skill")
+                .description("A test skill")
+                .build();
+
+        Map<String, Object> map = props.toMap();
+
+        assertThat(map).doesNotContainKey("metadata");
+    }
+
+    @Test
+    void shouldConvertToMapIncludingNonEmptyMetadata() {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("key1", "value1");
+
+        SkillProperties props = SkillProperties.builder()
+                .name("my-skill")
+                .description("A test skill")
+                .metadata(metadata)
+                .build();
+
+        Map<String, Object> map = props.toMap();
+
+        assertThat(map).containsKey("metadata");
+        assertThat((Map<String, String>) map.get("metadata")).containsEntry("key1", "value1");
+    }
+
+    @Test
+    void shouldThrowNullPointerExceptionForNullName() {
+        assertThatThrownBy(() -> SkillProperties.builder()
+                        .name(null)
+                        .description("A test skill")
+                        .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerExceptionForNullDescription() {
+        assertThatThrownBy(() -> SkillProperties.builder()
+                        .name("my-skill")
+                        .description(null)
+                        .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldCreateCopyOfMetadataMap() {
+        Map<String, String> originalMetadata = new HashMap<>();
+        originalMetadata.put("key1", "value1");
+
+        SkillProperties props = SkillProperties.builder()
+                .name("my-skill")
+                .description("A test skill")
+                .metadata(originalMetadata)
+                .build();
+
+        originalMetadata.put("key2", "value2");
+
+        // Original modification should not affect the properties instance
+        assertThat(props.getMetadata()).doesNotContainKey("key2");
+    }
+
+    @Test
+    void shouldReturnUnmodifiableMetadata() {
+        SkillProperties props = SkillProperties.builder()
+                .name("my-skill")
+                .description("A test skill")
+                .putMetadata("key1", "value1")
+                .build();
+
+        Map<String, String> metadata = props.getMetadata();
+
+        assertThatThrownBy(() -> metadata.put("key2", "value2")).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldImplementEquality() {
+        SkillProperties props1 = SkillProperties.builder()
+                .name("my-skill")
+                .description("A test skill")
+                .license("Apache 2.0")
+                .build();
+
+        SkillProperties props2 = SkillProperties.builder()
+                .name("my-skill")
+                .description("A test skill")
+                .license("Apache 2.0")
+                .build();
+
+        assertThat(props1).isEqualTo(props2);
+        assertThat(props1.hashCode()).isEqualTo(props2.hashCode());
+    }
+
+    @Test
+    void shouldImplementEqualityWithDifferentValues() {
+        SkillProperties props1 = SkillProperties.builder()
+                .name("my-skill")
+                .description("A test skill")
+                .build();
+
+        SkillProperties props2 = SkillProperties.builder()
+                .name("my-skill")
+                .description("A different skill")
+                .build();
+
+        assertThat(props1).isNotEqualTo(props2);
+    }
+}

--- a/langchain4j-skills-validator/src/test/java/dev/langchain4j/skills/validator/parser/FrontmatterParserTest.java
+++ b/langchain4j-skills-validator/src/test/java/dev/langchain4j/skills/validator/parser/FrontmatterParserTest.java
@@ -1,0 +1,146 @@
+package dev.langchain4j.skills.validator.parser;
+
+import static org.assertj.core.api.Assertions.*;
+
+import dev.langchain4j.skills.validator.error.ParseError;
+import dev.langchain4j.skills.validator.error.ValidationError;
+import dev.langchain4j.skills.validator.model.SkillProperties;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FrontmatterParserTest {
+    private final FrontmatterParser parser = new FrontmatterParser();
+
+    @Test
+    void shouldFindSkillMdFile(@TempDir Path tempDir) throws Exception {
+        Path skillMd = Files.createFile(tempDir.resolve("SKILL.md"));
+
+        Path found = parser.findSkillMd(tempDir);
+
+        assertThat(found).isEqualTo(skillMd);
+    }
+
+    @Test
+    void shouldFindLowercaseSkillMd(@TempDir Path tempDir) throws Exception {
+        // Note: On case-insensitive filesystems, this will actually create a file
+        // that might be named SKILL.md. We just verify the file was found.
+        Path skillMd = Files.createFile(tempDir.resolve("skill.md"));
+
+        Path found = parser.findSkillMd(tempDir);
+
+        assertThat(found).isNotNull();
+        // The file exists, though the name might differ on case-insensitive filesystems
+        assertThat(Files.exists(found)).isTrue();
+    }
+
+    @Test
+    void shouldPreferUppercaseSkillMd(@TempDir Path tempDir) throws Exception {
+        // Note: On case-insensitive filesystems (macOS, Windows), creating both
+        // SKILL.md and skill.md will only create one file. This test verifies
+        // the parser prefers SKILL.md when available.
+        Path found = Files.createFile(tempDir.resolve("SKILL.md"));
+
+        Path result = parser.findSkillMd(tempDir);
+
+        assertThat(result).isEqualTo(found);
+    }
+
+    @Test
+    void shouldReturnNullIfSkillMdNotFound(@TempDir Path tempDir) {
+        Path found = parser.findSkillMd(tempDir);
+
+        assertThat(found).isNull();
+    }
+
+    @Test
+    void shouldParseFrontmatterCorrectly() throws ParseError {
+        String content = "---\nname: test-skill\ndescription: A test skill\nlicense: Apache 2.0\n---\nBody content";
+
+        FrontmatterParser.FrontmatterResult result = parser.parseFrontmatter(content);
+
+        assertThat(result.getMetadata()).containsEntry("name", "test-skill");
+        assertThat(result.getMetadata()).containsEntry("description", "A test skill");
+        assertThat(result.getMetadata()).containsEntry("license", "Apache 2.0");
+        assertThat(result.getBody()).isEqualTo("Body content");
+    }
+
+    @Test
+    void shouldThrowParseErrorIfNoFrontmatterStart() {
+        String content = "No frontmatter start";
+
+        assertThatThrownBy(() -> parser.parseFrontmatter(content))
+                .isInstanceOf(ParseError.class)
+                .hasMessageContaining("must start with YAML frontmatter");
+    }
+
+    @Test
+    void shouldThrowParseErrorIfFrontmatterNotClosed() {
+        String content = "---\nname: test\n\nBody without closing ---";
+
+        assertThatThrownBy(() -> parser.parseFrontmatter(content))
+                .isInstanceOf(ParseError.class)
+                .hasMessageContaining("Invalid YAML");
+    }
+
+    @Test
+    void shouldReadPropertiesFromSkillDirectory(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: test-skill\ndescription: A test skill\nlicense: Apache 2.0\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        SkillProperties props = parser.readProperties(tempDir);
+
+        assertThat(props.getName()).isEqualTo("test-skill");
+        assertThat(props.getDescription()).isEqualTo("A test skill");
+        assertThat(props.getLicense()).isEqualTo("Apache 2.0");
+    }
+
+    @Test
+    void shouldThrowParseErrorIfSkillMdNotFound(@TempDir Path tempDir) {
+        assertThatThrownBy(() -> parser.readProperties(tempDir))
+                .isInstanceOf(ParseError.class)
+                .hasMessageContaining("SKILL.md not found");
+    }
+
+    @Test
+    void shouldThrowValidationErrorIfNameMissing(@TempDir Path tempDir) throws Exception {
+        String content = "---\ndescription: A test skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        assertThatThrownBy(() -> parser.readProperties(tempDir))
+                .isInstanceOf(ValidationError.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    void shouldThrowValidationErrorIfDescriptionMissing(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: test-skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        assertThatThrownBy(() -> parser.readProperties(tempDir))
+                .isInstanceOf(ValidationError.class)
+                .hasMessageContaining("description");
+    }
+
+    @Test
+    void shouldParseMetadataField(@TempDir Path tempDir) throws Exception {
+        String content =
+                "---\nname: test-skill\ndescription: A test skill\nmetadata:\n  key1: value1\n  key2: value2\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        SkillProperties props = parser.readProperties(tempDir);
+
+        assertThat(props.getMetadata()).containsEntry("key1", "value1").containsEntry("key2", "value2");
+    }
+
+    @Test
+    void shouldHandleAllowedToolsField(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: test-skill\ndescription: A test skill\nallowed-tools: tool1, tool2\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        SkillProperties props = parser.readProperties(tempDir);
+
+        assertThat(props.getAllowedTools()).isEqualTo("tool1, tool2");
+    }
+}

--- a/langchain4j-skills-validator/src/test/java/dev/langchain4j/skills/validator/prompt/PromptGeneratorTest.java
+++ b/langchain4j-skills-validator/src/test/java/dev/langchain4j/skills/validator/prompt/PromptGeneratorTest.java
@@ -1,0 +1,109 @@
+package dev.langchain4j.skills.validator.prompt;
+
+import static org.assertj.core.api.Assertions.*;
+
+import dev.langchain4j.skills.validator.error.SkillError;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PromptGeneratorTest {
+    private final PromptGenerator generator = new PromptGenerator();
+
+    @Test
+    void shouldGenerateEmptyPromptForNoSkills() throws SkillError {
+        String prompt = generator.toPrompt(List.of());
+
+        assertThat(prompt).contains("<available_skills>").contains("</available_skills>");
+    }
+
+    @Test
+    void shouldGeneratePromptForSingleSkill(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: test-skill\ndescription: A test skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        String prompt = generator.toPrompt(List.of(tempDir));
+
+        assertThat(prompt)
+                .contains("<available_skills>")
+                .contains("<skill>")
+                .contains("<name>")
+                .contains("test-skill")
+                .contains("</name>")
+                .contains("<description>")
+                .contains("A test skill")
+                .contains("</description>")
+                .contains("<location>")
+                .contains("SKILL.md")
+                .contains("</location>")
+                .contains("</skill>")
+                .contains("</available_skills>");
+    }
+
+    @Test
+    void shouldGeneratePromptForMultipleSkills(@TempDir Path tempDir1, @TempDir Path tempDir2) throws Exception {
+        Files.writeString(tempDir1.resolve("SKILL.md"), "---\nname: skill-one\ndescription: First skill\n---\nBody");
+        Files.writeString(tempDir2.resolve("SKILL.md"), "---\nname: skill-two\ndescription: Second skill\n---\nBody");
+
+        String prompt = generator.toPrompt(List.of(tempDir1, tempDir2));
+
+        assertThat(prompt)
+                .contains("skill-one")
+                .contains("skill-two")
+                .contains("First skill")
+                .contains("Second skill");
+    }
+
+    @Test
+    void shouldEscapeXmlSpecialCharacters(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: test-skill\ndescription: Test & <skill> with \"quotes\"\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        String prompt = generator.toPrompt(List.of(tempDir));
+
+        assertThat(prompt)
+                .contains("Test &amp; &lt;skill&gt; with &quot;quotes&quot;")
+                .doesNotContain("Test & <skill> with \"quotes\"");
+    }
+
+    @Test
+    void shouldIncludeSkillMdLocation(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: test-skill\ndescription: A test skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        String prompt = generator.toPrompt(List.of(tempDir));
+
+        assertThat(prompt).contains("<location>").contains("SKILL.md").contains("</location>");
+    }
+
+    @Test
+    void shouldHandleSkillWithAllMetadata(@TempDir Path tempDir) throws Exception {
+        String content =
+                "---\nname: test-skill\ndescription: A test skill\nlicense: Apache 2.0\ncompatibility: Java 17+\nallowed-tools: tool1, tool2\nmetadata:\n  key: value\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        String prompt = generator.toPrompt(List.of(tempDir));
+
+        assertThat(prompt).contains("test-skill").contains("A test skill");
+    }
+
+    @Test
+    void shouldThrowSkillErrorIfSkillNotFound(@TempDir Path tempDir) {
+        assertThatThrownBy(() -> generator.toPrompt(List.of(tempDir.resolve("nonexistent"))))
+                .isInstanceOf(SkillError.class);
+    }
+
+    @Test
+    void shouldFormatXmlWithProperStructure(@TempDir Path tempDir) throws Exception {
+        String content = "---\nname: test-skill\ndescription: A test skill\n---\nBody";
+        Files.writeString(tempDir.resolve("SKILL.md"), content);
+
+        String prompt = generator.toPrompt(List.of(tempDir));
+
+        String[] lines = prompt.split("\n");
+        assertThat(lines[0]).isEqualTo("<available_skills>");
+        assertThat(lines[lines.length - 1]).isEqualTo("</available_skills>");
+    }
+}

--- a/langchain4j-skills-validator/src/test/resources/skills/data-analysis/SKILL.md
+++ b/langchain4j-skills-validator/src/test/resources/skills/data-analysis/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: data-analysis
+description: Performs statistical analysis, data visualization, and exploratory data analysis on structured datasets. Use when analyzing CSV, Excel, or database data, generating charts, or performing statistical tests.
+license: MIT
+metadata:
+  author: data-team
+  version: "2.1"
+  category: analytics
+---
+
+# Data Analysis Skill
+
+Comprehensive data analysis and visualization toolkit for structured data.
+
+## Capabilities
+
+1. **Statistical Analysis**
+   - Descriptive statistics (mean, median, std dev)
+   - Hypothesis testing (t-tests, ANOVA)
+   - Correlation and regression analysis
+
+2. **Data Visualization**
+   - Line plots, bar charts, histograms
+   - Scatter plots with trend lines
+   - Heatmaps and box plots
+
+3. **Data Processing**
+   - Data cleaning and normalization
+   - Missing value imputation
+   - Outlier detection
+
+## When to Use
+
+- Analyzing sales or business metrics
+- Exploring scientific datasets
+- Creating data-driven reports
+- Identifying trends and patterns
+
+## Supported Formats
+
+- CSV files
+- Excel spreadsheets (.xlsx, .xls)
+- SQL databases
+- JSON data files

--- a/langchain4j-skills-validator/src/test/resources/skills/empty-dir/.gitkeep
+++ b/langchain4j-skills-validator/src/test/resources/skills/empty-dir/.gitkeep
@@ -1,0 +1,1 @@
+# This is a placeholder to ensure the directory is included in test resources

--- a/langchain4j-skills-validator/src/test/resources/skills/invalid-consecutive-hyphens/SKILL.md
+++ b/langchain4j-skills-validator/src/test/resources/skills/invalid-consecutive-hyphens/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: invalid--consecutive--hyphens
+description: This skill has consecutive hyphens in the name which is not allowed.
+---
+
+# Invalid Consecutive Hyphens
+
+This skill should fail validation.

--- a/langchain4j-skills-validator/src/test/resources/skills/invalid-long-description/SKILL.md
+++ b/langchain4j-skills-validator/src/test/resources/skills/invalid-long-description/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: invalid-long-description
+description: This is an extremely long description that exceeds the maximum allowed character limit of 1024 characters. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur.
+---
+
+# Invalid Long Description
+
+This skill has a description that is too long.

--- a/langchain4j-skills-validator/src/test/resources/skills/invalid-missing-name/SKILL.md
+++ b/langchain4j-skills-validator/src/test/resources/skills/invalid-missing-name/SKILL.md
@@ -1,0 +1,7 @@
+---
+description: This skill is missing the required name field.
+---
+
+# Invalid Skill Without Name
+
+The name field is required but missing from this skill.

--- a/langchain4j-skills-validator/src/test/resources/skills/invalid-starts-hyphen/SKILL.md
+++ b/langchain4j-skills-validator/src/test/resources/skills/invalid-starts-hyphen/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: -invalid-starts-hyphen
+description: This skill name starts with a hyphen which is not allowed.
+---
+
+# Invalid Start Hyphen
+
+This skill should fail validation.

--- a/langchain4j-skills-validator/src/test/resources/skills/invalid-uppercase/SKILL.md
+++ b/langchain4j-skills-validator/src/test/resources/skills/invalid-uppercase/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: Invalid-Uppercase
+description: This skill has uppercase letters in the name which violates the specification.
+---
+
+# Invalid Uppercase Skill
+
+This skill should fail validation due to uppercase letters in the name.

--- a/langchain4j-skills-validator/src/test/resources/skills/pdf-processing/SKILL.md
+++ b/langchain4j-skills-validator/src/test/resources/skills/pdf-processing/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: pdf-processing
+description: Extracts text and tables from PDF files, fills PDF forms, and merges multiple PDFs. Use when working with PDF documents or when the user mentions PDFs, forms, or document extraction.
+license: Apache-2.0
+compatibility: Requires Python 3.8+ and PyPDF2 library
+metadata:
+  author: langchain4j-team
+  version: "1.0"
+allowed-tools: Bash(python:*) Read Write
+---
+
+# PDF Processing Skill
+
+This skill provides comprehensive PDF processing capabilities.
+
+## Features
+
+- Extract text and tables from PDF files
+- Fill PDF forms programmatically
+- Merge multiple PDF documents
+- Split PDF pages
+- Convert PDF to images
+
+## Usage
+
+Use this skill when you need to:
+- Extract information from PDF documents
+- Automate PDF form filling
+- Combine multiple PDFs into one
+- Process large batches of PDF files
+
+## Requirements
+
+- Python 3.8 or higher
+- PyPDF2 library
+- pdfplumber for table extraction
+
+## Examples
+
+### Extract Text
+```python
+from pypdf2 import PdfReader
+reader = PdfReader("document.pdf")
+text = reader.pages[0].extract_text()
+```
+
+### Merge PDFs
+```python
+from pypdf2 import PdfMerger
+merger = PdfMerger()
+merger.append("file1.pdf")
+merger.append("file2.pdf")
+merger.write("merged.pdf")
+```

--- a/langchain4j-skills-validator/src/test/resources/skills/valid-skill/SKILL.md
+++ b/langchain4j-skills-validator/src/test/resources/skills/valid-skill/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: valid-skill
+description: A minimal valid skill for testing basic validation. Use this when testing skill validator functionality.
+---
+
+# Valid Skill
+
+This is a minimal valid skill with only required fields.
+
+## Usage
+
+This skill is used for testing purposes only.

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
         <module>langchain4j-agentic-mcp</module>
         <module>langchain4j-agentic-patterns</module>
         <module>langchain4j-skills</module>
+        <module>langchain4j-skills-validator</module>
 
         <!-- observability -->
         <module>langchain4j-micrometer-metrics</module>


### PR DESCRIPTION
## Summary

This PR introduces a new module: `langchain4j-skills-validator`.

The module provides a CLI tool and supporting utilities to validate skills references and related metadata as per the spec defined at https://agentskills.io/specification.

## Motivation
As the LangChain4j ecosystem grows, ensuring consistency and correctness in skill references becomes increasingly important. This validator helps developers detect issues early by validating skill definitions and references before they are used in applications.

This tool can be used:
- during development
- in CI pipelines
- as a standalone CLI validation utility

## Key Features
- CLI tool for validating skills references
- Clear validation errors and diagnostics
- Lightweight and dependency-minimal module
- Packaged as an executable Uber JAR
- Can be integrated into CI workflows

Example usage:

```bash
java -jar skills-validator.jar --help
```