### PR TITLE
Add MCP Progress API client support

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -18,6 +18,7 @@ import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.mcp.client.logging.DefaultMcpLogMessageHandler;
 import dev.langchain4j.mcp.client.logging.McpLogMessageHandler;
+import dev.langchain4j.mcp.client.progress.McpProgressHandler;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpCallToolRequest;
@@ -76,6 +77,7 @@ public class DefaultMcpClient implements McpClient {
     private final Map<Long, CompletableFuture<JsonNode>> pendingOperations = new ConcurrentHashMap<>();
     private final McpOperationHandler messageHandler;
     private final McpLogMessageHandler logHandler;
+    private final McpProgressHandler progressHandler;
     private final AtomicReference<List<McpResource>> resourceRefs = new AtomicReference<>();
     private final AtomicReference<List<McpResourceTemplate>> resourceTemplateRefs = new AtomicReference<>();
     private final AtomicReference<List<McpPrompt>> promptRefs = new AtomicReference<>();
@@ -104,6 +106,7 @@ public class DefaultMcpClient implements McpClient {
             resourcesTimeout = getOrDefault(builder.resourcesTimeout, Duration.ofSeconds(60));
             promptsTimeout = getOrDefault(builder.promptsTimeout, Duration.ofSeconds(60));
             logHandler = getOrDefault(builder.logHandler, new DefaultMcpLogMessageHandler());
+            progressHandler = builder.progressHandler;
             pingTimeout = getOrDefault(builder.pingTimeout, Duration.ofSeconds(10));
             reconnectInterval = getOrDefault(builder.reconnectInterval, Duration.ofSeconds(5));
             autoHealthCheck = getOrDefault(builder.autoHealthCheck, Boolean.TRUE);
@@ -126,7 +129,8 @@ public class DefaultMcpClient implements McpClient {
                     mcpRoots::get,
                     transport,
                     logHandler::handleLogMessage,
-                    () -> toolListOutOfDate.set(true));
+                    () -> toolListOutOfDate.set(true),
+                    progressHandler);
             ((ObjectNode) RESULT_TIMEOUT)
                     .putObject("result")
                     .putArray("content")
@@ -259,7 +263,9 @@ public class DefaultMcpClient implements McpClient {
             throw new ToolArgumentsException(e);
         }
         long operationId = idGenerator.getAndIncrement();
-        McpCallToolRequest operation = new McpCallToolRequest(operationId, executionRequest.name(), arguments);
+        String progressToken = progressHandler != null ? String.valueOf(operationId) : null;
+        McpCallToolRequest operation =
+                new McpCallToolRequest(operationId, executionRequest.name(), arguments, progressToken);
         long timeoutMillis = toolExecutionTimeout.toMillis() == 0 ? Integer.MAX_VALUE : toolExecutionTimeout.toMillis();
         CompletableFuture<JsonNode> resultFuture = null;
         JsonNode result = null;
@@ -605,6 +611,7 @@ public class DefaultMcpClient implements McpClient {
         private List<McpRoot> roots;
         private Boolean cacheToolList;
         private McpClientListener listener;
+        private McpProgressHandler progressHandler;
 
         /**
          * Sets the transport protocol to use for communicating with the
@@ -783,6 +790,16 @@ public class DefaultMcpClient implements McpClient {
          */
         public Builder listener(McpClientListener listener) {
             this.listener = listener;
+            return this;
+        }
+
+        /**
+         * Sets the progress handler for the client. When set, the client will include
+         * a progress token in tool execution requests, and progress notifications
+         * received from the server will be forwarded to this handler.
+         */
+        public Builder progressHandler(McpProgressHandler progressHandler) {
+            this.progressHandler = progressHandler;
             return this;
         }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/progress/McpProgressHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/progress/McpProgressHandler.java
@@ -1,0 +1,16 @@
+package dev.langchain4j.mcp.client.progress;
+
+/**
+ * Handler for MCP progress notifications.
+ * Implement this interface to receive progress updates from the MCP server
+ * during long-running tool executions.
+ */
+public interface McpProgressHandler {
+
+    /**
+     * Called when a progress notification is received from the MCP server.
+     *
+     * @param notification the progress notification
+     */
+    void onProgress(McpProgressNotification notification);
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/progress/McpProgressNotification.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/progress/McpProgressNotification.java
@@ -1,0 +1,77 @@
+package dev.langchain4j.mcp.client.progress;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Objects;
+
+/**
+ * Represents a progress notification received from an MCP server,
+ * sent in response to a request that included a progress token.
+ */
+public class McpProgressNotification {
+
+    private final String progressToken;
+    private final double progress;
+    private final Double total;
+    private final String message;
+
+    public McpProgressNotification(String progressToken, double progress, Double total, String message) {
+        this.progressToken = progressToken;
+        this.progress = progress;
+        this.total = total;
+        this.message = message;
+    }
+
+    /**
+     * Parses a McpProgressNotification from the contents of the 'params' object
+     * inside a 'notifications/progress' message.
+     */
+    public static McpProgressNotification fromJson(JsonNode params) {
+        String progressToken = params.path("progressToken").asText(null);
+        double progress = params.path("progress").asDouble();
+        Double total = params.has("total") ? params.get("total").asDouble() : null;
+        String message = params.has("message") ? params.get("message").asText() : null;
+        return new McpProgressNotification(progressToken, progress, total, message);
+    }
+
+    public String progressToken() {
+        return progressToken;
+    }
+
+    public double progress() {
+        return progress;
+    }
+
+    public Double total() {
+        return total;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        McpProgressNotification that = (McpProgressNotification) obj;
+        return Double.compare(this.progress, that.progress) == 0
+                && Objects.equals(this.progressToken, that.progressToken)
+                && Objects.equals(this.total, that.total)
+                && Objects.equals(this.message, that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(progressToken, progress, total, message);
+    }
+
+    @Override
+    public String toString() {
+        return "McpProgressNotification["
+                + "progressToken=" + progressToken
+                + ", progress=" + progress
+                + ", total=" + total
+                + ", message=" + message
+                + ']';
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
@@ -3,6 +3,8 @@ package dev.langchain4j.mcp.client.transport;
 import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.mcp.client.McpRoot;
 import dev.langchain4j.mcp.client.logging.McpLogMessage;
+import dev.langchain4j.mcp.client.progress.McpProgressHandler;
+import dev.langchain4j.mcp.client.progress.McpProgressNotification;
 import dev.langchain4j.mcp.protocol.McpPingResponse;
 import dev.langchain4j.mcp.protocol.McpRootsListResponse;
 import java.util.List;
@@ -27,6 +29,7 @@ public class McpOperationHandler {
     private final Consumer<McpLogMessage> logMessageConsumer;
     private final Runnable onToolListUpdate;
     private final Supplier<List<McpRoot>> roots;
+    private final McpProgressHandler progressHandler;
 
     public McpOperationHandler(
             Map<Long, CompletableFuture<JsonNode>> pendingOperations,
@@ -34,11 +37,22 @@ public class McpOperationHandler {
             McpTransport transport,
             Consumer<McpLogMessage> logMessageConsumer,
             Runnable onToolListUpdate) {
+        this(pendingOperations, roots, transport, logMessageConsumer, onToolListUpdate, null);
+    }
+
+    public McpOperationHandler(
+            Map<Long, CompletableFuture<JsonNode>> pendingOperations,
+            Supplier<List<McpRoot>> roots,
+            McpTransport transport,
+            Consumer<McpLogMessage> logMessageConsumer,
+            Runnable onToolListUpdate,
+            McpProgressHandler progressHandler) {
         this.pendingOperations = pendingOperations;
         this.transport = transport;
         this.logMessageConsumer = logMessageConsumer;
         this.onToolListUpdate = onToolListUpdate;
         this.roots = roots;
+        this.progressHandler = progressHandler;
     }
 
     public void handle(JsonNode message) {
@@ -79,6 +93,10 @@ public class McpOperationHandler {
                 }
             } else if (method.equals("notifications/tools/list_changed")) {
                 onToolListUpdate.run();
+            } else if (method.equals("notifications/progress")) {
+                if (progressHandler != null && message.has("params")) {
+                    progressHandler.onProgress(McpProgressNotification.fromJson(message.get("params")));
+                }
             } else {
                 log.warn("Received unknown message: {}", message);
             }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolRequest.java
@@ -13,10 +13,17 @@ public class McpCallToolRequest extends McpClientMessage {
     private Map<String, Object> params;
 
     public McpCallToolRequest(Long id, String toolName, ObjectNode arguments) {
+        this(id, toolName, arguments, null);
+    }
+
+    public McpCallToolRequest(Long id, String toolName, ObjectNode arguments, String progressToken) {
         super(id, McpClientMethod.TOOLS_CALL);
         this.params = new HashMap<>();
         this.params.put("name", toolName);
         this.params.put("arguments", arguments);
+        if (progressToken != null) {
+            this.params.put("_meta", Map.of("progressToken", progressToken));
+        }
     }
 
     public Map<String, Object> getParams() {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpProgressStdioTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpProgressStdioTransportIT.java
@@ -1,0 +1,38 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getJBangCommand;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getPathToScript;
+
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+class McpProgressStdioTransportIT extends McpProgressTestBase {
+
+    @BeforeAll
+    static void setup() {
+        McpServerHelper.skipTestsIfJbangNotAvailable();
+        McpTransport transport = new StdioMcpTransport.Builder()
+                .command(List.of(
+                        getJBangCommand(), "--quiet", "--fresh", "run", getPathToScript("progress_mcp_server.java")))
+                .logEvents(true)
+                .build();
+        progressHandler = new TestProgressHandler();
+        mcpClient = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .toolExecutionTimeout(Duration.ofSeconds(10))
+                .progressHandler(progressHandler)
+                .build();
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (mcpClient != null) {
+            mcpClient.close();
+        }
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpProgressTestBase.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpProgressTestBase.java
@@ -1,0 +1,80 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.progress.McpProgressHandler;
+import dev.langchain4j.mcp.client.progress.McpProgressNotification;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public abstract class McpProgressTestBase {
+
+    static McpClient mcpClient;
+    static TestProgressHandler progressHandler;
+
+    @BeforeEach
+    public void clearMessages() {
+        progressHandler.clear();
+    }
+
+    @Test
+    public void receiveProgressNotifications() throws TimeoutException {
+        String result = mcpClient
+                .executeTool(ToolExecutionRequest.builder()
+                        .arguments("{}")
+                        .name("progressOperation")
+                        .build())
+                .resultText();
+        assertThat(result).isEqualTo("done");
+
+        List<TestProgressHandler.ProgressEvent> events = progressHandler.waitForMessages(3, Duration.ofSeconds(10));
+        assertThat(events).hasSize(3);
+
+        assertThat(events.get(0).progress()).isEqualTo(1);
+        assertThat(events.get(0).total()).isEqualTo(3);
+        assertThat(events.get(0).message()).isEqualTo("Step 1 of 3");
+
+        assertThat(events.get(2).progress()).isEqualTo(3);
+    }
+
+    public static class TestProgressHandler implements McpProgressHandler {
+
+        public record ProgressEvent(double progress, double total, String message) {}
+
+        private final List<ProgressEvent> events = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onProgress(McpProgressNotification notification) {
+            events.add(new ProgressEvent(
+                    notification.progress(),
+                    notification.total() != null ? notification.total() : 0,
+                    notification.message()));
+        }
+
+        public List<ProgressEvent> waitForMessages(int count, Duration timeout) throws TimeoutException {
+            long start = System.currentTimeMillis();
+            while (events.size() < count) {
+                if (System.currentTimeMillis() - start > timeout.toMillis()) {
+                    throw new TimeoutException("Expected " + count + " events but got " + events.size());
+                }
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+            return events;
+        }
+
+        public void clear() {
+            events.clear();
+        }
+    }
+}

--- a/langchain4j-mcp/src/test/resources/progress_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/progress_mcp_server.java
@@ -1,0 +1,27 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS io.quarkus:quarkus-bom:${quarkus.version:3.27.0}@pom
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.7.2
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.7.2
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-websocket:1.7.2
+
+import io.quarkiverse.mcp.server.Progress;
+import io.quarkiverse.mcp.server.Tool;
+
+public class progress_mcp_server {
+
+    @Tool(description = "A tool that reports progress notifications")
+    public String progressOperation(Progress progress) {
+        if (progress.token().isEmpty()) {
+            return "no-progress-token";
+        }
+        for (int i = 1; i <= 3; i++) {
+            progress.notificationBuilder()
+                    .setProgress(i)
+                    .setTotal(3)
+                    .setMessage("Step " + i + " of 3")
+                    .build()
+                    .sendAndForget();
+        }
+        return "done";
+    }
+}


### PR DESCRIPTION
Closes #2830

- Add McpProgressNotification data class (progressToken, progress, total, message)
- Add McpProgressHandler interface for receiving progress notifications
- Handle notifications/progress in McpOperationHandler
- Send _meta.progressToken in tool execution requests when a handler is set
- Add progressHandler builder method to DefaultMcpClient
- Add progress_mcp_server.java test script and McpProgressStdioTransportIT

## Issue
Closes #2830

## Change
Implements the client side of the MCP Progress API as specified in the [MCP spec](https://
modelcontextprotocol.io/specification/2025-03-26/basic/utilities/progress).

When a McpProgressHandler is configured on the client, tool execution requests will include a
_meta.progressToken in the request params. The client will then route incoming
notifications/progress messages from the server to the handler.

New classes:
- McpProgressNotification — data class representing a progress notification (progressToken,
progress, total, message)
- McpProgressHandler — interface to implement for receiving progress notifications

Usage:
java
McpClient client = new DefaultMcpClient.Builder()
    .transport(transport)
    .progressHandler(notification -> {
        System.out.println("Progress: " + notification.progress() + "/" + notification.total());
    })
    .build();


## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/
changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and
they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo
- [ ] I have added/updated Spring Boot starter(s)