### PR TITLE
fix: ToolExecutionResult.equals() self-comparison typo on attributes

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionResult.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionResult.java
@@ -1,15 +1,14 @@
 package dev.langchain4j.service.tool;
 
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.quoted;
+
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.ChatMemory;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.memory.ChatMemory;
-
-import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.Utils.quoted;
 
 /**
  * Represents the result of a tool execution.
@@ -97,7 +96,7 @@ public class ToolExecutionResult {
         return isError == that.isError
                 && Objects.equals(result, that.result)
                 && Objects.equals(resultText(), that.resultText())
-                && Objects.equals(attributes, attributes);
+                && Objects.equals(attributes, that.attributes);
     }
 
     @Override

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutionResultTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutionResultTest.java
@@ -3,6 +3,7 @@ package dev.langchain4j.service.tool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -202,5 +203,59 @@ class ToolExecutionResultTest {
         // but should be called at least once and significantly fewer times than thread count
         // (accepting rare duplicate computation in concurrent scenarios)
         assertThat(callCount.get()).isGreaterThanOrEqualTo(1).isLessThanOrEqualTo(threads.length);
+    }
+
+    @Test
+    void should_not_be_equal_when_attributes_differ() {
+        // given
+        ToolExecutionResult result1 = ToolExecutionResult.builder()
+                .result("obj")
+                .resultText("text")
+                .attributes(Map.of("key", "value1"))
+                .build();
+
+        ToolExecutionResult result2 = ToolExecutionResult.builder()
+                .result("obj")
+                .resultText("text")
+                .attributes(Map.of("key", "value2"))
+                .build();
+
+        // when/then
+        assertThat(result1).isNotEqualTo(result2);
+        assertThat(result2).isNotEqualTo(result1);
+    }
+
+    @Test
+    void should_be_equal_when_attributes_are_the_same() {
+        // given
+        ToolExecutionResult result1 = ToolExecutionResult.builder()
+                .result("obj")
+                .resultText("text")
+                .attributes(Map.of("key", "value"))
+                .build();
+
+        ToolExecutionResult result2 = ToolExecutionResult.builder()
+                .result("obj")
+                .resultText("text")
+                .attributes(Map.of("key", "value"))
+                .build();
+
+        // when/then
+        assertThat(result1).isEqualTo(result2);
+        assertThat(result1.hashCode()).isEqualTo(result2.hashCode());
+    }
+
+    @Test
+    void should_be_equal_when_both_have_null_attributes() {
+        // given
+        ToolExecutionResult result1 =
+                ToolExecutionResult.builder().result("obj").resultText("text").build();
+
+        ToolExecutionResult result2 =
+                ToolExecutionResult.builder().result("obj").resultText("text").build();
+
+        // when/then
+        assertThat(result1).isEqualTo(result2);
+        assertThat(result1.hashCode()).isEqualTo(result2.hashCode());
     }
 }


### PR DESCRIPTION
## Issue
Closes #4801

## Change

One-character fix in `ToolExecutionResult.equals()`: the `attributes` field was compared to itself instead of `that.attributes`.

**Before (line 100):**
```java
&& Objects.equals(attributes, attributes);
```

**After:**
```java
&& Objects.equals(attributes, that.attributes);
```

This caused any two `ToolExecutionResult` instances with different `attributes` maps to be incorrectly considered equal. The `hashCode()` method was already correct.

### Tests added
- `should_not_be_equal_when_attributes_differ` — verifies different attributes yield `equals() == false`
- `should_be_equal_when_attributes_are_the_same` — verifies same attributes yield `equals() == true` and matching `hashCode()`
- `should_be_equal_when_both_have_null_attributes` — verifies null attributes behave correctly

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
