### PR TITLE
Feature/anthropic adaptive thinking support

### DIFF
--- a/langchain4j-anthropic/pom.xml
+++ b/langchain4j-anthropic/pom.xml
@@ -49,7 +49,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-
         <!-- test dependencies -->
 
         <dependency>

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -69,6 +69,8 @@ public class AnthropicChatModel implements ChatModel {
     private final boolean cacheTools;
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
+    private final AnthropicThinkingDisplay thinkingDisplay;
+    private final AnthropicThinkingEffort thinkingEffort;
     private final boolean returnThinking;
     private final boolean sendThinking;
     private final int maxRetries;
@@ -101,6 +103,8 @@ public class AnthropicChatModel implements ChatModel {
         this.cacheTools = getOrDefault(builder.cacheTools, false);
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
+        this.thinkingDisplay = builder.thinkingDisplay;
+        this.thinkingEffort = builder.thinkingEffort;
         this.returnThinking = getOrDefault(builder.returnThinking, false);
         this.sendThinking = getOrDefault(builder.sendThinking, true);
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
@@ -166,6 +170,8 @@ public class AnthropicChatModel implements ChatModel {
         private Boolean cacheTools;
         private String thinkingType;
         private Integer thinkingBudgetTokens;
+        private AnthropicThinkingDisplay thinkingDisplay;
+        private AnthropicThinkingEffort thinkingEffort;
         private Boolean returnThinking;
         private Boolean sendThinking;
         private Duration timeout;
@@ -350,9 +356,35 @@ public class AnthropicChatModel implements ChatModel {
 
         /**
          * Configures <a href="https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking">thinking</a>.
+         * Required for manual ({@code "enabled"}) mode; not used for adaptive ({@code "adaptive"}) mode.
          */
         public AnthropicChatModelBuilder thinkingBudgetTokens(Integer thinkingBudgetTokens) {
             this.thinkingBudgetTokens = thinkingBudgetTokens;
+            return this;
+        }
+
+        /**
+         * Controls how thinking content is returned in API responses.
+         * <ul>
+         *   <li>{@code "summarized"} (default) – thinking blocks contain summarized text.</li>
+         *   <li>{@code "omitted"} – thinking blocks are returned with an empty {@code thinking} field;
+         *       the encrypted {@code signature} is still included for multi-turn continuity.
+         *       Reduces time-to-first-text-token when streaming.</li>
+         * </ul>
+         * Cannot be used when thinking type is {@code "disabled"}.
+         */
+        public AnthropicChatModelBuilder thinkingDisplay(AnthropicThinkingDisplay thinkingDisplay) {
+            this.thinkingDisplay = thinkingDisplay;
+            return this;
+        }
+
+        /**
+         * Soft guidance for thinking depth when using adaptive thinking ({@code thinkingType = "adaptive"}).
+         * Accepted values: {@code "max"} (Opus 4.6 only), {@code "high"} (default), {@code "medium"}, {@code "low"}.
+         * Passed as {@code output_config.effort} in the API request.
+         */
+        public AnthropicChatModelBuilder thinkingEffort(AnthropicThinkingEffort thinkingEffort) {
+            this.thinkingEffort = thinkingEffort;
             return this;
         }
 
@@ -479,7 +511,7 @@ public class AnthropicChatModel implements ChatModel {
 
         AnthropicCreateMessageRequest anthropicRequest = createAnthropicRequest(
                 chatRequest,
-                toThinking(thinkingType, thinkingBudgetTokens),
+                toThinking(thinkingType, thinkingBudgetTokens, thinkingDisplay),
                 sendThinking,
                 cacheSystemMessages ? EPHEMERAL : NO_CACHE,
                 cacheTools ? EPHEMERAL : NO_CACHE,
@@ -490,7 +522,8 @@ public class AnthropicChatModel implements ChatModel {
                 toolMetadataKeysToSend,
                 userId,
                 customParameters,
-                strictTools);
+                strictTools,
+                thinkingEffort);
 
         ParsedAndRawResponse response =
                 withRetryMappingExceptions(() -> client.createMessageWithRawResponse(anthropicRequest), maxRetries);
@@ -514,11 +547,13 @@ public class AnthropicChatModel implements ChatModel {
                 .build();
     }
 
-    static AnthropicThinking toThinking(String thinkingType, Integer thinkingBudgetTokens) {
+    static AnthropicThinking toThinking(
+            String thinkingType, Integer thinkingBudgetTokens, AnthropicThinkingDisplay thinkingDisplay) {
         if (thinkingType != null || thinkingBudgetTokens != null) {
             return AnthropicThinking.builder()
                     .type(thinkingType)
                     .budgetTokens(thinkingBudgetTokens)
+                    .display(thinkingDisplay)
                     .build();
         }
         return null;

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -66,6 +66,8 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
     private final boolean cacheTools;
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
+    private final AnthropicThinkingDisplay thinkingDisplay;
+    private final AnthropicThinkingEffort thinkingEffort;
     private final boolean returnThinking;
     private final boolean sendThinking;
     private final List<ChatModelListener> listeners;
@@ -115,6 +117,8 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         this.cacheTools = getOrDefault(builder.cacheTools, false);
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
+        this.thinkingDisplay = builder.thinkingDisplay;
+        this.thinkingEffort = builder.thinkingEffort;
         this.returnThinking = getOrDefault(builder.returnThinking, false);
         this.sendThinking = getOrDefault(builder.sendThinking, true);
         this.listeners = copy(builder.listeners);
@@ -152,6 +156,8 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         private Boolean cacheTools;
         private String thinkingType;
         private Integer thinkingBudgetTokens;
+        private AnthropicThinkingDisplay thinkingDisplay;
+        private AnthropicThinkingEffort thinkingEffort;
         private Boolean returnThinking;
         private Boolean sendThinking;
         private Duration timeout;
@@ -264,9 +270,35 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
 
         /**
          * Configures <a href="https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking">thinking</a>.
+         * Required for manual ({@code "enabled"}) mode; not used for adaptive ({@code "adaptive"}) mode.
          */
         public AnthropicStreamingChatModelBuilder thinkingBudgetTokens(Integer thinkingBudgetTokens) {
             this.thinkingBudgetTokens = thinkingBudgetTokens;
+            return this;
+        }
+
+        /**
+         * Controls how thinking content is returned in API responses.
+         * <ul>
+         *   <li>{@code "summarized"} (default) – thinking blocks contain summarized text.</li>
+         *   <li>{@code "omitted"} – thinking blocks are returned with an empty {@code thinking} field;
+         *       the encrypted {@code signature} is still included for multi-turn continuity.
+         *       Reduces time-to-first-text-token when streaming.</li>
+         * </ul>
+         * Cannot be used when thinking type is {@code "disabled"}.
+         */
+        public AnthropicStreamingChatModelBuilder thinkingDisplay(AnthropicThinkingDisplay thinkingDisplay) {
+            this.thinkingDisplay = thinkingDisplay;
+            return this;
+        }
+
+        /**
+         * Soft guidance for thinking depth when using adaptive thinking ({@code thinkingType = "adaptive"}).
+         * Accepted values: {@code "max"} (Opus 4.6 only), {@code "high"} (default), {@code "medium"}, {@code "low"}.
+         * Passed as {@code output_config.effort} in the API request.
+         */
+        public AnthropicStreamingChatModelBuilder thinkingEffort(AnthropicThinkingEffort thinkingEffort) {
+            this.thinkingEffort = thinkingEffort;
             return this;
         }
 
@@ -460,7 +492,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         validate(chatRequest.parameters());
         AnthropicCreateMessageRequest anthropicRequest = createAnthropicRequest(
                 chatRequest,
-                toThinking(thinkingType, thinkingBudgetTokens),
+                toThinking(thinkingType, thinkingBudgetTokens, thinkingDisplay),
                 sendThinking,
                 cacheSystemMessages ? EPHEMERAL : NO_CACHE,
                 cacheTools ? EPHEMERAL : NO_CACHE,
@@ -471,7 +503,8 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 toolMetadataKeysToSend,
                 userId,
                 customParameters,
-                strictTools);
+                strictTools,
+                thinkingEffort);
         client.createMessage(
                 anthropicRequest, new AnthropicCreateMessageOptions(returnThinking, returnServerToolResults), handler);
     }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicThinkingDisplay.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicThinkingDisplay.java
@@ -1,0 +1,36 @@
+package dev.langchain4j.model.anthropic;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Controls how thinking content is returned in API responses when extended or adaptive thinking is enabled.
+ *
+ * @see <a href="https://platform.claude.com/docs/en/build-with-claude/extended-thinking#controlling-thinking-display">Controlling thinking display</a>
+ */
+public enum AnthropicThinkingDisplay {
+
+    /**
+     * Thinking blocks contain summarized thinking text.
+     * This is the default when no display value is specified.
+     */
+    @JsonProperty("summarized")
+    SUMMARIZED,
+
+    /**
+     * Thinking blocks are returned with an empty {@code thinking} field.
+     * The encrypted {@code signature} is still included for multi-turn continuity.
+     * <p>
+     * Primary benefit: faster time-to-first-text-token when streaming, because the server
+     * skips streaming thinking tokens entirely and delivers only the signature.
+     * <p>
+     * Note: you are still billed for the full thinking tokens; omitting reduces latency, not cost.
+     * Cannot be used when thinking type is {@code "disabled"}.
+     */
+    @JsonProperty("omitted")
+    OMITTED;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicThinkingEffort.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicThinkingEffort.java
@@ -1,0 +1,45 @@
+package dev.langchain4j.model.anthropic;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Controls the depth of thinking when using adaptive thinking
+ * ({@code thinkingType = "adaptive"}).
+ * Acts as soft guidance — Claude may deviate based on the actual request complexity.
+ *
+ * @see <a href="https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking">Adaptive thinking</a>
+ * @see <a href="https://platform.claude.com/docs/en/build-with-claude/effort">Effort parameter</a>
+ */
+public enum AnthropicThinkingEffort {
+
+    /**
+     * Claude always thinks with no constraints on thinking depth.
+     * Only supported on Claude Opus 4.6; requests using {@code MAX} on other models return an error.
+     */
+    @JsonProperty("max")
+    MAX,
+
+    /**
+     * Claude always thinks. Provides deep reasoning on complex tasks.
+     * This is the default when no effort level is specified.
+     */
+    @JsonProperty("high")
+    HIGH,
+
+    /**
+     * Claude uses moderate thinking. May skip thinking for very simple queries.
+     */
+    @JsonProperty("medium")
+    MEDIUM,
+
+    /**
+     * Claude minimises thinking. Skips thinking for simple tasks where speed matters most.
+     */
+    @JsonProperty("low")
+    LOW;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
@@ -38,7 +38,8 @@ class InternalAnthropicHelper {
         if (parameters.presencePenalty() != null) {
             unsupportedFeatures.add("Presence Penalty");
         }
-        if (parameters.responseFormat() != null && parameters.responseFormat().type() == JSON
+        if (parameters.responseFormat() != null
+                && parameters.responseFormat().type() == JSON
                 && parameters.responseFormat().jsonSchema() == null) {
             unsupportedFeatures.add("Schemaless JSON response format");
         }
@@ -65,7 +66,8 @@ class InternalAnthropicHelper {
             Set<String> toolMetadataKeysToSend,
             String userId,
             Map<String, Object> customParameters,
-            Boolean strictTools) {
+            Boolean strictTools,
+            AnthropicThinkingEffort thinkingEffort) {
 
         AnthropicCreateMessageRequest.Builder requestBuilder = AnthropicCreateMessageRequest.builder().stream(stream)
                 .model(chatRequest.modelName())
@@ -77,7 +79,7 @@ class InternalAnthropicHelper {
                 .topP(chatRequest.topP())
                 .topK(chatRequest.topK())
                 .thinking(thinking)
-                .outputConfig(toAnthropicOutputConfig(chatRequest.responseFormat()))
+                .outputConfig(toAnthropicOutputConfig(chatRequest.responseFormat(), thinkingEffort))
                 .customParameters(customParameters);
 
         List<AnthropicTool> tools = new ArrayList<>();
@@ -85,7 +87,8 @@ class InternalAnthropicHelper {
             tools.addAll(toAnthropicTools(serverTools));
         }
         if (!isNullOrEmpty(chatRequest.toolSpecifications())) {
-            tools.addAll(toAnthropicTools(chatRequest.toolSpecifications(), toolsCacheType, toolMetadataKeysToSend, strictTools));
+            tools.addAll(toAnthropicTools(
+                    chatRequest.toolSpecifications(), toolsCacheType, toolMetadataKeysToSend, strictTools));
         }
         if (!tools.isEmpty()) {
             requestBuilder.tools(tools);
@@ -104,12 +107,20 @@ class InternalAnthropicHelper {
     }
 
     public static AnthropicOutputConfig toAnthropicOutputConfig(ResponseFormat responseFormat) {
-        if (responseFormat == null || responseFormat.type() == TEXT || responseFormat.jsonSchema() == null) {
+        return toAnthropicOutputConfig(responseFormat, null);
+    }
+
+    public static AnthropicOutputConfig toAnthropicOutputConfig(
+            ResponseFormat responseFormat, AnthropicThinkingEffort effort) {
+        AnthropicFormat format = null;
+        if (responseFormat != null && responseFormat.type() != TEXT && responseFormat.jsonSchema() != null) {
+            format = AnthropicFormat.fromJsonSchema(responseFormat.jsonSchema());
+        }
+
+        if (format == null && effort == null) {
             return null;
         }
 
-        return AnthropicOutputConfig.builder()
-                .format(AnthropicFormat.fromJsonSchema(responseFormat.jsonSchema()))
-                .build();
+        return AnthropicOutputConfig.builder().format(format).effort(effort).build();
     }
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicOutputConfig.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicOutputConfig.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.model.anthropic.internal.api;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -8,10 +10,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-
+import dev.langchain4j.model.anthropic.AnthropicThinkingEffort;
 import java.util.Objects;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonDeserialize(builder = AnthropicOutputConfig.Builder.class)
 @JsonInclude(NON_NULL)
@@ -21,12 +21,30 @@ public class AnthropicOutputConfig {
     @JsonProperty
     private final AnthropicFormat format;
 
+    /**
+     * Soft guidance for how much thinking Claude should do when using adaptive thinking
+     * ({@code thinking.type = "adaptive"}).
+     * <ul>
+     *   <li>{@code "max"}    – always think with no constraints (Opus 4.6 only).</li>
+     *   <li>{@code "high"}   – always think; deep reasoning (default).</li>
+     *   <li>{@code "medium"} – moderate thinking; may skip thinking for simple queries.</li>
+     *   <li>{@code "low"}    – minimal thinking; skips thinking for simple tasks.</li>
+     * </ul>
+     */
+    @JsonProperty
+    private final AnthropicThinkingEffort effort;
+
     private AnthropicOutputConfig(Builder builder) {
         this.format = builder.format;
+        this.effort = builder.effort;
     }
 
     public AnthropicFormat getFormat() {
         return format;
+    }
+
+    public AnthropicThinkingEffort getEffort() {
+        return effort;
     }
 
     public static Builder builder() {
@@ -35,12 +53,12 @@ public class AnthropicOutputConfig {
 
     @Override
     public String toString() {
-        return "AnthropicOutputConfig[" + "format" + format + "]";
+        return "AnthropicOutputConfig[format=" + format + ", effort=" + effort + "]";
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(format);
+        return Objects.hash(format, effort);
     }
 
     @Override
@@ -49,7 +67,7 @@ public class AnthropicOutputConfig {
     }
 
     public boolean equalsTo(AnthropicOutputConfig other) {
-        return Objects.equals(format, other.format);
+        return Objects.equals(format, other.format) && Objects.equals(effort, other.effort);
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -58,9 +76,18 @@ public class AnthropicOutputConfig {
     public static class Builder {
 
         private AnthropicFormat format;
+        private AnthropicThinkingEffort effort;
 
         public Builder format(AnthropicFormat format) {
             this.format = format;
+            return this;
+        }
+
+        /**
+         * Sets the effort level for adaptive thinking.
+         */
+        public Builder effort(AnthropicThinkingEffort effort) {
+            this.effort = effort;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicThinking.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicThinking.java
@@ -4,20 +4,61 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import dev.langchain4j.model.anthropic.AnthropicThinkingDisplay;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class AnthropicThinking {
 
+    /**
+     * Thinking type. Accepted values:
+     * <ul>
+     *   <li>{@code "enabled"}  – manual extended thinking with a fixed token budget (deprecated on Opus 4.6 / Sonnet 4.6).</li>
+     *   <li>{@code "adaptive"} – adaptive thinking, recommended for Opus 4.6 and Sonnet 4.6.
+     *       Claude decides when and how much to think based on request complexity.
+     *       Use together with {@code output_config.effort} instead of {@code budget_tokens}.</li>
+     *   <li>{@code "disabled"} – thinking disabled.</li>
+     * </ul>
+     */
     @JsonProperty
     private final String type;
 
+    /**
+     * Maximum thinking tokens for manual ({@code "enabled"}) mode.
+     * Deprecated on Opus 4.6 / Sonnet 4.6 – use adaptive mode with {@code effort} instead.
+     */
     @JsonProperty
     private final Integer budgetTokens;
+
+    /**
+     * Controls how thinking content is returned in API responses.
+     * <ul>
+     *   <li>{@code "summarized"} (default) – thinking blocks contain summarized text.</li>
+     *   <li>{@code "omitted"} – thinking blocks are returned with an empty {@code thinking} field;
+     *       the encrypted {@code signature} is still included for multi-turn continuity.
+     *       Reduces time-to-first-text-token when streaming.</li>
+     * </ul>
+     * Invalid when {@code type} is {@code "disabled"}.
+     */
+    @JsonProperty
+    private final AnthropicThinkingDisplay display;
 
     public AnthropicThinking(Builder builder) {
         this.type = builder.type;
         this.budgetTokens = builder.budgetTokens;
+        this.display = builder.display;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Integer getBudgetTokens() {
+        return budgetTokens;
+    }
+
+    public AnthropicThinkingDisplay getDisplay() {
+        return display;
     }
 
     public static Builder builder() {
@@ -28,9 +69,9 @@ public class AnthropicThinking {
 
         private String type;
         private Integer budgetTokens;
+        private AnthropicThinkingDisplay display;
 
-        private Builder() {
-        }
+        private Builder() {}
 
         public Builder type(String type) {
             this.type = type;
@@ -39,6 +80,14 @@ public class AnthropicThinking {
 
         public Builder budgetTokens(Integer budgetTokens) {
             this.budgetTokens = budgetTokens;
+            return this;
+        }
+
+        /**
+         * Controls how thinking content is returned.
+         */
+        public Builder display(AnthropicThinkingDisplay display) {
+            this.display = display;
             return this;
         }
 

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelThinkingIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelThinkingIT.java
@@ -5,8 +5,8 @@ import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_OPUS
 import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_SONNET_4_5_20250929;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
 
-import java.util.List;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
@@ -19,6 +19,7 @@ import dev.langchain4j.http.client.jdk.JdkHttpClient;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,27 +33,29 @@ class AnthropicChatModelThinkingIT {
     private static final int THINKING_BUDGET_TOKENS = 1024;
 
     @ParameterizedTest
-    @EnumSource(value = AnthropicChatModelName.class, mode = EXCLUDE, names = {
-            "CLAUDE_3_HAIKU_20240307",
-    })
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = EXCLUDE,
+            names = {
+                "CLAUDE_3_HAIKU_20240307",
+            })
     void should_return_and_send_thinking(AnthropicChatModelName modelName) {
 
         // given
         boolean returnThinking = true;
         // sendThinking = true by default
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         ChatModel model = AnthropicChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(modelName)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -91,28 +94,30 @@ class AnthropicChatModelThinkingIT {
     }
 
     @ParameterizedTest
-    @EnumSource(value = AnthropicChatModelName.class, mode = EXCLUDE, names = {
-            "CLAUDE_3_HAIKU_20240307",
-    })
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = EXCLUDE,
+            names = {
+                "CLAUDE_3_HAIKU_20240307",
+            })
     void should_return_and_NOT_send_thinking(AnthropicChatModelName modelName) {
 
         // given
         boolean returnThinking = true;
         boolean sendThinking = false;
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         ChatModel model = AnthropicChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(modelName)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
                 .sendThinking(sendThinking)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -151,9 +156,12 @@ class AnthropicChatModelThinkingIT {
     }
 
     @ParameterizedTest
-    @EnumSource(value = AnthropicChatModelName.class, mode = EXCLUDE, names = {
-            "CLAUDE_3_HAIKU_20240307",
-    })
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = EXCLUDE,
+            names = {
+                "CLAUDE_3_HAIKU_20240307",
+            })
     void should_return_and_send_thinking_with_tools(AnthropicChatModelName modelName) {
 
         // given
@@ -168,19 +176,18 @@ class AnthropicChatModelThinkingIT {
                         .build())
                 .build();
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         ChatModel model = AnthropicChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(modelName)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
                 .toolSpecifications(toolSpecification)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -197,7 +204,8 @@ class AnthropicChatModelThinkingIT {
         String signature1 = aiMessage1.attribute("thinking_signature", String.class);
         assertThat(signature1).isNotBlank();
         assertThat(aiMessage1.toolExecutionRequests()).hasSize(1);
-        ToolExecutionRequest toolExecutionRequest1 = aiMessage1.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest1 =
+                aiMessage1.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest1.name()).isEqualTo(toolSpecification.name());
         assertThat(toolExecutionRequest1.arguments()).contains("Munich");
 
@@ -227,7 +235,8 @@ class AnthropicChatModelThinkingIT {
         String signature2 = aiMessage3.attribute("thinking_signature", String.class);
         assertThat(signature2).isNotBlank();
         assertThat(aiMessage3.toolExecutionRequests()).hasSize(1);
-        ToolExecutionRequest toolExecutionRequest2 = aiMessage3.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest2 =
+                aiMessage3.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest2.name()).isEqualTo(toolSpecification.name());
         assertThat(toolExecutionRequest2.arguments()).contains("Paris");
 
@@ -235,7 +244,8 @@ class AnthropicChatModelThinkingIT {
         ToolExecutionResultMessage toolResultMessage2 = ToolExecutionResultMessage.from(toolExecutionRequest2, "rainy");
 
         // when
-        ChatResponse chatResponse4 = model.chat(userMessage1, aiMessage1, toolResultMessage1, aiMessage2, userMessage2, aiMessage3, toolResultMessage2);
+        ChatResponse chatResponse4 = model.chat(
+                userMessage1, aiMessage1, toolResultMessage1, aiMessage2, userMessage2, aiMessage3, toolResultMessage2);
 
         // then
         AiMessage aiMessage4 = chatResponse4.aiMessage();
@@ -247,12 +257,8 @@ class AnthropicChatModelThinkingIT {
         // should send thinking in the follow-up requests
         List<HttpRequest> httpRequests = spyingHttpClient.requests();
         assertThat(httpRequests).hasSize(4);
-        assertThat(httpRequests.get(1).body())
-                .contains(jsonify(thinking1))
-                .contains(jsonify(signature1));
-        assertThat(httpRequests.get(3).body())
-                .contains(jsonify(thinking2))
-                .contains(jsonify(signature2));
+        assertThat(httpRequests.get(1).body()).contains(jsonify(thinking1)).contains(jsonify(signature1));
+        assertThat(httpRequests.get(3).body()).contains(jsonify(thinking2)).contains(jsonify(signature2));
     }
 
     @Test
@@ -273,12 +279,12 @@ class AnthropicChatModelThinkingIT {
                         .build())
                 .build();
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         ChatModel model = AnthropicChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
-
                 .beta(beta)
                 .modelName(modelName)
                 .thinkingType("enabled")
@@ -286,7 +292,6 @@ class AnthropicChatModelThinkingIT {
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
                 .toolSpecifications(toolSpecification)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -306,7 +311,8 @@ class AnthropicChatModelThinkingIT {
         assertThat(signature1).isNotBlank();
 
         assertThat(aiMessage1.toolExecutionRequests()).hasSize(1);
-        ToolExecutionRequest toolExecutionRequest1 = aiMessage1.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest1 =
+                aiMessage1.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest1.name()).isEqualTo(toolSpecification.name());
         assertThat(toolExecutionRequest1.arguments()).contains("Munich");
 
@@ -344,7 +350,8 @@ class AnthropicChatModelThinkingIT {
         assertThat(signature3).isNotBlank();
 
         assertThat(aiMessage3.toolExecutionRequests()).hasSize(1);
-        ToolExecutionRequest toolExecutionRequest2 = aiMessage3.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest2 =
+                aiMessage3.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest2.name()).isEqualTo(toolSpecification.name());
         assertThat(toolExecutionRequest2.arguments()).contains("Paris");
 
@@ -352,7 +359,8 @@ class AnthropicChatModelThinkingIT {
         ToolExecutionResultMessage toolResultMessage2 = ToolExecutionResultMessage.from(toolExecutionRequest2, "rainy");
 
         // when
-        ChatResponse chatResponse4 = model.chat(userMessage1, aiMessage1, toolResultMessage1, aiMessage2, userMessage2, aiMessage3, toolResultMessage2);
+        ChatResponse chatResponse4 = model.chat(
+                userMessage1, aiMessage1, toolResultMessage1, aiMessage2, userMessage2, aiMessage3, toolResultMessage2);
 
         // then
         AiMessage aiMessage4 = chatResponse4.aiMessage();
@@ -369,15 +377,9 @@ class AnthropicChatModelThinkingIT {
         // should send thinking in the follow-up requests
         List<HttpRequest> httpRequests = spyingHttpClient.requests();
         assertThat(httpRequests).hasSize(4);
-        assertThat(httpRequests.get(1).body())
-                .contains(jsonify(thinking1))
-                .contains(jsonify(signature1));
-        assertThat(httpRequests.get(2).body())
-                .contains(jsonify(thinking2))
-                .contains(jsonify(signature2));
-        assertThat(httpRequests.get(3).body())
-                .contains(jsonify(thinking3))
-                .contains(jsonify(signature3));
+        assertThat(httpRequests.get(1).body()).contains(jsonify(thinking1)).contains(jsonify(signature1));
+        assertThat(httpRequests.get(2).body()).contains(jsonify(thinking2)).contains(jsonify(signature2));
+        assertThat(httpRequests.get(3).body()).contains(jsonify(thinking3)).contains(jsonify(signature3));
     }
 
     @ParameterizedTest
@@ -389,12 +391,10 @@ class AnthropicChatModelThinkingIT {
         ChatModel model = AnthropicChatModel.builder()
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(CLAUDE_SONNET_4_5_20250929)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -409,5 +409,241 @@ class AnthropicChatModelThinkingIT {
         assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
         assertThat(aiMessage.thinking()).isNull();
         assertThat(aiMessage.attributes()).isEmpty();
+    }
+
+    // =========================================================================
+    // Adaptive thinking tests (Opus 4.6 / Sonnet 4.6)
+    // =========================================================================
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = INCLUDE,
+            names = {
+                "CLAUDE_OPUS_4_6",
+                "CLAUDE_SONNET_4_6",
+            })
+    void should_use_adaptive_thinking(AnthropicChatModelName modelName) {
+
+        // given
+        ChatModel model = AnthropicChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName)
+                .thinkingType("adaptive")
+                .maxTokens(4000)
+                .returnThinking(true)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        // when
+        UserMessage userMessage = UserMessage.from("What is the capital of Germany?");
+        ChatResponse chatResponse = model.chat(userMessage);
+
+        // then
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
+        // with default HIGH effort, Claude almost always thinks
+        // thinking may or may not be present depending on complexity, but text must be present
+        assertThat(aiMessage.text()).isNotBlank();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = INCLUDE,
+            names = {
+                "CLAUDE_OPUS_4_6",
+                "CLAUDE_SONNET_4_6",
+            })
+    void should_use_adaptive_thinking_and_return_thinking(AnthropicChatModelName modelName) {
+
+        // given
+        ChatModel model = AnthropicChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName)
+                .thinkingType("adaptive")
+                .thinkingEffort(AnthropicThinkingEffort.HIGH)
+                .maxTokens(4000)
+                .returnThinking(true)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        // when
+        UserMessage userMessage = UserMessage.from("Explain why the sum of two even numbers is always even.");
+        ChatResponse chatResponse = model.chat(userMessage);
+
+        // then
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).isNotBlank();
+        // HIGH effort → Claude always thinks
+        assertThat(aiMessage.thinking()).isNotBlank();
+        assertThat(aiMessage.attribute("thinking_signature", String.class)).isNotBlank();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = INCLUDE,
+            names = {
+                "CLAUDE_OPUS_4_6",
+                "CLAUDE_SONNET_4_6",
+            })
+    void should_send_adaptive_thinking_in_request_json(AnthropicChatModelName modelName) {
+
+        // given – spy on outgoing requests
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        ChatModel model = AnthropicChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName)
+                .thinkingType("adaptive")
+                .thinkingEffort(AnthropicThinkingEffort.MEDIUM)
+                .maxTokens(4000)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        // when
+        model.chat("What is 2 + 2?");
+
+        // then – verify serialized request contains adaptive config and no budget_tokens
+        List<HttpRequest> requests = spyingHttpClient.requests();
+        assertThat(requests).hasSize(1);
+        String body = requests.get(0).body();
+        assertThat(body).contains("\"adaptive\"");
+        assertThat(body).contains("\"medium\"");
+        assertThat(body).doesNotContain("budget_tokens");
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = INCLUDE,
+            names = {
+                "CLAUDE_OPUS_4_6",
+                "CLAUDE_SONNET_4_6",
+            })
+    void should_use_adaptive_thinking_with_display_OMITTED(AnthropicChatModelName modelName) {
+
+        // given
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        ChatModel model = AnthropicChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName)
+                .thinkingType("adaptive")
+                .thinkingDisplay(AnthropicThinkingDisplay.OMITTED)
+                .maxTokens(4000)
+                .returnThinking(true)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        // when
+        UserMessage userMessage = UserMessage.from("What is the capital of France?");
+        ChatResponse chatResponse = model.chat(userMessage);
+
+        // then
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Paris");
+        // With display=OMITTED the thinking field is empty but signature is still returned
+        // thinking() will be null or blank; signature should still be present for multi-turn
+        String signature = aiMessage.attribute("thinking_signature", String.class);
+        assertThat(signature).isNotBlank();
+
+        // verify request body contains display:omitted
+        String body = spyingHttpClient.requests().get(0).body();
+        assertThat(body).contains("\"omitted\"");
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = INCLUDE,
+            names = {
+                "CLAUDE_OPUS_4_6",
+                "CLAUDE_SONNET_4_6",
+            })
+    void should_use_adaptive_thinking_with_low_effort(AnthropicChatModelName modelName) {
+
+        // given
+        ChatModel model = AnthropicChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName)
+                .thinkingType("adaptive")
+                .thinkingEffort(AnthropicThinkingEffort.LOW)
+                .maxTokens(4000)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        // when – simple question where LOW effort may skip thinking
+        UserMessage userMessage = UserMessage.from("What is the capital of Japan?");
+        ChatResponse chatResponse = model.chat(userMessage);
+
+        // then
+        assertThat(chatResponse.aiMessage().text()).containsIgnoringCase("Tokyo");
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = INCLUDE,
+            names = {
+                "CLAUDE_OPUS_4_6",
+                "CLAUDE_SONNET_4_6",
+            })
+    void should_return_and_send_adaptive_thinking_multi_turn(AnthropicChatModelName modelName) {
+
+        // given
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        ChatModel model = AnthropicChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName)
+                .thinkingType("adaptive")
+                .thinkingEffort(AnthropicThinkingEffort.HIGH)
+                .maxTokens(4000)
+                .returnThinking(true)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage1 = UserMessage.from("What is the capital of Germany?");
+
+        // when
+        ChatResponse chatResponse1 = model.chat(userMessage1);
+
+        // then
+        AiMessage aiMessage1 = chatResponse1.aiMessage();
+        assertThat(aiMessage1.text()).containsIgnoringCase("Berlin");
+        assertThat(aiMessage1.thinking()).isNotBlank();
+        String signature1 = aiMessage1.attribute("thinking_signature", String.class);
+        assertThat(signature1).isNotBlank();
+
+        // given
+        UserMessage userMessage2 = UserMessage.from("What is the capital of France?");
+
+        // when
+        ChatResponse chatResponse2 = model.chat(userMessage1, aiMessage1, userMessage2);
+
+        // then
+        AiMessage aiMessage2 = chatResponse2.aiMessage();
+        assertThat(aiMessage2.text()).containsIgnoringCase("Paris");
+
+        // should send thinking signature in the follow-up request
+        List<HttpRequest> httpRequests = spyingHttpClient.requests();
+        assertThat(httpRequests).hasSize(2);
+        assertThat(httpRequests.get(1).body())
+                .contains(jsonify(aiMessage1.thinking()))
+                .contains(jsonify(signature1));
     }
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelThinkingIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelThinkingIT.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_OPUS
 import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_SONNET_4_5_20250929;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeast;
@@ -13,7 +14,6 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import java.util.List;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
@@ -26,6 +26,7 @@ import dev.langchain4j.http.client.jdk.JdkHttpClient;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,27 +41,29 @@ class AnthropicStreamingChatModelThinkingIT {
     private static final int THINKING_BUDGET_TOKENS = 1024;
 
     @ParameterizedTest
-    @EnumSource(value = AnthropicChatModelName.class, mode = EXCLUDE, names = {
-            "CLAUDE_3_HAIKU_20240307",
-    })
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = EXCLUDE,
+            names = {
+                "CLAUDE_3_HAIKU_20240307",
+            })
     void should_return_and_send_thinking(AnthropicChatModelName modelName) {
 
         // given
         boolean returnThinking = true;
         // sendThinking = true by default
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         StreamingChatModel model = AnthropicStreamingChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(modelName)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -74,9 +77,7 @@ class AnthropicStreamingChatModelThinkingIT {
         // then
         AiMessage aiMessage1 = spyHandler1.get().aiMessage();
         assertThat(aiMessage1.text()).containsIgnoringCase("Berlin");
-        assertThat(aiMessage1.thinking())
-                .containsIgnoringCase("Berlin")
-                .isEqualTo(spyHandler1.getThinking());
+        assertThat(aiMessage1.thinking()).containsIgnoringCase("Berlin").isEqualTo(spyHandler1.getThinking());
         String signature1 = aiMessage1.attribute("thinking_signature", String.class);
         assertThat(signature1).isNotBlank();
 
@@ -119,30 +120,31 @@ class AnthropicStreamingChatModelThinkingIT {
                 .contains(jsonify(signature1));
     }
 
-
     @ParameterizedTest
-    @EnumSource(value = AnthropicChatModelName.class, mode = EXCLUDE, names = {
-            "CLAUDE_3_HAIKU_20240307",
-    })
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = EXCLUDE,
+            names = {
+                "CLAUDE_3_HAIKU_20240307",
+            })
     void should_return_and_NOT_send_thinking(AnthropicChatModelName modelName) {
 
         // given
         boolean returnThinking = true;
         boolean sendThinking = false;
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         StreamingChatModel model = AnthropicStreamingChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(modelName)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
                 .sendThinking(sendThinking)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -199,9 +201,12 @@ class AnthropicStreamingChatModelThinkingIT {
     }
 
     @ParameterizedTest
-    @EnumSource(value = AnthropicChatModelName.class, mode = EXCLUDE, names = {
-            "CLAUDE_3_HAIKU_20240307",
-    })
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = EXCLUDE,
+            names = {
+                "CLAUDE_3_HAIKU_20240307",
+            })
     void should_return_and_send_thinking_with_tools(AnthropicChatModelName modelName) {
 
         // given
@@ -216,19 +221,18 @@ class AnthropicStreamingChatModelThinkingIT {
                         .build())
                 .build();
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         StreamingChatModel model = AnthropicStreamingChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(modelName)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
                 .toolSpecifications(toolSpecification)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -246,18 +250,21 @@ class AnthropicStreamingChatModelThinkingIT {
         String signature1 = aiMessage1.attribute("thinking_signature", String.class);
         assertThat(signature1).isNotBlank();
         assertThat(aiMessage1.toolExecutionRequests()).hasSize(1);
-        ToolExecutionRequest toolExecutionRequest1 = aiMessage1.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest1 =
+                aiMessage1.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest1.name()).isEqualTo(toolSpecification.name());
         assertThat(toolExecutionRequest1.arguments()).contains("Munich");
 
         InOrder inOrder1 = inOrder(spyHandler1);
         inOrder1.verify(spyHandler1).get();
         inOrder1.verify(spyHandler1, atLeastOnce()).onPartialThinking(any(), any());
-        inOrder1.verify(spyHandler1, atLeast(0)).onPartialResponse(any(), any()); // do not care if onPartialResponse was called
-        inOrder1.verify(spyHandler1, atLeastOnce()).onPartialToolCall(argThat(toolCall ->
-                toolCall.name().equals(toolExecutionRequest1.name())), any());
-        inOrder1.verify(spyHandler1).onCompleteToolCall(argThat(toolCall ->
-                toolCall.toolExecutionRequest().equals(toolExecutionRequest1)));
+        inOrder1.verify(spyHandler1, atLeast(0))
+                .onPartialResponse(any(), any()); // do not care if onPartialResponse was called
+        inOrder1.verify(spyHandler1, atLeastOnce())
+                .onPartialToolCall(argThat(toolCall -> toolCall.name().equals(toolExecutionRequest1.name())), any());
+        inOrder1.verify(spyHandler1)
+                .onCompleteToolCall(
+                        argThat(toolCall -> toolCall.toolExecutionRequest().equals(toolExecutionRequest1)));
         inOrder1.verify(spyHandler1).onCompleteResponse(any());
         inOrder1.verifyNoMoreInteractions();
         verifyNoMoreInteractions(spyHandler1);
@@ -297,18 +304,21 @@ class AnthropicStreamingChatModelThinkingIT {
         String signature2 = aiMessage3.attribute("thinking_signature", String.class);
         assertThat(signature2).isNotBlank();
         assertThat(aiMessage3.toolExecutionRequests()).hasSize(1);
-        ToolExecutionRequest toolExecutionRequest2 = aiMessage3.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest2 =
+                aiMessage3.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest2.name()).isEqualTo(toolSpecification.name());
         assertThat(toolExecutionRequest2.arguments()).contains("Paris");
 
         InOrder inOrder3 = inOrder(spyHandler3);
         inOrder3.verify(spyHandler3).get();
         inOrder3.verify(spyHandler3, atLeastOnce()).onPartialThinking(any(), any());
-        inOrder3.verify(spyHandler3, atLeast(0)).onPartialResponse(any(), any()); // do not care if onPartialResponse was called
-        inOrder3.verify(spyHandler3, atLeastOnce()).onPartialToolCall(argThat(toolCall ->
-                toolCall.name().equals(toolExecutionRequest2.name())), any());
-        inOrder3.verify(spyHandler3).onCompleteToolCall(argThat(toolCall ->
-                toolCall.toolExecutionRequest().equals(toolExecutionRequest2)));
+        inOrder3.verify(spyHandler3, atLeast(0))
+                .onPartialResponse(any(), any()); // do not care if onPartialResponse was called
+        inOrder3.verify(spyHandler3, atLeastOnce())
+                .onPartialToolCall(argThat(toolCall -> toolCall.name().equals(toolExecutionRequest2.name())), any());
+        inOrder3.verify(spyHandler3)
+                .onCompleteToolCall(
+                        argThat(toolCall -> toolCall.toolExecutionRequest().equals(toolExecutionRequest2)));
         inOrder3.verify(spyHandler3).onCompleteResponse(any());
         inOrder3.verifyNoMoreInteractions();
         verifyNoMoreInteractions(spyHandler3);
@@ -318,7 +328,16 @@ class AnthropicStreamingChatModelThinkingIT {
 
         // when
         TestStreamingChatResponseHandler spyHandler4 = spy(new TestStreamingChatResponseHandler());
-        model.chat(List.of(userMessage1, aiMessage1, toolResultMessage1, aiMessage2, userMessage2, aiMessage3, toolResultMessage2), spyHandler4);
+        model.chat(
+                List.of(
+                        userMessage1,
+                        aiMessage1,
+                        toolResultMessage1,
+                        aiMessage2,
+                        userMessage2,
+                        aiMessage3,
+                        toolResultMessage2),
+                spyHandler4);
 
         // then
         AiMessage aiMessage4 = spyHandler4.get().aiMessage();
@@ -337,12 +356,8 @@ class AnthropicStreamingChatModelThinkingIT {
         // should send thinking in the follow-up requests
         List<HttpRequest> httpRequests = spyingHttpClient.requests();
         assertThat(httpRequests).hasSize(4);
-        assertThat(httpRequests.get(1).body())
-                .contains(jsonify(thinking1))
-                .contains(jsonify(signature1));
-        assertThat(httpRequests.get(3).body())
-                .contains(jsonify(thinking2))
-                .contains(jsonify(signature2));
+        assertThat(httpRequests.get(1).body()).contains(jsonify(thinking1)).contains(jsonify(signature1));
+        assertThat(httpRequests.get(3).body()).contains(jsonify(thinking2)).contains(jsonify(signature2));
     }
 
     @Test
@@ -363,12 +378,12 @@ class AnthropicStreamingChatModelThinkingIT {
                         .build())
                 .build();
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         StreamingChatModel model = AnthropicStreamingChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
-
                 .beta(beta)
                 .modelName(modelName)
                 .thinkingType("enabled")
@@ -376,7 +391,6 @@ class AnthropicStreamingChatModelThinkingIT {
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
                 .toolSpecifications(toolSpecification)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -397,7 +411,8 @@ class AnthropicStreamingChatModelThinkingIT {
         assertThat(signature1).isNotBlank();
 
         assertThat(aiMessage1.toolExecutionRequests()).hasSize(1);
-        ToolExecutionRequest toolExecutionRequest1 = aiMessage1.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest1 =
+                aiMessage1.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest1.name()).isEqualTo(toolSpecification.name());
         assertThat(toolExecutionRequest1.arguments()).contains("Munich");
 
@@ -405,10 +420,11 @@ class AnthropicStreamingChatModelThinkingIT {
         inOrder1.verify(spyHandler1).get();
         inOrder1.verify(spyHandler1, atLeastOnce()).onPartialThinking(any(), any());
         inOrder1.verify(spyHandler1, atLeastOnce()).onPartialResponse(any(), any());
-        inOrder1.verify(spyHandler1, atLeastOnce()).onPartialToolCall(argThat(toolCall ->
-                toolCall.name().equals(toolExecutionRequest1.name())), any());
-        inOrder1.verify(spyHandler1).onCompleteToolCall(argThat(toolCall ->
-                toolCall.toolExecutionRequest().equals(toolExecutionRequest1)));
+        inOrder1.verify(spyHandler1, atLeastOnce())
+                .onPartialToolCall(argThat(toolCall -> toolCall.name().equals(toolExecutionRequest1.name())), any());
+        inOrder1.verify(spyHandler1)
+                .onCompleteToolCall(
+                        argThat(toolCall -> toolCall.toolExecutionRequest().equals(toolExecutionRequest1)));
         inOrder1.verify(spyHandler1).onCompleteResponse(any());
         inOrder1.verifyNoMoreInteractions();
         verifyNoMoreInteractions(spyHandler1);
@@ -457,7 +473,8 @@ class AnthropicStreamingChatModelThinkingIT {
         assertThat(signature3).isNotBlank();
 
         assertThat(aiMessage3.toolExecutionRequests()).hasSize(1);
-        ToolExecutionRequest toolExecutionRequest2 = aiMessage3.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest2 =
+                aiMessage3.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest2.name()).isEqualTo(toolSpecification.name());
         assertThat(toolExecutionRequest2.arguments()).contains("Paris");
 
@@ -465,10 +482,11 @@ class AnthropicStreamingChatModelThinkingIT {
         inOrder3.verify(spyHandler3).get();
         inOrder3.verify(spyHandler3, atLeastOnce()).onPartialThinking(any(), any());
         inOrder3.verify(spyHandler3, atLeastOnce()).onPartialResponse(any(), any());
-        inOrder3.verify(spyHandler3, atLeastOnce()).onPartialToolCall(argThat(toolCall ->
-                toolCall.name().equals(toolExecutionRequest2.name())), any());
-        inOrder3.verify(spyHandler3).onCompleteToolCall(argThat(toolCall ->
-                toolCall.toolExecutionRequest().equals(toolExecutionRequest2)));
+        inOrder3.verify(spyHandler3, atLeastOnce())
+                .onPartialToolCall(argThat(toolCall -> toolCall.name().equals(toolExecutionRequest2.name())), any());
+        inOrder3.verify(spyHandler3)
+                .onCompleteToolCall(
+                        argThat(toolCall -> toolCall.toolExecutionRequest().equals(toolExecutionRequest2)));
         inOrder3.verify(spyHandler3).onCompleteResponse(any());
         inOrder3.verifyNoMoreInteractions();
         verifyNoMoreInteractions(spyHandler3);
@@ -478,7 +496,16 @@ class AnthropicStreamingChatModelThinkingIT {
 
         // when
         TestStreamingChatResponseHandler spyHandler4 = spy(new TestStreamingChatResponseHandler());
-        model.chat(List.of(userMessage1, aiMessage1, toolResultMessage1, aiMessage2, userMessage2, aiMessage3, toolResultMessage2), spyHandler4);
+        model.chat(
+                List.of(
+                        userMessage1,
+                        aiMessage1,
+                        toolResultMessage1,
+                        aiMessage2,
+                        userMessage2,
+                        aiMessage3,
+                        toolResultMessage2),
+                spyHandler4);
 
         // then
         AiMessage aiMessage4 = spyHandler4.get().aiMessage();
@@ -503,15 +530,9 @@ class AnthropicStreamingChatModelThinkingIT {
         // should send thinking in the follow-up requests
         List<HttpRequest> httpRequests = spyingHttpClient.requests();
         assertThat(httpRequests).hasSize(4);
-        assertThat(httpRequests.get(1).body())
-                .contains(jsonify(thinking1))
-                .contains(jsonify(signature1));
-        assertThat(httpRequests.get(2).body())
-                .contains(jsonify(thinking2))
-                .contains(jsonify(signature2));
-        assertThat(httpRequests.get(3).body())
-                .contains(jsonify(thinking3))
-                .contains(jsonify(signature3));
+        assertThat(httpRequests.get(1).body()).contains(jsonify(thinking1)).contains(jsonify(signature1));
+        assertThat(httpRequests.get(2).body()).contains(jsonify(thinking2)).contains(jsonify(signature2));
+        assertThat(httpRequests.get(3).body()).contains(jsonify(thinking3)).contains(jsonify(signature3));
     }
 
     @ParameterizedTest
@@ -523,12 +544,10 @@ class AnthropicStreamingChatModelThinkingIT {
         StreamingChatModel model = AnthropicStreamingChatModel.builder()
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(CLAUDE_SONNET_4_5_20250929)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -551,5 +570,196 @@ class AnthropicStreamingChatModelThinkingIT {
         inOrder.verify(spyHandler).onCompleteResponse(any());
         inOrder.verifyNoMoreInteractions();
         verifyNoMoreInteractions(spyHandler);
+    }
+
+    // =========================================================================
+    // Adaptive thinking tests (Opus 4.6 / Sonnet 4.6)
+    // =========================================================================
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = INCLUDE,
+            names = {
+                "CLAUDE_OPUS_4_6",
+                "CLAUDE_SONNET_4_6",
+            })
+    void should_stream_with_adaptive_thinking(AnthropicChatModelName modelName) {
+
+        // given
+        StreamingChatModel model = AnthropicStreamingChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName)
+                .thinkingType("adaptive")
+                .thinkingEffort(AnthropicThinkingEffort.HIGH)
+                .maxTokens(4000)
+                .returnThinking(true)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler = spy(new TestStreamingChatResponseHandler());
+        model.chat("Explain why the square root of 2 is irrational.", handler);
+
+        // then
+        AiMessage aiMessage = handler.get().aiMessage();
+        assertThat(aiMessage.text()).isNotBlank();
+        // HIGH effort → Claude always thinks; partial thinking events expected
+        assertThat(aiMessage.thinking()).isNotBlank();
+        assertThat(aiMessage.attribute("thinking_signature", String.class)).isNotBlank();
+
+        InOrder inOrder = inOrder(handler);
+        inOrder.verify(handler).get();
+        inOrder.verify(handler, atLeastOnce()).onPartialThinking(any(), any());
+        inOrder.verify(handler, atLeastOnce()).onPartialResponse(any(), any());
+        inOrder.verify(handler).onCompleteResponse(any());
+        inOrder.verifyNoMoreInteractions();
+        verifyNoMoreInteractions(handler);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = INCLUDE,
+            names = {
+                "CLAUDE_OPUS_4_6",
+                "CLAUDE_SONNET_4_6",
+            })
+    void should_stream_with_adaptive_thinking_and_display_OMITTED(AnthropicChatModelName modelName) {
+
+        // given – OMITTED means no thinking_delta SSE events; only a signature_delta arrives
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        StreamingChatModel model = AnthropicStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName)
+                .thinkingType("adaptive")
+                .thinkingDisplay(AnthropicThinkingDisplay.OMITTED)
+                .maxTokens(4000)
+                .returnThinking(true)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler = spy(new TestStreamingChatResponseHandler());
+        model.chat("What is the capital of France?", handler);
+
+        // then
+        AiMessage aiMessage = handler.get().aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Paris");
+        // With display=OMITTED, thinking text is empty but signature is still delivered
+        assertThat(aiMessage.attribute("thinking_signature", String.class)).isNotBlank();
+        // onPartialThinking must NOT have been called (no thinking_delta events)
+        InOrder inOrder = inOrder(handler);
+        inOrder.verify(handler).get();
+        inOrder.verify(handler, atLeastOnce()).onPartialResponse(any(), any());
+        inOrder.verify(handler).onCompleteResponse(any());
+        inOrder.verifyNoMoreInteractions();
+        verifyNoMoreInteractions(handler);
+
+        // verify request body contains display:omitted
+        String body = spyingHttpClient.requests().get(0).body();
+        assertThat(body).contains("\"omitted\"");
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = INCLUDE,
+            names = {
+                "CLAUDE_OPUS_4_6",
+                "CLAUDE_SONNET_4_6",
+            })
+    void should_stream_adaptive_thinking_sends_correct_json(AnthropicChatModelName modelName) {
+
+        // given
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        StreamingChatModel model = AnthropicStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName)
+                .thinkingType("adaptive")
+                .thinkingEffort(AnthropicThinkingEffort.MEDIUM)
+                .maxTokens(4000)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        model.chat("What is 2 + 2?", handler);
+        handler.get(); // wait for completion
+
+        // then – verify serialized request
+        List<HttpRequest> requests = spyingHttpClient.requests();
+        assertThat(requests).hasSize(1);
+        String body = requests.get(0).body();
+        assertThat(body).contains("\"adaptive\"");
+        assertThat(body).contains("\"medium\"");
+        assertThat(body).doesNotContain("budget_tokens");
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = INCLUDE,
+            names = {
+                "CLAUDE_OPUS_4_6",
+                "CLAUDE_SONNET_4_6",
+            })
+    void should_stream_adaptive_thinking_multi_turn(AnthropicChatModelName modelName) {
+
+        // given
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        StreamingChatModel model = AnthropicStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName)
+                .thinkingType("adaptive")
+                .thinkingEffort(AnthropicThinkingEffort.HIGH)
+                .maxTokens(4000)
+                .returnThinking(true)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage1 = UserMessage.from("What is the capital of Germany?");
+
+        // when – turn 1
+        TestStreamingChatResponseHandler handler1 = spy(new TestStreamingChatResponseHandler());
+        model.chat(List.of(userMessage1), handler1);
+
+        // then
+        AiMessage aiMessage1 = handler1.get().aiMessage();
+        assertThat(aiMessage1.text()).containsIgnoringCase("Berlin");
+        assertThat(aiMessage1.thinking()).isNotBlank();
+        String signature1 = aiMessage1.attribute("thinking_signature", String.class);
+        assertThat(signature1).isNotBlank();
+
+        // given – turn 2
+        UserMessage userMessage2 = UserMessage.from("What is the capital of France?");
+
+        // when
+        TestStreamingChatResponseHandler handler2 = spy(new TestStreamingChatResponseHandler());
+        model.chat(List.of(userMessage1, aiMessage1, userMessage2), handler2);
+
+        // then
+        AiMessage aiMessage2 = handler2.get().aiMessage();
+        assertThat(aiMessage2.text()).containsIgnoringCase("Paris");
+
+        // should send thinking in the follow-up request
+        List<HttpRequest> httpRequests = spyingHttpClient.requests();
+        assertThat(httpRequests).hasSize(2);
+        assertThat(httpRequests.get(1).body())
+                .contains(jsonify(aiMessage1.thinking()))
+                .contains(jsonify(signature1));
     }
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicThinkingConfigTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicThinkingConfigTest.java
@@ -1,0 +1,269 @@
+package dev.langchain4j.model.anthropic;
+
+import static dev.langchain4j.model.anthropic.AnthropicChatModel.toThinking;
+import static dev.langchain4j.model.anthropic.InternalAnthropicHelper.toAnthropicOutputConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicOutputConfig;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicThinking;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for the thinking configuration types: {@link AnthropicThinkingEffort},
+ * {@link AnthropicThinkingDisplay}, {@link AnthropicThinking}, and {@link AnthropicOutputConfig}.
+ * <p>
+ * Tests cover:
+ * <ul>
+ *   <li>Enum JSON serialization via {@code @JsonProperty}</li>
+ *   <li>{@code toThinking()} factory method in all combinations</li>
+ *   <li>{@code toAnthropicOutputConfig()} null-handling and merging</li>
+ * </ul>
+ */
+class AnthropicThinkingConfigTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    // -------------------------------------------------------------------------
+    // AnthropicThinkingEffort – serialization
+    // -------------------------------------------------------------------------
+
+    @Test
+    void effort_MAX_serializes_to_max() throws JsonProcessingException {
+        assertThat(MAPPER.writeValueAsString(AnthropicThinkingEffort.MAX)).isEqualTo("\"max\"");
+    }
+
+    @Test
+    void effort_HIGH_serializes_to_high() throws JsonProcessingException {
+        assertThat(MAPPER.writeValueAsString(AnthropicThinkingEffort.HIGH)).isEqualTo("\"high\"");
+    }
+
+    @Test
+    void effort_MEDIUM_serializes_to_medium() throws JsonProcessingException {
+        assertThat(MAPPER.writeValueAsString(AnthropicThinkingEffort.MEDIUM)).isEqualTo("\"medium\"");
+    }
+
+    @Test
+    void effort_LOW_serializes_to_low() throws JsonProcessingException {
+        assertThat(MAPPER.writeValueAsString(AnthropicThinkingEffort.LOW)).isEqualTo("\"low\"");
+    }
+
+    @Test
+    void effort_toString_is_lowercase() {
+        assertThat(AnthropicThinkingEffort.MAX.toString()).isEqualTo("max");
+        assertThat(AnthropicThinkingEffort.HIGH.toString()).isEqualTo("high");
+        assertThat(AnthropicThinkingEffort.MEDIUM.toString()).isEqualTo("medium");
+        assertThat(AnthropicThinkingEffort.LOW.toString()).isEqualTo("low");
+    }
+
+    // -------------------------------------------------------------------------
+    // AnthropicThinkingDisplay – serialization
+    // -------------------------------------------------------------------------
+
+    @Test
+    void display_SUMMARIZED_serializes_to_summarized() throws JsonProcessingException {
+        assertThat(MAPPER.writeValueAsString(AnthropicThinkingDisplay.SUMMARIZED))
+                .isEqualTo("\"summarized\"");
+    }
+
+    @Test
+    void display_OMITTED_serializes_to_omitted() throws JsonProcessingException {
+        assertThat(MAPPER.writeValueAsString(AnthropicThinkingDisplay.OMITTED)).isEqualTo("\"omitted\"");
+    }
+
+    @Test
+    void display_toString_is_lowercase() {
+        assertThat(AnthropicThinkingDisplay.SUMMARIZED.toString()).isEqualTo("summarized");
+        assertThat(AnthropicThinkingDisplay.OMITTED.toString()).isEqualTo("omitted");
+    }
+
+    // -------------------------------------------------------------------------
+    // toThinking() – factory method
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toThinking_returns_null_when_type_and_budget_and_display_are_all_null() {
+        assertThat(toThinking(null, null, null)).isNull();
+    }
+
+    @Test
+    void toThinking_enabled_with_budget_no_display() throws JsonProcessingException {
+        AnthropicThinking thinking = toThinking("enabled", 1024, null);
+
+        assertThat(thinking).isNotNull();
+        assertThat(thinking.getType()).isEqualTo("enabled");
+        assertThat(thinking.getBudgetTokens()).isEqualTo(1024);
+        assertThat(thinking.getDisplay()).isNull();
+
+        // display must be absent from JSON (NON_NULL)
+        String json = MAPPER.writeValueAsString(thinking);
+        assertThat(json).contains("\"type\":\"enabled\"");
+        assertThat(json).contains("\"budget_tokens\":1024");
+        assertThat(json).doesNotContain("display");
+    }
+
+    @Test
+    void toThinking_adaptive_no_budget_no_display() throws JsonProcessingException {
+        AnthropicThinking thinking = toThinking("adaptive", null, null);
+
+        assertThat(thinking).isNotNull();
+        assertThat(thinking.getType()).isEqualTo("adaptive");
+        assertThat(thinking.getBudgetTokens()).isNull();
+        assertThat(thinking.getDisplay()).isNull();
+
+        String json = MAPPER.writeValueAsString(thinking);
+        assertThat(json).contains("\"type\":\"adaptive\"");
+        assertThat(json).doesNotContain("budget_tokens");
+        assertThat(json).doesNotContain("display");
+    }
+
+    @Test
+    void toThinking_adaptive_with_display_OMITTED() throws JsonProcessingException {
+        AnthropicThinking thinking = toThinking("adaptive", null, AnthropicThinkingDisplay.OMITTED);
+
+        assertThat(thinking.getType()).isEqualTo("adaptive");
+        assertThat(thinking.getDisplay()).isEqualTo(AnthropicThinkingDisplay.OMITTED);
+
+        String json = MAPPER.writeValueAsString(thinking);
+        assertThat(json).contains("\"type\":\"adaptive\"");
+        assertThat(json).contains("\"display\":\"omitted\"");
+        assertThat(json).doesNotContain("budget_tokens");
+    }
+
+    @Test
+    void toThinking_enabled_with_display_SUMMARIZED() throws JsonProcessingException {
+        AnthropicThinking thinking = toThinking("enabled", 2048, AnthropicThinkingDisplay.SUMMARIZED);
+
+        assertThat(thinking.getBudgetTokens()).isEqualTo(2048);
+        assertThat(thinking.getDisplay()).isEqualTo(AnthropicThinkingDisplay.SUMMARIZED);
+
+        String json = MAPPER.writeValueAsString(thinking);
+        assertThat(json).contains("\"type\":\"enabled\"");
+        assertThat(json).contains("\"budget_tokens\":2048");
+        assertThat(json).contains("\"display\":\"summarized\"");
+    }
+
+    @Test
+    void toThinking_returns_non_null_when_only_budget_is_set() {
+        // budgetTokens alone (without type) should still produce an object
+        AnthropicThinking thinking = toThinking(null, 512, null);
+        assertThat(thinking).isNotNull();
+        assertThat(thinking.getBudgetTokens()).isEqualTo(512);
+        assertThat(thinking.getType()).isNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // toAnthropicOutputConfig() – null-handling and effort/format merging
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toAnthropicOutputConfig_returns_null_when_both_args_null() {
+        assertThat(toAnthropicOutputConfig(null, null)).isNull();
+        assertThat(toAnthropicOutputConfig(null)).isNull();
+    }
+
+    @Test
+    void toAnthropicOutputConfig_returns_null_for_TEXT_response_format_and_null_effort() {
+        assertThat(toAnthropicOutputConfig(ResponseFormat.TEXT, null)).isNull();
+    }
+
+    @Test
+    void toAnthropicOutputConfig_with_effort_only_omits_format_field() throws JsonProcessingException {
+        AnthropicOutputConfig config = toAnthropicOutputConfig(null, AnthropicThinkingEffort.MEDIUM);
+
+        assertThat(config).isNotNull();
+        assertThat(config.getEffort()).isEqualTo(AnthropicThinkingEffort.MEDIUM);
+        assertThat(config.getFormat()).isNull();
+
+        String json = MAPPER.writeValueAsString(config);
+        assertThat(json).contains("\"effort\":\"medium\"");
+        assertThat(json).doesNotContain("format");
+    }
+
+    @Test
+    void toAnthropicOutputConfig_with_TEXT_format_and_effort_includes_only_effort() throws JsonProcessingException {
+        // TEXT response format with no JSON schema → format stays null, effort is set
+        AnthropicOutputConfig config = toAnthropicOutputConfig(ResponseFormat.TEXT, AnthropicThinkingEffort.LOW);
+
+        assertThat(config).isNotNull();
+        assertThat(config.getEffort()).isEqualTo(AnthropicThinkingEffort.LOW);
+        assertThat(config.getFormat()).isNull();
+
+        String json = MAPPER.writeValueAsString(config);
+        assertThat(json).contains("\"effort\":\"low\"");
+        assertThat(json).doesNotContain("format");
+    }
+
+    @ParameterizedTest
+    @CsvSource({"MAX,max", "HIGH,high", "MEDIUM,medium", "LOW,low"})
+    void toAnthropicOutputConfig_effort_serializes_correctly(AnthropicThinkingEffort effort, String expectedJson)
+            throws JsonProcessingException {
+        AnthropicOutputConfig config = toAnthropicOutputConfig(null, effort);
+        assertThat(MAPPER.writeValueAsString(config)).contains("\"effort\":\"" + expectedJson + "\"");
+    }
+
+    // -------------------------------------------------------------------------
+    // AnthropicOutputConfig – equals / hashCode
+    // -------------------------------------------------------------------------
+
+    @Test
+    void outputConfig_equals_same_effort() {
+        AnthropicOutputConfig a = AnthropicOutputConfig.builder()
+                .effort(AnthropicThinkingEffort.HIGH)
+                .build();
+        AnthropicOutputConfig b = AnthropicOutputConfig.builder()
+                .effort(AnthropicThinkingEffort.HIGH)
+                .build();
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void outputConfig_not_equals_different_effort() {
+        AnthropicOutputConfig a = AnthropicOutputConfig.builder()
+                .effort(AnthropicThinkingEffort.HIGH)
+                .build();
+        AnthropicOutputConfig b = AnthropicOutputConfig.builder()
+                .effort(AnthropicThinkingEffort.LOW)
+                .build();
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void outputConfig_toString_includes_effort() {
+        AnthropicOutputConfig config = AnthropicOutputConfig.builder()
+                .effort(AnthropicThinkingEffort.MEDIUM)
+                .build();
+        assertThat(config.toString()).contains("medium");
+    }
+
+    // -------------------------------------------------------------------------
+    // AnthropicThinking – builder edge cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    void thinking_builder_produces_correct_object() {
+        AnthropicThinking thinking = AnthropicThinking.builder()
+                .type("adaptive")
+                .display(AnthropicThinkingDisplay.OMITTED)
+                .build();
+
+        assertThat(thinking.getType()).isEqualTo("adaptive");
+        assertThat(thinking.getBudgetTokens()).isNull();
+        assertThat(thinking.getDisplay()).isEqualTo(AnthropicThinkingDisplay.OMITTED);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(booleans = false)
+    void toThinking_returns_null_when_type_null_and_budget_null(Boolean ignored) {
+        // display alone without type/budget is meaningless — toThinking must return null
+        assertThat(toThinking(null, null, AnthropicThinkingDisplay.SUMMARIZED)).isNull();
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicThinkingConfigTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicThinkingConfigTest.java
@@ -3,267 +3,110 @@ package dev.langchain4j.model.anthropic;
 import static dev.langchain4j.model.anthropic.AnthropicChatModel.toThinking;
 import static dev.langchain4j.model.anthropic.InternalAnthropicHelper.toAnthropicOutputConfig;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicOutputConfig;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicThinking;
 import dev.langchain4j.model.chat.request.ResponseFormat;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Unit tests for the thinking configuration types: {@link AnthropicThinkingEffort},
- * {@link AnthropicThinkingDisplay}, {@link AnthropicThinking}, and {@link AnthropicOutputConfig}.
- * <p>
- * Tests cover:
- * <ul>
- *   <li>Enum JSON serialization via {@code @JsonProperty}</li>
- *   <li>{@code toThinking()} factory method in all combinations</li>
- *   <li>{@code toAnthropicOutputConfig()} null-handling and merging</li>
- * </ul>
- */
 class AnthropicThinkingConfigTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     // -------------------------------------------------------------------------
-    // AnthropicThinkingEffort – serialization
+    // Enum serialization + toString
     // -------------------------------------------------------------------------
 
-    @Test
-    void effort_MAX_serializes_to_max() throws JsonProcessingException {
-        assertThat(MAPPER.writeValueAsString(AnthropicThinkingEffort.MAX)).isEqualTo("\"max\"");
+    @ParameterizedTest
+    @CsvSource({"MAX,max", "HIGH,high", "MEDIUM,medium", "LOW,low"})
+    void effort_enum_should_serialize_and_to_string_correctly(AnthropicThinkingEffort effort, String expected)
+            throws JsonProcessingException {
+
+        assertThat(MAPPER.writeValueAsString(effort)).isEqualTo("\"" + expected + "\"");
+
+        assertThat(effort.toString()).isEqualTo(expected);
     }
 
-    @Test
-    void effort_HIGH_serializes_to_high() throws JsonProcessingException {
-        assertThat(MAPPER.writeValueAsString(AnthropicThinkingEffort.HIGH)).isEqualTo("\"high\"");
-    }
+    @ParameterizedTest
+    @CsvSource({"SUMMARIZED,summarized", "OMITTED,omitted"})
+    void display_enum_should_serialize_and_to_string_correctly(AnthropicThinkingDisplay display, String expected)
+            throws JsonProcessingException {
 
-    @Test
-    void effort_MEDIUM_serializes_to_medium() throws JsonProcessingException {
-        assertThat(MAPPER.writeValueAsString(AnthropicThinkingEffort.MEDIUM)).isEqualTo("\"medium\"");
-    }
+        assertThat(MAPPER.writeValueAsString(display)).isEqualTo("\"" + expected + "\"");
 
-    @Test
-    void effort_LOW_serializes_to_low() throws JsonProcessingException {
-        assertThat(MAPPER.writeValueAsString(AnthropicThinkingEffort.LOW)).isEqualTo("\"low\"");
-    }
-
-    @Test
-    void effort_toString_is_lowercase() {
-        assertThat(AnthropicThinkingEffort.MAX.toString()).isEqualTo("max");
-        assertThat(AnthropicThinkingEffort.HIGH.toString()).isEqualTo("high");
-        assertThat(AnthropicThinkingEffort.MEDIUM.toString()).isEqualTo("medium");
-        assertThat(AnthropicThinkingEffort.LOW.toString()).isEqualTo("low");
+        assertThat(display.toString()).isEqualTo(expected);
     }
 
     // -------------------------------------------------------------------------
-    // AnthropicThinkingDisplay – serialization
+    // toThinking()
     // -------------------------------------------------------------------------
 
-    @Test
-    void display_SUMMARIZED_serializes_to_summarized() throws JsonProcessingException {
-        assertThat(MAPPER.writeValueAsString(AnthropicThinkingDisplay.SUMMARIZED))
-                .isEqualTo("\"summarized\"");
-    }
-
-    @Test
-    void display_OMITTED_serializes_to_omitted() throws JsonProcessingException {
-        assertThat(MAPPER.writeValueAsString(AnthropicThinkingDisplay.OMITTED)).isEqualTo("\"omitted\"");
-    }
-
-    @Test
-    void display_toString_is_lowercase() {
-        assertThat(AnthropicThinkingDisplay.SUMMARIZED.toString()).isEqualTo("summarized");
-        assertThat(AnthropicThinkingDisplay.OMITTED.toString()).isEqualTo("omitted");
-    }
-
-    // -------------------------------------------------------------------------
-    // toThinking() – factory method
-    // -------------------------------------------------------------------------
-
-    @Test
-    void toThinking_returns_null_when_type_and_budget_and_display_are_all_null() {
-        assertThat(toThinking(null, null, null)).isNull();
-    }
-
-    @Test
-    void toThinking_enabled_with_budget_no_display() throws JsonProcessingException {
-        AnthropicThinking thinking = toThinking("enabled", 1024, null);
+    @ParameterizedTest
+    @CsvSource({
+        "enabled,1024,,enabled,1024",
+        "adaptive,,,adaptive,",
+        "adaptive,,OMITTED,adaptive,",
+        "enabled,2048,SUMMARIZED,enabled,2048",
+        ",512,,,512"
+    })
+    void to_thinking_should_build_expected_object(
+            String type,
+            Integer budget,
+            AnthropicThinkingDisplay display,
+            String expectedType,
+            Integer expectedBudget) {
+        AnthropicThinking thinking = toThinking(type, budget, display);
 
         assertThat(thinking).isNotNull();
-        assertThat(thinking.getType()).isEqualTo("enabled");
-        assertThat(thinking.getBudgetTokens()).isEqualTo(1024);
-        assertThat(thinking.getDisplay()).isNull();
-
-        // display must be absent from JSON (NON_NULL)
-        String json = MAPPER.writeValueAsString(thinking);
-        assertThat(json).contains("\"type\":\"enabled\"");
-        assertThat(json).contains("\"budget_tokens\":1024");
-        assertThat(json).doesNotContain("display");
+        assertThat(thinking.getType()).isEqualTo(expectedType);
+        assertThat(thinking.getBudgetTokens()).isEqualTo(expectedBudget);
+        assertThat(thinking.getDisplay()).isEqualTo(display);
     }
 
-    @Test
-    void toThinking_adaptive_no_budget_no_display() throws JsonProcessingException {
-        AnthropicThinking thinking = toThinking("adaptive", null, null);
-
-        assertThat(thinking).isNotNull();
-        assertThat(thinking.getType()).isEqualTo("adaptive");
-        assertThat(thinking.getBudgetTokens()).isNull();
-        assertThat(thinking.getDisplay()).isNull();
-
-        String json = MAPPER.writeValueAsString(thinking);
-        assertThat(json).contains("\"type\":\"adaptive\"");
-        assertThat(json).doesNotContain("budget_tokens");
-        assertThat(json).doesNotContain("display");
+    @ParameterizedTest
+    @MethodSource("nullThinkingCases")
+    void to_thinking_should_return_null(String type, Integer budget, AnthropicThinkingDisplay display) {
+        assertThat(toThinking(type, budget, display)).isNull();
     }
 
-    @Test
-    void toThinking_adaptive_with_display_OMITTED() throws JsonProcessingException {
-        AnthropicThinking thinking = toThinking("adaptive", null, AnthropicThinkingDisplay.OMITTED);
-
-        assertThat(thinking.getType()).isEqualTo("adaptive");
-        assertThat(thinking.getDisplay()).isEqualTo(AnthropicThinkingDisplay.OMITTED);
-
-        String json = MAPPER.writeValueAsString(thinking);
-        assertThat(json).contains("\"type\":\"adaptive\"");
-        assertThat(json).contains("\"display\":\"omitted\"");
-        assertThat(json).doesNotContain("budget_tokens");
-    }
-
-    @Test
-    void toThinking_enabled_with_display_SUMMARIZED() throws JsonProcessingException {
-        AnthropicThinking thinking = toThinking("enabled", 2048, AnthropicThinkingDisplay.SUMMARIZED);
-
-        assertThat(thinking.getBudgetTokens()).isEqualTo(2048);
-        assertThat(thinking.getDisplay()).isEqualTo(AnthropicThinkingDisplay.SUMMARIZED);
-
-        String json = MAPPER.writeValueAsString(thinking);
-        assertThat(json).contains("\"type\":\"enabled\"");
-        assertThat(json).contains("\"budget_tokens\":2048");
-        assertThat(json).contains("\"display\":\"summarized\"");
-    }
-
-    @Test
-    void toThinking_returns_non_null_when_only_budget_is_set() {
-        // budgetTokens alone (without type) should still produce an object
-        AnthropicThinking thinking = toThinking(null, 512, null);
-        assertThat(thinking).isNotNull();
-        assertThat(thinking.getBudgetTokens()).isEqualTo(512);
-        assertThat(thinking.getType()).isNull();
+    private static Stream<Arguments> nullThinkingCases() {
+        return Stream.of(arguments(null, null, null), arguments(null, null, AnthropicThinkingDisplay.SUMMARIZED));
     }
 
     // -------------------------------------------------------------------------
-    // toAnthropicOutputConfig() – null-handling and effort/format merging
+    // toAnthropicOutputConfig()
     // -------------------------------------------------------------------------
 
-    @Test
-    void toAnthropicOutputConfig_returns_null_when_both_args_null() {
-        assertThat(toAnthropicOutputConfig(null, null)).isNull();
-        assertThat(toAnthropicOutputConfig(null)).isNull();
+    @ParameterizedTest
+    @MethodSource("nullOutputConfigCases")
+    void output_config_should_return_null(ResponseFormat format, AnthropicThinkingEffort effort) {
+        assertThat(toAnthropicOutputConfig(format, effort)).isNull();
     }
 
-    @Test
-    void toAnthropicOutputConfig_returns_null_for_TEXT_response_format_and_null_effort() {
-        assertThat(toAnthropicOutputConfig(ResponseFormat.TEXT, null)).isNull();
-    }
-
-    @Test
-    void toAnthropicOutputConfig_with_effort_only_omits_format_field() throws JsonProcessingException {
-        AnthropicOutputConfig config = toAnthropicOutputConfig(null, AnthropicThinkingEffort.MEDIUM);
-
-        assertThat(config).isNotNull();
-        assertThat(config.getEffort()).isEqualTo(AnthropicThinkingEffort.MEDIUM);
-        assertThat(config.getFormat()).isNull();
-
-        String json = MAPPER.writeValueAsString(config);
-        assertThat(json).contains("\"effort\":\"medium\"");
-        assertThat(json).doesNotContain("format");
-    }
-
-    @Test
-    void toAnthropicOutputConfig_with_TEXT_format_and_effort_includes_only_effort() throws JsonProcessingException {
-        // TEXT response format with no JSON schema → format stays null, effort is set
-        AnthropicOutputConfig config = toAnthropicOutputConfig(ResponseFormat.TEXT, AnthropicThinkingEffort.LOW);
-
-        assertThat(config).isNotNull();
-        assertThat(config.getEffort()).isEqualTo(AnthropicThinkingEffort.LOW);
-        assertThat(config.getFormat()).isNull();
-
-        String json = MAPPER.writeValueAsString(config);
-        assertThat(json).contains("\"effort\":\"low\"");
-        assertThat(json).doesNotContain("format");
+    private static Stream<Arguments> nullOutputConfigCases() {
+        return Stream.of(arguments(null, null), arguments(ResponseFormat.TEXT, null));
     }
 
     @ParameterizedTest
     @CsvSource({"MAX,max", "HIGH,high", "MEDIUM,medium", "LOW,low"})
-    void toAnthropicOutputConfig_effort_serializes_correctly(AnthropicThinkingEffort effort, String expectedJson)
+    void output_config_should_serialize_effort_correctly(AnthropicThinkingEffort effort, String expected)
             throws JsonProcessingException {
+
         AnthropicOutputConfig config = toAnthropicOutputConfig(null, effort);
-        assertThat(MAPPER.writeValueAsString(config)).contains("\"effort\":\"" + expectedJson + "\"");
-    }
 
-    // -------------------------------------------------------------------------
-    // AnthropicOutputConfig – equals / hashCode
-    // -------------------------------------------------------------------------
+        assertThat(config).isNotNull();
+        assertThat(config.getEffort()).isEqualTo(effort);
+        assertThat(config.getFormat()).isNull();
 
-    @Test
-    void outputConfig_equals_same_effort() {
-        AnthropicOutputConfig a = AnthropicOutputConfig.builder()
-                .effort(AnthropicThinkingEffort.HIGH)
-                .build();
-        AnthropicOutputConfig b = AnthropicOutputConfig.builder()
-                .effort(AnthropicThinkingEffort.HIGH)
-                .build();
-        assertThat(a).isEqualTo(b);
-        assertThat(a.hashCode()).isEqualTo(b.hashCode());
-    }
-
-    @Test
-    void outputConfig_not_equals_different_effort() {
-        AnthropicOutputConfig a = AnthropicOutputConfig.builder()
-                .effort(AnthropicThinkingEffort.HIGH)
-                .build();
-        AnthropicOutputConfig b = AnthropicOutputConfig.builder()
-                .effort(AnthropicThinkingEffort.LOW)
-                .build();
-        assertThat(a).isNotEqualTo(b);
-    }
-
-    @Test
-    void outputConfig_toString_includes_effort() {
-        AnthropicOutputConfig config = AnthropicOutputConfig.builder()
-                .effort(AnthropicThinkingEffort.MEDIUM)
-                .build();
-        assertThat(config.toString()).contains("medium");
-    }
-
-    // -------------------------------------------------------------------------
-    // AnthropicThinking – builder edge cases
-    // -------------------------------------------------------------------------
-
-    @Test
-    void thinking_builder_produces_correct_object() {
-        AnthropicThinking thinking = AnthropicThinking.builder()
-                .type("adaptive")
-                .display(AnthropicThinkingDisplay.OMITTED)
-                .build();
-
-        assertThat(thinking.getType()).isEqualTo("adaptive");
-        assertThat(thinking.getBudgetTokens()).isNull();
-        assertThat(thinking.getDisplay()).isEqualTo(AnthropicThinkingDisplay.OMITTED);
-    }
-
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(booleans = false)
-    void toThinking_returns_null_when_type_null_and_budget_null(Boolean ignored) {
-        // display alone without type/budget is meaningless — toThinking must return null
-        assertThat(toThinking(null, null, AnthropicThinkingDisplay.SUMMARIZED)).isNull();
+        assertThat(MAPPER.writeValueAsString(config))
+                .contains("\"effort\":\"" + expected + "\"")
+                .doesNotContain("format");
     }
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicChatModelIT.java
@@ -3,9 +3,6 @@ package dev.langchain4j.model.anthropic.common;
 import static dev.langchain4j.internal.Utils.readBytes;
 import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_HAIKU_4_5_20251001;
 
-import java.util.Base64;
-import java.util.List;
-
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.anthropic.AnthropicChatResponseMetadata;
@@ -15,6 +12,8 @@ import dev.langchain4j.model.chat.common.AbstractChatModelIT;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.Base64;
+import java.util.List;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -65,9 +64,7 @@ class AnthropicChatModelIT extends AbstractChatModelIT {
 
     @Override
     protected ChatRequestParameters createIntegrationSpecificParameters(int maxOutputTokens) {
-        return ChatRequestParameters.builder()
-                .maxOutputTokens(maxOutputTokens)
-                .build();
+        return ChatRequestParameters.builder().maxOutputTokens(maxOutputTokens).build();
     }
 
     @Override

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicStreamingChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicStreamingChatModelIT.java
@@ -18,7 +18,6 @@ import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.TokenUsage;
-
 import java.util.Base64;
 import java.util.List;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -74,9 +73,7 @@ class AnthropicStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Override
     protected ChatRequestParameters createIntegrationSpecificParameters(int maxOutputTokens) {
-        return ChatRequestParameters.builder()
-                .maxOutputTokens(maxOutputTokens)
-                .build();
+        return ChatRequestParameters.builder().maxOutputTokens(maxOutputTokens).build();
     }
 
     @Override
@@ -109,13 +106,16 @@ class AnthropicStreamingChatModelIT extends AbstractStreamingChatModelIT {
         // Anthropic can talk before calling a tool. "atLeast(0)" is meant to ignore it.
         io.verify(handler, atLeast(0)).onPartialResponse(any(), any());
 
-        io.verify(handler, atLeast(1)).onPartialToolCall(argThat(toolCall ->
-                // Anthropic does not output same tokens consistently, so we can't easily assert partialArguments
-                toolCall.index() == 0
-                        && toolCall.id().equals(id)
-                        && toolCall.name().equals("getWeather")
-                        && !toolCall.partialArguments().isBlank()
-        ), any());
+        io.verify(handler, atLeast(1))
+                .onPartialToolCall(
+                        argThat(toolCall ->
+                                // Anthropic does not output same tokens consistently, so we can't easily assert
+                                // partialArguments
+                                toolCall.index() == 0
+                                        && toolCall.id().equals(id)
+                                        && toolCall.name().equals("getWeather")
+                                        && !toolCall.partialArguments().isBlank()),
+                        any());
         io.verify(handler).onCompleteToolCall(complete(0, id, "getWeather", "{\"city\": \"Munich\"}"));
     }
 
@@ -123,13 +123,16 @@ class AnthropicStreamingChatModelIT extends AbstractStreamingChatModelIT {
     protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id1, String id2) {
         verifyToolCallbacks(handler, io, id1);
 
-        io.verify(handler, atLeast(1)).onPartialToolCall(argThat(toolCall ->
-                // Anthropic does not output same tokens consistently, so we can't easily assert partialArguments
-                toolCall.index() == 1
-                        && toolCall.id().equals(id2)
-                        && toolCall.name().equals("getTime")
-                        && !toolCall.partialArguments().isBlank()
-        ), any());
+        io.verify(handler, atLeast(1))
+                .onPartialToolCall(
+                        argThat(toolCall ->
+                                // Anthropic does not output same tokens consistently, so we can't easily assert
+                                // partialArguments
+                                toolCall.index() == 1
+                                        && toolCall.id().equals(id2)
+                                        && toolCall.name().equals("getTime")
+                                        && !toolCall.partialArguments().isBlank()),
+                        any());
         io.verify(handler).onCompleteToolCall(complete(1, id2, "getTime", "{\"country\": \"France\"}"));
     }
 


### PR DESCRIPTION
## Summary
This PR adds support for **Anthropic adaptive thinking** in LangChain4j.

Previously, `AnthropicThinking` supported only manual extended thinking using:

- `type = "enabled"`
- `budget_tokens`

This PR enhances the Anthropic integration to also support:

- `type = "adaptive"`
- `effort` (`low`, `medium`, `high`, `max`)

This enables users to leverage Anthropic’s adaptive reasoning capabilities while preserving backward compatibility with the existing extended thinking mode.

---

## Changes made
- Added support for `effort` in `AnthropicThinking`
- Updated the builder to allow configuring adaptive thinking effort
- Preserved existing `budgetTokens` support for extended thinking
- Added validation for supported thinking modes and combinations
- Updated `AnthropicChatModel` request mapping to serialize adaptive thinking requests correctly

---

## Example usage

### Extended thinking
```java
AnthropicChatModel.builder()
    .thinkingType("enabled")
    .thinkingBudgetTokens(8000)
    .build();
```

### Adaptive thinking
```java
AnthropicChatModel.builder()
    .thinkingType("adaptive")
    .thinkingEffort("medium")
    .build();
```

---

References: 
https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
