### PR TITLE
Add MiniMax as a new chat model provider

### DIFF
--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -148,6 +148,12 @@
 
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-minimax</artifactId>
+                <version>${langchain4j.stable.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-mistral-ai</artifactId>
                 <version>${langchain4j.stable.version}</version>
             </dependency>

--- a/langchain4j-minimax/pom.xml
+++ b/langchain4j-minimax/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-parent</artifactId>
+        <version>1.13.0-beta23-SNAPSHOT</version>
+        <relativePath>../langchain4j-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-minimax</artifactId>
+    <version>1.13.0-SNAPSHOT</version>
+    <name>LangChain4j :: Integration :: MiniMax</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-open-ai</artifactId>
+            <version>1.13.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>1.13.0-SNAPSHOT</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-http-client</artifactId>
+            <version>1.13.0-SNAPSHOT</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/MiniMaxChatModel.java
+++ b/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/MiniMaxChatModel.java
@@ -1,0 +1,272 @@
+package dev.langchain4j.model.minimax;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.model.minimax.MiniMaxUtils.DEFAULT_MINIMAX_URL;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+import static java.util.Arrays.asList;
+
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.minimax.spi.MiniMaxChatModelBuilderFactory;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiChatRequestParameters;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+
+/**
+ * Represents a MiniMax language model with a chat completion interface.
+ * MiniMax provides an OpenAI-compatible API, so this module delegates to the OpenAI client
+ * with MiniMax-specific defaults (base URL, model names, temperature clamping).
+ *
+ * @see <a href="https://platform.minimax.io/docs/api-reference/text-openai-api">MiniMax Chat API</a>
+ */
+public class MiniMaxChatModel implements ChatModel {
+
+    private final OpenAiChatModel delegate;
+
+    public MiniMaxChatModel(MiniMaxChatModelBuilder builder) {
+        this.delegate = OpenAiChatModel.builder()
+                .httpClientBuilder(builder.httpClientBuilder)
+                .baseUrl(getOrDefault(builder.baseUrl, DEFAULT_MINIMAX_URL))
+                .apiKey(builder.apiKey)
+                .modelName(getOrDefault(builder.modelName, MiniMaxChatModelName.MINIMAX_M2_7.toString()))
+                .temperature(MiniMaxUtils.clampTemperature(builder.temperature))
+                .topP(builder.topP)
+                .stop(builder.stop)
+                .maxTokens(builder.maxTokens)
+                .maxCompletionTokens(builder.maxCompletionTokens)
+                .presencePenalty(builder.presencePenalty)
+                .frequencyPenalty(builder.frequencyPenalty)
+                .responseFormat(builder.responseFormat)
+                .supportedCapabilities(builder.supportedCapabilities)
+                .strictJsonSchema(builder.strictJsonSchema)
+                .strictTools(builder.strictTools)
+                .timeout(builder.timeout)
+                .maxRetries(builder.maxRetries)
+                .logRequests(builder.logRequests)
+                .logResponses(builder.logResponses)
+                .logger(builder.logger)
+                .customHeaders(builder.customHeadersSupplier)
+                .customQueryParams(builder.customQueryParams)
+                .customParameters(builder.customParameters)
+                .listeners(builder.listeners)
+                .build();
+    }
+
+    @Override
+    public ChatRequestParameters defaultRequestParameters() {
+        return delegate.defaultRequestParameters();
+    }
+
+    @Override
+    public Set<Capability> supportedCapabilities() {
+        return delegate.supportedCapabilities();
+    }
+
+    @Override
+    public ChatResponse doChat(ChatRequest chatRequest) {
+        return delegate.doChat(chatRequest);
+    }
+
+    @Override
+    public List<ChatModelListener> listeners() {
+        return delegate.listeners();
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return ModelProvider.OTHER;
+    }
+
+    public static MiniMaxChatModelBuilder builder() {
+        for (MiniMaxChatModelBuilderFactory factory : loadFactories(MiniMaxChatModelBuilderFactory.class)) {
+            return factory.get();
+        }
+        return new MiniMaxChatModelBuilder();
+    }
+
+    public static class MiniMaxChatModelBuilder {
+
+        HttpClientBuilder httpClientBuilder;
+        String baseUrl;
+        String apiKey;
+        String modelName;
+        Double temperature;
+        Double topP;
+        List<String> stop;
+        Integer maxTokens;
+        Integer maxCompletionTokens;
+        Double presencePenalty;
+        Double frequencyPenalty;
+        ResponseFormat responseFormat;
+        Set<Capability> supportedCapabilities;
+        Boolean strictJsonSchema;
+        Boolean strictTools;
+        Duration timeout;
+        Integer maxRetries;
+        Boolean logRequests;
+        Boolean logResponses;
+        Logger logger;
+        Supplier<Map<String, String>> customHeadersSupplier;
+        Map<String, String> customQueryParams;
+        Map<String, Object> customParameters;
+        List<ChatModelListener> listeners;
+
+        public MiniMaxChatModelBuilder() {
+            // This is public so it can be extended
+        }
+
+        public MiniMaxChatModelBuilder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder modelName(MiniMaxChatModelName modelName) {
+            this.modelName = modelName.toString();
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder stop(List<String> stop) {
+            this.stop = stop;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder maxTokens(Integer maxTokens) {
+            this.maxTokens = maxTokens;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder maxCompletionTokens(Integer maxCompletionTokens) {
+            this.maxCompletionTokens = maxCompletionTokens;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder presencePenalty(Double presencePenalty) {
+            this.presencePenalty = presencePenalty;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder frequencyPenalty(Double frequencyPenalty) {
+            this.frequencyPenalty = frequencyPenalty;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder responseFormat(ResponseFormat responseFormat) {
+            this.responseFormat = responseFormat;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder supportedCapabilities(Set<Capability> supportedCapabilities) {
+            this.supportedCapabilities = supportedCapabilities;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder supportedCapabilities(Capability... supportedCapabilities) {
+            return supportedCapabilities(new java.util.HashSet<>(asList(supportedCapabilities)));
+        }
+
+        public MiniMaxChatModelBuilder strictJsonSchema(Boolean strictJsonSchema) {
+            this.strictJsonSchema = strictJsonSchema;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder strictTools(Boolean strictTools) {
+            this.strictTools = strictTools;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder logger(Logger logger) {
+            this.logger = logger;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder customQueryParams(Map<String, String> customQueryParams) {
+            this.customQueryParams = customQueryParams;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder customParameters(Map<String, Object> customParameters) {
+            this.customParameters = customParameters;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder listeners(List<ChatModelListener> listeners) {
+            this.listeners = listeners;
+            return this;
+        }
+
+        public MiniMaxChatModelBuilder listeners(ChatModelListener... listeners) {
+            return listeners(asList(listeners));
+        }
+
+        public MiniMaxChatModel build() {
+            return new MiniMaxChatModel(this);
+        }
+    }
+}

--- a/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/MiniMaxChatModelName.java
+++ b/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/MiniMaxChatModelName.java
@@ -1,0 +1,24 @@
+package dev.langchain4j.model.minimax;
+
+/**
+ * Represents available MiniMax chat model names.
+ * MiniMax provides OpenAI-compatible API endpoints.
+ *
+ * @see <a href="https://platform.minimax.io/docs/api-reference/text-openai-api">MiniMax Chat API</a>
+ */
+public enum MiniMaxChatModelName {
+
+    MINIMAX_M2_7("MiniMax-M2.7"),
+    MINIMAX_M2_7_HIGHSPEED("MiniMax-M2.7-highspeed");
+
+    private final String stringValue;
+
+    MiniMaxChatModelName(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+    @Override
+    public String toString() {
+        return stringValue;
+    }
+}

--- a/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/MiniMaxStreamingChatModel.java
+++ b/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/MiniMaxStreamingChatModel.java
@@ -1,0 +1,247 @@
+package dev.langchain4j.model.minimax;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.model.minimax.MiniMaxUtils.DEFAULT_MINIMAX_URL;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+import static java.util.Arrays.asList;
+
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.minimax.spi.MiniMaxStreamingChatModelBuilderFactory;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+
+/**
+ * Represents a MiniMax language model with a streaming chat completion interface.
+ * MiniMax provides an OpenAI-compatible API, so this module delegates to the OpenAI streaming client
+ * with MiniMax-specific defaults (base URL, model names, temperature clamping).
+ *
+ * @see <a href="https://platform.minimax.io/docs/api-reference/text-openai-api">MiniMax Chat API</a>
+ */
+public class MiniMaxStreamingChatModel implements StreamingChatModel {
+
+    private final OpenAiStreamingChatModel delegate;
+
+    public MiniMaxStreamingChatModel(MiniMaxStreamingChatModelBuilder builder) {
+        this.delegate = OpenAiStreamingChatModel.builder()
+                .httpClientBuilder(builder.httpClientBuilder)
+                .baseUrl(getOrDefault(builder.baseUrl, DEFAULT_MINIMAX_URL))
+                .apiKey(builder.apiKey)
+                .modelName(getOrDefault(builder.modelName, MiniMaxChatModelName.MINIMAX_M2_7.toString()))
+                .temperature(MiniMaxUtils.clampTemperature(builder.temperature))
+                .topP(builder.topP)
+                .stop(builder.stop)
+                .maxTokens(builder.maxTokens)
+                .maxCompletionTokens(builder.maxCompletionTokens)
+                .presencePenalty(builder.presencePenalty)
+                .frequencyPenalty(builder.frequencyPenalty)
+                .responseFormat(builder.responseFormat)
+                .strictJsonSchema(builder.strictJsonSchema)
+                .strictTools(builder.strictTools)
+                .timeout(builder.timeout)
+                .logRequests(builder.logRequests)
+                .logResponses(builder.logResponses)
+                .logger(builder.logger)
+                .customHeaders(builder.customHeadersSupplier)
+                .customQueryParams(builder.customQueryParams)
+                .customParameters(builder.customParameters)
+                .listeners(builder.listeners)
+                .build();
+    }
+
+    @Override
+    public ChatRequestParameters defaultRequestParameters() {
+        return delegate.defaultRequestParameters();
+    }
+
+    @Override
+    public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+        delegate.doChat(chatRequest, handler);
+    }
+
+    @Override
+    public List<ChatModelListener> listeners() {
+        return delegate.listeners();
+    }
+
+    @Override
+    public ModelProvider provider() {
+        return ModelProvider.OTHER;
+    }
+
+    public static MiniMaxStreamingChatModelBuilder builder() {
+        for (MiniMaxStreamingChatModelBuilderFactory factory :
+                loadFactories(MiniMaxStreamingChatModelBuilderFactory.class)) {
+            return factory.get();
+        }
+        return new MiniMaxStreamingChatModelBuilder();
+    }
+
+    public static class MiniMaxStreamingChatModelBuilder {
+
+        HttpClientBuilder httpClientBuilder;
+        String baseUrl;
+        String apiKey;
+        String modelName;
+        Double temperature;
+        Double topP;
+        List<String> stop;
+        Integer maxTokens;
+        Integer maxCompletionTokens;
+        Double presencePenalty;
+        Double frequencyPenalty;
+        ResponseFormat responseFormat;
+        Boolean strictJsonSchema;
+        Boolean strictTools;
+        Duration timeout;
+        Boolean logRequests;
+        Boolean logResponses;
+        Logger logger;
+        Supplier<Map<String, String>> customHeadersSupplier;
+        Map<String, String> customQueryParams;
+        Map<String, Object> customParameters;
+        List<ChatModelListener> listeners;
+
+        public MiniMaxStreamingChatModelBuilder() {
+            // This is public so it can be extended
+        }
+
+        public MiniMaxStreamingChatModelBuilder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder modelName(MiniMaxChatModelName modelName) {
+            this.modelName = modelName.toString();
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder stop(List<String> stop) {
+            this.stop = stop;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder maxTokens(Integer maxTokens) {
+            this.maxTokens = maxTokens;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder maxCompletionTokens(Integer maxCompletionTokens) {
+            this.maxCompletionTokens = maxCompletionTokens;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder presencePenalty(Double presencePenalty) {
+            this.presencePenalty = presencePenalty;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder frequencyPenalty(Double frequencyPenalty) {
+            this.frequencyPenalty = frequencyPenalty;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder responseFormat(ResponseFormat responseFormat) {
+            this.responseFormat = responseFormat;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder strictJsonSchema(Boolean strictJsonSchema) {
+            this.strictJsonSchema = strictJsonSchema;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder strictTools(Boolean strictTools) {
+            this.strictTools = strictTools;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder logger(Logger logger) {
+            this.logger = logger;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder customQueryParams(Map<String, String> customQueryParams) {
+            this.customQueryParams = customQueryParams;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder customParameters(Map<String, Object> customParameters) {
+            this.customParameters = customParameters;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder listeners(List<ChatModelListener> listeners) {
+            this.listeners = listeners;
+            return this;
+        }
+
+        public MiniMaxStreamingChatModelBuilder listeners(ChatModelListener... listeners) {
+            return listeners(asList(listeners));
+        }
+
+        public MiniMaxStreamingChatModel build() {
+            return new MiniMaxStreamingChatModel(this);
+        }
+    }
+}

--- a/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/MiniMaxUtils.java
+++ b/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/MiniMaxUtils.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.model.minimax;
+
+/**
+ * Utility constants and methods for the MiniMax integration.
+ */
+class MiniMaxUtils {
+
+    static final String DEFAULT_MINIMAX_URL = "https://api.minimax.io/v1";
+
+    /**
+     * Clamps temperature to the MiniMax-supported range [0.0, 1.0].
+     * MiniMax accepts temperature values between 0.0 and 1.0 inclusive.
+     *
+     * @param temperature the requested temperature, or null
+     * @return the clamped temperature, or null if input is null
+     */
+    static Double clampTemperature(Double temperature) {
+        if (temperature == null) {
+            return null;
+        }
+        return Math.max(0.0, Math.min(1.0, temperature));
+    }
+}

--- a/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/spi/MiniMaxChatModelBuilderFactory.java
+++ b/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/spi/MiniMaxChatModelBuilderFactory.java
@@ -1,0 +1,11 @@
+package dev.langchain4j.model.minimax.spi;
+
+import dev.langchain4j.model.minimax.MiniMaxChatModel;
+
+import java.util.function.Supplier;
+
+/**
+ * A factory for building {@link MiniMaxChatModel.MiniMaxChatModelBuilder} instances.
+ */
+public interface MiniMaxChatModelBuilderFactory extends Supplier<MiniMaxChatModel.MiniMaxChatModelBuilder> {
+}

--- a/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/spi/MiniMaxStreamingChatModelBuilderFactory.java
+++ b/langchain4j-minimax/src/main/java/dev/langchain4j/model/minimax/spi/MiniMaxStreamingChatModelBuilderFactory.java
@@ -1,0 +1,11 @@
+package dev.langchain4j.model.minimax.spi;
+
+import dev.langchain4j.model.minimax.MiniMaxStreamingChatModel;
+
+import java.util.function.Supplier;
+
+/**
+ * A factory for building {@link MiniMaxStreamingChatModel.MiniMaxStreamingChatModelBuilder} instances.
+ */
+public interface MiniMaxStreamingChatModelBuilderFactory extends Supplier<MiniMaxStreamingChatModel.MiniMaxStreamingChatModelBuilder> {
+}

--- a/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxChatModelIT.java
+++ b/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxChatModelIT.java
@@ -1,0 +1,78 @@
+package dev.langchain4j.model.minimax;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Integration tests for {@link MiniMaxChatModel}.
+ * These tests require a valid MINIMAX_API_KEY environment variable.
+ */
+@EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".+")
+class MiniMaxChatModelIT {
+
+    @Test
+    void should_generate_response() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey(System.getenv("MINIMAX_API_KEY"))
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_7)
+                .temperature(0.1)
+                .maxTokens(100)
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("What is 2+2? Answer with just the number."))
+                .build();
+
+        ChatResponse response = model.chat(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.aiMessage()).isNotNull();
+        assertThat(response.aiMessage().text()).contains("4");
+    }
+
+    @Test
+    void should_generate_response_with_highspeed_model() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey(System.getenv("MINIMAX_API_KEY"))
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_7_HIGHSPEED)
+                .temperature(0.1)
+                .maxTokens(100)
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("What is 3+3? Answer with just the number."))
+                .build();
+
+        ChatResponse response = model.chat(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.aiMessage()).isNotNull();
+        assertThat(response.aiMessage().text()).contains("6");
+    }
+
+    @Test
+    void should_respect_max_tokens() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey(System.getenv("MINIMAX_API_KEY"))
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_7_HIGHSPEED)
+                .temperature(0.1)
+                .maxTokens(10)
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Write a very long essay about artificial intelligence."))
+                .build();
+
+        ChatResponse response = model.chat(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.aiMessage()).isNotNull();
+        // With max 10 tokens, the response should be short
+        assertThat(response.aiMessage().text().length()).isLessThan(200);
+    }
+}

--- a/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxChatModelNameTest.java
+++ b/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxChatModelNameTest.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.model.minimax;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MiniMaxChatModelNameTest {
+
+    @Test
+    void should_return_correct_string_for_m2_7() {
+        assertThat(MiniMaxChatModelName.MINIMAX_M2_7.toString()).isEqualTo("MiniMax-M2.7");
+    }
+
+    @Test
+    void should_return_correct_string_for_m2_7_highspeed() {
+        assertThat(MiniMaxChatModelName.MINIMAX_M2_7_HIGHSPEED.toString()).isEqualTo("MiniMax-M2.7-highspeed");
+    }
+
+    @Test
+    void should_have_expected_number_of_values() {
+        assertThat(MiniMaxChatModelName.values()).hasSize(2);
+    }
+}

--- a/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxChatModelTest.java
+++ b/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxChatModelTest.java
@@ -1,0 +1,113 @@
+package dev.langchain4j.model.minimax;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.ModelProvider;
+import org.junit.jupiter.api.Test;
+
+class MiniMaxChatModelTest {
+
+    @Test
+    void should_create_with_defaults() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-api-key")
+                .build();
+
+        assertThat(model).isNotNull();
+        assertThat(model.provider()).isEqualTo(ModelProvider.OTHER);
+        assertThat(model.defaultRequestParameters()).isNotNull();
+        assertThat(model.defaultRequestParameters().modelName()).isEqualTo("MiniMax-M2.7");
+    }
+
+    @Test
+    void should_create_with_custom_model() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-api-key")
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_7_HIGHSPEED)
+                .build();
+
+        assertThat(model).isNotNull();
+        assertThat(model.defaultRequestParameters().modelName()).isEqualTo("MiniMax-M2.7-highspeed");
+    }
+
+    @Test
+    void should_create_with_string_model_name() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-api-key")
+                .modelName("MiniMax-M2.7")
+                .build();
+
+        assertThat(model).isNotNull();
+        assertThat(model.defaultRequestParameters().modelName()).isEqualTo("MiniMax-M2.7");
+    }
+
+    @Test
+    void should_create_with_custom_base_url() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-api-key")
+                .baseUrl("https://custom-url.example.com/v1")
+                .build();
+
+        assertThat(model).isNotNull();
+    }
+
+    @Test
+    void should_clamp_temperature() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-api-key")
+                .temperature(2.0)
+                .build();
+
+        assertThat(model).isNotNull();
+        assertThat(model.defaultRequestParameters().temperature()).isEqualTo(1.0);
+    }
+
+    @Test
+    void should_pass_valid_temperature() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-api-key")
+                .temperature(0.5)
+                .build();
+
+        assertThat(model).isNotNull();
+        assertThat(model.defaultRequestParameters().temperature()).isEqualTo(0.5);
+    }
+
+    @Test
+    void should_accept_zero_temperature() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-api-key")
+                .temperature(0.0)
+                .build();
+
+        assertThat(model).isNotNull();
+        assertThat(model.defaultRequestParameters().temperature()).isEqualTo(0.0);
+    }
+
+    @Test
+    void should_create_with_max_tokens() {
+        MiniMaxChatModel model = MiniMaxChatModel.builder()
+                .apiKey("test-api-key")
+                .maxTokens(4096)
+                .build();
+
+        assertThat(model).isNotNull();
+        assertThat(model.defaultRequestParameters().maxOutputTokens()).isEqualTo(4096);
+    }
+
+    @Test
+    void builder_should_support_fluent_api() {
+        MiniMaxChatModel.MiniMaxChatModelBuilder builder = MiniMaxChatModel.builder()
+                .apiKey("test-api-key")
+                .modelName("MiniMax-M2.7")
+                .temperature(0.7)
+                .topP(0.9)
+                .maxTokens(2048)
+                .maxRetries(3)
+                .logRequests(true)
+                .logResponses(true);
+
+        MiniMaxChatModel model = builder.build();
+        assertThat(model).isNotNull();
+    }
+}

--- a/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxStreamingChatModelIT.java
+++ b/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxStreamingChatModelIT.java
@@ -1,0 +1,100 @@
+package dev.langchain4j.model.minimax;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Integration tests for {@link MiniMaxStreamingChatModel}.
+ * These tests require a valid MINIMAX_API_KEY environment variable.
+ */
+@EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".+")
+class MiniMaxStreamingChatModelIT {
+
+    @Test
+    void should_stream_response() throws Exception {
+        MiniMaxStreamingChatModel model = MiniMaxStreamingChatModel.builder()
+                .apiKey(System.getenv("MINIMAX_API_KEY"))
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_7)
+                .temperature(0.1)
+                .maxTokens(100)
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("What is 2+2? Answer with just the number."))
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        StringBuilder contentBuilder = new StringBuilder();
+
+        model.chat(request, new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+                contentBuilder.append(partialResponse);
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+
+        ChatResponse response = future.get(30, TimeUnit.SECONDS);
+
+        assertThat(response).isNotNull();
+        assertThat(response.aiMessage()).isNotNull();
+        assertThat(response.aiMessage().text()).contains("4");
+        assertThat(contentBuilder.toString()).contains("4");
+    }
+
+    @Test
+    void should_stream_response_with_highspeed_model() throws Exception {
+        MiniMaxStreamingChatModel model = MiniMaxStreamingChatModel.builder()
+                .apiKey(System.getenv("MINIMAX_API_KEY"))
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_7_HIGHSPEED)
+                .temperature(0.1)
+                .maxTokens(100)
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("What is 3+3? Answer with just the number."))
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+
+        model.chat(request, new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+                // Streaming content received
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                future.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                future.completeExceptionally(error);
+            }
+        });
+
+        ChatResponse response = future.get(30, TimeUnit.SECONDS);
+
+        assertThat(response).isNotNull();
+        assertThat(response.aiMessage()).isNotNull();
+        assertThat(response.aiMessage().text()).contains("6");
+    }
+}

--- a/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxStreamingChatModelTest.java
+++ b/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxStreamingChatModelTest.java
@@ -1,0 +1,69 @@
+package dev.langchain4j.model.minimax;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.ModelProvider;
+import org.junit.jupiter.api.Test;
+
+class MiniMaxStreamingChatModelTest {
+
+    @Test
+    void should_create_with_defaults() {
+        MiniMaxStreamingChatModel model = MiniMaxStreamingChatModel.builder()
+                .apiKey("test-api-key")
+                .build();
+
+        assertThat(model).isNotNull();
+        assertThat(model.provider()).isEqualTo(ModelProvider.OTHER);
+        assertThat(model.defaultRequestParameters()).isNotNull();
+        assertThat(model.defaultRequestParameters().modelName()).isEqualTo("MiniMax-M2.7");
+    }
+
+    @Test
+    void should_create_with_custom_model() {
+        MiniMaxStreamingChatModel model = MiniMaxStreamingChatModel.builder()
+                .apiKey("test-api-key")
+                .modelName(MiniMaxChatModelName.MINIMAX_M2_7_HIGHSPEED)
+                .build();
+
+        assertThat(model).isNotNull();
+        assertThat(model.defaultRequestParameters().modelName()).isEqualTo("MiniMax-M2.7-highspeed");
+    }
+
+    @Test
+    void should_clamp_temperature() {
+        MiniMaxStreamingChatModel model = MiniMaxStreamingChatModel.builder()
+                .apiKey("test-api-key")
+                .temperature(2.0)
+                .build();
+
+        assertThat(model).isNotNull();
+        assertThat(model.defaultRequestParameters().temperature()).isEqualTo(1.0);
+    }
+
+    @Test
+    void should_accept_zero_temperature() {
+        MiniMaxStreamingChatModel model = MiniMaxStreamingChatModel.builder()
+                .apiKey("test-api-key")
+                .temperature(0.0)
+                .build();
+
+        assertThat(model).isNotNull();
+        assertThat(model.defaultRequestParameters().temperature()).isEqualTo(0.0);
+    }
+
+    @Test
+    void builder_should_support_fluent_api() {
+        MiniMaxStreamingChatModel.MiniMaxStreamingChatModelBuilder builder = MiniMaxStreamingChatModel.builder()
+                .apiKey("test-api-key")
+                .modelName("MiniMax-M2.7")
+                .temperature(0.7)
+                .topP(0.9)
+                .maxTokens(2048)
+                .logRequests(true)
+                .logResponses(true);
+
+        MiniMaxStreamingChatModel model = builder.build();
+        assertThat(model).isNotNull();
+    }
+}

--- a/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxUtilsTest.java
+++ b/langchain4j-minimax/src/test/java/dev/langchain4j/model/minimax/MiniMaxUtilsTest.java
@@ -1,0 +1,36 @@
+package dev.langchain4j.model.minimax;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class MiniMaxUtilsTest {
+
+    @Test
+    void should_return_null_for_null_temperature() {
+        assertThat(MiniMaxUtils.clampTemperature(null)).isNull();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "0.0, 0.0",
+        "0.5, 0.5",
+        "1.0, 1.0",
+        "0.7, 0.7",
+        "-0.1, 0.0",
+        "-1.0, 0.0",
+        "1.1, 1.0",
+        "2.0, 1.0",
+        "100.0, 1.0"
+    })
+    void should_clamp_temperature(double input, double expected) {
+        assertThat(MiniMaxUtils.clampTemperature(input)).isEqualTo(expected);
+    }
+
+    @Test
+    void should_have_correct_default_url() {
+        assertThat(MiniMaxUtils.DEFAULT_MINIMAX_URL).isEqualTo("https://api.minimax.io/v1");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>langchain4j-hugging-face</module>
         <module>langchain4j-jina</module>
         <module>langchain4j-local-ai</module>
+        <module>langchain4j-minimax</module>
         <module>langchain4j-mistral-ai</module>
         <module>langchain4j-nomic</module>
         <module>langchain4j-ollama</module>


### PR DESCRIPTION
## Summary

Add  module that integrates [MiniMax](https://www.minimax.io/) as a new chat model provider. MiniMax offers an OpenAI-compatible API, so this module delegates to the existing  client with MiniMax-specific defaults.

### What's included

- **MiniMaxChatModel** - Synchronous chat model delegating to OpenAiChatModel
- **MiniMaxStreamingChatModel** - Streaming chat model delegating to OpenAiStreamingChatModel
- **MiniMaxChatModelName** - Enum with supported models:  (default) and 
- **Temperature clamping** to MiniMax's supported range [0.0, 1.0]
- **SPI builder factories** for Spring Boot auto-configuration
- Module registered in root  and 

### Models

| Model | Description | Context Window |
|-------|-------------|----------------|
| MiniMax-M2.7 | Peak Performance. Ultimate Value. | 204,800 tokens |
| MiniMax-M2.7-highspeed | Same performance, faster and more agile | 204,800 tokens |

### API Details

- Base URL:  (OpenAI-compatible)
- Auth: 
- [API Documentation](https://platform.minimax.io/docs/api-reference/text-openai-api)

### Tests

- 28 unit tests covering model construction, defaults, temperature clamping, fluent API
- 5 integration tests covering synchronous and streaming chat with both models

## Test plan

- [x] Unit tests pass (28/28)
- [x] Integration tests pass with live MiniMax API (5/5)
- [x] Module compiles successfully as part of the reactor build
- [ ] CI pipeline passes
