### PR TITLE
Fix NPE in MistralAiModerationModel when categories is null

### DIFF
--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiModerationModel.java
@@ -79,7 +79,8 @@ public class MistralAiModerationModel implements ModerationModel {
 
     private int findFirstFlaggedIndex(List<MistralAiModerationResult> results) {
         for (int i = 0; i < results.size(); i++) {
-            if (isAnyCategoryFlagged(results.get(i).getCategories())) {
+            MistralAiCategories categories = results.get(i).getCategories();
+            if (categories != null && isAnyCategoryFlagged(categories)) {
                 return i;
             }
         }


### PR DESCRIPTION
The NPE was possible before #4695.