### PR TITLE
Retrive the AgenticScope of agents related events from the InvocationContext

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentBuilder.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentBuilder.java
@@ -218,11 +218,9 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
 
         if (agentListener != null) {
             aiServices.beforeToolExecution(beforeToolExecution ->
-                    agentListener.beforeAgentToolExecution(new BeforeAgentToolExecution(
-                            (AgenticScope) LangChain4jManaged.current().get(AgenticScope.class), agent, beforeToolExecution)));
+                    agentListener.beforeAgentToolExecution(new BeforeAgentToolExecution(agent, beforeToolExecution)));
             aiServices.afterToolExecution(afterToolExecution ->
-                    agentListener.afterAgentToolExecution(new AfterAgentToolExecution(
-                            (AgenticScope) LangChain4jManaged.current().get(AgenticScope.class), agent, afterToolExecution)));
+                    agentListener.afterAgentToolExecution(new AfterAgentToolExecution(agent, afterToolExecution)));
         }
 
         return (T) agent;

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentInvocationHandler.java
@@ -24,6 +24,8 @@ import dev.langchain4j.observability.api.listener.AiServiceResponseReceivedListe
 import dev.langchain4j.service.AiServiceContext;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
 import dev.langchain4j.service.memory.ChatMemoryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -36,8 +38,11 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
 import static dev.langchain4j.agentic.observability.ComposedAgentListener.listenerOfType;
+import static dev.langchain4j.agentic.scope.DefaultAgenticScope.ephemeralAgenticScope;
 
 public class AgentInvocationHandler implements InvocationHandler, InternalAgent {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AgentInvocationHandler.class);
 
     private final AiServiceContext context;
     private final AgentBuilder<?, ?> builder;
@@ -68,8 +73,9 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
             return switch (method.getName()) {
                 case "getEventClass" -> AiServiceResponseReceivedEvent.class;
                 case "onEvent" -> {
-                    Object agenticScopeId = ((AgenticScope) LangChain4jManaged.current().get(AgenticScope.class)).memoryId();
-                    lastResponseEvents.put(agenticScopeId, (AiServiceResponseReceivedEvent) args[0]);
+                    AiServiceResponseReceivedEvent event = (AiServiceResponseReceivedEvent) args[0];
+                    AgenticScope agenticScope = (AgenticScope) event.invocationContext().managedParameters().get(AgenticScope.class);
+                    lastResponseEvents.put(agenticScope.memoryId(), event);
                     yield null;
                 }
                 default ->
@@ -150,7 +156,18 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
             };
         }
 
-        return method.invoke(agent, args);
+        AgenticScope agenticScope = LangChain4jManaged.current(AgenticScope.class);
+        if (agenticScope == null) {
+            LOGGER.warn("Improper invocation of a standalone agent outside of an agentic system, consider using AiServices instead.");
+            LangChain4jManaged.setCurrent(Map.of(AgenticScope.class, ephemeralAgenticScope()));
+        }
+        try {
+            return method.invoke(agent, args);
+        } finally {
+            if (agenticScope == null) {
+                LangChain4jManaged.removeCurrent();
+            }
+        }
     }
 
     private static Optional<UserMessage> lastUserMessage(Collection<ChatMessage> messages) {
@@ -180,11 +197,9 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
         if (parentListener != null && parentListener.inheritedBySubagents() && isNewListener(agentListener, parentListener)) {
             agentListener = composeWithInherited(agentListener, parentListener);
             context.toolService.beforeToolExecution(beforeToolExecution ->
-                    agentListener.beforeAgentToolExecution(new BeforeAgentToolExecution(
-                            (AgenticScope) LangChain4jManaged.current().get(AgenticScope.class), this, beforeToolExecution)));
+                    agentListener.beforeAgentToolExecution(new BeforeAgentToolExecution(this, beforeToolExecution)));
             context.toolService.afterToolExecution(toolExecution ->
-                    agentListener.afterAgentToolExecution(new AfterAgentToolExecution(
-                            (AgenticScope) LangChain4jManaged.current().get(AgenticScope.class), this, toolExecution)));
+                    agentListener.afterAgentToolExecution(new AfterAgentToolExecution(this, toolExecution)));
         }
     }
 

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/AfterAgentToolExecution.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/AfterAgentToolExecution.java
@@ -4,5 +4,9 @@ import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.service.tool.ToolExecution;
 
