### PR TITLE
fix: add null/empty candidates guard in GeminiStreamingResponseBuilder

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilder.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilder.java
@@ -59,7 +59,12 @@ class GeminiStreamingResponseBuilder {
             return new TextAndTools(Optional.empty(), Optional.empty(), List.of());
         }
 
-        GeminiCandidate firstCandidate = partialResponse.candidates().get(0);
+        List<GeminiCandidate> candidates = partialResponse.candidates();
+        if (candidates == null || candidates.isEmpty()) {
+            return new TextAndTools(Optional.empty(), Optional.empty(), List.of());
+        }
+
+        GeminiCandidate firstCandidate = candidates.get(0);
 
         updateId(partialResponse);
         updateModelName(partialResponse);

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilderTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiStreamingResponseBuilderTest.java
@@ -1,0 +1,61 @@
+package dev.langchain4j.model.googleai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.googleai.GeminiGenerateContentResponse.GeminiCandidate;
+import dev.langchain4j.model.googleai.GeminiStreamingResponseBuilder.TextAndTools;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GeminiStreamingResponseBuilderTest {
+
+    private final GeminiStreamingResponseBuilder builder = new GeminiStreamingResponseBuilder(false, null);
+
+    @Test
+    void should_return_empty_when_partial_response_is_null() {
+        TextAndTools result = builder.append(null);
+
+        assertThat(result.maybeText()).isEmpty();
+        assertThat(result.maybeThought()).isEmpty();
+        assertThat(result.tools()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_when_candidates_is_null() {
+        GeminiGenerateContentResponse response = new GeminiGenerateContentResponse(null, null, null, null, null);
+
+        TextAndTools result = builder.append(response);
+
+        assertThat(result.maybeText()).isEmpty();
+        assertThat(result.maybeThought()).isEmpty();
+        assertThat(result.tools()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_when_candidates_is_empty() {
+        GeminiGenerateContentResponse response =
+                new GeminiGenerateContentResponse(null, null, Collections.emptyList(), null, null);
+
+        TextAndTools result = builder.append(response);
+
+        assertThat(result.maybeText()).isEmpty();
+        assertThat(result.maybeThought()).isEmpty();
+        assertThat(result.tools()).isEmpty();
+    }
+
+    @Test
+    void should_return_text_when_candidate_has_content() {
+        GeminiContent content = new GeminiContent(
+                List.of(new GeminiContent.GeminiPart("Hello", null, null, null, null, null, null, null, null, null)),
+                "model");
+        GeminiCandidate candidate = new GeminiCandidate(content, null, null, null);
+        GeminiGenerateContentResponse response =
+                new GeminiGenerateContentResponse("id-1", "gemini-pro", List.of(candidate), null, null);
+
+        TextAndTools result = builder.append(response);
+
+        assertThat(result.maybeText()).hasValue("Hello");
+        assertThat(result.tools()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #4808

## Change
Added a null/empty guard for `candidates` in `GeminiStreamingResponseBuilder.append()` before accessing `.get(0)`.

**Before:**
```java
GeminiCandidate firstCandidate = partialResponse.candidates().get(0);
```

**After:**
```java
List<GeminiCandidate> candidates = partialResponse.candidates();
if (candidates == null || candidates.isEmpty()) {
    return new TextAndTools(Optional.empty(), Optional.empty(), List.of());
}
GeminiCandidate firstCandidate = candidates.get(0);
```

This is consistent with the Vertex AI Gemini module's `StreamingChatResponseBuilder` which already has this guard (line 30-31).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
