### PR TITLE
Extract StoreIngestor interface from EmbeddingStoreIngestor

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestor.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * Including a document title or a short summary in each {@code TextSegment} is a common technique
  * to improve the quality of similarity searches.
  */
-public class EmbeddingStoreIngestor {
+public class EmbeddingStoreIngestor implements StoreIngestor {
 
     private static final Logger log = LoggerFactory.getLogger(EmbeddingStoreIngestor.class);
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestor.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * Including a document title or a short summary in each {@code TextSegment} is a common technique
  * to improve the quality of similarity searches.
  */
-public class EmbeddingStoreIngestor {
+public class EmbeddingStoreIngestor implements StoreIngestor {
 
     private static final Logger log = LoggerFactory.getLogger(EmbeddingStoreIngestor.class);
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/StoreIngestor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/StoreIngestor.java
@@ -1,0 +1,43 @@
+package dev.langchain4j.store.embedding;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
+import dev.langchain4j.data.document.Document;
+import java.util.List;
+
+/**
+ * Defines the contract for ingesting {@link Document}s.
+ *
+ * @see EmbeddingStoreIngestor
+ */
+public interface StoreIngestor {
+
+    /**
+     * Ingests specified documents.
+     *
+     * @param documents the documents to ingest.
+     * @return result including information related to the ingestion process.
+     */
+    IngestionResult ingest(List<Document> documents);
+
+    /**
+     * Ingests a specified document.
+     *
+     * @param document the document to ingest.
+     * @return result including information related to the ingestion process.
+     */
+    default IngestionResult ingest(Document document) {
+        return ingest(singletonList(document));
+    }
+
+    /**
+     * Ingests specified documents.
+     *
+     * @param documents the documents to ingest.
+     * @return result including information related to the ingestion process.
+     */
+    default IngestionResult ingest(Document... documents) {
+        return ingest(asList(documents));
+    }
+}


### PR DESCRIPTION
## Issue
Related to #3958

## Change
Adds a small StoreIngestor interface with ingest(List<Document>) as its contract and the same convenience overloads already exposed by EmbeddingStoreIngestor. EmbeddingStoreIngestor now implements it without changing existing behavior.

## Testing
- langchain4j-core: 1,282 tests passed
- git diff --check

This draft is intentionally limited to the reusable ingestion contract; implementation-specific SPI helpers remain on EmbeddingStoreIngestor.