-public record AfterAgentToolExecution(AgenticScope agenticScope, AgentInstance agentInstance, ToolExecution toolExecution) {
+public record AfterAgentToolExecution(AgentInstance agentInstance, ToolExecution toolExecution) {
+
+    public AgenticScope agenticScope() {
+        return (AgenticScope) toolExecution.invocationContext().managedParameters().get(AgenticScope.class);
+    }
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/BeforeAgentToolExecution.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/BeforeAgentToolExecution.java
@@ -4,5 +4,9 @@ import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.service.tool.BeforeToolExecution;
 
-public record BeforeAgentToolExecution(AgenticScope agenticScope, AgentInstance agentInstance, BeforeToolExecution toolExecution) {
+public record BeforeAgentToolExecution(AgentInstance agentInstance, BeforeToolExecution toolExecution) {
+
+    public AgenticScope agenticScope() {
+        return (AgenticScope) toolExecution.invocationContext().managedParameters().get(AgenticScope.class);
+    }
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticScopeRegistry.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticScopeRegistry.java
@@ -2,12 +2,14 @@ package dev.langchain4j.agentic.scope;
 
 import dev.langchain4j.Internal;
 import dev.langchain4j.agentic.observability.AgentListener;
+import org.jspecify.annotations.NonNull;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import java.util.Set;
 
 import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.beforeAgenticScopeDestroyed;
+import static dev.langchain4j.agentic.scope.DefaultAgenticScope.ephemeralAgenticScope;
 
 /**
  * Singleton registry for managing AgenticScope instances.
@@ -57,7 +59,7 @@ public class AgenticScopeRegistry {
     }
 
     public DefaultAgenticScope createEphemeralAgenticScope() {
-        DefaultAgenticScope agenticScope = new DefaultAgenticScope(DefaultAgenticScope.Kind.EPHEMERAL);
+        DefaultAgenticScope agenticScope = ephemeralAgenticScope();
         register(agenticScope);
         return agenticScope;
     }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
@@ -77,6 +77,10 @@ public class DefaultAgenticScope implements AgenticScope {
         this.lock = (kind == Kind.PERSISTENT) ? new ReentrantReadWriteLock() : null;
     }
 
+    public static DefaultAgenticScope ephemeralAgenticScope() {
+        return new DefaultAgenticScope(DefaultAgenticScope.Kind.EPHEMERAL);
+    }
+
     @Override
     public Object memoryId() {
         return memoryId;

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SingleAgentIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/SingleAgentIT.java
@@ -1,0 +1,138 @@
+package dev.langchain4j.agentic;
+
+import static dev.langchain4j.agentic.Models.baseModel;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.agentic.observability.AfterAgentToolExecution;
+import dev.langchain4j.agentic.observability.AgentInvocationError;
+import dev.langchain4j.agentic.observability.AgentListener;
+import dev.langchain4j.agentic.observability.AgentRequest;
+import dev.langchain4j.agentic.observability.AgentResponse;
+import dev.langchain4j.agentic.observability.BeforeAgentToolExecution;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.util.Map;
+
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "GOOGLE_AI_GEMINI_API_KEY", matches = ".+")
+public class SingleAgentIT {
+
+    @Test
+    public void invoke_standalone_agent_with_tools_and_listeners() {
+        ConsoleAgentListener listener = new ConsoleAgentListener("[agent-02-standalone]");
+        String topic = "dragons and wizards";
+
+        ToolProvider demoTools = buildDemoTools();
+
+        TextCreativeWriter writer = AgenticServices.agentBuilder(TextCreativeWriter.class)
+                .chatModel(baseModel())
+                .outputKey("story")
+                .toolProviders(demoTools)
+                .listener(listener)
+                .build();
+
+        String story = writer.generateStoryText(topic);
+        System.out.println("story:\n" + story);
+    }
+
+    private static ToolProvider buildDemoTools() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ToolSpecification spec = ToolSpecification.builder()
+                .name("demo_hint")
+                .description("Give a short story opening hint based on topic")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("topic", "Optional user topic")
+                        .build())
+                .build();
+
+        ToolExecutor executor = (ToolExecutionRequest request, Object memoryId) -> {
+            String topic = null;
+            try {
+                Map<?, ?> args = mapper.readValue(request.arguments(), Map.class);
+                Object v = args.get("topic");
+                topic = v == null ? null : String.valueOf(v);
+            } catch (Exception ignored) {
+                // demo only
+            }
+            String t = (topic == null || topic.isBlank()) ? "your topic" : topic.trim();
+            return "Opening hint: when you stare at \"" + t + "\", the story ignites.";
+        };
+
+        return ignored -> ToolProviderResult.builder().add(spec, executor).build();
+    }
+
+    private static final class ConsoleAgentListener implements AgentListener {
+
+        private final String tag;
+
+        private ConsoleAgentListener(String tag) {
+            this.tag = tag;
+        }
+
+        @Override
+        public void beforeAgentInvocation(AgentRequest request) {
+            System.out.println(tag + " beforeAgentInvocation agent=" + request.agent().name()
+                    + " inputs=" + request.inputs());
+        }
+
+        @Override
+        public void afterAgentInvocation(AgentResponse response) {
+            System.out.println(tag + " afterAgentInvocation agent=" + response.agent().name()
+                    + " output=" + response.output());
+        }
+
+        @Override
+        public void onAgentInvocationError(AgentInvocationError agentInvocationError) {
+            System.err.println(tag + " onAgentInvocationError " + agentInvocationError);
+        }
+
+        @Override
+        public void afterAgenticScopeCreated(AgenticScope agenticScope) {
+            System.out.println(tag + " afterAgenticScopeCreated scope=" + agenticScope);
+        }
+
+        @Override
+        public void beforeAgenticScopeDestroyed(AgenticScope agenticScope) {
+            System.out.println(tag + " beforeAgenticScopeDestroyed scope=" + agenticScope);
+        }
+
+        @Override
+        public void beforeAgentToolExecution(BeforeAgentToolExecution beforeAgentToolExecution) {
+            System.out.println(tag + " beforeAgentToolExecution " + beforeAgentToolExecution);
+        }
+
+        @Override
+        public void afterAgentToolExecution(AfterAgentToolExecution afterAgentToolExecution) {
+            System.out.println(tag + " afterAgentToolExecution " + afterAgentToolExecution);
+        }
+
+        @Override
+        public boolean inheritedBySubagents() {
+            return false;
+        }
+    }
+
+    public interface TextCreativeWriter {
+
+        @UserMessage("""
+            You are a creative fiction writer.
+            Blend the inspiration naturally into the story and output only the final story content.
+            Write a short story draft around the given topic in no more than 3 sentences.
+            Return only the story text, without any explanation, title, or extra prefix/suffix.
+            The topic is: {{topic}}.
+            """)
+        @Agent(outputKey = "story", description = "Generates a story based on topic (non-streaming)")
+        String generateStoryText(@V("topic") String topic);
+    }
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/StreamingIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/StreamingIT.java
@@ -1,12 +1,20 @@
 package dev.langchain4j.agentic;
 
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agentic.observability.AgentMonitor;
+import dev.langchain4j.agentic.observability.MonitoredAgent;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
 import org.junit.jupiter.api.Test;
 
 import static dev.langchain4j.agentic.Models.baseModel;
 import static dev.langchain4j.agentic.Models.streamingBaseModel;
+import static dev.langchain4j.agentic.observability.HtmlReportGenerator.generateReport;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -26,6 +34,8 @@ import dev.langchain4j.agentic.StreamingAgents.StreamingTechnicalExpert;
 import dev.langchain4j.agentic.StreamingAgents.StreamingStoryCreator;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -306,5 +316,105 @@ public class StreamingIT {
 
         assertThat(story).isNotBlank();
         assertThat(response.finishReason()).isEqualTo(FinishReason.STOP);
+    }
+
+    @Test
+    void streaming_sequence_with_tools_tests() {
+        GenerateSearchAgent generateSearchAgent = AgenticServices.agentBuilder(GenerateSearchAgent.class)
+                .tools(new ArticleSearchTool())
+                .chatModel(baseModel())
+                .build();
+
+        ArticleSearchAgent articleSearchAgent = AgenticServices.agentBuilder(ArticleSearchAgent.class)
+                .tools(new ArticleSearchTool())
+                .streamingChatModel(streamingBaseModel())
+                .build();
+
+        ChatAgent agent = AgenticServices.sequenceBuilder(ChatAgent.class)
+                .subAgents(generateSearchAgent, articleSearchAgent)
+                .build();
+
+        TokenStream tokenStream = agent.chat("asd", "testing article search");
+        StringBuilder answerBuilder = new StringBuilder();
+        ChatResponse response = waitCompleteResponse(tokenStream, answerBuilder);
+        String story = answerBuilder.toString();
+
+        assertThat(story).isNotBlank();
+        assertThat(response.finishReason()).isEqualTo(FinishReason.STOP);
+
+        AgentMonitor monitor = agent.agentMonitor();
+        assertThat(monitor).isNotNull();
+//        generateReport(monitor, Path.of("src", "test", "resources", "streaming-agents-exection.html"));
+    }
+
+    public record ArticleSearchDto(String keyword, Long authorId, String authorName, Long categoryId,
+                                   String categoryName, List<Long> tagIds, String startTime, String endTime,
+                                   Integer pageNum, Integer pageSize) {
+    }
+
+    public interface ArticleSearchAgent {
+        @UserMessage("""
+            # Role
+            You are a search execution agent. Your sole task is to execute a search using the provided parameters and
+            format the results.
+            
+            # Workflow
+            1. **Input**: Receive `searchParameters` from the previous step.
+            2. **Action**: **Directly** call the `searchArticle` tool using the provided `searchParameters` exactly as
+               they are. **Do not modify, rewrite, or optimize the parameters.**
+            3. **Output**: Once results are returned, generate a user-friendly response in **Chinese** following these rules:
+                - Format as a numbered Markdown list.
+                - Make titles clickable links: `[Title](https://example.com/article/{id})`.
+                - Include a brief summary below each title.
+                - If no results found, output: "> No articles found matching your query."
+                - Do not include JSON, code blocks, or extra explanations. Only output the formatted Markdown.
+            
+            The search parameters are: {{searchParameters}}
+            """)
+        @Agent(name = "searchArticle", outputKey = "result")
+        TokenStream searchArticle(@V("searchParameters") ArticleSearchDto searchParameters);
+    }
+
+    public interface ChatAgent extends MonitoredAgent {
+        @UserMessage("{{message}}")
+        @Agent(name = "start", outputKey = "result")
+        TokenStream chat(@MemoryId String memoryId, @V("message") String message);
+    }
+
+    public interface GenerateSearchAgent {
+
+        @SystemMessage("""
+            Based on the user input, generate a structured query parameter object in valid JSON format.
+            
+            Strictly follow these rules:
+            - Only include the fields I have defined; do not add any extra fields.
+            - For optional fields that are uncertain or not mentioned, set their value to null.
+            - Do not include comments, explanations, markdown, or any text outside the JSON.
+            - Output must be valid JSON and nothing else.
+            
+            """)
+        @UserMessage("{{message}}")
+        @Agent(name = "generateSearchDto", outputKey = "searchParameters")
+        ArticleSearchDto generateSearchDto(@V("message") String message);
+
+    }
+
+    public class ArticleSearchTool {
+
+        @Tool(name = "searchArticle", value = "Search for articles")
+        public List<String> searchArticle(ArticleSearchDto articleSearchDto) {
+            return List.of();
+        }
+
+
+        @Tool(name = "listAllCategory", value = "List all article categories")
+        public List<String> listAllCategory() {
+            return List.of("categoryName: test, id:1");
+        }
+
+        @Tool(name = "listAllTag", value = "List all article tags")
+        public List<String> listAllTag() {
+            return List.of("tag1", "tag2", "tag3");
+        }
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/invocation/LangChain4jManaged.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/invocation/LangChain4jManaged.java
@@ -24,6 +24,11 @@ public interface LangChain4jManaged {
         return CURRENT.get();
     }
 
+    static <T extends LangChain4jManaged> T current(Class<T> clazz) {
+        var current = CURRENT.get();
+        return current != null ? clazz.cast(current.get(clazz)) : null;
+    }
+
     static void removeCurrent() {
         CURRENT.remove();
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/BeforeToolExecution.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/BeforeToolExecution.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import java.util.Objects;
 import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
 
 /**
  * @since 1.2.0
@@ -13,9 +14,11 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 public class BeforeToolExecution {
 
     private final ToolExecutionRequest request;
+    private final InvocationContext invocationContext;
 
     private BeforeToolExecution(Builder builder) {
         this.request = ensureNotNull(builder.request, "request");
+        this.invocationContext = ensureNotNull(builder.invocationContext, "invocationContext");
     }
 
     /**
@@ -25,6 +28,13 @@ public class BeforeToolExecution {
      */
     public ToolExecutionRequest request() {
         return request;
+    }
+
+    /**
+     * Returns the invocation context of the tool request that is about to be executed.
+     */
+    public InvocationContext invocationContext() {
+        return invocationContext;
     }
 
     @Override
@@ -54,11 +64,17 @@ public class BeforeToolExecution {
     public static class Builder {
 
         private ToolExecutionRequest request;
+        private InvocationContext invocationContext;
 
         private Builder() {}
 
         public Builder request(ToolExecutionRequest request) {
             this.request = request;
+            return this;
+        }
+
+        public Builder invocationContext(InvocationContext invocationContext) {
+            this.invocationContext = invocationContext;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecution.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecution.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
@@ -16,12 +17,14 @@ public class ToolExecution {
     private final ToolExecutionResult result;
     private final LocalDateTime startTime;
     private final LocalDateTime finishTime;
+    private final InvocationContext invocationContext;
 
     private ToolExecution(Builder builder) {
         this.request = ensureNotNull(builder.request, "request");
         this.result = ensureNotNull(builder.result, "result");
         this.startTime = builder.startTime;
         this.finishTime = builder.finishTime;
+        this.invocationContext = builder.invocationContext;
     }
 
     /**
@@ -85,6 +88,13 @@ public class ToolExecution {
         return Duration.between(startTime, finishTime);
     }
 
+    /**
+     * Returns the invocation context of the tool execution.
+     */
+    public InvocationContext invocationContext() {
+        return invocationContext;
+    }
+
     @Override
     public boolean equals(final Object object) {
         if (this == object) return true;
@@ -121,6 +131,7 @@ public class ToolExecution {
         private ToolExecutionResult result;
         private LocalDateTime startTime;
         private LocalDateTime finishTime;
+        private InvocationContext invocationContext;
 
         private Builder() {
         }
@@ -142,6 +153,11 @@ public class ToolExecution {
 
         public Builder finishTime(LocalDateTime finishTime) {
             this.finishTime = finishTime;
+            return this;
+        }
+
+        public Builder invocationContext(InvocationContext invocationContext) {
+            this.invocationContext = invocationContext;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecution.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecution.java
@@ -24,7 +24,7 @@ public class ToolExecution {
         this.result = ensureNotNull(builder.result, "result");
         this.startTime = builder.startTime;
         this.finishTime = builder.finishTime;
-        this.invocationContext = builder.invocationContext;
+        this.invocationContext = ensureNotNull(builder.invocationContext, "invocationContext");
     }
 
     /**

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -376,8 +376,11 @@ public class ToolService {
                         .attributes(result.attributes())
                         .build();
 
-                ToolExecution toolExecution =
-                        ToolExecution.builder().request(request).result(result).build();
+                ToolExecution toolExecution = ToolExecution.builder()
+                        .request(request)
+                        .result(result)
+                        .invocationContext(invocationContext)
+                        .build();
                 toolExecutions.add(toolExecution);
 
                 fireToolExecutedEvent(invocationContext, request, toolExecution, context.eventListenerRegistrar);
@@ -634,8 +637,10 @@ public class ToolService {
             Consumer<BeforeToolExecution> beforeToolExecution,
             Consumer<ToolExecution> afterToolExecution) {
         if (beforeToolExecution != null) {
-            beforeToolExecution.accept(
-                    BeforeToolExecution.builder().request(toolRequest).build());
+            beforeToolExecution.accept(BeforeToolExecution.builder()
+                    .request(toolRequest)
+                    .invocationContext(invocationContext)
+                    .build());
         }
 
         LocalDateTime startTime = LocalDateTime.now();
@@ -652,6 +657,7 @@ public class ToolService {
                     .result(toolResult)
                     .startTime(startTime)
                     .finishTime(LocalDateTime.now())
+                    .invocationContext(invocationContext)
                     .build());
         }
         return toolResult;

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutionTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutionTest.java
@@ -3,6 +3,7 @@ package dev.langchain4j.service.tool;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
 import org.junit.jupiter.api.Test;
 
 class ToolExecutionTest {
@@ -12,12 +13,22 @@ class ToolExecutionTest {
 
         String textResult = "text result";
 
+        InvocationContext invocationContext = InvocationContext.builder()
+                .interfaceName("SomeInterface")
+                .methodName("someMethod")
+                .methodArgument("one")
+                .methodArgument("two")
+                .chatMemoryId("one")
+                .build();
+
         ToolExecution toolExecution = ToolExecution.builder()
                 .request(ToolExecutionRequest.builder().build())
                 .result(textResult)
+                .invocationContext(invocationContext)
                 .build();
 
         assertThat(toolExecution.result()).isEqualTo(textResult);
         assertThat(toolExecution.resultObject()).isNull();
+        assertThat(toolExecution.invocationContext()).isSameAs(invocationContext);
     }
 }


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #4795

## Change

The main improvement introduced by this pull request is adding the `InvocationContext` to both the `BeforeToolExecution` and `ToolExecution` classes. In this way the agentic framework can retrieve the current `AgenticScope` from there instead of relying on the `ThreadLocal`-based `LangChain4jManaged` that doesn't work in case of asynchronous executions. In the same way the agentic framework retrieves the `AgenticScope` from the `AiServiceResponseReceivedEvent` that already contained the `InvocationContext` even before.

Not strictly related to this it also creates an ephemeral `AgenticScope` in the degenerate case when a single agent is invoked in isolation, outside any agentic system, also emetting a warning when this happens.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
