### PR TITLE
Refactor PromptsHelper to use constants and improve readbility and te…

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpFields.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpFields.java
@@ -1,0 +1,6 @@
+package dev.langchain4j.mcp;
+
+public class McpFields {
+    public static final String RESULT_FIELD = "result";
+    public static final String PROMPTS_FIELD = "prompts";
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/PromptsHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/PromptsHelper.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.mcp.client;
 
+import static dev.langchain4j.mcp.McpFields.*;
 import static dev.langchain4j.mcp.client.DefaultMcpClient.OBJECT_MAPPER;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -8,32 +9,77 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Helper class to parse MCP responses into {@link McpPrompt} and
+ * {@link McpGetPromptResult} objects.
+ */
 class PromptsHelper {
 
     private static final Logger log = LoggerFactory.getLogger(PromptsHelper.class);
 
+    /**
+     * Parses a list of prompts from the MCP message JSON.
+     *
+     * <p>
+     * Example response that this method can parse:
+     *
+     * <pre>{@code
+     * {
+     *   "jsonrpc": "2.0",
+     *   "id": 1,
+     *   "result": {
+     *     "prompts": [
+     *       {
+     *         "name": "code_review",
+     *         "title": "Request Code Review",
+     *         "description": "Asks the LLM to analyze code quality and suggest improvements",
+     *         "arguments": [
+     *           {
+     *             "name": "code",
+     *             "description": "The code to review",
+     *             "required": true
+     *           }
+     *         ],
+     *         "icons": [
+     *           {
+     *             "src": "https://example.com/review-icon.svg",
+     *             "mimeType": "image/svg+xml",
+     *             "sizes": ["any"]
+     *           }
+     *         ]
+     *       }
+     *     ],
+     *     "nextCursor": "next-page-cursor"
+     *   }
+     * }
+     * }</pre>
+     *
+     * @param mcpMessage The MCP response JSON node
+     * @return list of {@link McpPrompt} parsed from the response
+     * @throws IllegalResponseException if 'result' or 'prompts' fields are missing
+     */
     static List<McpPrompt> parsePromptRefs(JsonNode mcpMessage) {
         McpErrorHelper.checkForErrors(mcpMessage);
-        if (mcpMessage.has("result")) {
-            JsonNode resultNode = mcpMessage.get("result");
-            if (resultNode.has("prompts")) {
-                List<McpPrompt> promptRefs = new ArrayList<>();
-                for (JsonNode promptNode : resultNode.get("prompts")) {
-                    promptRefs.add(OBJECT_MAPPER.convertValue(promptNode, McpPrompt.class));
-                }
-                return promptRefs;
-            } else {
-                log.warn("Result does not contain 'prompts' element: {}", resultNode);
-                throw new IllegalResponseException("Result does not contain 'prompts' element");
-            }
-        } else {
-            log.warn("Result does not contain 'result' element: {}", mcpMessage);
-            throw new IllegalResponseException("Result does not contain 'result' element");
+
+        JsonNode resultNode = mcpMessage.get(RESULT_FIELD);
+        if (resultNode == null) {
+            log.warn("Result does not contain '{}': {}", RESULT_FIELD, mcpMessage);
+            throw new IllegalResponseException(String.format("Result does not contain '%s' element", RESULT_FIELD));
         }
+
+        JsonNode promptsNode = resultNode.get(PROMPTS_FIELD);
+        if (promptsNode == null) {
+            log.warn("Result does not contain '{}': {}", PROMPTS_FIELD, resultNode);
+            throw new IllegalResponseException(String.format("Result does not contain '%s' element", PROMPTS_FIELD));
+        }
+
+        List<McpPrompt> promptRefs = new ArrayList<>();
+        promptsNode.forEach(node -> promptRefs.add(OBJECT_MAPPER.convertValue(node, McpPrompt.class)));
+        return promptRefs;
     }
 
     static McpGetPromptResult parsePromptContents(JsonNode mcpMessage) {
         McpErrorHelper.checkForErrors(mcpMessage);
-        return OBJECT_MAPPER.convertValue(mcpMessage.get("result"), McpGetPromptResult.class);
+        return OBJECT_MAPPER.convertValue(mcpMessage.get(RESULT_FIELD), McpGetPromptResult.class);
     }
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/PromptsHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/PromptsHelperTest.java
@@ -1,0 +1,123 @@
+package dev.langchain4j.mcp.client;
+
+import static dev.langchain4j.mcp.McpFields.PROMPTS_FIELD;
+import static dev.langchain4j.mcp.McpFields.RESULT_FIELD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PromptsHelperTest {
+
+    @Test
+    void should_parse_multiple_prompts_successfully_from_json_string() throws Exception {
+        // given: JSON string representing the full MCP response
+        String json =
+                """
+				{
+				  "jsonrpc": "2.0",
+				  "id": 1,
+				  "result": {
+				    "prompts": [
+				      {
+				        "name": "code_review",
+				        "title": "Request Code Review",
+				        "description": "Asks the LLM to analyze code quality and suggest improvements",
+				        "arguments": [
+				          {
+				            "name": "code",
+				            "description": "The code to review",
+				            "required": true
+				          }
+				        ],
+				        "icons": [
+				          {
+				            "src": "https://example.com/review-icon.svg",
+				            "mimeType": "image/svg+xml",
+				            "sizes": ["any"]
+				          }
+				        ]
+				      },
+				      {
+				        "name": "bug_report",
+				        "title": "Report a Bug",
+				        "description": "Collects information about a bug to report to the team",
+				        "arguments": [
+				          {
+				            "name": "steps",
+				            "description": "Steps to reproduce the bug",
+				            "required": true
+				          }
+				        ]
+				      }
+				    ],
+				    "nextCursor": "next-page-cursor"
+				  }
+				}
+				""";
+
+        // convert string to JsonNode
+        JsonNode root = DefaultMcpClient.OBJECT_MAPPER.readTree(json);
+
+        // when
+        List<McpPrompt> prompts = PromptsHelper.parsePromptRefs(root);
+
+        // then
+        assertThat(prompts).hasSize(2);
+
+        // verify first prompt
+        McpPrompt first = prompts.get(0);
+        assertThat(first.name()).isEqualTo("code_review");
+        assertThat(first.description()).isEqualTo("Asks the LLM to analyze code quality and suggest improvements");
+        assertThat(first.arguments()).hasSize(1);
+        assertThat(first.arguments().get(0).name()).isEqualTo("code");
+
+        // verify second prompt
+        McpPrompt second = prompts.get(1);
+        assertThat(second.name()).isEqualTo("bug_report");
+        assertThat(second.description()).isEqualTo("Collects information about a bug to report to the team");
+        assertThat(second.arguments()).hasSize(1);
+        assertThat(second.arguments().get(0).name()).isEqualTo("steps");
+    }
+
+    @Test
+    void should_throw_exception_when_result_is_missing() {
+        // given: empty JSON
+        ObjectNode root = JsonNodeFactory.instance.objectNode();
+
+        // when / then
+        assertThatThrownBy(() -> PromptsHelper.parsePromptRefs(root))
+                .isInstanceOf(IllegalResponseException.class)
+                .hasMessageContaining(String.format("Result does not contain '%s'", RESULT_FIELD));
+    }
+
+    @Test
+    void should_throw_exception_when_prompts_are_missing() {
+        // given: JSON with "result" but no "prompts"
+        ObjectNode root = JsonNodeFactory.instance.objectNode();
+        root.putObject(RESULT_FIELD);
+
+        // when / then
+        assertThatThrownBy(() -> PromptsHelper.parsePromptRefs(root))
+                .isInstanceOf(IllegalResponseException.class)
+                .hasMessageContaining(String.format("Result does not contain '%s'", PROMPTS_FIELD));
+    }
+
+    @Test
+    void should_handle_empty_prompts_array() {
+        // given: JSON with empty prompts array
+        ObjectNode root = JsonNodeFactory.instance.objectNode();
+        ObjectNode resultNode = root.putObject(RESULT_FIELD);
+        resultNode.putArray(PROMPTS_FIELD);
+
+        // when
+        List<McpPrompt> prompts = PromptsHelper.parsePromptRefs(root);
+
+        // then
+        assertThat(prompts).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary
This PR refactors the `PromptsHelper` class in `langchain4j-mcp-client` to improve readability, maintainability, and consistency in parsing MCP responses.

### Changes
- Replaced string literals `"result"` and `"prompts"` with constants from `McpFields`.
- Updated exception messages and logging to use `String.format()` with constants.
- Added detailed Javadoc with example MCP JSON response.
- Refactored `parsePromptRefs` for cleaner and safer parsing logic.
- Added unit tests covering:
  - Multiple prompts parsing
  - Missing `result` field
  - Missing `prompts` field
- Ensured consistent error handling and logging.

### Benefits
- Reduces the risk of typos in field names.
- Makes exception messages consistent and easier to maintain.
- Improves clarity for future developers.
- Provides unit test coverage for edge cases.