### PR TITLE
fix: support both integer and UUID point IDs in QdrantEmbeddingStore

### DIFF
--- a/langchain4j-qdrant/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStore.java
+++ b/langchain4j-qdrant/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStore.java
@@ -19,10 +19,12 @@ import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.*;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import io.qdrant.client.QdrantClient;
 import io.qdrant.client.QdrantGrpcClient;
 import io.qdrant.client.WithVectorsSelectorFactory;
 import io.qdrant.client.grpc.Common.Filter;
+import io.qdrant.client.grpc.Common.PointId;
 import io.qdrant.client.grpc.JsonWithInt.Value;
 import io.qdrant.client.grpc.Points;
 import io.qdrant.client.grpc.Points.DeletePoints;
@@ -60,7 +62,7 @@ public class QdrantEmbeddingStore implements EmbeddingStore<TextSegment> {
      * @param port           The GRPC port of the Qdrant instance.
      * @param useTls         Whether to use TLS(HTTPS).
      * @param payloadTextKey The field name of the text segment in the Qdrant
-     *                       payload.
+     * payload.
      * @param apiKey         The Qdrant API key to authenticate with.
      */
     public QdrantEmbeddingStore(
@@ -86,7 +88,7 @@ public class QdrantEmbeddingStore implements EmbeddingStore<TextSegment> {
      * @param client         A Qdrant client instance.
      * @param collectionName The name of the Qdrant collection.
      * @param payloadTextKey The field name of the text segment in the Qdrant
-     *                       payload.
+     * payload.
      */
     public QdrantEmbeddingStore(QdrantClient client, String collectionName, String payloadTextKey) {
         this.client = client;
@@ -140,16 +142,18 @@ public class QdrantEmbeddingStore implements EmbeddingStore<TextSegment> {
             for (int i = 0; i < embeddings.size(); i++) {
 
                 String id = ids.get(i);
-                UUID uuid = UUID.fromString(id);
+                PointId qdrantId = toPointId(id);
                 Embedding embedding = embeddings.get(i);
 
                 PointStruct.Builder pointBuilder =
-                        PointStruct.newBuilder().setId(id(uuid)).setVectors(vectors(embedding.vector()));
+                        PointStruct.newBuilder().setId(qdrantId).setVectors(vectors(embedding.vector()));
 
                 if (textSegments != null) {
                     Map<String, Object> metadata =
                             textSegments.get(i).metadata().toMap();
 
+                    // Assuming ValueMapFactory is available in your actual codebase imports
+                    // If not, it might be an internal class you need to make sure is accessible
                     Map<String, Value> payload = ValueMapFactory.valueMap(metadata);
                     payload.put(payloadTextKey, value(textSegments.get(i).text()));
                     pointBuilder.putAllPayload(payload);
@@ -178,7 +182,7 @@ public class QdrantEmbeddingStore implements EmbeddingStore<TextSegment> {
         try {
 
             Points.PointsIdsList pointsIdsList = Points.PointsIdsList.newBuilder()
-                    .addAllIds(ids.stream().map(id -> id(UUID.fromString(id))).toList())
+                    .addAllIds(ids.stream().map(QdrantEmbeddingStore::toPointId).collect(toList()))
                     .build();
             PointsSelector pointsSelector =
                     PointsSelector.newBuilder().setPoints(pointsIdsList).build();
@@ -291,7 +295,7 @@ public class QdrantEmbeddingStore implements EmbeddingStore<TextSegment> {
 
         return new EmbeddingMatch<>(
                 RelevanceScore.fromCosineSimilarity(cosineSimilarity),
-                scoredPoint.getId().getUuid(),
+                pointIdToString(scoredPoint.getId()),
                 embedding,
                 textSegmentValue == null
                         ? null
@@ -352,8 +356,8 @@ public class QdrantEmbeddingStore implements EmbeddingStore<TextSegment> {
 
         /**
          * @param payloadTextKey The field name of the text segment in the payload.
-         *                       Defaults to
-         *                       "text_segment".
+         * Defaults to
+         * "text_segment".
          * @return
          */
         public Builder payloadTextKey(String payloadTextKey) {
@@ -385,5 +389,22 @@ public class QdrantEmbeddingStore implements EmbeddingStore<TextSegment> {
             }
             return new QdrantEmbeddingStore(collectionName, host, port, useTls, payloadTextKey, apiKey);
         }
+    }
+
+    private static PointId toPointId(String id) {
+        try {
+            long num = Long.parseUnsignedLong(id);
+            return id(num);
+        } catch (NumberFormatException e) {
+            return id(UUID.fromString(id));
+        }
+    }
+
+    private static String pointIdToString(PointId pointId) {
+        return switch (pointId.getPointIdOptionsCase()) {
+            case NUM -> Long.toUnsignedString(pointId.getNum());
+            case UUID -> pointId.getUuid();
+            default -> throw new IllegalStateException("Unknown point ID type: " + pointId.getPointIdOptionsCase());
+        };
     }
 }

--- a/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStoreIT.java
+++ b/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStoreIT.java
@@ -2,11 +2,15 @@ package dev.langchain4j.store.embedding.qdrant;
 
 import static dev.langchain4j.internal.Utils.randomUUID;
 import static io.qdrant.client.grpc.Collections.Distance.Cosine;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreWithFilteringIT;
 import dev.langchain4j.store.embedding.filter.Filter;
@@ -22,12 +26,14 @@ import io.qdrant.client.QdrantClient;
 import io.qdrant.client.QdrantGrpcClient;
 import io.qdrant.client.grpc.Collections.VectorParams;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -87,6 +93,34 @@ class QdrantEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
     @Override
     protected void clearStore() {
         EMBEDDING_STORE.clearStore();
+    }
+
+    @Test
+    void should_support_integer_point_ids() {
+        // given
+        String text = "testing integer id";
+        Embedding embedding = embeddingModel().embed(text).content();
+        TextSegment segment = TextSegment.from(text);
+        String integerId = "42";
+
+        // when
+        embeddingStore()
+                .addAll(
+                        Collections.singletonList(integerId),
+                        Collections.singletonList(embedding),
+                        Collections.singletonList(segment));
+
+        // then
+        EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                .queryEmbedding(embedding)
+                .maxResults(1)
+                .build();
+        List<EmbeddingMatch<TextSegment>> relevant =
+                embeddingStore().search(request).matches();
+
+        assertThat(relevant).hasSize(1);
+        assertThat(relevant.get(0).embeddingId()).isEqualTo(integerId);
+        assertThat(relevant.get(0).embedded().text()).isEqualTo(text);
     }
 
     @Override


### PR DESCRIPTION
## Issue
Closes #4806

## Change
Replaced hardcoded `UUID.fromString(id)` parsing in `QdrantEmbeddingStore` with a helper method (`toPointId`) that natively supports both unsigned 64-bit integers and UUIDs per Qdrant's specifications. 

Specifically updated `addAll`, `removeAll`, and `toEmbeddingMatch` to safely map between Java strings, integer point IDs, and UUID point IDs without throwing an `IllegalArgumentException`. Added a dedicated integration test (`should_support_integer_point_ids`) to verify the behavior.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [x] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j