### PR TITLE
Fix reversed isAssignableFrom in writeArgumentToScope type guard

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
@@ -143,7 +143,8 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
             if (argType != null) {
                 Object existingValue = agenticScope.readState(key);
                 // avoid overwriting a structured state with an unstructured argument generated from supervisor's LLM response
-                return !argType.isAssignableFrom(existingValue.getClass()) || value.getClass().isAssignableFrom(argType);
+                return !argType.isAssignableFrom(existingValue.getClass())
+                        || (value != null && argType.isAssignableFrom(value.getClass()));
             }
         }
         return true;

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
@@ -155,6 +155,9 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
                     .orElse(null);
             if (argType != null) {
                 Object existingValue = agenticScope.readState(key);
+                if (existingValue == null) {
+                    return true;
+                }
                 // avoid overwriting a structured state with an unstructured argument generated from supervisor's LLM
                 // response
                 return !argType.isAssignableFrom(existingValue.getClass())

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
@@ -1,9 +1,7 @@
 package dev.langchain4j.agentic.supervisor;
 
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import static java.util.stream.Collectors.toMap;
+
 import dev.langchain4j.agentic.internal.Context;
 import dev.langchain4j.agentic.planner.Action;
 import dev.langchain4j.agentic.planner.AgentArgument;
@@ -19,10 +17,12 @@ import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static java.util.stream.Collectors.toMap;
 
 public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
 
@@ -54,9 +54,15 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
 
     private String request;
 
-    public SupervisorPlanner(ChatModel chatModel, ChatMemoryProvider chatMemoryProvider, int maxAgentsInvocations,
-                             SupervisorContextStrategy contextStrategy, SupervisorResponseStrategy responseStrategy,
-                             Function<AgenticScope, String> requestGenerator, String outputKey, Function<AgenticScope, Object> output) {
+    public SupervisorPlanner(
+            ChatModel chatModel,
+            ChatMemoryProvider chatMemoryProvider,
+            int maxAgentsInvocations,
+            SupervisorContextStrategy contextStrategy,
+            SupervisorResponseStrategy responseStrategy,
+            Function<AgenticScope, String> requestGenerator,
+            String outputKey,
+            Function<AgenticScope, Object> output) {
         this.chatModel = chatModel;
         this.chatMemoryProvider = chatMemoryProvider;
         this.maxAgentsInvocations = maxAgentsInvocations;
@@ -69,22 +75,26 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
 
     @Override
     public void init(final InitPlanningContext initPlanningContext) {
-        this.agents = initPlanningContext.subagents().stream().collect(toMap(AgentInstance::agentId, Function.identity()));
+        this.agents =
+                initPlanningContext.subagents().stream().collect(toMap(AgentInstance::agentId, Function.identity()));
         this.agentsList = initPlanningContext.subagents().stream()
                 .map(SupervisorPlanner::toCard)
                 .collect(Collectors.joining(", "));
 
-        this.request = requestGenerator != null ? requestGenerator.apply(initPlanningContext.agenticScope()) : initPlanningContext.agenticScope().readState("request", "");
+        this.request = requestGenerator != null
+                ? requestGenerator.apply(initPlanningContext.agenticScope())
+                : initPlanningContext.agenticScope().readState("request", "");
         if (responseStrategy == SupervisorResponseStrategy.SCORED) {
-            this.responseAgent = AiServices.builder(ResponseAgent.class).chatModel(chatModel).build();
+            this.responseAgent =
+                    AiServices.builder(ResponseAgent.class).chatModel(chatModel).build();
         }
     }
 
     @Override
     public Action nextAction(PlanningContext planningContext) {
-        String lastResponse = planningContext.previousAgentInvocation() == null ?
-                "" :
-                planningContext.previousAgentInvocation().output().toString();
+        String lastResponse = planningContext.previousAgentInvocation() == null
+                ? ""
+                : planningContext.previousAgentInvocation().output().toString();
         if (loopCount++ >= maxAgentsInvocations) {
             return doneAction(planningContext.agenticScope(), lastResponse, null);
         }
@@ -104,7 +114,8 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
                 ? SUPERVISOR_CONTEXT_PREFIX + "'" + agenticScope.readState(SUPERVISOR_CONTEXT_KEY, "") + "'."
                 : "";
 
-        AgentInvocation agentInvocation = planner(agenticScope).plan(agenticScope.memoryId(), agentsList, request, lastResponse, supervisorContext);
+        AgentInvocation agentInvocation = planner(agenticScope)
+                .plan(agenticScope.memoryId(), agentsList, request, lastResponse, supervisorContext);
         LOG.info("Agent Invocation: {}", agentInvocation);
 
         if (agentInvocation.getAgentName().equalsIgnoreCase("done")) {
@@ -139,10 +150,13 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
         if (agenticScope.hasState(key)) {
             Class<?> argType = agent.arguments().stream()
                     .filter(arg -> arg.name().equals(key))
-                    .findFirst().map(AgentArgument::rawType).orElse(null);
+                    .findFirst()
+                    .map(AgentArgument::rawType)
+                    .orElse(null);
             if (argType != null) {
                 Object existingValue = agenticScope.readState(key);
-                // avoid overwriting a structured state with an unstructured argument generated from supervisor's LLM response
+                // avoid overwriting a structured state with an unstructured argument generated from supervisor's LLM
+                // response
                 return !argType.isAssignableFrom(existingValue.getClass())
                         || (value != null && argType.isAssignableFrom(value.getClass()));
             }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/StubAgentInstance.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/StubAgentInstance.java
@@ -1,0 +1,36 @@
+package dev.langchain4j.agentic;
+
+import dev.langchain4j.agentic.planner.AgentArgument;
+import dev.langchain4j.agentic.planner.AgentInstance;
+import dev.langchain4j.agentic.planner.AgenticSystemTopology;
+import dev.langchain4j.agentic.planner.Planner;
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * Minimal {@link AgentInstance} stub for unit testing.
+ * Only {@link #arguments()} and {@link #name()} are meaningful; other methods return defaults.
+ */
+class StubAgentInstance implements AgentInstance {
+
+    private final String name;
+    private final List<AgentArgument> arguments;
+
+    StubAgentInstance(String name, List<AgentArgument> arguments) {
+        this.name = name;
+        this.arguments = arguments;
+    }
+
+    @Override public String name() { return name; }
+    @Override public List<AgentArgument> arguments() { return arguments; }
+    @Override public String agentId() { return name; }
+    @Override public String description() { return ""; }
+    @Override public Class<?> type() { return Object.class; }
+    @Override public Class<? extends Planner> plannerType() { return null; }
+    @Override public Type outputType() { return String.class; }
+    @Override public String outputKey() { return null; }
+    @Override public boolean async() { return false; }
+    @Override public AgentInstance parent() { return null; }
+    @Override public List<AgentInstance> subagents() { return List.of(); }
+    @Override public AgenticSystemTopology topology() { return AgenticSystemTopology.AI_AGENT; }
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/StubAgentInstance.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/StubAgentInstance.java
@@ -21,16 +21,63 @@ class StubAgentInstance implements AgentInstance {
         this.arguments = arguments;
     }
 
-    @Override public String name() { return name; }
-    @Override public List<AgentArgument> arguments() { return arguments; }
-    @Override public String agentId() { return name; }
-    @Override public String description() { return ""; }
-    @Override public Class<?> type() { return Object.class; }
-    @Override public Class<? extends Planner> plannerType() { return null; }
-    @Override public Type outputType() { return String.class; }
-    @Override public String outputKey() { return null; }
-    @Override public boolean async() { return false; }
-    @Override public AgentInstance parent() { return null; }
-    @Override public List<AgentInstance> subagents() { return List.of(); }
-    @Override public AgenticSystemTopology topology() { return AgenticSystemTopology.AI_AGENT; }
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public List<AgentArgument> arguments() {
+        return arguments;
+    }
+
+    @Override
+    public String agentId() {
+        return name;
+    }
+
+    @Override
+    public String description() {
+        return "";
+    }
+
+    @Override
+    public Class<?> type() {
+        return Object.class;
+    }
+
+    @Override
+    public Class<? extends Planner> plannerType() {
+        return null;
+    }
+
+    @Override
+    public Type outputType() {
+        return String.class;
+    }
+
+    @Override
+    public String outputKey() {
+        return null;
+    }
+
+    @Override
+    public boolean async() {
+        return false;
+    }
+
+    @Override
+    public AgentInstance parent() {
+        return null;
+    }
+
+    @Override
+    public List<AgentInstance> subagents() {
+        return List.of();
+    }
+
+    @Override
+    public AgenticSystemTopology topology() {
+        return AgenticSystemTopology.AI_AGENT;
+    }
 }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/WriteArgumentToScopeTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/WriteArgumentToScopeTest.java
@@ -6,9 +6,9 @@ import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import dev.langchain4j.agentic.supervisor.SupervisorContextStrategy;
 import dev.langchain4j.agentic.supervisor.SupervisorPlanner;
 import dev.langchain4j.agentic.supervisor.SupervisorResponseStrategy;
-import dev.langchain4j.agentic.supervisor.SupervisorContextStrategy;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -36,17 +36,21 @@ class WriteArgumentToScopeTest {
     @BeforeEach
     void setUp() throws Exception {
         planner = new SupervisorPlanner(
-                null, null, 10,
+                null,
+                null,
+                10,
                 SupervisorContextStrategy.CHAT_MEMORY,
                 SupervisorResponseStrategy.LAST,
-                null, null, null);
+                null,
+                null,
+                null);
 
         writeArgumentToScope = SupervisorPlanner.class.getDeclaredMethod(
                 "writeArgumentToScope", AgenticScope.class, AgentInstance.class, String.class, Object.class);
         writeArgumentToScope.setAccessible(true);
 
-        Constructor<DefaultAgenticScope> ctor = DefaultAgenticScope.class.getDeclaredConstructor(
-                DefaultAgenticScope.Kind.class);
+        Constructor<DefaultAgenticScope> ctor =
+                DefaultAgenticScope.class.getDeclaredConstructor(DefaultAgenticScope.Kind.class);
         ctor.setAccessible(true);
         scope = ctor.newInstance(DefaultAgenticScope.Kind.EPHEMERAL);
     }
@@ -69,7 +73,8 @@ class WriteArgumentToScopeTest {
         scope.writeState("data", new LinkedHashMap<>(Map.of("id", 1)));
 
         // Second call should be allowed
-        assertThat(shouldWrite(agent, "data", new LinkedHashMap<>(Map.of("id", 2)))).isTrue();
+        assertThat(shouldWrite(agent, "data", new LinkedHashMap<>(Map.of("id", 2))))
+                .isTrue();
     }
 
     @Test
@@ -87,7 +92,8 @@ class WriteArgumentToScopeTest {
 
         scope.writeState("payload", new LinkedHashMap<>(Map.of("old", 1)));
 
-        assertThat(shouldWrite(agent, "payload", new LinkedHashMap<>(Map.of("new", 2)))).isTrue();
+        assertThat(shouldWrite(agent, "payload", new LinkedHashMap<>(Map.of("new", 2))))
+                .isTrue();
     }
 
     @Test
@@ -107,7 +113,8 @@ class WriteArgumentToScopeTest {
 
         scope.writeState("loan", new LoanApplication("John", 30, 80000));
 
-        assertThat(shouldWrite(agent, "loan", new LinkedHashMap<>(Map.of("applicantName", "John")))).isFalse();
+        assertThat(shouldWrite(agent, "loan", new LinkedHashMap<>(Map.of("applicantName", "John"))))
+                .isFalse();
     }
 
     @Test
@@ -128,7 +135,8 @@ class WriteArgumentToScopeTest {
         // Scope has a LinkedHashMap but argType expects LoanApplication — incompatible existing value
         scope.writeState("loan", new LinkedHashMap<>(Map.of("stale", true)));
 
-        assertThat(shouldWrite(agent, "loan", new LinkedHashMap<>(Map.of("also_stale", true)))).isTrue();
+        assertThat(shouldWrite(agent, "loan", new LinkedHashMap<>(Map.of("also_stale", true))))
+                .isTrue();
     }
 
     // -- edge: null value should not overwrite structured state --
@@ -148,7 +156,8 @@ class WriteArgumentToScopeTest {
     void should_allow_first_write_when_scope_has_no_existing_state() throws Exception {
         AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(Map.class, "data")));
 
-        assertThat(shouldWrite(agent, "data", new LinkedHashMap<>(Map.of("id", 1)))).isTrue();
+        assertThat(shouldWrite(agent, "data", new LinkedHashMap<>(Map.of("id", 1))))
+                .isTrue();
     }
 
     // -- edge: key not declared on agent → allow write --

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/WriteArgumentToScopeTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/WriteArgumentToScopeTest.java
@@ -1,0 +1,177 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agentic.planner.AgentArgument;
+import dev.langchain4j.agentic.planner.AgentInstance;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import dev.langchain4j.agentic.supervisor.SupervisorPlanner;
+import dev.langchain4j.agentic.supervisor.SupervisorResponseStrategy;
+import dev.langchain4j.agentic.supervisor.SupervisorContextStrategy;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the type guard logic in {@code SupervisorPlanner.writeArgumentToScope()}.
+ *
+ * <p>Regression tests for <a href="https://github.com/langchain4j/langchain4j/issues/4686">#4686</a>:
+ * the guard blocked repeated invocations of the same agent because
+ * {@code isAssignableFrom} was called in the wrong direction.
+ *
+ * @see <a href="https://github.com/langchain4j/langchain4j/pull/4381">#4381</a> (introduced the guard)
+ */
+class WriteArgumentToScopeTest {
+
+    private SupervisorPlanner planner;
+    private Method writeArgumentToScope;
+    private AgenticScope scope;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        planner = new SupervisorPlanner(
+                null, null, 10,
+                SupervisorContextStrategy.CHAT_MEMORY,
+                SupervisorResponseStrategy.LAST,
+                null, null, null);
+
+        writeArgumentToScope = SupervisorPlanner.class.getDeclaredMethod(
+                "writeArgumentToScope", AgenticScope.class, AgentInstance.class, String.class, Object.class);
+        writeArgumentToScope.setAccessible(true);
+
+        Constructor<DefaultAgenticScope> ctor = DefaultAgenticScope.class.getDeclaredConstructor(
+                DefaultAgenticScope.Kind.class);
+        ctor.setAccessible(true);
+        scope = ctor.newInstance(DefaultAgenticScope.Kind.EPHEMERAL);
+    }
+
+    private boolean shouldWrite(AgentInstance agent, String key, Object value) throws Exception {
+        return (boolean) writeArgumentToScope.invoke(planner, scope, agent, key, value);
+    }
+
+    private static AgentInstance stubAgent(String name, List<AgentArgument> arguments) {
+        return new StubAgentInstance(name, arguments);
+    }
+
+    // -- repeated invocation: compatible values should overwrite --
+
+    @Test
+    void should_allow_overwriting_map_with_compatible_map() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(Map.class, "data")));
+
+        // First call writes to scope
+        scope.writeState("data", new LinkedHashMap<>(Map.of("id", 1)));
+
+        // Second call should be allowed
+        assertThat(shouldWrite(agent, "data", new LinkedHashMap<>(Map.of("id", 2)))).isTrue();
+    }
+
+    @Test
+    void should_allow_overwriting_list_with_compatible_list() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(List.class, "items")));
+
+        scope.writeState("items", new ArrayList<>(List.of("a")));
+
+        assertThat(shouldWrite(agent, "items", new ArrayList<>(List.of("b")))).isTrue();
+    }
+
+    @Test
+    void should_allow_overwriting_object_with_any_value() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(Object.class, "payload")));
+
+        scope.writeState("payload", new LinkedHashMap<>(Map.of("old", 1)));
+
+        assertThat(shouldWrite(agent, "payload", new LinkedHashMap<>(Map.of("new", 2)))).isTrue();
+    }
+
+    @Test
+    void should_allow_overwriting_string_with_string() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(String.class, "name")));
+
+        scope.writeState("name", "Alice");
+
+        assertThat(shouldWrite(agent, "name", "Bob")).isTrue();
+    }
+
+    // -- protection: unstructured should not overwrite structured (#4381) --
+
+    @Test
+    void should_block_map_overwriting_pojo() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(LoanApplication.class, "loan")));
+
+        scope.writeState("loan", new LoanApplication("John", 30, 80000));
+
+        assertThat(shouldWrite(agent, "loan", new LinkedHashMap<>(Map.of("applicantName", "John")))).isFalse();
+    }
+
+    @Test
+    void should_block_string_overwriting_pojo() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(LoanApplication.class, "loan")));
+
+        scope.writeState("loan", new LoanApplication("John", 30, 80000));
+
+        assertThat(shouldWrite(agent, "loan", "raw string from LLM")).isFalse();
+    }
+
+    // -- edge: existing value is incompatible with argType → allow overwrite --
+
+    @Test
+    void should_allow_overwrite_when_existing_value_is_incompatible() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(LoanApplication.class, "loan")));
+
+        // Scope has a LinkedHashMap but argType expects LoanApplication — incompatible existing value
+        scope.writeState("loan", new LinkedHashMap<>(Map.of("stale", true)));
+
+        assertThat(shouldWrite(agent, "loan", new LinkedHashMap<>(Map.of("also_stale", true)))).isTrue();
+    }
+
+    // -- edge: null value should not overwrite structured state --
+
+    @Test
+    void should_block_null_overwriting_typed_state() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(LoanApplication.class, "loan")));
+
+        scope.writeState("loan", new LoanApplication("John", 30, 80000));
+
+        assertThat(shouldWrite(agent, "loan", null)).isFalse();
+    }
+
+    // -- edge: no existing state → always allow first write --
+
+    @Test
+    void should_allow_first_write_when_scope_has_no_existing_state() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(Map.class, "data")));
+
+        assertThat(shouldWrite(agent, "data", new LinkedHashMap<>(Map.of("id", 1)))).isTrue();
+    }
+
+    // -- edge: key not declared on agent → allow write --
+
+    @Test
+    void should_allow_write_when_key_is_not_declared_on_agent() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(String.class, "name")));
+
+        scope.writeState("extra", "old");
+
+        assertThat(shouldWrite(agent, "extra", "new")).isTrue();
+    }
+
+    // -- edge: Number subtype compatibility --
+
+    @Test
+    void should_allow_overwriting_number_with_other_number_subtype() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(Number.class, "amount")));
+
+        scope.writeState("amount", 1);
+
+        assertThat(shouldWrite(agent, "amount", 2.5)).isTrue();
+    }
+
+    record LoanApplication(String applicantName, int applicantAge, int amount) {}
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/WriteArgumentToScopeTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/WriteArgumentToScopeTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.agentic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.langchain4j.agentic.internal.DelayedResponse;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.scope.AgenticScope;
@@ -148,6 +149,30 @@ class WriteArgumentToScopeTest {
         scope.writeState("loan", new LoanApplication("John", 30, 80000));
 
         assertThat(shouldWrite(agent, "loan", null)).isFalse();
+    }
+
+    // -- edge: existing value resolved to null (async agent) → allow overwrite --
+
+    @Test
+    void should_allow_overwrite_when_existing_value_resolves_to_null() throws Exception {
+        AgentInstance agent = stubAgent("agent", List.of(new AgentArgument(Map.class, "data")));
+
+        // Write a DelayedResponse that resolves to null — simulates an async agent whose output is null.
+        // hasState() sees a non-null object → true, but readState() resolves it to null.
+        scope.writeState("data", new DelayedResponse<Object>() {
+            @Override
+            public boolean isDone() {
+                return true;
+            }
+
+            @Override
+            public Object blockingGet() {
+                return null;
+            }
+        });
+
+        assertThat(shouldWrite(agent, "data", new LinkedHashMap<>(Map.of("id", 1))))
+                .isTrue();
     }
 
     // -- edge: no existing state → always allow first write --


### PR DESCRIPTION
## Issue
Closes #4686

## Change
The `writeArgumentToScope()` type guard in `SupervisorPlanner` had two bugs:

1. **Reversed `isAssignableFrom` direction** — `value.getClass().isAssignableFrom(argType)` checks "is argType a subclass of value's class?" instead of the intended "is value compatible with argType?" This caused repeated invocations of the same agent to be blocked when the argument type is a parent class (e.g., `Map`, `List`, `Number`), because a `LinkedHashMap` value would fail the reversed check against `Map` argType.

2. **Missing null guard** — `value.getClass()` throws `NullPointerException` when `value` is null. Additionally, `existingValue` can be null when a `DelayedResponse` from an async agent resolves to null.

The fix:
- Flips `isAssignableFrom` to the correct direction: `argType.isAssignableFrom(value.getClass())`
- Adds null guard for `value` (null cannot overwrite typed state)
- Adds null guard for `existingValue` (allow overwrite when async result resolved to null)

The original protection from #4381 is preserved: unstructured LLM output (Map/String) still cannot overwrite structured POJO state.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)