### PR TITLE
Add MongoDB-backed ChatMemoryStore implementation

### DIFF
--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -312,6 +312,12 @@
 
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-mongodb</artifactId>
+                <version>${langchain4j.beta.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-mongodb-atlas</artifactId>
                 <version>${langchain4j.beta.version}</version>
             </dependency>

--- a/langchain4j-mongodb/pom.xml
+++ b/langchain4j-mongodb/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-parent</artifactId>
+        <version>1.13.0-beta23-SNAPSHOT</version>
+        <relativePath>../langchain4j-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>langchain4j-mongodb</artifactId>
+    <name>LangChain4j :: Integration :: MongoDB</name>
+
+    <properties>
+        <mongodb-client.version>5.6.0</mongodb-client.version>
+        <enforcer.skipRules>dependencyConvergence</enforcer.skipRules>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>1.13.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>${mongodb-client.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-core</artifactId>
+            <version>1.13.0-SNAPSHOT</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/langchain4j-mongodb/src/main/java/dev/langchain4j/store/memory/chat/mongodb/MongoDbChatMemoryStore.java
+++ b/langchain4j-mongodb/src/main/java/dev/langchain4j/store/memory/chat/mongodb/MongoDbChatMemoryStore.java
@@ -1,0 +1,162 @@
+package dev.langchain4j.store.memory.chat.mongodb;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.ReplaceOptions;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.bson.Document;
+
+/**
+ * Implementation of {@link ChatMemoryStore} backed by MongoDB.
+ * <p>
+ * It persists chat messages as serialized JSON within a MongoDB collection, and
+ * supports automatic message expiration via a MongoDB TTL index.
+ */
+public class MongoDbChatMemoryStore implements ChatMemoryStore {
+
+    private final MongoCollection<Document> collection;
+
+    /**
+     * Constructor for MongoDbChatMemoryStore.
+     *
+     * @param mongoClient        The MongoDB client instance.
+     * @param databaseName       The name of the MongoDB database.
+     * @param collectionName     The name of the MongoDB collection to store chat memory.
+     * @param expireAfterSeconds The TTL in seconds for the chat memory. If {@code null} or {@code <= 0}, no TTL is applied.
+     */
+    public MongoDbChatMemoryStore(
+            MongoClient mongoClient, String databaseName, String collectionName, Long expireAfterSeconds) {
+        ensureNotNull(mongoClient, "mongoClient");
+        ensureNotBlank(databaseName, "databaseName");
+        ensureNotBlank(collectionName, "collectionName");
+
+        this.collection = mongoClient.getDatabase(databaseName).getCollection(collectionName);
+
+        if (expireAfterSeconds != null && expireAfterSeconds > 0) {
+            IndexOptions indexOptions = new IndexOptions().expireAfter(expireAfterSeconds, TimeUnit.SECONDS);
+            try {
+                this.collection.createIndex(Indexes.ascending("updatedAt"), indexOptions);
+            } catch (MongoCommandException e) {
+                if (e.getErrorCode() == 85) {
+                    throw new RuntimeException(
+                            "An index on 'updatedAt' already exists with different options. "
+                                    + "Drop the existing index manually in MongoDB to apply the new expireAfterSeconds value.",
+                            e);
+                } else {
+                    throw new RuntimeException("Failed to create TTL index for ChatMemoryStore", e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public List<ChatMessage> getMessages(Object memoryId) {
+        Document doc = collection.find(Filters.eq("_id", memoryId.toString())).first();
+        if (doc == null || !doc.containsKey("messages")) {
+            return new ArrayList<>();
+        }
+        String json = doc.getString("messages");
+        return ChatMessageDeserializer.messagesFromJson(json);
+    }
+
+    @Override
+    public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+        String json = ChatMessageSerializer.messagesToJson(messages);
+        Document doc = new Document("_id", memoryId.toString())
+                .append("messages", json)
+                .append("updatedAt", new Date());
+
+        collection.replaceOne(Filters.eq("_id", memoryId.toString()), doc, new ReplaceOptions().upsert(true));
+    }
+
+    @Override
+    public void deleteMessages(Object memoryId) {
+        collection.deleteOne(Filters.eq("_id", memoryId.toString()));
+    }
+
+    /**
+     * Creates a new builder for {@link MongoDbChatMemoryStore}.
+     *
+     * @return A new builder instance.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link MongoDbChatMemoryStore}.
+     */
+    public static class Builder {
+        private MongoClient mongoClient;
+        private String databaseName;
+        private String collectionName = "chat_memory";
+        private Long expireAfterSeconds;
+
+        /**
+         * Sets the MongoDB client.
+         *
+         * @param mongoClient The MongoDB client.
+         * @return This builder.
+         */
+        public Builder mongoClient(MongoClient mongoClient) {
+            this.mongoClient = mongoClient;
+            return this;
+        }
+
+        /**
+         * Sets the database name.
+         *
+         * @param databaseName The database name.
+         * @return This builder.
+         */
+        public Builder databaseName(String databaseName) {
+            this.databaseName = databaseName;
+            return this;
+        }
+
+        /**
+         * Sets the collection name. Defaults to "chat_memory".
+         *
+         * @param collectionName The collection name.
+         * @return This builder.
+         */
+        public Builder collectionName(String collectionName) {
+            this.collectionName = collectionName;
+            return this;
+        }
+
+        /**
+         * Sets the expiration time for chat memory documents.
+         *
+         * @param expireAfterSeconds The number of seconds after which documents expire.
+         * @return This builder.
+         */
+        public Builder expireAfterSeconds(Long expireAfterSeconds) {
+            this.expireAfterSeconds = expireAfterSeconds;
+            return this;
+        }
+
+        /**
+         * Builds the {@link MongoDbChatMemoryStore}.
+         *
+         * @return A configured instance of {@link MongoDbChatMemoryStore}.
+         */
+        public MongoDbChatMemoryStore build() {
+            return new MongoDbChatMemoryStore(mongoClient, databaseName, collectionName, expireAfterSeconds);
+        }
+    }
+}

--- a/langchain4j-mongodb/src/test/java/dev/langchain4j/store/memory/chat/mongodb/MongoDbChatMemoryStoreIT.java
+++ b/langchain4j-mongodb/src/test/java/dev/langchain4j/store/memory/chat/mongodb/MongoDbChatMemoryStoreIT.java
@@ -1,0 +1,171 @@
+package dev.langchain4j.store.memory.chat.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import java.util.ArrayList;
+import java.util.List;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+class MongoDbChatMemoryStoreIT {
+
+    static MongoDBContainer mongoDBContainer = new MongoDBContainer(DockerImageName.parse("mongo:6.0")).withReuse(true);
+
+    static MongoClient mongoClient;
+    static ChatMemoryStore store;
+
+    @BeforeAll
+    static void setUp() {
+        mongoDBContainer.start();
+        mongoClient = MongoClients.create(mongoDBContainer.getReplicaSetUrl());
+
+        store = MongoDbChatMemoryStore.builder()
+                .mongoClient(mongoClient)
+                .databaseName("test_db")
+                .collectionName("test_collection")
+                .build();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @BeforeEach
+    void cleanDatabase() {
+        mongoClient.getDatabase("test_db").getCollection("test_collection").drop();
+    }
+
+    @Test
+    void should_store_and_retrieve_messages() {
+        // given
+        String memoryId = "user-123";
+        assertThat(store.getMessages(memoryId)).isEmpty();
+
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(UserMessage.from("Hello"));
+        messages.add(AiMessage.from("Hi there!"));
+
+        // when
+        store.updateMessages(memoryId, messages);
+
+        // then
+        List<ChatMessage> retrieved = store.getMessages(memoryId);
+        assertThat(retrieved).hasSize(2);
+        assertThat(retrieved.get(0)).isInstanceOf(UserMessage.class);
+        assertThat(retrieved.get(1)).isInstanceOf(AiMessage.class);
+    }
+
+    @Test
+    void should_update_existing_messages() {
+        // given
+        String memoryId = "user-789";
+        List<ChatMessage> messages = new ArrayList<>();
+
+        messages.add(UserMessage.from("Hello"));
+        store.updateMessages(memoryId, messages);
+        assertThat(store.getMessages(memoryId)).hasSize(1);
+
+        // when
+        messages.add(AiMessage.from("Hi there!"));
+        store.updateMessages(memoryId, messages);
+
+        // then
+        List<ChatMessage> retrieved = store.getMessages(memoryId);
+        assertThat(retrieved).hasSize(2);
+        assertThat(retrieved.get(0)).isInstanceOf(UserMessage.class);
+        assertThat(retrieved.get(1)).isInstanceOf(AiMessage.class);
+    }
+
+    @Test
+    void should_delete_messages() {
+        // given
+        String memoryId = "user-456";
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(UserMessage.from("Delete me"));
+
+        store.updateMessages(memoryId, messages);
+        assertThat(store.getMessages(memoryId)).hasSize(1);
+
+        // when
+        store.deleteMessages(memoryId);
+
+        // then
+        assertThat(store.getMessages(memoryId)).isEmpty();
+    }
+
+    @Test
+    void should_throw_exception_when_invalid_parameters() {
+        // when / then
+        assertThatThrownBy(() -> MongoDbChatMemoryStore.builder()
+                        .databaseName("test_db")
+                        .collectionName("test_collection")
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mongoClient cannot be null");
+
+        // when / then
+        assertThatThrownBy(() -> MongoDbChatMemoryStore.builder()
+                        .mongoClient(mongoClient)
+                        .collectionName("test_collection")
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("databaseName cannot be null or blank");
+    }
+
+    @Test
+    void should_create_ttl_index_without_errors() {
+        // when
+        MongoDbChatMemoryStore storeWithTtl = MongoDbChatMemoryStore.builder()
+                .mongoClient(mongoClient)
+                .databaseName("test_db")
+                .collectionName("test_collection_ttl")
+                .expireAfterSeconds(3600L)
+                .build();
+
+        // then
+        boolean indexExists = false;
+        for (Document index : mongoClient
+                .getDatabase("test_db")
+                .getCollection("test_collection_ttl")
+                .listIndexes()) {
+            if ("updatedAt_1".equals(index.getString("name"))) {
+                indexExists = true;
+                break;
+            }
+        }
+        assertThat(indexExists).isTrue();
+    }
+
+    @Test
+    void should_isolate_messages_by_memory_id() {
+        // given
+        String memoryId1 = "user-1";
+        String memoryId2 = "user-2";
+
+        List<ChatMessage> messages1 = List.of(UserMessage.from("Hello from user 1"));
+        List<ChatMessage> messages2 = List.of(UserMessage.from("Hello from user 2"));
+
+        // when
+        store.updateMessages(memoryId1, messages1);
+        store.updateMessages(memoryId2, messages2);
+
+        // then
+        assertThat(store.getMessages(memoryId1)).containsExactly(UserMessage.from("Hello from user 1"));
+        assertThat(store.getMessages(memoryId2)).containsExactly(UserMessage.from("Hello from user 2"));
+    }
+}

--- a/langchain4j-mongodb/src/test/resources/logback-test.xml
+++ b/langchain4j-mongodb/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <logger name="org.testcontainers" level="INFO"/>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <module>langchain4j-infinispan</module>
         <module>langchain4j-mariadb</module>
         <module>langchain4j-milvus</module>
+        <module>langchain4j-mongodb</module>
         <module>langchain4j-mongodb-atlas</module>
         <module>langchain4j-oracle</module>
         <module>langchain4j-opensearch</module>


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #4830

## Change
This PR introduces `MongoDbChatMemoryStore`, providing a native MongoDB-backed implementation for chat history persistence. This allows users already utilizing MongoDB in their architecture to store chat memory without needing to introduce a relational database.

**Architectural & Design Decisions:**
* **New Module (`langchain4j-mongodb`):** I created a new module rather than merging this into the existing `langchain4j-mongodb-atlas` module. The `ChatMemoryStore` relies on standard MongoDB collections and works with any MongoDB deployment (local, self-hosted, etc.). Keeping it separate ensures users don't have to pull in Atlas-specific vector search dependencies if they just want standard MongoDB chat storage.
* **Serialization:** Messages are serialized to JSON strings using the core `ChatMessageSerializer` rather than custom BSON arrays. This guarantees out-of-the-box compatibility with all current and future `ChatMessage` types (e.g., Tool execution, System messages) without needing to maintain complex BSON codecs.
* **TTL Support:** Added native support for automatic message expiration via MongoDB TTL indexes (`expireAfterSeconds`). It includes graceful error handling for `MongoCommandException` (Error 85) if a user updates the TTL value on an existing index.

**Testing:**
* Added `MongoDbChatMemoryStoreIT` using Testcontainers (`mongo:6.0`).
* Tests cover positive CRUD operations as well as negative validation cases.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
