### PR TITLE
Fix Ollama ToolCall missing id field

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -90,6 +90,7 @@ class InternalOllamaHelper {
     static List<ToolExecutionRequest> toToolExecutionRequests(List<ToolCall> toolCalls) {
         return toolCalls.stream()
                 .map(toolCall -> ToolExecutionRequest.builder()
+                        .id(toolCall.getId())
                         .name(toolCall.getFunction().getName())
                         .arguments(toJsonWithoutIdent(toolCall.getFunction().getArguments()))
                         .build())
@@ -235,7 +236,10 @@ class InternalOllamaHelper {
                                         .name(toolExecutionRequest.name())
                                         .arguments(fromJson(toolExecutionRequest.arguments(), typeReference))
                                         .build();
-                                return ToolCall.builder().function(functionCall).build();
+                                return ToolCall.builder()
+                                        .id(toolExecutionRequest.id())
+                                        .function(functionCall)
+                                        .build();
                             })
                             .collect(Collectors.toList()))
                     .orElse(null);

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
@@ -211,6 +211,7 @@ class OllamaClient {
                         }
 
                         toolCallBuilder.updateName(toolCall.getFunction().getName());
+                        toolCallBuilder.updateId(toolCall.getId());
 
                         String partialArguments =
                                 toJsonWithoutIdent(toolCall.getFunction().getArguments());

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/ToolCall.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/ToolCall.java
@@ -1,28 +1,37 @@
 package dev.langchain4j.model.ollama;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 class ToolCall {
 
+    private String id;
     private FunctionCall function;
 
-    ToolCall() {
-    }
+    ToolCall() {}
 
-    ToolCall(FunctionCall function) {
+    ToolCall(String id, FunctionCall function) {
+        this.id = id;
         this.function = function;
     }
 
     static Builder builder() {
         return new Builder();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 
     public FunctionCall getFunction() {
@@ -35,7 +44,13 @@ class ToolCall {
 
     static class Builder {
 
+        private String id;
         private FunctionCall function;
+
+        Builder id(String id) {
+            this.id = id;
+            return this;
+        }
 
         Builder function(FunctionCall function) {
             this.function = function;
@@ -43,7 +58,7 @@ class ToolCall {
         }
 
         ToolCall build() {
-            return new ToolCall(function);
+            return new ToolCall(id, function);
         }
     }
 }

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaChatModelIT.java
@@ -20,14 +20,12 @@ import dev.langchain4j.model.ollama.LC4jOllamaContainer;
 import dev.langchain4j.model.ollama.OllamaChatModel;
 import dev.langchain4j.model.ollama.OllamaChatRequestParameters;
 import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiChatResponseMetadata;
+import dev.langchain4j.model.openai.OpenAiTokenUsage;
+import dev.langchain4j.model.output.TokenUsage;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import dev.langchain4j.model.openai.OpenAiChatResponseMetadata;
-import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
-import dev.langchain4j.model.openai.OpenAiTokenUsage;
-import dev.langchain4j.model.output.TokenUsage;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -121,8 +119,7 @@ class OllamaChatModelIT extends AbstractChatModelIT {
 
     @Override
     @Disabled("llama 3.1 cannot do it properly")
-    protected void should_execute_a_tool_then_answer_respecting_JSON_response_format_with_schema(ChatModel model) {
-    }
+    protected void should_execute_a_tool_then_answer_respecting_JSON_response_format_with_schema(ChatModel model) {}
 
     @Override
     @ParameterizedTest
@@ -221,7 +218,7 @@ class OllamaChatModelIT extends AbstractChatModelIT {
     protected boolean supportsMultipleImageInputsAsPublicURLs() {
         return false; // vision model only supports a single image per message
     }
-    
+
     @Override
     protected boolean assertResponseId() {
         return false; // Ollama does not return response ID
@@ -229,7 +226,7 @@ class OllamaChatModelIT extends AbstractChatModelIT {
 
     @Override
     protected boolean assertToolId(ChatModel model) {
-        return model instanceof OpenAiStreamingChatModel; // Ollama does not return tool ID via Ollama API
+        return true; // Ollama returns tool call id since v0.12.10
     }
 
     @Override

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaStreamingChatModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/common/OllamaStreamingChatModelIT.java
@@ -16,9 +16,6 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.common.AbstractStreamingChatModelIT;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
@@ -32,6 +29,9 @@ import dev.langchain4j.model.openai.OpenAiChatResponseMetadata;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import dev.langchain4j.model.openai.OpenAiTokenUsage;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -123,8 +123,8 @@ class OllamaStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Override
     @Disabled("llama 3.1 cannot do it properly")
-    protected void should_execute_a_tool_then_answer_respecting_JSON_response_format_with_schema(StreamingChatModel model) {
-    }
+    protected void should_execute_a_tool_then_answer_respecting_JSON_response_format_with_schema(
+            StreamingChatModel model) {}
 
     @Override
     @ParameterizedTest
@@ -214,7 +214,7 @@ class OllamaStreamingChatModelIT extends AbstractStreamingChatModelIT {
         return false; // Ollama does not support tool choice
         // also for OpenAI-compatible API: https://github.com/ollama/ollama/blob/main/docs/openai.md
     }
-    
+
     @Override
     protected boolean supportsMultipleImageInputsAsBase64EncodedStrings() {
         return false; // vision model only supports a single image per message
@@ -232,7 +232,7 @@ class OllamaStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Override
     protected boolean assertToolId(StreamingChatModel model) {
-        return model instanceof OpenAiStreamingChatModel; // Ollama does not return tool ID via Ollama API
+        return true; // Ollama returns tool call id since v0.12.10
     }
 
     @Override
@@ -276,7 +276,8 @@ class OllamaStreamingChatModelIT extends AbstractStreamingChatModelIT {
     }
 
     @Override
-    protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id, StreamingChatModel model) {
+    protected void verifyToolCallbacks(
+            StreamingChatResponseHandler handler, InOrder io, String id, StreamingChatModel model) {
         if (model instanceof OpenAiStreamingChatModel) {
             io.verify(handler).onPartialToolCall(eq(partial(0, id, "getWeather", "{\"city\":\"Munich\"}")), any());
         }
@@ -286,26 +287,27 @@ class OllamaStreamingChatModelIT extends AbstractStreamingChatModelIT {
     @Override
     protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, StreamingChatModel model) {
         if (model instanceof OpenAiStreamingChatModel) {
-            io.verify(handler).onPartialToolCall(argThat(toolCall ->
-                    toolCall.index() == 0
-                            && !toolCall.id().isBlank()
-                            && toolCall.name().equals("get_current_time")
-                            && toolCall.partialArguments().equals("{}")
-            ), any());
+            io.verify(handler)
+                    .onPartialToolCall(
+                            argThat(toolCall -> toolCall.index() == 0
+                                    && !toolCall.id().isBlank()
+                                    && toolCall.name().equals("get_current_time")
+                                    && toolCall.partialArguments().equals("{}")),
+                            any());
         }
 
         // Ollama talks in-between for some reason
         io.verify(handler, atLeast(0)).onPartialResponse(any(), any());
 
-        io.verify(handler).onCompleteToolCall(argThat(request ->
-                request.index() == 0
+        io.verify(handler)
+                .onCompleteToolCall(argThat(request -> request.index() == 0
                         && request.toolExecutionRequest().name().equals("get_current_time")
-                        && request.toolExecutionRequest().arguments().equals("{}")
-        ));
+                        && request.toolExecutionRequest().arguments().equals("{}")));
     }
 
     @Override
-    protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id1, String id2, StreamingChatModel model) {
+    protected void verifyToolCallbacks(
+            StreamingChatResponseHandler handler, InOrder io, String id1, String id2, StreamingChatModel model) {
         verifyToolCallbacks(handler, io, id1, model);
 
         if (model instanceof OpenAiStreamingChatModel) {


### PR DESCRIPTION
## Issue
Closes #4720

## Change
Ollama has been returning `id` in `/api/chat` tool calls since [v0.12.10](https://github.com/ollama/ollama/releases/tag/v0.12.10) (Nov 2025, [ollama/ollama#12732](https://github.com/ollama/ollama/pull/12732)), but `ToolCall` class lacked the `id` field. Combined with `@JsonIgnoreProperties(ignoreUnknown = true)`, the `id` was silently discarded during deserialization.

This PR adds `id` support across all three code paths:
- **Non-streaming** (`InternalOllamaHelper.toToolExecutionRequests`): propagate `id` from `ToolCall` to `ToolExecutionRequest`
- **Streaming** (`OllamaClient.streamingChat`): pass `id` to `ToolCallBuilder`
- **Reverse mapping** (`InternalOllamaHelper.otherMessages`): carry `id` back from `ToolExecutionRequest` to `ToolCall`

The change is backward-compatible — for older Ollama versions that don't return `id`, the field stays `null`, preserving existing behavior.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)