### PR TITLE
Anthropic ModelCatalog: populate maxInputTokens and maxOutputTokens

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicModelCatalog.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicModelCatalog.java
@@ -71,8 +71,8 @@ public class AnthropicModelCatalog implements ModelCatalog {
         if (modelInfo.maxInputTokens != null) {
             builder.maxInputTokens(modelInfo.maxInputTokens);
         }
-        if (modelInfo.maxTokens != null) {
-            builder.maxOutputTokens(modelInfo.maxTokens);
+        if (modelInfo.maxOutputTokens != null) {
+            builder.maxOutputTokens(modelInfo.maxOutputTokens);
         }
 
         return builder.build();

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicModelCatalog.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicModelCatalog.java
@@ -1,5 +1,9 @@
 package dev.langchain4j.model.anthropic;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.model.ModelProvider.ANTHROPIC;
+
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicModelInfo;
@@ -7,17 +11,12 @@ import dev.langchain4j.model.anthropic.internal.api.AnthropicModelsListResponse;
 import dev.langchain4j.model.anthropic.internal.client.AnthropicClient;
 import dev.langchain4j.model.catalog.ModelCatalog;
 import dev.langchain4j.model.catalog.ModelDescription;
-import org.slf4j.Logger;
-
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-import static dev.langchain4j.model.ModelProvider.ANTHROPIC;
+import org.slf4j.Logger;
 
 /**
  * Anthropic implementation of {@link ModelCatalog}.
@@ -57,19 +56,26 @@ public class AnthropicModelCatalog implements ModelCatalog {
     @Override
     public List<ModelDescription> listModels() {
         AnthropicModelsListResponse response = client.listModels();
-        List<ModelDescription> models = response.data.stream()
-                .map(this::mapToModelDescription)
-                .toList();
+        List<ModelDescription> models =
+                response.data.stream().map(this::mapToModelDescription).toList();
         return models;
     }
 
     private ModelDescription mapToModelDescription(AnthropicModelInfo modelInfo) {
-        return ModelDescription.builder()
+        ModelDescription.Builder builder = ModelDescription.builder()
                 .name(modelInfo.id)
                 .provider(ANTHROPIC)
                 .displayName(isNullOrBlank(modelInfo.displayName) ? null : modelInfo.displayName)
-                .createdAt(modelInfo.createdAt != null ? parse(modelInfo.createdAt) : null)
-                .build();
+                .createdAt(modelInfo.createdAt != null ? parse(modelInfo.createdAt) : null);
+
+        if (modelInfo.maxInputTokens != null) {
+            builder.maxInputTokens(modelInfo.maxInputTokens);
+        }
+        if (modelInfo.maxTokens != null) {
+            builder.maxOutputTokens(modelInfo.maxTokens);
+        }
+
+        return builder.build();
     }
 
     private static Instant parse(String createdAt) {

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicModelInfo.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicModelInfo.java
@@ -4,6 +4,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.Objects;
@@ -45,13 +46,13 @@ public class AnthropicModelInfo {
 
     /**
      * Maximum number of output tokens the model can generate.
-     * Named {@code max_tokens} in the Anthropic API.
      */
-    public Integer maxTokens;
+    @JsonProperty("max_tokens")
+    public Integer maxOutputTokens;
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, createdAt, displayName, type, maxInputTokens, maxTokens);
+        return Objects.hash(id, createdAt, displayName, type, maxInputTokens, maxOutputTokens);
     }
 
     @Override
@@ -64,7 +65,7 @@ public class AnthropicModelInfo {
                 && Objects.equals(displayName, that.displayName)
                 && Objects.equals(type, that.type)
                 && Objects.equals(maxInputTokens, that.maxInputTokens)
-                && Objects.equals(maxTokens, that.maxTokens);
+                && Objects.equals(maxOutputTokens, that.maxOutputTokens);
     }
 
     @Override
