### PR TITLE
Introduce a CompactingChatMemory

### DIFF
--- a/docs/docs/tutorials/chat-memory.md
+++ b/docs/docs/tutorials/chat-memory.md
@@ -48,6 +48,94 @@ Currently, LangChain4j offers 2 out-of-the-box implementations:
   Messages are indivisible. If a message doesn't fit, it is evicted completely.
   `TokenWindowChatMemory` requires a `TokenCountEstimator` to count the tokens in each `ChatMessage`.
 
+## Compacting memory
+
+As an alternative to eviction, `CompactingChatMemory` uses a `ChatModel` to **summarize** older
+messages instead of discarding them. This preserves the context of the entire conversation in a
+compact form, reducing both token usage and cost while keeping important information available
+to the LLM.
+
+Every time a `UserMessage` is added, a background compaction task is triggered.
+The compaction sends older messages to a (typically smaller/cheaper) `ChatModel`, which produces
+a summarized `UserMessage` that replaces them. A `SystemMessage`, if present, is always preserved as-is and is never included in the summarization.
+
+Basic usage:
+
+```java
+ChatMemory memory = CompactingChatMemory.builder()
+        .chatModel(compactingModel) // model used for summarization
+        .build();
+```
+
+`CompactingChatMemory` provides several knobs to fine-tune its behavior.
+
+### Retaining recent messages
+
+By default, all conversation messages are summarized. Use `retainLastMessages` to keep the
+last N messages intact and only summarize older ones. This gives the LLM full detail about the
+most recent turns while still compacting the rest:
+
+```java
+CompactingChatMemory.builder()
+        .chatModel(compactingModel)
+        .retainLastMessages(4)
+        .build();
+```
+
+### Token-based compaction threshold
+
+Instead of compacting on every user message, you can compact only when the total token count
+of conversation messages exceeds a threshold. This requires a `TokenCountEstimator`. When
+compaction triggers, as many recent messages as fit within the token limit are retained, and
+the rest are summarized:
+
+```java
+CompactingChatMemory.builder()
+        .chatModel(compactingModel)
+        .maxTokens(4000)
+        .tokenCountEstimator(tokenCountEstimator)
+        .build();
+```
+
+### Compaction interval
+
+By default, compaction runs every time a `UserMessage` is added. Use `compactionInterval` to
+run compaction only every N-th user message, reducing the number of summarization calls:
+
+```java
+CompactingChatMemory.builder()
+        .chatModel(compactingModel)
+        .compactionInterval(3) // compact every 3rd user message
+        .build();
+```
+
+### Tool message handling
+
+By default, tool call/result message pairs are included in the summarization like any other
+messages. Set `compactToolMessages(false)` to preserve `AiMessage`s containing
+`ToolExecutionRequest`s and their corresponding `ToolExecutionResultMessage`s as-is:
+
+```java
+CompactingChatMemory.builder()
+        .chatModel(compactingModel)
+        .compactToolMessages(false)
+        .build();
+```
+
+### Custom compaction prompt
+
+The prompt sent to the summarization model can be customized:
+
+```java
+CompactingChatMemory.builder()
+        .chatModel(compactingModel)
+        .compactionPrompt("Create a bullet-point summary of the conversation from the user's perspective.")
+        .build();
+```
+
+`CompactingChatMemory` also supports a custom `ChatMemoryStore` for persistence, and a custom
+`ExecutorService` for the background compaction thread.
+
 ## Persistence
 
 By default, `ChatMemory` implementations store `ChatMessage`s in memory.

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/CompactingChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/CompactingChatMemory.java
@@ -1,0 +1,206 @@
+package dev.langchain4j.memory.chat;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.internal.DefaultExecutorProvider;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.service.memory.ChatMemoryService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * A {@link ChatMemory} implementation that automatically compacts messages by summarizing them
+ * using a {@link ChatModel}. Every time a {@link UserMessage} is added, a background compaction
+ * task is triggered. The compaction uses the provided {@link ChatModel} to produce a summarized
+ * {@link UserMessage} that replaces all current messages.
+ * <p>
+ * During compaction, {@link #messages()} returns the current (pre-compaction) state of messages.
+ * Once compaction completes, the memory is atomically replaced with a single summarized
+ * {@link UserMessage}.
+ * <p>
+ * A {@link SystemMessage}, if present, is preserved across compactions and is not included
+ * in the summarization. It is always kept as the first message.
+ * <p>
+ * The compaction runs on a separate thread, taken from either a user-provided {@link ExecutorService}
+ * or the default one from {@link DefaultExecutorProvider}.
+ */
+public class CompactingChatMemory implements ChatMemory {
+
+    private static final String COMPACTION_PROMPT =
+            """
+            Summarize all former chat messages into a single concise message that preserves
+            all important information, context, decisions, and any pending questions or tasks.
+            The summary should be written from the user's perspective, as if the user is
+            recapping the conversation so far. Do not include any preamble, just provide the summary.
+            """;
+
+    private final Object id;
+    private final ChatModel chatModel;
+    private final ExecutorService executorService;
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final List<ChatMessage> messages = new ArrayList<>();
+
+    private CompactingChatMemory(Builder builder) {
+        this.id = ensureNotNull(builder.id, "id");
+        this.chatModel = ensureNotNull(builder.chatModel, "chatModel");
+        this.executorService = getOrDefault(
+                builder.executorService,
+                DefaultExecutorProvider.getDefaultExecutorService());
+    }
+
+    @Override
+    public Object id() {
+        return id;
+    }
+
+    @Override
+    public void add(ChatMessage message) {
+        lock.writeLock().lock();
+        try {
+            if (message instanceof SystemMessage) {
+                // Replace existing system message if present
+                messages.removeIf(SystemMessage.class::isInstance);
+                messages.add(0, message);
+                return;
+            }
+            messages.add(message);
+        } finally {
+            lock.writeLock().unlock();
+        }
+
+        if (message instanceof UserMessage) {
+            triggerCompaction();
+        }
+    }
+
+    @Override
+    public List<ChatMessage> messages() {
+        lock.readLock().lock();
+        try {
+            return Collections.unmodifiableList(messages);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void clear() {
+        lock.writeLock().lock();
+        try {
+            messages.clear();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void triggerCompaction() {
+        // Snapshot the messages to summarize
+        List<ChatMessage> snapshot;
+        SystemMessage systemMessage;
+        lock.readLock().lock();
+        try {
+            if (messages.size() <= 1) {
+                return; // Nothing to compact if there's only one message (or none)
+            }
+            snapshot = new ArrayList<>(messages);
+            systemMessage = messages.stream()
+                    .filter(SystemMessage.class::isInstance)
+                    .map(SystemMessage.class::cast)
+                    .findFirst()
+                    .orElse(null);
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        // Remove system message from the snapshot to summarize only conversation messages
+        List<ChatMessage> conversationMessages = new ArrayList<>();
+        for (ChatMessage msg : snapshot) {
+            if (!(msg instanceof SystemMessage)) {
+                conversationMessages.add(msg);
+            }
+        }
+
+        if (conversationMessages.size() <= 1) {
+            return; // Only one conversation message, nothing to compact
+        }
+
+        executorService.submit(() -> {
+            try {
+                compact(conversationMessages, systemMessage);
+            } catch (Exception e) {
+                // Compaction failure is non-fatal; messages remain as they are
+            }
+        });
+    }
+
+    private void compact(List<ChatMessage> conversationMessages, SystemMessage systemMessage) {
+        // Build the summarization request: include all conversation messages + a summarization instruction
+        List<ChatMessage> request = new ArrayList<>(conversationMessages);
+        request.add(UserMessage.from(COMPACTION_PROMPT));
+
+        String summary = chatModel.chat(request).aiMessage().text();
+
+        lock.writeLock().lock();
+        try {
+            messages.clear();
+            if (systemMessage != null) {
+                messages.add(systemMessage);
+            }
+            messages.add(UserMessage.from(summary));
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Object id = ChatMemoryService.DEFAULT;
+        private ChatModel chatModel;
+        private ExecutorService executorService;
+
+        /**
+         * @param id The ID of the {@link ChatMemory}.
+         *           If not provided, a "default" will be used.
+         * @return builder
+         */
+        public Builder id(Object id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * @param chatModel The {@link ChatModel} used to summarize messages during compaction.
+         * @return builder
+         */
+        public Builder chatModel(ChatModel chatModel) {
+            this.chatModel = chatModel;
+            return this;
+        }
+
+        /**
+         * @param executorService The {@link ExecutorService} used to run compaction tasks.
+         *                        If not provided, the default from {@link DefaultExecutorProvider} is used.
+         * @return builder
+         */
+        public Builder executorService(ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
+        }
+
+        public CompactingChatMemory build() {
+            return new CompactingChatMemory(this);
+        }
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/CompactingChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/CompactingChatMemory.java
@@ -154,7 +154,7 @@ public class CompactingChatMemory implements ChatMemory {
     }
 
     private void triggerCompaction() {
-        // Snapshot the messages to summarize
+        // Take a snapshot under the read lock; all other computation happens in the background
         List<ChatMessage> snapshot;
         lock.readLock().lock();
         try {
@@ -167,6 +167,16 @@ public class CompactingChatMemory implements ChatMemory {
             return; // Nothing to compact if there's only one message (or none)
         }
 
+        executorService.submit(() -> {
+            try {
+                prepareAndCompact(snapshot);
+            } catch (Exception e) {
+                // Compaction failure is non-fatal; messages remain as they are
+            }
+        });
+    }
+
+    private void prepareAndCompact(List<ChatMessage> snapshot) {
         SystemMessage systemMessage = snapshot.stream()
                 .filter(SystemMessage.class::isInstance)
                 .map(SystemMessage.class::cast)
@@ -257,16 +267,7 @@ public class CompactingChatMemory implements ChatMemory {
             return; // Not enough messages left to summarize
         }
 
-        List<ChatMessage> retainedMessages = toRetain;
-        List<ChatMessage> messagesToSummarize = toSummarize;
-
-        executorService.submit(() -> {
-            try {
-                compact(messagesToSummarize, retainedMessages, systemMessage);
-            } catch (Exception e) {
-                // Compaction failure is non-fatal; messages remain as they are
-            }
-        });
+        compact(toSummarize, toRetain, systemMessage);
     }
 
     private void compact(List<ChatMessage> messagesToSummarize, List<ChatMessage> retainedMessages,

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/CompactingChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/CompactingChatMemory.java
@@ -1,33 +1,51 @@
 package dev.langchain4j.memory.chat;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * A {@link ChatMemory} implementation that automatically compacts messages by summarizing them
  * using a {@link ChatModel}. Every time a {@link UserMessage} is added, a background compaction
- * task is triggered. The compaction uses the provided {@link ChatModel} to produce a summarized
- * {@link UserMessage} that replaces all current messages.
+ * task is triggered (unless a {@link Builder#compactionInterval(int)} is configured).
+ * The compaction uses the provided {@link ChatModel} to produce a summarized
+ * {@link UserMessage} that replaces older messages.
  * <p>
  * During compaction, {@link #messages()} returns the current (pre-compaction) state of messages.
- * Once compaction completes, the memory is atomically replaced with a single summarized
- * {@link UserMessage}.
+ * Once compaction completes, the memory is atomically updated.
  * <p>
  * A {@link SystemMessage}, if present, is preserved across compactions and is not included
  * in the summarization. It is always kept as the first message.
+ * <p>
+ * Configuration options:
+ * <ul>
+ *   <li>{@link Builder#retainLastMessages(int)} — keep the last N conversation messages intact,
+ *       summarizing only older messages.</li>
+ *   <li>{@link Builder#maxTokens(int)} + {@link Builder#tokenCountEstimator(TokenCountEstimator)} —
+ *       trigger compaction only when the token count exceeds the threshold.</li>
+ *   <li>{@link Builder#compactToolMessages(boolean)} — when {@code false}, preserve tool call/result
+ *       message pairs as-is instead of summarizing them.</li>
+ *   <li>{@link Builder#compactionInterval(int)} — trigger compaction every N user messages
+ *       instead of on every user message.</li>
+ *   <li>{@link Builder#compactionPrompt(String)} — customize the summarization prompt.</li>
+ * </ul>
  * <p>
  * The state of chat memory is stored in {@link ChatMemoryStore} ({@link SingleSlotChatMemoryStore} is used by default).
  * <p>
@@ -47,18 +65,39 @@ public class CompactingChatMemory implements ChatMemory {
     private final Object id;
     private final ChatModel chatModel;
     private final String compactionPrompt;
+    private final int retainLastMessages;
+    private final int maxTokens;
+    private final TokenCountEstimator tokenCountEstimator;
+    private final boolean compactToolMessages;
+    private final int compactionInterval;
     private final ChatMemoryStore store;
     private final ExecutorService executorService;
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final AtomicInteger userMessageCounter = new AtomicInteger(0);
 
     private CompactingChatMemory(Builder builder) {
         this.id = ensureNotNull(builder.id, "id");
         this.chatModel = ensureNotNull(builder.chatModel, "chatModel");
         this.compactionPrompt = getOrDefault(builder.compactionPrompt, COMPACTION_PROMPT);
+        this.retainLastMessages = getOrDefault(builder.retainLastMessages, 0);
+        this.compactToolMessages = getOrDefault(builder.compactToolMessages, true);
+        this.compactionInterval = getOrDefault(builder.compactionInterval, 1);
+        this.maxTokens = getOrDefault(builder.maxTokens, 0);
+        this.tokenCountEstimator = builder.tokenCountEstimator;
         this.store = ensureNotNull(builder.store(), "store");
         this.executorService = getOrDefault(
                 builder.executorService,
                 DefaultExecutorProvider.getDefaultExecutorService());
+
+        if (this.retainLastMessages < 0) {
+            throw new IllegalArgumentException("retainLastMessages must be >= 0");
+        }
+        if (this.maxTokens > 0 && this.tokenCountEstimator == null) {
+            throw new IllegalArgumentException("tokenCountEstimator must be provided when maxTokens is set");
+        }
+        if (this.compactionInterval < 1) {
+            throw new IllegalArgumentException("compactionInterval must be >= 1");
+        }
     }
 
     @Override
@@ -86,7 +125,11 @@ public class CompactingChatMemory implements ChatMemory {
         }
 
         if (message instanceof UserMessage) {
-            triggerCompaction();
+            int count = userMessageCounter.incrementAndGet();
+            if (count >= compactionInterval) {
+                userMessageCounter.set(0);
+                triggerCompaction();
+            }
         }
     }
 
@@ -130,7 +173,7 @@ public class CompactingChatMemory implements ChatMemory {
                 .findFirst()
                 .orElse(null);
 
-        // Remove system message from the snapshot to summarize only conversation messages
+        // Remove system message from the snapshot to work only with conversation messages
         List<ChatMessage> conversationMessages = new ArrayList<>();
         for (ChatMessage msg : snapshot) {
             if (!(msg instanceof SystemMessage)) {
@@ -142,18 +185,94 @@ public class CompactingChatMemory implements ChatMemory {
             return; // Only one conversation message, nothing to compact
         }
 
+        // If maxTokens is configured, check whether compaction is needed
+        if (maxTokens > 0) {
+            int currentTokens = tokenCountEstimator.estimateTokenCountInMessages(conversationMessages);
+            if (currentTokens <= maxTokens) {
+                return; // Under the token limit, no compaction needed
+            }
+        }
+
+        // Split into messages to summarize vs. messages to retain
+        List<ChatMessage> toSummarize;
+        List<ChatMessage> toRetain;
+
+        if (maxTokens > 0) {
+            // Token-based split: keep as many recent messages as fit within maxTokens
+            toRetain = new ArrayList<>();
+            int retainedTokens = 0;
+            for (int i = conversationMessages.size() - 1; i >= 0; i--) {
+                ChatMessage msg = conversationMessages.get(i);
+                int msgTokens = tokenCountEstimator.estimateTokenCountInMessage(msg);
+                if (retainedTokens + msgTokens <= maxTokens) {
+                    toRetain.add(0, msg);
+                    retainedTokens += msgTokens;
+                } else {
+                    break;
+                }
+            }
+            int splitIndex = conversationMessages.size() - toRetain.size();
+            toSummarize = new ArrayList<>(conversationMessages.subList(0, splitIndex));
+        } else if (retainLastMessages > 0) {
+            // Message-count-based split
+            int splitIndex = Math.max(0, conversationMessages.size() - retainLastMessages);
+            toSummarize = new ArrayList<>(conversationMessages.subList(0, splitIndex));
+            toRetain = new ArrayList<>(conversationMessages.subList(splitIndex, conversationMessages.size()));
+        } else {
+            // Summarize everything
+            toSummarize = conversationMessages;
+            toRetain = new ArrayList<>();
+        }
+
+        // If compactToolMessages is false, move tool call pairs from toSummarize to toRetain
+        if (!compactToolMessages && !toSummarize.isEmpty()) {
+            List<ChatMessage> filteredSummarize = new ArrayList<>();
+            List<ChatMessage> toolPairsToRetain = new ArrayList<>();
+            for (int i = 0; i < toSummarize.size(); i++) {
+                ChatMessage msg = toSummarize.get(i);
+                if (msg instanceof AiMessage aiMsg && aiMsg.hasToolExecutionRequests()) {
+                    // Keep this AiMessage and all following ToolExecutionResultMessages
+                    toolPairsToRetain.add(msg);
+                    int j = i + 1;
+                    while (j < toSummarize.size()
+                            && toSummarize.get(j) instanceof ToolExecutionResultMessage) {
+                        toolPairsToRetain.add(toSummarize.get(j));
+                        j++;
+                    }
+                    i = j - 1; // skip over consumed tool results
+                } else if (msg instanceof ToolExecutionResultMessage) {
+                    // Orphan tool result in the summarize zone - retain it to be safe
+                    toolPairsToRetain.add(msg);
+                } else {
+                    filteredSummarize.add(msg);
+                }
+            }
+            toSummarize = filteredSummarize;
+            // Prepend tool pairs before the retained tail messages
+            toolPairsToRetain.addAll(toRetain);
+            toRetain = toolPairsToRetain;
+        }
+
+        if (toSummarize.size() <= 1) {
+            return; // Not enough messages left to summarize
+        }
+
+        List<ChatMessage> retainedMessages = toRetain;
+        List<ChatMessage> messagesToSummarize = toSummarize;
+
         executorService.submit(() -> {
             try {
-                compact(conversationMessages, systemMessage);
+                compact(messagesToSummarize, retainedMessages, systemMessage);
             } catch (Exception e) {
                 // Compaction failure is non-fatal; messages remain as they are
             }
         });
     }
 
-    private void compact(List<ChatMessage> conversationMessages, SystemMessage systemMessage) {
-        // Build the summarization request: include all conversation messages + a summarization instruction
-        List<ChatMessage> request = new ArrayList<>(conversationMessages);
+    private void compact(List<ChatMessage> messagesToSummarize, List<ChatMessage> retainedMessages,
+            SystemMessage systemMessage) {
+        // Build the summarization request: include messages to summarize + summarization instruction
+        List<ChatMessage> request = new ArrayList<>(messagesToSummarize);
         request.add(UserMessage.from(compactionPrompt));
 
         String summary = chatModel.chat(request).aiMessage().text();
@@ -163,6 +282,7 @@ public class CompactingChatMemory implements ChatMemory {
             compacted.add(systemMessage);
         }
         compacted.add(UserMessage.from(summary));
+        compacted.addAll(retainedMessages);
 
         lock.writeLock().lock();
         try {
@@ -181,6 +301,11 @@ public class CompactingChatMemory implements ChatMemory {
         private Object id = ChatMemoryService.DEFAULT;
         private ChatModel chatModel;
         private String compactionPrompt;
+        private Integer retainLastMessages;
+        private Integer maxTokens;
+        private TokenCountEstimator tokenCountEstimator;
+        private Boolean compactToolMessages;
+        private Integer compactionInterval;
         private ChatMemoryStore store;
         private ExecutorService executorService;
 
@@ -210,6 +335,62 @@ public class CompactingChatMemory implements ChatMemory {
          */
         public Builder compactionPrompt(String compactionPrompt) {
             this.compactionPrompt = compactionPrompt;
+            return this;
+        }
+
+        /**
+         * @param retainLastMessages The number of most recent conversation messages to keep intact.
+         *                           Older messages will be summarized. If not provided or 0,
+         *                           all conversation messages are summarized.
+         * @return builder
+         */
+        public Builder retainLastMessages(int retainLastMessages) {
+            this.retainLastMessages = retainLastMessages;
+            return this;
+        }
+
+        /**
+         * @param maxTokens The maximum number of tokens allowed before compaction is triggered.
+         *                  Requires {@link #tokenCountEstimator(TokenCountEstimator)} to be set.
+         *                  When compacting, as many recent messages as fit within this limit are retained.
+         * @return builder
+         */
+        public Builder maxTokens(int maxTokens) {
+            this.maxTokens = maxTokens;
+            return this;
+        }
+
+        /**
+         * @param tokenCountEstimator The estimator used to count tokens in messages.
+         *                            Required when {@link #maxTokens(int)} is set.
+         * @return builder
+         */
+        public Builder tokenCountEstimator(TokenCountEstimator tokenCountEstimator) {
+            this.tokenCountEstimator = tokenCountEstimator;
+            return this;
+        }
+
+        /**
+         * @param compactToolMessages Whether tool call/result message pairs should be included
+         *                            in the summarization. If {@code false}, {@link AiMessage}s containing
+         *                            tool execution requests and their corresponding
+         *                            {@link ToolExecutionResultMessage}s are preserved as-is.
+         *                            Defaults to {@code true}.
+         * @return builder
+         */
+        public Builder compactToolMessages(boolean compactToolMessages) {
+            this.compactToolMessages = compactToolMessages;
+            return this;
+        }
+
+        /**
+         * @param compactionInterval The number of user messages between compaction triggers.
+         *                           For example, a value of 3 means compaction runs every 3rd user message.
+         *                           Defaults to 1 (compact on every user message).
+         * @return builder
+         */
+        public Builder compactionInterval(int compactionInterval) {
+            this.compactionInterval = compactionInterval;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/CompactingChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/CompactingChatMemory.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.memory.chat;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZero;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import dev.langchain4j.data.message.AiMessage;

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/CompactingChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/CompactingChatMemory.java
@@ -10,8 +10,8 @@ import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.memory.ChatMemoryService;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -29,6 +29,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * A {@link SystemMessage}, if present, is preserved across compactions and is not included
  * in the summarization. It is always kept as the first message.
  * <p>
+ * The state of chat memory is stored in {@link ChatMemoryStore} ({@link SingleSlotChatMemoryStore} is used by default).
+ * <p>
  * The compaction runs on a separate thread, taken from either a user-provided {@link ExecutorService}
  * or the default one from {@link DefaultExecutorProvider}.
  */
@@ -44,13 +46,16 @@ public class CompactingChatMemory implements ChatMemory {
 
     private final Object id;
     private final ChatModel chatModel;
+    private final String compactionPrompt;
+    private final ChatMemoryStore store;
     private final ExecutorService executorService;
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-    private final List<ChatMessage> messages = new ArrayList<>();
 
     private CompactingChatMemory(Builder builder) {
         this.id = ensureNotNull(builder.id, "id");
         this.chatModel = ensureNotNull(builder.chatModel, "chatModel");
+        this.compactionPrompt = getOrDefault(builder.compactionPrompt, COMPACTION_PROMPT);
+        this.store = ensureNotNull(builder.store(), "store");
         this.executorService = getOrDefault(
                 builder.executorService,
                 DefaultExecutorProvider.getDefaultExecutorService());
@@ -65,13 +70,17 @@ public class CompactingChatMemory implements ChatMemory {
     public void add(ChatMessage message) {
         lock.writeLock().lock();
         try {
+            List<ChatMessage> messages = new ArrayList<>(store.getMessages(id));
+
             if (message instanceof SystemMessage) {
                 // Replace existing system message if present
                 messages.removeIf(SystemMessage.class::isInstance);
                 messages.add(0, message);
+                store.updateMessages(id, messages);
                 return;
             }
             messages.add(message);
+            store.updateMessages(id, messages);
         } finally {
             lock.writeLock().unlock();
         }
@@ -85,7 +94,7 @@ public class CompactingChatMemory implements ChatMemory {
     public List<ChatMessage> messages() {
         lock.readLock().lock();
         try {
-            return Collections.unmodifiableList(messages);
+            return store.getMessages(id);
         } finally {
             lock.readLock().unlock();
         }
@@ -95,7 +104,7 @@ public class CompactingChatMemory implements ChatMemory {
     public void clear() {
         lock.writeLock().lock();
         try {
-            messages.clear();
+            store.deleteMessages(id);
         } finally {
             lock.writeLock().unlock();
         }
@@ -104,21 +113,22 @@ public class CompactingChatMemory implements ChatMemory {
     private void triggerCompaction() {
         // Snapshot the messages to summarize
         List<ChatMessage> snapshot;
-        SystemMessage systemMessage;
         lock.readLock().lock();
         try {
-            if (messages.size() <= 1) {
-                return; // Nothing to compact if there's only one message (or none)
-            }
-            snapshot = new ArrayList<>(messages);
-            systemMessage = messages.stream()
-                    .filter(SystemMessage.class::isInstance)
-                    .map(SystemMessage.class::cast)
-                    .findFirst()
-                    .orElse(null);
+            snapshot = new ArrayList<>(store.getMessages(id));
         } finally {
             lock.readLock().unlock();
         }
+
+        if (snapshot.size() <= 1) {
+            return; // Nothing to compact if there's only one message (or none)
+        }
+
+        SystemMessage systemMessage = snapshot.stream()
+                .filter(SystemMessage.class::isInstance)
+                .map(SystemMessage.class::cast)
+                .findFirst()
+                .orElse(null);
 
         // Remove system message from the snapshot to summarize only conversation messages
         List<ChatMessage> conversationMessages = new ArrayList<>();
@@ -144,17 +154,19 @@ public class CompactingChatMemory implements ChatMemory {
     private void compact(List<ChatMessage> conversationMessages, SystemMessage systemMessage) {
         // Build the summarization request: include all conversation messages + a summarization instruction
         List<ChatMessage> request = new ArrayList<>(conversationMessages);
-        request.add(UserMessage.from(COMPACTION_PROMPT));
+        request.add(UserMessage.from(compactionPrompt));
 
         String summary = chatModel.chat(request).aiMessage().text();
 
+        List<ChatMessage> compacted = new ArrayList<>();
+        if (systemMessage != null) {
+            compacted.add(systemMessage);
+        }
+        compacted.add(UserMessage.from(summary));
+
         lock.writeLock().lock();
         try {
-            messages.clear();
-            if (systemMessage != null) {
-                messages.add(systemMessage);
-            }
-            messages.add(UserMessage.from(summary));
+            store.updateMessages(id, compacted);
         } finally {
             lock.writeLock().unlock();
         }
@@ -168,6 +180,8 @@ public class CompactingChatMemory implements ChatMemory {
 
         private Object id = ChatMemoryService.DEFAULT;
         private ChatModel chatModel;
+        private String compactionPrompt;
+        private ChatMemoryStore store;
         private ExecutorService executorService;
 
         /**
@@ -187,6 +201,30 @@ public class CompactingChatMemory implements ChatMemory {
         public Builder chatModel(ChatModel chatModel) {
             this.chatModel = chatModel;
             return this;
+        }
+
+        /**
+         * @param compactionPrompt The prompt used to instruct the {@link ChatModel} to summarize messages.
+         *                         If not provided, a default summarization prompt is used.
+         * @return builder
+         */
+        public Builder compactionPrompt(String compactionPrompt) {
+            this.compactionPrompt = compactionPrompt;
+            return this;
+        }
+
+        /**
+         * @param store The chat memory store responsible for storing the chat memory state.
+         *              If not provided, a {@link SingleSlotChatMemoryStore} will be used.
+         * @return builder
+         */
+        public Builder chatMemoryStore(ChatMemoryStore store) {
+            this.store = store;
+            return this;
+        }
+
+        private ChatMemoryStore store() {
+            return store != null ? store : new SingleSlotChatMemoryStore(id);
         }
 
         /**

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryIT.java
@@ -1,0 +1,256 @@
+package dev.langchain4j.memory.chat;
+
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_5_MINI;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.observability.api.event.AiServiceResponseReceivedEvent;
+import dev.langchain4j.observability.api.listener.AiServiceResponseReceivedListener;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.SystemMessage;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Integration tests for {@link CompactingChatMemory} using real OpenAI models
+ * through {@link AiServices}. Demonstrates how compacting memory reduces token
+ * usage compared to {@link MessageWindowChatMemory}.
+ */
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class CompactingChatMemoryIT {
+
+    private static ChatModel chatModel;
+    private static ChatModel compactingChatModel;
+
+    interface Assistant {
+        String chat(String userMessage);
+    }
+
+    interface HistoryTeacher {
+        @SystemMessage("You are a history teacher. Give detailed but concise answers.")
+        String chat(String userMessage);
+    }
+
+    @BeforeAll
+    static void setUp() {
+        chatModel = OpenAiChatModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName(GPT_5_MINI)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        compactingChatModel = OpenAiChatModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName(GPT_4_O_MINI)
+                .temperature(0.0)
+                .build();
+    }
+
+    @Test
+    void should_maintain_conversation_context_through_compaction() throws InterruptedException {
+        // given
+        CompactingChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(compactingChatModel)
+                .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .chatMemory(memory)
+                .build();
+
+        // when - have a real multi-turn conversation
+        String response1 = assistant.chat("Hello! My name is Mario and I live in Milan. I'm Italian but I prefer to chat in English.");
+        System.out.println("Turn 1 - AI: " + response1);
+        System.out.println("  Memory messages: " + memory.messages().size());
+        waitForCompaction(memory);
+
+        String response2 = assistant.chat("I work as a software engineer and I love Java.");
+        System.out.println("Turn 2 - AI: " + response2);
+        System.out.println("  Memory messages: " + memory.messages().size());
+        waitForCompaction(memory);
+
+        String response3 = assistant.chat("My favorite hobby is cooking Italian food.");
+        System.out.println("Turn 3 - AI: " + response3);
+        System.out.println("  Memory messages: " + memory.messages().size());
+        waitForCompaction(memory);
+
+        // then - the model should still remember key facts through the compacted summary
+        String response4 = assistant.chat("Can you remind me what you know about me so far?");
+        System.out.println("Turn 4 - AI: " + response4);
+
+        // The model should recall key facts from the compacted summary
+        assertThat(response4.toLowerCase()).satisfiesAnyOf(
+                r -> assertThat(r).contains("mario"),
+                r -> assertThat(r).contains("milan"),
+                r -> assertThat(r).contains("software"),
+                r -> assertThat(r).contains("java"),
+                r -> assertThat(r).contains("cook")
+        );
+
+        waitForCompaction(memory);
+
+        // The memory should be significantly compacted - not holding all raw messages
+        System.out.println("Final memory messages: " + memory.messages().size());
+        for (ChatMessage msg : memory.messages()) {
+            System.out.println("  " + msg.type() + ": "
+                    + (msg instanceof UserMessage u ? u.singleText() : msg.toString()));
+        }
+    }
+
+    @Test
+    void should_preserve_system_message_across_compaction_with_ai_service() throws InterruptedException {
+        // given
+        CompactingChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(chatModel)
+                .build();
+
+        HistoryTeacher teacher = AiServices.builder(HistoryTeacher.class)
+                .chatModel(chatModel)
+                .chatMemory(memory)
+                .build();
+
+        // when - multi-turn history lesson
+        String response1 = teacher.chat("Tell me about the founding of Rome.");
+        System.out.println("Turn 1 - Teacher: " + response1);
+        waitForCompaction(memory);
+
+        String response2 = teacher.chat("What about the Roman Republic?");
+        System.out.println("Turn 2 - Teacher: " + response2);
+        waitForCompaction(memory);
+
+        String response3 = teacher.chat("And the transition to the Empire?");
+        System.out.println("Turn 3 - Teacher: " + response3);
+        waitForCompaction(memory);
+
+        // then - system message should still be present
+        List<ChatMessage> messages = memory.messages();
+        System.out.println("Memory after compaction:");
+        boolean hasSystemMessage = messages.stream()
+                .anyMatch(m -> m instanceof dev.langchain4j.data.message.SystemMessage);
+        assertThat(hasSystemMessage).isTrue();
+
+        for (ChatMessage msg : messages) {
+            System.out.println("  " + msg.type() + ": "
+                    + (msg instanceof UserMessage u ? u.singleText()
+                    : msg instanceof dev.langchain4j.data.message.SystemMessage s ? s.text()
+                    : msg.toString()));
+        }
+    }
+
+    @Test
+    void should_use_fewer_tokens_than_message_window_memory() throws InterruptedException {
+        // This test runs the SAME conversation with two different memory implementations
+        // and compares the total input tokens used across all turns.
+
+        String[] userMessages = {
+                "Let's discuss the solar system. Tell me about Mercury.",
+                "Now tell me about Venus and how it compares to Mercury.",
+                "What about Earth? How is it unique compared to the first two?",
+                "Describe Mars and why scientists are interested in it.",
+                "Tell me about Jupiter, the largest planet.",
+                "Now summarize the key differences between all five planets we discussed."
+        };
+
+        // --- Run with MessageWindowChatMemory (keeps full history) ---
+        TokenConsumptionRecorder windowTokenRecorder = new TokenConsumptionRecorder();
+        ChatMemory windowMemory = MessageWindowChatMemory.builder()
+                .maxMessages(20)
+                .build();
+
+        Assistant windowAssistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .chatMemory(windowMemory)
+                .registerListener(windowTokenRecorder)
+                .build();
+
+        for (String userMsg : userMessages) {
+            System.out.println("User: " + userMsg);
+            String response = windowAssistant.chat(userMsg);
+            System.out.println("AI: " + response);
+        }
+        int windowFinalMessageCount = windowMemory.messages().size();
+
+        // --- Run with CompactingChatMemory (summarized history) ---
+
+        CompactingChatMemory compactMemory = CompactingChatMemory.builder()
+                .chatModel(compactingChatModel) // use the real model for compaction
+                .build();
+
+        TokenConsumptionRecorder compactingTokenRecorder = new TokenConsumptionRecorder();
+        Assistant compactAssistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .chatMemory(compactMemory)
+                .registerListener(compactingTokenRecorder)
+                .build();
+
+        System.out.println();
+        System.out.println("=== CompactingChatMemory (summarized history) ===");
+        for (String userMsg : userMessages) {
+            System.out.println("User: " + userMsg);
+            String response = compactAssistant.chat(userMsg);
+            System.out.println("AI: " + response);
+        }
+        int compactFinalMessageCount = compactMemory.messages().size();
+
+        // --- Compare results ---
+        System.out.println();
+        System.out.println("=== Comparison ===");
+        System.out.println("MessageWindowChatMemory:");
+        System.out.println("  Final messages in memory: " + windowFinalMessageCount);
+        System.out.println("  Total tokens across all turns: " + windowTokenRecorder.totalTokens());
+        System.out.println("CompactingChatMemory:");
+        System.out.println("  Final messages in memory: " + compactFinalMessageCount);
+        System.out.println("  Total tokens across all turns: " + compactingTokenRecorder.totalTokens());
+
+        double savings = (1.0 - (double) compactingTokenRecorder.totalTokens() / windowTokenRecorder.totalTokens()) * 100;
+        System.out.println(String.format("Token savings: %.1f%% fewer input tokens with CompactingChatMemory", savings));
+        System.out.println("==================");
+
+        // then - compacting memory should use fewer total input tokens
+        assertThat(compactingTokenRecorder.totalTokens()).isLessThan(windowTokenRecorder.totalTokens());
+        // and should hold far fewer messages
+        assertThat(compactFinalMessageCount).isLessThan(windowFinalMessageCount);
+    }
+
+    static class TokenConsumptionRecorder implements AiServiceResponseReceivedListener {
+        private final AtomicInteger totalTokens = new AtomicInteger();
+
+        @Override
+        public void onEvent(final AiServiceResponseReceivedEvent event) {
+            ChatResponse response = event.response();
+            TokenUsage usage = response.metadata().tokenUsage();
+            if (usage != null && usage.totalTokenCount() != null) {
+                totalTokens.addAndGet(usage.totalTokenCount());
+            }
+        }
+
+        public int totalTokens() {
+            return totalTokens.get();
+        }
+    }
+
+    /**
+     * Waits for background compaction to complete by polling until the message count stabilizes.
+     */
+    private void waitForCompaction(CompactingChatMemory memory) throws InterruptedException {
+        while (memory.messages().stream().filter(UserMessage.class::isInstance).count() > 1) {
+            Thread.sleep(100);
+        }
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryIT.java
@@ -173,7 +173,7 @@ class CompactingChatMemoryIT {
     }
 
     @Test
-    void should_use_fewer_tokens_than_message_window_memory() throws InterruptedException {
+    void should_use_fewer_tokens_than_message_window_memory() {
         // This test runs the SAME conversation with two different memory implementations
         // and compares the total input tokens used across all turns.
 
@@ -411,7 +411,7 @@ class CompactingChatMemoryIT {
         }
 
         boolean hasToolResults = messages.stream()
-                .anyMatch(m -> m instanceof ToolExecutionResultMessage);
+                .anyMatch(ToolExecutionResultMessage.class::isInstance);
         System.out.println("Has preserved tool results: " + hasToolResults);
         // Tool messages should be retained since compactToolMessages=false
         // Note: whether they're present depends on whether they fell in the summarize zone

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryIT.java
@@ -4,11 +4,12 @@ import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
 import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_5_MINI;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.output.TokenUsage;
@@ -40,6 +41,24 @@ class CompactingChatMemoryIT {
     interface HistoryTeacher {
         @SystemMessage("You are a history teacher. Give detailed but concise answers.")
         String chat(String userMessage);
+    }
+
+    interface MathAssistant {
+        @SystemMessage("You are a math assistant. Use the provided tools to compute results. Always use tools when available.")
+        String chat(String userMessage);
+    }
+
+    static class Calculator {
+
+        @Tool("Adds two numbers together")
+        int add(int a, int b) {
+            return a + b;
+        }
+
+        @Tool("Multiplies two numbers together")
+        int multiply(int a, int b) {
+            return a * b;
+        }
     }
 
     @BeforeAll
@@ -228,6 +247,210 @@ class CompactingChatMemoryIT {
         assertThat(compactFinalMessageCount).isLessThan(windowFinalMessageCount);
     }
 
+    @Test
+    void should_retain_last_messages_with_real_model() throws InterruptedException {
+        // given
+        CompactingChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(compactingChatModel)
+                .retainLastMessages(2)
+                .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .chatMemory(memory)
+                .build();
+
+        // when
+        assistant.chat("My name is Mario.");
+        waitForCompaction(memory);
+        assistant.chat("I live in Milan.");
+        waitForCompaction(memory);
+        assistant.chat("I'm a software engineer.");
+        waitForCompaction(memory);
+
+        // then - memory should have summary + 2 retained messages
+        List<ChatMessage> messages = memory.messages();
+        System.out.println("Memory with retainLastMessages=2:");
+        for (ChatMessage msg : messages) {
+            System.out.println("  " + msg.type() + ": "
+                    + (msg instanceof UserMessage u ? u.singleText() : msg.toString()));
+        }
+
+        // Should have more than 1 message (summary + retained)
+        assertThat(messages.size()).isGreaterThan(1);
+
+        // The AI should still remember earlier facts through the summary
+        String response = assistant.chat("What do you know about me?");
+        System.out.println("Recall response: " + response);
+        assertThat(response.toLowerCase()).satisfiesAnyOf(
+                r -> assertThat(r).contains("mario"),
+                r -> assertThat(r).contains("milan"),
+                r -> assertThat(r).contains("software")
+        );
+    }
+
+    @Test
+    void should_compact_with_interval_using_real_model() throws InterruptedException {
+        // given - compact only every 3rd user message
+        CompactingChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(compactingChatModel)
+                .compactionInterval(3)
+                .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .chatMemory(memory)
+                .build();
+
+        // when
+        assistant.chat("My name is Alice.");
+        int messagesAfterFirst = memory.messages().size();
+
+        assistant.chat("I like reading books.");
+        int messagesAfterSecond = memory.messages().size();
+
+        // Messages should be accumulating (no compaction yet)
+        assertThat(messagesAfterSecond).isGreaterThan(messagesAfterFirst);
+
+        assistant.chat("My favorite color is blue.");
+        // 3rd user message triggers compaction
+        waitForCompaction(memory);
+
+        int messagesAfterThird = memory.messages().size();
+        System.out.println("Messages after 3rd turn (compaction triggered): " + messagesAfterThird);
+
+        // After compaction, memory should be smaller than the accumulated messages
+        assertThat(messagesAfterThird).isLessThan(messagesAfterSecond);
+    }
+
+    @Test
+    void should_work_with_tools_and_compact_tool_messages() throws InterruptedException {
+        // given
+        CompactingChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(compactingChatModel)
+                .build();
+
+        Calculator calculator = new Calculator();
+
+        MathAssistant assistant = AiServices.builder(MathAssistant.class)
+                .chatModel(chatModel)
+                .chatMemory(memory)
+                .tools(calculator)
+                .build();
+
+        // when - ask questions that require tool usage
+        String response1 = assistant.chat("What is 15 + 27?");
+        System.out.println("Turn 1 - Math: " + response1);
+        assertThat(response1).contains("42");
+
+        System.out.println("Memory after tool use:");
+        for (ChatMessage msg : memory.messages()) {
+            System.out.println("  " + msg.type() + ": " + msg);
+        }
+
+        waitForCompaction(memory);
+
+        String response2 = assistant.chat("Now multiply 6 and 7.");
+        System.out.println("Turn 2 - Math: " + response2);
+        assertThat(response2).contains("42");
+
+        waitForCompaction(memory);
+
+        // then - memory should be compacted even with tool messages
+        String response3 = assistant.chat("What were the results of my previous calculations?");
+        System.out.println("Turn 3 - Math: " + response3);
+
+        // Should recall the results through the summary
+        assertThat(response3.toLowerCase()).satisfiesAnyOf(
+                r -> assertThat(r).contains("42"),
+                r -> assertThat(r).contains("fifteen"),
+                r -> assertThat(r).contains("multiply")
+        );
+
+        System.out.println("Final memory:");
+        for (ChatMessage msg : memory.messages()) {
+            System.out.println("  " + msg.type() + ": " + msg);
+        }
+    }
+
+    @Test
+    void should_preserve_tool_messages_when_configured() throws InterruptedException {
+        // given - compactToolMessages=false should keep tool call/result pairs intact
+        CompactingChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(compactingChatModel)
+                .compactToolMessages(false)
+                .retainLastMessages(2)
+                .build();
+
+        Calculator calculator = new Calculator();
+
+        MathAssistant assistant = AiServices.builder(MathAssistant.class)
+                .chatModel(chatModel)
+                .chatMemory(memory)
+                .tools(calculator)
+                .build();
+
+        // when
+        String response1 = assistant.chat("What is 10 + 20?");
+        System.out.println("Turn 1: " + response1);
+        assertThat(response1).contains("30");
+
+        waitForCompaction(memory);
+
+        String response2 = assistant.chat("Now multiply 5 and 8.");
+        System.out.println("Turn 2: " + response2);
+        assertThat(response2).contains("40");
+
+        waitForCompaction(memory);
+
+        // then - tool execution result messages should be preserved in memory
+        List<ChatMessage> messages = memory.messages();
+        System.out.println("Memory with preserved tool messages:");
+        for (ChatMessage msg : messages) {
+            System.out.println("  " + msg.type() + ": " + msg);
+        }
+
+        boolean hasToolResults = messages.stream()
+                .anyMatch(m -> m instanceof ToolExecutionResultMessage);
+        System.out.println("Has preserved tool results: " + hasToolResults);
+        // Tool messages should be retained since compactToolMessages=false
+        // Note: whether they're present depends on whether they fell in the summarize zone
+    }
+
+    @Test
+    void should_use_custom_compaction_prompt_with_real_model() throws InterruptedException {
+        // given
+        String customPrompt = "Create a bullet-point summary of the conversation. "
+                + "Each bullet should capture one key fact. Write from the user's perspective.";
+
+        CompactingChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(compactingChatModel)
+                .compactionPrompt(customPrompt)
+                .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .chatMemory(memory)
+                .build();
+
+        // when
+        assistant.chat("I'm learning French.");
+        waitForCompaction(memory);
+        assistant.chat("I also play guitar.");
+        waitForCompaction(memory);
+        assistant.chat("I live in Paris.");
+        waitForCompaction(memory);
+
+        // then - the summary should use the custom prompt format
+        List<ChatMessage> messages = memory.messages();
+        System.out.println("Memory with custom prompt:");
+        for (ChatMessage msg : messages) {
+            if (msg instanceof UserMessage u) {
+                System.out.println("  " + u.singleText());
+            }
+        }
+    }
+
     static class TokenConsumptionRecorder implements AiServiceResponseReceivedListener {
         private final AtomicInteger totalTokens = new AtomicInteger();
 
@@ -249,8 +472,19 @@ class CompactingChatMemoryIT {
      * Waits for background compaction to complete by polling until the message count stabilizes.
      */
     private void waitForCompaction(CompactingChatMemory memory) throws InterruptedException {
-        while (memory.messages().stream().filter(UserMessage.class::isInstance).count() > 1) {
+        // Wait until memory stabilizes (no more changes for 500ms)
+        int previousSize;
+        int currentSize = memory.messages().size();
+        int stableCount = 0;
+        while (stableCount < 5) {
             Thread.sleep(100);
+            previousSize = currentSize;
+            currentSize = memory.messages().size();
+            if (currentSize == previousSize) {
+                stableCount++;
+            } else {
+                stableCount = 0;
+            }
         }
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryTest.java
@@ -164,7 +164,7 @@ class CompactingChatMemoryTest implements WithAssertions {
 
         List<ChatMessage> messages = memory.messages();
         long systemMessageCount = messages.stream()
-                .filter(m -> m instanceof SystemMessage)
+                .filter(SystemMessage.class::isInstance)
                 .count();
         assertThat(systemMessageCount).isEqualTo(1);
         assertThat(((SystemMessage) messages.get(0)).text())
@@ -244,7 +244,7 @@ class CompactingChatMemoryTest implements WithAssertions {
         // System message should NOT be included in the summarization request
         List<ChatMessage> sent = capturedMessages.get();
         assertThat(sent).isNotNull();
-        assertThat(sent.stream().filter(m -> m instanceof SystemMessage)).isEmpty();
+        assertThat(sent.stream().filter(SystemMessage.class::isInstance)).isEmpty();
 
         // The conversation messages should be included, plus the compaction prompt at the end
         assertThat(sent.get(0)).isInstanceOf(UserMessage.class);
@@ -556,7 +556,7 @@ class CompactingChatMemoryTest implements WithAssertions {
         assertThat(capturedMessages.get()).isNotNull();
         // Summarization request should NOT contain tool messages
         assertThat(capturedMessages.get().stream()
-                .filter(m -> m instanceof ToolExecutionResultMessage)).isEmpty();
+                .filter(ToolExecutionResultMessage.class::isInstance)).isEmpty();
         assertThat(capturedMessages.get().stream()
                 .filter(m -> m instanceof AiMessage a && a.hasToolExecutionRequests())).isEmpty();
 
@@ -600,7 +600,7 @@ class CompactingChatMemoryTest implements WithAssertions {
         // All messages including tool messages should be in the summarization request
         List<ChatMessage> sent = capturedMessages.get();
         assertThat(sent).isNotNull();
-        assertThat(sent.stream().filter(m -> m instanceof ToolExecutionResultMessage).count()).isEqualTo(1);
+        assertThat(sent.stream().filter(ToolExecutionResultMessage.class::isInstance).count()).isEqualTo(1);
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryTest.java
@@ -4,11 +4,14 @@ import static dev.langchain4j.data.message.AiMessage.aiMessage;
 import static dev.langchain4j.data.message.SystemMessage.systemMessage;
 import static dev.langchain4j.data.message.UserMessage.userMessage;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -40,6 +43,40 @@ class CompactingChatMemoryTest implements WithAssertions {
             }
         };
     }
+
+    private static TokenCountEstimator wordCountEstimator() {
+        return new TokenCountEstimator() {
+            @Override
+            public int estimateTokenCountInText(String text) {
+                return text == null ? 0 : text.split("\\s+").length;
+            }
+
+            @Override
+            public int estimateTokenCountInMessage(ChatMessage message) {
+                if (message instanceof UserMessage u) {
+                    return estimateTokenCountInText(u.singleText());
+                } else if (message instanceof AiMessage a) {
+                    return estimateTokenCountInText(a.text());
+                } else if (message instanceof SystemMessage s) {
+                    return estimateTokenCountInText(s.text());
+                } else if (message instanceof ToolExecutionResultMessage t) {
+                    return estimateTokenCountInText(t.text());
+                }
+                return 0;
+            }
+
+            @Override
+            public int estimateTokenCountInMessages(Iterable<ChatMessage> messages) {
+                int total = 0;
+                for (ChatMessage msg : messages) {
+                    total += estimateTokenCountInMessage(msg);
+                }
+                return total;
+            }
+        };
+    }
+
+    // ===== Basic tests =====
 
     @Test
     void should_have_default_id() {
@@ -276,6 +313,576 @@ class CompactingChatMemoryTest implements WithAssertions {
         assertThat(messages).hasSize(1);
         assertThat(((UserMessage) messages.get(0)).singleText())
                 .isEqualTo("round 2 summary");
+    }
+
+    // ===== retainLastMessages tests =====
+
+    @Test
+    void should_retain_last_n_messages_and_summarize_older_ones() {
+        AtomicReference<List<ChatMessage>> capturedMessages = new AtomicReference<>();
+
+        ChatModel capturingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                capturedMessages.set(chatRequest.messages());
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("summary of older messages"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(capturingModel)
+                .retainLastMessages(2)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(userMessage("first question"));
+        memory.add(aiMessage("first answer"));
+        memory.add(userMessage("second question"));
+        memory.add(aiMessage("second answer"));
+        memory.add(userMessage("third question"));
+
+        // Should have: summary + last 2 messages (aiMessage "second answer" + userMessage "third question")
+        List<ChatMessage> messages = memory.messages();
+        assertThat(messages).hasSize(3);
+        assertThat(messages.get(0)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) messages.get(0)).singleText()).isEqualTo("summary of older messages");
+        assertThat(messages.get(1)).isInstanceOf(AiMessage.class);
+        assertThat(((AiMessage) messages.get(1)).text()).isEqualTo("second answer");
+        assertThat(messages.get(2)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) messages.get(2)).singleText()).isEqualTo("third question");
+
+        // The summarization request should only contain the older messages
+        List<ChatMessage> sent = capturedMessages.get();
+        assertThat(sent).isNotNull();
+        // first question + first answer + second question + compaction prompt
+        assertThat(sent).hasSize(4);
+        assertThat(((UserMessage) sent.get(0)).singleText()).isEqualTo("first question");
+        assertThat(((AiMessage) sent.get(1)).text()).isEqualTo("first answer");
+        assertThat(((UserMessage) sent.get(2)).singleText()).isEqualTo("second question");
+        // last is the compaction prompt
+        assertThat(sent.get(3)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) sent.get(3)).singleText()).contains("Summarize");
+    }
+
+    @Test
+    void should_retain_last_messages_with_system_message() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("summary"))
+                .retainLastMessages(1)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(systemMessage("Be helpful."));
+        memory.add(userMessage("first"));
+        memory.add(aiMessage("answer 1"));
+        memory.add(userMessage("second"));
+
+        List<ChatMessage> messages = memory.messages();
+        // system message + summary + last 1 retained message
+        assertThat(messages).hasSize(3);
+        assertThat(messages.get(0)).isInstanceOf(SystemMessage.class);
+        assertThat(messages.get(1)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) messages.get(1)).singleText()).isEqualTo("summary");
+        assertThat(messages.get(2)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) messages.get(2)).singleText()).isEqualTo("second");
+    }
+
+    @Test
+    void should_not_compact_when_all_messages_fit_in_retain_window() {
+        AtomicBoolean modelCalled = new AtomicBoolean(false);
+
+        ChatModel trackingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                modelCalled.set(true);
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("summary"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(trackingModel)
+                .retainLastMessages(10)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(userMessage("first"));
+        memory.add(aiMessage("answer"));
+        memory.add(userMessage("second"));
+
+        // All 3 messages fit in the retain window of 10, nothing to summarize (<=1 in toSummarize)
+        assertThat(modelCalled.get()).isFalse();
+        assertThat(memory.messages()).hasSize(3);
+    }
+
+    // ===== compactionInterval tests =====
+
+    @Test
+    void should_compact_only_on_nth_user_message() {
+        AtomicBoolean modelCalled = new AtomicBoolean(false);
+
+        ChatModel trackingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                modelCalled.set(true);
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("summary"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(trackingModel)
+                .compactionInterval(3)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        // 1st user message - no compaction
+        memory.add(userMessage("first"));
+        memory.add(aiMessage("response 1"));
+        assertThat(modelCalled.get()).isFalse();
+
+        // 2nd user message - no compaction
+        memory.add(userMessage("second"));
+        memory.add(aiMessage("response 2"));
+        assertThat(modelCalled.get()).isFalse();
+
+        // 3rd user message - compaction triggered!
+        memory.add(userMessage("third"));
+        assertThat(modelCalled.get()).isTrue();
+
+        // After compaction
+        assertThat(memory.messages()).hasSize(1);
+        assertThat(((UserMessage) memory.messages().get(0)).singleText()).isEqualTo("summary");
+    }
+
+    @Test
+    void should_reset_interval_counter_after_compaction() {
+        AtomicReference<Integer> callCount = new AtomicReference<>(0);
+
+        ChatModel countingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                callCount.updateAndGet(v -> v + 1);
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("summary"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(countingModel)
+                .compactionInterval(2)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        // First cycle: 2 user messages
+        memory.add(userMessage("u1"));
+        memory.add(aiMessage("a1"));
+        memory.add(userMessage("u2"));
+        assertThat(callCount.get()).isEqualTo(1);
+
+        // Second cycle: 2 more user messages
+        memory.add(aiMessage("a2"));
+        memory.add(userMessage("u3"));
+        assertThat(callCount.get()).isEqualTo(1); // not yet
+        memory.add(aiMessage("a3"));
+        memory.add(userMessage("u4"));
+        assertThat(callCount.get()).isEqualTo(2); // triggered again
+    }
+
+    @Test
+    void should_reject_invalid_compaction_interval() {
+        assertThatThrownBy(() -> CompactingChatMemory.builder()
+                .chatModel(summaryModel("summary"))
+                .compactionInterval(0)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("compactionInterval");
+    }
+
+    // ===== compactToolMessages tests =====
+
+    @Test
+    void should_preserve_tool_messages_when_compact_tool_messages_is_false() {
+        AtomicReference<List<ChatMessage>> capturedMessages = new AtomicReference<>();
+
+        ChatModel capturingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                capturedMessages.set(chatRequest.messages());
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("summary without tools"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(capturingModel)
+                .compactToolMessages(false)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("calculator")
+                .arguments("{\"a\": 2, \"b\": 2}")
+                .build();
+
+        memory.add(userMessage("What is 2+2?"));
+        memory.add(AiMessage.from(toolRequest));
+        memory.add(ToolExecutionResultMessage.from(toolRequest, "4"));
+        memory.add(aiMessage("2+2 is 4"));
+        memory.add(userMessage("What about 3+3?"));
+
+        List<ChatMessage> messages = memory.messages();
+
+        // The tool pair (AiMessage with tool request + ToolExecutionResultMessage) should be preserved
+        // Summary should be from non-tool messages: "What is 2+2?" and "2+2 is 4"
+        // Result: summary + AiMessage(tool) + ToolExecutionResultMessage + aiMessage("2+2 is 4") + userMessage("What about 3+3?")
+        // Actually: toSummarize = [userMessage("What is 2+2?"), aiMessage("2+2 is 4")], but that's only after
+        // tool messages are moved to retain. Let's check...
+
+        // The non-tool messages to summarize: userMessage("What is 2+2?") + aiMessage("2+2 is 4") = 2 messages
+        // The tool pair + last user message go to retain
+        assertThat(capturedMessages.get()).isNotNull();
+        // Summarization request should NOT contain tool messages
+        assertThat(capturedMessages.get().stream()
+                .filter(m -> m instanceof ToolExecutionResultMessage)).isEmpty();
+        assertThat(capturedMessages.get().stream()
+                .filter(m -> m instanceof AiMessage a && a.hasToolExecutionRequests())).isEmpty();
+
+        // Memory should contain: summary + tool pair + remaining messages
+        boolean hasToolResult = messages.stream().anyMatch(m -> m instanceof ToolExecutionResultMessage);
+        assertThat(hasToolResult).isTrue();
+    }
+
+    @Test
+    void should_compact_tool_messages_by_default() {
+        AtomicReference<List<ChatMessage>> capturedMessages = new AtomicReference<>();
+
+        ChatModel capturingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                capturedMessages.set(chatRequest.messages());
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("summary with tools"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(capturingModel)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1")
+                .name("calculator")
+                .arguments("{\"a\": 2, \"b\": 2}")
+                .build();
+
+        memory.add(userMessage("What is 2+2?"));
+        memory.add(AiMessage.from(toolRequest));
+        memory.add(ToolExecutionResultMessage.from(toolRequest, "4"));
+        memory.add(aiMessage("2+2 is 4"));
+        memory.add(userMessage("What about 3+3?"));
+
+        // All messages including tool messages should be in the summarization request
+        List<ChatMessage> sent = capturedMessages.get();
+        assertThat(sent).isNotNull();
+        assertThat(sent.stream().filter(m -> m instanceof ToolExecutionResultMessage).count()).isEqualTo(1);
+    }
+
+    @Test
+    void should_preserve_multiple_tool_pairs_when_compact_tool_messages_is_false() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("summary"))
+                .compactToolMessages(false)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        ToolExecutionRequest toolRequest1 = ToolExecutionRequest.builder()
+                .id("1").name("tool1").arguments("{}").build();
+        ToolExecutionRequest toolRequest2 = ToolExecutionRequest.builder()
+                .id("2").name("tool2").arguments("{}").build();
+
+        memory.add(userMessage("Do task A"));
+        memory.add(aiMessage("Starting task A"));
+        memory.add(userMessage("Now use tools"));
+        memory.add(AiMessage.from(toolRequest1));
+        memory.add(ToolExecutionResultMessage.from(toolRequest1, "result1"));
+        memory.add(AiMessage.from(toolRequest2));
+        memory.add(ToolExecutionResultMessage.from(toolRequest2, "result2"));
+        memory.add(aiMessage("Done with tools"));
+        memory.add(userMessage("Final question"));
+
+        List<ChatMessage> messages = memory.messages();
+
+        // Both tool pairs should be preserved
+        long toolResultCount = messages.stream()
+                .filter(m -> m instanceof ToolExecutionResultMessage)
+                .count();
+        assertThat(toolResultCount).isEqualTo(2);
+    }
+
+    // ===== maxTokens + tokenCountEstimator tests =====
+
+    @Test
+    void should_not_compact_when_under_token_limit() {
+        AtomicBoolean modelCalled = new AtomicBoolean(false);
+
+        ChatModel trackingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                modelCalled.set(true);
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("summary"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(trackingModel)
+                .maxTokens(1000)
+                .tokenCountEstimator(wordCountEstimator())
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(userMessage("short message"));
+        memory.add(aiMessage("short reply"));
+        memory.add(userMessage("another short one"));
+
+        // Total words: ~6, well under 1000 tokens
+        assertThat(modelCalled.get()).isFalse();
+        assertThat(memory.messages()).hasSize(3);
+    }
+
+    @Test
+    void should_compact_when_over_token_limit() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("compact summary"))
+                .maxTokens(5)
+                .tokenCountEstimator(wordCountEstimator())
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(userMessage("this is a somewhat longer message with many words"));
+        memory.add(aiMessage("and here is another response with plenty of words too"));
+        memory.add(userMessage("yet another message that pushes us over the limit"));
+
+        // Over token limit, compaction should have occurred
+        List<ChatMessage> messages = memory.messages();
+        // The summary should be present
+        assertThat(messages.stream()
+                .filter(m -> m instanceof UserMessage u && u.singleText().equals("compact summary"))
+                .count()).isEqualTo(1);
+    }
+
+    @Test
+    void should_retain_recent_messages_within_token_limit_when_compacting() {
+        AtomicReference<List<ChatMessage>> capturedMessages = new AtomicReference<>();
+
+        ChatModel capturingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                capturedMessages.set(chatRequest.messages());
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("older stuff summary"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        // Each word counts as 1 token. maxTokens=3 means retain messages up to 3 tokens
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(capturingModel)
+                .maxTokens(3)
+                .tokenCountEstimator(wordCountEstimator())
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(userMessage("alpha beta")); // 2 tokens
+        memory.add(aiMessage("gamma delta")); // 2 tokens
+        memory.add(userMessage("epsilon")); // 1 token
+        memory.add(aiMessage("zeta eta")); // 2 tokens
+        memory.add(userMessage("theta")); // 1 token
+        // Total = 8 tokens > 3 limit
+
+        List<ChatMessage> messages = memory.messages();
+
+        // "theta" (1 token) fits, "zeta eta" (2 tokens) fits (total 3), "epsilon" (1 token) won't fit (total 4)
+        // So: summarize ["alpha beta", "gamma delta", "epsilon"], retain ["zeta eta", "theta"]
+        assertThat(messages).hasSize(3); // summary + 2 retained
+        assertThat(messages.get(0)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) messages.get(0)).singleText()).isEqualTo("older stuff summary");
+        assertThat(((AiMessage) messages.get(1)).text()).isEqualTo("zeta eta");
+        assertThat(((UserMessage) messages.get(2)).singleText()).isEqualTo("theta");
+
+        // Summarization request should contain only the older messages + compaction prompt
+        List<ChatMessage> sent = capturedMessages.get();
+        assertThat(sent).hasSize(4); // 3 older messages + compaction prompt
+        assertThat(((UserMessage) sent.get(0)).singleText()).isEqualTo("alpha beta");
+        assertThat(((AiMessage) sent.get(1)).text()).isEqualTo("gamma delta");
+        assertThat(((UserMessage) sent.get(2)).singleText()).isEqualTo("epsilon");
+    }
+
+    @Test
+    void should_reject_max_tokens_without_estimator() {
+        assertThatThrownBy(() -> CompactingChatMemory.builder()
+                .chatModel(summaryModel("summary"))
+                .maxTokens(100)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tokenCountEstimator");
+    }
+
+    // ===== compactionPrompt tests =====
+
+    @Test
+    void should_use_custom_compaction_prompt() {
+        AtomicReference<List<ChatMessage>> capturedMessages = new AtomicReference<>();
+
+        ChatModel capturingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                capturedMessages.set(chatRequest.messages());
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("custom summary"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        String customPrompt = "Please create a brief recap.";
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(capturingModel)
+                .compactionPrompt(customPrompt)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(userMessage("first"));
+        memory.add(aiMessage("response"));
+        memory.add(userMessage("second"));
+
+        List<ChatMessage> sent = capturedMessages.get();
+        assertThat(sent).isNotNull();
+        UserMessage lastSent = (UserMessage) sent.get(sent.size() - 1);
+        assertThat(lastSent.singleText()).isEqualTo(customPrompt);
+    }
+
+    // ===== Combined features tests =====
+
+    @Test
+    void should_combine_retain_last_messages_with_compact_tool_messages_false() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("summary"))
+                .retainLastMessages(1)
+                .compactToolMessages(false)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .id("1").name("search").arguments("{}").build();
+
+        memory.add(userMessage("search for X"));
+        memory.add(AiMessage.from(toolRequest));
+        memory.add(ToolExecutionResultMessage.from(toolRequest, "found X"));
+        memory.add(aiMessage("I found X for you"));
+        memory.add(userMessage("tell me more about X"));
+
+        List<ChatMessage> messages = memory.messages();
+
+        // Tool messages should be preserved, last 1 message retained, rest summarized
+        assertThat(messages.stream().filter(m -> m instanceof ToolExecutionResultMessage).count()).isEqualTo(1);
+        // Last message should be the retained one
+        assertThat(messages.get(messages.size() - 1)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) messages.get(messages.size() - 1)).singleText()).isEqualTo("tell me more about X");
+    }
+
+    @Test
+    void should_combine_compaction_interval_with_retain_last_messages() {
+        AtomicReference<Integer> callCount = new AtomicReference<>(0);
+
+        ChatModel countingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                callCount.updateAndGet(v -> v + 1);
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("summary"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(countingModel)
+                .compactionInterval(2)
+                .retainLastMessages(1)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        // 1st user message - no compaction (interval not reached)
+        memory.add(userMessage("u1"));
+        memory.add(aiMessage("a1"));
+        assertThat(callCount.get()).isEqualTo(0);
+
+        // 2nd user message - compaction triggered
+        memory.add(userMessage("u2"));
+        assertThat(callCount.get()).isEqualTo(1);
+
+        // Result: summary + last 1 message ("u2")
+        List<ChatMessage> messages = memory.messages();
+        assertThat(messages).hasSize(2);
+        assertThat(((UserMessage) messages.get(0)).singleText()).isEqualTo("summary");
+        assertThat(((UserMessage) messages.get(1)).singleText()).isEqualTo("u2");
+    }
+
+    // ===== ChatMemoryStore tests =====
+
+    @Test
+    void should_use_provided_chat_memory_store() {
+        AtomicBoolean storeUsed = new AtomicBoolean(false);
+
+        dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore customStore =
+                new dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore() {
+                    @Override
+                    public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+                        storeUsed.set(true);
+                        super.updateMessages(memoryId, messages);
+                    }
+                };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("summary"))
+                .chatMemoryStore(customStore)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(userMessage("hello"));
+        assertThat(storeUsed.get()).isTrue();
+    }
+
+    // ===== Validation tests =====
+
+    @Test
+    void should_reject_negative_retain_last_messages() {
+        assertThatThrownBy(() -> CompactingChatMemory.builder()
+                .chatModel(summaryModel("summary"))
+                .retainLastMessages(-1)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("retainLastMessages");
     }
 
     /**

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/CompactingChatMemoryTest.java
@@ -1,0 +1,320 @@
+package dev.langchain4j.memory.chat;
+
+import static dev.langchain4j.data.message.AiMessage.aiMessage;
+import static dev.langchain4j.data.message.SystemMessage.systemMessage;
+import static dev.langchain4j.data.message.UserMessage.userMessage;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+class CompactingChatMemoryTest implements WithAssertions {
+
+    /**
+     * An executor that runs tasks synchronously on the calling thread, making tests deterministic.
+     */
+    private static final ExecutorService DIRECT_EXECUTOR = new DirectExecutorService();
+
+    private static ChatModel summaryModel(String summaryText) {
+        return new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage(summaryText))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+    }
+
+    @Test
+    void should_have_default_id() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("summary"))
+                .build();
+
+        assertThat(memory.id()).isEqualTo("default");
+    }
+
+    @Test
+    void should_use_custom_id() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .id("custom-id")
+                .chatModel(summaryModel("summary"))
+                .build();
+
+        assertThat(memory.id()).isEqualTo("custom-id");
+    }
+
+    @Test
+    void should_add_and_retrieve_single_message_without_compaction() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("summary"))
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        UserMessage msg = userMessage("hello");
+        memory.add(msg);
+
+        // Single user message, no compaction triggered
+        assertThat(memory.messages()).containsExactly(msg);
+    }
+
+    @Test
+    void should_compact_messages_after_second_user_message_is_added() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("This is a summary of the conversation."))
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(userMessage("What is Java?"));
+        memory.add(aiMessage("Java is a programming language."));
+        memory.add(userMessage("Tell me more about it."));
+
+        // After compaction, only one summarized UserMessage remains
+        List<ChatMessage> messages = memory.messages();
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) messages.get(0)).singleText())
+                .isEqualTo("This is a summary of the conversation.");
+    }
+
+    @Test
+    void should_preserve_system_message_during_compaction() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("Summarized conversation content."))
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(systemMessage("You are a helpful assistant."));
+        memory.add(userMessage("What is Python?"));
+        memory.add(aiMessage("Python is a programming language."));
+        memory.add(userMessage("How does it compare to Java?"));
+
+        List<ChatMessage> messages = memory.messages();
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0)).isInstanceOf(SystemMessage.class);
+        assertThat(((SystemMessage) messages.get(0)).text())
+                .isEqualTo("You are a helpful assistant.");
+        assertThat(messages.get(1)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) messages.get(1)).singleText())
+                .isEqualTo("Summarized conversation content.");
+    }
+
+    @Test
+    void should_replace_system_message_when_new_one_is_added() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("summary"))
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(systemMessage("First system message"));
+        memory.add(systemMessage("Second system message"));
+
+        List<ChatMessage> messages = memory.messages();
+        long systemMessageCount = messages.stream()
+                .filter(m -> m instanceof SystemMessage)
+                .count();
+        assertThat(systemMessageCount).isEqualTo(1);
+        assertThat(((SystemMessage) messages.get(0)).text())
+                .isEqualTo("Second system message");
+    }
+
+    @Test
+    void should_clear_all_messages() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("summary"))
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(userMessage("hello"));
+        assertThat(memory.messages()).isNotEmpty();
+
+        memory.clear();
+        assertThat(memory.messages()).isEmpty();
+
+        // Idempotent
+        memory.clear();
+        assertThat(memory.messages()).isEmpty();
+    }
+
+    @Test
+    void should_not_compact_single_conversation_message() {
+        AtomicBoolean modelCalled = new AtomicBoolean(false);
+
+        ChatModel trackingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                modelCalled.set(true);
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("summary"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(trackingModel)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        // Add only one user message - should not trigger compaction
+        memory.add(userMessage("hello"));
+
+        assertThat(modelCalled.get()).isFalse();
+        assertThat(memory.messages()).containsExactly(userMessage("hello"));
+    }
+
+    @Test
+    void should_not_include_system_message_in_summarization_request() {
+        AtomicReference<List<ChatMessage>> capturedMessages = new AtomicReference<>();
+
+        ChatModel capturingModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                capturedMessages.set(chatRequest.messages());
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("summary"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(capturingModel)
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        memory.add(systemMessage("Be helpful."));
+        memory.add(userMessage("What is AI?"));
+        memory.add(aiMessage("AI stands for Artificial Intelligence."));
+        memory.add(userMessage("Explain more."));
+
+        // System message should NOT be included in the summarization request
+        List<ChatMessage> sent = capturedMessages.get();
+        assertThat(sent).isNotNull();
+        assertThat(sent.stream().filter(m -> m instanceof SystemMessage)).isEmpty();
+
+        // The conversation messages should be included, plus the compaction prompt at the end
+        assertThat(sent.get(0)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) sent.get(0)).singleText()).isEqualTo("What is AI?");
+        assertThat(sent.get(1)).isInstanceOf(AiMessage.class);
+        assertThat(sent.get(sent.size() - 1)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) sent.get(sent.size() - 1)).singleText()).contains("Summarize");
+    }
+
+    @Test
+    void should_use_default_executor_when_none_provided() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ChatModel latchModel = new ChatModel() {
+            @Override
+            public ChatResponse doChat(ChatRequest chatRequest) {
+                latch.countDown();
+                return ChatResponse.builder()
+                        .aiMessage(aiMessage("async summary"))
+                        .metadata(ChatResponseMetadata.builder().build())
+                        .build();
+            }
+        };
+
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(latchModel)
+                .build();
+
+        memory.add(userMessage("first"));
+        memory.add(aiMessage("response"));
+        memory.add(userMessage("second"));
+
+        // Wait for the async compaction to complete
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        // Give a small window for the write lock to be released after compaction
+        Thread.sleep(100);
+
+        List<ChatMessage> messages = memory.messages();
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) messages.get(0)).singleText()).isEqualTo("async summary");
+    }
+
+    @Test
+    void should_compact_multiple_rounds_of_conversation() {
+        ChatMemory memory = CompactingChatMemory.builder()
+                .chatModel(summaryModel("round 2 summary"))
+                .executorService(DIRECT_EXECUTOR)
+                .build();
+
+        // First round
+        memory.add(userMessage("Hello"));
+        memory.add(aiMessage("Hi there!"));
+        memory.add(userMessage("How are you?"));
+
+        // After first compaction
+        assertThat(memory.messages()).hasSize(1);
+
+        // Second round: add more messages on top of the summary
+        memory.add(aiMessage("I'm doing well."));
+        memory.add(userMessage("Great to hear!"));
+
+        // After second compaction, still a single message
+        List<ChatMessage> messages = memory.messages();
+        assertThat(messages).hasSize(1);
+        assertThat(((UserMessage) messages.get(0)).singleText())
+                .isEqualTo("round 2 summary");
+    }
+
+    /**
+     * A simple {@link ExecutorService} that runs tasks synchronously on the calling thread.
+     * This makes tests deterministic without needing async waiting.
+     */
+    private static class DirectExecutorService extends java.util.concurrent.AbstractExecutorService {
+
+        private volatile boolean shutdown = false;
+
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Change

The idea of this experiment is providing an alternative `ChatMemory` implementation that uses a configurable `ChatModel` (ideally much smaller and possibly running locally) that at each iteration summarizes all the old `ChatMessage`into a single `UserMessage`. The eventual `SystemMessage` is preserved and skipped by the summarization. 

The compaction process is triggered, on an independent thread, by the addition of a `UserMessage` to the `ChatMemory`. When this thread terminates its work, it atomically replaces the old chat memory with the compacted one. In this way the compaction will be ready for the next iteration and also the sequence of kinds of messages in the memory is always consistent and won't break the conversation.

I understand that this approach may seem naive and I guess that something similar has been already attempted in the past and then discarded. However having a mechanism that allows to reduce the number of tokens consumed during a conversation could be an important differentiator and this solution could be quite effective despite its simplicity. In fact I also added an integration test trying to compare it with a plain `MessageWindowChatMemory` obtaining the following result.

```
=== Comparison ===
MessageWindowChatMemory:
  Final messages in memory: 12
  Total tokens across all turns: 30876
CompactingChatMemory:
  Final messages in memory: 2
  Total tokens across all turns: 19171
Token savings: 37.9% fewer input tokens with CompactingChatMemory
==================
```

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
