### PR TITLE
MCP _meta fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ langchain4j-core/target_test-classes/
 
 ## AI Coding Assistants ###
 CLAUDE.md
+
+### Quarkus stuff ###
+.quarkus

--- a/docs/docs/tutorials/mcp.md
+++ b/docs/docs/tutorials/mcp.md
@@ -254,6 +254,32 @@ The `title` field that exists directly in the MCP tool definition is exposed und
 `McpToolMetadataKeys.TITLE` key in the metadata map to distinguish it from the title
 that is retrieved from annotations - that one is exposed under the `McpToolMetadataKeys.ANNOTATION_TITLE` key.
 
+## Providing `_meta` fields
+
+The MCP protocol allows clients to attach a `_meta` object to the `params` of every
+request and notification sent to the server. This can be used for passing
+OpenTelemetry trace context, custom application metadata, or any other
+out-of-band information that the server may need.
+
+To supply `_meta` fields, register an `McpMetaSupplier` on the client builder.
+The supplier is called before every request or notification, and the returned
+map is placed into `params._meta`. Unlike HTTP headers, this works across
+all transports (stdio, HTTP, WebSocket).
+
+```java
+McpClient mcpClient = DefaultMcpClient.builder()
+    .transport(transport)
+    .metaSupplier(context -> Map.of(
+        "traceparent", "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01",
+        "custom-key", "custom-value"))
+    .build();
+```
+
+The supplier receives an `McpCallContext` (nullable) that contains the
+message being sent and, when applicable, the `InvocationContext` of the
+AI service call that triggered it. This allows the supplier to vary
+the metadata based on which operation is being performed.
+
 ## Logging
 
 The MCP protocol also defines a way for the server to send log messages to

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -23,6 +23,10 @@ import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
 import dev.langchain4j.mcp.protocol.McpCallToolRequest;
 import dev.langchain4j.mcp.protocol.McpCancellationNotification;
+import dev.langchain4j.mcp.protocol.McpClientMessage;
+import dev.langchain4j.mcp.protocol.McpClientNotification;
+import dev.langchain4j.mcp.protocol.McpClientParams;
+import dev.langchain4j.mcp.protocol.McpClientRequest;
 import dev.langchain4j.mcp.protocol.McpGetPromptRequest;
 import dev.langchain4j.mcp.protocol.McpImplementation;
 import dev.langchain4j.mcp.protocol.McpInitializeParams;