@@ -74,7 +75,7 @@ public class AnthropicModelInfo {
                 + createdAt + '\'' + ", displayName='"
                 + displayName + '\'' + ", type='"
                 + type + '\'' + ", maxInputTokens="
-                + maxInputTokens + ", maxTokens="
-                + maxTokens + '}';
+                + maxInputTokens + ", maxOutputTokens="
+                + maxOutputTokens + '}';
     }
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicModelInfo.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicModelInfo.java
@@ -38,9 +38,20 @@ public class AnthropicModelInfo {
      */
     public String type;
 
+    /**
+     * Maximum number of input tokens the model can accept.
+     */
+    public Integer maxInputTokens;
+
+    /**
+     * Maximum number of output tokens the model can generate.
+     * Named {@code max_tokens} in the Anthropic API.
+     */
+    public Integer maxTokens;
+
     @Override
     public int hashCode() {
-        return Objects.hash(id, createdAt, displayName, type);
+        return Objects.hash(id, createdAt, displayName, type, maxInputTokens, maxTokens);
     }
 
     @Override
@@ -51,7 +62,9 @@ public class AnthropicModelInfo {
         return Objects.equals(id, that.id)
                 && Objects.equals(createdAt, that.createdAt)
                 && Objects.equals(displayName, that.displayName)
-                && Objects.equals(type, that.type);
+                && Objects.equals(type, that.type)
+                && Objects.equals(maxInputTokens, that.maxInputTokens)
+                && Objects.equals(maxTokens, that.maxTokens);
     }
 
     @Override
@@ -60,6 +73,8 @@ public class AnthropicModelInfo {
                 + id + '\'' + ", createdAt='"
                 + createdAt + '\'' + ", displayName='"
                 + displayName + '\'' + ", type='"
-                + type + '\'' + '}';
+                + type + '\'' + ", maxInputTokens="
+                + maxInputTokens + ", maxTokens="
+                + maxTokens + '}';
     }
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicModelCatalogIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicModelCatalogIT.java
@@ -1,17 +1,16 @@
 package dev.langchain4j.model.anthropic.common;
 
+import static dev.langchain4j.model.ModelProvider.ANTHROPIC;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.anthropic.AnthropicModelCatalog;
 import dev.langchain4j.model.catalog.AbstractModelCatalogIT;
 import dev.langchain4j.model.catalog.ModelCatalog;
 import dev.langchain4j.model.catalog.ModelDescription;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-
-import java.util.List;
-
-import static dev.langchain4j.model.ModelProvider.ANTHROPIC;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
 class AnthropicModelCatalogIT extends AbstractModelCatalogIT {
@@ -36,5 +35,25 @@ class AnthropicModelCatalogIT extends AbstractModelCatalogIT {
 
         assertThat(models).isNotEmpty();
         assertThat(models).anyMatch(m -> m.createdAt() != null);
+    }
+
+    @Test
+    void should_have_max_input_tokens() {
+        ModelCatalog catalog = createModelCatalog();
+
+        List<ModelDescription> models = catalog.listModels();
+
+        assertThat(models).isNotEmpty();
+        assertThat(models).anyMatch(m -> m.maxInputTokens() != null && m.maxInputTokens() > 0);
+    }
+
+    @Test
+    void should_have_max_output_tokens() {
+        ModelCatalog catalog = createModelCatalog();
+
+        List<ModelDescription> models = catalog.listModels();
+
+        assertThat(models).isNotEmpty();
+        assertThat(models).anyMatch(m -> m.maxOutputTokens() != null && m.maxOutputTokens() > 0);
     }
 }


### PR DESCRIPTION
## Summary

- Parse `max_input_tokens` and `max_tokens` fields from the Anthropic `/v1/models` API response in `AnthropicModelInfo`
- Map them to `ModelDescription.maxInputTokens()` and `ModelDescription.maxOutputTokens()` in `AnthropicModelCatalog`
- Add integration tests matching the existing `GoogleAiGeminiModelCatalogIT` pattern

## Context

The Anthropic Models API returns `max_input_tokens` and `max_tokens` per model, but these fields were being silently discarded by `@JsonIgnoreProperties(ignoreUnknown = true)`. Google Gemini's catalog implementation already populates these fields correctly — this PR brings Anthropic to parity.

## Changes

### `AnthropicModelInfo.java`
- Added `maxInputTokens` (`Integer`) and `maxTokens` (`Integer`) fields
- These auto-map from `max_input_tokens` and `max_tokens` via the existing `@JsonNaming(SnakeCaseStrategy.class)`
- Updated `equals()`, `hashCode()`, and `toString()` to include new fields

### `AnthropicModelCatalog.java`
- Updated `mapToModelDescription()` to set `maxInputTokens` and `maxOutputTokens` on the `ModelDescription` builder when non-null

### `AnthropicModelCatalogIT.java`
- Added `should_have_max_input_tokens()` and `should_have_max_output_tokens()` integration tests

Closes #4835