### PR TITLE
Add $ref and $defs support to MCP tool specification parser

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.mcp.client;
 
+import static dev.langchain4j.mcp.client.McpToolMetadataKeys.*;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -14,14 +16,14 @@ import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
 import dev.langchain4j.model.chat.request.json.JsonNullSchema;
 import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.StreamSupport;
-
-import static dev.langchain4j.mcp.client.McpToolMetadataKeys.*;
 
 class ToolSpecificationHelper {
 
@@ -70,6 +72,12 @@ class ToolSpecificationHelper {
             }
             return anyOf.build();
         }
+        // Handle $ref (JSON Schema reference)
+        if (node.has("$ref")) {
+            return JsonReferenceSchema.builder()
+                    .reference(extractReferenceKey(node.get("$ref").asText()))
+                    .build();
+        }
         JsonNode typeNode = node.get("type");
         // If no type is specified, default to object schema
         if (typeNode == null
@@ -90,6 +98,15 @@ class ToolSpecificationHelper {
             }
             if (node.has("additionalProperties")) {
                 builder.additionalProperties(node.get("additionalProperties").asBoolean(false));
+            }
+            // Handle $defs (draft 2019-09+) and definitions (draft-07)
+            JsonNode defsNode = node.has("$defs") ? node.get("$defs") : node.get("definitions");
+            if (defsNode != null) {
+                Map<String, JsonSchemaElement> definitions = new LinkedHashMap<>();
+                for (Map.Entry<String, JsonNode> entry : ((ObjectNode) defsNode).properties()) {
+                    definitions.put(entry.getKey(), jsonNodeToJsonSchemaElement(entry.getValue()));
+                }
+                builder.definitions(definitions);
             }
             return builder.build();
         } else if (node.get("type").getNodeType() == JsonNodeType.STRING) {
@@ -206,6 +223,20 @@ class ToolSpecificationHelper {
         }
     }
 
