### PR TITLE
Preserve missing Ollama message fields in chat requests

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -224,8 +224,13 @@ class InternalOllamaHelper {
                     .build();
         }
 
+        Message.Builder builder =
+                Message.builder().role(toOllamaRole(chatMessage.type())).content(toText(chatMessage));
+
         List<ToolCall> toolCalls = null;
         if (chatMessage instanceof AiMessage aiMessage) {
+            builder.thinking(aiMessage.thinking()).attributes(aiMessage.attributes());
+
             List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
             toolCalls = Optional.ofNullable(toolExecutionRequests)
                     .map(reqs -> reqs.stream()
@@ -243,12 +248,13 @@ class InternalOllamaHelper {
                             })
                             .collect(Collectors.toList()))
                     .orElse(null);
+        } else if (chatMessage instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+            builder.id(toolExecutionResultMessage.id())
+                    .toolName(toolExecutionResultMessage.toolName())
+                    .isError(toolExecutionResultMessage.isError())
+                    .attributes(toolExecutionResultMessage.attributes());
         }
-        return Message.builder()
-                .role(toOllamaRole(chatMessage.type()))
-                .content(toText(chatMessage))
-                .toolCalls(toolCalls)
-                .build();
+        return builder.toolCalls(toolCalls).build();
     }
 
     private static String toText(ChatMessage chatMessage) {

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/Message.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/Message.java
@@ -19,6 +19,10 @@ class Message {
     private Role role;
     private String content;
     private String thinking;
+    private String id;
+    private String toolName;
+    private Boolean isError;
+    private Map<String, Object> attributes;
     private List<String> images;
     private List<ToolCall> toolCalls;
     private Map<String, Object> additionalFields;
@@ -29,6 +33,10 @@ class Message {
         this.role = builder.role;
         this.content = builder.content;
         this.thinking = builder.thinking;
+        this.id = builder.id;
+        this.toolName = builder.toolName;
+        this.isError = builder.isError;
+        this.attributes = builder.attributes;
         this.images = builder.images;
         this.toolCalls = builder.toolCalls;
         this.additionalFields = builder.additionalFields;
@@ -88,11 +96,47 @@ class Message {
         this.thinking = thinking;
     }
 
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getToolName() {
+        return toolName;
+    }
+
+    public void setToolName(String toolName) {
+        this.toolName = toolName;
+    }
+
+    public Boolean getIsError() {
+        return isError;
+    }
+
+    public void setIsError(Boolean isError) {
+        this.isError = isError;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
     static class Builder {
 
         private Role role;
         private String content;
         private String thinking;
+        private String id;
+        private String toolName;
+        private Boolean isError;
+        private Map<String, Object> attributes;
         private List<String> images;
         private List<ToolCall> toolCalls;
         private Map<String, Object> additionalFields;
@@ -109,6 +153,26 @@ class Message {
 
         Builder thinking(String thinking) {
             this.thinking = thinking;
+            return this;
+        }
+
+        Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        Builder toolName(String toolName) {
+            this.toolName = toolName;
+            return this;
+        }
+
+        Builder isError(Boolean isError) {
+            this.isError = isError;
+            return this;
+        }
+
+        Builder attributes(Map<String, Object> attributes) {
+            this.attributes = attributes;
             return this;
         }
 

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
@@ -1,0 +1,55 @@
+package dev.langchain4j.model.ollama;
+
+import static dev.langchain4j.model.ollama.OllamaJsonUtils.toJsonWithoutIdent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InternalOllamaHelperTest {
+
+    @Test
+    void should_include_thinking_and_attributes_for_ai_messages() {
+        AiMessage aiMessage = AiMessage.builder()
+                .text("The answer is 4.")
+                .thinking("Calculate the square root.")
+                .attributes(Map.of("source", "reasoning"))
+                .build();
+
+        Message message =
+                InternalOllamaHelper.toOllamaMessages(List.of(aiMessage)).get(0);
+        String json = toJsonWithoutIdent(message);
+
+        assertThat(message.getRole()).isEqualTo(Role.ASSISTANT);
+        assertThat(message.getContent()).isEqualTo("The answer is 4.");
+        assertThat(json)
+                .contains("\"thinking\":\"Calculate the square root.\"")
+                .contains("\"attributes\":{\"source\":\"reasoning\"}");
+    }
+
+    @Test
+    void should_include_tool_execution_result_metadata() {
+        ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.builder()
+                .id("call-1")
+                .toolName("brewCoffee")
+                .text("Out of coffee beans.")
+                .isError(true)
+                .attributes(Map.of("code", "OUT_OF_BEANS"))
+                .build();
+
+        Message message = InternalOllamaHelper.toOllamaMessages(List.of(toolExecutionResultMessage))
+                .get(0);
+        String json = toJsonWithoutIdent(message);
+
+        assertThat(message.getRole()).isEqualTo(Role.TOOL);
+        assertThat(message.getContent()).isEqualTo("Out of coffee beans.");
+        assertThat(json)
+                .contains("\"id\":\"call-1\"")
+                .contains("\"tool_name\":\"brewCoffee\"")
+                .contains("\"is_error\":true")
+                .contains("\"attributes\":{\"code\":\"OUT_OF_BEANS\"}");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #4743
Closes #4742

## Change
- preserve `thinking` and `attributes` when serializing `AiMessage` instances into Ollama chat request messages
- preserve `id`, `toolName`, `isError`, and `attributes` when serializing `ToolExecutionResultMessage` instances into Ollama chat request messages
- add regression tests that assert the serialized Ollama request payload contains the missing fields for both affected message types

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

Attempted extra verification: `./mvnw.cmd -pl langchain4j-core,langchain4j test` currently fails on `upstream/main` during unrelated guardrail test compilation (`GuardrailResult` / `ParsedJson` symbols), before reaching this Ollama change.

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
