### PR TITLE
Add ModelRegistry to expose AI model capabilities

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/ChatModel.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/ChatModel.java
@@ -13,6 +13,8 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.info.ModelInfo;
+import dev.langchain4j.model.info.util.ModelRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -24,6 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @see StreamingChatModel
  */
 public interface ChatModel {
+    static final ModelRegistry MODEL_REGISTRY = ModelRegistry.fromApi();
 
     /**
      * This is the main API to interact with the chat model.
@@ -94,5 +97,17 @@ public interface ChatModel {
 
     default Set<Capability> supportedCapabilities() {
         return Set.of();
+    }
+
+    default ModelInfo modelInfo() {
+        return MODEL_REGISTRY.getModelInfo(providerId(), modelId());
+    }
+
+    default String providerId() {
+        throw new RuntimeException("providerId is not set");
+    }
+
+    default String modelId() {
+        throw new RuntimeException("modelId is not set");
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/info/Cost.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/info/Cost.java
@@ -1,0 +1,150 @@
+package dev.langchain4j.model.info;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+/**
+ * Represents the cost structure for a model. Costs are typically per million
+ * tokens.
+ */
+public class Cost {
+    private Double input;
+    private Double output;
+
+    @JsonProperty("output_audio")
+    private Double outputAudio;
+
+    @JsonProperty("input_audio")
+    private Double inputAudio;
+
+    @JsonProperty("cache_read")
+    private Double cacheRead;
+
+    @JsonProperty("cache_write")
+    private Double cacheWrite;
+
+    public Cost() {}
+
+    public Cost(Double input, Double output) {
+        this.input = input;
+        this.output = output;
+    }
+
+    public Double getInput() {
+        return input;
+    }
+
+    public void setInput(Double input) {
+        this.input = input;
+    }
+
+    public Double getOutput() {
+        return output;
+    }
+
+    public void setOutput(Double output) {
+        this.output = output;
+    }
+
+    public Double getOutputAudio() {
+        return outputAudio;
+    }
+
+    public void setOutputAudio(Double outputAudio) {
+        this.outputAudio = outputAudio;
+    }
+
+    public Double getCacheRead() {
+        return cacheRead;
+    }
+
+    public void setCacheRead(Double cacheRead) {
+        this.cacheRead = cacheRead;
+    }
+
+    public Double getCacheWrite() {
+        return cacheWrite;
+    }
+
+    public void setCacheWrite(Double cacheWrite) {
+        this.cacheWrite = cacheWrite;
+    }
+
+    /**
+     * Calculate total cost for a given number of input and output tokens.
+     *
+     * @param inputTokens  number of input tokens
+     * @param outputTokens number of output tokens
+     * @return total cost
+     */
+    public double calculateCost(long inputTokens, long outputTokens) {
+        double totalCost = 0.0;
+        if (input != null) {
+            totalCost += (inputTokens / 1_000_000.0) * input;
+        }
+        if (output != null) {
+            totalCost += (outputTokens / 1_000_000.0) * output;
+        }
+        return totalCost;
+    }
+
+    /**
+     * Calculate cost including cache usage.
+     *
+     * @param inputTokens      number of input tokens
+     * @param outputTokens     number of output tokens
+     * @param cacheReadTokens  number of cache read tokens
+     * @param cacheWriteTokens number of cache write tokens
+     * @return total cost
+     */
+    public double calculateCostWithCache(
+            long inputTokens, long outputTokens, long cacheReadTokens, long cacheWriteTokens) {
+        double totalCost = calculateCost(inputTokens, outputTokens);
+
+        if (cacheRead != null) {
+            totalCost += (cacheReadTokens / 1_000_000.0) * cacheRead;
+        }
+        if (cacheWrite != null) {
+            totalCost += (cacheWriteTokens / 1_000_000.0) * cacheWrite;
+        }
+
+        return totalCost;
+    }
+
+    public boolean isFree() {
+        return (input == null || input == 0.0) && (output == null || output == 0.0);
+    }
+
+    public Double getInputAudio() {
+        return inputAudio;
+    }
+
+    public void setInputAudio(Double inputAudio) {
+        this.inputAudio = inputAudio;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cacheRead, cacheWrite, input, inputAudio, output, outputAudio);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        Cost other = (Cost) obj;
+        return Objects.equals(cacheRead, other.cacheRead)
+                && Objects.equals(cacheWrite, other.cacheWrite)
+                && Objects.equals(input, other.input)
+                && Objects.equals(inputAudio, other.inputAudio)
+                && Objects.equals(output, other.output)
+                && Objects.equals(outputAudio, other.outputAudio);
+    }
+
+    @Override
+    public String toString() {
+        return "Cost [input=" + input + ", output=" + output + ", outputAudio=" + outputAudio + ", inputAudio="
+                + inputAudio + ", cacheRead=" + cacheRead + ", cacheWrite=" + cacheWrite + "]";
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/info/Interleaved.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/info/Interleaved.java
@@ -1,0 +1,42 @@
+package dev.langchain4j.model.info;
+
+import java.util.Objects;
+
+/**
+ * Represents interleaved reasoning configuration for a model.
+ */
+public class Interleaved {
+    private String field;
+
+    public Interleaved() {}
+
+    public Interleaved(String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Interleaved that = (Interleaved) o;
+        return Objects.equals(field, that.field);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field);
+    }
+
+    @Override
+    public String toString() {
+        return "Interleaved{" + "field='" + field + '\'' + '}';
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/info/Limit.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/info/Limit.java
@@ -1,0 +1,81 @@
+package dev.langchain4j.model.info;
+
+import java.util.Objects;
+
+/**
+ * Represents the token limits for a model.
+ */
+public class Limit {
+
+    private Integer context;
+    private Integer input;
+    private Integer output;
+
+    public Limit() {}
+
+    public Limit(Integer context, Integer input, Integer output) {
+        this.context = context;
+        this.input = input;
+        this.output = output;
+    }
+
+    public Integer getContext() {
+        return context;
+    }
+
+    public void setContext(Integer context) {
+        this.context = context;
+    }
+
+    public Integer getInput() {
+        return input;
+    }
+
+    public void setInput(Integer input) {
+        this.input = input;
+    }
+
+    public Integer getOutput() {
+        return output;
+    }
+
+    public void setOutput(Integer output) {
+        this.output = output;
+    }
+
+    public boolean canHandle(int requiredContext, int requiredInput, int requiredOutput) {
+        boolean contextOk = context == null || context >= requiredContext;
+        boolean inputOk = input == null || input >= requiredInput;
+        boolean outputOk = output == null || output >= requiredOutput;
+
+        return contextOk && inputOk && outputOk;
+    }
+
+    public boolean hasLargeContext() {
+        return context != null && context >= 100_000;
+    }
+
+    public boolean hasExtendedContext() {
+        return context != null && context >= 200_000;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Limit limit = (Limit) o;
+        return Objects.equals(context, limit.context)
+                && Objects.equals(input, limit.input)
+                && Objects.equals(output, limit.output);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(context, input, output);
+    }
+
+    @Override
+    public String toString() {
+        return "Limit{" + "context=" + context + ", input=" + input + ", output=" + output + '}';
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/info/Modalities.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/info/Modalities.java
@@ -1,0 +1,77 @@
+package dev.langchain4j.model.info;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents the input/output modalities supported by a model.
+ */
+public class Modalities {
+    private List<String> input;
+    private List<String> output;
+
+    public Modalities() {}
+
+    public Modalities(List<String> input, List<String> output) {
+        this.input = input;
+        this.output = output;
+    }
+
+    public List<String> getInput() {
+        return input;
+    }
+
+    public void setInput(List<String> input) {
+        this.input = input;
+    }
+
+    public List<String> getOutput() {
+        return output;
+    }
+
+    public void setOutput(List<String> output) {
+        this.output = output;
+    }
+
+    public boolean supportsInputModality(String modality) {
+        return input != null && input.contains(modality);
+    }
+
+    public boolean supportsOutputModality(String modality) {
+        return output != null && output.contains(modality);
+    }
+
+    public boolean supportsText() {
+        return supportsInputModality("text") || supportsOutputModality("text");
+    }
+
+    public boolean supportsImage() {
+        return supportsInputModality("image") || supportsOutputModality("image");
+    }
+
+    public boolean supportsVideo() {
+        return supportsInputModality("video") || supportsOutputModality("video");
+    }
+
+    public boolean supportsAudio() {
+        return supportsInputModality("audio") || supportsOutputModality("audio");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Modalities that = (Modalities) o;
+        return Objects.equals(input, that.input) && Objects.equals(output, that.output);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(input, output);
+    }
+
+    @Override
+    public String toString() {
+        return "Modalities{" + "input=" + input + ", output=" + output + '}';
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/info/ModelInfo.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/info/ModelInfo.java
@@ -1,0 +1,273 @@
+package dev.langchain4j.model.info;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+/**
+ * Represents an AI model with its capabilities and configuration.
+ */
+public class ModelInfo {
+    private String id;
+    private String name;
+    private String family;
+    private Boolean attachment;
+    private Boolean reasoning;
+
+    @JsonProperty("tool_call")
+    private Boolean toolCall;
+
+    private Object interleaved;
+    private Boolean temperature;
+    private String knowledge;
+
+    @JsonProperty("release_date")
+    private String releaseDate;
+
+    @JsonProperty("last_updated")
+    private String lastUpdated;
+
+    private Modalities modalities;
+
+    @JsonProperty("open_weights")
+    private Boolean openWeights;
+
+    private Cost cost;
+    private Limit limit;
+
+    @JsonProperty("structured_output")
+    private Boolean structuredOutput;
+
+    private String status;
+
+    public ModelInfo() {}
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getFamily() {
+        return family;
+    }
+
+    public void setFamily(String family) {
+        this.family = family;
+    }
+
+    public Boolean getAttachment() {
+        return attachment;
+    }
+
+    public void setAttachment(Boolean attachment) {
+        this.attachment = attachment;
+    }
+
+    public Boolean getReasoning() {
+        return reasoning;
+    }
+
+    public void setReasoning(Boolean reasoning) {
+        this.reasoning = reasoning;
+    }
+
+    public Boolean getToolCall() {
+        return toolCall;
+    }
+
+    public void setToolCall(Boolean toolCall) {
+        this.toolCall = toolCall;
+    }
+
+    public Object getInterleaved() {
+        return interleaved;
+    }
+
+    public void setInterleaved(Object interleaved) {
+        this.interleaved = interleaved;
+    }
+
+    public Boolean getTemperature() {
+        return temperature;
+    }
+
+    public void setTemperature(Boolean temperature) {
+        this.temperature = temperature;
+    }
+
+    public String getKnowledge() {
+        return knowledge;
+    }
+
+    public void setKnowledge(String knowledge) {
+        this.knowledge = knowledge;
+    }
+
+    public String getReleaseDate() {
+        return releaseDate;
+    }
+
+    public void setReleaseDate(String releaseDate) {
+        this.releaseDate = releaseDate;
+    }
+
+    public String getLastUpdated() {
+        return lastUpdated;
+    }
+
+    public void setLastUpdated(String lastUpdated) {
+        this.lastUpdated = lastUpdated;
+    }
+
+    public Modalities getModalities() {
+        return modalities;
+    }
+
+    public void setModalities(Modalities modalities) {
+        this.modalities = modalities;
+    }
+
+    public Boolean getOpenWeights() {
+        return openWeights;
+    }
+
+    public void setOpenWeights(Boolean openWeights) {
+        this.openWeights = openWeights;
+    }
+
+    public Cost getCost() {
+        return cost;
+    }
+
+    public void setCost(Cost cost) {
+        this.cost = cost;
+    }
+
+    public Limit getLimit() {
+        return limit;
+    }
+
+    public void setLimit(Limit limit) {
+        this.limit = limit;
+    }
+
+    // Utility methods
+    public boolean supportsReasoning() {
+        return Boolean.TRUE.equals(reasoning);
+    }
+
+    public boolean supportsToolCalls() {
+        return Boolean.TRUE.equals(toolCall);
+    }
+
+    public boolean supportsAttachments() {
+        return Boolean.TRUE.equals(attachment);
+    }
+
+    public boolean supportsTemperature() {
+        return Boolean.TRUE.equals(temperature);
+    }
+
+    public boolean hasOpenWeights() {
+        return Boolean.TRUE.equals(openWeights);
+    }
+
+    public Boolean getStructuredOutput() {
+        return structuredOutput;
+    }
+
+    public void setStructuredOutput(Boolean structuredOutput) {
+        this.structuredOutput = structuredOutput;
+    }
+
+    public boolean isMultimodal() {
+        if (modalities == null || modalities.getInput() == null) {
+            return false;
+        }
+        return modalities.getInput().size() > 1
+                || (modalities.getInput().size() == 1 && !modalities.getInput().contains("text"));
+    }
+
+    public boolean isFree() {
+        return cost != null && cost.isFree();
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ModelInfo model = (ModelInfo) o;
+        return Objects.equals(id, model.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "ModelInfo [id=" + id + ", name=" + name + ", family=" + family + ", attachment=" + attachment
+                + ", reasoning=" + reasoning + ", toolCall=" + toolCall + ", interleaved=" + interleaved
+                + ", temperature=" + temperature + ", knowledge=" + knowledge + ", releaseDate=" + releaseDate
+                + ", lastUpdated=" + lastUpdated + ", modalities=" + modalities + ", openWeights=" + openWeights
+                + ", cost=" + cost + ", limit=" + limit + ", structuredOutput=" + structuredOutput + ", status="
+                + status + "]";
+    }
+
+    public String prettyPrint() {
+        return """
+	    ----------------------------------------
+	    Model ID        : %s
+	    Name            : %s
+	    Family          : %s
+	    Reasoning       : %s
+	    Tool Calls      : %s
+	    Attachments     : %s
+	    Temperature     : %s
+	    Open Weights    : %s
+	    Structured Out  : %s
+	    Release Date    : %s
+	    Last Updated    : %s
+	    Status          : %s
+	    Modalities      : %s
+	    Cost            : %s
+	    Limit           : %s
+	    ----------------------------------------
+	    """
+                .formatted(
+                        id,
+                        name,
+                        family,
+                        reasoning,
+                        toolCall,
+                        attachment,
+                        temperature,
+                        openWeights,
+                        structuredOutput,
+                        releaseDate,
+                        lastUpdated,
+                        status,
+                        modalities,
+                        cost,
+                        limit);
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/info/Provider.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/info/Provider.java
@@ -1,0 +1,139 @@
+package dev.langchain4j.model.info;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Represents an AI model provider with its configuration and available models.
+ */
+public class Provider {
+    private String id;
+    private List<String> env;
+    private String npm;
+    private String api;
+    private String name;
+    private String doc;
+    private Map<String, ModelInfo> models;
+
+    public Provider() {}
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<String> getEnv() {
+        return env;
+    }
+
+    public void setEnv(List<String> env) {
+        this.env = env;
+    }
+
+    public String getNpm() {
+        return npm;
+    }
+
+    public void setNpm(String npm) {
+        this.npm = npm;
+    }
+
+    public String getApi() {
+        return api;
+    }
+
+    public void setApi(String api) {
+        this.api = api;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDoc() {
+        return doc;
+    }
+
+    public void setDoc(String doc) {
+        this.doc = doc;
+    }
+
+    public Map<String, ModelInfo> getModels() {
+        return models;
+    }
+
+    public void setModels(Map<String, ModelInfo> models) {
+        this.models = models;
+    }
+
+    // Utility methods
+    public ModelInfo getModel(String modelId) {
+        return models != null ? models.get(modelId) : null;
+    }
+
+    public List<ModelInfo> getAllModels() {
+        return models != null ? models.values().stream().collect(Collectors.toList()) : List.of();
+    }
+
+    public List<ModelInfo> getModelsByFamily(String family) {
+        if (models == null) {
+            return List.of();
+        }
+        return models.values().stream()
+                .filter(m -> family.equals(m.getFamily()))
+                .collect(Collectors.toList());
+    }
+
+    public List<ModelInfo> getFreeModels() {
+        if (models == null) {
+            return List.of();
+        }
+        return models.values().stream().filter(ModelInfo::isFree).collect(Collectors.toList());
+    }
+
+    public List<ModelInfo> getReasoningModels() {
+        if (models == null) {
+            return List.of();
+        }
+        return models.values().stream().filter(ModelInfo::supportsReasoning).collect(Collectors.toList());
+    }
+
+    public List<ModelInfo> getMultimodalModels() {
+        if (models == null) {
+            return List.of();
+        }
+        return models.values().stream().filter(ModelInfo::isMultimodal).collect(Collectors.toList());
+    }
+
+    public int getModelCount() {
+        return models != null ? models.size() : 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Provider provider = (Provider) o;
+        return Objects.equals(id, provider.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "Provider{" + "id='" + id + '\'' + ", name='" + name + '\'' + ", api='" + api + '\'' + ", modelCount="
+                + getModelCount() + '}';
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/info/util/CostCalculator.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/info/util/CostCalculator.java
@@ -1,0 +1,129 @@
+package dev.langchain4j.model.info.util;
+
+import dev.langchain4j.model.info.Cost;
+import dev.langchain4j.model.info.ModelInfo;
+
+/**
+ * Utility class for calculating costs across different usage patterns.
+ */
+public class CostCalculator {
+
+    private CostCalculator() {
+        // Utility class
+    }
+
+    /**
+     * Calculate cost for a simple conversation.
+     *
+     * @param model the model
+     * @param inputTokens number of input tokens
+     * @param outputTokens number of output tokens
+     * @return total cost
+     */
+    public static double calculateCost(ModelInfo model, long inputTokens, long outputTokens) {
+        if (model.getCost() == null) {
+            return 0.0;
+        }
+        return model.getCost().calculateCost(inputTokens, outputTokens);
+    }
+
+    /**
+     * Calculate cost with caching.
+     *
+     * @param model the model
+     * @param inputTokens number of input tokens
+     * @param outputTokens number of output tokens
+     * @param cacheReadTokens number of cache read tokens
+     * @param cacheWriteTokens number of cache write tokens
+     * @return total cost
+     */
+    public static double calculateCostWithCache(
+            ModelInfo model, long inputTokens, long outputTokens, long cacheReadTokens, long cacheWriteTokens) {
+        if (model.getCost() == null) {
+            return 0.0;
+        }
+        return model.getCost().calculateCostWithCache(inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens);
+    }
+
+    /**
+     * Calculate monthly cost based on daily usage.
+     *
+     * @param model the model
+     * @param dailyInputTokens average daily input tokens
+     * @param dailyOutputTokens average daily output tokens
+     * @return estimated monthly cost
+     */
+    public static double calculateMonthlyCost(ModelInfo model, long dailyInputTokens, long dailyOutputTokens) {
+        double dailyCost = calculateCost(model, dailyInputTokens, dailyOutputTokens);
+        return dailyCost * 30;
+    }
+
+    /**
+     * Compare cost efficiency between two models for the same workload.
+     *
+     * @param model1 first model
+     * @param model2 second model
+     * @param inputTokens number of input tokens
+     * @param outputTokens number of output tokens
+     * @return negative if model1 is cheaper, positive if model2 is cheaper, 0 if equal
+     */
+    public static double compareCost(ModelInfo model1, ModelInfo model2, long inputTokens, long outputTokens) {
+        double cost1 = calculateCost(model1, inputTokens, outputTokens);
+        double cost2 = calculateCost(model2, inputTokens, outputTokens);
+        return cost1 - cost2;
+    }
+
+    /**
+     * Calculate cost per 1000 tokens (useful for comparison).
+     *
+     * @param cost the cost object
+     * @return cost per 1000 tokens (input + output average)
+     */
+    public static double costPer1000Tokens(Cost cost) {
+        if (cost == null) {
+            return 0.0;
+        }
+        double input = cost.getInput() != null ? cost.getInput() : 0.0;
+        double output = cost.getOutput() != null ? cost.getOutput() : 0.0;
+        return ((input + output) / 2.0) / 1000.0;
+    }
+
+    /**
+     * Estimate cost for a document processing task.
+     *
+     * @param model the model
+     * @param documentTokens size of document in tokens
+     * @param summaryTokens expected summary size in tokens
+     * @param documentCount number of documents to process
+     * @return total estimated cost
+     */
+    public static double estimateDocumentProcessingCost(
+            ModelInfo model, long documentTokens, long summaryTokens, int documentCount) {
+        double costPerDocument = calculateCost(model, documentTokens, summaryTokens);
+        return costPerDocument * documentCount;
+    }
+
+    /**
+     * Calculate savings from using caching.
+     *
+     * @param model the model
+     * @param inputTokens total input tokens
+     * @param outputTokens total output tokens
+     * @param cacheHitRate percentage of cache hits (0.0 to 1.0)
+     * @return cost savings amount
+     */
+    public static double calculateCacheSavings(
+            ModelInfo model, long inputTokens, long outputTokens, double cacheHitRate) {
+        if (model.getCost() == null || model.getCost().getCacheRead() == null) {
+            return 0.0;
+        }
+
+        long cacheReadTokens = (long) (inputTokens * cacheHitRate);
+        long actualInputTokens = inputTokens - cacheReadTokens;
+
+        double costWithoutCache = calculateCost(model, inputTokens, outputTokens);
+        double costWithCache = calculateCostWithCache(model, actualInputTokens, outputTokens, cacheReadTokens, 0);
+
+        return costWithoutCache - costWithCache;
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/info/util/ModelRegistry.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/info/util/ModelRegistry.java
@@ -1,0 +1,338 @@
+package dev.langchain4j.model.info.util;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.model.info.ModelInfo;
+import dev.langchain4j.model.info.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Central registry for managing and querying AI model providers and their
+ * models.
+ */
+public class ModelRegistry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModelRegistry.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String DEFAULT_API_URL = "https://models.dev/api.json";
+    private final Map<String, Provider> providers;
+
+    private String apiUrl;
+
+    static {
+        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    private ModelRegistry(Map<String, Provider> providers) {
+        this.providers = providers;
+        this.apiUrl = DEFAULT_API_URL;
+    }
+
+    public static ModelRegistry fromApi() {
+        try {
+            return fromApi(DEFAULT_API_URL);
+        } catch (Exception e) {
+            LOGGER.error("Error occurred while initializing ModelRegistry {}", e);
+            return new ModelRegistry(Collections.emptyMap());
+        }
+    }
+
+    /**
+     * Load providers from a custom API endpoint.
+     *
+     * @param apiUrl the API URL
+     * @return ModelRegistry instance
+     * @throws IOException          if loading fails
+     * @throws InterruptedException if the request is interrupted
+     */
+    public static ModelRegistry fromApi(String apiUrl) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request =
+                HttpRequest.newBuilder().uri(URI.create(apiUrl)).GET().build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            throw new IOException("Failed to fetch API data: HTTP " + response.statusCode());
+        }
+
+        ModelRegistry registry = fromJson(response.body());
+        registry.apiUrl = apiUrl;
+        return registry;
+    }
+
+    /**
+     * Load providers from a JSON string.
+     *
+     * @param json the JSON string
+     * @return ModelRegistry instance
+     * @throws IOException if parsing fails
+     */
+    public static ModelRegistry fromJson(String json) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Map<String, Object>> data = OBJECT_MAPPER.readValue(json, Map.class);
+
+        Map<String, Provider> providers = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Map<String, Object>> entry : data.entrySet()) {
+            String providerId = entry.getKey();
+            Provider provider = OBJECT_MAPPER.convertValue(entry.getValue(), Provider.class);
+            provider.setId(providerId);
+            providers.put(providerId, provider);
+        }
+
+        return new ModelRegistry(providers);
+    }
+
+    /**
+     * Load providers from a classpath resource.
+     *
+     * @param resourcePath the resource path
+     * @return ModelRegistry instance
+     * @throws IOException if loading fails
+     */
+    public static ModelRegistry fromResource(String resourcePath) throws IOException {
+        try (InputStream is = ModelRegistry.class.getResourceAsStream(resourcePath)) {
+            if (is == null) {
+                throw new IOException("Resource not found: " + resourcePath);
+            }
+
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, Object>> data = OBJECT_MAPPER.readValue(is, Map.class);
+
+            Map<String, Provider> providers = new LinkedHashMap<>();
+
+            for (Map.Entry<String, Map<String, Object>> entry : data.entrySet()) {
+                String providerId = entry.getKey();
+                Provider provider = OBJECT_MAPPER.convertValue(entry.getValue(), Provider.class);
+                provider.setId(providerId);
+                providers.put(providerId, provider);
+            }
+
+            return new ModelRegistry(providers);
+        }
+    }
+
+    // Provider methods
+    public Provider getProvider(String providerId) {
+        return providers.get(providerId);
+    }
+
+    public List<Provider> getAllProviders() {
+        return new ArrayList<>(providers.values());
+    }
+
+    public List<String> getProviderIds() {
+        return new ArrayList<>(providers.keySet());
+    }
+
+    public int getProviderCount() {
+        return providers.size();
+    }
+
+    // Model lookup methods
+
+    /**
+     * Get a model by provider ID and model ID.
+     *
+     * @param providerId the provider ID
+     * @param modelId    the model ID
+     * @return the model, or null if not found
+     */
+    public ModelInfo getModelInfo(String providerId, String modelId) {
+        Provider provider = providers.get(providerId);
+        return provider != null ? provider.getModel(modelId) : null;
+    }
+
+    /**
+     * Get a model by provider and model ID using a single method call. This is a
+     * convenience method that combines provider and model lookup.
+     *
+     * @param provider the provider instance
+     * @param modelId  the model ID
+     * @return the model, or null if not found
+     * @throws IllegalArgumentException if provider is null
+     */
+    public ModelInfo getModelInfo(Provider provider, String modelId) {
+        if (provider == null) {
+            throw new IllegalArgumentException("Provider cannot be null");
+        }
+        return provider.getModel(modelId);
+    }
+
+    public List<ModelInfo> getAllModelsInfo() {
+        return providers.values().stream()
+                .flatMap(p -> p.getAllModels().stream())
+                .collect(Collectors.toList());
+    }
+
+    public List<ModelInfo> getModelsByProvider(String providerId) {
+        Provider provider = providers.get(providerId);
+        return provider != null ? provider.getAllModels() : List.of();
+    }
+
+    public List<ModelInfo> getModelsByFamily(String family) {
+        return getAllModelsInfo().stream()
+                .filter(m -> family.equals(m.getFamily()))
+                .collect(Collectors.toList());
+    }
+
+    public List<ModelInfo> getFreeModels() {
+        return getAllModelsInfo().stream().filter(ModelInfo::isFree).collect(Collectors.toList());
+    }
+
+    public List<ModelInfo> getReasoningModels() {
+        return getAllModelsInfo().stream().filter(ModelInfo::supportsReasoning).collect(Collectors.toList());
+    }
+
+    public List<ModelInfo> getMultimodalModels() {
+        return getAllModelsInfo().stream().filter(ModelInfo::isMultimodal).collect(Collectors.toList());
+    }
+
+    public List<ModelInfo> getOpenWeightModels() {
+        return getAllModelsInfo().stream().filter(ModelInfo::hasOpenWeights).collect(Collectors.toList());
+    }
+
+    public List<ModelInfo> getModelsWithToolCalls() {
+        return getAllModelsInfo().stream().filter(ModelInfo::supportsToolCalls).collect(Collectors.toList());
+    }
+
+    // Search methods
+    public List<ModelInfo> searchByName(String query) {
+        String lowerQuery = query.toLowerCase();
+        return getAllModelsInfo().stream()
+                .filter(m -> m.getName().toLowerCase().contains(lowerQuery)
+                        || m.getId().toLowerCase().contains(lowerQuery))
+                .collect(Collectors.toList());
+    }
+
+    public List<ModelInfo> getModelsWithLargeContext(int minContextSize) {
+        return getAllModelsInfo().stream()
+                .filter(m -> m.getLimit() != null
+                        && m.getLimit().getContext() != null
+                        && m.getLimit().getContext() >= minContextSize)
+                .collect(Collectors.toList());
+    }
+
+    public List<ModelInfo> getModelsBelowCost(double maxInputCost, double maxOutputCost) {
+        return getAllModelsInfo().stream()
+                .filter(m -> m.getCost() != null
+                        && (m.getCost().getInput() == null || m.getCost().getInput() <= maxInputCost)
+                        && (m.getCost().getOutput() == null || m.getCost().getOutput() <= maxOutputCost))
+                .collect(Collectors.toList());
+    }
+
+    // Statistics methods
+    public int getTotalModelCount() {
+        return getAllModelsInfo().size();
+    }
+
+    public Map<String, Long> getModelCountByProvider() {
+        return providers.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e ->
+                (long) e.getValue().getModelCount()));
+    }
+
+    public Map<String, Long> getModelCountByFamily() {
+        return getAllModelsInfo().stream().collect(Collectors.groupingBy(ModelInfo::getFamily, Collectors.counting()));
+    }
+
+    public double getAverageInputCost() {
+        return getAllModelsInfo().stream()
+                .filter(m -> m.getCost() != null && m.getCost().getInput() != null)
+                .mapToDouble(m -> m.getCost().getInput())
+                .average()
+                .orElse(0.0);
+    }
+
+    public double getAverageOutputCost() {
+        return getAllModelsInfo().stream()
+                .filter(m -> m.getCost() != null && m.getCost().getOutput() != null)
+                .mapToDouble(m -> m.getCost().getOutput())
+                .average()
+                .orElse(0.0);
+    }
+
+    // Refresh methods
+
+    /**
+     * Refresh the model data from the API. This will reload all providers and
+     * models from the original API URL.
+     *
+     * @throws IOException                   if loading fails
+     * @throws InterruptedException          if the request is interrupted
+     * @throws UnsupportedOperationException if the registry was not loaded from an
+     *                                       API
+     */
+    public void refresh() throws IOException, InterruptedException {
+        if (apiUrl == null) {
+            throw new UnsupportedOperationException("Cannot refresh: registry was not loaded from an API. "
+                    + "Use refreshFrom(url) to specify an API endpoint.");
+        }
+        refreshFrom(apiUrl);
+    }
+
+    /**
+     * Refresh the model data from a specific API URL. This will reload all
+     * providers and models, replacing the existing data.
+     *
+     * @param apiUrl the API URL to refresh from
+     * @throws IOException          if loading fails
+     * @throws InterruptedException if the request is interrupted
+     */
+    public void refreshFrom(String apiUrl) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request =
+                HttpRequest.newBuilder().uri(URI.create(apiUrl)).GET().build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            throw new IOException("Failed to fetch API data: HTTP " + response.statusCode());
+        }
+
+        // Parse the new data
+        @SuppressWarnings("unchecked")
+        Map<String, Map<String, Object>> data = OBJECT_MAPPER.readValue(response.body(), Map.class);
+
+        // Clear existing providers
+        providers.clear();
+
+        // Load new providers
+        for (Map.Entry<String, Map<String, Object>> entry : data.entrySet()) {
+            String providerId = entry.getKey();
+            Provider provider = OBJECT_MAPPER.convertValue(entry.getValue(), Provider.class);
+            provider.setId(providerId);
+            providers.put(providerId, provider);
+        }
+
+        // Update the API URL
+        this.apiUrl = apiUrl;
+    }
+
+    /**
+     * Get the API URL that this registry is using (if loaded from API).
+     *
+     * @return the API URL, or null if not loaded from an API
+     */
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
+    @Override
+    public String toString() {
+        return "ModelRegistry{" + "providers=" + providers.size() + ", totalModels=" + getTotalModelCount()
+                + ", apiUrl='" + apiUrl + '\'' + '}';
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/info/ModelInfoTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/info/ModelInfoTest.java
@@ -1,0 +1,115 @@
+package dev.langchain4j.model.info;
+
+import java.util.List;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+class ModelInfoTest implements WithAssertions {
+
+    @Test
+    void getters_setters_and_defaults() {
+        ModelInfo model = new ModelInfo();
+
+        // Set fields
+        model.setId("gpt-4");
+        model.setName("GPT-4");
+        model.setFamily("gpt");
+        model.setAttachment(true);
+        model.setReasoning(true);
+        model.setToolCall(true);
+        model.setTemperature(true);
+        model.setOpenWeights(true);
+        model.setStructuredOutput(true);
+        model.setReleaseDate("2025-02-01");
+        model.setLastUpdated("2025-03-01");
+        model.setStatus("preview");
+
+        // Verify getters
+        assertThat(model.getId()).isEqualTo("gpt-4");
+        assertThat(model.getName()).isEqualTo("GPT-4");
+        assertThat(model.getFamily()).isEqualTo("gpt");
+        assertThat(model.getAttachment()).isTrue();
+        assertThat(model.getReasoning()).isTrue();
+        assertThat(model.getToolCall()).isTrue();
+        assertThat(model.getTemperature()).isTrue();
+        assertThat(model.hasOpenWeights()).isTrue();
+        assertThat(model.getStructuredOutput()).isTrue();
+        assertThat(model.getReleaseDate()).isEqualTo("2025-02-01");
+        assertThat(model.getLastUpdated()).isEqualTo("2025-03-01");
+        assertThat(model.getStatus()).isEqualTo("preview");
+    }
+
+    @Test
+    void utility_methods() {
+        ModelInfo model = new ModelInfo();
+        model.setReasoning(true);
+        model.setToolCall(true);
+        model.setAttachment(true);
+        model.setTemperature(true);
+        model.setOpenWeights(true);
+
+        assertThat(model.supportsReasoning()).isTrue();
+        assertThat(model.supportsToolCalls()).isTrue();
+        assertThat(model.supportsAttachments()).isTrue();
+        assertThat(model.supportsTemperature()).isTrue();
+        assertThat(model.hasOpenWeights()).isTrue();
+    }
+
+    @Test
+    void multimodal_logic() {
+        ModelInfo model = new ModelInfo();
+
+        // No modalities -> false
+        assertThat(model.isMultimodal()).isFalse();
+
+        Modalities m1 = new Modalities();
+        m1.setInput(List.of("text"));
+        model.setModalities(m1);
+        assertThat(model.isMultimodal()).isFalse(); // only text
+
+        Modalities m2 = new Modalities();
+        m2.setInput(List.of("text", "image"));
+        model.setModalities(m2);
+        assertThat(model.isMultimodal()).isTrue(); // multiple inputs
+
+        Modalities m3 = new Modalities();
+        m3.setInput(List.of("image"));
+        model.setModalities(m3);
+        assertThat(model.isMultimodal()).isTrue(); // single non-text
+    }
+
+    @Test
+    void free_model_logic() {
+        ModelInfo model = new ModelInfo();
+
+        Cost freeCost = new Cost();
+        freeCost.setInput(0.0);
+        freeCost.setOutput(0.0);
+        model.setCost(freeCost);
+
+        assertThat(model.isFree()).isTrue();
+
+        Cost paidCost = new Cost();
+        paidCost.setInput(0.1);
+        paidCost.setOutput(0.2);
+        model.setCost(paidCost);
+
+        assertThat(model.isFree()).isFalse();
+    }
+
+    @Test
+    void equals_and_hashcode() {
+        ModelInfo m1 = new ModelInfo();
+        m1.setId("gpt-4");
+
+        ModelInfo m2 = new ModelInfo();
+        m2.setId("gpt-4");
+
+        ModelInfo m3 = new ModelInfo();
+        m3.setId("gpt-3");
+
+        assertThat(m1).isEqualTo(m2).hasSameHashCodeAs(m2).isNotEqualTo(m3).doesNotHaveSameHashCodeAs(m3);
+
+        assertThat(m1).isNotEqualTo(null).isNotEqualTo(new Object());
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/info/util/ModelRegistryTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/info/util/ModelRegistryTest.java
@@ -1,0 +1,139 @@
+package dev.langchain4j.model.info.util;
+
+import dev.langchain4j.model.info.ModelInfo;
+import dev.langchain4j.model.info.Provider;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+class ModelRegistryTest implements WithAssertions {
+
+    private static final String JSON =
+            """
+			{
+			  "openai": {
+			    "name": "OpenAI",
+			    "models": {
+			      "gpt-4": {
+			        "id": "gpt-4",
+			        "name": "GPT-4",
+			        "family": "gpt",
+			        "reasoning": true,
+			        "tool_call": true,
+			        "open_weights": true
+			      }
+			    }
+			  },
+			  "google": {
+			    "name": "Google",
+			    "models": {
+			      "gemini-pro": {
+			        "id": "gemini-pro",
+			        "name": "Gemini Pro",
+			        "family": "gemini",
+			        "reasoning": false,
+			        "tool_call": false,
+			        "open_weights": true
+			      }
+			    }
+			  }
+			}
+			""";
+
+    @Test
+    void load_from_json() throws IOException {
+
+        ModelRegistry registry = ModelRegistry.fromJson(JSON);
+
+        assertThat(registry.getProviderCount()).isEqualTo(2);
+        assertThat(registry.getProviderIds()).containsExactly("openai", "google");
+        assertThat(registry.getTotalModelCount()).isEqualTo(2);
+    }
+
+    @Test
+    void provider_lookup() throws IOException {
+
+        ModelRegistry registry = ModelRegistry.fromJson(JSON);
+
+        Provider provider = registry.getProvider("openai");
+
+        assertThat(provider).isNotNull();
+        assertThat(provider.getId()).isEqualTo("openai");
+    }
+
+    @Test
+    void model_lookup() throws IOException {
+
+        ModelRegistry registry = ModelRegistry.fromJson(JSON);
+
+        ModelInfo model = registry.getModelInfo("openai", "gpt-4");
+
+        assertThat(model).isNotNull();
+        assertThat(model.getName()).isEqualTo("GPT-4");
+        assertThat(model.supportsReasoning()).isTrue();
+        assertThat(model.supportsToolCalls()).isTrue();
+    }
+
+    @Test
+    void get_all_models() throws IOException {
+
+        ModelRegistry registry = ModelRegistry.fromJson(JSON);
+
+        List<ModelInfo> models = registry.getAllModelsInfo();
+
+        assertThat(models).hasSize(2);
+    }
+
+    @Test
+    void search_by_name() throws IOException {
+
+        ModelRegistry registry = ModelRegistry.fromJson(JSON);
+
+        List<ModelInfo> result = registry.searchByName("gpt");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("gpt-4");
+    }
+
+    @Test
+    void get_models_by_family() throws IOException {
+
+        ModelRegistry registry = ModelRegistry.fromJson(JSON);
+
+        List<ModelInfo> models = registry.getModelsByFamily("gemini");
+
+        assertThat(models).hasSize(1);
+        assertThat(models.get(0).getId()).isEqualTo("gemini-pro");
+    }
+
+    @Test
+    void reasoning_models() throws IOException {
+
+        ModelRegistry registry = ModelRegistry.fromJson(JSON);
+
+        List<ModelInfo> models = registry.getReasoningModels();
+
+        assertThat(models).hasSize(1);
+        assertThat(models.get(0).getId()).isEqualTo("gpt-4");
+    }
+
+    @Test
+    void statistics() throws IOException {
+
+        ModelRegistry registry = ModelRegistry.fromJson(JSON);
+
+        Map<String, Long> countByProvider = registry.getModelCountByProvider();
+
+        assertThat(countByProvider).containsEntry("openai", 1L).containsEntry("google", 1L);
+    }
+
+    @Test
+    void to_string() throws IOException {
+
+        ModelRegistry registry = ModelRegistry.fromJson(JSON);
+
+        assertThat(registry.toString()).contains("providers=2").contains("totalModels=2");
+    }
+}


### PR DESCRIPTION
- Integrated Models.dev API (https://models.dev/api.json) into LangChain4j via a new ModelRegistry.
- Added `default ModelInfo modelInfo()` method to ChatLanguageModel interface to programmatically access model capabilities:
    - Context window sizes
    - Supported modalities (text, image, audio)
    - Tool calling support
    - Structured output support
    - Other provider-specific metadata
- Enables developers to dynamically query model capabilities instead of hardcoding.
- Designed to be backward compatible using a default interface method in ChatModel
- Future improvements may include caching, versioning, and fallback handling.

 - References:
 https://github.com/anomalyco/models.dev
 https://models.dev/api.json

## Note
- Enhanced ChatModel interface by adding default methods to get the model information by provider and model ids. **Check this**

