### PR TITLE
docs: add prompt repetition documentation

### DIFF
--- a/docs/docs/integrations/prompt-repetition/_category_.json
+++ b/docs/docs/integrations/prompt-repetition/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Prompt Repetition",
+  "position": 22,
+  "link": {
+    "type": "generated-index",
+    "description": "Prompt repetition utilities for AI Services guardrails and RAG query transformation"
+  }
+}

--- a/docs/docs/integrations/prompt-repetition/prompt-repetition.md
+++ b/docs/docs/integrations/prompt-repetition/prompt-repetition.md
@@ -4,12 +4,14 @@ sidebar_position: 1
 
 # Prompt Repetition
 
-`langchain4j-community-prompt-repetition` is an optional community module that provides prompt repetition utilities for two LangChain4j integration points:
+`langchain4j-community-prompt-repetition` is an optional community module that provides ready-made prompt repetition integrations for two LangChain4j integration points:
 
 - AI Services input guardrails
 - RAG query transformation
 
-The module is experimental and is intended for workload-specific evaluation. It is inspired by recent prompt repetition research, but it should not be treated as a default optimization for all prompts or models.
+It is inspired by the paper [Prompt Repetition Improves Non-Reasoning LLMs](https://arxiv.org/html/2512.14982v1), which reports gains on a range of non-reasoning workloads. In LangChain4j, the module exposes the core repeated-input transformation through framework-native components and adds conservative defaults for real applications.
+
+The module is experimental, and its effectiveness is workload-dependent. Validate it on your own prompts, models, and tasks before broad rollout.
 
 ## What It Is
 
@@ -128,9 +130,10 @@ This keeps the transformation inside the retrieval stage and avoids duplicating 
 
 ## When to Use It
 
-Use this module as an optional optimization, not as a default prompt policy.
+Use this module when you want a ready-made way to apply prompt repetition in LangChain4j, not when you want a universal default prompt policy.
 
 - Start with `PromptRepetitionMode.AUTO`
+- Prefer it for non-reasoning or low-reasoning workloads first
 - Evaluate it with A/B tests on your own prompts, models, and tasks
 - Keep the default safety constraints unless you have a clear reason to relax them
 - Treat improvements as workload-dependent rather than guaranteed

--- a/docs/docs/integrations/prompt-repetition/prompt-repetition.md
+++ b/docs/docs/integrations/prompt-repetition/prompt-repetition.md
@@ -1,0 +1,136 @@
+---
+sidebar_position: 1
+---
+
+# Prompt Repetition
+
+`langchain4j-community-prompt-repetition` is an optional community module that provides prompt repetition utilities for two LangChain4j integration points:
+
+- AI Services input guardrails
+- RAG query transformation
+
+The module is experimental and is intended for workload-specific evaluation. It is inspired by recent prompt repetition research, but it should not be treated as a default optimization for all prompts or models.
+
+## What It Is
+
+Prompt repetition rewrites text in the following form:
+
+```text
+Q -> Q\nQ
+```
+
+In LangChain4j, this can be applied in two different places:
+
+- Before a non-RAG AI Services call, using `PromptRepeatingInputGuardrail`
+- Before retrieval in an advanced RAG pipeline, using `RepeatingQueryTransformer`
+
+For RAG, the repetition should be applied only to the retrieval query, not to the final augmented prompt sent to the model.
+
+## Maven Dependencies
+
+If you already use community modules, importing the community BOM is recommended:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-community-bom</artifactId>
+            <version>${latest version here}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+Then add the prompt repetition module:
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-community-prompt-repetition</artifactId>
+</dependency>
+```
+
+You can also declare the module directly:
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-community-prompt-repetition</artifactId>
+    <version>${latest version here}</version>
+</dependency>
+```
+
+## Components
+
+The module provides three main APIs:
+
+- `PromptRepeatingInputGuardrail` repeats eligible single-text user input before the model is called
+- `RepeatingQueryTransformer` repeats the retrieval query in advanced RAG pipelines
+- `PromptRepetitionPolicy` contains the shared repetition rules used by both integrations
+
+All of these APIs are marked as `@Experimental`.
+
+## Non-RAG Usage
+
+For non-RAG AI Services calls, attach `PromptRepeatingInputGuardrail` to the `AiServices` builder:
+
+```java
+PromptRepetitionPolicy policy = PromptRepetitionPolicy.builder()
+        .mode(PromptRepetitionMode.AUTO)
+        .maxChars(8_000)
+        .build();
+
+Assistant assistant = AiServices.builder(Assistant.class)
+        .chatModel(chatModel)
+        .inputGuardrails(new PromptRepeatingInputGuardrail(policy))
+        .build();
+```
+
+This is the preferred integration point when you want to rewrite the user input before the model call and you are not operating on an augmented RAG prompt.
+
+## RAG Usage
+
+For RAG, repeat the retrieval query only:
+
+```java
+PromptRepetitionPolicy policy = PromptRepetitionPolicy.builder()
+        .mode(PromptRepetitionMode.AUTO)
+        .maxChars(8_000)
+        .build();
+
+RetrievalAugmentor retrievalAugmentor = DefaultRetrievalAugmentor.builder()
+        .queryTransformer(new RepeatingQueryTransformer(policy))
+        .build();
+```
+
+This keeps the transformation inside the retrieval stage and avoids duplicating the final prompt after retrieved content has already been injected.
+
+## Modes
+
+`PromptRepetitionPolicy` supports three modes:
+
+- `NEVER`: disables repetition
+- `ALWAYS`: repeats eligible input
+- `AUTO`: conservative mode that skips already repeated text, very long input, and prompts that appear to request explicit reasoning
+
+`AUTO` is the safest starting point for evaluation.
+
+## Safety and Constraints
+
+- `PromptRepeatingInputGuardrail` only rewrites eligible single-text user input
+- It is not intended to be the main integration point for multimodal requests
+- By default, the guardrail skips requests when RAG augmentation has already happened
+- In RAG setups, use `RepeatingQueryTransformer` to repeat the retrieval query instead of repeating the final augmented prompt
+- The module is experimental, so APIs and behavior may change in future versions
+
+## When to Use It
+
+Use this module as an optional optimization, not as a default prompt policy.
+
+- Start with `PromptRepetitionMode.AUTO`
+- Evaluate it with A/B tests on your own prompts, models, and tasks
+- Keep the default safety constraints unless you have a clear reason to relax them
+- Treat improvements as workload-dependent rather than guaranteed

--- a/docs/docs/tutorials/guardrails.md
+++ b/docs/docs/tutorials/guardrails.md
@@ -70,6 +70,7 @@ Some examples of things you could do:
 - Check that there are enough documents in the augmentation results
 - Ensure the user is not asking the same question multiple times
 - Mitigate potential prompt injection attack
+- Rewrite eligible single-text input with the community [Prompt Repetition](/integrations/prompt-repetition/) module
 
 Input guardrails can be used whether the operation is synchronous or asynchronous/streaming.
 
@@ -121,6 +122,10 @@ var assistant = AiServices.builder(Assistant.class)
     .inputGuardrails(new FirstInputGuardrail(), new SecondInputGuardrail())
     .build();
 ```
+
+:::info
+If you want a ready-made experimental input guardrail that rewrites eligible single-text input using prompt repetition, see the community [Prompt Repetition](/integrations/prompt-repetition/) module.
+:::
 
 In the first scenario, classes that implement `InputGuardrail` are passed. New instances of these classes are created dynamically using reflection.
 

--- a/docs/docs/tutorials/rag.md
+++ b/docs/docs/tutorials/rag.md
@@ -787,6 +787,8 @@ Some known approaches to improve retrieval include:
 
 More details can be found [here](https://blog.langchain.dev/query-transformations/).
 
+LangChain4j also has an optional community [Prompt Repetition](/integrations/prompt-repetition/) module that provides `RepeatingQueryTransformer`. It repeats the retrieval query before content retrieval and should be used to transform the query itself, not the final augmented prompt sent to the model.
+
 #### Default Query Transformer
 `DefaultQueryTransformer` is the default implementation used in `DefaultRetrievalAugmentor`.
 It does not make any modifications to the `Query`, it just passes it through.


### PR DESCRIPTION
## Summary
- add a dedicated docs page for the `langchain4j-community-prompt-repetition` module
- add discovery links from the guardrails and RAG tutorials
- document the module as an experimental, ready-made prompt repetition integration

## Details
This adds documentation in the main `langchain4j` docs site for the community prompt repetition module introduced in `langchain4j-community`.

It includes:
- a new integration page under `Integrations > Prompt Repetition`
- a short pointer from the guardrails tutorial to `PromptRepeatingInputGuardrail`
- a short pointer from the RAG tutorial to `RepeatingQueryTransformer`

The docs position the module as:
- an optional community module
- an experimental but real integration, not just an evaluation harness
- inspired by the paper [Prompt Repetition Improves Non-Reasoning LLMs](https://arxiv.org/html/2512.14982v1)
- a way to apply the core repeated-input transformation in LangChain4j for eligible inputs
- something users should still validate on their own prompts, models, and tasks

The wording intentionally avoids claiming that this module reproduces the paper's full methodology or results.