### PR TITLE
Re-query ToolProviders within inference loop to support dynamic tool lists

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -392,6 +392,22 @@ public class ToolService {
                         .build();
             }
 
+            // Re-query ToolProviders after tool executions to pick up dynamically
+            // added tools (e.g. MCP servers that update their tool list via
+            // notifications/tools/list_changed after a category-loader tool is called).
+            if (!toolProviders.isEmpty()) {
+                ToolServiceContext refreshed = refreshToolServiceContext(
+                        toolServiceContext, invocationContext, messages, chatMemory);
+                if (refreshed != toolServiceContext) {
+                    toolServiceContext = refreshed;
+                    // Update parameters so the next LLM request includes the refreshed tool specs
+                    parameters = parameters.overrideWith(
+                            ChatRequestParameters.builder()
+                                    .toolSpecifications(toolServiceContext.effectiveTools())
+                                    .build());
+                }
+            }
+
             if (chatMemory != null) {
                 messages = chatMemory.messages();
             }
@@ -420,6 +436,43 @@ public class ToolService {
                 .toolExecutions(toolExecutions)
                 .aggregateTokenUsage(aggregateTokenUsage)
                 .build();
+    }
+
+    /**
+     * Re-queries all ToolProviders and returns a new ToolServiceContext if any tools
+     * have been added or removed. This supports dynamic tool providers (e.g. MCP servers)
+     * that update their tool list during the inference loop.
+     *
+     * Returns the original context unchanged if no tools changed (cheap identity check).
+     */
+    private ToolServiceContext refreshToolServiceContext(
+            ToolServiceContext currentContext,
+            InvocationContext invocationContext,
+            List<ChatMessage> messages,
+            ChatMemory chatMemory) {
+
+        // Extract the last UserMessage from messages for the ToolProviderRequest
+        UserMessage userMessage = null;
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            if (messages.get(i) instanceof UserMessage um) {
+                userMessage = um;
+                break;
+            }
+        }
+        if (userMessage == null) {
+            // Cannot build ToolProviderRequest without a UserMessage; skip refresh
+            return currentContext;
+        }
+
+        // Build a fresh context using the existing createContext() logic
+        ToolServiceContext refreshed = createContext(invocationContext, userMessage, chatMemory);
+
+        // If nothing changed, return the original to signal no update needed
+        if (refreshed.equals(currentContext)) {
+            return currentContext;
+        }
+
+        return refreshed;
     }
 
     private void fireToolExecutedEvent(


### PR DESCRIPTION
## Summary

`ToolService.executeInferenceAndToolsLoop()` currently freezes the tool list at the start of the loop (via `createContext()`) and never re-queries `ToolProvider`s, even when the underlying tool inventory changes mid-conversation. This PR adds a refresh step after each batch of tool executions so that dynamically added or removed tools are picked up before the next LLM call.

## Problem

MCP servers that implement a **dynamic category-loader pattern** expose a small set of meta-tools initially (e.g. `use_instances_tools`, `use_clouds_tools`) and lazily load the actual tools for a category when the corresponding meta-tool is called via `tools/call`. The server signals that its tool list has changed by sending a `notifications/tools/list_changed` SSE event, and `DefaultMcpClient` correctly sets its `toolListOutOfDate` flag in response.

However, `ToolService` builds a `ToolServiceContext` once before the loop starts and wraps its maps in `Collections.unmodifiableMap/List`. The loop never re-calls `provideTools()`, so:

1. The LLM calls a category-loader tool (e.g. `use_instances_tools`)
2. `McpToolExecutor` sends `tools/call` to the MCP server
3. The server returns tool definitions as text content and sends `notifications/tools/list_changed`
4. `DefaultMcpClient` sets `toolListOutOfDate = true`
5. **But the loop never re-fetches tools** — the `ToolServiceContext` is stale
6. The LLM sees the tool definitions as text and treats them as the "answer" instead of being able to call them

This makes it impossible to use MCP servers that dynamically register tools during the conversation, a pattern that keeps LLM context small by only loading relevant tool categories on demand.

## Solution

After tool executions complete and before the next LLM request is built, `executeInferenceAndToolsLoop()` now calls a new private method `refreshToolServiceContext()` which:

1. Extracts the last `UserMessage` from the messages list (needed for `ToolProviderRequest`)
2. Re-calls `createContext()` which triggers `ToolProvider.provideTools()` on all configured providers
3. Compares the result to the current context via `equals()` — if unchanged, returns the original instance (identity preserved)
4. If changed, the caller updates both `toolServiceContext` and `parameters` (via `overrideWith()`) so the next `ChatRequest` includes the new tool specifications

### Performance characteristics

- **No-op when nothing changed:** `DefaultMcpClient.listTools()` checks `isToolListRefreshNeeded()` internally — if no `tools/list_changed` notification was received, it returns the cached tool list without an RPC call. The `ToolServiceContext.equals()` check then detects no change and the original context is kept.
- **No API changes:** This is purely an internal change to the loop logic. No method signatures, constructors, or public APIs were modified.
- **Reuses existing `createContext()` logic:** No duplication of the tool provider querying/merging code.

## Testing

This was tested against a production MCP server (Morpheus) that implements the category-loader pattern with ~50 categories and ~300+ tools across ~20 tool providers. Before this change, the LLM would receive tool definitions as text and stop. After this change, dynamically loaded tools are correctly available for the LLM to call in subsequent loop iterations.

A unit/integration test that exercises this path would need a `ToolProvider` that returns different tools on successive `provideTools()` calls. Happy to add one if desired.

## Related

- `DefaultMcpClient` already handles `notifications/tools/list_changed` correctly (sets `toolListOutOfDate` flag)
- `McpToolProvider.provideTools()` delegates to `DefaultMcpClient.listTools()` which respects the flag
- `ToolServiceContext` has proper `equals()` implementation for change detection