### PR TITLE
fix(ollama): add missing contextLength to RunningOllamaMode

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/RunningOllamaModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/RunningOllamaModel.java
@@ -1,18 +1,17 @@
 package dev.langchain4j.model.ollama;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.time.OffsetDateTime;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(SnakeCaseStrategy.class)
 public class RunningOllamaModel {
 
     private String name;
@@ -20,14 +19,24 @@ public class RunningOllamaModel {
     private Long size;
     private String digest;
     private OllamaModelDetails details;
+
     @JsonDeserialize(using = OllamaDateDeserializer.class)
     private OffsetDateTime expiresAt;
+
     private Long sizeVram;
+    private Integer contextLength;
 
-    RunningOllamaModel() {
-    }
+    RunningOllamaModel() {}
 
-    RunningOllamaModel(String name, String model, Long size, OllamaModelDetails details, String digest, OffsetDateTime expiresAt, Long sizeVram) {
+    RunningOllamaModel(
+            String name,
+            String model,
+            Long size,
+            OllamaModelDetails details,
+            String digest,
+            OffsetDateTime expiresAt,
+            Long sizeVram,
+            Integer contextLength) {
         this.name = name;
         this.model = model;
         this.size = size;
@@ -35,6 +44,7 @@ public class RunningOllamaModel {
         this.digest = digest;
         this.expiresAt = expiresAt;
         this.sizeVram = sizeVram;
+        this.contextLength = contextLength;
     }
 
     public String getName() {
@@ -93,6 +103,14 @@ public class RunningOllamaModel {
         this.sizeVram = sizeVram;
     }
 
+    public Integer getContextLength() {
+        return contextLength;
+    }
+
+    public void setContextLength(Integer contextLength) {
+        this.contextLength = contextLength;
+    }
+
     static Builder builder() {
         return new Builder();
     }
@@ -106,6 +124,7 @@ public class RunningOllamaModel {
         private OllamaModelDetails details;
         private OffsetDateTime expiresAt;
         private Long sizeVram;
+        private Integer contextLength;
 
         Builder name(String name) {
             this.name = name;
@@ -142,8 +161,13 @@ public class RunningOllamaModel {
             return this;
         }
 
+        Builder contextLength(Integer contextLength) {
+            this.contextLength = contextLength;
+            return this;
+        }
+
         RunningOllamaModel build() {
-            return new RunningOllamaModel(name, model, size, details, digest, expiresAt, sizeVram);
+            return new RunningOllamaModel(name, model, size, details, digest, expiresAt, sizeVram, contextLength);
         }
     }
 }

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaModelsIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaModelsIT.java
@@ -92,6 +92,7 @@ class OllamaModelsIT extends AbstractOllamaLanguageModelInfrastructure {
             assertThat(runningOllamaModel.getName()).contains(TINY_DOLPHIN_MODEL);
             assertThat(runningOllamaModel.getDigest()).isNotBlank();
             assertThat(runningOllamaModel.getExpiresAt()).isNotNull();
+            assertThat(runningOllamaModel.getContextLength()).isPositive();
         });
     }
 }

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/RunningOllamaModelTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/RunningOllamaModelTest.java
@@ -1,0 +1,44 @@
+package dev.langchain4j.model.ollama;
+
+import static dev.langchain4j.model.ollama.OllamaJsonUtils.fromJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RunningOllamaModelTest {
+
+    @Test
+    void should_deserialize_context_length_from_running_models_response() {
+        String json = """
+                {
+                  "models": [
+                    {
+                      "name": "gemma3",
+                      "model": "gemma3",
+                      "size": 6591830464,
+                      "digest": "a2af6cc3eb7fa8be8504abaf9b04e88f17a119ec3f04a3addf55f92841195f5a",
+                      "details": {
+                        "format": "gguf",
+                        "family": "gemma3",
+                        "families": [
+                          "gemma3"
+                        ],
+                        "parameter_size": "4.3B",
+                        "quantization_level": "Q4_K_M"
+                      },
+                      "expires_at": "2025-10-17T16:47:07.93355-07:00",
+                      "size_vram": 5333539264,
+                      "context_length": 4096
+                    }
+                  ]
+                }
+                """;
+
+        RunningModelsListResponse response = fromJson(json, RunningModelsListResponse.class);
+
+        assertThat(response.getModels()).singleElement().satisfies(model -> {
+            assertThat(model.getName()).isEqualTo("gemma3");
+            assertThat(model.getContextLength()).isEqualTo(4096);
+        });
+    }
+}


### PR DESCRIPTION
## Issue
Closes #4833

## Change
This PR adds the missing `contextLength` field to `RunningOllamaModel` so the `context_length` value returned by Ollama `/api/ps` is preserved instead of being silently dropped during deserialization.

Changes included:
- add `contextLength` field, getter/setter, and builder support to `RunningOllamaModel`
- add a unit test to verify `context_length` is deserialized from the running models response
- extend the existing `OllamaModelsIT` assertion to check that `contextLength` is present for running models

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
