### PR TITLE
Fix ClassPathSourceTests URL path handling

### DIFF
--- a/langchain4j/src/test/java/dev/langchain4j/data/document/source/ClassPathSourceTests.java
+++ b/langchain4j/src/test/java/dev/langchain4j/data/document/source/ClassPathSourceTests.java
@@ -5,10 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.Metadata;
-import java.io.File;
 import java.io.IOException;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -23,7 +21,6 @@ class ClassPathSourceTests {
                         "'resourceShouldntExist/because/it/just/shouldnt.txt' was not found as a classpath resource");
     }
 
-    @Disabled("TODO fix")
     @ParameterizedTest
     @ValueSource(
             strings = {
@@ -35,10 +32,10 @@ class ClassPathSourceTests {
     void findFile(String classPathResource) throws IOException {
         var classPathSource = ClassPathSource.from(classPathResource);
         var urlString = classPathSource.url().getFile();
-        var filename = urlString.substring(urlString.lastIndexOf(File.separatorChar) + 1);
+        var filename = urlString.substring(urlString.lastIndexOf('/') + 1);
         var expectedMetaData = new Metadata()
                 .put(Document.URL, urlString)
-                .put(Document.FILE_NAME, urlString.substring(urlString.lastIndexOf(File.separatorChar) + 1));
+                .put(Document.FILE_NAME, filename);
 
         assertThat(classPathSource)
                 .isNotNull()

--- a/langchain4j/src/test/java/dev/langchain4j/data/document/source/ClassPathSourceTests.java
+++ b/langchain4j/src/test/java/dev/langchain4j/data/document/source/ClassPathSourceTests.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.Metadata;
 import java.io.IOException;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -33,9 +32,7 @@ class ClassPathSourceTests {
         var classPathSource = ClassPathSource.from(classPathResource);
         var urlString = classPathSource.url().getFile();
         var filename = urlString.substring(urlString.lastIndexOf('/') + 1);
-        var expectedMetaData = new Metadata()
-                .put(Document.URL, urlString)
-                .put(Document.FILE_NAME, filename);
+        var expectedMetaData = new Metadata().put(Document.URL, urlString).put(Document.FILE_NAME, filename);
 
         assertThat(classPathSource)
                 .isNotNull()
@@ -47,10 +44,7 @@ class ClassPathSourceTests {
     }
 
     @ParameterizedTest
-    @CsvSource(
-            delimiter = '|',
-            textBlock =
-                    """
+    @CsvSource(delimiter = '|', textBlock = """
       classPathSourceTests                               | false
       classPathSourceTests/file1.txt                      | false
       classPathSourceTests/anotherDir                    | false


### PR DESCRIPTION
## Issue
Closes #4857

## Change

Re-enabled `ClassPathSourceTests.findFile()` and updated the test to use URL path semantics when deriving the expected filename.

The test previously used `File.separatorChar` against `URL#getFile()`, which is incorrect because URL paths always use `/`. The expected metadata now reuses the derived `filename` value, matching the current `ClassPathSource` implementation.

I ran `./mvnw -pl langchain4j -Dtest=ClassPathSourceTests test` to verify the restored test passes.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
