### PR TITLE
Setup checkstyle plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>dev.langchain4j</groupId>
@@ -148,6 +149,8 @@
         <langchain4j.stable.version>1.13.0-SNAPSHOT</langchain4j.stable.version>
         <langchain4j.beta.version>1.13.0-beta23-SNAPSHOT</langchain4j.beta.version>
         <gib.disable>true</gib.disable>
+        <checkstyle.failOnViolation>false</checkstyle.failOnViolation>
+        <checkstyle.failsOnError>false</checkstyle.failsOnError>
     </properties>
 
     <build>
@@ -182,6 +185,27 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <configLocation>google_checks.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>false</failsOnError>
+                    <failOnViolation>false</failOnViolation>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.simpligility.maven.plugins</groupId>
                 <artifactId>android-maven-plugin</artifactId>
                 <version>4.6.0</version>
@@ -197,6 +221,8 @@
                 </executions>
             </plugin>
         </plugins>
+
+
         <extensions>
             <extension>
                 <groupId>io.github.gitflow-incremental-builder</groupId>
@@ -205,7 +231,6 @@
             </extension>
         </extensions>
     </build>
-
     <reporting>
         <plugins>
             <plugin>


### PR DESCRIPTION
## Issue
Closes #4770 

## Change
Added the `maven-checkstyle-plugin` (using `google_checks.xml`) to the root `pom.xml` to begin standardizing code quality across the repository. 

As discussed in the issue, `failOnViolation` and `failsOnError` are intentionally set to `false` for this initial PR. This allows the CI pipeline to report existing formatting violations as warnings without breaking the build, paving the way for gradual, module-by-module enforcement in the future.