### PR TITLE
Add name and description attributes to @P annotation

### DIFF
--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -13,7 +13,7 @@ All LLMs supporting tools can be found [here](/integrations/language-models) (se
 :::note
 Not all LLMs support tools equally well.
 The ability to understand, select, and correctly use tools depends heavily on the specific model and its capabilities.
-Some models may not support tools at all, while others might require careful prompt engineering 
+Some models may not support tools at all, while others might require careful prompt engineering
 or additional system instructions.
 :::
 
@@ -35,6 +35,7 @@ it should first call one of the provided math tools.
 Let's see how this works in practice (with and without tools):
 
 An example of a message exchange without tools:
+
 ```
 Request:
 - messages:
@@ -45,9 +46,11 @@ Response:
 - AiMessage:
     - text: The square root of 475695037565 is approximately 689710.
 ```
+
 Close, but not correct.
 
 An example of a message exchange with the following tools:
+
 ```java
 @Tool("Sums 2 given numbers")
 double sum(double a, double b) {
@@ -105,6 +108,7 @@ then summarize it and send the summary via email using the `sendEmail` tool.
 :::note
 To increase the chances of the LLM calling the right tool with the right arguments,
 we should provide a clear and unambiguous:
+
 - name of the tool
 - description of what the tool does and when it should be used
 - description of every tool parameter
@@ -119,7 +123,8 @@ Some models can even call multiple tools at once, for example,
 
 :::note
 Please note that not all models support tools.
-To see which models support tools, refer to the "Tools" column on [this](https://docs.langchain4j.dev/integrations/language-models/) page.
+To see which models support tools, refer to the "Tools" column
+on [this](https://docs.langchain4j.dev/integrations/language-models/) page.
 :::
 
 :::note
@@ -129,6 +134,7 @@ Please note that tools/function calling is not the same as [JSON mode](/tutorial
 # 2 levels of abstraction
 
 LangChain4j provides two levels of abstraction for using tools:
+
 - Low-level, using the `ChatModel` and `ToolSpecification` APIs
 - High-level, using [AI Services](/tutorials/ai-services) and `@Tool`-annotated Java methods
 
@@ -140,15 +146,16 @@ of the `ChatModel`. A similar method is also present in the `StreamingChatModel`
 You can specify one or more `ToolSpecification`s when creating the `ChatRequest`.
 
 `ToolSpecification` is an object that contains all the information about the tool:
+
 - The `name` of the tool
 - The `description` of the tool
 - The `parameters` of the tool and their descriptions
 - The `metadata` of the tool.
-By default, it is not sent to the LLM provider, you must explicitly specify which metadata keys should be sent
-when creating a `ChatModel`.
-Currently, tool metadata is supported only by the `langchain4j-anthropic` module.
-When tools are provided by the [McpToolProvider](/tutorials/mcp#mcp-tool-provider),
-`metadata` can contain MCP-specific entries.
+  By default, it is not sent to the LLM provider, you must explicitly specify which metadata keys should be sent
+  when creating a `ChatModel`.
+  Currently, tool metadata is supported only by the `langchain4j-anthropic` module.
+  When tools are provided by the [McpToolProvider](/tutorials/mcp#mcp-tool-provider),
+  `metadata` can contain MCP-specific entries.
 
 It is recommended to provide as much information about the tool as possible:
 a clear name, a comprehensive description, and a description for each parameter, etc.
@@ -158,31 +165,33 @@ a clear name, a comprehensive description, and a description for each parameter,
 There are two ways to create a `ToolSpecification`:
 
 1. Manually
+
 ```java
 ToolSpecification toolSpecification = ToolSpecification.builder()
-    .name("getWeather")
-    .description("Returns the weather forecast for a given city")
-    .parameters(JsonObjectSchema.builder()
-        .addStringProperty("city", "The city for which the weather forecast should be returned")
-        .addEnumProperty("temperatureUnit", List.of("CELSIUS", "FAHRENHEIT"))
-        .required("city") // the required properties should be specified explicitly
-        .build())
-    .build();
+        .name("getWeather")
+        .description("Returns the weather forecast for a given city")
+        .parameters(JsonObjectSchema.builder()
+                .addStringProperty("city", "The city for which the weather forecast should be returned")
+                .addEnumProperty("temperatureUnit", List.of("CELSIUS", "FAHRENHEIT"))
+                .required("city") // the required properties should be specified explicitly
+                .build())
+        .build();
 ```
 
 You can find more information on `JsonObjectSchema` [here](/tutorials/structured-outputs#jsonobjectschema).
 
 2. Using helper methods:
+
 - `ToolSpecifications.toolSpecificationsFrom(Class)`
 - `ToolSpecifications.toolSpecificationsFrom(Object)`
 - `ToolSpecifications.toolSpecificationFrom(Method)`
 
 ```java
-class WeatherTools { 
-  
+class WeatherTools {
+
     @Tool("Returns the weather forecast for a given city")
     String getWeather(
-            @P("The city for which the weather forecast should be returned") String city,
+            @P(value = "The city for which the weather forecast should be returned", name = "city") String city,
             TemperatureUnit temperatureUnit
     ) {
         ...
@@ -211,6 +220,7 @@ in `META-INF/services/dev.langchain4j.spi.agent.tool.ToolSpecificationJsonCodecF
 ### Using `ChatModel`
 
 Once you have a `List<ToolSpecification>`, you can call the model:
+
 ```java
 ChatRequest request = ChatRequest.builder()
     .messages(UserMessage.from("What will the weather be like in London tomorrow?"))
@@ -227,6 +237,7 @@ Depending on the LLM, it can contain one or multiple `ToolExecutionRequest` obje
 (some LLMs support calling multiple tools in parallel).
 
 Each `ToolExecutionRequest` should contain:
+
 - The `id` of the tool call. Please note that some LLM providers (e.g., Google, Ollama) may omit this ID.
 - The `name` of the tool to be called, for example: `getWeather`
 - The `arguments`, for example: `{ "city": "London", "temperatureUnit": "CELSIUS" }`
@@ -236,6 +247,7 @@ You'll need to manually execute the tool(s) using information from the `ToolExec
 If you want to send the result of the tool execution back to the LLM,
 you need to create a `ToolExecutionResultMessage` (one for each `ToolExecutionRequest`)
 and send it along with all previous messages:
+
 ```java
 
 String result = "It is expected to rain in London tomorrow.";
@@ -250,6 +262,7 @@ ChatResponse response2 = model.chat(request2);
 ### Using `StreamingChatModel`
 
 Once you have a `List<ToolSpecification>`, you can call the model:
+
 ```java
 ChatRequest request = ChatRequest.builder()
     .messages(UserMessage.from("What will the weather be like in London tomorrow?"))
@@ -296,6 +309,7 @@ In those cases, `onPartialToolCall` callback won't be invoked - only `onComplete
 :::
 
 Here's an example of what streaming of a single tool call might look like:
+
 ```
 onPartialToolCall(index = 0, id = "call_abc", name = "get_weather", partialArguments = "{\"")
 onPartialToolCall(index = 0, id = "call_abc", name = "get_weather", partialArguments = "city")
@@ -312,6 +326,7 @@ When complete response streaming is over and `onCompleteResponse(ChatResponse)` 
 the `AiMessage` inside the `ChatResponse` will contain all the tool calls that occurred during streaming.
 
 ## High Level Tool API
+
 At a high level of abstraction, you can annotate any Java method with the `@Tool` annotation
 and specify them when creating [AI Service](/tutorials/ai-services#tools-function-calling).
 
@@ -322,26 +337,32 @@ and the return value of the method (if any) will be sent back to the LLM.
 You can find implementation details in `DefaultToolExecutor`.
 
 A few tool examples:
+
 ```java
+
 @Tool("Searches Google for relevant URLs, given the query")
-public List<String> searchGoogle(@P("search query") String query) {
+public List<String> searchGoogle(@P(value = "search query", name = "query") String query) {
     return googleSearchService.search(query);
 }
 
 @Tool("Returns the content of a web page, given the URL")
-public String getWebPageContent(@P("URL of the page") String url) {
+public String getWebPageContent(@P(value = "URL of the page", name = "url") String url) {
     Document jsoupDocument = Jsoup.connect(url).get();
     return jsoupDocument.body().text();
 }
 ```
 
 ### Tool Method Limitations
+
 Methods annotated with `@Tool`:
+
 - can be either static or non-static
 - can have any visibility (public, private, etc.).
 
 ### Tool Method Parameters
+
 Methods annotated with `@Tool` can accept any number of parameters of various types:
+
 - Primitive types: `int`, `double`, etc
 - Object types: `String`, `Integer`, `Double`, etc
 - Custom POJOs (can contain nested POJOs)
@@ -351,12 +372,35 @@ Methods annotated with `@Tool` can accept any number of parameters of various ty
 
 Methods without parameters are supported as well.
 
+#### Parameter Name
+
+By default, if the `name` attribute of `@P` is not specified, the method registration will automatically obtain the
+default parameter names of the method through reflection, such as `arg0`, `arg1`, `arg2`, etc., depending on the number
+of parameters. However, this will cause the key values of the parameters obtained through `ToolExecutionRequest` to also
+be `arg0`, `arg1`, `arg2`, etc. 。 If there are any special requirements, please use @P's name attribute to specify the
+name of the parameter.
+
+**Example:**
+
+```java
+
+@Tool
+void getTemperature(
+        @P(value = "Temperature value", name = "value") double value,
+        @P(value = "Unit of temperature", name = "unit") Optional<String> unit
+) {
+    ...
+}
+```
+
 #### Required and Optional
 
 By default, all tool method parameters are considered **_required_**.
 This means that the LLM will have to produce a value for such a parameter.
 A parameter can be made optional by annotating it with `@P(required = false)`:
+
 ```java
+
 @Tool
 void getTemperature(String location, @P(value = "Unit of temperature", required = false) Unit unit) {
     ...
@@ -366,9 +410,11 @@ void getTemperature(String location, @P(value = "Unit of temperature", required 
 #### Alternative: Using `Optional<T>` for Optional Parameters
 
 Instead of annotating parameters with `@P(required = false)`, you simply declare the parameter as `Optional<T>`.
-Any parameter of type `Optional<T>` will be treated as optional automatically, even without specify `required = false` in the `@P` annotation.
+Any parameter of type `Optional<T>` will be treated as optional automatically, even without specify `required = false`
+in the `@P` annotation.
 
 **Example:**
+
 ```java
 @Tool
 void getTemperature(
@@ -381,6 +427,7 @@ void getTemperature(
 
 Fields and sub-fields of complex parameters are also considered **_required_** by default.
 You can make a field optional by annotating it with `@JsonProperty(required = false)`:
+
 ```java
 record User(String name, @JsonProperty(required = false) String email) {}
 
@@ -399,6 +446,7 @@ Recursive parameters (e.g., a `Person` class having a `Set<Person> children` fie
 are currently supported only by OpenAI.
 
 ### Tool Method Return Types
+
 Methods annotated with `@Tool` can return any type, including `void`.
 If the method has a `void` return type, "Success" string is sent to the LLM if the method returns successfully.
 
@@ -408,7 +456,9 @@ For other return types, the returned value is converted into a JSON string befor
 
 ### AI services as tools for other AI services
 
-AI services can also be used as tools for other AI services. This can be useful in many agentic use cases, where one AI service can ask the help of another, more specialized, AI service to perform a specific task. For instance, having defined the following AI services:
+AI services can also be used as tools for other AI services. This can be useful in many agentic use cases, where one AI
+service can ask the help of another, more specialized, AI service to perform a specific task. For instance, having
+defined the following AI services:
 
 ```java
     interface RouterAgent {
@@ -457,7 +507,8 @@ AI services can also be used as tools for other AI services. This can be useful 
     }
 ```
 
-The `RouterAgent` can be configured to use as tools the 3 other AI services, experts in specific fields, routing the user request to one of them.
+The `RouterAgent` can be configured to use as tools the 3 other AI services, experts in specific fields, routing the
+user request to one of them.
 
 ```java
 MedicalExpert medicalExpert = AiServices.builder(MedicalExpert.class)
@@ -479,16 +530,22 @@ routerAgent.askToExpert("I broke my leg what should I do");
 ```
 
 :::note
-Using AI services as tools for other AI services is a powerful feature that enables to build complex agentic systems. However, this approach also comes with a few relevant drawbacks that are important to be aware of:
-- This implementation requires the LLM to copy-paste the user request without modifications as a tool call and this could be an error-prone operation.
-- The LLM calling the other LLM as a tool has to reprocess its response, as it happens for any other tool invocation, and this could be a wasteful computation in terms of both time and consumed tokens.
-- The agent-tool, being a totally separated AI service, has no access to the chat memory of the agent calling it, so it cannot use the chat memory to provide a more informed answer.
-:::
+Using AI services as tools for other AI services is a powerful feature that enables to build complex agentic systems.
+However, this approach also comes with a few relevant drawbacks that are important to be aware of:
 
+- This implementation requires the LLM to copy-paste the user request without modifications as a tool call and this
+  could be an error-prone operation.
+- The LLM calling the other LLM as a tool has to reprocess its response, as it happens for any other tool invocation,
+  and this could be a wasteful computation in terms of both time and consumed tokens.
+- The agent-tool, being a totally separated AI service, has no access to the chat memory of the agent calling it, so it
+  cannot use the chat memory to provide a more informed answer.
+  :::
 
 ### `@Tool`
+
 Any Java method annotated with `@Tool`
 and _explicitly_ specified during the build of an AI Service can be executed by the LLM:
+
 ```java
 interface MathGenius {
     
@@ -522,13 +579,15 @@ When the `ask` method is called, 2 interactions with the LLM occur, as described
 In between those interactions, the `squareRoot` method is called automatically.
 
 The `@Tool` annotation has these fields:
+
 - `name`: the tool's name. If this is not provided, the method's name will serve as the tool's name.
 - `value`: the tool's description.
-- `returnBehavior`: see [this](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) for more details
+- `returnBehavior`: see [this](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) for more
+  details
 - `metadata`: a valid JSON string that contains LLM-provider-specific tool metadata entries.
-By default, it is not sent to the LLM provider, you must explicitly specify which metadata keys should be sent
-when creating a `ChatModel`.
-Currently, tool metadata is supported only by the `langchain4j-anthropic` module.
+  By default, it is not sent to the LLM provider, you must explicitly specify which metadata keys should be sent
+  when creating a `ChatModel`.
+  Currently, tool metadata is supported only by the `langchain4j-anthropic` module.
 
 Depending on the tool, the LLM might understand it well even without any description
 (for example, `add(a, b)` is obvious),
@@ -536,13 +595,17 @@ but it is usually better to provide clear and meaningful names and descriptions.
 This way, the LLM has more information to decide whether or not to call the given tool, and how to do so.
 
 ### `@P`
+
 Method parameters can optionally be annotated with `@P`.
 
-The `@P` annotation has 2 fields
+The `@P` annotation has 3 fields
+
 - `value`: description of the parameter. Mandatory field.
+- `name` : name of the parameter, default value is `""`. Optional field.
 - `required`: whether the parameter is required, default is `true`. Optional field.
 
 ### `@Description`
+
 The description of classes and fields can be specified using the `@Description` annotation:
 
 ```java
@@ -565,6 +628,7 @@ Result executeQuery(Query query) {
 :::note
 Please note that `@Description` placed on an `enum` value has **_no effect_** and **_is not_** included
 in the generated JSON schema:
+
 ```java
 enum Priority {
 
@@ -578,11 +642,14 @@ enum Priority {
     LOW
 }
 ```
+
 :::
 
 ### `InvocationParameters`
+
 If you wish to pass extra data into the tool when invoking AI Service, you can do it with
 `InvocationParameters`:
+
 ```java
 
 interface Assistant {
@@ -606,10 +673,11 @@ In this case, the LLM is not aware of these parameters;
 they are only visible to LangChain4j and user code.
 
 `InvocationParameters` can also be accessed within other AI Service components, such as:
+
 - [`ToolProvider`](/tutorials/tools#specifying-tools-dynamically): inside the `ToolProviderRequest`
 - [`ToolArgumentsErrorHandler`](/tutorials/tools#handling-tool-arguments-errors)
-and [`ToolExecutionErrorHandler`](https://docs.langchain4j.dev/tutorials/tools#handling-tool-execution-errors):
-inside the `ToolErrorContext`
+  and [`ToolExecutionErrorHandler`](https://docs.langchain4j.dev/tutorials/tools#handling-tool-execution-errors):
+  inside the `ToolErrorContext`
 - [RAG components](/tutorials/rag/): inside the `Query` -> `Metadata`
 
 Parameters are stored in a mutable, thread safe `Map`.
@@ -639,6 +707,7 @@ In this case, the LLM is not aware of these parameters;
 they are only visible to LangChain4j and user code.
 
 ### `@ToolMemoryId`
+
 If your AI Service method has a parameter annotated with `@MemoryId`,
 you can also annotate a parameter of a `@Tool` method with `@ToolMemoryId`:
 
@@ -670,23 +739,27 @@ If you enable one of these options, the tools will be executed concurrently (wit
 using either the default or the specified `Executor`.
 
 #### When using `ChatModel`:
+
 - When the LLM calls multiple tools, they are executed concurrently in separate threads
-using the `Executor`.
+  using the `Executor`.
 - When the LLM calls a single tool, it is executed in the same (caller) thread,
-the `Executor` is **_not_** used to avoid wasting resources.
+  the `Executor` is **_not_** used to avoid wasting resources.
 
 #### When using `StreamingChatModel`:
+
 - When the LLM calls multiple tools, they are executed concurrently in separate threads
-using the `Executor`.
-Each tool is executed as soon as `StreamingChatResponseHandler.onCompleteToolCall(CompleteToolCall)`
-is called, without waiting for other tools or for the response streaming to complete.
+  using the `Executor`.
+  Each tool is executed as soon as `StreamingChatResponseHandler.onCompleteToolCall(CompleteToolCall)`
+  is called, without waiting for other tools or for the response streaming to complete.
 - When the LLM calls a single tool, it is executed in a separate thread using the `Executor`.
-We cannot execute it in the same thread because, at that point,
-we do not yet know how many tools the LLM will call.
+  We cannot execute it in the same thread because, at that point,
+  we do not yet know how many tools the LLM will call.
 
 ### Accessing Executed Tools
+
 If you wish to access tools executed during the invocation of an AI Service,
 you can easily do so by wrapping the return type in the `Result` class:
+
 ```java
 interface Assistant {
 
@@ -705,6 +778,7 @@ Object resultObject = toolExecution.resultObject(); // actual value returned by 
 ```
 
 In streaming mode, you can do so by specifying `onToolExecuted` callback:
+
 ```java
 interface Assistant {
 
@@ -729,6 +803,7 @@ from external sources such as databases and configuration files.
 
 Tool names, descriptions, parameter names, and descriptions
 can all be configured using `ToolSpecification`:
+
 ```java
 ToolSpecification toolSpecification = ToolSpecification.builder()
         .name("get_booking_details")
@@ -745,6 +820,7 @@ ToolSpecification toolSpecification = ToolSpecification.builder()
 
 For each `ToolSpecification`, one needs to provide a `ToolExecutor` implementation
 that will be handling tool execution requests generated by the LLM:
+
 ```java
 ToolExecutor toolExecutor = (toolExecutionRequest, memoryId) -> {
     Map<String, Object> arguments = fromJson(toolExecutionRequest.arguments());
@@ -756,6 +832,7 @@ ToolExecutor toolExecutor = (toolExecutionRequest, memoryId) -> {
 
 LangChain4j also provides the `DefaultToolExecutor`, which can automatically invoke methods on Java objects and handle
 parameter mapping:
+
 ```java
 class BookingTools {
     String getBookingDetails(String bookingNumber) {
@@ -771,6 +848,7 @@ ToolExecutor toolExecutor = new DefaultToolExecutor(tools, method);
 
 Once we have one or multiple (`ToolSpecification`, `ToolExecutor`) pairs,
 we can specify them when creating an AI Service:
+
 ```java
 Assistant assistant = AiServices.builder(Assistant.class)
     .chatModel(chatModel)
@@ -778,7 +856,9 @@ Assistant assistant = AiServices.builder(Assistant.class)
     .build();
 ```
 
-Additionally, we can pass a list of tool names that should [immediately/directly return](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) their results and not send them to the LLM for reprocessing.
+Additionally, we can pass a list of tool names that
+should [immediately/directly return](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request)
+their results and not send them to the LLM for reprocessing.
 
 ```java
 Set<String> immediateReturnToolNames = Set.of("get_booking_details");
@@ -798,7 +878,9 @@ The `ToolProvider` accepts a `ToolProviderRequest`
 (that contains the `UserMessage`, chat memory ID and [`InvocationParameters`](/tutorials/tools#invocationparameters))
 and returns a `ToolProviderResult` that contains tools in a form of a `Map` from `ToolSpecification` to `ToolExecutor`.
 
-Here is an example of how to add the `get_booking_details` tool only when the user's message contains the word "booking":
+Here is an example of how to add the `get_booking_details` tool only when the user's message contains the word "
+booking":
+
 ```java
 ToolProvider toolProvider = (toolProviderRequest) -> {
     if (toolProviderRequest.userMessage().singleText().contains("booking")) {
@@ -825,7 +907,9 @@ Assistant assistant = AiServices.builder(Assistant.class)
 
 #### Configuring Immediate Return in Dynamic Tools
 
-When building `ToolProviderResult`, you can mark tools for [immediate return](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) using the ToolProviderResult.builder():
+When building `ToolProviderResult`, you can mark tools
+for [immediate return](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) using the
+ToolProviderResult.builder():
 
 ```java
 ToolProvider toolProvider = (toolProviderRequest) -> {
@@ -858,6 +942,7 @@ that allows tools to be discovered dynamically by the LLM itself,
 instead of being exposed upfront.
 
 The core idea is simple:
+
 - Initially, the LLM is exposed to one or more special tool-search tools
 - The LLM can call these tools to search for relevant tools
 - Once relevant tools are found, they are included in subsequent requests to the LLM
@@ -867,15 +952,16 @@ This enables scalable, token-efficient, and model-driven tool discovery.
 #### How Tool Search Works
 
 A tool search flow typically looks like this:
+
 1. Initial request:
-   - The LLM sees only tool-search tools (not the full tool set)
+    - The LLM sees only tool-search tools (not the full tool set)
 2. Tool search
-   - The LLM calls a tool-search tool, describing what kind of tool it needs
-   - The tool-search strategy matches the request against available tools
+    - The LLM calls a tool-search tool, describing what kind of tool it needs
+    - The tool-search strategy matches the request against available tools
 4. Tool exposure
-   - Matching tools are added to the next request to the LLM
+    - Matching tools are added to the next request to the LLM
 5. Tool execution
-   - The LLM can now call the found tools normally
+    - The LLM can now call the found tools normally
 
 Previously found tools are accumulated across multiple tool-search calls.
 Each time the LLM invokes the tool-search tool,
@@ -902,11 +988,13 @@ public interface ToolSearchStrategy {
 ```
 
 A `ToolSearchStrategy` is responsible for:
+
 - Exposing tool-search tools to the LLM
 - Executing tool search requests generated by the LLM
 - Returning matching tool names, which will then be resolved and exposed
 
 LangChain4j currently provides 2 out-of-the-box implementations:
+
 - `SimpleToolSearchStrategy` – keyword-based matching
 - `VectorToolSearchStrategy` – semantic search using embeddings
 
@@ -929,6 +1017,7 @@ Assistant assistant = AiServices.builder(Assistant.class)
 ```
 
 Once configured:
+
 - The LLM no longer sees all tools upfront
 - Tool discovery becomes an explicit, model-driven step
 - Token usage is reduced, especially with large tool sets
@@ -936,6 +1025,7 @@ Once configured:
 #### When to Use Tool Search
 
 Tool search is especially useful when:
+
 - You have many tools (dozens or hundreds)
 - Tools are domain-specific or rarely used
 - Tool availability depends on context, user, or permissions
@@ -950,6 +1040,7 @@ When tool search is enabled, tools are normally hidden from the LLM until they a
 However, in some cases you may want certain tools to always be visible to the LLM.
 
 Typical use cases:
+
 - Core tools that should always be accessible
 - Frequently used tools where search overhead is unnecessary
 - Utility tools
@@ -959,6 +1050,7 @@ LangChain4j supports this via the `ALWAYS_VISIBLE` tool search behavior.
 ##### How It Works
 
 When a tool is marked as `ALWAYS_VISIBLE`:
+
 - It is exposed to the LLM in the very first request
 - It does not require discovery via tool search
 - It remains visible throughout the AI Service invocation
@@ -969,6 +1061,7 @@ All other tools continue to follow the normal tool-search flow.
 ##### Using `@Tool` Annotation
 
 You can mark a tool as always visible via the @Tool annotation:
+
 ```java
 @Tool(searchBehavior = ALWAYS_VISIBLE)
 String getWeather(String city) {
@@ -990,6 +1083,7 @@ McpToolProvider.builder()
 ##### Using `ToolSpecification`
 
 If you configure tools programmatically, you can mark them as always visible using `metadata`:
+
 ```java
 ToolSpecification toolSpecification = ToolSpecification.builder()
     .name("getWeather")
@@ -1014,7 +1108,11 @@ Tool search is currently marked as experimental and may evolve in future release
 
 ### Returning immediately the result of a tool execution request
 
-By default, the result of a tool execution request is sent back to the LLM that uses this result and further reprocesses it. However, in some circumstances, the result produced by that tool execution request already represents the expected result of the AI service invocation. In this case it is possible to configure the tool to immediately/directly return its result, skipping a wasteful and resource consuming reprocessing by the LLM. This can be done by configuring the `returnBehavior` field of the `@Tool` annotation as in the following example:
+By default, the result of a tool execution request is sent back to the LLM that uses this result and further reprocesses
+it. However, in some circumstances, the result produced by that tool execution request already represents the expected
+result of the AI service invocation. In this case it is possible to configure the tool to immediately/directly return
+its result, skipping a wasteful and resource consuming reprocessing by the LLM. This can be done by configuring the
+`returnBehavior` field of the `@Tool` annotation as in the following example:
 
 ```java
 class CalculatorWithImmediateReturn {
@@ -1027,7 +1125,9 @@ class CalculatorWithImmediateReturn {
 ```
 
 :::note
-This feature is supported only on AI Services having a `Result<T>` return type. Attempting to use it on AI Service with a different return type will produce an `IllegalConfigurationException`. See [Return Types](/tutorials/ai-services#return-types) for more information about `Result<T>`.
+This feature is supported only on AI Services having a `Result<T>` return type. Attempting to use it on AI Service with
+a different return type will produce an `IllegalConfigurationException`.
+See [Return Types](/tutorials/ai-services#return-types) for more information about `Result<T>`.
 :::
 
 In this way, an `Assistant` service like the following
@@ -1053,14 +1153,16 @@ will return a response directly from the tool invocation. For instance, promptin
 Result<String> result = assistant.chat("How much is 37 plus 87?");
 ```
 
-will produce a `Result` with a null content, while the actual response of `124` will have to be retrieved from the `result.toolExecutions()`. Without the immediate return, the LLM would have to reprocess the result of the `add` tool execution request, thus returning a response like: `The result of adding 37 and 87 is 124.`
+will produce a `Result` with a null content, while the actual response of `124` will have to be retrieved from the
+`result.toolExecutions()`. Without the immediate return, the LLM would have to reprocess the result of the `add` tool
+execution request, thus returning a response like: `The result of adding 37 and 87 is 124.`
 
 Also note that if the LLM calls multiple tools and at least one of them is not immediate, then reprocessing will happen.
 
 :::note
 When using programmatic tools, you can mark tools for immediate return by passing a set of tool names
-to the `.tools()` method. When using dynamic tools via `ToolProvider`, you can use the overloaded method, 
-`.add(ToolSpecification, ToolExecutor, ReturnBehavior)`, on `ToolProviderResult.builder()`. 
+to the `.tools()` method. When using dynamic tools via `ToolProvider`, you can use the overloaded method,
+`.add(ToolSpecification, ToolExecutor, ReturnBehavior)`, on `ToolProviderResult.builder()`.
 See the respective sections above for examples.
 :::
 
@@ -1074,7 +1176,11 @@ In this case by default LangChain4j will throw an exception reporting the proble
 but it is possible to configure a different behavior providing the AI service
 with a strategy to be used in this situation.
 
-This strategy is an implementation of a `Function<ToolExecutionRequest, ToolExecutionResultMessage>` defining which `ToolExecutionResultMessage` should be produced as the result for a `ToolExecutionRequest` containing the request to invoke a tool that is not available. For instance, it could be possible to configure the AI service with a strategy that returns to the LLM a response that hopefully will push it to retry a different tool invocation, knowing that the formerly required tool doesn't exist, as in the following example:
+This strategy is an implementation of a `Function<ToolExecutionRequest, ToolExecutionResultMessage>` defining which
+`ToolExecutionResultMessage` should be produced as the result for a `ToolExecutionRequest` containing the request to
+invoke a tool that is not available. For instance, it could be possible to configure the AI service with a strategy that
+returns to the LLM a response that hopefully will push it to retry a different tool invocation, knowing that the
+formerly required tool doesn't exist, as in the following example:
 
 ```java
 AssistantHallucinatedTool assistant = AiServices.builder(AssistantHallucinatedTool.class)

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -182,7 +182,7 @@ class WeatherTools {
   
     @Tool("Returns the weather forecast for a given city")
     String getWeather(
-            @P(description = "The city for which the weather forecast should be returned", name = "city") String city,
+            @P("The city for which the weather forecast should be returned") String city,
             TemperatureUnit temperatureUnit
     ) {
         ...
@@ -324,12 +324,12 @@ You can find implementation details in `DefaultToolExecutor`.
 A few tool examples:
 ```java
 @Tool("Searches Google for relevant URLs, given the query")
-public List<String> searchGoogle(@P(description = "search query", name = "query") String query) {
+public List<String> searchGoogle(@P("search query") String query) {
     return googleSearchService.search(query);
 }
 
 @Tool("Returns the content of a web page, given the URL")
-public String getWebPageContent(@P(description = "URL of the page", name = "url") String url) {
+public String getWebPageContent(@P("URL of the page") String url) {
     Document jsoupDocument = Jsoup.connect(url).get();
     return jsoupDocument.body().text();
 }
@@ -353,25 +353,25 @@ Methods without parameters are supported as well.
 
 #### Parameter Name
 
-By default, if the `name` attribute of `@P` is not specified, the method registration will automatically obtain the
-default parameter names of the method through reflection, such as `arg0`, `arg1`, `arg2`, etc., depending on the number
-of parameters. This is what LLM will see. If there are any special requirements, please use @P's name attribute to specify the
-name of the parameter.
+By default, if the `name` attribute of `@P` is not specified, the parameter name is obtained via reflection.
+However, without the `-parameters` javac option, reflection returns generic names like `arg0`, `arg1`, etc.
+The semantic meaning of the parameter is lost, which may confuse the LLM.
 
-Also it is worth mentioning that argX is happening when javac -parameters is not enabled.
-So when using LC4j with Quarkus/Spring/etc, this is not a problem,
-as -parameters option is enabled by default by those frameworks,
-so the actual names of method parameters are preserved and one does not need to specify the name in @P.
+Setting `name` in `@P` is useful in two cases:
+
+1. **Missing `-parameters` javac option** — to avoid generic `arg0`/`arg1` names that the LLM would otherwise see.
+   Note that frameworks like Quarkus and Spring enable `-parameters` by default,
+   so the actual method parameter names are preserved and you typically do not need to set `name` when using those frameworks.
+2. **Custom name for the LLM** — when you want the LLM to see a different parameter name than the one in the source code
+   (for example, to match a specific API contract or to provide a more descriptive name).
 
 **Example:**
 
 ```java
-
 @Tool
 void getTemperature(
-        @P(description = "Temperature value", name = "value") double value,
-        @P(description = "Unit of temperature", name = "unit") Optional<String> unit
-) {
+        @P("Temperature value") double value,
+        @P("Unit of temperature") Optional<String> unit) {
     ...
 }
 ```
@@ -383,7 +383,7 @@ This means that the LLM will have to produce a value for such a parameter.
 A parameter can be made optional by annotating it with `@P(required = false)`:
 ```java
 @Tool
-void getTemperature(String location, @P(description = "Unit of temperature", required = false, name = "unit") Unit unit) {
+void getTemperature(String location, @P("Unit of temperature", required = false) Unit unit) {
     ...
 }
 ```
@@ -397,8 +397,8 @@ Any parameter of type `Optional<T>` will be treated as optional automatically, e
 ```java
 @Tool
 void getTemperature(
-    @P(description = "Temperature value") double value,
-    @P(description = "Unit of temperature") Optional<String> unit
+    @P("Temperature value") double value,
+    @P("Unit of temperature") Optional<String> unit
 ) {
     ...
 }
@@ -563,12 +563,44 @@ This way, the LLM has more information to decide whether or not to call the give
 ### `@P`
 Method parameters can optionally be annotated with `@P`.
 
-The `@P` annotation has 4 fields
+The `@P` annotation has the following optional fields:
 
-- `value`: description of the parameter. Mandatory field.
-- `description`: alias of value. Use description instead.
-- `name` : name of the parameter, default value is `""`. Optional field.
-- `required`: whether the parameter is required, default is `true`. Optional field.
+- `name`: name of the parameter as seen by the LLM. If not specified, the actual method parameter name is used.
+- `description`: description of the parameter (alias of `value`). Empty by default.
+- `value`: description of the parameter (alias of `description`). Empty by default.
+- `required`: whether the parameter is required, default is `true`.
+
+#### Parameter Name
+
+The `name` attribute overrides the parameter name that the LLM will see.
+Setting `name` is useful in two cases:
+
+1. **Missing `-parameters` javac option.**
+   Without the `-parameters` javac option, Java reflection returns generic names such as `arg0`, `arg1`, etc.
+   The semantic meaning of the parameter is lost, which may confuse the LLM.
+   Setting `name` restores a meaningful name.
+   Note that frameworks like Quarkus and Spring enable `-parameters` by default,
+   so the actual method parameter names are preserved and you typically do not need to set `name` when using those frameworks.
+
+2. **Custom name for the LLM.**
+   When you want the LLM to see a different parameter name than the one the developer uses in the source code
+   (for example, to match a specific API contract or to provide a more descriptive name).
+
+
+#### Parameter Description
+
+`description` and `value` are interchangeable — they both set the parameter's description that the LLM will see.
+When only a description is needed, use the shorthand `value` form:
+```java
+@Tool
+void getWeather(@P("The city name") String city) { ... }
+```
+
+When both a name and a description are needed, use named attributes:
+```java
+@Tool
+void getWeather(@P(name = "city", description = "The city name") String city) { ... }
+```
 
 ### `@Description`
 The description of classes and fields can be specified using the `@Description` annotation:

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -144,11 +144,11 @@ You can specify one or more `ToolSpecification`s when creating the `ChatRequest`
 - The `description` of the tool
 - The `parameters` of the tool and their descriptions
 - The `metadata` of the tool.
-  By default, it is not sent to the LLM provider, you must explicitly specify which metadata keys should be sent
-  when creating a `ChatModel`.
-  Currently, tool metadata is supported only by the `langchain4j-anthropic` module.
-  When tools are provided by the [McpToolProvider](/tutorials/mcp#mcp-tool-provider),
-  `metadata` can contain MCP-specific entries.
+By default, it is not sent to the LLM provider, you must explicitly specify which metadata keys should be sent
+when creating a `ChatModel`.
+Currently, tool metadata is supported only by the `langchain4j-anthropic` module.
+When tools are provided by the [McpToolProvider](/tutorials/mcp#mcp-tool-provider),
+`metadata` can contain MCP-specific entries.
 
 It is recommended to provide as much information about the tool as possible:
 a clear name, a comprehensive description, and a description for each parameter, etc.
@@ -508,7 +508,7 @@ Using AI services as tools for other AI services is a powerful feature that enab
 - This implementation requires the LLM to copy-paste the user request without modifications as a tool call and this could be an error-prone operation.
 - The LLM calling the other LLM as a tool has to reprocess its response, as it happens for any other tool invocation, and this could be a wasteful computation in terms of both time and consumed tokens.
 - The agent-tool, being a totally separated AI service, has no access to the chat memory of the agent calling it, so it cannot use the chat memory to provide a more informed answer.
-  :::
+:::
 
 
 ### `@Tool`
@@ -551,9 +551,9 @@ The `@Tool` annotation has these fields:
 - `value`: the tool's description.
 - `returnBehavior`: see [this](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) for more details
 - `metadata`: a valid JSON string that contains LLM-provider-specific tool metadata entries.
-  By default, it is not sent to the LLM provider, you must explicitly specify which metadata keys should be sent
-  when creating a `ChatModel`.
-  Currently, tool metadata is supported only by the `langchain4j-anthropic` module.
+By default, it is not sent to the LLM provider, you must explicitly specify which metadata keys should be sent
+when creating a `ChatModel`.
+Currently, tool metadata is supported only by the `langchain4j-anthropic` module.
 
 Depending on the tool, the LLM might understand it well even without any description
 (for example, `add(a, b)` is obvious),
@@ -636,8 +636,8 @@ they are only visible to LangChain4j and user code.
 `InvocationParameters` can also be accessed within other AI Service components, such as:
 - [`ToolProvider`](/tutorials/tools#specifying-tools-dynamically): inside the `ToolProviderRequest`
 - [`ToolArgumentsErrorHandler`](/tutorials/tools#handling-tool-arguments-errors)
-  and [`ToolExecutionErrorHandler`](https://docs.langchain4j.dev/tutorials/tools#handling-tool-execution-errors):
-  inside the `ToolErrorContext`
+and [`ToolExecutionErrorHandler`](https://docs.langchain4j.dev/tutorials/tools#handling-tool-execution-errors):
+inside the `ToolErrorContext`
 - [RAG components](/tutorials/rag/): inside the `Query` -> `Metadata`
 
 Parameters are stored in a mutable, thread safe `Map`.
@@ -699,18 +699,18 @@ using either the default or the specified `Executor`.
 
 #### When using `ChatModel`:
 - When the LLM calls multiple tools, they are executed concurrently in separate threads
-  using the `Executor`.
+using the `Executor`.
 - When the LLM calls a single tool, it is executed in the same (caller) thread,
-  the `Executor` is **_not_** used to avoid wasting resources.
+the `Executor` is **_not_** used to avoid wasting resources.
 
 #### When using `StreamingChatModel`:
 - When the LLM calls multiple tools, they are executed concurrently in separate threads
-  using the `Executor`.
-  Each tool is executed as soon as `StreamingChatResponseHandler.onCompleteToolCall(CompleteToolCall)`
-  is called, without waiting for other tools or for the response streaming to complete.
+using the `Executor`.
+Each tool is executed as soon as `StreamingChatResponseHandler.onCompleteToolCall(CompleteToolCall)`
+is called, without waiting for other tools or for the response streaming to complete.
 - When the LLM calls a single tool, it is executed in a separate thread using the `Executor`.
-  We cannot execute it in the same thread because, at that point,
-  we do not yet know how many tools the LLM will call.
+We cannot execute it in the same thread because, at that point,
+we do not yet know how many tools the LLM will call.
 
 ### Accessing Executed Tools
 If you wish to access tools executed during the invocation of an AI Service,
@@ -896,14 +896,14 @@ This enables scalable, token-efficient, and model-driven tool discovery.
 
 A tool search flow typically looks like this:
 1. Initial request:
-    - The LLM sees only tool-search tools (not the full tool set)
+   - The LLM sees only tool-search tools (not the full tool set)
 2. Tool search
-    - The LLM calls a tool-search tool, describing what kind of tool it needs
-    - The tool-search strategy matches the request against available tools
+   - The LLM calls a tool-search tool, describing what kind of tool it needs
+   - The tool-search strategy matches the request against available tools
 4. Tool exposure
-    - Matching tools are added to the next request to the LLM
+   - Matching tools are added to the next request to the LLM
 5. Tool execution
-    - The LLM can now call the found tools normally
+   - The LLM can now call the found tools normally
 
 Previously found tools are accumulated across multiple tool-search calls.
 Each time the LLM invokes the tool-search tool,
@@ -1087,8 +1087,8 @@ Also note that if the LLM calls multiple tools and at least one of them is not i
 
 :::note
 When using programmatic tools, you can mark tools for immediate return by passing a set of tool names
-to the `.tools()` method. When using dynamic tools via `ToolProvider`, you can use the overloaded method,
-`.add(ToolSpecification, ToolExecutor, ReturnBehavior)`, on `ToolProviderResult.builder()`.
+to the `.tools()` method. When using dynamic tools via `ToolProvider`, you can use the overloaded method, 
+`.add(ToolSpecification, ToolExecutor, ReturnBehavior)`, on `ToolProviderResult.builder()`. 
 See the respective sections above for examples.
 :::
 
@@ -1144,10 +1144,10 @@ Assistant assistant = AiServices.builder(Assistant.class)
         .build();
 
 try {
-        assistant.chat(...);
+    assistant.chat(...);
 } catch (MyCustomException e) {
-        // handle e
-        }
+    // handle e
+}
 ```
 
 Here is an example of the second approach:

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -35,7 +35,6 @@ it should first call one of the provided math tools.
 Let's see how this works in practice (with and without tools):
 
 An example of a message exchange without tools:
-
 ```
 Request:
 - messages:
@@ -46,11 +45,9 @@ Response:
 - AiMessage:
     - text: The square root of 475695037565 is approximately 689710.
 ```
-
 Close, but not correct.
 
 An example of a message exchange with the following tools:
-
 ```java
 @Tool("Sums 2 given numbers")
 double sum(double a, double b) {
@@ -108,7 +105,6 @@ then summarize it and send the summary via email using the `sendEmail` tool.
 :::note
 To increase the chances of the LLM calling the right tool with the right arguments,
 we should provide a clear and unambiguous:
-
 - name of the tool
 - description of what the tool does and when it should be used
 - description of every tool parameter
@@ -123,8 +119,7 @@ Some models can even call multiple tools at once, for example,
 
 :::note
 Please note that not all models support tools.
-To see which models support tools, refer to the "Tools" column
-on [this](https://docs.langchain4j.dev/integrations/language-models/) page.
+To see which models support tools, refer to the "Tools" column on [this](https://docs.langchain4j.dev/integrations/language-models/) page.
 :::
 
 :::note
@@ -134,7 +129,6 @@ Please note that tools/function calling is not the same as [JSON mode](/tutorial
 # 2 levels of abstraction
 
 LangChain4j provides two levels of abstraction for using tools:
-
 - Low-level, using the `ChatModel` and `ToolSpecification` APIs
 - High-level, using [AI Services](/tutorials/ai-services) and `@Tool`-annotated Java methods
 
@@ -146,7 +140,6 @@ of the `ChatModel`. A similar method is also present in the `StreamingChatModel`
 You can specify one or more `ToolSpecification`s when creating the `ChatRequest`.
 
 `ToolSpecification` is an object that contains all the information about the tool:
-
 - The `name` of the tool
 - The `description` of the tool
 - The `parameters` of the tool and their descriptions
@@ -165,33 +158,31 @@ a clear name, a comprehensive description, and a description for each parameter,
 There are two ways to create a `ToolSpecification`:
 
 1. Manually
-
 ```java
 ToolSpecification toolSpecification = ToolSpecification.builder()
-        .name("getWeather")
-        .description("Returns the weather forecast for a given city")
-        .parameters(JsonObjectSchema.builder()
-                .addStringProperty("city", "The city for which the weather forecast should be returned")
-                .addEnumProperty("temperatureUnit", List.of("CELSIUS", "FAHRENHEIT"))
-                .required("city") // the required properties should be specified explicitly
-                .build())
-        .build();
+    .name("getWeather")
+    .description("Returns the weather forecast for a given city")
+    .parameters(JsonObjectSchema.builder()
+        .addStringProperty("city", "The city for which the weather forecast should be returned")
+        .addEnumProperty("temperatureUnit", List.of("CELSIUS", "FAHRENHEIT"))
+        .required("city") // the required properties should be specified explicitly
+        .build())
+    .build();
 ```
 
 You can find more information on `JsonObjectSchema` [here](/tutorials/structured-outputs#jsonobjectschema).
 
 2. Using helper methods:
-
 - `ToolSpecifications.toolSpecificationsFrom(Class)`
 - `ToolSpecifications.toolSpecificationsFrom(Object)`
 - `ToolSpecifications.toolSpecificationFrom(Method)`
 
 ```java
-class WeatherTools {
-
+class WeatherTools { 
+  
     @Tool("Returns the weather forecast for a given city")
     String getWeather(
-            @P(value = "The city for which the weather forecast should be returned", name = "city") String city,
+            @P(description = "The city for which the weather forecast should be returned", name = "city") String city,
             TemperatureUnit temperatureUnit
     ) {
         ...
@@ -220,7 +211,6 @@ in `META-INF/services/dev.langchain4j.spi.agent.tool.ToolSpecificationJsonCodecF
 ### Using `ChatModel`
 
 Once you have a `List<ToolSpecification>`, you can call the model:
-
 ```java
 ChatRequest request = ChatRequest.builder()
     .messages(UserMessage.from("What will the weather be like in London tomorrow?"))
@@ -237,7 +227,6 @@ Depending on the LLM, it can contain one or multiple `ToolExecutionRequest` obje
 (some LLMs support calling multiple tools in parallel).
 
 Each `ToolExecutionRequest` should contain:
-
 - The `id` of the tool call. Please note that some LLM providers (e.g., Google, Ollama) may omit this ID.
 - The `name` of the tool to be called, for example: `getWeather`
 - The `arguments`, for example: `{ "city": "London", "temperatureUnit": "CELSIUS" }`
@@ -247,7 +236,6 @@ You'll need to manually execute the tool(s) using information from the `ToolExec
 If you want to send the result of the tool execution back to the LLM,
 you need to create a `ToolExecutionResultMessage` (one for each `ToolExecutionRequest`)
 and send it along with all previous messages:
-
 ```java
 
 String result = "It is expected to rain in London tomorrow.";
@@ -262,7 +250,6 @@ ChatResponse response2 = model.chat(request2);
 ### Using `StreamingChatModel`
 
 Once you have a `List<ToolSpecification>`, you can call the model:
-
 ```java
 ChatRequest request = ChatRequest.builder()
     .messages(UserMessage.from("What will the weather be like in London tomorrow?"))
@@ -309,7 +296,6 @@ In those cases, `onPartialToolCall` callback won't be invoked - only `onComplete
 :::
 
 Here's an example of what streaming of a single tool call might look like:
-
 ```
 onPartialToolCall(index = 0, id = "call_abc", name = "get_weather", partialArguments = "{\"")
 onPartialToolCall(index = 0, id = "call_abc", name = "get_weather", partialArguments = "city")
@@ -326,7 +312,6 @@ When complete response streaming is over and `onCompleteResponse(ChatResponse)` 
 the `AiMessage` inside the `ChatResponse` will contain all the tool calls that occurred during streaming.
 
 ## High Level Tool API
-
 At a high level of abstraction, you can annotate any Java method with the `@Tool` annotation
 and specify them when creating [AI Service](/tutorials/ai-services#tools-function-calling).
 
@@ -337,32 +322,26 @@ and the return value of the method (if any) will be sent back to the LLM.
 You can find implementation details in `DefaultToolExecutor`.
 
 A few tool examples:
-
 ```java
-
 @Tool("Searches Google for relevant URLs, given the query")
-public List<String> searchGoogle(@P(value = "search query", name = "query") String query) {
+public List<String> searchGoogle(@P(description = "search query", name = "query") String query) {
     return googleSearchService.search(query);
 }
 
 @Tool("Returns the content of a web page, given the URL")
-public String getWebPageContent(@P(value = "URL of the page", name = "url") String url) {
+public String getWebPageContent(@P(description = "URL of the page", name = "url") String url) {
     Document jsoupDocument = Jsoup.connect(url).get();
     return jsoupDocument.body().text();
 }
 ```
 
 ### Tool Method Limitations
-
 Methods annotated with `@Tool`:
-
 - can be either static or non-static
 - can have any visibility (public, private, etc.).
 
 ### Tool Method Parameters
-
 Methods annotated with `@Tool` can accept any number of parameters of various types:
-
 - Primitive types: `int`, `double`, etc
 - Object types: `String`, `Integer`, `Double`, etc
 - Custom POJOs (can contain nested POJOs)
@@ -376,9 +355,13 @@ Methods without parameters are supported as well.
 
 By default, if the `name` attribute of `@P` is not specified, the method registration will automatically obtain the
 default parameter names of the method through reflection, such as `arg0`, `arg1`, `arg2`, etc., depending on the number
-of parameters. However, this will cause the key values of the parameters obtained through `ToolExecutionRequest` to also
-be `arg0`, `arg1`, `arg2`, etc. 。 If there are any special requirements, please use @P's name attribute to specify the
+of parameters. This is what LLM will see. If there are any special requirements, please use @P's name attribute to specify the
 name of the parameter.
+
+Also it is worth mentioning that argX is happening when javac -parameters is not enabled.
+So when using LC4j with Quarkus/Spring/etc, this is not a problem,
+as -parameters option is enabled by default by those frameworks,
+so the actual names of method parameters are preserved and one does not need to specify the name in @P.
 
 **Example:**
 
@@ -386,8 +369,8 @@ name of the parameter.
 
 @Tool
 void getTemperature(
-        @P(value = "Temperature value", name = "value") double value,
-        @P(value = "Unit of temperature", name = "unit") Optional<String> unit
+        @P(description = "Temperature value", name = "value") double value,
+        @P(description = "Unit of temperature", name = "unit") Optional<String> unit
 ) {
     ...
 }
@@ -398,11 +381,9 @@ void getTemperature(
 By default, all tool method parameters are considered **_required_**.
 This means that the LLM will have to produce a value for such a parameter.
 A parameter can be made optional by annotating it with `@P(required = false)`:
-
 ```java
-
 @Tool
-void getTemperature(String location, @P(value = "Unit of temperature", required = false) Unit unit) {
+void getTemperature(String location, @P(description = "Unit of temperature", required = false, name = "unit") Unit unit) {
     ...
 }
 ```
@@ -410,16 +391,14 @@ void getTemperature(String location, @P(value = "Unit of temperature", required 
 #### Alternative: Using `Optional<T>` for Optional Parameters
 
 Instead of annotating parameters with `@P(required = false)`, you simply declare the parameter as `Optional<T>`.
-Any parameter of type `Optional<T>` will be treated as optional automatically, even without specify `required = false`
-in the `@P` annotation.
+Any parameter of type `Optional<T>` will be treated as optional automatically, even without specify `required = false` in the `@P` annotation.
 
 **Example:**
-
 ```java
 @Tool
 void getTemperature(
-    @P("Temperature value") double value,
-    @P("Unit of temperature") Optional<String> unit
+    @P(description = "Temperature value") double value,
+    @P(description = "Unit of temperature") Optional<String> unit
 ) {
     ...
 }
@@ -427,7 +406,6 @@ void getTemperature(
 
 Fields and sub-fields of complex parameters are also considered **_required_** by default.
 You can make a field optional by annotating it with `@JsonProperty(required = false)`:
-
 ```java
 record User(String name, @JsonProperty(required = false) String email) {}
 
@@ -446,7 +424,6 @@ Recursive parameters (e.g., a `Person` class having a `Set<Person> children` fie
 are currently supported only by OpenAI.
 
 ### Tool Method Return Types
-
 Methods annotated with `@Tool` can return any type, including `void`.
 If the method has a `void` return type, "Success" string is sent to the LLM if the method returns successfully.
 
@@ -456,9 +433,7 @@ For other return types, the returned value is converted into a JSON string befor
 
 ### AI services as tools for other AI services
 
-AI services can also be used as tools for other AI services. This can be useful in many agentic use cases, where one AI
-service can ask the help of another, more specialized, AI service to perform a specific task. For instance, having
-defined the following AI services:
+AI services can also be used as tools for other AI services. This can be useful in many agentic use cases, where one AI service can ask the help of another, more specialized, AI service to perform a specific task. For instance, having defined the following AI services:
 
 ```java
     interface RouterAgent {
@@ -507,8 +482,7 @@ defined the following AI services:
     }
 ```
 
-The `RouterAgent` can be configured to use as tools the 3 other AI services, experts in specific fields, routing the
-user request to one of them.
+The `RouterAgent` can be configured to use as tools the 3 other AI services, experts in specific fields, routing the user request to one of them.
 
 ```java
 MedicalExpert medicalExpert = AiServices.builder(MedicalExpert.class)
@@ -530,22 +504,16 @@ routerAgent.askToExpert("I broke my leg what should I do");
 ```
 
 :::note
-Using AI services as tools for other AI services is a powerful feature that enables to build complex agentic systems.
-However, this approach also comes with a few relevant drawbacks that are important to be aware of:
-
-- This implementation requires the LLM to copy-paste the user request without modifications as a tool call and this
-  could be an error-prone operation.
-- The LLM calling the other LLM as a tool has to reprocess its response, as it happens for any other tool invocation,
-  and this could be a wasteful computation in terms of both time and consumed tokens.
-- The agent-tool, being a totally separated AI service, has no access to the chat memory of the agent calling it, so it
-  cannot use the chat memory to provide a more informed answer.
+Using AI services as tools for other AI services is a powerful feature that enables to build complex agentic systems. However, this approach also comes with a few relevant drawbacks that are important to be aware of:
+- This implementation requires the LLM to copy-paste the user request without modifications as a tool call and this could be an error-prone operation.
+- The LLM calling the other LLM as a tool has to reprocess its response, as it happens for any other tool invocation, and this could be a wasteful computation in terms of both time and consumed tokens.
+- The agent-tool, being a totally separated AI service, has no access to the chat memory of the agent calling it, so it cannot use the chat memory to provide a more informed answer.
   :::
 
-### `@Tool`
 
+### `@Tool`
 Any Java method annotated with `@Tool`
 and _explicitly_ specified during the build of an AI Service can be executed by the LLM:
-
 ```java
 interface MathGenius {
     
@@ -579,11 +547,9 @@ When the `ask` method is called, 2 interactions with the LLM occur, as described
 In between those interactions, the `squareRoot` method is called automatically.
 
 The `@Tool` annotation has these fields:
-
 - `name`: the tool's name. If this is not provided, the method's name will serve as the tool's name.
 - `value`: the tool's description.
-- `returnBehavior`: see [this](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) for more
-  details
+- `returnBehavior`: see [this](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) for more details
 - `metadata`: a valid JSON string that contains LLM-provider-specific tool metadata entries.
   By default, it is not sent to the LLM provider, you must explicitly specify which metadata keys should be sent
   when creating a `ChatModel`.
@@ -595,17 +561,16 @@ but it is usually better to provide clear and meaningful names and descriptions.
 This way, the LLM has more information to decide whether or not to call the given tool, and how to do so.
 
 ### `@P`
-
 Method parameters can optionally be annotated with `@P`.
 
-The `@P` annotation has 3 fields
+The `@P` annotation has 4 fields
 
 - `value`: description of the parameter. Mandatory field.
+- `description`: alias of value. Use description instead.
 - `name` : name of the parameter, default value is `""`. Optional field.
 - `required`: whether the parameter is required, default is `true`. Optional field.
 
 ### `@Description`
-
 The description of classes and fields can be specified using the `@Description` annotation:
 
 ```java
@@ -628,7 +593,6 @@ Result executeQuery(Query query) {
 :::note
 Please note that `@Description` placed on an `enum` value has **_no effect_** and **_is not_** included
 in the generated JSON schema:
-
 ```java
 enum Priority {
 
@@ -642,14 +606,11 @@ enum Priority {
     LOW
 }
 ```
-
 :::
 
 ### `InvocationParameters`
-
 If you wish to pass extra data into the tool when invoking AI Service, you can do it with
 `InvocationParameters`:
-
 ```java
 
 interface Assistant {
@@ -673,7 +634,6 @@ In this case, the LLM is not aware of these parameters;
 they are only visible to LangChain4j and user code.
 
 `InvocationParameters` can also be accessed within other AI Service components, such as:
-
 - [`ToolProvider`](/tutorials/tools#specifying-tools-dynamically): inside the `ToolProviderRequest`
 - [`ToolArgumentsErrorHandler`](/tutorials/tools#handling-tool-arguments-errors)
   and [`ToolExecutionErrorHandler`](https://docs.langchain4j.dev/tutorials/tools#handling-tool-execution-errors):
@@ -707,7 +667,6 @@ In this case, the LLM is not aware of these parameters;
 they are only visible to LangChain4j and user code.
 
 ### `@ToolMemoryId`
-
 If your AI Service method has a parameter annotated with `@MemoryId`,
 you can also annotate a parameter of a `@Tool` method with `@ToolMemoryId`:
 
@@ -739,14 +698,12 @@ If you enable one of these options, the tools will be executed concurrently (wit
 using either the default or the specified `Executor`.
 
 #### When using `ChatModel`:
-
 - When the LLM calls multiple tools, they are executed concurrently in separate threads
   using the `Executor`.
 - When the LLM calls a single tool, it is executed in the same (caller) thread,
   the `Executor` is **_not_** used to avoid wasting resources.
 
 #### When using `StreamingChatModel`:
-
 - When the LLM calls multiple tools, they are executed concurrently in separate threads
   using the `Executor`.
   Each tool is executed as soon as `StreamingChatResponseHandler.onCompleteToolCall(CompleteToolCall)`
@@ -756,10 +713,8 @@ using either the default or the specified `Executor`.
   we do not yet know how many tools the LLM will call.
 
 ### Accessing Executed Tools
-
 If you wish to access tools executed during the invocation of an AI Service,
 you can easily do so by wrapping the return type in the `Result` class:
-
 ```java
 interface Assistant {
 
@@ -778,7 +733,6 @@ Object resultObject = toolExecution.resultObject(); // actual value returned by 
 ```
 
 In streaming mode, you can do so by specifying `onToolExecuted` callback:
-
 ```java
 interface Assistant {
 
@@ -803,7 +757,6 @@ from external sources such as databases and configuration files.
 
 Tool names, descriptions, parameter names, and descriptions
 can all be configured using `ToolSpecification`:
-
 ```java
 ToolSpecification toolSpecification = ToolSpecification.builder()
         .name("get_booking_details")
@@ -820,7 +773,6 @@ ToolSpecification toolSpecification = ToolSpecification.builder()
 
 For each `ToolSpecification`, one needs to provide a `ToolExecutor` implementation
 that will be handling tool execution requests generated by the LLM:
-
 ```java
 ToolExecutor toolExecutor = (toolExecutionRequest, memoryId) -> {
     Map<String, Object> arguments = fromJson(toolExecutionRequest.arguments());
@@ -832,7 +784,6 @@ ToolExecutor toolExecutor = (toolExecutionRequest, memoryId) -> {
 
 LangChain4j also provides the `DefaultToolExecutor`, which can automatically invoke methods on Java objects and handle
 parameter mapping:
-
 ```java
 class BookingTools {
     String getBookingDetails(String bookingNumber) {
@@ -848,7 +799,6 @@ ToolExecutor toolExecutor = new DefaultToolExecutor(tools, method);
 
 Once we have one or multiple (`ToolSpecification`, `ToolExecutor`) pairs,
 we can specify them when creating an AI Service:
-
 ```java
 Assistant assistant = AiServices.builder(Assistant.class)
     .chatModel(chatModel)
@@ -856,9 +806,7 @@ Assistant assistant = AiServices.builder(Assistant.class)
     .build();
 ```
 
-Additionally, we can pass a list of tool names that
-should [immediately/directly return](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request)
-their results and not send them to the LLM for reprocessing.
+Additionally, we can pass a list of tool names that should [immediately/directly return](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) their results and not send them to the LLM for reprocessing.
 
 ```java
 Set<String> immediateReturnToolNames = Set.of("get_booking_details");
@@ -878,9 +826,7 @@ The `ToolProvider` accepts a `ToolProviderRequest`
 (that contains the `UserMessage`, chat memory ID and [`InvocationParameters`](/tutorials/tools#invocationparameters))
 and returns a `ToolProviderResult` that contains tools in a form of a `Map` from `ToolSpecification` to `ToolExecutor`.
 
-Here is an example of how to add the `get_booking_details` tool only when the user's message contains the word "
-booking":
-
+Here is an example of how to add the `get_booking_details` tool only when the user's message contains the word "booking":
 ```java
 ToolProvider toolProvider = (toolProviderRequest) -> {
     if (toolProviderRequest.userMessage().singleText().contains("booking")) {
@@ -907,9 +853,7 @@ Assistant assistant = AiServices.builder(Assistant.class)
 
 #### Configuring Immediate Return in Dynamic Tools
 
-When building `ToolProviderResult`, you can mark tools
-for [immediate return](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) using the
-ToolProviderResult.builder():
+When building `ToolProviderResult`, you can mark tools for [immediate return](/tutorials/tools#returning-immediately-the-result-of-a-tool-execution-request) using the ToolProviderResult.builder():
 
 ```java
 ToolProvider toolProvider = (toolProviderRequest) -> {
@@ -942,7 +886,6 @@ that allows tools to be discovered dynamically by the LLM itself,
 instead of being exposed upfront.
 
 The core idea is simple:
-
 - Initially, the LLM is exposed to one or more special tool-search tools
 - The LLM can call these tools to search for relevant tools
 - Once relevant tools are found, they are included in subsequent requests to the LLM
@@ -952,7 +895,6 @@ This enables scalable, token-efficient, and model-driven tool discovery.
 #### How Tool Search Works
 
 A tool search flow typically looks like this:
-
 1. Initial request:
     - The LLM sees only tool-search tools (not the full tool set)
 2. Tool search
@@ -988,13 +930,11 @@ public interface ToolSearchStrategy {
 ```
 
 A `ToolSearchStrategy` is responsible for:
-
 - Exposing tool-search tools to the LLM
 - Executing tool search requests generated by the LLM
 - Returning matching tool names, which will then be resolved and exposed
 
 LangChain4j currently provides 2 out-of-the-box implementations:
-
 - `SimpleToolSearchStrategy` – keyword-based matching
 - `VectorToolSearchStrategy` – semantic search using embeddings
 
@@ -1017,7 +957,6 @@ Assistant assistant = AiServices.builder(Assistant.class)
 ```
 
 Once configured:
-
 - The LLM no longer sees all tools upfront
 - Tool discovery becomes an explicit, model-driven step
 - Token usage is reduced, especially with large tool sets
@@ -1025,7 +964,6 @@ Once configured:
 #### When to Use Tool Search
 
 Tool search is especially useful when:
-
 - You have many tools (dozens or hundreds)
 - Tools are domain-specific or rarely used
 - Tool availability depends on context, user, or permissions
@@ -1040,7 +978,6 @@ When tool search is enabled, tools are normally hidden from the LLM until they a
 However, in some cases you may want certain tools to always be visible to the LLM.
 
 Typical use cases:
-
 - Core tools that should always be accessible
 - Frequently used tools where search overhead is unnecessary
 - Utility tools
@@ -1050,7 +987,6 @@ LangChain4j supports this via the `ALWAYS_VISIBLE` tool search behavior.
 ##### How It Works
 
 When a tool is marked as `ALWAYS_VISIBLE`:
-
 - It is exposed to the LLM in the very first request
 - It does not require discovery via tool search
 - It remains visible throughout the AI Service invocation
@@ -1061,7 +997,6 @@ All other tools continue to follow the normal tool-search flow.
 ##### Using `@Tool` Annotation
 
 You can mark a tool as always visible via the @Tool annotation:
-
 ```java
 @Tool(searchBehavior = ALWAYS_VISIBLE)
 String getWeather(String city) {
@@ -1083,7 +1018,6 @@ McpToolProvider.builder()
 ##### Using `ToolSpecification`
 
 If you configure tools programmatically, you can mark them as always visible using `metadata`:
-
 ```java
 ToolSpecification toolSpecification = ToolSpecification.builder()
     .name("getWeather")
@@ -1108,11 +1042,7 @@ Tool search is currently marked as experimental and may evolve in future release
 
 ### Returning immediately the result of a tool execution request
 
-By default, the result of a tool execution request is sent back to the LLM that uses this result and further reprocesses
-it. However, in some circumstances, the result produced by that tool execution request already represents the expected
-result of the AI service invocation. In this case it is possible to configure the tool to immediately/directly return
-its result, skipping a wasteful and resource consuming reprocessing by the LLM. This can be done by configuring the
-`returnBehavior` field of the `@Tool` annotation as in the following example:
+By default, the result of a tool execution request is sent back to the LLM that uses this result and further reprocesses it. However, in some circumstances, the result produced by that tool execution request already represents the expected result of the AI service invocation. In this case it is possible to configure the tool to immediately/directly return its result, skipping a wasteful and resource consuming reprocessing by the LLM. This can be done by configuring the `returnBehavior` field of the `@Tool` annotation as in the following example:
 
 ```java
 class CalculatorWithImmediateReturn {
@@ -1125,9 +1055,7 @@ class CalculatorWithImmediateReturn {
 ```
 
 :::note
-This feature is supported only on AI Services having a `Result<T>` return type. Attempting to use it on AI Service with
-a different return type will produce an `IllegalConfigurationException`.
-See [Return Types](/tutorials/ai-services#return-types) for more information about `Result<T>`.
+This feature is supported only on AI Services having a `Result<T>` return type. Attempting to use it on AI Service with a different return type will produce an `IllegalConfigurationException`. See [Return Types](/tutorials/ai-services#return-types) for more information about `Result<T>`.
 :::
 
 In this way, an `Assistant` service like the following
@@ -1153,9 +1081,7 @@ will return a response directly from the tool invocation. For instance, promptin
 Result<String> result = assistant.chat("How much is 37 plus 87?");
 ```
 
-will produce a `Result` with a null content, while the actual response of `124` will have to be retrieved from the
-`result.toolExecutions()`. Without the immediate return, the LLM would have to reprocess the result of the `add` tool
-execution request, thus returning a response like: `The result of adding 37 and 87 is 124.`
+will produce a `Result` with a null content, while the actual response of `124` will have to be retrieved from the `result.toolExecutions()`. Without the immediate return, the LLM would have to reprocess the result of the `add` tool execution request, thus returning a response like: `The result of adding 37 and 87 is 124.`
 
 Also note that if the LLM calls multiple tools and at least one of them is not immediate, then reprocessing will happen.
 
@@ -1176,11 +1102,7 @@ In this case by default LangChain4j will throw an exception reporting the proble
 but it is possible to configure a different behavior providing the AI service
 with a strategy to be used in this situation.
 
-This strategy is an implementation of a `Function<ToolExecutionRequest, ToolExecutionResultMessage>` defining which
-`ToolExecutionResultMessage` should be produced as the result for a `ToolExecutionRequest` containing the request to
-invoke a tool that is not available. For instance, it could be possible to configure the AI service with a strategy that
-returns to the LLM a response that hopefully will push it to retry a different tool invocation, knowing that the
-formerly required tool doesn't exist, as in the following example:
+This strategy is an implementation of a `Function<ToolExecutionRequest, ToolExecutionResultMessage>` defining which `ToolExecutionResultMessage` should be produced as the result for a `ToolExecutionRequest` containing the request to invoke a tool that is not available. For instance, it could be possible to configure the AI service with a strategy that returns to the LLM a response that hopefully will push it to retry a different tool invocation, knowing that the formerly required tool doesn't exist, as in the following example:
 
 ```java
 AssistantHallucinatedTool assistant = AiServices.builder(AssistantHallucinatedTool.class)
@@ -1222,10 +1144,10 @@ Assistant assistant = AiServices.builder(Assistant.class)
         .build();
 
 try {
-    assistant.chat(...);
+        assistant.chat(...);
 } catch (MyCustomException e) {
-    // handle e
-}
+        // handle e
+        }
 ```
 
 Here is an example of the second approach:
@@ -1271,3 +1193,4 @@ More information on this can be found [here](/tutorials/mcp/#creating-an-mcp-too
 
 - [Example with Tools](https://github.com/langchain4j/langchain4j-examples/blob/main/other-examples/src/main/java/ServiceWithToolsExample.java)
 - [Example with dynamic Tools](https://github.com/langchain4j/langchain4j-examples/blob/main/other-examples/src/main/java/ServiceWithDynamicToolsExample.java)
+@

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
@@ -20,6 +20,12 @@ public @interface P {
     String value();
 
     /**
+     * Name of a parameter
+     * @return the name of a parameter
+     */
+    String name() default "";
+
+    /**
      * Whether the parameter is required
      * @return true if the parameter is required, false otherwise
      * Default is true.

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
@@ -7,33 +7,79 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Parameter of a Tool
+ * Annotation for parameters of a {@link Tool}-annotated method.
+ *
+ * <h2>Description</h2>
+ * {@link #value()} and {@link #description()} are aliases for the same thing: the parameter's description
+ * that the LLM will see. Use one or the other, but not both at the same time.
+ * <p>When only a description is needed, {@code value} can be used as a shorthand:
+ * <pre>{@code
+ * @Tool
+ * void getWeather(@P("The city name") String city) { ... }
+ * }</pre>
+ * <p>When both a name and a description are needed, use named attributes:
+ * <pre>{@code
+ * @Tool
+ * void getWeather(@P(name = "city", description = "The city name") String city) { ... }
+ * }</pre>
+ *
+ * <h2>Name</h2>
+ * The {@link #name()} attribute overrides the parameter name that the LLM will see.
+ * This is useful in two cases:
+ * <ol>
+ *   <li><b>Missing {@code -parameters} javac option.</b>
+ *       Without it (common when not using frameworks like Quarkus or Spring, which enable it by default),
+ *       Java reflection returns generic names such as {@code arg0}, {@code arg1}, etc.
+ *       The semantic meaning of the parameter is lost, which may confuse the LLM.
+ *       Setting {@code name} restores a meaningful name.</li>
+ *   <li><b>Custom name for the LLM.</b>
+ *       When you want the LLM to see a different parameter name than the one the developer uses in the source code
+ *       (for example, to match a specific API contract or to provide a more descriptive name).</li>
+ * </ol>
  */
 @Retention(RUNTIME)
 @Target({PARAMETER})
 public @interface P {
 
     /**
-     * Description of a parameter
-     * @return the description of a parameter
-     */
-    String value() default "";
-
-    /**
-     * Alias of value. Use description instead.
-     */
-    String description() default "";
-
-    /**
-     * Name of a parameter
-     * @return the name of a parameter
+     * Name of the parameter as seen by the LLM.
+     * <p>If not specified, the actual method parameter name is used (requires the {@code -parameters} javac option;
+     * otherwise the name defaults to {@code arg0}, {@code arg1}, etc.).
+     * <p>Setting this is useful when:
+     * <ul>
+     *   <li>The {@code -parameters} javac option is not enabled and you want to avoid
+     *       generic {@code arg0}/{@code arg1} names.
+     *       Note that frameworks like Quarkus and Spring enable {@code -parameters} by default,
+     *       so you typically do not need to set {@code name} when using those frameworks.</li>
+     *   <li>You want the LLM to see a different name than the one in the source code.</li>
+     * </ul>
+     *
+     * @return the name of the parameter
      */
     String name() default "";
 
     /**
-     * Whether the parameter is required
-     * @return true if the parameter is required, false otherwise
-     * Default is true.
+     * Description of the parameter. This is an alias for {@link #value()}.
+     * Use either {@code value} or {@code description}, but not both.
+     *
+     * @return the description of the parameter
+     */
+    String description() default "";
+
+    /**
+     * Description of the parameter. This is an alias for {@link #description()}.
+     * Use either {@code value} or {@code description}, but not both.
+     * <p>Convenient for the shorthand form: {@code @P("description here")}.
+     *
+     * @return the description of the parameter
+     */
+    String value() default "";
+
+    /**
+     * Whether the parameter is required.
+     * Default is {@code true}.
+     *
+     * @return {@code true} if the parameter is required, {@code false} otherwise
      */
     boolean required() default true;
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
@@ -17,7 +17,12 @@ public @interface P {
      * Description of a parameter
      * @return the description of a parameter
      */
-    String value();
+    String value() default "";
+
+    /**
+     * Alias of value. Use description instead.
+     */
+    String description() default "";
 
     /**
      * Name of a parameter

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
@@ -149,14 +149,20 @@ public class ToolSpecifications {
             }
 
             boolean isOptional = Optional.class.equals(parameter.getType());
+            P pAnnotation = parameter.getAnnotation(P.class);
             boolean isRequired = !isOptional
-                    && Optional.ofNullable(parameter.getAnnotation(P.class))
+                    && Optional.ofNullable(pAnnotation)
                             .map(P::required)
                             .orElse(true);
 
-            properties.put(parameter.getName(), jsonSchemaElementFrom(parameter, visited));
+            String paramName = Optional.ofNullable(pAnnotation)
+                    .map(P::name)
+                    .filter(s -> !s.isEmpty())
+                    .orElse(parameter.getName());
+
+            properties.put(paramName, jsonSchemaElementFrom(parameter, visited));
             if (isRequired) {
-                required.add(parameter.getName());
+                required.add(paramName);
             }
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
@@ -26,9 +26,6 @@ import java.util.Set;
 
 import static dev.langchain4j.agent.tool.SearchBehavior.SEARCHABLE;
 import static dev.langchain4j.agent.tool.ToolSpecification.METADATA_SEARCH_BEHAVIOR;
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Utility methods for {@link ToolSpecification}s.

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.agent.tool;
 
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
@@ -154,7 +155,7 @@ public class ToolSpecifications {
 
             String paramName = Optional.ofNullable(pAnnotation)
                     .map(P::name)
-                    .filter(s -> !s.isEmpty())
+                    .filter(name -> isNotNullOrBlank(name))
                     .orElse(parameter.getName());
 
             properties.put(paramName, jsonSchemaElementFrom(parameter, visited));
@@ -184,7 +185,14 @@ public class ToolSpecifications {
     private static JsonSchemaElement jsonSchemaElementFrom(
             Parameter parameter, Map<Class<?>, VisitedClassMetadata> visited) {
         P annotation = parameter.getAnnotation(P.class);
-        String description = annotation == null ? null : annotation.value();
+        String description = null;
+
+        if (annotation != null) {
+            // Use annotation.value() if annotation.description() is blank
+            description = isNotNullOrBlank(annotation.description())
+                    ? annotation.description()
+                    : annotation.value();
+        }
 
         Type type = parameter.getParameterizedType();
         Class<?> clazz = parameter.getType();

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
@@ -188,7 +188,11 @@ public class ToolSpecifications {
         String description = null;
 
         if (annotation != null) {
-            // Use annotation.value() if annotation.description() is blank
+            if (isNotNullOrBlank(annotation.value()) && isNotNullOrBlank(annotation.description())) {
+                throw new IllegalArgumentException(String.format(
+                        "Parameter '%s' has both 'value' and 'description' set in @P. Use one or the other, but not both.",
+                        parameter.getName()));
+            }
             description = isNotNullOrBlank(annotation.description())
                     ? annotation.description()
                     : annotation.value();

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
@@ -153,14 +153,14 @@ public class ToolSpecifications {
                             .map(P::required)
                             .orElse(true);
 
-            String paramName = Optional.ofNullable(pAnnotation)
+            String parameterName = Optional.ofNullable(pAnnotation)
                     .map(P::name)
                     .filter(name -> isNotNullOrBlank(name))
                     .orElse(parameter.getName());
 
-            properties.put(paramName, jsonSchemaElementFrom(parameter, visited));
+            properties.put(parameterName, jsonSchemaElementFrom(parameter, visited));
             if (isRequired) {
-                required.add(paramName);
+                required.add(parameterName);
             }
         }
 
@@ -193,9 +193,11 @@ public class ToolSpecifications {
                         "Parameter '%s' has both 'value' and 'description' set in @P. Use one or the other, but not both.",
                         parameter.getName()));
             }
-            description = isNotNullOrBlank(annotation.description())
-                    ? annotation.description()
-                    : annotation.value();
+            if (isNotNullOrBlank(annotation.description())) {
+                description = annotation.description();
+            } else if (isNotNullOrBlank(annotation.value())) {
+                description = annotation.value();
+            }
         }
 
         Type type = parameter.getParameterizedType();

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
@@ -432,4 +432,43 @@ class ToolSpecificationsTest implements WithAssertions {
         assertThat(schema.required()).containsExactly("arg0", "arg1"); // both required
         assertThat(schema.properties().keySet()).containsExactly("arg0", "arg1");
     }
+
+    @Test
+    void should_fail_when_both_value_and_description_are_set_in_P() throws NoSuchMethodException {
+        class Tools {
+            @Tool
+            public void tool(@P(value = "desc via value", description = "desc via description") String param) {}
+        }
+        Method method = Tools.class.getMethod("tool", String.class);
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ToolSpecifications.toolSpecificationFrom(method))
+                .withMessageContaining("has both 'value' and 'description' set in @P");
+    }
+
+    @Test
+    void should_use_description_when_only_description_is_set_in_P() throws NoSuchMethodException {
+        class Tools {
+            @Tool
+            public void tool(@P(description = "desc via description") String param) {}
+        }
+        Method method = Tools.class.getMethod("tool", String.class);
+        ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);
+
+        JsonSchemaElement element = ts.parameters().properties().get("arg0");
+        assertThat(element).isEqualTo(JsonStringSchema.builder().description("desc via description").build());
+    }
+
+    @Test
+    void should_use_value_when_only_value_is_set_in_P() throws NoSuchMethodException {
+        class Tools {
+            @Tool
+            public void tool(@P(value = "desc via value") String param) {}
+        }
+        Method method = Tools.class.getMethod("tool", String.class);
+        ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);
+
+        JsonSchemaElement element = ts.parameters().properties().get("arg0");
+        assertThat(element).isEqualTo(JsonStringSchema.builder().description("desc via value").build());
+    }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
@@ -471,4 +471,18 @@ class ToolSpecificationsTest implements WithAssertions {
         JsonSchemaElement element = ts.parameters().properties().get("arg0");
         assertThat(element).isEqualTo(JsonStringSchema.builder().description("desc via value").build());
     }
+
+    @Test
+    void should_have_null_description_when_only_name_is_set_in_P() throws NoSuchMethodException {
+        class Tools {
+            @Tool
+            public void tool(@P(name = "myParam") String param) {}
+        }
+        Method method = Tools.class.getMethod("tool", String.class);
+        ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);
+
+        assertThat(ts.parameters().properties()).containsKey("myParam");
+        JsonStringSchema element = (JsonStringSchema) ts.parameters().properties().get("myParam");
+        assertThat(element.description()).isNull();
+    }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -2,9 +2,11 @@ package dev.langchain4j.service.tool;
 
 import static dev.langchain4j.internal.Exceptions.unwrapRuntimeException;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.service.tool.ToolExecutionRequestUtil.argumentsAsMap;
 
+import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolMemoryId;
 import dev.langchain4j.exception.ToolArgumentsException;
@@ -194,7 +196,7 @@ public class DefaultToolExecutor implements ToolExecutor {
                 continue;
             }
 
-            String parameterName = parameter.getName();
+            String parameterName = getName(parameter);
             Object argument = argumentsMap.get(parameterName);
             Class<?> parameterClass = parameter.getType();
             Type parameterType = parameter.getParameterizedType();
@@ -207,6 +209,14 @@ public class DefaultToolExecutor implements ToolExecutor {
         }
 
         return arguments;
+    }
+
+    private static String getName(Parameter parameter) {
+        P pAnnotation = parameter.getAnnotation(P.class);
+        if (pAnnotation != null && isNotNullOrBlank(pAnnotation.name())) {
+            return pAnnotation.name();
+        }
+        return parameter.getName();
     }
 
     private static Type extractActualType(Type parameterType) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
@@ -28,6 +28,7 @@ import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.agent.tool.ToolSpecifications;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
@@ -658,7 +659,7 @@ class AiServicesWithToolsIT {
         assistant.chat(userMessage);
 
         // then
-        verify(stringArrayProcessor).processStrings(new String[] {"cat", "dog"});
+        verify(stringArrayProcessor).processStrings(new String[]{"cat", "dog"});
         verifyNoMoreInteractions(stringArrayProcessor);
 
         List<ChatMessage> messages = chatMemory.messages();
@@ -715,6 +716,34 @@ class AiServicesWithToolsIT {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("models")
+    void should_use_name_field_of_p(ChatModel chatModel) {
+
+        List<ToolSpecification> toolSpecifications = ToolSpecifications.toolSpecificationsFrom(BashTool.class);
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("Run a shell command 'ls -la'"))
+                .toolSpecifications(toolSpecifications)
+                .build();
+        ChatResponse chatResponse = chatModel.chat(chatRequest);
+
+        AiMessage aiMessage = chatResponse.aiMessage();
+
+        // 打印 toolExecutionRequests 中的参数名称与值
+        for (ToolExecutionRequest toolExecutionRequest : aiMessage.toolExecutionRequests()) {
+            assertThat(toolExecutionRequest.arguments()).contains("command");
+        }
+    }
+
+    static class BashTool {
+
+        @Tool(value = "Run a shell command.", name = "bash")
+        String runBash(@P(description = "The shell command to run.", name = "command") String command) {
+            return "Running command: " + command;
+        }
+    }
+
     @Test
     void should_use_tool_provider() {
 
@@ -757,17 +786,17 @@ class AiServicesWithToolsIT {
 
         // given
         ToolProvider addToolProvider = (toolProviderRequest) -> {
-                ToolSpecification toolSpecification = ToolSpecification.builder()
-                        .name("add")
-                        .parameters(JsonObjectSchema.builder()
-                                .addNumberProperty("a")
-                                .addNumberProperty("b")
-                                .required("a", "b")
-                                .build())
-                        .build();
-                return ToolProviderResult.builder()
-                        .add(toolSpecification, (request, memoryId) -> "does not matter")
-                        .build();
+            ToolSpecification toolSpecification = ToolSpecification.builder()
+                    .name("add")
+                    .parameters(JsonObjectSchema.builder()
+                            .addNumberProperty("a")
+                            .addNumberProperty("b")
+                            .required("a", "b")
+                            .build())
+                    .build();
+            return ToolProviderResult.builder()
+                    .add(toolSpecification, (request, memoryId) -> "does not matter")
+                    .build();
         };
 
         ToolProvider multiplyToolProvider = (toolProviderRequest) -> {
@@ -874,8 +903,8 @@ class AiServicesWithToolsIT {
                 .build();
 
         assertThat(assertThrows(
-                        IllegalConfigurationException.class,
-                        () -> assistant.chat("Apply the function xyz on the number 2027")))
+                IllegalConfigurationException.class,
+                () -> assistant.chat("Apply the function xyz on the number 2027")))
                 .hasMessageContaining("xyz");
     }
 
@@ -1098,7 +1127,7 @@ class AiServicesWithToolsIT {
                             public ToolExecutionResult executeWithContext(
                                     ToolExecutionRequest request, InvocationContext context) {
                                 assertThat((boolean)
-                                                context.invocationParameters().get(includeToolsKey))
+                                        context.invocationParameters().get(includeToolsKey))
                                         .isEqualTo(true);
                                 Map<String, Object> arguments = toMap(request.arguments());
                                 assertThat(arguments).containsExactly(entry("number", 2027));
@@ -1151,7 +1180,8 @@ class AiServicesWithToolsIT {
 
     private static Map<String, Object> toMap(String arguments) {
         try {
-            return new ObjectMapper().readValue(arguments, new TypeReference<>() {});
+            return new ObjectMapper().readValue(arguments, new TypeReference<>() {
+            });
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -1301,7 +1331,8 @@ class AiServicesWithToolsIT {
 
         LocalDate now = LocalDate.of(2025, 2, 24);
 
-        record ToolResult(LocalDate localDate) {}
+        record ToolResult(LocalDate localDate) {
+        }
 
         class Tools {
 
@@ -1377,12 +1408,12 @@ class AiServicesWithToolsIT {
 
         @dev.langchain4j.service.UserMessage(
                 """
-            Analyze the following user request and categorize it as 'legal', 'medical' or 'technical',
-            then forward the request as it is to the corresponding expert provided as a tool.
-            Finally return the answer that you received from the expert without any modification.
-
-            The user request is: '{{it}}'.
-            """)
+                        Analyze the following user request and categorize it as 'legal', 'medical' or 'technical',
+                        then forward the request as it is to the corresponding expert provided as a tool.
+                        Finally return the answer that you received from the expert without any modification.
+                        
+                        The user request is: '{{it}}'.
+                        """)
         String askToExpert(String request);
     }
 
@@ -1390,10 +1421,10 @@ class AiServicesWithToolsIT {
 
         @dev.langchain4j.service.UserMessage(
                 """
-            You are a medical expert.
-            Analyze the following user request under a medical point of view and provide the best possible answer.
-            The user request is {{it}}.
-            """)
+                        You are a medical expert.
+                        Analyze the following user request under a medical point of view and provide the best possible answer.
+                        The user request is {{it}}.
+                        """)
         @Tool("A medical expert")
         String medicalRequest(String request);
     }
@@ -1402,10 +1433,10 @@ class AiServicesWithToolsIT {
 
         @dev.langchain4j.service.UserMessage(
                 """
-            You are a legal expert.
-            Analyze the following user request under a legal point of view and provide the best possible answer.
-            The user request is {{it}}.
-            """)
+                        You are a legal expert.
+                        Analyze the following user request under a legal point of view and provide the best possible answer.
+                        The user request is {{it}}.
+                        """)
         @Tool("A legal expert")
         String legalRequest(String request);
     }
@@ -1414,10 +1445,10 @@ class AiServicesWithToolsIT {
 
         @dev.langchain4j.service.UserMessage(
                 """
-            You are a technical expert.
-            Analyze the following user request under a technical point of view and provide the best possible answer.
-            The user request is {{it}}.
-            """)
+                        You are a technical expert.
+                        Analyze the following user request under a technical point of view and provide the best possible answer.
+                        The user request is {{it}}.
+                        """)
         @Tool("A technical expert")
         String technicalRequest(String request);
     }
@@ -1462,7 +1493,8 @@ class AiServicesWithToolsIT {
 
         LocalDate now = LocalDate.of(2025, 2, 24);
 
-        record ToolResult(LocalDate localDate) {}
+        record ToolResult(LocalDate localDate) {
+        }
 
         class Tools {
 
@@ -1500,7 +1532,8 @@ class AiServicesWithToolsIT {
 
         LocalDate now = LocalDate.of(2025, 2, 24);
 
-        record ToolResult(LocalDate localDate) {}
+        record ToolResult(LocalDate localDate) {
+        }
 
         class Tools {
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
@@ -13,6 +13,7 @@ import static org.assertj.core.data.MapEntry.entry;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -28,7 +29,6 @@ import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.agent.tool.ToolSpecifications;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
@@ -718,30 +718,38 @@ class AiServicesWithToolsIT {
 
     @ParameterizedTest
     @MethodSource("models")
-    void should_use_name_field_of_p(ChatModel chatModel) {
+    void should_support_custom_tool_parameter_name(ChatModel chatModel) {
 
-        List<ToolSpecification> toolSpecifications = ToolSpecifications.toolSpecificationsFrom(BashTool.class);
+        // given
+        class BashTool {
 
-        ChatRequest chatRequest = ChatRequest.builder()
-                .messages(UserMessage.from("Run a shell command 'ls -la'"))
-                .toolSpecifications(toolSpecifications)
+            @Tool
+            String runBash(@P(name = "command") String cmd) {
+                return "Running command: " + cmd;
+            }
+        }
+
+        BashTool bashTool = spy(new BashTool());
+        ChatModel spyChatModel = spy(chatModel);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(spyChatModel)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(bashTool)
                 .build();
-        ChatResponse chatResponse = chatModel.chat(chatRequest);
 
-        AiMessage aiMessage = chatResponse.aiMessage();
+        // when
+        Result<String> result = assistant.chat("Run a shell command 'ls -la'");
 
-        // 打印 toolExecutionRequests 中的参数名称与值
-        for (ToolExecutionRequest toolExecutionRequest : aiMessage.toolExecutionRequests()) {
-            assertThat(toolExecutionRequest.arguments()).contains("command");
-        }
-    }
+        // then
+        verify(spyChatModel, atLeastOnce()).chat(argThat((ChatRequest request) -> {
+            ToolSpecification toolSpec = request.toolSpecifications().get(0);
+            return toolSpec.parameters().properties().containsKey("command");
+        }));
 
-    static class BashTool {
-
-        @Tool(value = "Run a shell command.", name = "bash")
-        String runBash(@P(description = "The shell command to run.", name = "command") String command) {
-            return "Running command: " + command;
-        }
+        // verify that the tool method is called with the expected argument value
+        verify(bashTool).runBash("ls -la");
+        assertThat(result.content()).contains("ls -la");
     }
 
     @Test


### PR DESCRIPTION
## Change

  - Add `name` attribute to `@P` to allow overriding the tool parameter name seen by the LLM
  - Add `description` attribute to `@P` as an alias for `value`

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)