@@ -93,6 +97,7 @@ public class DefaultMcpClient implements McpClient {
     private final AtomicReference<List<McpRoot>> mcpRoots;
     private final Boolean cacheToolList;
     private final McpClientListener listener;
+    private final McpMetaSupplier metaSupplier;
 
     public DefaultMcpClient(Builder builder) {
         try {
@@ -112,6 +117,7 @@ public class DefaultMcpClient implements McpClient {
             autoHealthCheck = getOrDefault(builder.autoHealthCheck, Boolean.TRUE);
             autoHealthCheckInterval = getOrDefault(builder.autoHealthCheckInterval, Duration.ofSeconds(30));
             listener = builder.listener;
+            metaSupplier = builder.metaSupplier;
             healthCheckScheduler = autoHealthCheck
                     ? Executors.newSingleThreadScheduledExecutor(r -> {
                         Thread t = new Thread(r, "mcp-server-health-checker");
@@ -165,6 +171,7 @@ public class DefaultMcpClient implements McpClient {
         McpInitializeRequest request = new McpInitializeRequest(operationId);
         McpInitializeParams params = createInitializeParams();
         request.setParams(params);
+        applyMeta(request, null);
         try {
             JsonNode capabilities =
                     transport.initialize(request).get(initializationTimeout.toMillis(), TimeUnit.MILLISECONDS);
@@ -274,13 +281,16 @@ public class DefaultMcpClient implements McpClient {
             if (listener != null) {
                 listener.beforeExecuteTool(context);
             }
+            applyMeta(operation, context);
             resultFuture = transport.executeOperationWithResponse(context);
             result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
         } catch (TimeoutException timeout) {
             if (listener != null) {
                 listener.onExecuteToolError(context, timeout);
             }
-            transport.executeOperationWithoutResponse(new McpCancellationNotification(operationId, "Timeout"));
+            McpCancellationNotification cancellation = new McpCancellationNotification(operationId, "Timeout");
+            applyMeta(cancellation, null);
+            transport.executeOperationWithoutResponse(cancellation);
             return ToolExecutionHelper.extractResult(RESULT_TIMEOUT, false);
         } catch (ExecutionException e) {
             if (listener != null) {
@@ -350,6 +360,7 @@ public class DefaultMcpClient implements McpClient {
         if (listener != null) {
             listener.beforeResourceGet(context);
         }
+        applyMeta(operation, context);
         try {
             resultFuture = transport.executeOperationWithResponse(context);
             result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
@@ -399,6 +410,7 @@ public class DefaultMcpClient implements McpClient {
         if (listener != null) {
             listener.beforePromptGet(context);
         }
+        applyMeta(operation, context);
         try {
             resultFuture = transport.executeOperationWithResponse(context);
             result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
@@ -432,6 +444,7 @@ public class DefaultMcpClient implements McpClient {
         transport.checkHealth();
         long operationId = idGenerator.getAndIncrement();
         McpPingRequest ping = new McpPingRequest(operationId);
+        applyMeta(ping, null);
         try {
             CompletableFuture<JsonNode> resultFuture = transport.executeOperationWithResponse(ping);
             resultFuture.get(pingTimeout.toMillis(), TimeUnit.MILLISECONDS);
@@ -445,7 +458,9 @@ public class DefaultMcpClient implements McpClient {
     @Override
     public void setRoots(final List<McpRoot> roots) {
         this.mcpRoots.set(roots);
-        transport.executeOperationWithoutResponse(new McpRootsListChangedNotification());
+        McpRootsListChangedNotification notification = new McpRootsListChangedNotification();
+        applyMeta(notification, null);
+        transport.executeOperationWithoutResponse(notification);
     }
 
     @Override
@@ -464,8 +479,9 @@ public class DefaultMcpClient implements McpClient {
 
     private synchronized void obtainToolList(InvocationContext invocationContext) {
         McpListToolsRequest operation = new McpListToolsRequest(idGenerator.getAndIncrement());
-        CompletableFuture<JsonNode> resultFuture =
-                transport.executeOperationWithResponse(new McpCallContext(invocationContext, operation));
+        McpCallContext context = new McpCallContext(invocationContext, operation);
+        applyMeta(operation, context);
+        CompletableFuture<JsonNode> resultFuture = transport.executeOperationWithResponse(context);
         JsonNode result = null;
         try {
             result = resultFuture.get();
@@ -485,11 +501,13 @@ public class DefaultMcpClient implements McpClient {
             return;
         }
         McpListResourcesRequest operation = new McpListResourcesRequest(idGenerator.getAndIncrement());
+        McpCallContext context = new McpCallContext(invocationContext, operation);
+        applyMeta(operation, context);
         long timeoutMillis = resourcesTimeout.toMillis() == 0 ? Integer.MAX_VALUE : resourcesTimeout.toMillis();
         JsonNode result = null;
         CompletableFuture<JsonNode> resultFuture = null;
         try {
-            resultFuture = transport.executeOperationWithResponse(new McpCallContext(invocationContext, operation));
+            resultFuture = transport.executeOperationWithResponse(context);
             result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
             resourceRefs.set(ResourcesHelper.parseResourceRefs(result));
         } catch (ExecutionException | InterruptedException | TimeoutException e) {
@@ -504,11 +522,13 @@ public class DefaultMcpClient implements McpClient {
             return;
         }
         McpListResourceTemplatesRequest operation = new McpListResourceTemplatesRequest(idGenerator.getAndIncrement());
+        McpCallContext context = new McpCallContext(invocationContext, operation);
+        applyMeta(operation, context);
         long timeoutMillis = toolExecutionTimeout.toMillis() == 0 ? Integer.MAX_VALUE : toolExecutionTimeout.toMillis();
         JsonNode result = null;
         CompletableFuture<JsonNode> resultFuture = null;
         try {
-            resultFuture = transport.executeOperationWithResponse(new McpCallContext(invocationContext, operation));
+            resultFuture = transport.executeOperationWithResponse(context);
             result = resultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
             resourceTemplateRefs.set(ResourcesHelper.parseResourceTemplateRefs(result));
         } catch (ExecutionException | InterruptedException | TimeoutException e) {
@@ -554,6 +574,7 @@ public class DefaultMcpClient implements McpClient {
             return;
         }
         McpListPromptsRequest operation = new McpListPromptsRequest(idGenerator.getAndIncrement());
+        applyMeta(operation, null);
         long timeoutMillis = promptsTimeout.toMillis() == 0 ? Integer.MAX_VALUE : promptsTimeout.toMillis();
         JsonNode result = null;
         CompletableFuture<JsonNode> resultFuture = null;
@@ -578,6 +599,27 @@ public class DefaultMcpClient implements McpClient {
             transport.close();
         } catch (Exception e) {
             log.warn("Cannot close MCP transport", e);
+        }
+    }
+
+    private void applyMeta(McpClientMessage message, McpCallContext context) {
+        if (metaSupplier == null) {
+            return;
+        }
+        Map<String, Object> meta = metaSupplier.apply(context);
+        if (meta == null || meta.isEmpty()) {
+            return;
+        }
+        if (message instanceof McpClientRequest request) {
+            if (request.getParams() == null) {
+                request.setParams(new McpClientParams());
+            }
+            request.getParams().setMeta(meta);
+        } else if (message instanceof McpClientNotification notification) {
+            if (notification.getParams() == null) {
+                notification.setParams(new McpClientParams());
+            }
+            notification.getParams().setMeta(meta);
         }
     }
 
@@ -612,6 +654,7 @@ public class DefaultMcpClient implements McpClient {
         private Boolean cacheToolList;
         private McpClientListener listener;
         private McpProgressHandler progressHandler;
+        private McpMetaSupplier metaSupplier;
 
         /**
          * Sets the transport protocol to use for communicating with the
@@ -800,6 +843,16 @@ public class DefaultMcpClient implements McpClient {
          */
         public Builder progressHandler(McpProgressHandler progressHandler) {
             this.progressHandler = progressHandler;
+            return this;
+        }
+
+        /**
+         * Sets a supplier of {@code _meta} fields for MCP client requests and notifications.
+         * The supplier is called before every request or notification sent to the server.
+         * Unlike HTTP headers, this applies to all transports.
+         */
+        public Builder metaSupplier(McpMetaSupplier metaSupplier) {
+            this.metaSupplier = metaSupplier;
             return this;
         }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpMetaSupplier.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpMetaSupplier.java
@@ -1,0 +1,13 @@
+package dev.langchain4j.mcp.client;
+
+import java.util.Map;
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A functional interface that supplies {@code _meta} fields for MCP client
+ * requests and notifications based on the given {@link McpCallContext}.
+ * Unlike HTTP headers, this applies to all transports.
+ */
+@FunctionalInterface
+public interface McpMetaSupplier extends Function<@Nullable McpCallContext, Map<String, Object>> {}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolParams.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolParams.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.Internal;
+
+/**
+ * Corresponds to the {@code params} of the {@code CallToolRequest} type from the MCP schema.
+ */
+@Internal
+public class McpCallToolParams extends McpClientParams {
+
+    private String name;
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private ObjectNode arguments;
+
+    public McpCallToolParams() {}
+
+    public McpCallToolParams(String name, ObjectNode arguments) {
+        this.name = name;
+        this.arguments = arguments;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ObjectNode getArguments() {
+        return arguments;
+    }
+
+    public void setArguments(ObjectNode arguments) {
+        this.arguments = arguments;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolRequest.java
@@ -1,16 +1,14 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.langchain4j.Internal;
-import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Corresponds to the {@code CallToolRequest} type from the MCP schema.
+ */
 @Internal
-public class McpCallToolRequest extends McpClientMessage {
-
-    @JsonInclude
-    private Map<String, Object> params;
+public class McpCallToolRequest extends McpClientRequest {
 
     public McpCallToolRequest(Long id, String toolName, ObjectNode arguments) {
         this(id, toolName, arguments, null);
@@ -18,15 +16,10 @@ public class McpCallToolRequest extends McpClientMessage {
 
     public McpCallToolRequest(Long id, String toolName, ObjectNode arguments, String progressToken) {
         super(id, McpClientMethod.TOOLS_CALL);
-        this.params = new HashMap<>();
-        this.params.put("name", toolName);
-        this.params.put("arguments", arguments);
+        McpCallToolParams params = new McpCallToolParams(toolName, arguments);
         if (progressToken != null) {
-            this.params.put("_meta", Map.of("progressToken", progressToken));
+            params.setMeta(Map.of("progressToken", progressToken));
         }
-    }
-
-    public Map<String, Object> getParams() {
-        return params;
+        setParams(params);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCallToolResult.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 import java.util.List;
 
+/**
+ * Corresponds to the {@code CallToolResult} type from the MCP schema.
+ */
 @Internal
 public class McpCallToolResult extends McpJsonRpcMessage {
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCancellationNotification.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCancellationNotification.java
@@ -1,27 +1,16 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
-import java.util.HashMap;
-import java.util.Map;
 import org.jspecify.annotations.NonNull;
 
+/**
+ * Corresponds to the {@code CancelledNotification} type from the MCP schema.
+ */
 @Internal
-public class McpCancellationNotification extends McpClientMessage {
-
-    @JsonInclude
-    private Map<String, Object> params;
+public class McpCancellationNotification extends McpClientNotification {
 
     public McpCancellationNotification(@NonNull Long requestId, String reason) {
-        super(null, McpClientMethod.NOTIFICATION_CANCELLED);
-        this.params = new HashMap<>();
-        this.params.put("requestId", requestId);
-        if (reason != null) {
-            this.params.put("reason", reason);
-        }
-    }
-
-    public Map<String, Object> getParams() {
-        return params;
+        super(McpClientMethod.NOTIFICATION_CANCELLED);
+        setParams(new McpCancellationParams(requestId, reason));
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCancellationParams.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpCancellationParams.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import dev.langchain4j.Internal;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Corresponds to the {@code params} of the {@code CancelledNotification} type from the MCP schema.
+ */
+@Internal
+public class McpCancellationParams extends McpClientParams {
+
+    private Long requestId;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String reason;
+
+    public McpCancellationParams() {}
+
+    public McpCancellationParams(@NonNull Long requestId, String reason) {
+        this.requestId = requestId;
+        this.reason = reason;
+    }
+
+    public Long getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(Long requestId) {
+        this.requestId = requestId;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpClientNotification.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpClientNotification.java
@@ -1,0 +1,26 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import dev.langchain4j.Internal;
+
+/**
+ * Corresponds to the {@code JSONRPCNotification} type from the MCP schema.
+ */
+@Internal
+public class McpClientNotification extends McpClientMessage {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private McpClientParams params;
+
+    public McpClientNotification(McpClientMethod method) {
+        super(null, method);
+    }
+
+    public McpClientParams getParams() {
+        return params;
+    }
+
+    public void setParams(McpClientParams params) {
+        this.params = params;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpClientParams.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpClientParams.java
@@ -1,0 +1,25 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.Internal;
+import java.util.Map;
+
+/**
+ * Corresponds to the {@code params} of the {@code JSONRPCRequest} type from the MCP schema.
+ */
+@Internal
+public class McpClientParams {
+
+    @JsonProperty("_meta")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Map<String, Object> meta;
+
+    public Map<String, Object> getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Map<String, Object> meta) {
+        this.meta = meta;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpClientRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpClientRequest.java
@@ -1,0 +1,26 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import dev.langchain4j.Internal;
+
+/**
+ * Corresponds to the {@code JSONRPCRequest} type from the MCP schema.
+ */
+@Internal
+public class McpClientRequest extends McpClientMessage {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private McpClientParams params;
+
+    public McpClientRequest(Long id, McpClientMethod method) {
+        super(id, method);
+    }
+
+    public McpClientParams getParams() {
+        return params;
+    }
+
+    public void setParams(McpClientParams params) {
+        this.params = params;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpClientResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpClientResponse.java
@@ -1,0 +1,14 @@
+package dev.langchain4j.mcp.protocol;
+
+import dev.langchain4j.Internal;
+
+/**
+ * Corresponds to the {@code JSONRPCResponse} type from the MCP schema.
+ */
+@Internal
+public class McpClientResponse extends McpClientMessage {
+
+    public McpClientResponse(Long id) {
+        super(id, null);
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpErrorResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpErrorResponse.java
@@ -3,6 +3,9 @@ package dev.langchain4j.mcp.protocol;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code JSONRPCError} type from the MCP schema.
+ */
 @Internal
 public class McpErrorResponse extends McpJsonRpcMessage {
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpGetPromptParams.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpGetPromptParams.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import dev.langchain4j.Internal;
+import java.util.Map;
+
+/**
+ * Corresponds to the {@code params} of the {@code GetPromptRequest} type from the MCP schema.
+ */
+@Internal
+public class McpGetPromptParams extends McpClientParams {
+
+    private String name;
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private Map<String, Object> arguments;
+
+    public McpGetPromptParams() {}
+
+    public McpGetPromptParams(String name, Map<String, Object> arguments) {
+        this.name = name;
+        this.arguments = arguments;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, Object> getArguments() {
+        return arguments;
+    }
+
+    public void setArguments(Map<String, Object> arguments) {
+        this.arguments = arguments;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpGetPromptRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpGetPromptRequest.java
@@ -1,24 +1,16 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
-import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Corresponds to the {@code GetPromptRequest} type from the MCP schema.
+ */
 @Internal
-public class McpGetPromptRequest extends McpClientMessage {
-
-    @JsonInclude
-    private Map<String, Object> params;
+public class McpGetPromptRequest extends McpClientRequest {
 
     public McpGetPromptRequest(Long id, String promptName, Map<String, Object> arguments) {
         super(id, McpClientMethod.PROMPTS_GET);
-        this.params = new HashMap<>();
-        this.params.put("name", promptName);
-        this.params.put("arguments", arguments);
-    }
-
-    public Map<String, Object> getParams() {
-        return params;
+        setParams(new McpGetPromptParams(promptName, arguments));
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpImplementation.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpImplementation.java
@@ -3,6 +3,9 @@ package dev.langchain4j.mcp.protocol;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code Implementation} type from the MCP schema.
+ */
 @Internal
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class McpImplementation {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializationNotification.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializationNotification.java
@@ -2,10 +2,13 @@ package dev.langchain4j.mcp.protocol;
 
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code InitializedNotification} type from the MCP schema.
+ */
 @Internal
-public class McpInitializationNotification extends McpClientMessage {
+public class McpInitializationNotification extends McpClientNotification {
 
     public McpInitializationNotification() {
-        super(null, McpClientMethod.NOTIFICATION_INITIALIZED);
+        super(McpClientMethod.NOTIFICATION_INITIALIZED);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeParams.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeParams.java
@@ -3,8 +3,11 @@ package dev.langchain4j.mcp.protocol;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code params} of the {@code InitializeRequest} type from the MCP schema.
+ */
 @Internal
-public class McpInitializeParams {
+public class McpInitializeParams extends McpClientParams {
 
     private String protocolVersion;
     private Capabilities capabilities;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeRequest.java
@@ -2,20 +2,13 @@ package dev.langchain4j.mcp.protocol;
 
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code InitializeRequest} type from the MCP schema.
+ */
 @Internal
-public class McpInitializeRequest extends McpClientMessage {
-
-    private McpInitializeParams params;
+public class McpInitializeRequest extends McpClientRequest {
 
     public McpInitializeRequest(Long id) {
         super(id, McpClientMethod.INITIALIZE);
-    }
-
-    public McpInitializeParams getParams() {
-        return params;
-    }
-
-    public void setParams(final McpInitializeParams params) {
-        this.params = params;
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeResult.java
@@ -3,6 +3,9 @@ package dev.langchain4j.mcp.protocol;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code InitializeResult} type from the MCP schema.
+ */
 @Internal
 public class McpInitializeResult extends McpJsonRpcMessage {
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpJsonRpcMessage.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpJsonRpcMessage.java
@@ -3,6 +3,9 @@ package dev.langchain4j.mcp.protocol;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code JSONRPCMessage} type from the MCP schema.
+ */
 @Internal
 public class McpJsonRpcMessage {
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListPromptsRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListPromptsRequest.java
@@ -2,8 +2,11 @@ package dev.langchain4j.mcp.protocol;
 
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code ListPromptsRequest} type from the MCP schema.
+ */
 @Internal
-public class McpListPromptsRequest extends McpClientMessage {
+public class McpListPromptsRequest extends McpClientRequest {
 
     public McpListPromptsRequest(Long id) {
         super(id, McpClientMethod.PROMPTS_LIST);

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourceTemplatesRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourceTemplatesRequest.java
@@ -2,8 +2,11 @@ package dev.langchain4j.mcp.protocol;
 
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code ListResourceTemplatesRequest} type from the MCP schema.
+ */
 @Internal
-public class McpListResourceTemplatesRequest extends McpClientMessage {
+public class McpListResourceTemplatesRequest extends McpClientRequest {
 
     public McpListResourceTemplatesRequest(Long id) {
         super(id, McpClientMethod.RESOURCES_TEMPLATES_LIST);

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourcesRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListResourcesRequest.java
@@ -2,8 +2,11 @@ package dev.langchain4j.mcp.protocol;
 
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code ListResourcesRequest} type from the MCP schema.
+ */
 @Internal
-public class McpListResourcesRequest extends McpClientMessage {
+public class McpListResourcesRequest extends McpClientRequest {
 
     public McpListResourcesRequest(Long id) {
         super(id, McpClientMethod.RESOURCES_LIST);

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListToolsParams.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListToolsParams.java
@@ -1,0 +1,22 @@
+package dev.langchain4j.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import dev.langchain4j.Internal;
+
+/**
+ * Corresponds to the {@code params} of the {@code ListToolsRequest} type from the MCP schema.
+ */
+@Internal
+public class McpListToolsParams extends McpClientParams {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String cursor;
+
+    public String getCursor() {
+        return cursor;
+    }
+
+    public void setCursor(String cursor) {
+        this.cursor = cursor;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListToolsRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListToolsRequest.java
@@ -1,28 +1,22 @@
 package dev.langchain4j.mcp.protocol;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
-import java.util.HashMap;
-import java.util.Map;
 
+/**
+ * Corresponds to the {@code ListToolsRequest} type from the MCP schema.
+ */
 @Internal
-public class McpListToolsRequest extends McpClientMessage {
-
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private Map<String, Object> params;
+public class McpListToolsRequest extends McpClientRequest {
 
     public McpListToolsRequest(Long id) {
         super(id, McpClientMethod.TOOLS_LIST);
-        this.params = new HashMap<>();
-    }
-
-    public Map<String, Object> getParams() {
-        return params;
     }
 
     @JsonIgnore
     public void setCursor(String cursor) {
-        this.params.put("cursor", cursor);
+        McpListToolsParams p = new McpListToolsParams();
+        p.setCursor(cursor);
+        setParams(p);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListToolsResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpListToolsResult.java
@@ -5,6 +5,9 @@ import dev.langchain4j.Internal;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Corresponds to the {@code ListToolsResult} type from the MCP schema.
+ */
 @Internal
 public class McpListToolsResult extends McpJsonRpcMessage {
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpPingRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpPingRequest.java
@@ -2,8 +2,11 @@ package dev.langchain4j.mcp.protocol;
 
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code PingRequest} type from the MCP schema.
+ */
 @Internal
-public class McpPingRequest extends McpClientMessage {
+public class McpPingRequest extends McpClientRequest {
 
     public McpPingRequest(Long id) {
         super(id, McpClientMethod.PING);

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpPingResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpPingResponse.java
@@ -5,15 +5,18 @@ import dev.langchain4j.Internal;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Corresponds to the {@code EmptyResult} type from the MCP schema (response to a {@code PingRequest}).
+ */
 @Internal
-public class McpPingResponse extends McpClientMessage {
+public class McpPingResponse extends McpClientResponse {
 
     // has to be an empty object
     @JsonInclude(JsonInclude.Include.ALWAYS)
     private final Map<String, Object> result = new HashMap<>();
 
     public McpPingResponse(Long id) {
-        super(id, null);
+        super(id);
     }
 
     public Map<String, Object> getResult() {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpReadResourceParams.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpReadResourceParams.java
@@ -1,0 +1,28 @@
+package dev.langchain4j.mcp.protocol;
+
+import dev.langchain4j.Internal;
+import java.util.Objects;
+
+/**
+ * Corresponds to the {@code params} of the {@code ReadResourceRequest} type from the MCP schema.
+ */
+@Internal
+public class McpReadResourceParams extends McpClientParams {
+
+    private String uri;
+
+    public McpReadResourceParams() {}
+
+    public McpReadResourceParams(String uri) {
+        Objects.requireNonNull(uri);
+        this.uri = uri;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpReadResourceRequest.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpReadResourceRequest.java
@@ -1,25 +1,15 @@
 package dev.langchain4j.mcp.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
 
+/**
+ * Corresponds to the {@code ReadResourceRequest} type from the MCP schema.
+ */
 @Internal
-public class McpReadResourceRequest extends McpClientMessage {
-
-    @JsonInclude
-    private Map<String, Object> params;
+public class McpReadResourceRequest extends McpClientRequest {
 
     public McpReadResourceRequest(Long id, String uri) {
         super(id, McpClientMethod.RESOURCES_READ);
-        this.params = new HashMap<>();
-        Objects.requireNonNull(uri);
-        this.params.put("uri", uri);
-    }
-
-    public Map<String, Object> getParams() {
-        return params;
+        setParams(new McpReadResourceParams(uri));
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpRootsListChangedNotification.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpRootsListChangedNotification.java
@@ -2,10 +2,13 @@ package dev.langchain4j.mcp.protocol;
 
 import dev.langchain4j.Internal;
 
+/**
+ * Corresponds to the {@code RootsListChangedNotification} type from the MCP schema.
+ */
 @Internal
-public class McpRootsListChangedNotification extends McpClientMessage {
+public class McpRootsListChangedNotification extends McpClientNotification {
 
     public McpRootsListChangedNotification() {
-        super(null, McpClientMethod.NOTIFICATION_ROOTS_LIST_CHANGED);
+        super(McpClientMethod.NOTIFICATION_ROOTS_LIST_CHANGED);
     }
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpRootsListResponse.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpRootsListResponse.java
@@ -7,14 +7,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Corresponds to the {@code ListRootsResult} type from the MCP schema.
+ */
 @Internal
-public class McpRootsListResponse extends McpClientMessage {
+public class McpRootsListResponse extends McpClientResponse {
 
     @JsonInclude(JsonInclude.Include.ALWAYS)
     private final Map<String, Object> result = new HashMap<>();
 
     public McpRootsListResponse(Long id, List<McpRoot> roots) {
-        super(id, null);
+        super(id);
         result.put("roots", roots);
     }
 

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -15,10 +15,13 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import dev.langchain4j.mcp.client.transport.McpTransport;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -257,6 +260,50 @@ public class DefaultMcpClientTest {
         assertThat(subsequentTools.get(0).name()).isEqualTo("testToolAnother");
         // and: the transport operation was executed as many times as tools were retrieved
         verify(transport, times(2)).executeOperationWithResponse(any(McpCallContext.class));
+    }
+
+    @Test
+    public void listener_should_run_before_meta_supplier() throws Exception {
+        // given
+        final McpTransport transport = getMinimalMcpTransportMock();
+        ObjectNode toolResult = JsonNodeFactory.instance.objectNode();
+        toolResult
+                .putObject("result")
+                .putArray("content")
+                .addObject()
+                .put("type", "text")
+                .put("text", "ok");
+        when(transport.executeOperationWithResponse(any(McpCallContext.class)))
+                .thenReturn(CompletableFuture.completedFuture(toolResult));
+
+        List<String> callOrder = new ArrayList<>();
+        McpClientListener listener = new McpClientListener() {
+            @Override
+            public void beforeExecuteTool(McpCallContext context) {
+                callOrder.add("listener");
+            }
+        };
+        McpMetaSupplier metaSupplier = ctx -> {
+            callOrder.add("meta");
+            return Map.of("key", "value");
+        };
+
+        DefaultMcpClient client = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .listener(listener)
+                .metaSupplier(metaSupplier)
+                .build();
+
+        // when
+        callOrder.clear();
+        client.executeTool(
+                ToolExecutionRequest.builder().name("test").arguments("{}").build());
+
+        // then
+        assertThat(callOrder)
+                .as("Listener must run before meta supplier so that listeners can set up context "
+                        + "(e.g. a tracing span) that the meta supplier can then reference")
+                .containsExactly("listener", "meta");
     }
 
     private static McpTransport getMinimalMcpTransportMock() {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpMetaStdioTransportIT.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/integration/McpMetaStdioTransportIT.java
@@ -1,0 +1,75 @@
+package dev.langchain4j.mcp.client.integration;
+
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getJBangCommand;
+import static dev.langchain4j.mcp.client.integration.McpServerHelper.getPathToScript;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class McpMetaStdioTransportIT {
+
+    static McpClient mcpClient;
+
+    @BeforeAll
+    static void setup() {
+        McpTransport transport = new StdioMcpTransport.Builder()
+                .command(List.of(
+                        getJBangCommand(), "--quiet", "--fresh", "run", getPathToScript("meta_mcp_server.java")))
+                .logEvents(true)
+                .build();
+        mcpClient = new DefaultMcpClient.Builder()
+                .transport(transport)
+                .toolExecutionTimeout(Duration.ofSeconds(10))
+                .metaSupplier(ctx -> Map.of(
+                        "traceparent", "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01",
+                        "custom-key", "custom-value"))
+                .build();
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (mcpClient != null) {
+            mcpClient.close();
+        }
+    }
+
+    @Test
+    void metaFieldsArePassedToServer() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .name("echoMeta")
+                .arguments("{\"key\": \"traceparent\"}")
+                .build();
+        String result = mcpClient.executeTool(request).resultText();
+        assertThat(result).isEqualTo("00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01");
+    }
+
+    @Test
+    void customMetaFieldIsPassedToServer() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .name("echoMeta")
+                .arguments("{\"key\": \"custom-key\"}")
+                .build();
+        String result = mcpClient.executeTool(request).resultText();
+        assertThat(result).isEqualTo("custom-value");
+    }
+
+    @Test
+    void missingMetaFieldReturnsNull() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .name("echoMeta")
+                .arguments("{\"key\": \"nonexistent\"}")
+                .build();
+        String result = mcpClient.executeTool(request).resultText();
+        assertThat(result).isEqualTo("null");
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/protocol/McpProtocolSerializationTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/protocol/McpProtocolSerializationTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class McpProtocolSerializationTest {
@@ -63,6 +65,125 @@ class McpProtocolSerializationTest {
         assertThat(json.get("clientInfo").get("name").asText()).isEqualTo("client");
         assertThat(json.get("clientInfo").get("version").asText()).isEqualTo("1.0");
         assertThat(json.get("clientInfo").get("title").asText()).isEqualTo("Client Title");
+    }
+
+    @Test
+    void should_serialize_call_tool_request() throws Exception {
+        ObjectNode args = OBJECT_MAPPER.createObjectNode();
+        args.put("location", "Prague");
+        McpCallToolRequest request = new McpCallToolRequest(1L, "get_weather", args);
+
+        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+
+        assertThat(json.get("jsonrpc").asText()).isEqualTo("2.0");
+        assertThat(json.get("id").asLong()).isEqualTo(1L);
+        assertThat(json.get("method").asText()).isEqualTo("tools/call");
+        assertThat(json.get("params").get("name").asText()).isEqualTo("get_weather");
+        assertThat(json.get("params").get("arguments").get("location").asText()).isEqualTo("Prague");
+        assertThat(json.get("params").has("_meta")).isFalse();
+    }
+
+    @Test
+    void should_serialize_call_tool_request_with_meta() throws Exception {
+        ObjectNode args = OBJECT_MAPPER.createObjectNode();
+        args.put("location", "Prague");
+        McpCallToolRequest request = new McpCallToolRequest(2L, "get_weather", args);
+        request.getParams().setMeta(Map.of("traceparent", "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01"));
+
+        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+
+        assertThat(json.get("params").get("_meta").get("traceparent").asText())
+                .isEqualTo("00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01");
+        assertThat(json.get("params").get("name").asText()).isEqualTo("get_weather");
+    }
+
+    @Test
+    void should_serialize_cancellation_notification() throws Exception {
+        McpCancellationNotification notification = new McpCancellationNotification(42L, "Timeout");
+
+        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(notification));
+
+        assertThat(json.has("id")).isFalse();
+        assertThat(json.get("method").asText()).isEqualTo("notifications/cancelled");
+        assertThat(json.get("params").get("requestId").asLong()).isEqualTo(42L);
+        assertThat(json.get("params").get("reason").asText()).isEqualTo("Timeout");
+    }
+
+    @Test
+    void should_serialize_cancellation_notification_without_reason() throws Exception {
+        McpCancellationNotification notification = new McpCancellationNotification(42L, null);
+
+        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(notification));
+
+        assertThat(json.get("params").get("requestId").asLong()).isEqualTo(42L);
+        assertThat(json.get("params").has("reason")).isFalse();
+    }
+
+    @Test
+    void should_serialize_get_prompt_request() throws Exception {
+        McpGetPromptRequest request = new McpGetPromptRequest(3L, "summarize", Map.of("text", "hello"));
+
+        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+
+        assertThat(json.get("method").asText()).isEqualTo("prompts/get");
+        assertThat(json.get("params").get("name").asText()).isEqualTo("summarize");
+        assertThat(json.get("params").get("arguments").get("text").asText()).isEqualTo("hello");
+    }
+
+    @Test
+    void should_serialize_read_resource_request() throws Exception {
+        McpReadResourceRequest request = new McpReadResourceRequest(4L, "file:///tmp/test.txt");
+
+        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+
+        assertThat(json.get("method").asText()).isEqualTo("resources/read");
+        assertThat(json.get("params").get("uri").asText()).isEqualTo("file:///tmp/test.txt");
+    }
+
+    @Test
+    void should_serialize_list_tools_request_without_cursor() throws Exception {
+        McpListToolsRequest request = new McpListToolsRequest(5L);
+
+        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+
+        assertThat(json.get("method").asText()).isEqualTo("tools/list");
+        assertThat(json.has("params")).isFalse();
+    }
+
+    @Test
+    void should_serialize_list_tools_request_with_cursor() throws Exception {
+        McpListToolsRequest request = new McpListToolsRequest(5L);
+        request.setCursor("next_page");
+
+        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+
+        assertThat(json.get("method").asText()).isEqualTo("tools/list");
+        assertThat(json.get("params").get("cursor").asText()).isEqualTo("next_page");
+    }
+
+    @Test
+    void should_serialize_ping_request_without_params() throws Exception {
+        McpPingRequest request = new McpPingRequest(6L);
+
+        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+
+        assertThat(json.get("method").asText()).isEqualTo("ping");
+        assertThat(json.has("params")).isFalse();
+    }
+
+    @Test
+    void should_serialize_initialize_request() throws Exception {
+        McpInitializeRequest request = new McpInitializeRequest(7L);
+        McpInitializeParams params = new McpInitializeParams();
+        params.setProtocolVersion("2025-06-18");
+        params.setClientInfo(new McpImplementation("test", "1.0", null));
+        request.setParams(params);
+
+        JsonNode json = OBJECT_MAPPER.readTree(OBJECT_MAPPER.writeValueAsString(request));
+
+        assertThat(json.get("method").asText()).isEqualTo("initialize");
+        assertThat(json.get("params").get("protocolVersion").asText()).isEqualTo("2025-06-18");
+        assertThat(json.get("params").get("clientInfo").get("name").asText()).isEqualTo("test");
     }
 
     @Test

--- a/langchain4j-mcp/src/test/resources/meta_mcp_server.java
+++ b/langchain4j-mcp/src/test/resources/meta_mcp_server.java
@@ -1,0 +1,16 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS io.quarkus:quarkus-bom:${quarkus.version:3.27.0}@pom
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.7.2
+
+import io.quarkiverse.mcp.server.Meta;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+
+public class meta_mcp_server {
+
+    @Tool(description = "Echoes the value of a _meta field")
+    public String echoMeta(Meta meta, @ToolArg(description = "The key to look up in _meta") String key) {
+        Object value = meta.asJsonObject().getValue(key);
+        return value != null ? value.toString() : "null";
+    }
+}


### PR DESCRIPTION
Allows passing `_meta` fields for MCP client invocations. See the `docs/docs/tutorials/mcp.md` file for explanation.

The first commit slightly reorganizes the internal protocol messages to more closely mirror the MCP schema (https://github.com/modelcontextprotocol/modelcontextprotocol/blob/2025-06-18/schema/2025-06-18/schema.json). It doesn't introduce any breaking change. The gist is the introduction of `McpClientRequest`,`McpClientResponse`,`McpClientNotification` in the middle of the hierarchy to provide the proper  distinction between these types of messages. `McpClientRequest` and ,`McpClientNotification` now contain a common `params` field instead of each implementation providing its own field - instead, where appropriate, they have their own subclass of `McpClientParams` to hold their specific params, so it's more typesafe and the meta fields can be applied to each request type in a unified way. I've also added javadoc comments to make it clear which schema type each class corresponds to.

This is a prerequisite for proper implementation of distributed tracing of MCP client (https://github.com/quarkiverse/quarkus-langchain4j/issues/2221)