### PR TITLE
Remove unnecessary double semicolons

### DIFF
--- a/langchain4j-workers-ai/src/test/java/dev/langchain4j/model/workersai/WorkersAiImageModelIT.java
+++ b/langchain4j-workers-ai/src/test/java/dev/langchain4j/model/workersai/WorkersAiImageModelIT.java
@@ -33,7 +33,7 @@ class WorkersAiImageModelIT {
 
     @Test
     void should_generate_an_image_as_binary() {
-        Response<Image> image = imageModel.generate("Draw me a squirrel");;
+        Response<Image> image = imageModel.generate("Draw me a squirrel");
         assertThat(image.content()).isNotNull();
         assertThat(image.content().base64Data()).isNotNull();
     }
@@ -42,7 +42,7 @@ class WorkersAiImageModelIT {
     void should_generate_an_image_as_file() {
         String homeDirectory = System.getProperty("user.home");
         Response<File> image = imageModel.generate("Draw me a squirrel",
-                System.getProperty("user.home") + "/langchain4j-squirrel.png");;
+                System.getProperty("user.home") + "/langchain4j-squirrel.png");
         assertThat(image.content()).exists();
     }
 


### PR DESCRIPTION
## Issue
N/A (Minor formatting fix)

## Change
Remove unnecessary double semicolons (;;) in `WorkersAiImageModelIT`.

- Location 1: `should_generate_an_image_as_binary()` method
- Location 2: `should_generate_an_image_as_file()` method


## General checklist
- [x] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j