### PR TITLE
Add opt-in thinking parsing to Azure chat model

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiChatModel.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiChatModel.java
@@ -7,6 +7,7 @@ import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.model.ModelProvider.AZURE_OPEN_AI;
 import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.aiMessageFrom;
+import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.chatCompletionsWithThinking;
 import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.finishReasonFrom;
 import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.setupSyncClient;
 import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.toAzureOpenAiResponseFormat;
@@ -86,6 +87,7 @@ public class AzureOpenAiChatModel implements ChatModel {
     private final Long seed;
     private final Boolean strictJsonSchema;
     private final Integer maxCompletionTokens;
+    private final Boolean returnThinking;
     private final ReasoningEffortValue reasoningEffort;
 
     private final List<ChatModelListener> listeners;
@@ -166,6 +168,7 @@ public class AzureOpenAiChatModel implements ChatModel {
         this.seed = builder.seed;
         this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
         this.maxCompletionTokens = builder.maxCompletionTokens;
+        this.returnThinking = getOrDefault(builder.returnThinking, false);
         this.reasoningEffort = builder.reasoningEffort;
 
         this.listeners = copy(builder.listeners);
@@ -211,8 +214,18 @@ public class AzureOpenAiChatModel implements ChatModel {
             options.setToolChoice(toToolChoice(parameters.toolChoice()));
         }
 
-        ChatCompletions chatCompletions = AzureOpenAiExceptionMapper.INSTANCE.withExceptionMapper(
-                () -> client.getChatCompletions(parameters.modelName(), options));
+        ChatCompletions chatCompletions;
+        String thinking = null;
+        if (returnThinking) {
+            InternalAzureOpenAiHelper.ChatCompletionsWithThinking response =
+                    AzureOpenAiExceptionMapper.INSTANCE.withExceptionMapper(
+                            () -> chatCompletionsWithThinking(client, parameters.modelName(), options));
+            chatCompletions = response.chatCompletions();
+            thinking = response.thinking();
+        } else {
+            chatCompletions = AzureOpenAiExceptionMapper.INSTANCE.withExceptionMapper(
+                    () -> client.getChatCompletions(parameters.modelName(), options));
+        }
 
         ChatChoice chatChoice = chatCompletions.getChoices().get(0);
 
@@ -227,7 +240,7 @@ public class AzureOpenAiChatModel implements ChatModel {
         }
 
         return ChatResponse.builder()
-                .aiMessage(aiMessageFrom(chatChoice.getMessage()))
+                .aiMessage(aiMessageFrom(chatChoice.getMessage(), thinking))
                 .metadata(ChatResponseMetadata.builder()
                         .id(chatCompletions.getId())
                         .modelName(chatCompletions.getModel())
@@ -279,6 +292,7 @@ public class AzureOpenAiChatModel implements ChatModel {
         private Long seed;
         private ResponseFormat responseFormat;
         private Boolean strictJsonSchema;
+        private Boolean returnThinking;
         private Duration timeout;
         private Integer maxRetries;
         private RetryOptions retryOptions;
@@ -442,6 +456,15 @@ public class AzureOpenAiChatModel implements ChatModel {
 
         public Builder strictJsonSchema(Boolean strictJsonSchema) {
             this.strictJsonSchema = strictJsonSchema;
+            return this;
+        }
+
+        /**
+         * Controls whether to expose provider-specific reasoning text inside {@link dev.langchain4j.data.message.AiMessage#thinking()}.
+         * When disabled, reasoning text (if any) is ignored.
+         */
+        public Builder returnThinking(Boolean returnThinking) {
+            this.returnThinking = returnThinking;
             return this;
         }
 

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
@@ -1,6 +1,5 @@
 package dev.langchain4j.model.azure;
 
-import static dev.langchain4j.data.message.AiMessage.aiMessage;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
@@ -17,12 +16,14 @@ import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.ai.openai.OpenAIServiceVersion;
+import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsFunctionToolCall;
 import com.azure.ai.openai.models.ChatCompletionsFunctionToolDefinition;
 import com.azure.ai.openai.models.ChatCompletionsFunctionToolDefinitionFunction;
 import com.azure.ai.openai.models.ChatCompletionsJsonResponseFormat;
 import com.azure.ai.openai.models.ChatCompletionsJsonSchemaResponseFormat;
 import com.azure.ai.openai.models.ChatCompletionsJsonSchemaResponseFormatJsonSchema;
+import com.azure.ai.openai.models.ChatCompletionsOptions;
 import com.azure.ai.openai.models.ChatCompletionsResponseFormat;
 import com.azure.ai.openai.models.ChatCompletionsTextResponseFormat;
 import com.azure.ai.openai.models.ChatCompletionsToolCall;
@@ -56,6 +57,8 @@ import com.azure.core.http.policy.RetryOptions;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Header;
 import com.azure.core.util.HttpClientOptions;
+import com.azure.json.JsonProviders;
+import com.azure.json.JsonWriter;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -68,6 +71,7 @@ import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.internal.Json;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
@@ -77,6 +81,8 @@ import dev.langchain4j.model.chat.request.json.JsonRawSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
+import java.io.IOException;
+import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
@@ -88,6 +94,10 @@ import java.util.Map;
 
 @Internal
 class InternalAzureOpenAiHelper {
+
+    private static final String REASONING_CONTENT = "reasoning_content";
+    private static final String REASONING_CONTENT_CAMEL_CASE = "reasoningContent";
+    private static final String THINKING = "thinking";
 
     static final String DEFAULT_USER_AGENT = "langchain4j-azure-openai";
 
@@ -379,24 +389,107 @@ class InternalAzureOpenAiHelper {
     }
 
     static AiMessage aiMessageFrom(ChatResponseMessage chatResponseMessage) {
+        return aiMessageFrom(chatResponseMessage, null);
+    }
+
+    static AiMessage aiMessageFrom(ChatResponseMessage chatResponseMessage, String thinking) {
         String text = chatResponseMessage.getContent();
 
         if (isNullOrEmpty(chatResponseMessage.getToolCalls())) {
-            return aiMessage(text);
-        } else {
-            List<ToolExecutionRequest> toolExecutionRequests = chatResponseMessage.getToolCalls().stream()
-                    .filter(toolCall -> toolCall instanceof ChatCompletionsFunctionToolCall)
-                    .map(toolCall -> (ChatCompletionsFunctionToolCall) toolCall)
-                    .map(chatCompletionsFunctionToolCall -> ToolExecutionRequest.builder()
-                            .id(chatCompletionsFunctionToolCall.getId())
-                            .name(chatCompletionsFunctionToolCall.getFunction().getName())
-                            .arguments(chatCompletionsFunctionToolCall
-                                    .getFunction()
-                                    .getArguments())
-                            .build())
-                    .collect(toList());
+            return AiMessage.builder()
+                    .text(isNullOrBlank(text) ? null : text)
+                    .thinking(isNullOrBlank(thinking) ? null : thinking)
+                    .build();
+        }
 
-            return isNullOrBlank(text) ? aiMessage(toolExecutionRequests) : aiMessage(text, toolExecutionRequests);
+        List<ToolExecutionRequest> toolExecutionRequests = chatResponseMessage.getToolCalls().stream()
+                .filter(toolCall -> toolCall instanceof ChatCompletionsFunctionToolCall)
+                .map(toolCall -> (ChatCompletionsFunctionToolCall) toolCall)
+                .map(chatCompletionsFunctionToolCall -> ToolExecutionRequest.builder()
+                        .id(chatCompletionsFunctionToolCall.getId())
+                        .name(chatCompletionsFunctionToolCall.getFunction().getName())
+                        .arguments(chatCompletionsFunctionToolCall.getFunction().getArguments())
+                        .build())
+                .collect(toList());
+
+        return AiMessage.builder()
+                .text(isNullOrBlank(text) ? null : text)
+                .thinking(isNullOrBlank(thinking) ? null : thinking)
+                .toolExecutionRequests(toolExecutionRequests)
+                .build();
+    }
+
+    static ChatCompletionsWithThinking chatCompletionsWithThinking(
+            OpenAIClient client, String deploymentName, ChatCompletionsOptions options) {
+        String responseJson = client.getChatCompletionsWithResponse(deploymentName, requestBodyFrom(options), null)
+                .getValue()
+                .toString();
+
+        try (var jsonReader = JsonProviders.createReader(responseJson)) {
+            return new ChatCompletionsWithThinking(ChatCompletions.fromJson(jsonReader), thinkingFrom(responseJson));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse Azure OpenAI chat completions response", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static String thinkingFrom(String responseJson) {
+        Map<String, Object> root = Json.fromJson(responseJson, Map.class);
+        Object choicesObject = root.get("choices");
+        if (!(choicesObject instanceof List<?> choices) || choices.isEmpty()) {
+            return null;
+        }
+
+        Object firstChoiceObject = choices.get(0);
+        if (!(firstChoiceObject instanceof Map<?, ?> firstChoice)) {
+            return null;
+        }
+
+        Object messageObject = firstChoice.get("message");
+        if (!(messageObject instanceof Map<?, ?> message)) {
+            return null;
+        }
+
+        return firstNonBlankString(message, REASONING_CONTENT, REASONING_CONTENT_CAMEL_CASE, THINKING);
+    }
+
+    private static BinaryData requestBodyFrom(ChatCompletionsOptions options) {
+        StringWriter stringWriter = new StringWriter();
+        try (JsonWriter jsonWriter = JsonProviders.createWriter(stringWriter)) {
+            options.toJson(jsonWriter);
+            jsonWriter.flush();
+            return BinaryData.fromString(stringWriter.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialize Azure OpenAI chat completions request", e);
+        }
+    }
+
+    private static String firstNonBlankString(Map<?, ?> values, String... keys) {
+        for (String key : keys) {
+            Object value = values.get(key);
+            if (value instanceof String stringValue && !isNullOrBlank(stringValue)) {
+                return stringValue;
+            }
+        }
+        return null;
+    }
+
+    static final class ChatCompletionsWithThinking {
+
+        private final ChatCompletions chatCompletions;
+        private final String thinking;
+
+        private ChatCompletionsWithThinking(ChatCompletions chatCompletions, String thinking) {
+            this.chatCompletions = chatCompletions;
+            this.thinking = thinking;
+        }
+
+        ChatCompletions chatCompletions() {
+            return chatCompletions;
+        }
+
+        String thinking() {
+            return thinking;
         }
     }
 

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.model.azure;
 
 import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.aiMessageFrom;
+import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.thinkingFrom;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.azure.ai.openai.OpenAIAsyncClient;
@@ -176,6 +177,72 @@ class InternalAzureOpenAiHelperTest {
                         .name(functionName)
                         .arguments(functionArguments)
                         .build());
+    }
+
+    @Test
+    void whenThinkingIsProvidedShouldReturnAiMessageWithThinking() throws IOException {
+
+        // language=json
+        String responseJson =
+                """
+                {
+                  "role": "ASSISTANT",
+                  "content": "Hello",
+                  "reasoning_content": "Let me think first"
+                }
+                """;
+
+        ChatResponseMessage responseMessage;
+        try (JsonReader jsonReader = DefaultJsonReader.fromString(responseJson, new JsonOptions())) {
+            responseMessage = ChatResponseMessage.fromJson(jsonReader);
+        }
+
+        AiMessage aiMessage = aiMessageFrom(responseMessage, "Let me think first");
+
+        assertThat(aiMessage.text()).isEqualTo("Hello");
+        assertThat(aiMessage.thinking()).isEqualTo("Let me think first");
+        assertThat(aiMessage.toolExecutionRequests()).isEmpty();
+    }
+
+    @Test
+    void thinkingFrom_shouldExtractReasoningContent() {
+        // language=json
+        String responseJson =
+                """
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "role": "assistant",
+                        "content": "Answer",
+                        "reasoning_content": "Let me think first"
+                      }
+                    }
+                  ]
+                }
+                """;
+
+        assertThat(thinkingFrom(responseJson)).isEqualTo("Let me think first");
+    }
+
+    @Test
+    void thinkingFrom_shouldReturnNullWhenReasoningContentIsMissing() {
+        // language=json
+        String responseJson =
+                """
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "role": "assistant",
+                        "content": "Answer"
+                      }
+                    }
+                  ]
+                }
+                """;
+
+        assertThat(thinkingFrom(responseJson)).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Issue
Related to #3637

## Change
- add `returnThinking(Boolean)` to `AzureOpenAiChatModel.Builder`, mirroring the existing opt-in behavior in `langchain4j-open-ai`
- when `returnThinking` is enabled, call the Azure SDK raw `BinaryData` chat-completions response path once, parse the normal typed response from the raw JSON, and extract `reasoning_content` into `AiMessage.thinking()`
- keep the default behavior unchanged when `returnThinking` is not enabled
- add focused regression tests for thinking extraction and `AiMessage` mapping

## Notes
- this PR intentionally fixes the synchronous `AzureOpenAiChatModel` path first, which is the reproduction path in the issue
- I did not change `AzureOpenAiStreamingChatModel` here because the current Azure Chat Completions streaming SDK surface still drops unknown reasoning fields from the typed delta model
- I kept reasoning exposure opt-in to avoid changing Azure defaults and to stay aligned with the existing OpenAI module behavior

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for big features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root pom.xml and langchain4j-bom/pom.xml

## Checklist for adding new embedding store integration
- [ ] I have added a {NameOfIntegration}EmbeddingStoreIT ...
- [ ] I have added a {NameOfIntegration}EmbeddingStoreRemovalIT ...

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the {NameOfIntegration}EmbeddingStore works correctly ...

## Verification
- `./mvnw.cmd -pl langchain4j-azure-open-ai test`
- `./mvnw.cmd -pl langchain4j-azure-open-ai -Dtest=InternalAzureOpenAiHelperTest test`
- `./mvnw.cmd -pl langchain4j-azure-open-ai -Pspotless com.diffplug.spotless:spotless-maven-plugin:2.44.4:check`