+    /**
+     * Extracts the reference key from a JSON Schema $ref value.
+     * For example, "#/$defs/Foo" returns "Foo", "#/definitions/Bar" returns "Bar".
+     */
+    private static String extractReferenceKey(String ref) {
+        if (ref.startsWith("#/$defs/")) {
+            return ref.substring("#/$defs/".length());
+        }
+        if (ref.startsWith("#/definitions/")) {
+            return ref.substring("#/definitions/".length());
+        }
+        return ref;
+    }
+
     private static String[] toStringArray(ArrayNode jsonArray) {
         String[] result = new String[jsonArray.size()];
         for (int i = 0; i < jsonArray.size(); i++) {
@@ -214,38 +245,34 @@ class ToolSpecificationHelper {
         return result;
     }
 
-    private static void processMcpToolAnnotations(JsonNode annotations,
-                                                  ToolSpecification.Builder builder) {
-        if(annotations.has(DESTRUCTIVE_HINT)) {
-            builder.addMetadata(DESTRUCTIVE_HINT,
-                    annotations.get(DESTRUCTIVE_HINT).asBoolean());
+    private static void processMcpToolAnnotations(JsonNode annotations, ToolSpecification.Builder builder) {
+        if (annotations.has(DESTRUCTIVE_HINT)) {
+            builder.addMetadata(
+                    DESTRUCTIVE_HINT, annotations.get(DESTRUCTIVE_HINT).asBoolean());
         }
-        if(annotations.has(IDEMPOTENT_HINT)) {
-            builder.addMetadata(IDEMPOTENT_HINT,
-                    annotations.get(IDEMPOTENT_HINT).asBoolean());
+        if (annotations.has(IDEMPOTENT_HINT)) {
+            builder.addMetadata(
+                    IDEMPOTENT_HINT, annotations.get(IDEMPOTENT_HINT).asBoolean());
         }
-        if(annotations.has(OPEN_WORLD_HINT)) {
-            builder.addMetadata(OPEN_WORLD_HINT,
-                    annotations.get(OPEN_WORLD_HINT).asBoolean());
+        if (annotations.has(OPEN_WORLD_HINT)) {
+            builder.addMetadata(
+                    OPEN_WORLD_HINT, annotations.get(OPEN_WORLD_HINT).asBoolean());
         }
-        if(annotations.has(READ_ONLY_HINT)) {
-            builder.addMetadata(READ_ONLY_HINT,
-                    annotations.get(READ_ONLY_HINT).asBoolean());
+        if (annotations.has(READ_ONLY_HINT)) {
+            builder.addMetadata(READ_ONLY_HINT, annotations.get(READ_ONLY_HINT).asBoolean());
         }
-        // note that the TITLE_ANNOTATION constant doesn't contain 'title' to disambiguate it with the other title that is
+        // note that the TITLE_ANNOTATION constant doesn't contain 'title' to disambiguate it with the other title that
+        // is
         // stored directly in the Tool object
-        if(annotations.has("title")) {
-            builder.addMetadata(TITLE_ANNOTATION,
-                    annotations.get("title").asText());
+        if (annotations.has("title")) {
+            builder.addMetadata(TITLE_ANNOTATION, annotations.get("title").asText());
         }
     }
 
-    private static void processMcpToolMetadata(JsonNode meta,
-                                               ToolSpecification.Builder builder) {
+    private static void processMcpToolMetadata(JsonNode meta, ToolSpecification.Builder builder) {
         for (Map.Entry<String, JsonNode> property : meta.properties()) {
             // convert the value to a nested Map (independent of Jackson) and store it in the metadata
             builder.addMetadata(property.getKey(), OBJECT_MAPPER.convertValue(property.getValue(), Object.class));
         }
     }
-
 }

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
@@ -21,6 +20,7 @@ import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
 import dev.langchain4j.model.chat.request.json.JsonNullSchema;
 import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import java.util.List;
@@ -477,7 +477,9 @@ class ToolSpecificationHelperTest {
                 }]
                 """;
         ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
-        Map<String, Object> metadata = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json).get(0).metadata();
+        Map<String, Object> metadata = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0)
+                .metadata();
         assertThat(metadata.get(TITLE_ANNOTATION)).isEqualTo("A tool with annotations");
         assertThat(metadata.get(TITLE)).isEqualTo("A title in the root tool object");
         assertThat(metadata.get(READ_ONLY_HINT)).isEqualTo(false);
@@ -505,12 +507,183 @@ class ToolSpecificationHelperTest {
                 }]
                 """;
         ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
-        Map<String, Object> metadata = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json).get(0).metadata();
+        Map<String, Object> metadata = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0)
+                .metadata();
 
         assertThat(metadata.get("example.org/array")).isEqualTo(List.of(1, 2, 3));
         assertThat(metadata.get("example.org/string")).isEqualTo("hello");
         assertThat(metadata.get("complex")).isInstanceOf(Map.class);
         Map<String, Object> complex = (Map<String, Object>) metadata.get("complex");
         assertThat(complex.get("a")).isEqualTo(true);
+    }
+
+    @Test
+    void toolWithRefAndDefs() throws JsonProcessingException {
+        // a tool whose inputSchema uses $defs and $ref for a recursive/shared type
+        String text =
+                // language=json
+                """
+                [{
+                    "name": "create_node",
+                    "description": "Creates a tree node",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "node": {
+                          "$ref": "#/$defs/TreeNode"
+                        }
+                      },
+                      "required": ["node"],
+                      "$defs": {
+                        "TreeNode": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "Node value"
+                            },
+                            "children": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/$defs/TreeNode"
+                              }
+                            }
+                          },
+                          "required": ["value"]
+                        }
+                      }
+                    }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+        assertThat(toolSpecifications).hasSize(1);
+        ToolSpecification toolSpecification = toolSpecifications.get(0);
+        assertThat(toolSpecification.name()).isEqualTo("create_node");
+
+        JsonObjectSchema parameters = toolSpecification.parameters();
+
+        // the "node" property should be a reference
+        JsonSchemaElement nodeParam = parameters.properties().get("node");
+        assertThat(nodeParam).isInstanceOf(JsonReferenceSchema.class);
+        assertThat(((JsonReferenceSchema) nodeParam).reference()).isEqualTo("TreeNode");
+
+        // $defs should be parsed into definitions
+        assertThat(parameters.definitions()).isNotNull();
+        assertThat(parameters.definitions()).containsKey("TreeNode");
+        JsonObjectSchema treeNodeDef =
+                (JsonObjectSchema) parameters.definitions().get("TreeNode");
+        assertThat(treeNodeDef.properties()).containsOnlyKeys("value", "children");
+
+        // the "children" items should also be a reference
+        JsonArraySchema children = (JsonArraySchema) treeNodeDef.properties().get("children");
+        assertThat(children.items()).isInstanceOf(JsonReferenceSchema.class);
+        assertThat(((JsonReferenceSchema) children.items()).reference()).isEqualTo("TreeNode");
+    }
+
+    @Test
+    void toolWithDraft07Definitions() throws JsonProcessingException {
+        // uses "definitions" (draft-07) instead of "$defs" (draft 2019-09+)
+        String text =
+                // language=json
+                """
+                [{
+                    "name": "send_message",
+                    "description": "Sends a message",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "recipient": {
+                          "$ref": "#/definitions/Contact"
+                        }
+                      },
+                      "definitions": {
+                        "Contact": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "email": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["name", "email"]
+                        }
+                      }
+                    }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+        assertThat(toolSpecifications).hasSize(1);
+
+        JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
+
+        // the "recipient" property should be a reference
+        JsonSchemaElement recipientParam = parameters.properties().get("recipient");
+        assertThat(recipientParam).isInstanceOf(JsonReferenceSchema.class);
+        assertThat(((JsonReferenceSchema) recipientParam).reference()).isEqualTo("Contact");
+
+        // definitions should be parsed
+        assertThat(parameters.definitions()).containsKey("Contact");
+        JsonObjectSchema contactDef =
+                (JsonObjectSchema) parameters.definitions().get("Contact");
+        assertThat(contactDef.properties()).containsOnlyKeys("name", "email");
+        assertThat(contactDef.required()).containsExactly("name", "email");
+    }
+
+    @Test
+    void toolWithRefInAnyOf() throws JsonProcessingException {
+        // $ref used inside an anyOf
+        String text =
+                // language=json
+                """
+                [{
+                    "name": "process",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "input": {
+                          "anyOf": [
+                            { "$ref": "#/$defs/TextInput" },
+                            { "type": "string" }
+                          ],
+                          "description": "The input to process"
+                        }
+                      },
+                      "$defs": {
+                        "TextInput": {
+                          "type": "object",
+                          "properties": {
+                            "text": { "type": "string" },
+                            "language": { "type": "string" }
+                          }
+                        }
+                      }
+                    }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+        assertThat(toolSpecifications).hasSize(1);
+
+        JsonObjectSchema parameters = toolSpecifications.get(0).parameters();
+
+        // the "input" property should be anyOf with a $ref and a string
+        JsonSchemaElement inputParam = parameters.properties().get("input");
+        assertThat(inputParam).isInstanceOf(JsonAnyOfSchema.class);
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) inputParam;
+        assertThat(anyOf.anyOf()).hasSize(2);
+        assertThat(anyOf.anyOf().get(0)).isInstanceOf(JsonReferenceSchema.class);
+        assertThat(((JsonReferenceSchema) anyOf.anyOf().get(0)).reference()).isEqualTo("TextInput");
+        assertThat(anyOf.anyOf().get(1)).isInstanceOf(JsonStringSchema.class);
+
+        // $defs should be parsed into definitions
+        assertThat(parameters.definitions()).containsKey("TextInput");
+        JsonObjectSchema textInputDef =
+                (JsonObjectSchema) parameters.definitions().get("TextInput");
+        assertThat(textInputDef.properties()).containsOnlyKeys("text", "language");
     }
 }


### PR DESCRIPTION
## Summary

Closes #3105

`ToolSpecificationHelper.jsonNodeToJsonSchemaElement()` did not handle JSON Schema `$ref` and `$defs`/`definitions`. A `$ref` node would silently become an empty `JsonObjectSchema`, and `$defs` at the root level was ignored.

This PR adds:
- `$ref` detection → returns `JsonReferenceSchema` with the extracted definition key
- `$defs` (draft 2019-09+) and `definitions` (draft-07) parsing → populates `JsonObjectSchema.definitions`

Changes are scoped to `langchain4j-mcp` only — no changes needed in `langchain4j-core`.

## Test plan
- [x] `toolWithRefAndDefs` — recursive `$ref` with `$defs`
- [x] `toolWithDraft07Definitions` — `$ref` with `definitions` (draft-07)
- [x] `toolWithRefInAnyOf` — `$ref` inside `anyOf`
- [x] All 13 existing + new tests pass
- [x] `spotless:check` passes