### PR TITLE
Add compound index support to ColumnsMetadataHandler for pgvector

### DIFF
--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandler.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandler.java
@@ -1,8 +1,10 @@
 package dev.langchain4j.store.embedding.pgvector;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.store.embedding.filter.Filter;
-
 import java.sql.*;
 import java.util.Collections;
 import java.util.HashMap;
@@ -10,9 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 
 /**
  * Handle Metadata stored in independent columns
@@ -33,9 +32,10 @@ class ColumnsMetadataHandler implements MetadataHandler {
     public ColumnsMetadataHandler(MetadataStorageConfig config) {
         List<String> columnsDefinitionList = ensureNotEmpty(config.columnDefinitions(), "Metadata definition");
         this.columnsDefinition = columnsDefinitionList.stream()
-                .map(MetadataColumDefinition::from).collect(Collectors.toList());
-        this.columnsName = columnsDefinition.stream()
-                .map(MetadataColumDefinition::getName).collect(Collectors.toList());
+                .map(MetadataColumDefinition::from)
+                .collect(Collectors.toList());
+        this.columnsName =
+                columnsDefinition.stream().map(MetadataColumDefinition::getName).collect(Collectors.toList());
         this.filterMapper = new ColumnFilterMapper();
         this.indexes = getOrDefault(config.indexes(), Collections.emptyList());
         this.indexType = config.indexType();
@@ -45,7 +45,8 @@ class ColumnsMetadataHandler implements MetadataHandler {
     @Override
     public String columnDefinitionsString() {
         return this.columnsDefinition.stream()
-                .map(MetadataColumDefinition::getFullDefinition).collect(Collectors.joining(","));
+                .map(MetadataColumDefinition::getFullDefinition)
+                .collect(Collectors.joining(","));
     }
 
     @Override
@@ -56,21 +57,20 @@ class ColumnsMetadataHandler implements MetadataHandler {
     @Override
     public void createMetadataIndexes(Statement statement, String table) {
         String indexTypeSql = indexType == null ? "" : "USING " + indexType;
-        this.indexes.stream().map(String::trim)
-                .forEach(index -> {
-                    String indexSql = String.format("create index if not exists %s_%s on %s %s ( %s )",
-                            table, index, table, indexTypeSql, index);
-                    try {
-                        statement.executeUpdate(indexSql);
-                    } catch (SQLException e) {
-                        throw new RuntimeException(String.format("Cannot create indexes %s: %s", index, e));
-                    }
-                });
+        this.indexes.stream().map(String::trim).forEach(index -> {
+            String indexSql = String.format(
+                    "create index if not exists %s_%s on %s %s ( %s )", table, index, table, indexTypeSql, index);
+            try {
+                statement.executeUpdate(indexSql);
+            } catch (SQLException e) {
+                throw new RuntimeException(String.format("Cannot create indexes %s: %s", index, e));
+            }
+        });
         this.compoundIndexes.forEach(columns -> {
             String indexName = table + "_" + String.join("_", columns);
             String columnList = String.join(", ", columns);
-            String indexSql = String.format("create index if not exists %s on %s %s ( %s )",
-                    indexName, table, indexTypeSql, columnList);
+            String indexSql = String.format(
+                    "create index if not exists %s on %s %s ( %s )", indexName, table, indexTypeSql, columnList);
             try {
                 statement.executeUpdate(indexSql);
             } catch (SQLException e) {
@@ -81,7 +81,8 @@ class ColumnsMetadataHandler implements MetadataHandler {
 
     @Override
     public String insertClause() {
-        return this.columnsName.stream().map(c -> String.format("%s = EXCLUDED.%s", c, c))
+        return this.columnsName.stream()
+                .map(c -> String.format("%s = EXCLUDED.%s", c, c))
                 .collect(Collectors.joining(","));
     }
 
@@ -120,5 +121,4 @@ class ColumnsMetadataHandler implements MetadataHandler {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandler.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandler.java
@@ -24,6 +24,7 @@ class ColumnsMetadataHandler implements MetadataHandler {
     final PgVectorFilterMapper filterMapper;
     final List<String> indexes;
     final String indexType;
+    final List<List<String>> compoundIndexes;
 
     /**
      * MetadataHandler constructor
@@ -38,6 +39,7 @@ class ColumnsMetadataHandler implements MetadataHandler {
         this.filterMapper = new ColumnFilterMapper();
         this.indexes = getOrDefault(config.indexes(), Collections.emptyList());
         this.indexType = config.indexType();
+        this.compoundIndexes = getOrDefault(config.compoundIndexes(), Collections.emptyList());
     }
 
     @Override
@@ -64,6 +66,17 @@ class ColumnsMetadataHandler implements MetadataHandler {
                         throw new RuntimeException(String.format("Cannot create indexes %s: %s", index, e));
                     }
                 });
+        this.compoundIndexes.forEach(columns -> {
+            String indexName = table + "_" + String.join("_", columns);
+            String columnList = String.join(", ", columns);
+            String indexSql = String.format("create index if not exists %s on %s %s ( %s )",
+                    indexName, table, indexTypeSql, columnList);
+            try {
+                statement.executeUpdate(indexSql);
+            } catch (SQLException e) {
+                throw new RuntimeException(String.format("Cannot create compound index %s: %s", indexName, e));
+            }
+        });
     }
 
     @Override

--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/DefaultMetadataStorageConfig.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/DefaultMetadataStorageConfig.java
@@ -21,7 +21,12 @@ public class DefaultMetadataStorageConfig implements MetadataStorageConfig {
         // Just for javadoc warning ?
     }
 
-    public DefaultMetadataStorageConfig(MetadataStorageMode storageMode, List<String> columnDefinitions, List<String> indexes, String indexType, List<List<String>> compoundIndexes) {
+    public DefaultMetadataStorageConfig(
+            MetadataStorageMode storageMode,
+            List<String> columnDefinitions,
+            List<String> indexes,
+            String indexType,
+            List<List<String>> compoundIndexes) {
         this.storageMode = storageMode;
         this.columnDefinitions = columnDefinitions;
         this.indexes = indexes;
@@ -72,8 +77,7 @@ public class DefaultMetadataStorageConfig implements MetadataStorageConfig {
         private String indexType;
         private List<List<String>> compoundIndexes;
 
-        DefaultMetadataStorageConfigBuilder() {
-        }
+        DefaultMetadataStorageConfigBuilder() {}
 
         public DefaultMetadataStorageConfigBuilder storageMode(MetadataStorageMode storageMode) {
             this.storageMode = storageMode;
@@ -101,11 +105,14 @@ public class DefaultMetadataStorageConfig implements MetadataStorageConfig {
         }
 
         public DefaultMetadataStorageConfig build() {
-            return new DefaultMetadataStorageConfig(this.storageMode, this.columnDefinitions, this.indexes, this.indexType, this.compoundIndexes);
+            return new DefaultMetadataStorageConfig(
+                    this.storageMode, this.columnDefinitions, this.indexes, this.indexType, this.compoundIndexes);
         }
 
         public String toString() {
-            return "DefaultMetadataStorageConfig.DefaultMetadataStorageConfigBuilder(storageMode=" + this.storageMode + ", columnDefinitions=" + this.columnDefinitions + ", indexes=" + this.indexes + ", indexType=" + this.indexType + ", compoundIndexes=" + this.compoundIndexes + ")";
+            return "DefaultMetadataStorageConfig.DefaultMetadataStorageConfigBuilder(storageMode=" + this.storageMode
+                    + ", columnDefinitions=" + this.columnDefinitions + ", indexes=" + this.indexes + ", indexType="
+                    + this.indexType + ", compoundIndexes=" + this.compoundIndexes + ")";
         }
     }
 }

--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/DefaultMetadataStorageConfig.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/DefaultMetadataStorageConfig.java
@@ -11,6 +11,7 @@ public class DefaultMetadataStorageConfig implements MetadataStorageConfig {
     private List<String> columnDefinitions;
     private List<String> indexes;
     private String indexType;
+    private List<List<String>> compoundIndexes;
 
     /**
      * Just for warnings ?
@@ -20,11 +21,12 @@ public class DefaultMetadataStorageConfig implements MetadataStorageConfig {
         // Just for javadoc warning ?
     }
 
-    public DefaultMetadataStorageConfig(MetadataStorageMode storageMode, List<String> columnDefinitions, List<String> indexes, String indexType) {
+    public DefaultMetadataStorageConfig(MetadataStorageMode storageMode, List<String> columnDefinitions, List<String> indexes, String indexType, List<List<String>> compoundIndexes) {
         this.storageMode = storageMode;
         this.columnDefinitions = columnDefinitions;
         this.indexes = indexes;
         this.indexType = indexType;
+        this.compoundIndexes = compoundIndexes;
     }
 
     /**
@@ -59,11 +61,16 @@ public class DefaultMetadataStorageConfig implements MetadataStorageConfig {
         return this.indexType;
     }
 
+    public List<List<String>> compoundIndexes() {
+        return this.compoundIndexes != null ? this.compoundIndexes : Collections.emptyList();
+    }
+
     public static class DefaultMetadataStorageConfigBuilder {
         private MetadataStorageMode storageMode;
         private List<String> columnDefinitions;
         private List<String> indexes;
         private String indexType;
+        private List<List<String>> compoundIndexes;
 
         DefaultMetadataStorageConfigBuilder() {
         }
@@ -88,12 +95,17 @@ public class DefaultMetadataStorageConfig implements MetadataStorageConfig {
             return this;
         }
 
+        public DefaultMetadataStorageConfigBuilder compoundIndexes(List<List<String>> compoundIndexes) {
+            this.compoundIndexes = compoundIndexes;
+            return this;
+        }
+
         public DefaultMetadataStorageConfig build() {
-            return new DefaultMetadataStorageConfig(this.storageMode, this.columnDefinitions, this.indexes, this.indexType);
+            return new DefaultMetadataStorageConfig(this.storageMode, this.columnDefinitions, this.indexes, this.indexType, this.compoundIndexes);
         }
 
         public String toString() {
-            return "DefaultMetadataStorageConfig.DefaultMetadataStorageConfigBuilder(storageMode=" + this.storageMode + ", columnDefinitions=" + this.columnDefinitions + ", indexes=" + this.indexes + ", indexType=" + this.indexType + ")";
+            return "DefaultMetadataStorageConfig.DefaultMetadataStorageConfigBuilder(storageMode=" + this.storageMode + ", columnDefinitions=" + this.columnDefinitions + ", indexes=" + this.indexes + ", indexType=" + this.indexType + ", compoundIndexes=" + this.compoundIndexes + ")";
         }
     }
 }

--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/MetadataStorageConfig.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/MetadataStorageConfig.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.store.embedding.pgvector;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -50,4 +51,17 @@ public interface MetadataStorageConfig {
      * @return Index Type
      */
     String indexType();
