### PR TITLE
Expose getServerCapabilities and optional helper methods in DefaultMc…

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -26,6 +26,7 @@ import dev.langchain4j.mcp.protocol.McpGetPromptRequest;
 import dev.langchain4j.mcp.protocol.McpImplementation;
 import dev.langchain4j.mcp.protocol.McpInitializeParams;
 import dev.langchain4j.mcp.protocol.McpInitializeRequest;
+import dev.langchain4j.mcp.protocol.McpInitializeResult;
 import dev.langchain4j.mcp.protocol.McpListPromptsRequest;
 import dev.langchain4j.mcp.protocol.McpListResourceTemplatesRequest;
 import dev.langchain4j.mcp.protocol.McpListResourcesRequest;
@@ -38,6 +39,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -82,6 +84,7 @@ public class DefaultMcpClient implements McpClient {
     private final AtomicReference<List<ToolSpecification>> toolListRefs = new AtomicReference<>();
     private final AtomicBoolean toolListOutOfDate = new AtomicBoolean(true);
     private final AtomicReference<CompletableFuture<Void>> toolListUpdateInProgress = new AtomicReference<>(null);
+    private final AtomicReference<McpInitializeResult> initializeResultRef = new AtomicReference<>();
     private final Duration reconnectInterval;
     private volatile boolean closed = false;
     private final Boolean autoHealthCheck;
@@ -164,12 +167,50 @@ public class DefaultMcpClient implements McpClient {
         try {
             JsonNode capabilities =
                     transport.initialize(request).get(initializationTimeout.toMillis(), TimeUnit.MILLISECONDS);
+
+            setServerCapabilities(capabilities);
+
             log.debug("MCP server capabilities: {}", capabilities.get("result"));
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {
             pendingOperations.remove(operationId);
         }
+    }
+
+    private void setServerCapabilities(JsonNode capabilities) {
+        try {
+            // Convert JsonNode -> McpInitializeResult
+            McpInitializeResult initializeResult = OBJECT_MAPPER.treeToValue(capabilities, McpInitializeResult.class);
+
+            // Persist it
+            initializeResultRef.set(initializeResult);
+        } catch (Exception e) {
+            log.error("Failed to extract MCP capabilities", e);
+        }
+    }
+
+    public McpInitializeResult.Capabilities getServerCapabilities() {
+        McpInitializeResult result = initializeResultRef.get();
+        return result != null ? result.getResult().getCapabilities() : null;
+    }
+
+    public boolean supportsTools() {
+        return Optional.ofNullable(getServerCapabilities())
+                .map(McpInitializeResult.Capabilities::getTools)
+                .isPresent();
+    }
+
+    public boolean supportsPrompts() {
+        return Optional.ofNullable(getServerCapabilities())
+                .map(McpInitializeResult.Capabilities::getPrompts)
+                .isPresent();
+    }
+
+    public boolean supportsResources() {
+        return Optional.ofNullable(getServerCapabilities())
+                .map(McpInitializeResult.Capabilities::getResources)
+                .isPresent();
     }
 
     private McpInitializeParams createInitializeParams() {

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpImplementation.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpImplementation.java
@@ -1,10 +1,12 @@
 package dev.langchain4j.mcp.protocol;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import dev.langchain4j.Internal;
 
 @Internal
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class McpImplementation {
 
     private String name;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeResult.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpInitializeResult.java
@@ -1,6 +1,9 @@
 package dev.langchain4j.mcp.protocol;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.langchain4j.Internal;
 
 @Internal
@@ -8,7 +11,8 @@ public class McpInitializeResult extends McpJsonRpcMessage {
 
     private final Result result;
 
-    public McpInitializeResult(Long id, Result result) {
+    @JsonCreator
+    public McpInitializeResult(@JsonProperty("id") Long id, @JsonProperty("result") Result result) {
         super(id);
         this.result = result;
     }
@@ -18,13 +22,18 @@ public class McpInitializeResult extends McpJsonRpcMessage {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Result {
 
         private final String protocolVersion;
         private final Capabilities capabilities;
         private final McpImplementation serverInfo;
 
-        public Result(String protocolVersion, Capabilities capabilities, McpImplementation serverInfo) {
+        @JsonCreator
+        public Result(
+                @JsonProperty("protocolVersion") String protocolVersion,
+                @JsonProperty("capabilities") Capabilities capabilities,
+                @JsonProperty("serverInfo") McpImplementation serverInfo) {
             this.protocolVersion = protocolVersion;
             this.capabilities = capabilities;
             this.serverInfo = serverInfo;
@@ -43,22 +52,83 @@ public class McpInitializeResult extends McpJsonRpcMessage {
         }
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Capabilities {
 
-        private final Tools tools;
+        private Logging logging;
+        private Prompts prompts;
+        private Resources resources;
+        private Tools tools;
 
-        public Capabilities(Tools tools) {
-            this.tools = tools;
+        private Capabilities() {}
+
+        public Logging getLogging() {
+            return logging;
+        }
+
+        public Prompts getPrompts() {
+            return prompts;
+        }
+
+        public Resources getResources() {
+            return resources;
         }
 
         public Tools getTools() {
             return tools;
         }
 
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        public static class Tools {
+        // ---------- Sub-capabilities ----------
 
-            private final Boolean listChanged;
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public static class Logging {
+            // marker capability
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public static class Prompts {
+            private Boolean listChanged;
+
+            public Prompts() {}
+
+            public Prompts(Boolean listChanged) {
+                this.listChanged = listChanged;
+            }
+
+            public Boolean getListChanged() {
+                return listChanged;
+            }
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Resources {
+            private Boolean subscribe;
+            private Boolean listChanged;
+
+            public Resources() {}
+
+            public Resources(Boolean subscribe, Boolean listChanged) {
+                this.subscribe = subscribe;
+                this.listChanged = listChanged;
+            }
+
+            public Boolean getSubscribe() {
+                return subscribe;
+            }
+
+            public Boolean getListChanged() {
+                return listChanged;
+            }
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Tools {
+            private Boolean listChanged;
+
+            public Tools() {}
 
             public Tools(Boolean listChanged) {
                 this.listChanged = listChanged;
@@ -67,6 +137,45 @@ public class McpInitializeResult extends McpJsonRpcMessage {
             public Boolean getListChanged() {
                 return listChanged;
             }
+        }
+
+        // ---------- Builder ----------
+
+        public static class Builder {
+
+            private final Capabilities capabilities;
+
+            public Builder() {
+                this.capabilities = new Capabilities();
+            }
+
+            public Builder logging() {
+                capabilities.logging = new Logging();
+                return this;
+            }
+
+            public Builder prompts(Boolean listChanged) {
+                capabilities.prompts = new Prompts(listChanged);
+                return this;
+            }
+
+            public Builder resources(Boolean subscribe, Boolean listChanged) {
+                capabilities.resources = new Resources(subscribe, listChanged);
+                return this;
+            }
+
+            public Builder tools(Boolean listChanged) {
+                capabilities.tools = new Tools(listChanged);
+                return this;
+            }
+
+            public Capabilities build() {
+                return capabilities;
+            }
+        }
+
+        public static Builder builder() {
+            return new Builder();
         }
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/DefaultMcpClientTest.java
@@ -290,6 +290,106 @@ public class DefaultMcpClientTest {
         return rootNode;
     }
 
+    @Test
+    public void should_parse_and_store_server_capabilities_on_initialize() throws Exception {
+        // given
+        McpTransport transport = mock(McpTransport.class);
+
+        ObjectNode response = JsonNodeFactory.instance.objectNode();
+        response.put("jsonrpc", "2.0");
+        response.put("id", 1);
+
+        ObjectNode result = response.putObject("result");
+        result.put("protocolVersion", "2025-11-25");
+
+        ObjectNode capabilities = result.putObject("capabilities");
+        capabilities.putObject("logging");
+        capabilities.putObject("tools").put("listChanged", true);
+
+        when(transport.initialize(any())).thenReturn(CompletableFuture.completedFuture(response));
+
+        // when
+        DefaultMcpClient client =
+                new DefaultMcpClient.Builder().transport(transport).build();
+
+        // then
+        assertThat(client.getServerCapabilities()).isNotNull();
+        assertThat(client.getServerCapabilities().getLogging()).isNotNull();
+        assertThat(client.getServerCapabilities().getTools().getListChanged()).isTrue();
+    }
+
+    @Test
+    public void should_correctly_report_supported_capabilities() throws Exception {
+        // given
+        McpTransport transport = mock(McpTransport.class);
+
+        ObjectNode response = JsonNodeFactory.instance.objectNode();
+        response.put("jsonrpc", "2.0");
+        response.put("id", 1);
+
+        ObjectNode result = response.putObject("result");
+        ObjectNode capabilities = result.putObject("capabilities");
+
+        capabilities.putObject("tools").put("listChanged", true);
+        capabilities.putObject("prompts").put("listChanged", true);
+
+        when(transport.initialize(any())).thenReturn(CompletableFuture.completedFuture(response));
+
+        DefaultMcpClient client =
+                new DefaultMcpClient.Builder().transport(transport).build();
+
+        // then
+        assertThat(client.supportsTools()).isTrue();
+        assertThat(client.supportsPrompts()).isTrue();
+        assertThat(client.supportsResources()).isFalse();
+    }
+
+    @Test
+    public void should_update_capabilities_on_reinitialize() throws Exception {
+        // given
+        McpTransport transport = mock(McpTransport.class);
+
+        ArgumentCaptor<Runnable> onFailureCaptor = ArgumentCaptor.forClass(Runnable.class);
+        doNothing().when(transport).onFailure(onFailureCaptor.capture());
+
+        ObjectNode firstResponse = JsonNodeFactory.instance.objectNode();
+        firstResponse.put("jsonrpc", "2.0");
+        firstResponse.put("id", 1);
+        firstResponse
+                .putObject("result")
+                .putObject("capabilities")
+                .putObject("tools")
+                .put("listChanged", true);
+
+        ObjectNode secondResponse = JsonNodeFactory.instance.objectNode();
+        secondResponse.put("jsonrpc", "2.0");
+        secondResponse.put("id", 2);
+        secondResponse
+                .putObject("result")
+                .putObject("capabilities")
+                .putObject("resources")
+                .put("subscribe", true);
+
+        when(transport.initialize(any()))
+                .thenReturn(
+                        CompletableFuture.completedFuture(firstResponse),
+                        CompletableFuture.completedFuture(secondResponse));
+
+        DefaultMcpClient client =
+                new DefaultMcpClient.Builder().transport(transport).build();
+
+        // initial state
+        assertThat(client.supportsTools()).isTrue();
+        assertThat(client.supportsResources()).isFalse();
+
+        // when: reconnect happens
+        onFailureCaptor.getValue().run();
+
+        // then: updated capabilities
+        assertThat(client.supportsTools()).isFalse();
+        assertThat(client.supportsResources()).isTrue();
+    }
+
     private static record ToolDefinition(String name, String description, ToolArg... args) {}
 
     private static record ToolArg(String name, String type, String description) {}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/protocol/McpProtocolSerializationTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/protocol/McpProtocolSerializationTest.java
@@ -69,8 +69,8 @@ class McpProtocolSerializationTest {
     void should_serialize_initialize_result_with_server_info() throws Exception {
         // given
         McpImplementation serverInfo = new McpImplementation("server", "1.0", "Server Title");
-        McpInitializeResult.Capabilities.Tools tools = new McpInitializeResult.Capabilities.Tools(true);
-        McpInitializeResult.Capabilities capabilities = new McpInitializeResult.Capabilities(tools);
+        McpInitializeResult.Capabilities capabilities =
+                McpInitializeResult.Capabilities.builder().tools(true).build();
         McpInitializeResult.Result result = new McpInitializeResult.Result("2025-06-18", capabilities, serverInfo);
         McpInitializeResult response = new McpInitializeResult(1L, result);
 
@@ -90,5 +90,96 @@ class McpProtocolSerializationTest {
                         .get("listChanged")
                         .asBoolean())
                 .isTrue();
+    }
+
+    @Test
+    void should_deserialize_initialize_result_with_full_capabilities_json() throws Exception {
+
+        // given
+        String jsonString =
+                """
+            {
+              "jsonrpc": "2.0",
+              "id": 1,
+              "result": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {
+                  "logging": {},
+                  "prompts": {
+                    "listChanged": true
+                  },
+                  "resources": {
+                    "subscribe": true,
+                    "listChanged": true
+                  },
+                  "tools": {
+                    "listChanged": true
+                  },
+                  "tasks": {
+                    "list": {},
+                    "cancel": {},
+                    "requests": {
+                      "tools": {
+                        "call": {}
+                      }
+                    }
+                  }
+                },
+                "serverInfo": {
+                  "name": "ExampleServer",
+                  "title": "Example Server Display Name",
+                  "version": "1.0.0",
+                  "description": "An example MCP server providing tools and resources",
+                  "icons": [
+                    {
+                      "src": "https://example.com/server-icon.svg",
+                      "mimeType": "image/svg+xml",
+                      "sizes": ["any"]
+                    }
+                  ],
+                  "websiteUrl": "https://example.com/server"
+                },
+                "instructions": "Optional instructions for the client"
+              }
+            }
+            """;
+
+        // when
+        McpInitializeResult response = OBJECT_MAPPER.readValue(jsonString, McpInitializeResult.class);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(1L);
+
+        McpInitializeResult.Result result = response.getResult();
+        assertThat(result).isNotNull();
+        assertThat(result.getProtocolVersion()).isEqualTo("2025-11-25");
+
+        // ---- capabilities ----
+        McpInitializeResult.Capabilities capabilities = result.getCapabilities();
+        assertThat(capabilities).isNotNull();
+
+        // logging (marker object)
+        assertThat(capabilities.getLogging()).isNotNull();
+
+        // prompts
+        assertThat(capabilities.getPrompts()).isNotNull();
+        assertThat(capabilities.getPrompts().getListChanged()).isTrue();
+
+        // resources
+        assertThat(capabilities.getResources()).isNotNull();
+        assertThat(capabilities.getResources().getSubscribe()).isTrue();
+        assertThat(capabilities.getResources().getListChanged()).isTrue();
+
+        // tools
+        assertThat(capabilities.getTools()).isNotNull();
+        assertThat(capabilities.getTools().getListChanged()).isTrue();
+
+        // ---- server info ----
+        McpImplementation serverInfo = result.getServerInfo();
+        assertThat(serverInfo).isNotNull();
+        assertThat(serverInfo.getName()).isEqualTo("ExampleServer");
+        assertThat(serverInfo.getVersion()).isEqualTo("1.0.0");
+        assertThat(serverInfo.getTitle()).isEqualTo("Example Server Display Name");
     }
 }


### PR DESCRIPTION
### Summary
This PR exposes the `getServerCapabilities()` method in `DefaultMcpClient`, along with optional helper methods to retrieve server initialization data safely. These methods allow clients to perform preventive checks before making server calls, reducing the risk of exceptions when server capabilities are missing or incomplete.

### Changes
- Added `getServerCapabilities()` to safely return server capabilities.
- Added optional helper methods for accessing other initialization results.
- Updated unit tests to cover missing capabilities scenarios.

### Future Use
These methods can be leveraged by clients as preventive checks prior to executing server calls, improving stability and robustness of MCP client integrations.

### Testing
- Added unit tests for `getServerCapabilities()` with missing and present capabilities.