### PR TITLE
Reduce token usage when tool calling results are sent to the LLM (disable INDENT_OUTPUT in JacksonJsonCodec)

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
@@ -2,7 +2,6 @@ package dev.langchain4j.internal;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.PropertyAccessor.FIELD;
-import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
@@ -20,7 +19,6 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import dev.langchain4j.Internal;
-
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.time.LocalDate;
@@ -79,8 +77,12 @@ class JacksonJsonCodec implements Json.JsonCodec {
                 if (node.isObject()) {
                     int hour = node.get("hour").asInt();
                     int minute = node.get("minute").asInt();
-                    int second = Optional.ofNullable(node.get("second")).map(JsonNode::asInt).orElse(0);
-                    int nano = Optional.ofNullable(node.get("nano")).map(JsonNode::asInt).orElse(0);
+                    int second = Optional.ofNullable(node.get("second"))
+                            .map(JsonNode::asInt)
+                            .orElse(0);
+                    int nano = Optional.ofNullable(node.get("nano"))
+                            .map(JsonNode::asInt)
+                            .orElse(0);
                     return LocalTime.of(hour, minute, second, nano);
                 } else {
                     return LocalTime.parse(node.asText(), ISO_LOCAL_TIME);
@@ -108,8 +110,12 @@ class JacksonJsonCodec implements Json.JsonCodec {
                     JsonNode time = node.get("time");
                     int hour = time.get("hour").asInt();
                     int minute = time.get("minute").asInt();
-                    int second = Optional.ofNullable(time.get("second")).map(JsonNode::asInt).orElse(0);
-                    int nano = Optional.ofNullable(time.get("nano")).map(JsonNode::asInt).orElse(0);
+                    int second = Optional.ofNullable(time.get("second"))
+                            .map(JsonNode::asInt)
+                            .orElse(0);
+                    int nano = Optional.ofNullable(time.get("nano"))
+                            .map(JsonNode::asInt)
+                            .orElse(0);
                     return LocalDateTime.of(year, month, day, hour, minute, second, nano);
                 } else {
                     return LocalDateTime.parse(node.asText(), ISO_LOCAL_DATE_TIME);
@@ -121,7 +127,6 @@ class JacksonJsonCodec implements Json.JsonCodec {
         // to prevent issues caused by LLM hallucinations
         return JsonMapper.builder()
                 .visibility(FIELD, ANY)
-                .enable(INDENT_OUTPUT)
                 .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
                 .build()
                 .findAndRegisterModules()
@@ -141,7 +146,7 @@ class JacksonJsonCodec implements Json.JsonCodec {
      * Constructs a JacksonJsonCodec instance with a default ObjectMapper.
      * The default ObjectMapper is configured with custom serializers and deserializers
      * for Java 8 date/time types such as LocalDate, LocalTime, and LocalDateTime.
-     * It also registers other modules found on the classpath, enables formatted JSON output,
+     * It also registers other modules found on the classpath
      * and throws exceptions for unknown properties to improve handling of unexpected input.
      */
     public JacksonJsonCodec() {

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonTest.java
@@ -1,71 +1,64 @@
 package dev.langchain4j.internal;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class JsonTest {
 
-  @Test
-  void conversionToJsonAndFromJsonWorks() {
-    TestData testData = new TestData();
-    testData.setSampleDate(LocalDate.of(2023, 1, 15));
-    testData.setSampleDateTime(LocalDateTime.of(2023, 1, 15, 10, 20));
-    testData.setSomeValue("value");
+    @Test
+    void conversionToJsonAndFromJsonWorks() {
+        TestData testData = new TestData();
+        testData.setSampleDate(LocalDate.of(2023, 1, 15));
+        testData.setSampleDateTime(LocalDateTime.of(2023, 1, 15, 10, 20));
+        testData.setSomeValue("value");
 
-    String json = Json.toJson(testData);
+        String json = Json.toJson(testData);
 
-    // language=json
-    assertThat(json)
-      .isEqualToIgnoringWhitespace(
-        """
-        {
-          "sampleDate": "2023-01-15",
-          "sampleDateTime": "2023-01-15T10:20:00",
-          "some_value": "value"
-        }"""
-      );
+        assertThat(json)
+                .isEqualTo(
+                        "{\"sampleDate\":\"2023-01-15\",\"sampleDateTime\":\"2023-01-15T10:20:00\",\"some_value\":\"value\"}");
 
-    TestData deserializedData = Json.fromJson(json, TestData.class);
+        TestData deserializedData = Json.fromJson(json, TestData.class);
 
-    assertThat(deserializedData.getSampleDate()).isEqualTo(testData.getSampleDate());
-    assertThat(deserializedData.getSampleDateTime()).isEqualTo(testData.getSampleDateTime());
-    assertThat(deserializedData.getSomeValue()).isEqualTo(testData.getSomeValue());
-  }
-
-  private static class TestData {
-
-    private LocalDate sampleDate;
-    private LocalDateTime sampleDateTime;
-    @JsonProperty("some_value")
-    private String someValue;
-
-    LocalDate getSampleDate() {
-      return sampleDate;
+        assertThat(deserializedData.getSampleDate()).isEqualTo(testData.getSampleDate());
+        assertThat(deserializedData.getSampleDateTime()).isEqualTo(testData.getSampleDateTime());
+        assertThat(deserializedData.getSomeValue()).isEqualTo(testData.getSomeValue());
     }
 
-    void setSampleDate(LocalDate sampleDate) {
-      this.sampleDate = sampleDate;
-    }
+    private static class TestData {
 
-    LocalDateTime getSampleDateTime() {
-      return sampleDateTime;
-    }
+        private LocalDate sampleDate;
+        private LocalDateTime sampleDateTime;
 
-    void setSampleDateTime(LocalDateTime sampleDateTime) {
-      this.sampleDateTime = sampleDateTime;
-    }
+        @JsonProperty("some_value")
+        private String someValue;
 
-    String getSomeValue() {
-      return someValue;
-    }
+        LocalDate getSampleDate() {
+            return sampleDate;
+        }
 
-    void setSomeValue(String someValue) {
-      this.someValue = someValue;
+        void setSampleDate(LocalDate sampleDate) {
+            this.sampleDate = sampleDate;
+        }
+
+        LocalDateTime getSampleDateTime() {
+            return sampleDateTime;
+        }
+
+        void setSampleDateTime(LocalDateTime sampleDateTime) {
+            this.sampleDateTime = sampleDateTime;
+        }
+
+        String getSomeValue() {
+            return someValue;
+        }
+
+        void setSomeValue(String someValue) {
+            this.someValue = someValue;
+        }
     }
-  }
 }


### PR DESCRIPTION
## Summary
Closes #4009.

- Remove `.enable(INDENT_OUTPUT)` from `JacksonJsonCodec.createObjectMapper()` so that `Json.toJson()` produces compact JSON
- This reduces token usage when tool calling results are sent to the LLM via `DefaultToolExecutor.toText()` → `Json.toJson()`
- Update existing test assertion from `isEqualToIgnoringWhitespace` to exact `isEqualTo` with compact JSON string

Only the core `JacksonJsonCodec` is changed. Provider modules (OpenAI, Anthropic, Gemini, etc.) have their own `ObjectMapper` instances and are not affected.

`Json` is `@Internal`, so no public API contract is broken.

## Test plan
- [x] `JsonTest.conversionToJsonAndFromJsonWorks` passes with compact output assertion
- [ ] Verify no other tests rely on pretty-printed `Json.toJson()` output format

