### PR TITLE
Refactor McpOperationHandler to use enum-based dispatch

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -18,6 +18,7 @@ import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.mcp.client.logging.DefaultMcpLogMessageHandler;
 import dev.langchain4j.mcp.client.logging.McpLogMessageHandler;
+import dev.langchain4j.mcp.client.progress.McpProgressHandler;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpCallToolRequest;
@@ -76,6 +77,7 @@ public class DefaultMcpClient implements McpClient {
     private final Map<Long, CompletableFuture<JsonNode>> pendingOperations = new ConcurrentHashMap<>();
     private final McpOperationHandler messageHandler;
     private final McpLogMessageHandler logHandler;
+    private final McpProgressHandler progressHandler;
     private final AtomicReference<List<McpResource>> resourceRefs = new AtomicReference<>();
     private final AtomicReference<List<McpResourceTemplate>> resourceTemplateRefs = new AtomicReference<>();
     private final AtomicReference<List<McpPrompt>> promptRefs = new AtomicReference<>();
@@ -104,6 +106,7 @@ public class DefaultMcpClient implements McpClient {
             resourcesTimeout = getOrDefault(builder.resourcesTimeout, Duration.ofSeconds(60));
             promptsTimeout = getOrDefault(builder.promptsTimeout, Duration.ofSeconds(60));
             logHandler = getOrDefault(builder.logHandler, new DefaultMcpLogMessageHandler());
+            progressHandler = builder.progressHandler;
             pingTimeout = getOrDefault(builder.pingTimeout, Duration.ofSeconds(10));
             reconnectInterval = getOrDefault(builder.reconnectInterval, Duration.ofSeconds(5));
             autoHealthCheck = getOrDefault(builder.autoHealthCheck, Boolean.TRUE);
@@ -126,7 +129,8 @@ public class DefaultMcpClient implements McpClient {
                     mcpRoots::get,
                     transport,
                     logHandler::handleLogMessage,
-                    () -> toolListOutOfDate.set(true));
+                    () -> toolListOutOfDate.set(true),
+                    progressHandler);
             ((ObjectNode) RESULT_TIMEOUT)
                     .putObject("result")
                     .putArray("content")
@@ -259,7 +263,9 @@ public class DefaultMcpClient implements McpClient {
             throw new ToolArgumentsException(e);
         }
         long operationId = idGenerator.getAndIncrement();
-        McpCallToolRequest operation = new McpCallToolRequest(operationId, executionRequest.name(), arguments);
+        String progressToken = progressHandler != null ? String.valueOf(operationId) : null;
+        McpCallToolRequest operation =
+                new McpCallToolRequest(operationId, executionRequest.name(), arguments, progressToken);
         long timeoutMillis = toolExecutionTimeout.toMillis() == 0 ? Integer.MAX_VALUE : toolExecutionTimeout.toMillis();
         CompletableFuture<JsonNode> resultFuture = null;
         JsonNode result = null;
@@ -605,6 +611,7 @@ public class DefaultMcpClient implements McpClient {
         private List<McpRoot> roots;
         private Boolean cacheToolList;
         private McpClientListener listener;
+        private McpProgressHandler progressHandler;
 
         /**
          * Sets the transport protocol to use for communicating with the
@@ -783,6 +790,16 @@ public class DefaultMcpClient implements McpClient {
          */
         public Builder listener(McpClientListener listener) {
             this.listener = listener;
+            return this;
+        }
+
+        /**
+         * Sets the progress handler for the client. When set, the client will include
+         * a progress token in tool execution requests, and progress notifications
+         * received from the server will be forwarded to this handler.
+         */
+        public Builder progressHandler(McpProgressHandler progressHandler) {
+            this.progressHandler = progressHandler;
             return this;
         }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/progress/McpProgressHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/progress/McpProgressHandler.java
@@ -1,0 +1,16 @@
+package dev.langchain4j.mcp.client.progress;
+
+/**
+ * Handler for MCP progress notifications.
+ * Implement this interface to receive progress updates from the MCP server
+ * during long-running tool executions.
+ */
+public interface McpProgressHandler {
+
+    /**
+     * Called when a progress notification is received from the MCP server.
+     *
+     * @param notification the progress notification
+     */
+    void onProgress(McpProgressNotification notification);
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/progress/McpProgressNotification.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/progress/McpProgressNotification.java
@@ -1,0 +1,77 @@
+package dev.langchain4j.mcp.client.progress;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Objects;
+
+/**
+ * Represents a progress notification received from an MCP server,
+ * sent in response to a request that included a progress token.
+ */
+public class McpProgressNotification {
+
+    private final String progressToken;
+    private final double progress;
+    private final Double total;
+    private final String message;
+
+    public McpProgressNotification(String progressToken, double progress, Double total, String message) {
+        this.progressToken = progressToken;
+        this.progress = progress;
+        this.total = total;
+        this.message = message;
+    }
+
+    /**
+     * Parses a McpProgressNotification from the contents of the 'params' object
+     * inside a 'notifications/progress' message.
+     */
+    public static McpProgressNotification fromJson(JsonNode params) {
+        String progressToken = params.path("progressToken").asText(null);
+        double progress = params.path("progress").asDouble();
+        Double total = params.has("total") ? params.get("total").asDouble() : null;
+        String message = params.has("message") ? params.get("message").asText() : null;
+        return new McpProgressNotification(progressToken, progress, total, message);
+    }
+
+    public String progressToken() {
+        return progressToken;
+    }
+
+    public double progress() {
+        return progress;
+    }
+
+    public Double total() {
+        return total;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        McpProgressNotification that = (McpProgressNotification) obj;
+        return Double.compare(this.progress, that.progress) == 0
+                && Objects.equals(this.progressToken, that.progressToken)
+                && Objects.equals(this.total, that.total)
+                && Objects.equals(this.message, that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(progressToken, progress, total, message);
+    }
+
+    @Override
+    public String toString() {
+        return "McpProgressNotification["
+                + "progressToken=" + progressToken
+                + ", progress=" + progress
+                + ", total=" + total
+                + ", message=" + message
+                + ']';
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
@@ -3,6 +3,8 @@ package dev.langchain4j.mcp.client.transport;
 import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.mcp.client.McpRoot;
 import dev.langchain4j.mcp.client.logging.McpLogMessage;
+import dev.langchain4j.mcp.client.progress.McpProgressHandler;
+import dev.langchain4j.mcp.client.progress.McpProgressNotification;
 import dev.langchain4j.mcp.protocol.McpPingResponse;
 import dev.langchain4j.mcp.protocol.McpRootsListResponse;
 import java.util.List;
@@ -27,6 +29,7 @@ public class McpOperationHandler {
     private final Consumer<McpLogMessage> logMessageConsumer;
     private final Runnable onToolListUpdate;
     private final Supplier<List<McpRoot>> roots;
+    private final McpProgressHandler progressHandler;
 
     public McpOperationHandler(
             Map<Long, CompletableFuture<JsonNode>> pendingOperations,
@@ -34,11 +37,22 @@ public class McpOperationHandler {
             McpTransport transport,
             Consumer<McpLogMessage> logMessageConsumer,
             Runnable onToolListUpdate) {
+        this(pendingOperations, roots, transport, logMessageConsumer, onToolListUpdate, null);
+    }
+
+    public McpOperationHandler(
+            Map<Long, CompletableFuture<JsonNode>> pendingOperations,
+            Supplier<List<McpRoot>> roots,
+            McpTransport transport,
+            Consumer<McpLogMessage> logMessageConsumer,
+            Runnable onToolListUpdate,
+            McpProgressHandler progressHandler) {
         this.pendingOperations = pendingOperations;
         this.transport = transport;
         this.logMessageConsumer = logMessageConsumer;
         this.onToolListUpdate = onToolListUpdate;
         this.roots = roots;
+        this.progressHandler = progressHandler;
     }
 
     public void handle(JsonNode message) {
@@ -79,6 +93,10 @@ public class McpOperationHandler {
                 }
             } else if (method.equals("notifications/tools/list_changed")) {
                 onToolListUpdate.run();
+            } else if (method.equals("notifications/progress")) {
+                if (progressHandler != null && message.has("params")) {
+                    progressHandler.onProgress(McpProgressNotification.fromJson(message.get("params")));
+                }
             } else {
                 log.warn("Received unknown message: {}", message);
             }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
@@ -7,6 +7,7 @@ import dev.langchain4j.mcp.client.progress.McpProgressHandler;
 import dev.langchain4j.mcp.client.progress.McpProgressNotification;
 import dev.langchain4j.mcp.protocol.McpPingResponse;
 import dev.langchain4j.mcp.protocol.McpRootsListResponse;
+import dev.langchain4j.mcp.protocol.McpServerMethod;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -18,7 +19,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Handles incoming messages from the MCP server. Transport implementations
  * should call the "handle" method on each received message. A transport also has
- * to call "startOperation" when before starting an operation that requires a response
+ * to call "startOperation" before starting an operation that requires a response
  * to register its ID in the map of pending operations.
  */
 public class McpOperationHandler {
@@ -57,49 +58,78 @@ public class McpOperationHandler {
 
     public void handle(JsonNode message) {
         if (message.has("id")) {
-            long messageId = message.get("id").asLong();
-            if (message.has("result") || message.has("error")) {
-                // if there is a result or error, we assume that this is related to a client-initiated operation
-                CompletableFuture<JsonNode> op = pendingOperations.remove(messageId);
-                if (op != null) {
-                    op.complete(message);
-                } else {
-                    log.warn("Received response for unknown message id: {}", messageId);
-                }
+            handleMessageWithId(message);
+        } else if (message.has("method")) {
+            handleNotification(message);
+        }
+    }
+
+    private void handleMessageWithId(JsonNode message) {
+        long messageId = message.get("id").asLong();
+        if (message.has("result") || message.has("error")) {
+            // response to a client-initiated operation
+            CompletableFuture<JsonNode> op = pendingOperations.remove(messageId);
+            if (op != null) {
+                op.complete(message);
             } else {
-                // this is a server-initiated operation, the pendingOperations map is not relevant
-                if (message.has("method")) {
-                    String method = message.get("method").asText();
-                    if (method.equals("ping")) {
-                        transport.executeOperationWithoutResponse(new McpPingResponse(messageId));
-                        return;
-                    } else if (method.equals("roots/list")) {
-                        transport.executeOperationWithoutResponse(new McpRootsListResponse(messageId, roots.get()));
-                        return;
-                    }
-                }
                 log.warn("Received response for unknown message id: {}", messageId);
             }
         } else if (message.has("method")) {
-            String method = message.get("method").asText();
-            if (method.equals("notifications/message")) {
-                // this is a log message
-                if (message.has("params")) {
-                    if (logMessageConsumer != null) {
-                        logMessageConsumer.accept(McpLogMessage.fromJson(message.get("params")));
-                    }
-                } else {
-                    log.warn("Received log message without params: {}", message);
-                }
-            } else if (method.equals("notifications/tools/list_changed")) {
-                onToolListUpdate.run();
-            } else if (method.equals("notifications/progress")) {
-                if (progressHandler != null && message.has("params")) {
-                    progressHandler.onProgress(McpProgressNotification.fromJson(message.get("params")));
-                }
-            } else {
-                log.warn("Received unknown message: {}", message);
+            // server-initiated request requiring a response
+            McpServerMethod method = McpServerMethod.from(message.get("method").asText());
+            if (method == null) {
+                log.warn("Received response for unknown message id: {}", messageId);
+                return;
             }
+            switch (method) {
+                case PING:
+                    transport.executeOperationWithoutResponse(new McpPingResponse(messageId));
+                    break;
+                case ROOTS_LIST:
+                    transport.executeOperationWithoutResponse(new McpRootsListResponse(messageId, roots.get()));
+                    break;
+                default:
+                    log.warn("Received response for unknown message id: {}", messageId);
+            }
+        } else {
+            log.warn("Received response for unknown message id: {}", messageId);
+        }
+    }
+
+    private void handleNotification(JsonNode message) {
+        McpServerMethod method = McpServerMethod.from(message.get("method").asText());
+        if (method == null) {
+            log.warn("Received unknown message: {}", message);
+            return;
+        }
+        switch (method) {
+            case NOTIFICATION_MESSAGE:
+                handleLogMessage(message);
+                break;
+            case NOTIFICATION_TOOLS_LIST_CHANGED:
+                onToolListUpdate.run();
+                break;
+            case NOTIFICATION_PROGRESS:
+                handleProgressNotification(message);
+                break;
+            default:
+                log.warn("Received unknown message: {}", message);
+        }
+    }
+
+    private void handleLogMessage(JsonNode message) {
+        if (message.has("params")) {
+            if (logMessageConsumer != null) {
+                logMessageConsumer.accept(McpLogMessage.fromJson(message.get("params")));
+            }
+        } else {
+            log.warn("Received log message without params: {}", message);
+        }
+    }
+
+    private void handleProgressNotification(JsonNode message) {
+        if (progressHandler != null && message.has("params")) {
+            progressHandler.onProgress(McpProgressNotification.fromJson(message.get("params")));
         }
     }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolRequest.java
@@ -13,10 +13,17 @@ public class McpCallToolRequest extends McpClientMessage {
     private Map<String, Object> params;
 
     public McpCallToolRequest(Long id, String toolName, ObjectNode arguments) {
+        this(id, toolName, arguments, null);
+    }
+
+    public McpCallToolRequest(Long id, String toolName, ObjectNode arguments, String progressToken) {
         super(id, McpClientMethod.TOOLS_CALL);
         this.params = new HashMap<>();
         this.params.put("name", toolName);
         this.params.put("arguments", arguments);
+        if (progressToken != null) {
+            this.params.put("_meta", Map.of("progressToken", progressToken));
+        }
     }
 
     public Map<String, Object> getParams() {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpServerMethod.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpServerMethod.java
@@ -1,0 +1,38 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import dev.langchain4j.Internal;
+
+/**
+ * Enum representing method names for server-initiated MCP messages.
+ */
+@Internal
+public enum McpServerMethod {
+    PING("ping"),
+    ROOTS_LIST("roots/list"),
+    NOTIFICATION_MESSAGE("notifications/message"),
+    NOTIFICATION_TOOLS_LIST_CHANGED("notifications/tools/list_changed"),
+    NOTIFICATION_PROGRESS("notifications/progress");
+
+    private final String value;
+
+    McpServerMethod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static McpServerMethod from(String value) {
+        for (McpServerMethod method : values()) {
+            if (method.value.equals(value)) {
+                return method;
+            }
+        }
+        return null;
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpProgressStdioTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpProgressStdioTransportIT.java
@@ -1,0 +1,38 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getJBangCommand;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getPathToScript;
+
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+class McpProgressStdioTransportIT extends McpProgressTestBase {
+
+    @BeforeAll
+    static void setup() {
+        McpServerHelper.skipTestsIfJbangNotAvailable();
+        McpTransport transport = new StdioMcpTransport.Builder()
+                .command(List.of(
+                        getJBangCommand(), "--quiet", "--fresh", "run", getPathToScript("progress_mcp_server.java")))
+                .logEvents(true)
+                .build();
+        progressHandler = new TestProgressHandler();
+        mcpClient = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .toolExecutionTimeout(Duration.ofSeconds(10))
+                .progressHandler(progressHandler)
+                .build();
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (mcpClient != null) {
+            mcpClient.close();
+        }
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpProgressTestBase.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpProgressTestBase.java
@@ -1,0 +1,80 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.progress.McpProgressHandler;
+import dev.langchain4j.mcp.client.progress.McpProgressNotification;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public abstract class McpProgressTestBase {
+
+    static McpClient mcpClient;
+    static TestProgressHandler progressHandler;
+
+    @BeforeEach
+    public void clearMessages() {
+        progressHandler.clear();
+    }
+
+    @Test
+    public void receiveProgressNotifications() throws TimeoutException {
+        String result = mcpClient
+                .executeTool(ToolExecutionRequest.builder()
+                        .arguments("{}")
+                        .name("progressOperation")
+                        .build())
+                .resultText();
+        assertThat(result).isEqualTo("done");
+
+        List<TestProgressHandler.ProgressEvent> events = progressHandler.waitForMessages(3, Duration.ofSeconds(10));
+        assertThat(events).hasSize(3);
+
+        assertThat(events.get(0).progress()).isEqualTo(1);
+        assertThat(events.get(0).total()).isEqualTo(3);
+        assertThat(events.get(0).message()).isEqualTo("Step 1 of 3");
+
+        assertThat(events.get(2).progress()).isEqualTo(3);
+    }
+
+    public static class TestProgressHandler implements McpProgressHandler {
+
+        public record ProgressEvent(double progress, double total, String message) {}
+
+        private final List<ProgressEvent> events = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onProgress(McpProgressNotification notification) {
+            events.add(new ProgressEvent(
+                    notification.progress(),
+                    notification.total() != null ? notification.total() : 0,
+                    notification.message()));
+        }
+
+        public List<ProgressEvent> waitForMessages(int count, Duration timeout) throws TimeoutException {
+            long start = System.currentTimeMillis();
+            while (events.size() < count) {
+                if (System.currentTimeMillis() - start > timeout.toMillis()) {
+                    throw new TimeoutException("Expected " + count + " events but got " + events.size());
+                }
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+            return events;
+        }
+
+        public void clear() {
+            events.clear();
+        }
+    }
+}

--- a/langchain4j-mcp/src/test/resources/progress_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/progress_mcp_server.java
@@ -1,0 +1,27 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS io.quarkus:quarkus-bom:${quarkus.version:3.27.0}@pom
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.7.2
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-sse:1.7.2
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-websocket:1.7.2
+
+import io.quarkiverse.mcp.server.Progress;
+import io.quarkiverse.mcp.server.Tool;
+
+public class progress_mcp_server {
+
+    @Tool(description = "A tool that reports progress notifications")
+    public String progressOperation(Progress progress) {
+        if (progress.token().isEmpty()) {
+            return "no-progress-token";
+        }
+        for (int i = 1; i <= 3; i++) {
+            progress.notificationBuilder()
+                    .setProgress(i)
+                    .setTotal(3)
+                    .setMessage("Step " + i + " of 3")
+                    .build()
+                    .sendAndForget();
+        }
+        return "done";
+    }
+}


### PR DESCRIPTION
## Issue
Closes #4777
Closes #2830 

## Change
Refactored McpOperationHandler.handle() to replace the growing if-else chain with enum-based
dispatch.

- Added McpServerMethod enum covering all server-initiated message method names (ping,
roots/list, notifications/message, notifications/tools/list_changed, notifications/progress),
consistent with the existing McpClientMethod enum for outgoing messages
- Replaced string comparisons in handle() with switch on McpServerMethod
- Extracted handleMessageWithId(), handleNotification(), handleLogMessage(), and
handleProgressNotification() private methods for clarity

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/
changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and
they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo
- [ ] I have added/updated Spring Boot starter(s)

Note on tests: no new tests were added since this is a pure refactor — all existing IT tests (
McpLoggingStdioTransportIT, McpProgressStdioTransportIT, McpToolsStdioTransportIT, etc.) cover
the behaviour and all pass green.

Only 2 files are relevant: McpServerMethod.java and McpOperationHandler.java.
Rest of the files are due to the Creating the branch from https://github.com/langchain4j/langchain4j/pull/4776. As this builds on top of that fix