### PR TITLE
Support Tools Returning Images

### DIFF
--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -247,6 +247,29 @@ ChatRequest request2 = ChatRequest.builder()
 ChatResponse response2 = model.chat(request2);
 ```
 
+#### Multimodal Tool Results
+`ToolExecutionResultMessage` can also carry non-text content such as images.
+Instead of using `text()`, you can use the builder with `contents()`:
+
+```java
+ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.builder()
+        .id(toolExecutionRequest.id())
+        .toolName(toolExecutionRequest.name())
+        .contents(
+                TextContent.from("Here is the photo"),
+                ImageContent.from(Image.builder()
+                        .base64Data(base64Data)
+                        .mimeType("image/png")
+                        .build())
+        )
+        .build();
+```
+
+:::note
+Not all LLM providers support multimodal tool results.
+See [Returning Images and Multimodal Content](/tutorials/tools#returning-images-and-multimodal-content) for details on provider support.
+:::
+
 ### Using `StreamingChatModel`
 
 Once you have a `List<ToolSpecification>`, you can call the model:
@@ -430,6 +453,47 @@ If the method has a `void` return type, "Success" string is sent to the LLM if t
 If the method has a `String` return type, the returned value is sent to the LLM as is, without any conversions.
 
 For other return types, the returned value is converted into a JSON string before being sent to the LLM.
+
+#### Returning Images and Multimodal Content
+
+Tools can also return images and other non-text content. When a tool returns one of the following types,
+the result is sent to the LLM as multimodal content (e.g., image) instead of being serialized to JSON text:
+
+- `Image` — sent as a single image
+- `ImageContent` — sent as a single image content
+- `Content` — sent as a single content element (e.g., `TextContent`, `ImageContent`)
+- `List<Content>` — sent as multiple content elements
+- `Content[]` — sent as multiple content elements
+
+For example, a tool that takes a photo and returns an image:
+```java
+@Tool("Takes a photo and returns it")
+Image takePhoto() {
+    byte[] imageBytes = camera.capture();
+    return Image.builder()
+            .base64Data(Base64.getEncoder().encodeToString(imageBytes))
+            .mimeType("image/png")
+            .build();
+}
+```
+
+Or a tool that returns both text and an image:
+```java
+@Tool("Takes a photo and returns it with a description")
+List<Content> takePhoto() {
+    Image image = camera.capture();
+    return List.of(
+            TextContent.from("Photo taken at " + LocalDateTime.now()),
+            ImageContent.from(image)
+    );
+}
+```
+
+:::note
+Not all LLM providers support multimodal tool results.
+Providers that currently support images in tool results include Anthropic, Amazon Bedrock, and Google AI Gemini.
+Other providers will throw an `UnsupportedFeatureException` if a tool returns non-text content.
+:::
 
 ### AI services as tools for other AI services
 
@@ -761,6 +825,7 @@ List<ToolExecution> toolExecutions = result.toolExecutions();
 ToolExecution toolExecution = toolExecutions.get(0);
 ToolExecutionRequest request = toolExecution.request();
 String result = toolExecution.result(); // tool execution result as text
+List<Content> resultContents = toolExecution.resultContents(); // tool execution result as content list (may include images)
 Object resultObject = toolExecution.resultObject(); // actual value returned by the tool
 ```
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolResultContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolResultContent.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(NON_NULL)
@@ -14,10 +15,24 @@ import java.util.Objects;
 public class AnthropicToolResultContent extends AnthropicMessageContent {
 
     public String toolUseId;
-    public String content;
+
+    /**
+     * Can be either a {@link String} (text-only tool result)
+     * or a {@link List} of {@link AnthropicMessageContent} (multimodal tool result).
+     */
+    public Object content;
+
     public Boolean isError;
 
     public AnthropicToolResultContent(String toolUseId, String content, Boolean isError) {
+        super("tool_result");
+        this.toolUseId = toolUseId;
+        this.content = content;
+        this.isError = isError;
+    }
+
+    public AnthropicToolResultContent(
+            String toolUseId, List<AnthropicMessageContent> content, Boolean isError) {
         super("tool_result");
         this.toolUseId = toolUseId;
         this.content = content;

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -115,8 +115,29 @@ public class AnthropicMapper {
     }
 
     private static AnthropicToolResultContent toAnthropicToolResultContent(ToolExecutionResultMessage message) {
+        if (message.hasSingleText()) {
+            return new AnthropicToolResultContent(
+                    message.id(), message.text(), Boolean.TRUE.equals(message.isError()) ? true : null);
+        }
+        List<AnthropicMessageContent> contentBlocks = new ArrayList<>();
+        for (dev.langchain4j.data.message.Content content : message.contents()) {
+            if (content instanceof TextContent textContent) {
+                contentBlocks.add(new AnthropicTextContent(textContent.text()));
+            } else if (content instanceof ImageContent imageContent) {
+                Image image = imageContent.image();
+                if (image.url() != null) {
+                    contentBlocks.add(AnthropicImageContent.fromUrl(image.url().toString()));
+                } else {
+                    contentBlocks.add(AnthropicImageContent.fromBase64(
+                            ensureNotBlank(image.mimeType(), "mimeType"),
+                            ensureNotBlank(image.base64Data(), "base64Data")));
+                }
+            } else {
+                throw illegalArgument("Unsupported content type in tool result: " + content.type());
+            }
+        }
         return new AnthropicToolResultContent(
-                message.id(), message.text(), Boolean.TRUE.equals(message.isError()) ? true : null);
+                message.id(), contentBlocks, Boolean.TRUE.equals(message.isError()) ? true : null);
     }
 
     private static List<AnthropicMessageContent> toAnthropicMessageContents(UserMessage message) {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicAiServiceWithToolsIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicAiServiceWithToolsIT.java
@@ -169,4 +169,9 @@ class AnthropicAiServiceWithToolsIT extends AbstractAiServiceWithToolsIT {
         verify(tools).getWeather(argThat(location -> location.contains("Munich")), eq(Unit.FAHRENHEIT));
         verifyNoMoreInteractions(tools);
     }
+
+    @Override
+    protected boolean supportsMultimodalToolResults() {
+        return true;
+    }
 }

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
@@ -241,6 +241,11 @@ class InternalAzureOpenAiHelper {
             chatRequestAssistantMessage.setToolCalls(toolExecutionRequestsFrom(message));
             return chatRequestAssistantMessage;
         } else if (message instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+            if (!toolExecutionResultMessage.hasSingleText()) {
+                throw new UnsupportedFeatureException(
+                        "Azure OpenAI does not support non-text content in tool results. "
+                                + "Only text content is supported.");
+            }
             return new ChatRequestToolMessage(toolExecutionResultMessage.text(), toolExecutionResultMessage.id());
         } else if (message instanceof SystemMessage systemMessage) {
             return new ChatRequestSystemMessage(systemMessage.text());

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
@@ -323,12 +323,45 @@ abstract class AbstractBedrockChatModel {
     }
 
     protected ContentBlock createToolResultBlock(ToolExecutionResultMessage toolResult) {
+        if (toolResult.hasSingleText()) {
+            return ContentBlock.builder()
+                    .toolResult(ToolResultBlock.builder()
+                            .toolUseId(toolResult.id())
+                            .content(ToolResultContentBlock.builder()
+                                    .text(toolResult.text())
+                                    .build())
+                            .build())
+                    .build();
+        }
+
+        List<ToolResultContentBlock> contentBlocks = new ArrayList<>();
+        for (Content content : toolResult.contents()) {
+            if (content instanceof TextContent textContent) {
+                contentBlocks.add(ToolResultContentBlock.builder()
+                        .text(textContent.text())
+                        .build());
+            } else if (content instanceof ImageContent imageContent) {
+                SdkBytes bytes = fromByteArray(
+                        nonNull(imageContent.image().base64Data())
+                                ? Base64.getDecoder().decode(imageContent.image().base64Data())
+                                : readBytes(String.valueOf(imageContent.image().url())));
+                String imgFormat = extractAndValidateFormat(imageContent.image());
+                contentBlocks.add(ToolResultContentBlock.builder()
+                        .image(ImageBlock.builder()
+                                .format(imgFormat)
+                                .source(ImageSource.builder().bytes(bytes).build())
+                                .build())
+                        .build());
+            } else {
+                throw new UnsupportedFeatureException(
+                        "Bedrock does not support content type '" + content.type()
+                                + "' in tool results. Only text and image content are supported.");
+            }
+        }
         return ContentBlock.builder()
                 .toolResult(ToolResultBlock.builder()
                         .toolUseId(toolResult.id())
-                        .content(ToolResultContentBlock.builder()
-                                .text(toolResult.text())
-                                .build())
+                        .content(contentBlocks)
                         .build())
                 .build();
     }

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/common/BedrockAiServiceWithToolsIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/common/BedrockAiServiceWithToolsIT.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.util.List;
 
-import static dev.langchain4j.model.bedrock.TestedModels.MISTRAL_LARGE;
+import static dev.langchain4j.model.bedrock.TestedModels.CLAUDE_3_HAIKU;
 import static dev.langchain4j.model.bedrock.common.BedrockAiServicesIT.sleepIfNeeded;
 
 @EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".+")
@@ -16,7 +16,7 @@ class BedrockAiServiceWithToolsIT extends AbstractAiServiceWithToolsIT {
 
     @Override
     protected List<ChatModel> models() {
-        return List.of(MISTRAL_LARGE);
+        return List.of(CLAUDE_3_HAIKU);
     }
 
     @Override
@@ -30,5 +30,10 @@ class BedrockAiServiceWithToolsIT extends AbstractAiServiceWithToolsIT {
     @AfterEach
     void afterEach() {
         sleepIfNeeded();
+    }
+
+    @Override
+    protected boolean supportsMultimodalToolResults() {
+        return true;
     }
 }

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/common/BedrockAiServiceWithToolsIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/common/BedrockAiServiceWithToolsIT.java
@@ -3,7 +3,6 @@ package dev.langchain4j.model.bedrock.common;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.service.common.AbstractAiServiceWithToolsIT;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.util.List;
@@ -20,20 +19,12 @@ class BedrockAiServiceWithToolsIT extends AbstractAiServiceWithToolsIT {
     }
 
     @Override
-    @Disabled("Bedrock is too strict and expects assistant message after tool message")
-    protected void should_keep_memory_consistent_using_return_immediate(ChatModel model) {}
-
-    @Override
-    @Disabled("Mistral is hallucinating in this test")
-    protected void should_return_immediately_from_first_tool_when_not_called_in_parallel(ChatModel model) {}
+    protected boolean supportsMultimodalToolResults() {
+        return true;
+    }
 
     @AfterEach
     void afterEach() {
         sleepIfNeeded();
-    }
-
-    @Override
-    protected boolean supportsMultimodalToolResults() {
-        return true;
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/TextContent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/TextContent.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import static dev.langchain4j.data.message.ContentType.TEXT;
 import static dev.langchain4j.internal.Utils.quoted;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 /**
  * Represents a text content.
@@ -18,7 +18,7 @@ public class TextContent implements Content {
      * @param text the text.
      */
     public TextContent(String text) {
-        this.text = ensureNotBlank(text, "text");
+        this.text = ensureNotNull(text, "text");
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
@@ -3,21 +3,28 @@ package dev.langchain4j.data.message;
 import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.util.Arrays.asList;
 
+import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 /**
  * Represents the result of a tool execution in response to a {@link ToolExecutionRequest}.
  * {@link ToolExecutionRequest}s come from a previous {@link AiMessage#toolExecutionRequests()}.
+ * <br>
+ * <br>
+ * The result is stored as a list of {@link Content}s. Typically, the result is a single {@link TextContent},
+ * but some LLM providers also support {@link ImageContent} in tool results.
  */
 public class ToolExecutionResultMessage implements ChatMessage {
 
     private final String id;
     private final String toolName;
-    private final String text;
+    private final List<Content> contents;
     private final Boolean isError;
     private final Map<String, Object> attributes;
 
@@ -29,7 +36,19 @@ public class ToolExecutionResultMessage implements ChatMessage {
     public ToolExecutionResultMessage(Builder builder) {
         this.id = builder.id;
         this.toolName = builder.toolName;
-        this.text = ensureNotNull(builder.text, "text");
+
+        boolean hasText = builder.text != null;
+        boolean hasContents = builder.contents != null && !builder.contents.isEmpty();
+        if (hasText && hasContents) {
+            throw new IllegalArgumentException("Either text or contents must be provided, not both");
+        } else if (hasContents) {
+            this.contents = copy(builder.contents);
+        } else if (hasText) {
+            this.contents = List.of(TextContent.from(builder.text));
+        } else {
+            throw new IllegalArgumentException("Either text or contents must be provided");
+        }
+
         this.isError = builder.isError;
         this.attributes = copy(builder.attributes);
     }
@@ -43,7 +62,7 @@ public class ToolExecutionResultMessage implements ChatMessage {
     public ToolExecutionResultMessage(String id, String toolName, String text) {
         this.id = id;
         this.toolName = toolName;
-        this.text = ensureNotNull(text, "text");
+        this.contents = List.of(TextContent.from(ensureNotNull(text, "text")));
         this.isError = null;
         this.attributes = Map.of();
     }
@@ -65,11 +84,42 @@ public class ToolExecutionResultMessage implements ChatMessage {
     }
 
     /**
-     * Returns the result of the tool execution.
-     * @return the result of the tool execution.
+     * Returns the result of the tool execution as text.
+     *
+     * @return the text result of the tool execution.
+     * @throws IllegalStateException if contents contains non-text or multiple content elements.
+     *                               Use {@link #contents()} instead.
      */
     public String text() {
-        return text;
+        if (contents.size() == 1 && contents.get(0) instanceof TextContent textContent) {
+            return textContent.text();
+        }
+        throw new IllegalStateException(
+                "text() cannot be called when contents contains non-text or multiple content elements. "
+                        + "Use contents() instead.");
+    }
+
+    /**
+     * Returns the {@link Content}s of the tool execution result.
+     *
+     * @return the contents.
+     * @since 1.13.0
+     */
+    @Experimental
+    public List<Content> contents() {
+        return contents;
+    }
+
+    /**
+     * Whether this message contains a single {@link TextContent}.
+     *
+     * @return {@code true} if this message contains exactly one element which is a {@link TextContent}.
+     * @since 1.13.0
+     * @see #text()
+     */
+    @Experimental
+    public boolean hasSingleText() {
+        return contents.size() == 1 && contents.get(0) instanceof TextContent;
     }
 
     /**
@@ -102,14 +152,14 @@ public class ToolExecutionResultMessage implements ChatMessage {
         ToolExecutionResultMessage that = (ToolExecutionResultMessage) o;
         return Objects.equals(this.id, that.id)
                 && Objects.equals(this.toolName, that.toolName)
-                && Objects.equals(this.text, that.text)
+                && Objects.equals(this.contents, that.contents)
                 && Objects.equals(this.isError, that.isError)
                 && Objects.equals(this.attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, toolName, text, isError, attributes);
+        return Objects.hash(id, toolName, contents, isError, attributes);
     }
 
     @Override
@@ -117,7 +167,7 @@ public class ToolExecutionResultMessage implements ChatMessage {
         return "ToolExecutionResultMessage{" +
                 "id='" + id + '\'' +
                 ", toolName='" + toolName + '\'' +
-                ", text='" + text + '\'' +
+                ", contents=" + contents +
                 ", isError=" + isError +
                 ", attributes=" + attributes +
                 '}';
@@ -136,6 +186,7 @@ public class ToolExecutionResultMessage implements ChatMessage {
         private String id;
         private String toolName;
         private String text;
+        private List<Content> contents;
         private Boolean isError;
         private Map<String, Object> attributes;
 
@@ -161,12 +212,42 @@ public class ToolExecutionResultMessage implements ChatMessage {
 
         /**
          * Sets the result text of the tool execution.
+         * The text will be wrapped into a single {@link TextContent}.
+         * Mutually exclusive with {@link #contents(List)}.
+         *
          * @param text the result of the tool execution.
          * @return the builder.
          */
         public Builder text(String text) {
             this.text = text;
             return this;
+        }
+
+        /**
+         * Sets the contents of the tool execution result.
+         * Mutually exclusive with {@link #text(String)}.
+         *
+         * @param contents the contents.
+         * @return the builder.
+         * @since 1.13.0
+         */
+        @Experimental
+        public Builder contents(List<Content> contents) {
+            this.contents = contents;
+            return this;
+        }
+
+        /**
+         * Sets the contents of the tool execution result.
+         * Mutually exclusive with {@link #text(String)}.
+         *
+         * @param contents the contents.
+         * @return the builder.
+         * @since 1.13.0
+         */
+        @Experimental
+        public Builder contents(Content... contents) {
+            return contents(asList(contents));
         }
 
         /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/ToolExecutionResultMessage.java
@@ -41,10 +41,10 @@ public class ToolExecutionResultMessage implements ChatMessage {
         boolean hasContents = builder.contents != null && !builder.contents.isEmpty();
         if (hasText && hasContents) {
             throw new IllegalArgumentException("Either text or contents must be provided, not both");
-        } else if (hasContents) {
-            this.contents = copy(builder.contents);
         } else if (hasText) {
             this.contents = List.of(TextContent.from(builder.text));
+        } else if (hasContents) {
+            this.contents = copy(builder.contents);
         } else {
             throw new IllegalArgumentException("Either text or contents must be provided");
         }

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/ToolExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/ToolExecutedEvent.java
@@ -1,23 +1,43 @@
 package dev.langchain4j.observability.api.event;
 
+import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.observability.event.DefaultToolExecutedEvent;
+
+import java.util.List;
 
 /**
  * Invoked after the tool is executed.
  * It is important to note that this can be invoked multiple times within a single AI Service invocation.
  */
 public interface ToolExecutedEvent extends AiServiceEvent {
+
     /**
      * Gets the {@link ToolExecutionRequest} that initiated the tool execution.
      */
     ToolExecutionRequest request();
 
     /**
-     * Gets the result of the tool execution
+     * Returns the tool execution result as a plain text string.
+     * This is a convenience method for when the result is known to be a single {@link TextContent}.
+     *
+     * @return the text of the single {@link TextContent} element.
+     * @throws IllegalStateException if the result contains non-text or multiple content elements.
+     *                               Use {@link #resultContents()} instead.
      */
     String resultText();
+
+    /**
+     * Returns the contents of the tool execution result.
+     *
+     * @return the list of {@link Content} elements, never {@code null}.
+     * @since 1.13.0
+     */
+    @Experimental
+    List<Content> resultContents();
 
     /**
      * Creates a new builder instance for constructing a {@link ToolExecutedEvent}.
@@ -37,8 +57,10 @@ public interface ToolExecutedEvent extends AiServiceEvent {
     }
 
     class ToolExecutedEventBuilder extends Builder<ToolExecutedEvent> {
+
         private ToolExecutionRequest request;
         private String resultText;
+        private List<Content> resultContents;
 
         protected ToolExecutedEventBuilder() {}
 
@@ -49,6 +71,7 @@ public interface ToolExecutedEvent extends AiServiceEvent {
             super(src);
             request(src.request());
             resultText(src.resultText());
+            resultContents(src.resultContents());
         }
 
         /**
@@ -60,10 +83,23 @@ public interface ToolExecutedEvent extends AiServiceEvent {
         }
 
         /**
-         * Sets the tool execution result text.
+         * Sets the tool execution result text. The text will be wrapped into a single {@link TextContent}.
+         * Mutually exclusive with {@link #resultContents(List)}.
          */
         public ToolExecutedEventBuilder resultText(String resultText) {
             this.resultText = resultText;
+            return this;
+        }
+
+        /**
+         * Sets the tool execution result contents.
+         * Mutually exclusive with {@link #resultText(String)}.
+         *
+         * @since 1.13.0
+         */
+        @Experimental
+        public ToolExecutedEventBuilder resultContents(List<Content> resultContents) {
+            this.resultContents = resultContents;
             return this;
         }
 
@@ -75,6 +111,10 @@ public interface ToolExecutedEvent extends AiServiceEvent {
             return resultText;
         }
 
+        public List<Content> resultContents() {
+            return resultContents;
+        }
+
         @Override
         public ToolExecutedEventBuilder invocationContext(InvocationContext invocationContext) {
             return (ToolExecutedEventBuilder) super.invocationContext(invocationContext);
@@ -82,6 +122,8 @@ public interface ToolExecutedEvent extends AiServiceEvent {
 
         /**
          * Builds a {@link ToolExecutedEvent}.
+         *
+         * @throws IllegalArgumentException if neither or both of {@code resultText} and {@code resultContents} are set.
          */
         public ToolExecutedEvent build() {
             return new DefaultToolExecutedEvent(this);

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultToolExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultToolExecutedEvent.java
@@ -1,9 +1,15 @@
 package dev.langchain4j.observability.event;
 
+import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
+import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.observability.api.event.ToolExecutedEvent;
+
+import java.util.List;
 
 /**
  * Default implementation of {@link ToolExecutedEvent}.
@@ -11,12 +17,24 @@ import dev.langchain4j.observability.api.event.ToolExecutedEvent;
 public class DefaultToolExecutedEvent extends AbstractAiServiceEvent implements ToolExecutedEvent {
 
     private final ToolExecutionRequest request;
-    private final String resultText;
+    private final List<Content> resultContents;
 
     public DefaultToolExecutedEvent(ToolExecutedEventBuilder builder) {
         super(builder);
         this.request = ensureNotNull(builder.request(), "request");
-        this.resultText = ensureNotNull(builder.resultText(), "resultText");
+
+        boolean hasResultContents = builder.resultContents() != null;
+        boolean hasResultText = builder.resultText() != null;
+
+        if (hasResultContents && hasResultText) {
+            throw new IllegalArgumentException("resultText and resultContents are mutually exclusive");
+        } else if (hasResultContents) {
+            this.resultContents = copy(builder.resultContents());
+        } else if (hasResultText) {
+            this.resultContents = List.of(TextContent.from(builder.resultText()));
+        } else {
+            throw new IllegalArgumentException("Either resultText or resultContents must be provided");
+        }
     }
 
     @Override
@@ -26,6 +44,17 @@ public class DefaultToolExecutedEvent extends AbstractAiServiceEvent implements 
 
     @Override
     public String resultText() {
-        return resultText;
+        if (resultContents.size() == 1 && resultContents.get(0) instanceof TextContent textContent) {
+            return textContent.text();
+        }
+        throw new IllegalStateException(
+                "resultText() cannot be called when resultContents contains non-text or multiple content elements. "
+                        + "Use resultContents() instead.");
+    }
+
+    @Override
+    @Experimental
+    public List<Content> resultContents() {
+        return resultContents;
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultToolExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultToolExecutedEvent.java
@@ -23,15 +23,15 @@ public class DefaultToolExecutedEvent extends AbstractAiServiceEvent implements 
         super(builder);
         this.request = ensureNotNull(builder.request(), "request");
 
-        boolean hasResultContents = builder.resultContents() != null;
         boolean hasResultText = builder.resultText() != null;
+        boolean hasResultContents = builder.resultContents() != null && !builder.resultContents().isEmpty();
 
-        if (hasResultContents && hasResultText) {
+        if (hasResultText && hasResultContents) {
             throw new IllegalArgumentException("resultText and resultContents are mutually exclusive");
-        } else if (hasResultContents) {
-            this.resultContents = copy(builder.resultContents());
         } else if (hasResultText) {
             this.resultContents = List.of(TextContent.from(builder.resultText()));
+        } else if (hasResultContents) {
+            this.resultContents = copy(builder.resultContents());
         } else {
             throw new IllegalArgumentException("Either resultText or resultContents must be provided");
         }

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/ChatMessageSerializerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/ChatMessageSerializerTest.java
@@ -95,7 +95,7 @@ class ChatMessageSerializerTest {
                         "{\"text\":\"test-text\",\"thinking\":\"test-thinking\",\"toolExecutionRequests\":[{\"name\":\"weather\",\"arguments\":\"{\\\"city\\\": \\\"Munich\\\"}\"}],\"attributes\":{\"name\":\"Klaus\",\"age\":42,\"extra\":[\"one\",\"two\"]},\"type\":\"AI\"}"),
                 Arguments.of(
                         ToolExecutionResultMessage.from("12345", "weather", "sunny"),
-                        "{\"id\":\"12345\",\"toolName\":\"weather\",\"text\":\"sunny\",\"attributes\":{},\"type\":\"TOOL_EXECUTION_RESULT\"}"),
+                        "{\"id\":\"12345\",\"toolName\":\"weather\",\"contents\":[{\"text\":\"sunny\",\"type\":\"TEXT\"}],\"attributes\":{},\"type\":\"TOOL_EXECUTION_RESULT\"}"),
                 Arguments.of(
                         ToolExecutionResultMessage.builder()
                                 .id("12345")
@@ -103,13 +103,13 @@ class ChatMessageSerializerTest {
                                 .text("error occurred")
                                 .isError(true)
                                 .build(),
-                        "{\"id\":\"12345\",\"toolName\":\"weather\",\"text\":\"error occurred\",\"isError\":true,\"attributes\":{},\"type\":\"TOOL_EXECUTION_RESULT\"}"),
+                        "{\"id\":\"12345\",\"toolName\":\"weather\",\"contents\":[{\"text\":\"error occurred\",\"type\":\"TEXT\"}],\"isError\":true,\"attributes\":{},\"type\":\"TOOL_EXECUTION_RESULT\"}"),
                 Arguments.of(
                         ToolExecutionResultMessage.from(null, null, "sunny"),
-                        "{\"text\":\"sunny\",\"attributes\":{},\"type\":\"TOOL_EXECUTION_RESULT\"}"),
+                        "{\"contents\":[{\"text\":\"sunny\",\"type\":\"TEXT\"}],\"attributes\":{},\"type\":\"TOOL_EXECUTION_RESULT\"}"),
                 Arguments.of(
                         ToolExecutionResultMessage.from("", "", "sunny"),
-                        "{\"id\":\"\",\"toolName\":\"\",\"text\":\"sunny\",\"attributes\":{},\"type\":\"TOOL_EXECUTION_RESULT\"}"),
+                        "{\"id\":\"\",\"toolName\":\"\",\"contents\":[{\"text\":\"sunny\",\"type\":\"TEXT\"}],\"attributes\":{},\"type\":\"TOOL_EXECUTION_RESULT\"}"),
                 Arguments.of(
                         ToolExecutionResultMessage.builder()
                                 .id("67890")
@@ -121,7 +121,7 @@ class ChatMessageSerializerTest {
                                     }
                                 })
                                 .build(),
-                        "{\"id\":\"67890\",\"toolName\":\"tool_search_tool\",\"text\":\"Tools found: weather, time\",\"attributes\":{\"found_tools\":[\"weather\", \"time\"]},\"type\":\"TOOL_EXECUTION_RESULT\"}"),
+                        "{\"id\":\"67890\",\"toolName\":\"tool_search_tool\",\"contents\":[{\"text\":\"Tools found: weather, time\",\"type\":\"TEXT\"}],\"attributes\":{\"found_tools\":[\"weather\", \"time\"]},\"type\":\"TOOL_EXECUTION_RESULT\"}"),
                 Arguments.of(
                         CustomMessage.from(new LinkedHashMap<>() {
                             {
@@ -194,6 +194,7 @@ class ChatMessageSerializerTest {
         assertThat(deserialized.id()).isEqualTo("12345");
         assertThat(deserialized.toolName()).isEqualTo("weather");
         assertThat(deserialized.text()).isEqualTo("sunny");
+        assertThat(deserialized.contents()).isEqualTo(List.of(TextContent.from("sunny")));
         assertThat(deserialized.isError()).isNull();
     }
 
@@ -206,6 +207,7 @@ class ChatMessageSerializerTest {
         assertThat(deserialized.id()).isEqualTo("12345");
         assertThat(deserialized.toolName()).isEqualTo("weather");
         assertThat(deserialized.text()).isEqualTo("sunny");
+        assertThat(deserialized.contents()).isEqualTo(List.of(TextContent.from("sunny")));
         assertThat(deserialized.attributes()).isEmpty();
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/ToolExecutionResultMessageTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/ToolExecutionResultMessageTest.java
@@ -1,8 +1,13 @@
 package dev.langchain4j.data.message;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.image.Image;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
 
 class ToolExecutionResultMessageTest implements WithAssertions {
 
@@ -12,12 +17,15 @@ class ToolExecutionResultMessageTest implements WithAssertions {
         assertThat(tm.id()).isEqualTo("id");
         assertThat(tm.toolName()).isEqualTo("toolName");
         assertThat(tm.text()).isEqualTo("text");
+        assertThat(tm.contents()).hasSize(1);
+        assertThat(tm.contents().get(0)).isInstanceOf(TextContent.class);
+        assertThat(tm.hasSingleText()).isTrue();
         assertThat(tm.isError()).isNull();
         assertThat(tm.type()).isEqualTo(ChatMessageType.TOOL_EXECUTION_RESULT);
-
-        assertThat(tm)
-                .hasToString(
-                        "ToolExecutionResultMessage{id='id', toolName='toolName', text='text', isError=null, attributes={}}");
+        assertThat(tm.toString())
+                .contains("id='id'", "toolName='toolName'", "isError=null")
+                .contains("TextContent")
+                .contains("text");
     }
 
     @Test
@@ -31,12 +39,14 @@ class ToolExecutionResultMessageTest implements WithAssertions {
         assertThat(tm.id()).isEqualTo("id");
         assertThat(tm.toolName()).isEqualTo("toolName");
         assertThat(tm.text()).isEqualTo("error message");
+        assertThat(tm.contents()).containsExactly(TextContent.from("error message"));
         assertThat(tm.isError()).isTrue();
         assertThat(tm.type()).isEqualTo(ChatMessageType.TOOL_EXECUTION_RESULT);
 
-        assertThat(tm)
-                .hasToString(
-                        "ToolExecutionResultMessage{id='id', toolName='toolName', text='error message', isError=true, attributes={}}");
+        assertThat(tm.toString())
+                .contains("id='id'", "toolName='toolName'", "isError=true")
+                .contains("TextContent")
+                .contains("error message");
     }
 
     @Test
@@ -88,10 +98,166 @@ class ToolExecutionResultMessageTest implements WithAssertions {
                         .build());
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void should_allow_empty_or_blank_text(String text) {
+        ToolExecutionResultMessage message = new ToolExecutionResultMessage("id", "toolName", text);
+        assertThat(message.text()).isEqualTo(text);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void should_allow_empty_or_blank_text__builder_text(String text) {
+        ToolExecutionResultMessage message = ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("toolName")
+                .text(text)
+                .build();
+        assertThat(message.text()).isEqualTo(text);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void should_allow_empty_or_blank_text__builder_contents(String text) {
+        ToolExecutionResultMessage message = ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("toolName")
+                .contents(TextContent.from(text))
+                .build();
+        assertThat(message.text()).isEqualTo(text);
+    }
+
     @Test
-    void should_allow_empty_text() {
-        // empty tool output is a valid use case (e.g., "no data" or side-effect-only tool)
-        ToolExecutionResultMessage message = new ToolExecutionResultMessage("id", "toolName", "");
-        assertThat(message.text()).isEqualTo("");
+    void builder_text_should_produce_single_TextContent() {
+        ToolExecutionResultMessage message = ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("tool")
+                .text("hello")
+                .build();
+
+        assertThat(message.text()).isEqualTo("hello");
+        assertThat(message.contents()).containsExactly(TextContent.from("hello"));
+        assertThat(message.hasSingleText()).isTrue();
+    }
+
+    @Test
+    void builder_contents_with_single_TextContent() {
+        ToolExecutionResultMessage message = ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("tool")
+                .contents(TextContent.from("hello"))
+                .build();
+
+        assertThat(message.text()).isEqualTo("hello");
+        assertThat(message.contents()).containsExactly(TextContent.from("hello"));
+        assertThat(message.hasSingleText()).isTrue();
+    }
+
+    @Test
+    void builder_contents_with_single_ImageContent() {
+        ImageContent image = ImageContent.from(
+                Image.builder().base64Data("abc").mimeType("image/png").build());
+
+        ToolExecutionResultMessage message = ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("tool")
+                .contents(image)
+                .build();
+
+        assertThat(message.contents()).containsExactly(image);
+        assertThat(message.hasSingleText()).isFalse();
+        assertThatThrownBy(message::text)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Use contents() instead");
+    }
+
+    @Test
+    void builder_contents_with_text_and_image() {
+        TextContent text = TextContent.from("description");
+        ImageContent image = ImageContent.from(
+                Image.builder().base64Data("abc").mimeType("image/png").build());
+
+        ToolExecutionResultMessage message = ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("tool")
+                .contents(text, image)
+                .build();
+
+        assertThat(message.contents()).containsExactly(text, image);
+        assertThat(message.hasSingleText()).isFalse();
+        assertThatThrownBy(message::text)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Use contents() instead");
+    }
+
+    @Test
+    void builder_contents_with_multiple_TextContent() {
+        ToolExecutionResultMessage message = ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("tool")
+                .contents(TextContent.from("first"), TextContent.from("second"))
+                .build();
+
+        assertThat(message.contents()).hasSize(2);
+        assertThat(message.hasSingleText()).isFalse();
+        assertThatThrownBy(message::text)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Use contents() instead");
+    }
+
+    @Test
+    void builder_contents_with_list() {
+        List<Content> contents = List.of(
+                TextContent.from("text"),
+                ImageContent.from(Image.builder().base64Data("abc").mimeType("image/png").build()));
+
+        ToolExecutionResultMessage message = ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("tool")
+                .contents(contents)
+                .build();
+
+        assertThat(message.contents()).isEqualTo(contents);
+        assertThat(message.hasSingleText()).isFalse();
+    }
+
+    @Test
+    void builder_should_fail_when_both_text_and_contents_set() {
+        assertThatThrownBy(() -> ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("tool")
+                .text("hello")
+                .contents(TextContent.from("world"))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not both");
+    }
+
+    @Test
+    void builder_should_fail_when_neither_text_nor_contents_set() {
+        assertThatThrownBy(() -> ToolExecutionResultMessage.builder()
+                .id("id")
+                .toolName("tool")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Either text or contents must be provided");
+    }
+
+    @Test
+    void constructor_text_produces_single_TextContent() {
+        ToolExecutionResultMessage message = new ToolExecutionResultMessage("id", "tool", "hello");
+
+        assertThat(message.text()).isEqualTo("hello");
+        assertThat(message.contents()).containsExactly(TextContent.from("hello"));
+        assertThat(message.hasSingleText()).isTrue();
+    }
+
+    @Test
+    void constructor_empty_text_produces_single_empty_TextContent() {
+        ToolExecutionResultMessage message = new ToolExecutionResultMessage("id", "tool", "");
+
+        assertThat(message.text()).isEmpty();
+        assertThat(message.contents()).containsExactly(TextContent.from(""));
+        assertThat(message.hasSingleText()).isTrue();
     }
 }

--- a/langchain4j-github-models/src/main/java/dev/langchain4j/model/github/InternalGitHubModelHelper.java
+++ b/langchain4j-github-models/src/main/java/dev/langchain4j/model/github/InternalGitHubModelHelper.java
@@ -67,6 +67,7 @@ import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -206,6 +207,11 @@ class InternalGitHubModelHelper {
             return chatRequestAssistantMessage;
         } else if (message instanceof ToolExecutionResultMessage) {
             ToolExecutionResultMessage toolExecutionResultMessage = (ToolExecutionResultMessage) message;
+            if (!toolExecutionResultMessage.hasSingleText()) {
+                throw new UnsupportedFeatureException(
+                        "GitHub Models does not support non-text content in tool results. "
+                                + "Only text content is supported.");
+            }
             ChatRequestToolMessage chatRequestToolMessage = new ChatRequestToolMessage(toolExecutionResultMessage.id());
             chatRequestToolMessage.setContent(toolExecutionResultMessage.text());
             return chatRequestToolMessage;

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
@@ -36,6 +36,7 @@ import dev.langchain4j.model.googleai.GeminiContent.GeminiPart.GeminiFunctionRes
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -352,6 +353,30 @@ final class PartsAndContentsMapper {
                                     GeminiRole.USER.toString());
                         case TOOL_EXECUTION_RESULT:
                             ToolExecutionResultMessage toolResultMessage = (ToolExecutionResultMessage) msg;
+
+                            if (!toolResultMessage.hasSingleText()) {
+                                List<GeminiContent.GeminiPart> toolParts = new ArrayList<>();
+                                Map<String, String> responseMap = new HashMap<>();
+                                for (dev.langchain4j.data.message.Content content : toolResultMessage.contents()) {
+                                    if (content instanceof TextContent textContent) {
+                                        responseMap.put("response", textContent.text());
+                                    } else if (content instanceof ImageContent imageContent) {
+                                        toolParts.add(fromContentToGPart(imageContent, mediaResolutionPerPartEnabled));
+                                    } else {
+                                        throw new UnsupportedFeatureException(
+                                                "Google AI Gemini does not support content type '"
+                                                        + content.type() + "' in tool results.");
+                                    }
+                                }
+                                if (responseMap.isEmpty()) {
+                                    responseMap.put("response", "");
+                                }
+                                toolParts.add(0, GeminiContent.GeminiPart.builder()
+                                        .functionResponse(new GeminiFunctionResponse(
+                                                toolResultMessage.toolName(), responseMap))
+                                        .build());
+                                return new GeminiContent(toolParts, GeminiRole.USER.toString());
+                            }
 
                             return new GeminiContent(
                                     List.of(GeminiContent.GeminiPart.builder()

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/common/GoogleAiGeminiAiServiceWithToolsIT.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/common/GoogleAiGeminiAiServiceWithToolsIT.java
@@ -35,4 +35,9 @@ class GoogleAiGeminiAiServiceWithToolsIT extends AbstractAiServiceWithToolsIT {
     @ParameterizedTest
     @MethodSource("models")
     protected void should_execute_tool_with_list_of_strings_parameter(ChatModel model) {}
+
+    @Override
+    protected boolean supportsMultimodalToolResults() {
+        return true;
+    }
 }

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/common/GoogleAiGeminiAiServiceWithToolsIT.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/common/GoogleAiGeminiAiServiceWithToolsIT.java
@@ -17,7 +17,7 @@ class GoogleAiGeminiAiServiceWithToolsIT extends AbstractAiServiceWithToolsIT {
     protected List<ChatModel> models() {
         return Collections.singletonList(GoogleAiGeminiChatModel.builder()
                 .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
-                .modelName("gemini-2.0-flash")
+                .modelName("gemini-2.5-flash")
                 .temperature(0.0)
                 .logRequests(true)
                 .logResponses(true)
@@ -29,12 +29,6 @@ class GoogleAiGeminiAiServiceWithToolsIT extends AbstractAiServiceWithToolsIT {
     @ParameterizedTest
     @MethodSource("models")
     protected void should_execute_tool_with_pojo_with_nested_pojo(ChatModel model) {}
-
-    @Disabled("Gemini cannot do it properly")
-    @Override
-    @ParameterizedTest
-    @MethodSource("models")
-    protected void should_execute_tool_with_list_of_strings_parameter(ChatModel model) {}
 
     @Override
     protected boolean supportsMultimodalToolResults() {

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaChatModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaChatModel.java
@@ -19,6 +19,7 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.internal.RetryUtils;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
@@ -145,6 +146,11 @@ public class JlamaChatModel implements ChatModel {
                 }
                 case TOOL_EXECUTION_RESULT -> {
                     ToolExecutionResultMessage toolMessage = (ToolExecutionResultMessage) message;
+                    if (!toolMessage.hasSingleText()) {
+                        throw new UnsupportedFeatureException(
+                                "Jlama does not support non-text content in tool results. "
+                                        + "Only text content is supported.");
+                    }
                     ToolResult result = ToolResult.from(toolMessage.toolName(), toolMessage.id(), toolMessage.text());
                     promptBuilder.addToolResult(result);
                 }

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingChatModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingChatModel.java
@@ -19,6 +19,7 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.internal.RetryUtils;
 import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -163,6 +164,11 @@ public class JlamaStreamingChatModel implements StreamingChatModel {
                 }
                 case TOOL_EXECUTION_RESULT -> {
                     ToolExecutionResultMessage toolMessage = (ToolExecutionResultMessage) message;
+                    if (!toolMessage.hasSingleText()) {
+                        throw new UnsupportedFeatureException(
+                                "Jlama does not support non-text content in tool results. "
+                                        + "Only text content is supported.");
+                    }
                     ToolResult result = ToolResult.from(toolMessage.toolName(), toolMessage.id(), toolMessage.text());
                     promptBuilder.addToolResult(result);
                 }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/mapper/MistralAiMapper.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/mapper/MistralAiMapper.java
@@ -24,6 +24,7 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
@@ -100,6 +101,11 @@ public class MistralAiMapper {
         }
 
         if (message instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+            if (!toolExecutionResultMessage.hasSingleText()) {
+                throw new UnsupportedFeatureException(
+                        "Mistral AI does not support non-text content in tool results. "
+                                + "Only text content is supported.");
+            }
             return MistralAiChatMessage.builder()
                     .role(MistralAiRole.TOOL)
                     .toolCallId(toolExecutionResultMessage.id())

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -259,6 +259,11 @@ class InternalOllamaHelper {
         } else if (chatMessage instanceof AiMessage aiMessage) {
             return aiMessage.text();
         } else if (chatMessage instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+            if (!toolExecutionResultMessage.hasSingleText()) {
+                throw new UnsupportedFeatureException(
+                        "Ollama does not support non-text content in tool results. "
+                                + "Only text content is supported.");
+            }
             return toolExecutionResultMessage.text();
         } else {
             throw new IllegalArgumentException("Unsupported message type: " + chatMessage.type());

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -117,6 +117,11 @@ class InternalOpenAiOfficialHelper {
         }
 
         if (message instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+            if (!toolExecutionResultMessage.hasSingleText()) {
+                throw new UnsupportedFeatureException(
+                        "OpenAI Chat Completions API does not support non-text content in tool results. "
+                                + "Only text content is supported.");
+            }
             return ChatCompletionMessageParam.ofTool(ChatCompletionToolMessageParam.builder()
                     .toolCallId(toolExecutionResultMessage.id())
                     .content(toolExecutionResultMessage.text())

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
@@ -56,6 +56,7 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.internal.ExceptionMapper;
 import dev.langchain4j.model.ModelProvider;
@@ -360,6 +361,11 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
 
             return items;
         } else if (msg instanceof ToolExecutionResultMessage toolResultMessage) {
+            if (!toolResultMessage.hasSingleText()) {
+                throw new UnsupportedFeatureException(
+                        "OpenAI Responses API does not support non-text content in tool results. "
+                                + "Only text content is supported in function_call_output.");
+            }
             // Tool execution result - convert to function call output
             return List.of(ResponseInputItem.ofFunctionCallOutput(ResponseInputItem.FunctionCallOutput.builder()
                     .callId(toolResultMessage.id())

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -366,6 +366,11 @@ class OpenAiResponsesClient {
 
             return items;
         } else if (msg instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+            if (!toolExecutionResultMessage.hasSingleText()) {
+                throw new UnsupportedFeatureException(
+                        "OpenAI Responses API does not support non-text content in tool results. "
+                                + "Only text content is supported in function_call_output.");
+            }
             var outputEntry = new HashMap<String, Object>();
             outputEntry.put(FIELD_TYPE, TYPE_FUNCTION_CALL_OUTPUT);
             outputEntry.put(FIELD_CALL_ID, toolExecutionResultMessage.id());

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
@@ -172,6 +172,11 @@ public class OpenAiUtils {
         }
 
         if (message instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+            if (!toolExecutionResultMessage.hasSingleText()) {
+                throw new UnsupportedFeatureException(
+                        "OpenAI Chat Completions API does not support non-text content in tool results. "
+                                + "Only text content is supported.");
+            }
 
             if (toolExecutionResultMessage.id() == null) {
                 return FunctionMessage.from(toolExecutionResultMessage.toolName(), toolExecutionResultMessage.text());

--- a/langchain4j-vertex-ai-anthropic/src/main/java/dev/langchain4j/model/vertexai/anthropic/internal/mapper/AnthropicRequestMapper.java
+++ b/langchain4j-vertex-ai-anthropic/src/main/java/dev/langchain4j/model/vertexai/anthropic/internal/mapper/AnthropicRequestMapper.java
@@ -110,6 +110,11 @@ public class AnthropicRequestMapper {
     }
 
     private static AnthropicContent toAnthropicToolResultContent(ToolExecutionResultMessage message) {
+        if (!message.hasSingleText()) {
+            throw new UnsupportedFeatureException(
+                    "Vertex AI Anthropic does not support non-text content in tool results. "
+                            + "Only text content is supported.");
+        }
         return AnthropicContent.toolResult(message.id(), message.text());
     }
 

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
@@ -13,6 +13,7 @@ import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
 import dev.langchain4j.data.audio.Audio;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.AudioContent;
@@ -107,6 +108,11 @@ class PartsMapper {
             return singletonList(
                     Part.newBuilder().setText((systemMessage).text()).build());
         } else if (message instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+            if (!toolExecutionResultMessage.hasSingleText()) {
+                throw new UnsupportedFeatureException(
+                        "Vertex AI Gemini does not support non-text content in tool results. "
+                                + "Only text content is supported.");
+            }
             String functionResponseText = toolExecutionResultMessage.text();
             Struct responseStruct = parseFunctionResponseToStruct(functionResponseText);
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/Converter.java
@@ -221,6 +221,11 @@ class Converter {
     }
 
     private static ToolMessage toToolMessage(ToolExecutionResultMessage toolExecutionResultMessage) {
+        if (!toolExecutionResultMessage.hasSingleText()) {
+            throw new UnsupportedFeatureException(
+                    "watsonx does not support non-text content in tool results. "
+                            + "Only text content is supported.");
+        }
         return ToolMessage.of(toolExecutionResultMessage.text(), toolExecutionResultMessage.id());
     }
 }

--- a/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/WorkersAiChatModel.java
+++ b/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/WorkersAiChatModel.java
@@ -5,6 +5,7 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -180,6 +181,11 @@ public class WorkersAiChatModel extends AbstractWorkersAIModel implements ChatMo
         } else if (chatMessage instanceof AiMessage aiMessage) {
             return aiMessage.text();
         } else if (chatMessage instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+            if (!toolExecutionResultMessage.hasSingleText()) {
+                throw new UnsupportedFeatureException(
+                        "Workers AI does not support non-text content in tool results. "
+                                + "Only text content is supported.");
+            }
             return toolExecutionResultMessage.text();
         } else {
             throw new IllegalArgumentException("Unsupported message type: " + chatMessage.type());

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -247,7 +247,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         context.eventListenerRegistrar.fireEvent(ToolExecutedEvent.builder()
                 .invocationContext(invocationContext)
                 .request(toolRequestResult.request())
-                .resultText(toolRequestResult.result().resultText())
+                .resultContents(toolRequestResult.result().resultContents())
                 .build());
     }
 
@@ -302,13 +302,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                         ToolExecutionRequest toolRequest = toolRequestResult.request();
                         ToolExecutionResult toolResult = toolRequestResult.result();
                         toolResults.add(toolResult);
-                        ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.builder()
-                                .id(toolRequest.id())
-                                .toolName(toolRequest.name())
-                                .text(toolResult.resultText())
-                                .isError(toolResult.isError())
-                                .attributes(toolResult.attributes())
-                                .build();
+                        ToolExecutionResultMessage toolExecutionResultMessage =
+                                toResultMessage(toolRequest, toolResult);
                         addToMemory(toolExecutionResultMessage);
                         immediateToolReturn = immediateToolReturn
                                 && context.toolService.isImmediateTool(toolExecutionResultMessage.toolName());
@@ -329,13 +324,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     toolResults.add(toolResult);
                     ToolRequestResult toolRequestResult = new ToolRequestResult(toolRequest, toolResult);
                     fireToolExecutedEvent(toolRequestResult);
-                    ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.builder()
-                            .id(toolRequest.id())
-                            .toolName(toolRequest.name())
-                            .text(toolResult.resultText())
-                            .isError(toolResult.isError())
-                            .attributes(toolResult.attributes())
-                            .build();
+                    ToolExecutionResultMessage toolExecutionResultMessage =
+                            toResultMessage(toolRequest, toolResult);
                     addToMemory(toolExecutionResultMessage);
                     immediateToolReturn =
                             immediateToolReturn && context.toolService.isImmediateTool(toolRequest.name());
@@ -444,6 +434,17 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private ToolExecutionResult execute(ToolExecutionRequest toolRequest) {
         return context.toolService.executeTool(
                 invocationContext, toolExecutors, toolRequest, beforeToolExecutionHandler, toolExecutionHandler);
+    }
+
+    private static ToolExecutionResultMessage toResultMessage(
+            ToolExecutionRequest request, ToolExecutionResult result) {
+        return ToolExecutionResultMessage.builder()
+                .id(request.id())
+                .toolName(request.name())
+                .contents(result.resultContents())
+                .isError(result.isError())
+                .attributes(result.attributes())
+                .build();
     }
 
     private ChatMemory getMemory() {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -7,6 +7,9 @@ import static dev.langchain4j.service.tool.ToolExecutionRequestUtil.argumentsAsM
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolMemoryId;
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.internal.Json;
@@ -21,6 +24,7 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -149,10 +153,33 @@ public class DefaultToolExecutor implements ToolExecutor {
 
     private ToolExecutionResult execute(Object[] arguments) throws IllegalAccessException, InvocationTargetException {
         Object result = methodToInvoke.invoke(object, arguments);
+
+        List<Content> resultContents = toContents(result);
+        if (resultContents != null) {
+            return ToolExecutionResult.builder()
+                    .result(result)
+                    .resultContents(resultContents)
+                    .build();
+        }
+
         return ToolExecutionResult.builder()
                 .result(result)
                 .resultTextSupplier(() -> toText(result))
                 .build();
+    }
+
+    private List<Content> toContents(Object result) {
+        if (result instanceof Image image) {
+            return List.of(ImageContent.from(image));
+        } else if (result instanceof Content content) {
+            return List.of(content);
+        } else if (result instanceof Collection<?> collection && !collection.isEmpty()
+                && collection.iterator().next() instanceof Content) {
+            return collection.stream().map(Content.class::cast).toList();
+        } else if (result instanceof Content[] array) {
+            return List.of(array);
+        }
+        return null;
     }
 
     private String toText(Object result) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecution.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecution.java
@@ -2,8 +2,12 @@ package dev.langchain4j.service.tool;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
+import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.TextContent;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
@@ -37,10 +41,24 @@ public class ToolExecution {
      * Returns the tool execution result as text.
      *
      * @return the result of the tool execution.
+     * @see #resultContents()
      * @see #resultObject()
      */
     public String result() {
         return result.resultText();
+    }
+
+    /**
+     * Returns the contents of the tool execution result.
+     * For text-only results, returns a singleton list containing a {@link TextContent}.
+     *
+     * @see #result()
+     * @see #resultObject()
+     * @since 1.13.0
+     */
+    @Experimental
+    public List<Content> resultContents() {
+        return result.resultContents();
     }
 
     /**
@@ -49,6 +67,7 @@ public class ToolExecution {
      *
      * @return the result of the tool execution.
      * @see #result()
+     * @see #resultContents()
      */
     public Object resultObject() {
         return result.result();

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionResult.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionResult.java
@@ -1,18 +1,19 @@
 package dev.langchain4j.service.tool;
 
-import static dev.langchain4j.internal.Utils.copy;
-
 import dev.langchain4j.Experimental;
 import dev.langchain4j.data.message.Content;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.memory.ChatMemory;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+
+import static dev.langchain4j.internal.Utils.copy;
 
 /**
  * Represents the result of a tool execution.
@@ -21,9 +22,10 @@ import java.util.function.Supplier;
  * <ul>
  *   <li>{@link Builder#resultText(String)} — a text result, stored internally as a single {@link TextContent}.</li>
  *   <li>{@link Builder#resultTextSupplier(Supplier)} — a lazily computed text result.
- *       The supplier is invoked on first access to {@link #resultContents()} and the result is cached.</li>
- *   <li>{@link Builder#resultContents(List)} — a multimodal result containing
- *       any combination of {@link Content} elements (e.g. {@link TextContent}, {@link ImageContent}).</li>
+ *       The supplier is invoked on first access to {@link #resultContents()} or {@link #resultText()}
+ *       and the result is cached.</li>
+ *   <li>{@link Builder#resultContents(List)} — a result containing any combination of
+ *   {@link Content} elements (e.g. {@link TextContent}, {@link ImageContent}).</li>
  * </ul>
  *
  * <p>Regardless of which builder method was used, the canonical accessor is {@link #resultContents()},
@@ -44,11 +46,26 @@ public class ToolExecutionResult {
         this.isError = builder.isError;
         this.result = builder.result;
 
-        boolean hasResultContents = builder.resultContents != null;
         boolean hasResultText = builder.resultText != null;
         boolean hasResultTextSupplier = builder.resultTextSupplier != null;
+        boolean hasResultContents = builder.resultContents != null && !builder.resultContents.isEmpty();
+        validate(hasResultText, hasResultTextSupplier, hasResultContents);
+        if (hasResultText) {
+            this.resultContents = new AtomicReference<>(List.of(TextContent.from(builder.resultText)));
+            this.resultTextSupplier = null;
+        } else if (hasResultTextSupplier) {
+            this.resultContents = new AtomicReference<>();
+            this.resultTextSupplier = builder.resultTextSupplier;
+        } else {
+            this.resultContents = new AtomicReference<>(copy(builder.resultContents));
+            this.resultTextSupplier = null;
+        }
 
-        int setCount = (hasResultContents ? 1 : 0) + (hasResultText ? 1 : 0) + (hasResultTextSupplier ? 1 : 0);
+        this.attributes = copy(builder.attributes);
+    }
+
+    private static void validate(boolean hasResultText, boolean hasResultTextSupplier, boolean hasResultContents) {
+        int setCount = (hasResultText ? 1 : 0) + (hasResultTextSupplier ? 1 : 0) + (hasResultContents ? 1 : 0);
         if (setCount == 0) {
             throw new IllegalArgumentException(
                     "One of resultText, resultTextSupplier, or resultContents must be provided");
@@ -57,19 +74,6 @@ public class ToolExecutionResult {
             throw new IllegalArgumentException(
                     "resultText, resultTextSupplier, and resultContents are mutually exclusive");
         }
-
-        if (hasResultContents) {
-            this.resultContents = new AtomicReference<>(copy(builder.resultContents));
-            this.resultTextSupplier = null;
-        } else if (hasResultText) {
-            this.resultContents = new AtomicReference<>(List.of(TextContent.from(builder.resultText)));
-            this.resultTextSupplier = null;
-        } else {
-            this.resultContents = new AtomicReference<>();
-            this.resultTextSupplier = builder.resultTextSupplier;
-        }
-
-        this.attributes = copy(builder.attributes);
     }
 
     /**
@@ -242,7 +246,7 @@ public class ToolExecutionResult {
         }
 
         /**
-         * Sets the multimodal contents of the tool execution result.
+         * Sets the contents of the tool execution result.
          * Can contain any combination of {@link Content} elements
          * (e.g. {@link TextContent}, {@code ImageContent}).
          * Mutually exclusive with {@link #resultText(String)} and {@link #resultTextSupplier(Supplier)}.

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionResult.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionResult.java
@@ -1,10 +1,14 @@
 package dev.langchain4j.service.tool;
 
 import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.Utils.quoted;
 
+import dev.langchain4j.Experimental;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.memory.ChatMemory;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
@@ -13,13 +17,26 @@ import java.util.function.Supplier;
 /**
  * Represents the result of a tool execution.
  *
+ * <p>The result can be provided in three mutually exclusive ways via the builder:
+ * <ul>
+ *   <li>{@link Builder#resultText(String)} — a text result, stored internally as a single {@link TextContent}.</li>
+ *   <li>{@link Builder#resultTextSupplier(Supplier)} — a lazily computed text result.
+ *       The supplier is invoked on first access to {@link #resultContents()} and the result is cached.</li>
+ *   <li>{@link Builder#resultContents(List)} — a multimodal result containing
+ *       any combination of {@link Content} elements (e.g. {@link TextContent}, {@link ImageContent}).</li>
+ * </ul>
+ *
+ * <p>Regardless of which builder method was used, the canonical accessor is {@link #resultContents()},
+ * which always returns a {@code List<Content>}. The convenience method {@link #resultText()} can be used
+ * when the result is known to be a single {@link TextContent}; it throws {@link IllegalStateException} otherwise.
+ *
  * @since 1.6.0
  */
 public class ToolExecutionResult {
 
     private final boolean isError;
     private final Object result;
-    private final AtomicReference<String> resultText;
+    private final AtomicReference<List<Content>> resultContents;
     private final Supplier<String> resultTextSupplier;
     private final Map<String, Object> attributes;
 
@@ -27,61 +44,108 @@ public class ToolExecutionResult {
         this.isError = builder.isError;
         this.result = builder.result;
 
-        // If resultText is provided directly, use it; otherwise use the supplier
-        if (builder.resultText != null) {
-            this.resultText = new AtomicReference<>(builder.resultText);
+        boolean hasResultContents = builder.resultContents != null;
+        boolean hasResultText = builder.resultText != null;
+        boolean hasResultTextSupplier = builder.resultTextSupplier != null;
+
+        int setCount = (hasResultContents ? 1 : 0) + (hasResultText ? 1 : 0) + (hasResultTextSupplier ? 1 : 0);
+        if (setCount == 0) {
+            throw new IllegalArgumentException(
+                    "One of resultText, resultTextSupplier, or resultContents must be provided");
+        }
+        if (setCount > 1) {
+            throw new IllegalArgumentException(
+                    "resultText, resultTextSupplier, and resultContents are mutually exclusive");
+        }
+
+        if (hasResultContents) {
+            this.resultContents = new AtomicReference<>(copy(builder.resultContents));
             this.resultTextSupplier = null;
-        } else if (builder.resultTextSupplier != null) {
-            this.resultText = new AtomicReference<>();
-            this.resultTextSupplier = builder.resultTextSupplier;
+        } else if (hasResultText) {
+            this.resultContents = new AtomicReference<>(List.of(TextContent.from(builder.resultText)));
+            this.resultTextSupplier = null;
         } else {
-            throw new IllegalArgumentException("Either resultText or resultTextSupplier must be provided");
+            this.resultContents = new AtomicReference<>();
+            this.resultTextSupplier = builder.resultTextSupplier;
         }
 
         this.attributes = copy(builder.attributes);
     }
 
     /**
-     * Indicates whether the tool execution result represents an error.
+     * Returns whether the tool execution resulted in an error.
+     *
+     * @return {@code true} if the tool execution failed, {@code false} otherwise.
      */
     public boolean isError() {
         return isError;
     }
 
     /**
-     * Returns the tool execution result as object.
-     * This object is the actual value returned by the tool.
+     * Returns the raw object returned by the tool method.
+     * This is the original value before any conversion to {@link Content}.
+     * It is not sent to the LLM.
      *
+     * @return the raw result object, or {@code null} if not set.
      * @see #resultText()
+     * @see #resultContents()
      */
     public Object result() {
         return result;
     }
 
     /**
-     * Returns the tool execution result as text.
-     * It is a {@link #result()} that is serialized into JSON string.
-     * The text is calculated lazily on first access and then cached.
+     * Returns the tool execution result as a plain text string.
+     * This is a convenience method for when the result is known to be a single {@link TextContent}.
      *
-     * <p>Thread-safety: In rare concurrent scenarios, the supplier may be invoked
-     * multiple times, but only one result will be cached. Suppliers should be
-     * idempotent and side-effect free.
-     *
-     * <p>Virtual thread friendly: Uses lock-free atomic operations that do not
-     * pin carrier threads.
-     *
-     * @see #result()
+     * @return the text of the single {@link TextContent} element.
+     * @throws IllegalStateException if the result contains non-text or multiple content elements.
+     *                               Use {@link #resultContents()} instead.
+     * @see #resultContents()
      */
     public String resultText() {
-        return resultText.updateAndGet(
-                current -> current != null ? current : (resultTextSupplier != null ? resultTextSupplier.get() : null));
+        List<Content> contents = resultContents();
+        if (contents.size() == 1 && contents.get(0) instanceof TextContent textContent) {
+            return textContent.text();
+        }
+        throw new IllegalStateException(
+                "resultText() cannot be called when resultContents contains non-text or multiple content elements. "
+                        + "Use resultContents() instead.");
     }
 
     /**
-     * Returns attributes associated with tool execution.
-     * These attributes will be propagated into {@link ToolExecutionResultMessage#attributes()}
-     * and can be persisted in a {@link ChatMemory}. They will not be sent to the LLM.
+     * Returns the contents of the tool execution result that will be sent to the LLM.
      *
+     * <p>When built with {@link Builder#resultTextSupplier(Supplier)}, the contents are
+     * calculated lazily on first access and then cached.
+     *
+     * <p>Thread-safety: in rare concurrent scenarios, the supplier may be invoked
+     * multiple times, but only one result will be cached. Suppliers should be
+     * idempotent and side-effect free.
+     *
+     * <p>Virtual thread friendly: uses lock-free atomic operations that do not
+     * pin carrier threads.
+     *
+     * @return the list of {@link Content} elements, never {@code null}.
+     * @since 1.13.0
+     */
+    @Experimental
+    public List<Content> resultContents() {
+        return resultContents.updateAndGet(current -> {
+            if (current != null) {
+                return current;
+            }
+            String text = resultTextSupplier.get();
+            return text == null ? List.of() : List.of(TextContent.from(text));
+        });
+    }
+
+    /**
+     * Returns attributes associated with the tool execution.
+     * Attributes are propagated into {@link ToolExecutionResultMessage#attributes()}
+     * and can be persisted in a {@link ChatMemory}. They are not sent to the LLM.
+     *
+     * @return an unmodifiable map of attributes, or an empty map if none were set.
      * @since 1.12.0
      */
     public Map<String, Object> attributes() {
@@ -95,13 +159,13 @@ public class ToolExecutionResult {
         ToolExecutionResult that = (ToolExecutionResult) object;
         return isError == that.isError
                 && Objects.equals(result, that.result)
-                && Objects.equals(resultText(), that.resultText())
+                && Objects.equals(resultContents(), that.resultContents())
                 && Objects.equals(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isError, result, resultText(), attributes);
+        return Objects.hash(isError, result, resultContents(), attributes);
     }
 
     @Override
@@ -109,7 +173,7 @@ public class ToolExecutionResult {
         return "ToolExecutionResult {"
                 + "isError = " + isError
                 + ", result = " + result
-                + ", resultText = " + quoted(resultText())
+                + ", resultContents = " + resultContents()
                 + ", attributes = " + attributes
                 + '}';
     }
@@ -124,43 +188,82 @@ public class ToolExecutionResult {
         private Object result;
         private String resultText;
         private Supplier<String> resultTextSupplier;
+        private List<Content> resultContents;
         private Map<String, Object> attributes;
 
+        /**
+         * Sets whether the tool execution resulted in an error.
+         *
+         * @param isError {@code true} if the tool execution failed.
+         * @return this builder.
+         */
         public Builder isError(boolean isError) {
             this.isError = isError;
             return this;
         }
 
+        /**
+         * Sets the raw object returned by the tool method.
+         * This value is not sent to the LLM.
+         *
+         * @param result the raw result object.
+         * @return this builder.
+         */
         public Builder result(Object result) {
             this.result = result;
             return this;
         }
 
+        /**
+         * Sets the result as a text string. The text will be wrapped into a single {@link TextContent}.
+         * Mutually exclusive with {@link #resultTextSupplier(Supplier)} and {@link #resultContents(List)}.
+         *
+         * @param resultText the text result.
+         * @return this builder.
+         */
         public Builder resultText(String resultText) {
             this.resultText = resultText;
-            this.resultTextSupplier = null;
             return this;
         }
 
         /**
          * Sets a supplier for lazy calculation of the result text.
-         * The supplier will be called only when {@link ToolExecutionResult#resultText()} is first accessed.
+         * The supplier will be called on first access to {@link ToolExecutionResult#resultContents()}
+         * and the result will be wrapped into a single {@link TextContent} and cached.
+         * Mutually exclusive with {@link #resultText(String)} and {@link #resultContents(List)}.
          *
-         * @param resultTextSupplier the supplier to calculate result text on demand
-         * @return this builder
+         * @param resultTextSupplier the supplier to calculate result text on demand.
+         * @return this builder.
          * @since 1.9.0
          */
         public Builder resultTextSupplier(Supplier<String> resultTextSupplier) {
             this.resultTextSupplier = resultTextSupplier;
-            this.resultText = null;
             return this;
         }
 
         /**
-         * Sets attributes associated with tool execution.
-         * These attributes will be propagated into {@link ToolExecutionResultMessage#attributes()}
-         * and can be persisted in a {@link ChatMemory}. They will not be sent to the LLM.
+         * Sets the multimodal contents of the tool execution result.
+         * Can contain any combination of {@link Content} elements
+         * (e.g. {@link TextContent}, {@code ImageContent}).
+         * Mutually exclusive with {@link #resultText(String)} and {@link #resultTextSupplier(Supplier)}.
          *
+         * @param resultContents the contents.
+         * @return this builder.
+         * @since 1.13.0
+         */
+        @Experimental
+        public Builder resultContents(List<Content> resultContents) {
+            this.resultContents = resultContents;
+            return this;
+        }
+
+        /**
+         * Sets attributes associated with the tool execution.
+         * Attributes are propagated into {@link ToolExecutionResultMessage#attributes()}
+         * and can be persisted in a {@link ChatMemory}. They are not sent to the LLM.
+         *
+         * @param attributes the attributes.
+         * @return this builder.
          * @since 1.12.0
          */
         public Builder attributes(Map<String, Object> attributes) {
@@ -168,6 +271,13 @@ public class ToolExecutionResult {
             return this;
         }
 
+        /**
+         * Builds a {@link ToolExecutionResult}.
+         *
+         * @return the built instance.
+         * @throws IllegalArgumentException if none of {@code resultText}, {@code resultTextSupplier},
+         *                                  or {@code resultContents} was set, or if more than one was set.
+         */
         public ToolExecutionResult build() {
             return new ToolExecutionResult(this);
         }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -368,13 +368,7 @@ public class ToolService {
             for (Map.Entry<ToolExecutionRequest, ToolExecutionResult> entry : toolResults.entrySet()) {
                 ToolExecutionRequest request = entry.getKey();
                 ToolExecutionResult result = entry.getValue();
-                ToolExecutionResultMessage resultMessage = ToolExecutionResultMessage.builder()
-                        .id(request.id())
-                        .toolName(request.name())
-                        .text(result.resultText())
-                        .isError(result.isError())
-                        .attributes(result.attributes())
-                        .build();
+                ToolExecutionResultMessage resultMessage = toResultMessage(request, result);
 
                 ToolExecution toolExecution =
                         ToolExecution.builder().request(request).result(result).build();
@@ -517,7 +511,7 @@ public class ToolService {
         listenerRegistrar.fireEvent(ToolExecutedEvent.builder()
                 .invocationContext(invocationContext)
                 .request(request)
-                .resultText(toolExecution.result())
+                .resultContents(toolExecution.resultContents())
                 .build());
     }
 
@@ -683,6 +677,16 @@ public class ToolService {
                     .resultText(errorHandlerResult.text())
                     .build();
         }
+    }
+
+    static ToolExecutionResultMessage toResultMessage(ToolExecutionRequest request, ToolExecutionResult result) {
+        return ToolExecutionResultMessage.builder()
+                .id(request.id())
+                .toolName(request.name())
+                .contents(result.resultContents())
+                .isError(result.isError())
+                .attributes(result.attributes())
+                .build();
     }
 
     private static Throwable getCause(Exception e) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
@@ -1822,6 +1822,53 @@ class AiServicesWithToolsIT {
     }
 
     @Test
+    void should_send_null_as_text_to_LLM_when_tool_returns_null() {
+
+        // given
+        class ToolReturningNull {
+
+            @Tool("Returns nothing")
+            Integer doSomething() {
+                return null;
+            }
+        }
+
+        ToolReturningNull tools = spy(new ToolReturningNull());
+
+        ChatModel chatModel = spy(ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("1")
+                        .name("doSomething")
+                        .arguments("{}")
+                        .build()),
+                AiMessage.from("OK, got null")
+        ));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .tools(tools)
+                .build();
+
+        // when
+        assistant.chat("Do something");
+
+        // then
+        verify(tools).doSomething();
+
+        verify(chatModel, times(2)).chat(argThat((ChatRequest request) -> {
+            if (request.messages().size() < 3) {
+                return true; // first call
+            }
+            ToolExecutionResultMessage toolResult = request.messages().stream()
+                    .filter(ToolExecutionResultMessage.class::isInstance)
+                    .map(ToolExecutionResultMessage.class::cast)
+                    .findFirst()
+                    .orElse(null);
+            return toolResult != null && toolResult.text().equals("null");
+        }));
+    }
+
+    @Test
     void should_send_ImageContent_to_LLM_when_tool_with_Object_return_type_returns_Image() {
 
         // given

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
@@ -29,6 +29,7 @@ import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
@@ -1818,5 +1819,156 @@ class AiServicesWithToolsIT {
         ));
 
         verifyNoMoreInteractionsFor(spyChatModel);
+    }
+
+    @Test
+    void should_send_ImageContent_to_LLM_when_tool_with_Object_return_type_returns_Image() {
+
+        // given
+        class ToolReturningObjectThatIsImage {
+
+            @Tool("Takes a photo")
+            Object takePhoto() {
+                return Image.builder()
+                        .base64Data("iVBOR")
+                        .mimeType("image/png")
+                        .build();
+            }
+        }
+
+        ToolReturningObjectThatIsImage tools = spy(new ToolReturningObjectThatIsImage());
+
+        ChatModel chatModel = spy(ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("1")
+                        .name("takePhoto")
+                        .arguments("{}")
+                        .build()),
+                AiMessage.from("I see a cat")
+        ));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .tools(tools)
+                .build();
+
+        // when
+        assistant.chat("Take a photo");
+
+        // then
+        verify(tools).takePhoto();
+
+        verify(chatModel, times(2)).chat(argThat((ChatRequest request) -> {
+            if (request.messages().size() < 3) {
+                return true; // first call
+            }
+            // second call should have ToolExecutionResultMessage with ImageContent
+            ToolExecutionResultMessage toolResult = request.messages().stream()
+                    .filter(ToolExecutionResultMessage.class::isInstance)
+                    .map(ToolExecutionResultMessage.class::cast)
+                    .findFirst()
+                    .orElse(null);
+            return toolResult != null
+                    && toolResult.contents().size() == 1
+                    && toolResult.contents().get(0) instanceof dev.langchain4j.data.message.ImageContent;
+        }));
+    }
+
+    @Test
+    void should_send_text_to_LLM_when_tool_with_Image_return_type_returns_null() {
+
+        // given
+        class ToolReturningNullImage {
+
+            @Tool("Takes a photo")
+            Image takePhoto() {
+                return null;
+            }
+        }
+
+        ToolReturningNullImage tools = spy(new ToolReturningNullImage());
+
+        ChatModel chatModel = spy(ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("1")
+                        .name("takePhoto")
+                        .arguments("{}")
+                        .build()),
+                AiMessage.from("No photo available")
+        ));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .tools(tools)
+                .build();
+
+        // when
+        assistant.chat("Take a photo");
+
+        // then
+        verify(tools).takePhoto();
+
+        verify(chatModel, times(2)).chat(argThat((ChatRequest request) -> {
+            if (request.messages().size() < 3) {
+                return true; // first call
+            }
+            // second call should have ToolExecutionResultMessage with text (null serialized)
+            ToolExecutionResultMessage toolResult = request.messages().stream()
+                    .filter(ToolExecutionResultMessage.class::isInstance)
+                    .map(ToolExecutionResultMessage.class::cast)
+                    .findFirst()
+                    .orElse(null);
+            return toolResult != null && toolResult.text().equals("null");
+        }));
+    }
+
+    @Test
+    void should_send_error_text_to_LLM_when_tool_with_Image_return_type_throws_exception() {
+
+        // given
+        class ToolThrowingException {
+
+            @Tool("Takes a photo")
+            Image takePhoto() {
+                throw new RuntimeException("Camera is broken");
+            }
+        }
+
+        ToolThrowingException tools = spy(new ToolThrowingException());
+
+        ChatModel chatModel = spy(ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("1")
+                        .name("takePhoto")
+                        .arguments("{}")
+                        .build()),
+                AiMessage.from("Sorry, the camera is broken")
+        ));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModel)
+                .tools(tools)
+                .build();
+
+        // when
+        assistant.chat("Take a photo");
+
+        // then
+        verify(tools).takePhoto();
+
+        verify(chatModel, times(2)).chat(argThat((ChatRequest request) -> {
+            if (request.messages().size() < 3) {
+                return true; // first call
+            }
+            // second call should have ToolExecutionResultMessage with error text
+            ToolExecutionResultMessage toolResult = request.messages().stream()
+                    .filter(ToolExecutionResultMessage.class::isInstance)
+                    .map(ToolExecutionResultMessage.class::cast)
+                    .findFirst()
+                    .orElse(null);
+            return toolResult != null
+                    && toolResult.text().contains("Camera is broken")
+                    && Boolean.TRUE.equals(toolResult.isError());
+        }));
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
@@ -29,6 +29,7 @@ import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
@@ -1654,6 +1655,66 @@ class StreamingAiServicesWithToolsIT {
         ), any());
 
         verifyNoMoreInteractionsFor(spyModel);
+    }
+
+    @Test
+    void should_send_ImageContent_to_LLM_when_tool_returns_Image() throws Exception {
+
+        // given
+        class ToolReturningImage {
+
+            @Tool("Takes a photo")
+            Image takePhoto() {
+                return Image.builder()
+                        .base64Data("iVBOR")
+                        .mimeType("image/png")
+                        .build();
+            }
+        }
+
+        ToolReturningImage tools = spy(new ToolReturningImage());
+
+        StreamingChatModel streamingModel = spy(StreamingChatModelMock.thatAlwaysStreams(
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("1")
+                        .name("takePhoto")
+                        .arguments("{}")
+                        .build()),
+                AiMessage.from("I see a cat")
+        ));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .streamingChatModel(streamingModel)
+                .tools(tools)
+                .build();
+
+        CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
+
+        // when
+        assistant.chat("Take a photo")
+                .onCompleteResponse(futureResponse::complete)
+                .onError(futureResponse::completeExceptionally)
+                .start();
+        ChatResponse response = futureResponse.get(30, SECONDS);
+
+        // then
+        assertThat(response.aiMessage().text()).contains("cat");
+        verify(tools).takePhoto();
+
+        verify(streamingModel, times(2)).chat(argThat((ChatRequest request) -> {
+            if (request.messages().size() < 3) {
+                return true; // first call
+            }
+            // second call should have ToolExecutionResultMessage with ImageContent
+            ToolExecutionResultMessage toolResult = request.messages().stream()
+                    .filter(ToolExecutionResultMessage.class::isInstance)
+                    .map(ToolExecutionResultMessage.class::cast)
+                    .findFirst()
+                    .orElse(null);
+            return toolResult != null
+                    && toolResult.contents().size() == 1
+                    && toolResult.contents().get(0) instanceof dev.langchain4j.data.message.ImageContent;
+        }), any());
     }
 
     // TODO all other tests from sync version

--- a/langchain4j/src/test/java/dev/langchain4j/service/common/AbstractAiServiceWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/common/AbstractAiServiceWithToolsIT.java
@@ -4,10 +4,15 @@ import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.ReturnBehavior;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
@@ -23,6 +28,7 @@ import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.IllegalConfigurationException;
 import dev.langchain4j.service.Result;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,6 +46,7 @@ import java.util.UUID;
 
 import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
 import static dev.langchain4j.internal.Utils.generateUUIDFrom;
+import static dev.langchain4j.internal.Utils.readBytes;
 import static dev.langchain4j.service.AiServicesIT.verifyNoMoreInteractionsFor;
 import static dev.langchain4j.service.common.AbstractAiServiceWithToolsIT.ToolWithEnumParameter.TemperatureUnit.CELSIUS;
 import static dev.langchain4j.service.common.AbstractAiServiceWithToolsIT.ToolWithSetOfEnumsParameter.Color.GREEN;
@@ -1181,8 +1188,233 @@ public abstract class AbstractAiServiceWithToolsIT {
 
         verify(model).chat(argThat((ChatRequest request) ->
                 request.messages().size() == 3
-                        && request.messages().get(2).type() == TOOL_EXECUTION_RESULT
-                        && ((ToolExecutionResultMessage) request.messages().get(2)).text().isEmpty()
+                        && request.messages().get(2) instanceof ToolExecutionResultMessage toolResultMessage
+                        && toolResultMessage.text().isEmpty()
+                        && toolResultMessage.contents().equals(List.of(TextContent.from("")))
         ));
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    protected void should_allow_blank_tool_result(ChatModel model) {
+
+        // given
+        class Tools {
+
+            @Tool
+            String modify(int ignored) {
+                return " ";
+            }
+        }
+
+        model = spy(model);
+
+        Tools tools = spy(new Tools());
+
+        StringAssistant assistant = AiServices.builder(StringAssistant.class)
+                .chatModel(model)
+                .tools(tools)
+                .build();
+
+        String text = "Call tool 'modify' for argument '7'";
+
+        // when-then
+        assertThatNoException().isThrownBy(() -> assistant.chat(text));
+
+        verify(tools).modify(7);
+
+        verify(model).chat(argThat((ChatRequest request) ->
+                request.messages().size() == 3
+                        && request.messages().get(2) instanceof ToolExecutionResultMessage toolResultMessage
+                        && toolResultMessage.text().equals(" ")
+                        && toolResultMessage.contents().equals(List.of(TextContent.from(" ")))
+        ));
+    }
+
+    static final String CAT_IMAGE_URL =
+            "https://upload.wikimedia.org/wikipedia/commons/e/e9/Felis_silvestris_silvestris_small_gradual_decrease_of_quality.png";
+
+    protected Image catImage() {
+        String base64Data = java.util.Base64.getEncoder().encodeToString(readBytes(CAT_IMAGE_URL));
+        return Image.builder()
+                .base64Data(base64Data)
+                .mimeType("image/png")
+                .build();
+    }
+
+    static class ToolReturningImage {
+
+        private final Image image;
+
+        ToolReturningImage(Image image) {
+            this.image = image;
+        }
+
+        @Tool("Takes a photo and returns it")
+        Image takePhoto() {
+            return image;
+        }
+    }
+
+    static class ToolReturningImageContent {
+
+        private final Image image;
+
+        ToolReturningImageContent(Image image) {
+            this.image = image;
+        }
+
+        @Tool("Takes a photo and returns it")
+        ImageContent takePhoto() {
+            return ImageContent.from(image);
+        }
+    }
+
+    static class ToolReturningContentList {
+
+        private final Image image;
+
+        ToolReturningContentList(Image image) {
+            this.image = image;
+        }
+
+        @Tool("Takes a photo and returns it with a description")
+        List<Content> takePhoto() {
+            return List.of(
+                    TextContent.from("Its name is Whiskers"),
+                    ImageContent.from(image)
+            );
+        }
+    }
+
+    protected boolean supportsMultimodalToolResults() {
+        return false;
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    @EnabledIf("supportsMultimodalToolResults")
+    void should_execute_tool_returning_Image(ChatModel model) {
+
+        // given
+        model = spy(model);
+
+        ToolReturningImage tool = spy(new ToolReturningImage(catImage()));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tool)
+                .build();
+
+        // when
+        Result<String> result = assistant.chat(
+                "Use the takePhoto tool, then tell me what animal is in the photo. Answer in one word.");
+
+        // then
+        assertThat(result.content().toLowerCase()).containsAnyOf("cat", "lynx", "feline", "wildcat");
+        verify(tool).takePhoto();
+
+        verify(model, times(2)).chat(chatRequestCaptor.capture());
+        ToolExecutionResultMessage toolResult = chatRequestCaptor.getAllValues().get(1).messages().stream()
+                .filter(ToolExecutionResultMessage.class::isInstance)
+                .map(ToolExecutionResultMessage.class::cast)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(toolResult.hasSingleText()).isFalse();
+        assertThat(toolResult.contents()).hasSize(1);
+        assertThat(toolResult.contents().get(0)).isInstanceOf(ImageContent.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    @EnabledIf("supportsMultimodalToolResults")
+    void should_execute_tool_returning_ImageContent(ChatModel model) {
+
+        // given
+        model = spy(model);
+
+        ToolReturningImageContent tool = spy(new ToolReturningImageContent(catImage()));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tool)
+                .build();
+
+        // when
+        Result<String> result = assistant.chat(
+                "Use the takePhoto tool, then tell me what animal is in the photo. Answer in one word.");
+
+        // then
+        assertThat(result.content().toLowerCase()).containsAnyOf("cat", "lynx", "feline", "wildcat");
+        verify(tool).takePhoto();
+
+        verify(model, times(2)).chat(chatRequestCaptor.capture());
+        ToolExecutionResultMessage toolResult = chatRequestCaptor.getAllValues().get(1).messages().stream()
+                .filter(ToolExecutionResultMessage.class::isInstance)
+                .map(ToolExecutionResultMessage.class::cast)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(toolResult.hasSingleText()).isFalse();
+        assertThat(toolResult.contents()).hasSize(1);
+        assertThat(toolResult.contents().get(0)).isInstanceOf(ImageContent.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    @EnabledIf("supportsMultimodalToolResults")
+    void should_execute_tool_returning_ContentList(ChatModel model) {
+
+        // given
+        model = spy(model);
+
+        ToolReturningContentList tool = spy(new ToolReturningContentList(catImage()));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tool)
+                .build();
+
+        // when
+        Result<String> result = assistant.chat(
+                "Use the takePhoto tool, then tell me what animal is in the photo and what is its name.");
+
+        // then
+        String response = result.content().toLowerCase();
+        assertThat(response).containsAnyOf("cat", "lynx", "feline", "wildcat");
+        assertThat(response).contains("whiskers");
+        verify(tool).takePhoto();
+
+        verify(model, times(2)).chat(chatRequestCaptor.capture());
+        ToolExecutionResultMessage toolResult = chatRequestCaptor.getAllValues().get(1).messages().stream()
+                .filter(ToolExecutionResultMessage.class::isInstance)
+                .map(ToolExecutionResultMessage.class::cast)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(toolResult.hasSingleText()).isFalse();
+        assertThat(toolResult.contents()).hasSize(2);
+        assertThat(toolResult.contents().get(0)).isInstanceOf(TextContent.class);
+        assertThat(toolResult.contents().get(1)).isInstanceOf(ImageContent.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    @DisabledIf("supportsMultimodalToolResults")
+    void should_fail_when_tool_returns_image_and_provider_does_not_support_it(ChatModel model) {
+
+        // given
+        ToolReturningImage tool = spy(new ToolReturningImage(catImage()));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tool)
+                .build();
+
+        // when-then
+        assertThatThrownBy(() -> assistant.chat("Take a photo"))
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessageContaining("non-text content");
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/common/AbstractAiServiceWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/common/AbstractAiServiceWithToolsIT.java
@@ -44,7 +44,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import static dev.langchain4j.data.message.ChatMessageType.TOOL_EXECUTION_RESULT;
 import static dev.langchain4j.internal.Utils.generateUUIDFrom;
 import static dev.langchain4j.internal.Utils.readBytes;
 import static dev.langchain4j.service.AiServicesIT.verifyNoMoreInteractionsFor;

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutionResultTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutionResultTest.java
@@ -3,9 +3,16 @@ package dev.langchain4j.service.tool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.image.Image;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ToolExecutionResultTest {
 
@@ -68,42 +75,29 @@ class ToolExecutionResultTest {
         assertThatThrownBy(
                         () -> ToolExecutionResult.builder().result(new Object()).build())
                 .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Either resultText or resultTextSupplier must be provided");
+                .hasMessage("One of resultText, resultTextSupplier, or resultContents must be provided");
     }
 
     @Test
-    void should_use_last_set_value_when_both_provided() {
-        // given
-        AtomicInteger callCount = new AtomicInteger(0);
-
-        // when - resultText set first, then supplier
-        ToolExecutionResult toolExecutionResult1 = ToolExecutionResult.builder()
+    void should_fail_when_resultText_and_resultTextSupplier_both_set() {
+        assertThatThrownBy(() -> ToolExecutionResult.builder()
                 .result(new Object())
                 .resultText("direct text")
-                .resultTextSupplier(() -> {
-                    callCount.incrementAndGet();
-                    return "lazy result";
-                })
-                .build();
+                .resultTextSupplier(() -> "lazy result")
+                .build())
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mutually exclusive");
+    }
 
-        // then - supplier is used (last one wins)
-        assertThat(toolExecutionResult1.resultText()).isEqualTo("lazy result");
-        assertThat(callCount.get()).isEqualTo(1);
-
-        // when - supplier set first, then resultText
-        callCount.set(0);
-        ToolExecutionResult toolExecutionResult2 = ToolExecutionResult.builder()
+    @Test
+    void should_fail_when_resultTextSupplier_and_resultText_both_set() {
+        assertThatThrownBy(() -> ToolExecutionResult.builder()
                 .result(new Object())
-                .resultTextSupplier(() -> {
-                    callCount.incrementAndGet();
-                    return "lazy result";
-                })
+                .resultTextSupplier(() -> "lazy result")
                 .resultText("direct text")
-                .build();
-
-        // then - resultText is used (last one wins)
-        assertThat(toolExecutionResult2.resultText()).isEqualTo("direct text");
-        assertThat(callCount.get()).isEqualTo(0);
+                .build())
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mutually exclusive");
     }
 
     @Test
@@ -257,5 +251,159 @@ class ToolExecutionResultTest {
         // when/then
         assertThat(result1).isEqualTo(result2);
         assertThat(result1.hashCode()).isEqualTo(result2.hashCode());
+    }
+
+    @Test
+    void should_create_with_resultContents() {
+        // given
+        List<Content> contents = List.of(
+                TextContent.from("description"),
+                ImageContent.from(Image.builder().base64Data("abc").mimeType("image/png").build())
+        );
+
+        // when
+        ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+                .result(new Object())
+                .resultContents(contents)
+                .build();
+
+        // then
+        assertThat(toolExecutionResult.resultContents()).isEqualTo(contents);
+    }
+
+    @Test
+    void should_derive_resultContents_from_resultText() {
+        // when
+        ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+                .result(new Object())
+                .resultText("hello")
+                .build();
+
+        // then
+        assertThat(toolExecutionResult.resultContents()).hasSize(1);
+        assertThat(toolExecutionResult.resultContents().get(0)).isInstanceOf(TextContent.class);
+        assertThat(((TextContent) toolExecutionResult.resultContents().get(0)).text()).isEqualTo("hello");
+    }
+
+    @Test
+    void should_derive_resultContents_from_resultTextSupplier() {
+        // when
+        ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+                .result(new Object())
+                .resultTextSupplier(() -> "lazy")
+                .build();
+
+        // then
+        assertThat(toolExecutionResult.resultContents()).hasSize(1);
+        assertThat(((TextContent) toolExecutionResult.resultContents().get(0)).text()).isEqualTo("lazy");
+        assertThat(toolExecutionResult.resultText()).isEqualTo("lazy");
+    }
+
+    @Test
+    void should_derive_resultText_from_single_TextContent() {
+        // when
+        ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+                .result(new Object())
+                .resultContents(List.of(TextContent.from("hello")))
+                .build();
+
+        // then
+        assertThat(toolExecutionResult.resultText()).isEqualTo("hello");
+    }
+
+    @Test
+    void should_fail_resultText_when_resultContents_has_non_text() {
+        // given
+        List<Content> contents = List.of(
+                TextContent.from("first"),
+                ImageContent.from(Image.builder().base64Data("abc").mimeType("image/png").build())
+        );
+
+        ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+                .result(new Object())
+                .resultContents(contents)
+                .build();
+
+        // when/then
+        assertThatThrownBy(toolExecutionResult::resultText)
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Use resultContents() instead");
+    }
+
+    @Test
+    void should_fail_resultText_when_resultContents_has_multiple_text() {
+        // given
+        List<Content> contents = List.of(
+                TextContent.from("first"),
+                TextContent.from("second")
+        );
+
+        ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+                .result(new Object())
+                .resultContents(contents)
+                .build();
+
+        // when/then
+        assertThatThrownBy(toolExecutionResult::resultText)
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Use resultContents() instead");
+    }
+
+    @Test
+    void should_fail_when_resultText_and_resultContents_both_set() {
+        assertThatThrownBy(() -> ToolExecutionResult.builder()
+                .result(new Object())
+                .resultText("from text")
+                .resultContents(List.of(TextContent.from("from contents")))
+                .build())
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mutually exclusive");
+    }
+
+    @Test
+    void should_fail_when_resultContents_and_resultText_both_set() {
+        assertThatThrownBy(() -> ToolExecutionResult.builder()
+                .result(new Object())
+                .resultContents(List.of(TextContent.from("from contents")))
+                .resultText("from text")
+                .build())
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mutually exclusive");
+    }
+
+    @Test
+    void should_fail_when_resultContents_and_resultTextSupplier_both_set() {
+        assertThatThrownBy(() -> ToolExecutionResult.builder()
+                .result(new Object())
+                .resultContents(List.of(TextContent.from("from contents")))
+                .resultTextSupplier(() -> "from supplier")
+                .build())
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mutually exclusive");
+    }
+
+    @Test
+    void should_fail_when_resultTextSupplier_and_resultContents_both_set() {
+        assertThatThrownBy(() -> ToolExecutionResult.builder()
+                .result(new Object())
+                .resultTextSupplier(() -> "from supplier")
+                .resultContents(List.of(TextContent.from("from contents")))
+                .build())
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mutually exclusive");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void should_return_TextContent_in_resultContents_when_resultText_is(String text) {
+        // when
+        ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+                .result(new Object())
+                .resultText(text)
+                .build();
+
+        // then
+        assertThat(toolExecutionResult.resultContents()).containsExactly(TextContent.from(text));
+        assertThat(toolExecutionResult.resultText()).isEqualTo(text);
     }
 }


### PR DESCRIPTION
## Issue
Closes https://github.com/langchain4j/langchain4j/issues/4652

## Change
- Add support for `@Tool`-annotated methods to return multimodal content (images) to the LLM, not just text. Tools can now return `Image`, `ImageContent`, `Content`, `List<Content>`, `Content[]`, etc.
  - Refactor `ToolExecutionResultMessage` to store `List<Content>` internally instead of a plain `String`, with backward-compatible `text()` accessor and new `contents()` / `hasSingleText()`
  methods.
- Refactor `ToolExecutionResult` to support `resultContents(List<Content>)` as an alternative to `resultText(String)` and `resultTextSupplier(Supplier)`.
- Implement multimodal tool result mapping for providers that support it: Anthropic, Amazon Bedrock, and Google AI Gemini.
- Add `UnsupportedFeatureException` guards in providers that do not support non-text tool results: Azure OpenAI, GitHub Models, Jlama, Mistral AI, Ollama, OpenAI (Chat Completions
   & Responses), Vertex AI (Anthropic & Gemini), Watsonx, and Workers AI.
- Update `ToolExecutedEvent` / `DefaultToolExecutedEvent` to carry `resultContents` alongside the existing `resultText` accessor.
- Add comprehensive unit and integration tests (`should_execute_tool_returning_Image`, `should_execute_tool_returning_ImageContent`, `should_execute_tool_returning_ContentList`,
  `should_fail_when_tool_returns_image_and_provider_does_not_support_it`).
  - Update tools documentation with new "Returning Images and Multimodal Content" and "Multimodal Tool Results" sections.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)