+
+    /**
+     * Compound (multi-column) indexes. Each inner list defines the columns for one compound index.
+     * Example:
+     * <ul>
+     * <li><code>List.of(List.of("query_id", "type", "version"))</code> generates:
+     * <code>CREATE INDEX IF NOT EXISTS table_query_id_type_version ON table (query_id, type, version)</code>
+     * </ul>
+     * @return list of compound index column groups
+     */
+    default List<List<String>> compoundIndexes() {
+        return Collections.emptyList();
+    }
 }

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandlerTest.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandlerTest.java
@@ -1,7 +1,9 @@
 package dev.langchain4j.store.embedding.pgvector;
 
-import org.junit.jupiter.api.Test;
-import org.mockito.AdditionalAnswers;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -9,11 +11,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import org.mockito.AdditionalAnswers;
 
 class ColumnsMetadataHandlerTest {
 
@@ -34,8 +33,10 @@ class ColumnsMetadataHandlerTest {
         handler.createMetadataIndexes(statement, "ai_category");
 
         assertThat(sqlStatementQueries).hasSize(2);
-        assertThat(sqlStatementQueries.get(0)).isEqualTo("create index if not exists ai_category_query_id on ai_category  ( query_id )");
-        assertThat(sqlStatementQueries.get(1)).isEqualTo("create index if not exists ai_category_type on ai_category  ( type )");
+        assertThat(sqlStatementQueries.get(0))
+                .isEqualTo("create index if not exists ai_category_query_id on ai_category  ( query_id )");
+        assertThat(sqlStatementQueries.get(1))
+                .isEqualTo("create index if not exists ai_category_type on ai_category  ( type )");
     }
 
     @Test
@@ -55,8 +56,9 @@ class ColumnsMetadataHandlerTest {
         handler.createMetadataIndexes(statement, "ai_category");
 
         assertThat(sqlStatementQueries).hasSize(1);
-        assertThat(sqlStatementQueries.get(0)).isEqualTo(
-                "create index if not exists ai_category_query_id_type_version on ai_category  ( query_id, type, version )");
+        assertThat(sqlStatementQueries.get(0))
+                .isEqualTo(
+                        "create index if not exists ai_category_query_id_type_version on ai_category  ( query_id, type, version )");
     }
 
     @Test
@@ -77,7 +79,9 @@ class ColumnsMetadataHandlerTest {
         handler.createMetadataIndexes(statement, "ai_category");
 
         assertThat(sqlStatementQueries).hasSize(2);
-        assertThat(sqlStatementQueries.get(0)).isEqualTo("create index if not exists ai_category_version on ai_category  ( version )");
-        assertThat(sqlStatementQueries.get(1)).isEqualTo("create index if not exists ai_category_query_id_type on ai_category  ( query_id, type )");
+        assertThat(sqlStatementQueries.get(0))
+                .isEqualTo("create index if not exists ai_category_version on ai_category  ( version )");
+        assertThat(sqlStatementQueries.get(1))
+                .isEqualTo("create index if not exists ai_category_query_id_type on ai_category  ( query_id, type )");
     }
 }

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandlerTest.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandlerTest.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.store.embedding.pgvector;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.AdditionalAnswers;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ColumnsMetadataHandlerTest {
+
+    @Test
+    void createSingleColumnIndexes() throws SQLException {
+        Statement statement = mock(Statement.class);
+        List<String> sqlStatementQueries = new ArrayList<>();
+        when(statement.executeUpdate(anyString()))
+                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String) q)));
+
+        MetadataStorageConfig config = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COLUMN_PER_KEY)
+                .columnDefinitions(Arrays.asList("query_id uuid null", "type varchar null"))
+                .indexes(Arrays.asList("query_id", "type"))
+                .build();
+
+        ColumnsMetadataHandler handler = new ColumnsMetadataHandler(config);
+        handler.createMetadataIndexes(statement, "ai_category");
+
+        assertThat(sqlStatementQueries).hasSize(2);
+        assertThat(sqlStatementQueries.get(0)).isEqualTo("create index if not exists ai_category_query_id on ai_category  ( query_id )");
+        assertThat(sqlStatementQueries.get(1)).isEqualTo("create index if not exists ai_category_type on ai_category  ( type )");
+    }
+
+    @Test
+    void createCompoundIndex() throws SQLException {
+        Statement statement = mock(Statement.class);
+        List<String> sqlStatementQueries = new ArrayList<>();
+        when(statement.executeUpdate(anyString()))
+                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String) q)));
+
+        MetadataStorageConfig config = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COLUMN_PER_KEY)
+                .columnDefinitions(Arrays.asList("query_id uuid null", "type varchar null", "version varchar null"))
+                .compoundIndexes(Collections.singletonList(Arrays.asList("query_id", "type", "version")))
+                .build();
+
+        ColumnsMetadataHandler handler = new ColumnsMetadataHandler(config);
+        handler.createMetadataIndexes(statement, "ai_category");
+
+        assertThat(sqlStatementQueries).hasSize(1);
+        assertThat(sqlStatementQueries.get(0)).isEqualTo(
+                "create index if not exists ai_category_query_id_type_version on ai_category  ( query_id, type, version )");
+    }
+
+    @Test
+    void createMixedSingleAndCompoundIndexes() throws SQLException {
+        Statement statement = mock(Statement.class);
+        List<String> sqlStatementQueries = new ArrayList<>();
+        when(statement.executeUpdate(anyString()))
+                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String) q)));
+
+        MetadataStorageConfig config = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COLUMN_PER_KEY)
+                .columnDefinitions(Arrays.asList("query_id uuid null", "type varchar null", "version varchar null"))
+                .indexes(Collections.singletonList("version"))
+                .compoundIndexes(Collections.singletonList(Arrays.asList("query_id", "type")))
+                .build();
+
+        ColumnsMetadataHandler handler = new ColumnsMetadataHandler(config);
+        handler.createMetadataIndexes(statement, "ai_category");
+
+        assertThat(sqlStatementQueries).hasSize(2);
+        assertThat(sqlStatementQueries.get(0)).isEqualTo("create index if not exists ai_category_version on ai_category  ( version )");
+        assertThat(sqlStatementQueries.get(1)).isEqualTo("create index if not exists ai_category_query_id_type on ai_category  ( query_id, type )");
+    }
+}


### PR DESCRIPTION
Fixes #2695

- Add compoundIndexes() default method to MetadataStorageConfig interface
- Add compoundIndexes field and builder method to DefaultMetadataStorageConfig
- Generate compound index SQL in ColumnsMetadataHandler#createMetadataIndexes

## Issue
Closes #2695

## Change
Added support for compound (multi-column) indexes in ColumnsMetadataHandler for the pgvector
embedding store.

Previously, MetadataStorageConfig.indexes() only supported single-column indexes. This change
adds a new compoundIndexes() method that accepts a List<List<String>>, where each inner list
defines the columns for one compound index.

Example:
java
DefaultMetadataStorageConfig.builder()
    .compoundIndexes(List.of(List.of("query_id", "type", "version")))
    .build();

Generates:
sql
CREATE INDEX IF NOT EXISTS table_query_id_type_version ON table (query_id, type, version);


## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/
changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and
they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo
- [ ] I have added/updated Spring Boot starter(s)