### PR TITLE
Tavily: add missing Search API parameters (#4771)

### DIFF
--- a/web-search-engines/langchain4j-web-search-engine-tavily/src/main/java/dev/langchain4j/web/search/tavily/TavilyResponse.java
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/src/main/java/dev/langchain4j/web/search/tavily/TavilyResponse.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.web.search.tavily;
 
 import java.util.List;
+import java.util.Map;
 
 class TavilyResponse {
 
@@ -10,18 +11,32 @@ class TavilyResponse {
     private List<String> images;
     private List<String> followUpQuestions;
     private List<TavilySearchResult> results;
+    private Map<String, Object> autoParameters;
+    private Map<String, Object> usage;
+    private String requestId;
 
-    public TavilyResponse(String answer, String query, Double responseTime, List<String> images, List<String> followUpQuestions, List<TavilySearchResult> results) {
+    public TavilyResponse(
+            String answer,
+            String query,
+            Double responseTime,
+            List<String> images,
+            List<String> followUpQuestions,
+            List<TavilySearchResult> results,
+            Map<String, Object> autoParameters,
+            Map<String, Object> usage,
+            String requestId) {
         this.answer = answer;
         this.query = query;
         this.responseTime = responseTime;
         this.images = images;
         this.followUpQuestions = followUpQuestions;
         this.results = results;
+        this.autoParameters = autoParameters;
+        this.usage = usage;
+        this.requestId = requestId;
     }
 
-    public TavilyResponse() {
-    }
+    public TavilyResponse() {}
 
     public static TavilyResponseBuilder builder() {
         return new TavilyResponseBuilder();
@@ -51,6 +66,18 @@ class TavilyResponse {
         return this.results;
     }
 
+    public Map<String, Object> getAutoParameters() {
+        return this.autoParameters;
+    }
+
+    public Map<String, Object> getUsage() {
+        return this.usage;
+    }
+
+    public String getRequestId() {
+        return this.requestId;
+    }
+
     public static class TavilyResponseBuilder {
         private String answer;
         private String query;
@@ -58,9 +85,11 @@ class TavilyResponse {
         private List<String> images;
         private List<String> followUpQuestions;
         private List<TavilySearchResult> results;
+        private Map<String, Object> autoParameters;
+        private Map<String, Object> usage;
+        private String requestId;
 
-        TavilyResponseBuilder() {
-        }
+        TavilyResponseBuilder() {}
 
         public TavilyResponseBuilder answer(String answer) {
             this.answer = answer;
@@ -92,12 +121,39 @@ class TavilyResponse {
             return this;
         }
 
+        public TavilyResponseBuilder autoParameters(Map<String, Object> autoParameters) {
+            this.autoParameters = autoParameters;
+            return this;
+        }
+
+        public TavilyResponseBuilder usage(Map<String, Object> usage) {
+            this.usage = usage;
+            return this;
+        }
+
+        public TavilyResponseBuilder requestId(String requestId) {
+            this.requestId = requestId;
+            return this;
+        }
+
         public TavilyResponse build() {
-            return new TavilyResponse(this.answer, this.query, this.responseTime, this.images, this.followUpQuestions, this.results);
+            return new TavilyResponse(
+                    this.answer,
+                    this.query,
+                    this.responseTime,
+                    this.images,
+                    this.followUpQuestions,
+                    this.results,
+                    this.autoParameters,
+                    this.usage,
+                    this.requestId);
         }
 
         public String toString() {
-            return "TavilyResponse.TavilyResponseBuilder(answer=" + this.answer + ", query=" + this.query + ", responseTime=" + this.responseTime + ", images=" + this.images + ", followUpQuestions=" + this.followUpQuestions + ", results=" + this.results + ")";
+            return "TavilyResponse.TavilyResponseBuilder(answer=" + this.answer + ", query=" + this.query
+                    + ", responseTime=" + this.responseTime + ", images=" + this.images + ", followUpQuestions="
+                    + this.followUpQuestions + ", results=" + this.results + ", autoParameters=" + this.autoParameters
+                    + ", usage=" + this.usage + ", requestId=" + this.requestId + ")";
         }
     }
 }

--- a/web-search-engines/langchain4j-web-search-engine-tavily/src/main/java/dev/langchain4j/web/search/tavily/TavilySearchRequest.java
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/src/main/java/dev/langchain4j/web/search/tavily/TavilySearchRequest.java
@@ -12,8 +12,38 @@ class TavilySearchRequest {
     private Integer maxResults;
     private List<String> includeDomains;
     private List<String> excludeDomains;
+    private String topic;
+    private String timeRange;
+    private String startDate;
+    private String endDate;
+    private Boolean includeImages;
+    private Boolean includeImageDescriptions;
+    private Boolean includeFavicon;
+    private String country;
+    private Integer chunksPerSource;
+    private Boolean autoParameters;
+    private Boolean exactMatch;
 
-    TavilySearchRequest(String apiKey, String query, String searchDepth, Boolean includeAnswer, Boolean includeRawContent, Integer maxResults, List<String> includeDomains, List<String> excludeDomains) {
+    TavilySearchRequest(
+            String apiKey,
+            String query,
+            String searchDepth,
+            Boolean includeAnswer,
+            Boolean includeRawContent,
+            Integer maxResults,
+            List<String> includeDomains,
+            List<String> excludeDomains,
+            String topic,
+            String timeRange,
+            String startDate,
+            String endDate,
+            Boolean includeImages,
+            Boolean includeImageDescriptions,
+            Boolean includeFavicon,
+            String country,
+            Integer chunksPerSource,
+            Boolean autoParameters,
+            Boolean exactMatch) {
         this.apiKey = apiKey;
         this.query = query;
         this.searchDepth = searchDepth;
@@ -22,6 +52,17 @@ class TavilySearchRequest {
         this.maxResults = maxResults;
         this.includeDomains = includeDomains;
         this.excludeDomains = excludeDomains;
+        this.topic = topic;
+        this.timeRange = timeRange;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.includeImages = includeImages;
+        this.includeImageDescriptions = includeImageDescriptions;
+        this.includeFavicon = includeFavicon;
+        this.country = country;
+        this.chunksPerSource = chunksPerSource;
+        this.autoParameters = autoParameters;
+        this.exactMatch = exactMatch;
     }
 
     public static TavilySearchRequestBuilder builder() {
@@ -60,6 +101,50 @@ class TavilySearchRequest {
         return this.excludeDomains;
     }
 
+    public String getTopic() {
+        return this.topic;
+    }
+
+    public String getTimeRange() {
+        return this.timeRange;
+    }
+
+    public String getStartDate() {
+        return this.startDate;
+    }
+
+    public String getEndDate() {
+        return this.endDate;
+    }
+
+    public Boolean getIncludeImages() {
+        return this.includeImages;
+    }
+
+    public Boolean getIncludeImageDescriptions() {
+        return this.includeImageDescriptions;
+    }
+
+    public Boolean getIncludeFavicon() {
+        return this.includeFavicon;
+    }
+
+    public String getCountry() {
+        return this.country;
+    }
+
+    public Integer getChunksPerSource() {
+        return this.chunksPerSource;
+    }
+
+    public Boolean getAutoParameters() {
+        return this.autoParameters;
+    }
+
+    public Boolean getExactMatch() {
+        return this.exactMatch;
+    }
+
     public static class TavilySearchRequestBuilder {
         private String apiKey;
         private String query;
@@ -69,9 +154,19 @@ class TavilySearchRequest {
         private Integer maxResults;
         private List<String> includeDomains;
         private List<String> excludeDomains;
+        private String topic;
+        private String timeRange;
+        private String startDate;
+        private String endDate;
+        private Boolean includeImages;
+        private Boolean includeImageDescriptions;
+        private Boolean includeFavicon;
+        private String country;
+        private Integer chunksPerSource;
+        private Boolean autoParameters;
+        private Boolean exactMatch;
 
-        TavilySearchRequestBuilder() {
-        }
+        TavilySearchRequestBuilder() {}
 
         public TavilySearchRequestBuilder apiKey(String apiKey) {
             this.apiKey = apiKey;
@@ -113,12 +208,94 @@ class TavilySearchRequest {
             return this;
         }
 
+        public TavilySearchRequestBuilder topic(String topic) {
+            this.topic = topic;
+            return this;
+        }
+
+        public TavilySearchRequestBuilder timeRange(String timeRange) {
+            this.timeRange = timeRange;
+            return this;
+        }
+
+        public TavilySearchRequestBuilder startDate(String startDate) {
+            this.startDate = startDate;
+            return this;
+        }
+
+        public TavilySearchRequestBuilder endDate(String endDate) {
+            this.endDate = endDate;
+            return this;
+        }
+
+        public TavilySearchRequestBuilder includeImages(Boolean includeImages) {
+            this.includeImages = includeImages;
+            return this;
+        }
+
+        public TavilySearchRequestBuilder includeImageDescriptions(Boolean includeImageDescriptions) {
+            this.includeImageDescriptions = includeImageDescriptions;
+            return this;
+        }
+
+        public TavilySearchRequestBuilder includeFavicon(Boolean includeFavicon) {
+            this.includeFavicon = includeFavicon;
+            return this;
+        }
+
+        public TavilySearchRequestBuilder country(String country) {
+            this.country = country;
+            return this;
+        }
+
+        public TavilySearchRequestBuilder chunksPerSource(Integer chunksPerSource) {
+            this.chunksPerSource = chunksPerSource;
+            return this;
+        }
+
+        public TavilySearchRequestBuilder autoParameters(Boolean autoParameters) {
+            this.autoParameters = autoParameters;
+            return this;
+        }
+
+        public TavilySearchRequestBuilder exactMatch(Boolean exactMatch) {
+            this.exactMatch = exactMatch;
+            return this;
+        }
+
         public TavilySearchRequest build() {
-            return new TavilySearchRequest(this.apiKey, this.query, this.searchDepth, this.includeAnswer, this.includeRawContent, this.maxResults, this.includeDomains, this.excludeDomains);
+            return new TavilySearchRequest(
+                    this.apiKey,
+                    this.query,
+                    this.searchDepth,
+                    this.includeAnswer,
+                    this.includeRawContent,
+                    this.maxResults,
+                    this.includeDomains,
+                    this.excludeDomains,
+                    this.topic,
+                    this.timeRange,
+                    this.startDate,
+                    this.endDate,
+                    this.includeImages,
+                    this.includeImageDescriptions,
+                    this.includeFavicon,
+                    this.country,
+                    this.chunksPerSource,
+                    this.autoParameters,
+                    this.exactMatch);
         }
 
         public String toString() {
-            return "TavilySearchRequest.TavilySearchRequestBuilder(apiKey=" + this.apiKey + ", query=" + this.query + ", searchDepth=" + this.searchDepth + ", includeAnswer=" + this.includeAnswer + ", includeRawContent=" + this.includeRawContent + ", maxResults=" + this.maxResults + ", includeDomains=" + this.includeDomains + ", excludeDomains=" + this.excludeDomains + ")";
+            return "TavilySearchRequest.TavilySearchRequestBuilder(apiKey=" + this.apiKey + ", query=" + this.query
+                    + ", searchDepth=" + this.searchDepth + ", includeAnswer=" + this.includeAnswer
+                    + ", includeRawContent=" + this.includeRawContent + ", maxResults=" + this.maxResults
+                    + ", includeDomains=" + this.includeDomains + ", excludeDomains=" + this.excludeDomains
+                    + ", topic=" + this.topic + ", timeRange=" + this.timeRange + ", startDate=" + this.startDate
+                    + ", endDate=" + this.endDate + ", includeImages=" + this.includeImages
+                    + ", includeImageDescriptions=" + this.includeImageDescriptions + ", includeFavicon="
+                    + this.includeFavicon + ", country=" + this.country + ", chunksPerSource=" + this.chunksPerSource
+                    + ", autoParameters=" + this.autoParameters + ", exactMatch=" + this.exactMatch + ")";
         }
     }
 }

--- a/web-search-engines/langchain4j-web-search-engine-tavily/src/main/java/dev/langchain4j/web/search/tavily/TavilySearchResult.java
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/src/main/java/dev/langchain4j/web/search/tavily/TavilySearchResult.java
@@ -7,17 +7,27 @@ class TavilySearchResult {
     private String content;
     private String rawContent;
     private Double score;
+    private String publishedDate;
+    private String favicon;
 
-    public TavilySearchResult(String title, String url, String content, String rawContent, Double score) {
+    public TavilySearchResult(
+            String title,
+            String url,
+            String content,
+            String rawContent,
+            Double score,
+            String publishedDate,
+            String favicon) {
         this.title = title;
         this.url = url;
         this.content = content;
         this.rawContent = rawContent;
         this.score = score;
+        this.publishedDate = publishedDate;
+        this.favicon = favicon;
     }
 
-    public TavilySearchResult() {
-    }
+    public TavilySearchResult() {}
 
     public static TavilySearchResultBuilder builder() {
         return new TavilySearchResultBuilder();
@@ -43,15 +53,24 @@ class TavilySearchResult {
         return this.score;
     }
 
+    public String getPublishedDate() {
+        return this.publishedDate;
+    }
+
+    public String getFavicon() {
+        return this.favicon;
+    }
+
     public static class TavilySearchResultBuilder {
         private String title;
         private String url;
         private String content;
         private String rawContent;
         private Double score;
+        private String publishedDate;
+        private String favicon;
 
-        TavilySearchResultBuilder() {
-        }
+        TavilySearchResultBuilder() {}
 
         public TavilySearchResultBuilder title(String title) {
             this.title = title;
@@ -78,12 +97,25 @@ class TavilySearchResult {
             return this;
         }
 
+        public TavilySearchResultBuilder publishedDate(String publishedDate) {
+            this.publishedDate = publishedDate;
+            return this;
+        }
+
+        public TavilySearchResultBuilder favicon(String favicon) {
+            this.favicon = favicon;
+            return this;
+        }
+
         public TavilySearchResult build() {
-            return new TavilySearchResult(this.title, this.url, this.content, this.rawContent, this.score);
+            return new TavilySearchResult(
+                    this.title, this.url, this.content, this.rawContent, this.score, this.publishedDate, this.favicon);
         }
 
         public String toString() {
-            return "TavilySearchResult.TavilySearchResultBuilder(title=" + this.title + ", url=" + this.url + ", content=" + this.content + ", rawContent=" + this.rawContent + ", score=" + this.score + ")";
+            return "TavilySearchResult.TavilySearchResultBuilder(title=" + this.title + ", url=" + this.url
+                    + ", content=" + this.content + ", rawContent=" + this.rawContent + ", score=" + this.score
+                    + ", publishedDate=" + this.publishedDate + ", favicon=" + this.favicon + ")";
         }
     }
 }

--- a/web-search-engines/langchain4j-web-search-engine-tavily/src/main/java/dev/langchain4j/web/search/tavily/TavilyWebSearchEngine.java
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/src/main/java/dev/langchain4j/web/search/tavily/TavilyWebSearchEngine.java
@@ -14,12 +14,12 @@ import dev.langchain4j.web.search.WebSearchRequest;
 import dev.langchain4j.web.search.WebSearchResults;
 import java.net.URI;
 import java.time.Duration;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 /**
  * Represents Tavily Search API as a {@code WebSearchEngine}.
- * See more details <a href="https://docs.tavily.com/docs/tavily-api/rest_api">here</a>.
+ * See more details <a href="https://docs.tavily.com/documentation/api-reference/endpoint/search">here</a>.
  * <br>
  * When {@link #includeRawContent} is set to {@code true},
  * the raw content will appear in the {@link WebSearchOrganicResult#content()} field of each result.
@@ -28,6 +28,21 @@ import java.util.List;
  * the answer will appear in the {@link WebSearchOrganicResult#snippet()} field of the first result.
  * In this case, the {@link WebSearchOrganicResult#url()} of the first result will always be "https://tavily.com/" and
  * the {@link WebSearchOrganicResult#title()} will always be "Tavily Search API".
+ * <br>
+ * Additional parameters:
+ * <ul>
+ *   <li>{@link #topic} - Category of the search: "general" (default), "news", or "finance"</li>
+ *   <li>{@link #timeRange} - Time range filter: "day", "week", "month", or "year"</li>
+ *   <li>{@link #startDate} - Start date for results in "YYYY-MM-DD" format</li>
+ *   <li>{@link #endDate} - End date for results in "YYYY-MM-DD" format</li>
+ *   <li>{@link #includeImages} - Include query-related images in the response</li>
+ *   <li>{@link #includeImageDescriptions} - Include descriptions for images (requires includeImages)</li>
+ *   <li>{@link #includeFavicon} - Include a favicon URL for each result</li>
+ *   <li>{@link #country} - Country to boost search results from (e.g. "france", "united states")</li>
+ *   <li>{@link #chunksPerSource} - Number of content chunks per source (1-3, only for advanced depth)</li>
+ *   <li>{@link #autoParameters} - Let Tavily auto-select optimal parameters</li>
+ *   <li>{@link #exactMatch} - Require exact phrase matching for the query</li>
+ * </ul>
  */
 public class TavilyWebSearchEngine implements WebSearchEngine {
 
@@ -40,6 +55,17 @@ public class TavilyWebSearchEngine implements WebSearchEngine {
     private final Boolean includeRawContent;
     private final List<String> includeDomains;
     private final List<String> excludeDomains;
+    private final String topic;
+    private final String timeRange;
+    private final String startDate;
+    private final String endDate;
+    private final Boolean includeImages;
+    private final Boolean includeImageDescriptions;
+    private final Boolean includeFavicon;
+    private final String country;
+    private final Integer chunksPerSource;
+    private final Boolean autoParameters;
+    private final Boolean exactMatch;
 
     public TavilyWebSearchEngine(
             String baseUrl,
@@ -49,7 +75,18 @@ public class TavilyWebSearchEngine implements WebSearchEngine {
             Boolean includeAnswer,
             Boolean includeRawContent,
             List<String> includeDomains,
-            List<String> excludeDomains) {
+            List<String> excludeDomains,
+            String topic,
+            String timeRange,
+            String startDate,
+            String endDate,
+            Boolean includeImages,
+            Boolean includeImageDescriptions,
+            Boolean includeFavicon,
+            String country,
+            Integer chunksPerSource,
+            Boolean autoParameters,
+            Boolean exactMatch) {
         this.tavilyClient = TavilyClient.builder()
                 .baseUrl(getOrDefault(baseUrl, DEFAULT_BASE_URL))
                 .timeout(getOrDefault(timeout, ofSeconds(10)))
@@ -60,6 +97,17 @@ public class TavilyWebSearchEngine implements WebSearchEngine {
         this.includeRawContent = includeRawContent;
         this.includeDomains = copyIfNotNull(includeDomains);
         this.excludeDomains = copyIfNotNull(excludeDomains);
+        this.topic = topic;
+        this.timeRange = timeRange;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.includeImages = includeImages;
+        this.includeImageDescriptions = includeImageDescriptions;
+        this.includeFavicon = includeFavicon;
+        this.country = country;
+        this.chunksPerSource = chunksPerSource;
+        this.autoParameters = autoParameters;
+        this.exactMatch = exactMatch;
     }
 
     public static TavilyWebSearchEngineBuilder builder() {
@@ -78,6 +126,17 @@ public class TavilyWebSearchEngine implements WebSearchEngine {
                 .maxResults(webSearchRequest.maxResults())
                 .includeDomains(includeDomains)
                 .excludeDomains(excludeDomains)
+                .topic(topic)
+                .timeRange(timeRange)
+                .startDate(startDate)
+                .endDate(endDate)
+                .includeImages(includeImages)
+                .includeImageDescriptions(includeImageDescriptions)
+                .includeFavicon(includeFavicon)
+                .country(country)
+                .chunksPerSource(chunksPerSource)
+                .autoParameters(autoParameters)
+                .exactMatch(exactMatch)
                 .build();
 
         TavilyResponse tavilyResponse = tavilyClient.search(request);
@@ -100,12 +159,20 @@ public class TavilyWebSearchEngine implements WebSearchEngine {
     }
 
     private static WebSearchOrganicResult toWebSearchOrganicResult(TavilySearchResult tavilySearchResult) {
+        HashMap<String, String> metadata = new HashMap<>();
+        metadata.put("score", String.valueOf(tavilySearchResult.getScore()));
+        if (tavilySearchResult.getPublishedDate() != null) {
+            metadata.put("publishedDate", tavilySearchResult.getPublishedDate());
+        }
+        if (tavilySearchResult.getFavicon() != null) {
+            metadata.put("favicon", tavilySearchResult.getFavicon());
+        }
         return WebSearchOrganicResult.from(
                 tavilySearchResult.getTitle(),
                 UriUtils.createUriSafely(tavilySearchResult.getUrl()),
                 tavilySearchResult.getContent(),
                 tavilySearchResult.getRawContent(),
-                Collections.singletonMap("score", String.valueOf(tavilySearchResult.getScore())));
+                metadata);
     }
 
     public static class TavilyWebSearchEngineBuilder {
@@ -117,6 +184,17 @@ public class TavilyWebSearchEngine implements WebSearchEngine {
         private Boolean includeRawContent;
         private List<String> includeDomains;
         private List<String> excludeDomains;
+        private String topic;
+        private String timeRange;
+        private String startDate;
+        private String endDate;
+        private Boolean includeImages;
+        private Boolean includeImageDescriptions;
+        private Boolean includeFavicon;
+        private String country;
+        private Integer chunksPerSource;
+        private Boolean autoParameters;
+        private Boolean exactMatch;
 
         TavilyWebSearchEngineBuilder() {}
 
@@ -160,6 +238,61 @@ public class TavilyWebSearchEngine implements WebSearchEngine {
             return this;
         }
 
+        public TavilyWebSearchEngineBuilder topic(String topic) {
+            this.topic = topic;
+            return this;
+        }
+
+        public TavilyWebSearchEngineBuilder timeRange(String timeRange) {
+            this.timeRange = timeRange;
+            return this;
+        }
+
+        public TavilyWebSearchEngineBuilder startDate(String startDate) {
+            this.startDate = startDate;
+            return this;
+        }
+
+        public TavilyWebSearchEngineBuilder endDate(String endDate) {
+            this.endDate = endDate;
+            return this;
+        }
+
+        public TavilyWebSearchEngineBuilder includeImages(Boolean includeImages) {
+            this.includeImages = includeImages;
+            return this;
+        }
+
+        public TavilyWebSearchEngineBuilder includeImageDescriptions(Boolean includeImageDescriptions) {
+            this.includeImageDescriptions = includeImageDescriptions;
+            return this;
+        }
+
+        public TavilyWebSearchEngineBuilder includeFavicon(Boolean includeFavicon) {
+            this.includeFavicon = includeFavicon;
+            return this;
+        }
+
+        public TavilyWebSearchEngineBuilder country(String country) {
+            this.country = country;
+            return this;
+        }
+
+        public TavilyWebSearchEngineBuilder chunksPerSource(Integer chunksPerSource) {
+            this.chunksPerSource = chunksPerSource;
+            return this;
+        }
+
+        public TavilyWebSearchEngineBuilder autoParameters(Boolean autoParameters) {
+            this.autoParameters = autoParameters;
+            return this;
+        }
+
+        public TavilyWebSearchEngineBuilder exactMatch(Boolean exactMatch) {
+            this.exactMatch = exactMatch;
+            return this;
+        }
+
         public TavilyWebSearchEngine build() {
             return new TavilyWebSearchEngine(
                     this.baseUrl,
@@ -169,14 +302,30 @@ public class TavilyWebSearchEngine implements WebSearchEngine {
                     this.includeAnswer,
                     this.includeRawContent,
                     this.includeDomains,
-                    this.excludeDomains);
+                    this.excludeDomains,
+                    this.topic,
+                    this.timeRange,
+                    this.startDate,
+                    this.endDate,
+                    this.includeImages,
+                    this.includeImageDescriptions,
+                    this.includeFavicon,
+                    this.country,
+                    this.chunksPerSource,
+                    this.autoParameters,
+                    this.exactMatch);
         }
 
         public String toString() {
             return "TavilyWebSearchEngine.TavilyWebSearchEngineBuilder(baseUrl=" + this.baseUrl + ", apiKey="
                     + this.apiKey + ", timeout=" + this.timeout + ", searchDepth=" + this.searchDepth
                     + ", includeAnswer=" + this.includeAnswer + ", includeRawContent=" + this.includeRawContent
-                    + ", includeDomains=" + this.includeDomains + ", excludeDomains=" + this.excludeDomains + ")";
+                    + ", includeDomains=" + this.includeDomains + ", excludeDomains=" + this.excludeDomains
+                    + ", topic=" + this.topic + ", timeRange=" + this.timeRange + ", startDate=" + this.startDate
+                    + ", endDate=" + this.endDate + ", includeImages=" + this.includeImages
+                    + ", includeImageDescriptions=" + this.includeImageDescriptions + ", includeFavicon="
+                    + this.includeFavicon + ", country=" + this.country + ", chunksPerSource=" + this.chunksPerSource
+                    + ", autoParameters=" + this.autoParameters + ", exactMatch=" + this.exactMatch + ")";
         }
     }
 }

--- a/web-search-engines/langchain4j-web-search-engine-tavily/src/test/java/dev/langchain4j/web/search/tavily/TavilyWebSearchEngineIT.java
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/src/test/java/dev/langchain4j/web/search/tavily/TavilyWebSearchEngineIT.java
@@ -35,10 +35,11 @@ class TavilyWebSearchEngineIT extends WebSearchEngineIT {
             assertThat(result.title()).isNotBlank();
             assertThat(result.url()).isNotNull();
             assertThat(result.snippet()).isNotBlank();
-            assertThat(result.metadata()).containsOnlyKeys("score");
+            assertThat(result.metadata()).containsKey("score");
         });
 
-        assertThat(results).anyMatch(result -> result.content() != null && result.content().contains("LangChain4j"));
+        assertThat(results)
+                .anyMatch(result -> result.content() != null && result.content().contains("LangChain4j"));
     }
 
     void should_search_with_answer() {
@@ -87,6 +88,103 @@ class TavilyWebSearchEngineIT extends WebSearchEngineIT {
         // then
         List<WebSearchOrganicResult> results = webSearchResults.results();
         assertThat(results).hasSize(5 + 1); // +1 for answer
+    }
+
+    @Test
+    void should_search_with_topic_news() {
+        TavilyWebSearchEngine engine = TavilyWebSearchEngine.builder()
+                .apiKey(System.getenv("TAVILY_API_KEY"))
+                .topic("news")
+                .build();
+
+        WebSearchResults results = engine.search("latest technology news");
+
+        assertThat(results.results()).isNotEmpty();
+        results.results().forEach(result -> {
+            assertThat(result.title()).isNotBlank();
+            assertThat(result.url()).isNotNull();
+        });
+    }
+
+    @Test
+    void should_search_with_time_range() {
+        TavilyWebSearchEngine engine = TavilyWebSearchEngine.builder()
+                .apiKey(System.getenv("TAVILY_API_KEY"))
+                .timeRange("month")
+                .build();
+
+        WebSearchResults results = engine.search("artificial intelligence");
+
+        assertThat(results.results()).isNotEmpty();
+    }
+
+    @Test
+    void should_search_with_country() {
+        TavilyWebSearchEngine engine = TavilyWebSearchEngine.builder()
+                .apiKey(System.getenv("TAVILY_API_KEY"))
+                .country("france")
+                .build();
+
+        WebSearchResults results = engine.search("actualités technologie");
+
+        assertThat(results.results()).isNotEmpty();
+    }
+
+    @Test
+    void should_search_with_include_images() {
+        TavilyWebSearchEngine engine = TavilyWebSearchEngine.builder()
+                .apiKey(System.getenv("TAVILY_API_KEY"))
+                .includeImages(true)
+                .build();
+
+        WebSearchResults results = engine.search("Eiffel Tower");
+
+        assertThat(results.results()).isNotEmpty();
+    }
+
+    @Test
+    void should_search_with_topic_finance() {
+        TavilyWebSearchEngine engine = TavilyWebSearchEngine.builder()
+                .apiKey(System.getenv("TAVILY_API_KEY"))
+                .topic("finance")
+                .build();
+
+        WebSearchResults results = engine.search("NVIDIA stock price");
+
+        assertThat(results.results()).isNotEmpty();
+    }
+
+    @Test
+    void should_search_with_date_range() {
+        TavilyWebSearchEngine engine = TavilyWebSearchEngine.builder()
+                .apiKey(System.getenv("TAVILY_API_KEY"))
+                .startDate("2025-01-01")
+                .endDate("2025-12-31")
+                .build();
+
+        WebSearchResults results = engine.search("AI breakthroughs");
+
+        assertThat(results.results()).isNotEmpty();
+    }
+
+    @Test
+    void should_search_with_all_new_params_combined() {
+        TavilyWebSearchEngine engine = TavilyWebSearchEngine.builder()
+                .apiKey(System.getenv("TAVILY_API_KEY"))
+                .topic("news")
+                .timeRange("week")
+                .country("united states")
+                .includeImages(true)
+                .includeFavicon(true)
+                .build();
+
+        WebSearchResults results = engine.search("AI regulation");
+
+        assertThat(results.results()).isNotEmpty();
+        // Check that metadata contains expected keys
+        results.results().forEach(result -> {
+            assertThat(result.metadata()).containsKey("score");
+        });
     }
 
     @Override

--- a/web-search-engines/langchain4j-web-search-engine-tavily/src/test/java/dev/langchain4j/web/search/tavily/TavilyWebSearchEngineTest.java
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/src/test/java/dev/langchain4j/web/search/tavily/TavilyWebSearchEngineTest.java
@@ -1,0 +1,81 @@
+package dev.langchain4j.web.search.tavily;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TavilyWebSearchEngineTest {
+
+    @Test
+    void should_build_with_all_new_parameters() {
+        TavilyWebSearchEngine engine = TavilyWebSearchEngine.builder()
+                .apiKey("test-key")
+                .topic("news")
+                .timeRange("week")
+                .startDate("2025-01-01")
+                .endDate("2025-06-30")
+                .includeImages(true)
+                .includeImageDescriptions(true)
+                .includeFavicon(true)
+                .country("france")
+                .chunksPerSource(2)
+                .autoParameters(true)
+                .exactMatch(false)
+                .includeDomains(List.of("github.com"))
+                .excludeDomains(List.of("medium.com"))
+                .build();
+
+        assertThat(engine).isNotNull();
+    }
+
+    @Test
+    void should_build_with_only_api_key() {
+        // Backward compatibility — existing minimal usage still works
+        TavilyWebSearchEngine engine =
+                TavilyWebSearchEngine.builder().apiKey("test-key").build();
+
+        assertThat(engine).isNotNull();
+    }
+
+    @Test
+    void should_fail_without_api_key() {
+        assertThatThrownBy(() -> TavilyWebSearchEngine.builder().build()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_build_request_with_new_fields() {
+        TavilySearchRequest request = TavilySearchRequest.builder()
+                .apiKey("test-key")
+                .query("test query")
+                .topic("news")
+                .timeRange("day")
+                .country("france")
+                .includeImages(true)
+                .chunksPerSource(3)
+                .build();
+
+        assertThat(request.getQuery()).isEqualTo("test query");
+        assertThat(request.getTopic()).isEqualTo("news");
+        assertThat(request.getTimeRange()).isEqualTo("day");
+        assertThat(request.getCountry()).isEqualTo("france");
+        assertThat(request.getIncludeImages()).isTrue();
+        assertThat(request.getChunksPerSource()).isEqualTo(3);
+    }
+
+    @Test
+    void should_deserialize_result_with_published_date() {
+        TavilySearchResult result = TavilySearchResult.builder()
+                .title("Test")
+                .url("https://example.com")
+                .content("content")
+                .score(0.95)
+                .publishedDate("2025-03-01")
+                .favicon("https://example.com/favicon.ico")
+                .build();
+
+        assertThat(result.getPublishedDate()).isEqualTo("2025-03-01");
+        assertThat(result.getFavicon()).isEqualTo("https://example.com/favicon.ico");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #4771

## Change

Add missing Tavily Search API parameters to `langchain4j-web-search-engine-tavily`, bringing the Java integration closer to parity with the [Tavily REST API](https://docs.tavily.com/documentation/api-reference/endpoint/search) and the [Python SDK](https://github.com/tavily-ai/langchain-tavily).

All changes are additive and backward-compatible — existing code using `TavilyWebSearchEngine.withApiKey("key")` or the current builder works identically.

**New request parameters** (TavilySearchRequest + TavilyWebSearchEngine builder) — 11 new optional fields, null by default, omitted from JSON via `NON_NULL`:
- `topic` — `"general"` (default), `"news"`, `"finance"`
- `timeRange` — `"day"`, `"week"`, `"month"`, `"year"`
- `startDate` / `endDate` — date range in `YYYY-MM-DD` format
- `includeImages` / `includeImageDescriptions` — images in response
- `includeFavicon` — favicon URL per result
- `country` — boost results from a specific country
- `chunksPerSource` — content chunks per source, 1-3 (advanced depth only)
- `autoParameters` — let Tavily auto-configure params
- `exactMatch` — exact phrase matching

**New response fields:**
- Per result (`TavilySearchResult`): `publishedDate`, `favicon` — mapped into `WebSearchOrganicResult.metadata()` when present
- Response-level (`TavilyResponse`): `autoParameters`, `usage`, `requestId` — captured but not yet surfaced through `WebSearchResults`

**Metadata mapping:** `toWebSearchOrganicResult()` now uses a `HashMap` instead of `Collections.singletonMap`. `"score"` is always present; `"publishedDate"` and `"favicon"` are added conditionally. Consistent with how `GoogleCustomWebSearchEngine.toResultMetadataMap` handles dynamic metadata.

**Existing test assertion change:** In `should_search_with_raw_content`, `containsOnlyKeys("score")` → `containsKey("score")`. The Tavily API sometimes returns `published_date` on results even without explicitly requesting it, which breaks the strict assertion. This was already relaxed in `f160e91e` and `aec4c372b` for similar API-side instability — same approach here.

**Files changed** (5 modified, 1 new): `TavilySearchRequest.java`, `TavilySearchResult.java`, `TavilyResponse.java`, `TavilyWebSearchEngine.java`, `TavilyWebSearchEngineIT.java` (+7 IT tests), `TavilyWebSearchEngineTest.java` (new — unit tests for builder, backward compat, DTOs).

No changes to `TavilyApi.java`, `TavilyClient.java`, `pom.xml`, or anything in `langchain4j-core`.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
