### PR TITLE
Add thinking support to OpenAI Official chat completions

### DIFF
--- a/docs/docs/integrations/language-models/open-ai-official.md
+++ b/docs/docs/integrations/language-models/open-ai-official.md
@@ -235,6 +235,32 @@ OpenAiChatModel.builder()
 
 In this case AI Service will automatically generate a JSON schema from the given POJO and pass it to the LLM.
 
+## Thinking / Reasoning
+
+The chat-completions integration can also return reasoning text for OpenAI-compatible providers that expose it in
+the SDK additional properties.
+
+When `returnThinking(true)` is enabled while building `OpenAiOfficialChatModel` or `OpenAiOfficialStreamingChatModel`,
+LangChain4j will extract reasoning from compatible fields such as `reasoning_content`, `reasoningContent`, or
+`thinking` and store it in `AiMessage.thinking()`.
+
+When `returnThinking(true)` is enabled for `OpenAiOfficialStreamingChatModel`, the
+`StreamingChatResponseHandler.onPartialThinking()` and `TokenStream.onPartialThinking()` callbacks will also be
+invoked when reasoning chunks are present.
+
+Here is an example with an OpenAI reasoning-capable model:
+
+```java
+ChatModel model = OpenAiOfficialChatModel.builder()
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .modelName("o4-mini")
+        .defaultRequestParameters(OpenAiOfficialChatRequestParameters.builder()
+                .reasoningEffort("medium")
+                .build())
+        .returnThinking(true)
+        .build();
+```
+
 ## Configuring the models for streaming
 
 :::note

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -66,6 +66,10 @@ import java.util.stream.Collectors;
 
 class InternalOpenAiOfficialHelper {
 
+    private static final String REASONING_CONTENT = "reasoning_content";
+    private static final String REASONING_CONTENT_CAMEL_CASE = "reasoningContent";
+    private static final String THINKING = "thinking";
+
     static List<ChatCompletionMessageParam> toOpenAiMessages(List<ChatMessage> messages) {
         return messages.stream()
                 .map(InternalOpenAiOfficialHelper::toOpenAiMessage)
@@ -229,8 +233,13 @@ class InternalOpenAiOfficialHelper {
     }
 
     static AiMessage aiMessageFrom(ChatCompletion chatCompletion) {
+        return aiMessageFrom(chatCompletion, false);
+    }
+
+    static AiMessage aiMessageFrom(ChatCompletion chatCompletion, boolean returnThinking) {
         ChatCompletionMessage assistantMessage = chatCompletion.choices().get(0).message();
         Optional<String> text = assistantMessage.content();
+        String thinking = returnThinking ? thinkingFrom(assistantMessage) : null;
 
         Optional<List<ChatCompletionMessageToolCall>> toolCalls = assistantMessage.toolCalls();
         if (toolCalls.isPresent()) {
@@ -240,15 +249,52 @@ class InternalOpenAiOfficialHelper {
                     .collect(toList());
 
             if (text.isEmpty()) {
-                return AiMessage.from(toolExecutionRequests);
+                return AiMessage.builder()
+                        .thinking(thinking)
+                        .toolExecutionRequests(toolExecutionRequests)
+                        .build();
             } else if (toolExecutionRequests.isEmpty()) {
-                return AiMessage.from(text.get());
+                return AiMessage.builder().text(text.get()).thinking(thinking).build();
             } else {
-                return AiMessage.from(text.get(), toolExecutionRequests);
+                return AiMessage.builder()
+                        .text(text.get())
+                        .thinking(thinking)
+                        .toolExecutionRequests(toolExecutionRequests)
+                        .build();
             }
         }
 
-        return AiMessage.from(text.orElse(""));
+        return AiMessage.builder().text(text.orElse("")).thinking(thinking).build();
+    }
+
+    static String thinkingFrom(ChatCompletionMessage assistantMessage) {
+        return thinkingFrom(assistantMessage._additionalProperties());
+    }
+
+    static String thinkingFrom(ChatCompletionChunk.Choice.Delta delta) {
+        return thinkingFrom(delta._additionalProperties());
+    }
+
+    private static String thinkingFrom(Map<String, JsonValue> additionalProperties) {
+        return firstNonBlankString(additionalProperties, REASONING_CONTENT, REASONING_CONTENT_CAMEL_CASE, THINKING);
+    }
+
+    private static String firstNonBlankString(Map<String, JsonValue> additionalProperties, String... keys) {
+        for (String key : keys) {
+            JsonValue value = additionalProperties.get(key);
+            if (value == null) {
+                continue;
+            }
+            try {
+                String stringValue = value.convert(String.class);
+                if (stringValue != null && !stringValue.isBlank()) {
+                    return stringValue;
+                }
+            } catch (Exception ignored) {
+                // Ignore non-string provider-specific values.
+            }
+        }
+        return null;
     }
 
     private static ToolExecutionRequest toToolExecutionRequest(ChatCompletionMessageToolCall toolCall) {

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -69,6 +69,11 @@ class InternalOpenAiOfficialHelper {
     private static final String REASONING_CONTENT = "reasoning_content";
     private static final String REASONING_CONTENT_CAMEL_CASE = "reasoningContent";
     private static final String THINKING = "thinking";
+    // OpenAI-compatible providers do not expose reasoning consistently:
+    // some use snake_case, some camelCase, and some a plain `thinking` field.
+    private static final String[] THINKING_PROPERTY_NAMES = {
+        REASONING_CONTENT, REASONING_CONTENT_CAMEL_CASE, THINKING
+    };
 
     static List<ChatCompletionMessageParam> toOpenAiMessages(List<ChatMessage> messages) {
         return messages.stream()
@@ -276,7 +281,7 @@ class InternalOpenAiOfficialHelper {
     }
 
     private static String thinkingFrom(Map<String, JsonValue> additionalProperties) {
-        return firstNonBlankString(additionalProperties, REASONING_CONTENT, REASONING_CONTENT_CAMEL_CASE, THINKING);
+        return firstNonBlankString(additionalProperties, THINKING_PROPERTY_NAMES);
     }
 
     private static String firstNonBlankString(Map<String, JsonValue> additionalProperties, String... keys) {

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -71,9 +71,7 @@ class InternalOpenAiOfficialHelper {
     private static final String THINKING = "thinking";
     // OpenAI-compatible providers do not expose reasoning consistently:
     // some use snake_case, some camelCase, and some a plain `thinking` field.
-    private static final String[] THINKING_PROPERTY_NAMES = {
-        REASONING_CONTENT, REASONING_CONTENT_CAMEL_CASE, THINKING
-    };
+    private static final String[] THINKING_PROPERTY_NAMES = {REASONING_CONTENT, REASONING_CONTENT_CAMEL_CASE, THINKING};
 
     static List<ChatCompletionMessageParam> toOpenAiMessages(List<ChatMessage> messages) {
         return messages.stream()

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialChatModel.java
@@ -28,6 +28,8 @@ import java.util.Set;
 
 public class OpenAiOfficialChatModel extends OpenAiOfficialBaseChatModel implements ChatModel {
 
+    private final boolean returnThinking;
+
     public OpenAiOfficialChatModel(Builder builder) {
 
         if (builder.openAIClient != null) {
@@ -70,6 +72,7 @@ public class OpenAiOfficialChatModel extends OpenAiOfficialBaseChatModel impleme
                     false);
         }
         this.modelName = builder.modelName;
+        this.returnThinking = builder.returnThinking != null && builder.returnThinking;
     }
 
     @Override
@@ -124,7 +127,7 @@ public class OpenAiOfficialChatModel extends OpenAiOfficialBaseChatModel impleme
         }
 
         return ChatResponse.builder()
-                .aiMessage(aiMessageFrom(chatCompletion))
+                .aiMessage(aiMessageFrom(chatCompletion, returnThinking))
                 .metadata(responseMetadataBuilder.build())
                 .build();
     }
@@ -171,6 +174,7 @@ public class OpenAiOfficialChatModel extends OpenAiOfficialBaseChatModel impleme
         private Map<String, String> customHeaders;
         private List<ChatModelListener> listeners;
         private Set<Capability> capabilities;
+        private Boolean returnThinking;
 
         public Builder() {
             // This is public so it can be extended
@@ -302,6 +306,16 @@ public class OpenAiOfficialChatModel extends OpenAiOfficialBaseChatModel impleme
 
         public Builder strictJsonSchema(Boolean strictJsonSchema) {
             this.strictJsonSchema = strictJsonSchema;
+            return this;
+        }
+
+        /**
+         * Controls whether to return thinking/reasoning text (if available) inside {@link AiMessage#thinking()}.
+         * <p>
+         * If enabled, the thinking text will be stored within the {@link AiMessage} and may be persisted.
+         */
+        public Builder returnThinking(Boolean returnThinking) {
+            this.returnThinking = returnThinking;
             return this;
         }
 

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialChatModel.java
@@ -10,6 +10,7 @@ import com.openai.client.OpenAIClient;
 import com.openai.credential.Credential;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.TokenCountEstimator;

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialChatModel.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.openaiofficial;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.aiMessageFrom;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.finishReasonFrom;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.toOpenAiChatCompletionCreateParams;
@@ -73,7 +74,7 @@ public class OpenAiOfficialChatModel extends OpenAiOfficialBaseChatModel impleme
                     false);
         }
         this.modelName = builder.modelName;
-        this.returnThinking = builder.returnThinking != null && builder.returnThinking;
+        this.returnThinking = getOrDefault(builder.returnThinking, false);
     }
 
     @Override

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialStreamingChatModel.java
@@ -2,9 +2,11 @@ package dev.langchain4j.model.openaiofficial;
 
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteToolCall;
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialResponse;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialThinking;
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialToolCall;
 import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.finishReasonFrom;
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.thinkingFrom;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.toOpenAiChatCompletionCreateParams;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.tokenUsageFrom;
 
@@ -27,6 +29,7 @@ import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.response.StreamingHandle;
@@ -39,6 +42,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatModel implements StreamingChatModel {
+
+    private final boolean returnThinking;
 
     public OpenAiOfficialStreamingChatModel(Builder builder) {
 
@@ -82,6 +87,7 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
                     true);
         }
         this.modelName = builder.modelName;
+        this.returnThinking = builder.returnThinking != null && builder.returnThinking;
     }
 
     @Override
@@ -109,6 +115,7 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
                     OpenAiOfficialChatResponseMetadata.builder();
 
             StringBuffer textBuilder = new StringBuffer();
+            StringBuffer thinkingBuilder = new StringBuffer();
             ToolCallBuilder toolCallBuilder = new ToolCallBuilder();
             AtomicReference<StreamingHandle> streamingHandle = new AtomicReference<>();
 
@@ -126,6 +133,7 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
                                     streamingHandle.get(),
                                     responseMetadataBuilder,
                                     textBuilder,
+                                    thinkingBuilder,
                                     toolCallBuilder);
                         }
 
@@ -143,9 +151,11 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
                                 }
 
                                 String text = textBuilder.toString();
+                                String thinking = thinkingBuilder.toString();
 
                                 AiMessage aiMessage = AiMessage.builder()
                                         .text(text.isEmpty() ? null : text)
+                                        .thinking(thinking.isEmpty() ? null : thinking)
                                         .toolExecutionRequests(toolCallBuilder.allRequests())
                                         .build();
 
@@ -171,6 +181,7 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
             StreamingHandle streamingHandle,
             OpenAiOfficialChatResponseMetadata.Builder responseMetadataBuilder,
             StringBuffer text,
+            StringBuffer thinking,
             ToolCallBuilder toolCallBuilder) {
 
         responseMetadataBuilder.id(chatCompletionChunk.id());
@@ -194,6 +205,11 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
                 String partialResponse = choice.delta().content().get();
                 text.append(partialResponse);
                 onPartialResponse(handler, partialResponse, streamingHandle);
+            }
+            String partialThinking = returnThinking ? thinkingFrom(choice.delta()) : null;
+            if (isNotNullOrEmpty(partialThinking)) {
+                thinking.append(partialThinking);
+                onPartialThinking(handler, partialThinking, streamingHandle);
             }
             if (choice.delta().toolCalls().isPresent()) {
                 for (ChatCompletionChunk.Choice.Delta.ToolCall toolCall :
@@ -274,6 +290,7 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
         private Map<String, String> customHeaders;
         private List<ChatModelListener> listeners;
         private Set<Capability> capabilities;
+        private Boolean returnThinking;
 
         public Builder() {
             // This is public so it can be extended
@@ -405,6 +422,17 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
 
         public Builder strictJsonSchema(Boolean strictJsonSchema) {
             this.strictJsonSchema = strictJsonSchema;
+            return this;
+        }
+
+        /**
+         * Controls whether to return thinking/reasoning text (if available) inside {@link AiMessage#thinking()}
+         * and whether to invoke the {@link StreamingChatResponseHandler#onPartialThinking(PartialThinking)} callback.
+         * <p>
+         * If enabled, the thinking text will be stored within the {@link AiMessage} and may be persisted.
+         */
+        public Builder returnThinking(Boolean returnThinking) {
+            this.returnThinking = returnThinking;
             return this;
         }
 

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialStreamingChatModel.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialResponse;
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialThinking;
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialToolCall;
+import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.finishReasonFrom;
 import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.thinkingFrom;
@@ -87,7 +88,7 @@ public class OpenAiOfficialStreamingChatModel extends OpenAiOfficialBaseChatMode
                     true);
         }
         this.modelName = builder.modelName;
-        this.returnThinking = builder.returnThinking != null && builder.returnThinking;
+        this.returnThinking = getOrDefault(builder.returnThinking, false);
     }
 
     @Override

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
@@ -1,0 +1,67 @@
+package dev.langchain4j.model.openaiofficial;
+
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.aiMessageFrom;
+import static dev.langchain4j.model.openaiofficial.InternalOpenAiOfficialHelper.thinkingFrom;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openai.core.JsonValue;
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionChunk;
+import com.openai.models.chat.completions.ChatCompletionMessage;
+import org.junit.jupiter.api.Test;
+
+class InternalOpenAiOfficialHelperTest {
+
+    @Test
+    void should_include_thinking_content_when_returnThinking_is_true() {
+        ChatCompletion chatCompletion = chatCompletionWithReasoning("Let me think first");
+
+        assertThat(aiMessageFrom(chatCompletion, true).thinking()).isEqualTo("Let me think first");
+        assertThat(aiMessageFrom(chatCompletion, true).text()).isEqualTo("Answer");
+    }
+
+    @Test
+    void should_exclude_thinking_content_when_returnThinking_is_false() {
+        ChatCompletion chatCompletion = chatCompletionWithReasoning("Let me think first");
+
+        assertThat(aiMessageFrom(chatCompletion, false).thinking()).isNull();
+    }
+
+    @Test
+    void should_extract_thinking_from_streaming_delta() {
+        ChatCompletionChunk.Choice.Delta delta = ChatCompletionChunk.Choice.Delta.builder()
+                .content("Answer")
+                .putAdditionalProperty("reasoning_content", JsonValue.from("Let me think first"))
+                .build();
+
+        assertThat(thinkingFrom(delta)).isEqualTo("Let me think first");
+    }
+
+    @Test
+    void should_return_null_when_streaming_delta_has_no_thinking() {
+        ChatCompletionChunk.Choice.Delta delta =
+                ChatCompletionChunk.Choice.Delta.builder().content("Answer").build();
+
+        assertThat(thinkingFrom(delta)).isNull();
+    }
+
+    private static ChatCompletion chatCompletionWithReasoning(String reasoningContent) {
+        return ChatCompletion.builder()
+                .id("chatcmpl-1")
+                .created(1L)
+                .model("gpt-4.1")
+                .object_(JsonValue.from("chat.completion"))
+                .addChoice(ChatCompletion.Choice.builder()
+                        .index(0)
+                        .finishReason(ChatCompletion.Choice.FinishReason.STOP)
+                        .logprobs((ChatCompletion.Choice.Logprobs) null)
+                        .message(ChatCompletionMessage.builder()
+                                .role(JsonValue.from("assistant"))
+                                .content("Answer")
+                                .refusal((String) null)
+                                .putAdditionalProperty("reasoning_content", JsonValue.from(reasoningContent))
+                                .build())
+                        .build())
+                .build();
+    }
+}

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialChatModelThinkingIT.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialChatModelThinkingIT.java
@@ -1,0 +1,62 @@
+package dev.langchain4j.model.openaiofficial.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatRequestParameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class OpenAiOfficialChatModelThinkingIT {
+
+    @Test
+    void should_return_thinking() {
+
+        // given
+        ChatModel model = createModel(true);
+
+        // when
+        ChatResponse chatResponse = model.chat(UserMessage.from("What is the capital of Germany?"));
+
+        // then
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
+        assertThat(aiMessage.thinking()).isNotBlank();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(booleans = false)
+    void should_not_return_thinking(Boolean returnThinking) {
+
+        // given
+        ChatModel model = createModel(returnThinking);
+
+        // when
+        ChatResponse chatResponse = model.chat(UserMessage.from("What is the capital of Germany?"));
+
+        // then
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
+        assertThat(aiMessage.thinking()).isNull();
+    }
+
+    private static ChatModel createModel(Boolean returnThinking) {
+        return OpenAiOfficialChatModel.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .modelName("o4-mini")
+                .defaultRequestParameters(OpenAiOfficialChatRequestParameters.builder()
+                        .reasoningEffort("medium")
+                        .build())
+                .returnThinking(returnThinking)
+                .build();
+    }
+}

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialStreamingChatModelThinkingIT.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialStreamingChatModelThinkingIT.java
@@ -37,9 +37,7 @@ class OpenAiOfficialStreamingChatModelThinkingIT {
         // then
         AiMessage aiMessage = spyHandler.get().aiMessage();
         assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
-        assertThat(aiMessage.thinking())
-                .isNotBlank()
-                .isEqualTo(spyHandler.getThinking());
+        assertThat(aiMessage.thinking()).isNotBlank().isEqualTo(spyHandler.getThinking());
 
         InOrder inOrder = inOrder(spyHandler);
         inOrder.verify(spyHandler).get();

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialStreamingChatModelThinkingIT.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialStreamingChatModelThinkingIT.java
@@ -1,0 +1,84 @@
+package dev.langchain4j.model.openaiofficial.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialChatRequestParameters;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialStreamingChatModel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InOrder;
+
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class OpenAiOfficialStreamingChatModelThinkingIT {
+
+    @Test
+    void should_return_thinking() {
+
+        // given
+        StreamingChatModel model = createModel(true);
+
+        // when
+        TestStreamingChatResponseHandler spyHandler = spy(new TestStreamingChatResponseHandler());
+        model.chat("What is the capital of Germany?", spyHandler);
+
+        // then
+        AiMessage aiMessage = spyHandler.get().aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
+        assertThat(aiMessage.thinking())
+                .isNotBlank()
+                .isEqualTo(spyHandler.getThinking());
+
+        InOrder inOrder = inOrder(spyHandler);
+        inOrder.verify(spyHandler).get();
+        inOrder.verify(spyHandler, atLeastOnce()).onPartialThinking(any(), any());
+        inOrder.verify(spyHandler, atLeastOnce()).onPartialResponse(any(), any());
+        inOrder.verify(spyHandler).onCompleteResponse(any());
+        inOrder.verify(spyHandler).getThinking();
+        inOrder.verifyNoMoreInteractions();
+        verifyNoMoreInteractions(spyHandler);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(booleans = false)
+    void should_not_return_thinking(Boolean returnThinking) {
+
+        // given
+        StreamingChatModel model = createModel(returnThinking);
+
+        // when
+        TestStreamingChatResponseHandler spyHandler = spy(new TestStreamingChatResponseHandler());
+        model.chat("What is the capital of Germany?", spyHandler);
+
+        // then
+        AiMessage aiMessage = spyHandler.get().aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
+        assertThat(aiMessage.thinking()).isNull();
+
+        verify(spyHandler, never()).onPartialThinking(any(), any());
+    }
+
+    private static StreamingChatModel createModel(Boolean returnThinking) {
+        return OpenAiOfficialStreamingChatModel.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .modelName("o4-mini")
+                .defaultRequestParameters(OpenAiOfficialChatRequestParameters.builder()
+                        .reasoningEffort("medium")
+                        .build())
+                .returnThinking(returnThinking)
+                .build();
+    }
+}


### PR DESCRIPTION
﻿## Issue
Related to #3637

## Change
- add opt-in `returnThinking(Boolean)` support to `OpenAiOfficialChatModel.Builder` and `OpenAiOfficialStreamingChatModel.Builder`
- extract reasoning content from OpenAI SDK additional properties and map it into `AiMessage.thinking()` for the chat-completions sync path
- surface chat-completions streaming reasoning through `StreamingChatResponseHandler.onPartialThinking(...)` and the final `AiMessage.thinking()` when `returnThinking(true)` is enabled
- add focused regression tests for sync and streaming reasoning extraction helpers

## Notes
- this follow-up intentionally targets only the `open-ai-official` chat-completions path requested in #3637
- it avoids overlapping with `#4542`, which is already covering the Responses streaming path
- default behavior remains unchanged when `returnThinking` is not enabled

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for big features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

## Verification
- `./mvnw.cmd -pl langchain4j-open-ai-official test`
- `./mvnw.cmd -pl langchain4j-open-ai-official -Dtest=InternalOpenAiOfficialHelperTest test`
- `./mvnw.cmd -pl langchain4j-open-ai-official -Pspotless com.diffplug.spotless:spotless-maven-plugin:2.44.4:check`
