### PR TITLE
fix: replace Stream.toList() in Android crash paths

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 final class PartsAndContentsMapper {
 
@@ -348,7 +349,7 @@ final class PartsAndContentsMapper {
                             return new GeminiContent(
                                     userMessage.contents().stream()
                                             .map(content -> fromContentToGPart(content, mediaResolutionPerPartEnabled))
-                                            .toList(),
+                                            .collect(Collectors.toList()),
                                     GeminiRole.USER.toString());
                         case TOOL_EXECUTION_RESULT:
                             ToolExecutionResultMessage toolResultMessage = (ToolExecutionResultMessage) msg;
@@ -365,7 +366,7 @@ final class PartsAndContentsMapper {
                     }
                 })
                 .filter(Objects::nonNull)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     /**

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/PartsAndContentsMapperTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/PartsAndContentsMapperTest.java
@@ -126,6 +126,23 @@ class PartsAndContentsMapperTest {
     }
 
     @Test
+    void fromMessageToGContent_userMessageWithTextAndImageContent() {
+        String base64Image =
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+        UserMessage msg = new UserMessage(List.of(
+                new dev.langchain4j.data.message.TextContent("describe this image"),
+                ImageContent.from(base64Image, "image/png", ImageContent.DetailLevel.AUTO)));
+
+        List<GeminiContent> result = PartsAndContentsMapper.fromMessageToGContent(List.of(msg), null, false);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).role()).isEqualTo("user");
+        assertThat(result.get(0).parts()).hasSize(2);
+        assertThat(result.get(0).parts().get(0).text()).isEqualTo("describe this image");
+        assertThat(result.get(0).parts().get(1).inlineData().mimeType()).isEqualTo("image/png");
+    }
+
+    @Test
     void fromMessageToGContent_emptyMessageListReturnsEmpty() {
         List<GeminiContent> result = PartsAndContentsMapper.fromMessageToGContent(List.of(), null, false);
         assertThat(result).isEmpty();

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -94,7 +94,7 @@ class InternalOllamaHelper {
                         .name(toolCall.getFunction().getName())
                         .arguments(toJsonWithoutIdent(toolCall.getFunction().getArguments()))
                         .build())
-                .toList();
+                .collect(Collectors.toList());
     }
 
     static String toOllamaResponseFormat(ResponseFormat responseFormat) {

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
@@ -28,4 +28,11 @@ class InternalOllamaHelperTest {
                         .arguments("{\"city\":\"Shanghai\"}")
                         .build());
     }
+
+    @Test
+    void toToolExecutionRequests_handlesEmptyToolCalls() {
+        List<ToolExecutionRequest> result = InternalOllamaHelper.toToolExecutionRequests(List.of());
+
+        assertThat(result).isEmpty();
+    }
 }

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
@@ -1,0 +1,31 @@
+package dev.langchain4j.model.ollama;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InternalOllamaHelperTest {
+
+    @Test
+    void toToolExecutionRequests_mapsToolCalls() {
+        ToolCall toolCall = ToolCall.builder()
+                .id("tool-1")
+                .function(FunctionCall.builder()
+                        .name("lookupWeather")
+                        .arguments(Map.of("city", "Shanghai"))
+                        .build())
+                .build();
+
+        List<ToolExecutionRequest> result = InternalOllamaHelper.toToolExecutionRequests(List.of(toolCall));
+
+        assertThat(result)
+                .containsExactly(ToolExecutionRequest.builder()
+                        .id("tool-1")
+                        .name("lookupWeather")
+                        .arguments("{\"city\":\"Shanghai\"}")
+                        .build());
+    }
+}


### PR DESCRIPTION
## Issue
Closes #4839

## Change
This PR replaces the reported `Stream.toList()` usages with `Collectors.toList()` in the affected Android crash paths.
I manually verified the targeted tests for the affected Ollama and Gemini paths and confirmed the fix locally.


Changes included:
- Replaced `Stream.toList()` in Ollama's `InternalOllamaHelper`
- Replaced `Stream.toList()` in Gemini's `PartsAndContentsMapper`
- Added a unit test for `InternalOllamaHelper.toToolExecutionRequests`

This keeps the behavior unchanged while improving compatibility with Android runtimes that do not support `Stream.toList()`.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
