### PR TITLE
fix(gemini): add @JsonProperty annotations for Android compatibility

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BatchRequestResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BatchRequestResponse.java
@@ -18,19 +18,28 @@ public final class BatchRequestResponse {
     /**
      * Represents a batch operation that is currently pending or in progress.
      */
-    public record BatchIncomplete<T>(BatchName batchName, BatchJobState state) implements BatchResponse<T> {}
+    public record BatchIncomplete<T>(
+            @JsonProperty("batchName") BatchName batchName, @JsonProperty("state") BatchJobState state)
+            implements BatchResponse<T> {}
 
     /**
      * Represents a successful batch operation.
      */
-    public record BatchSuccess<T>(BatchName batchName, List<T> responses, @Nullable List<Operation.Status> errors)
+    public record BatchSuccess<T>(
+            @JsonProperty("batchName") BatchName batchName,
+            @JsonProperty("responses") List<T> responses,
+            @JsonProperty("errors") @Nullable List<Operation.Status> errors)
             implements BatchResponse<T> {}
 
     /**
      * Represents an error that occurred during a batch operation.
      */
     public record BatchError<T>(
-            BatchName batchName, int code, String message, BatchJobState state, List<Map<String, Object>> details)
+            @JsonProperty("batchName") BatchName batchName,
+            @JsonProperty("code") int code,
+            @JsonProperty("message") String message,
+            @JsonProperty("state") BatchJobState state,
+            @JsonProperty("details") List<Map<String, Object>> details)
             implements BatchResponse<T> {}
 
     /**
@@ -39,12 +48,13 @@ public final class BatchRequestResponse {
      * @param pageToken Token used to paginate to the next page.
      * @param responses List of batch responses.
      */
-    public record BatchList<T>(String pageToken, List<BatchResponse<T>> responses) {}
+    public record BatchList<T>(
+            @JsonProperty("pageToken") String pageToken, @JsonProperty("responses") List<BatchResponse<T>> responses) {}
 
     /**
      * Represents the name of a batch operation.
      */
-    public record BatchName(String value) {
+    public record BatchName(@JsonProperty("value") String value) {
         public BatchName {
             ensureOperationNameFormat(value);
         }
@@ -77,7 +87,7 @@ public final class BatchRequestResponse {
      *
      * @param <REQ> The type of request (e.g., GeminiGenerateContentRequest, GeminiEmbeddingRequest)
      */
-    record BatchCreateRequest<REQ>(Batch<REQ> batch) {
+    record BatchCreateRequest<REQ>(@JsonProperty("batch") Batch<REQ> batch) {
 
         /**
          * The batch configuration containing display name, input config, and priority.
@@ -90,21 +100,21 @@ public final class BatchRequestResponse {
         record Batch<REQ>(
                 @JsonProperty("display_name") String displayName,
                 @JsonProperty("input_config") InputConfig<REQ> inputConfig,
-                long priority) {}
+                @JsonProperty("priority") long priority) {}
 
         /**
          * Configures the input to the batch request.
          *
          * @param requests The list of inlined requests to be processed in the batch.
          */
-        record InputConfig<REQ>(Requests<REQ> requests) {}
+        record InputConfig<REQ>(@JsonProperty("requests") Requests<REQ> requests) {}
 
         /**
          * Wrapper for the list of inlined requests.
          *
          * @param requests The list of inlined requests to be processed in the batch.
          */
-        record Requests<REQ>(List<InlinedRequest<REQ>> requests) {}
+        record Requests<REQ>(@JsonProperty("requests") List<InlinedRequest<REQ>> requests) {}
 
         /**
          * Individual request to be processed in the batch.
@@ -112,10 +122,11 @@ public final class BatchRequestResponse {
          * @param request  Required. The request to be processed in the batch.
          * @param metadata Optional. The metadata to be associated with the request.
          */
-        record InlinedRequest<REQ>(REQ request, Map<String, String> metadata) {}
+        record InlinedRequest<REQ>(
+                @JsonProperty("request") REQ request, @JsonProperty("metadata") Map<String, String> metadata) {}
     }
 
-    record BatchCreateFileRequest(FileBatch batch) {
+    record BatchCreateFileRequest(@JsonProperty("batch") FileBatch batch) {
 
         record FileBatch(
                 @JsonProperty("display_name") String displayName,
@@ -130,7 +141,9 @@ public final class BatchRequestResponse {
      * @param <RESP> The type of response (e.g., GeminiGenerateContentResponse, GeminiEmbeddingResponse)
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record BatchCreateResponse<RESP>(@JsonProperty("@type") String type, InlinedResponses<RESP> inlinedResponses) {
+    record BatchCreateResponse<RESP>(
+            @JsonProperty("@type") String type,
+            @JsonProperty("inlinedResponses") InlinedResponses<RESP> inlinedResponses) {
 
         /**
          * Wrapper for the list of inlined responses.
@@ -138,7 +151,8 @@ public final class BatchRequestResponse {
          * @param inlinedResponses The list of individual response wrappers.
          */
         @JsonIgnoreProperties(ignoreUnknown = true)
-        record InlinedResponses<RESP>(List<InlinedResponseWrapper<RESP>> inlinedResponses) {}
+        record InlinedResponses<RESP>(
+                @JsonProperty("inlinedResponses") List<InlinedResponseWrapper<RESP>> inlinedResponses) {}
 
         /**
          * Wrapper for an individual (successful) response OR error.
@@ -147,7 +161,8 @@ public final class BatchRequestResponse {
          * @param error An error including message and code
          */
         @JsonIgnoreProperties(ignoreUnknown = true)
-        record InlinedResponseWrapper<RESP>(@Nullable RESP response, @Nullable Status error) {}
+        record InlinedResponseWrapper<RESP>(
+                @JsonProperty("response") @Nullable RESP response, @JsonProperty("error") @Nullable Status error) {}
     }
 
     /**
@@ -157,7 +172,11 @@ public final class BatchRequestResponse {
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
     record Operation<RESP>(
-            String name, Map<String, Object> metadata, boolean done, Status error, BatchCreateResponse<RESP> response) {
+            @JsonProperty("name") String name,
+            @JsonProperty("metadata") Map<String, Object> metadata,
+            @JsonProperty("done") boolean done,
+            @JsonProperty("error") Status error,
+            @JsonProperty("response") BatchCreateResponse<RESP> response) {
 
         /**
          * Represents the error status of an operation.
@@ -167,7 +186,10 @@ public final class BatchRequestResponse {
          * @param details A list of messages that carry the error details.
          */
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public record Status(int code, String message, @Nullable List<Map<String, Object>> details) {}
+        public record Status(
+                @JsonProperty("code") int code,
+                @JsonProperty("message") String message,
+                @JsonProperty("details") @Nullable List<Map<String, Object>> details) {}
     }
 
     /**
@@ -177,7 +199,9 @@ public final class BatchRequestResponse {
      * @param operations    a list of operations to be performed
      * @param nextPageToken a token for retrieving the next page of operations, if available; null if there are no more pages
      */
-    record ListOperationsResponse<RESP>(@Nullable List<Operation<RESP>> operations, @Nullable String nextPageToken) {}
+    record ListOperationsResponse<RESP>(
+            @JsonProperty("operations") @Nullable List<Operation<RESP>> operations,
+            @JsonProperty("nextPageToken") @Nullable String nextPageToken) {}
 
     /**
      * Represents a batch request for a file operation.
@@ -186,5 +210,6 @@ public final class BatchRequestResponse {
      * @param key     a unique identifier for the request
      * @param request the actual request payload containing the details of the operation
      */
-    public record BatchFileRequest<REQ>(String key, REQ request) {}
+    public record BatchFileRequest<REQ>(
+            @JsonProperty("key") String key, @JsonProperty("request") REQ request) {}
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BatchRequestResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BatchRequestResponse.java
@@ -19,8 +19,8 @@ public final class BatchRequestResponse {
      * Represents a batch operation that is currently pending or in progress.
      */
     public record BatchIncomplete<T>(
-            @JsonProperty("batchName") BatchName batchName, @JsonProperty("state") BatchJobState state)
-            implements BatchResponse<T> {}
+            @JsonProperty("batchName") BatchName batchName,
+            @JsonProperty("state") BatchJobState state) implements BatchResponse<T> {}
 
     /**
      * Represents a successful batch operation.
@@ -49,7 +49,8 @@ public final class BatchRequestResponse {
      * @param responses List of batch responses.
      */
     public record BatchList<T>(
-            @JsonProperty("pageToken") String pageToken, @JsonProperty("responses") List<BatchResponse<T>> responses) {}
+            @JsonProperty("pageToken") String pageToken,
+            @JsonProperty("responses") List<BatchResponse<T>> responses) {}
 
     /**
      * Represents the name of a batch operation.
@@ -123,7 +124,8 @@ public final class BatchRequestResponse {
          * @param metadata Optional. The metadata to be associated with the request.
          */
         record InlinedRequest<REQ>(
-                @JsonProperty("request") REQ request, @JsonProperty("metadata") Map<String, String> metadata) {}
+                @JsonProperty("request") REQ request,
+                @JsonProperty("metadata") Map<String, String> metadata) {}
     }
 
     record BatchCreateFileRequest(@JsonProperty("batch") FileBatch batch) {
@@ -162,7 +164,8 @@ public final class BatchRequestResponse {
          */
         @JsonIgnoreProperties(ignoreUnknown = true)
         record InlinedResponseWrapper<RESP>(
-                @JsonProperty("response") @Nullable RESP response, @JsonProperty("error") @Nullable Status error) {}
+                @JsonProperty("response") @Nullable RESP response,
+                @JsonProperty("error") @Nullable Status error) {}
     }
 
     /**
@@ -211,5 +214,6 @@ public final class BatchRequestResponse {
      * @param request the actual request payload containing the details of the operation
      */
     public record BatchFileRequest<REQ>(
-            @JsonProperty("key") String key, @JsonProperty("request") REQ request) {}
+            @JsonProperty("key") String key,
+            @JsonProperty("request") REQ request) {}
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiContent.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiContent.java
@@ -8,7 +8,9 @@ import java.util.List;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-record GeminiContent(@JsonProperty("parts") List<GeminiPart> parts, @JsonProperty("role") String role) {
+record GeminiContent(
+        @JsonProperty("parts") List<GeminiPart> parts,
+        @JsonProperty("role") String role) {
 
     GeminiContent {
         parts = mutableCopy(parts);
@@ -124,19 +126,23 @@ record GeminiContent(@JsonProperty("parts") List<GeminiPart> parts, @JsonPropert
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         record GeminiBlob(
-                @JsonProperty("mimeType") String mimeType, @JsonProperty("data") String data) {}
+                @JsonProperty("mimeType") String mimeType,
+                @JsonProperty("data") String data) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         record GeminiFunctionCall(
-                @JsonProperty("name") String name, @JsonProperty("args") Map<String, Object> args) {}
+                @JsonProperty("name") String name,
+                @JsonProperty("args") Map<String, Object> args) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         record GeminiFunctionResponse(
-                @JsonProperty("name") String name, @JsonProperty("response") Map<String, String> response) {}
+                @JsonProperty("name") String name,
+                @JsonProperty("response") Map<String, String> response) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         record GeminiFileData(
-                @JsonProperty("mimeType") String mimeType, @JsonProperty("fileUri") String fileUri) {}
+                @JsonProperty("mimeType") String mimeType,
+                @JsonProperty("fileUri") String fileUri) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         record GeminiExecutableCode(
@@ -161,7 +167,8 @@ record GeminiContent(@JsonProperty("parts") List<GeminiPart> parts, @JsonPropert
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         record GeminiCodeExecutionResult(
-                @JsonProperty("outcome") GeminiOutcome outcome, @JsonProperty("output") String output) {
+                @JsonProperty("outcome") GeminiOutcome outcome,
+                @JsonProperty("output") String output) {
             // TODO how to deal with the non-OK outcomes?
             enum GeminiOutcome {
                 OUTCOME_UNSPECIFIED,

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiContent.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiContent.java
@@ -3,11 +3,12 @@ package dev.langchain4j.model.googleai;
 import static dev.langchain4j.internal.Utils.mutableCopy;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-record GeminiContent(List<GeminiPart> parts, String role) {
+record GeminiContent(@JsonProperty("parts") List<GeminiPart> parts, @JsonProperty("role") String role) {
 
     GeminiContent {
         parts = mutableCopy(parts);
@@ -19,16 +20,16 @@ record GeminiContent(List<GeminiPart> parts, String role) {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     record GeminiPart(
-            String text,
-            GeminiBlob inlineData,
-            GeminiFunctionCall functionCall,
-            GeminiFunctionResponse functionResponse,
-            GeminiFileData fileData,
-            GeminiExecutableCode executableCode,
-            GeminiCodeExecutionResult codeExecutionResult,
-            Boolean thought,
-            String thoughtSignature,
-            GeminiMediaResolution mediaResolution) {
+            @JsonProperty("text") String text,
+            @JsonProperty("inlineData") GeminiBlob inlineData,
+            @JsonProperty("functionCall") GeminiFunctionCall functionCall,
+            @JsonProperty("functionResponse") GeminiFunctionResponse functionResponse,
+            @JsonProperty("fileData") GeminiFileData fileData,
+            @JsonProperty("executableCode") GeminiExecutableCode executableCode,
+            @JsonProperty("codeExecutionResult") GeminiCodeExecutionResult codeExecutionResult,
+            @JsonProperty("thought") Boolean thought,
+            @JsonProperty("thoughtSignature") String thoughtSignature,
+            @JsonProperty("mediaResolution") GeminiMediaResolution mediaResolution) {
 
         static GeminiPart ofText(String text) {
             return GeminiPart.builder().text(text).build();
@@ -122,19 +123,25 @@ record GeminiContent(List<GeminiPart> parts, String role) {
         }
 
         @JsonIgnoreProperties(ignoreUnknown = true)
-        record GeminiBlob(String mimeType, String data) {}
+        record GeminiBlob(
+                @JsonProperty("mimeType") String mimeType, @JsonProperty("data") String data) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
-        record GeminiFunctionCall(String name, Map<String, Object> args) {}
+        record GeminiFunctionCall(
+                @JsonProperty("name") String name, @JsonProperty("args") Map<String, Object> args) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
-        record GeminiFunctionResponse(String name, Map<String, String> response) {}
+        record GeminiFunctionResponse(
+                @JsonProperty("name") String name, @JsonProperty("response") Map<String, String> response) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
-        record GeminiFileData(String mimeType, String fileUri) {}
+        record GeminiFileData(
+                @JsonProperty("mimeType") String mimeType, @JsonProperty("fileUri") String fileUri) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
-        record GeminiExecutableCode(GeminiLanguage programmingLanguage, String code) {
+        record GeminiExecutableCode(
+                @JsonProperty("programmingLanguage") GeminiLanguage programmingLanguage,
+                @JsonProperty("code") String code) {
             enum GeminiLanguage {
                 PYTHON,
                 LANGUAGE_UNSPECIFIED;
@@ -153,7 +160,8 @@ record GeminiContent(List<GeminiPart> parts, String role) {
         }
 
         @JsonIgnoreProperties(ignoreUnknown = true)
-        record GeminiCodeExecutionResult(GeminiOutcome outcome, String output) {
+        record GeminiCodeExecutionResult(
+                @JsonProperty("outcome") GeminiOutcome outcome, @JsonProperty("output") String output) {
             // TODO how to deal with the non-OK outcomes?
             enum GeminiOutcome {
                 OUTCOME_UNSPECIFIED,

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCountTokensRequest.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCountTokensRequest.java
@@ -1,13 +1,15 @@
 package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.langchain4j.internal.Utils;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 record GeminiCountTokensRequest(
-        @Nullable List<GeminiContent> contents, @Nullable GeminiGenerateContentRequest generateContentRequest) {
+        @JsonProperty("contents") @Nullable List<GeminiContent> contents,
+        @JsonProperty("generateContentRequest") @Nullable GeminiGenerateContentRequest generateContentRequest) {
     GeminiCountTokensRequest {
         if (Utils.isNullOrEmpty(contents) && generateContentRequest == null) {
             throw new IllegalArgumentException("Either contents or generateContentRequest should be set");

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCountTokensResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCountTokensResponse.java
@@ -4,4 +4,5 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-record GeminiCountTokensResponse(@JsonProperty("totalTokens") Integer totalTokens) {}
+record GeminiCountTokensResponse(
+        @JsonProperty("totalTokens") Integer totalTokens) {}

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCountTokensResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCountTokensResponse.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-record GeminiCountTokensResponse(Integer totalTokens) {}
+record GeminiCountTokensResponse(@JsonProperty("totalTokens") Integer totalTokens) {}

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiEmbeddingRequestResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiEmbeddingRequestResponse.java
@@ -17,13 +17,16 @@ public final class GeminiEmbeddingRequestResponse {
             @JsonProperty("outputDimensionality") Integer outputDimensionality) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record GeminiEmbeddingResponse(@JsonProperty("embedding") GeminiEmbeddingResponseValues embedding) {
+    public record GeminiEmbeddingResponse(
+            @JsonProperty("embedding") GeminiEmbeddingResponseValues embedding) {
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public record GeminiEmbeddingResponseValues(@JsonProperty("values") List<Float> values) {}
+        public record GeminiEmbeddingResponseValues(
+                @JsonProperty("values") List<Float> values) {}
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record GeminiBatchEmbeddingRequest(@JsonProperty("requests") List<GeminiEmbeddingRequest> requests) {}
+    record GeminiBatchEmbeddingRequest(
+            @JsonProperty("requests") List<GeminiEmbeddingRequest> requests) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     record GeminiBatchEmbeddingResponse(

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiEmbeddingRequestResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiEmbeddingRequestResponse.java
@@ -17,14 +17,15 @@ public final class GeminiEmbeddingRequestResponse {
             @JsonProperty("outputDimensionality") Integer outputDimensionality) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record GeminiEmbeddingResponse(GeminiEmbeddingResponseValues embedding) {
+    public record GeminiEmbeddingResponse(@JsonProperty("embedding") GeminiEmbeddingResponseValues embedding) {
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public record GeminiEmbeddingResponseValues(List<Float> values) {}
+        public record GeminiEmbeddingResponseValues(@JsonProperty("values") List<Float> values) {}
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record GeminiBatchEmbeddingRequest(List<GeminiEmbeddingRequest> requests) {}
+    record GeminiBatchEmbeddingRequest(@JsonProperty("requests") List<GeminiEmbeddingRequest> requests) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record GeminiBatchEmbeddingResponse(List<GeminiEmbeddingResponseValues> embeddings) {}
+    record GeminiBatchEmbeddingResponse(
+            @JsonProperty("embeddings") List<GeminiEmbeddingResponseValues> embeddings) {}
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiFiles.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiFiles.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.model.googleai.Json.fromJson;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -233,20 +234,20 @@ public final class GeminiFiles {
     /**
      * Request body for initiating a resumable upload.
      */
-    private record GeminiFileMetadata(FileInfo file) {
-        record FileInfo(String display_name) {}
+    private record GeminiFileMetadata(@JsonProperty("file") FileInfo file) {
+        record FileInfo(@JsonProperty("display_name") String display_name) {}
     }
 
     /**
      * Response from the file upload containing file information.
      */
-    record GeminiFileResponse(GeminiFile file) {}
+    record GeminiFileResponse(@JsonProperty("file") GeminiFile file) {}
 
     /**
      * Response from listing files.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record GeminiFilesListResponse(List<GeminiFile> files) {}
+    record GeminiFilesListResponse(@JsonProperty("files") List<GeminiFile> files) {}
 
     static class GeminiUploadFailureException extends RuntimeException {
         GeminiUploadFailureException(String message, Throwable cause) {
@@ -324,16 +325,16 @@ public final class GeminiFiles {
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record GeminiFile(
-            String name,
-            @Nullable String displayName,
-            String mimeType,
-            Long sizeBytes,
-            String createTime,
-            String updateTime,
-            String expirationTime,
-            String sha256Hash,
-            String uri,
-            String state) {
+            @JsonProperty("name") String name,
+            @JsonProperty("displayName") @Nullable String displayName,
+            @JsonProperty("mimeType") String mimeType,
+            @JsonProperty("sizeBytes") Long sizeBytes,
+            @JsonProperty("createTime") String createTime,
+            @JsonProperty("updateTime") String updateTime,
+            @JsonProperty("expirationTime") String expirationTime,
+            @JsonProperty("sha256Hash") String sha256Hash,
+            @JsonProperty("uri") String uri,
+            @JsonProperty("state") String state) {
         /**
          * Returns whether the file is in ACTIVE state and ready to use.
          */

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiFunctionDeclaration.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiFunctionDeclaration.java
@@ -1,9 +1,13 @@
 package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-record GeminiFunctionDeclaration(String name, String description, GeminiSchema parameters) {
+record GeminiFunctionDeclaration(
+        @JsonProperty("name") String name,
+        @JsonProperty("description") String description,
+        @JsonProperty("parameters") GeminiSchema parameters) {
 
     static Builder builder() {
         return new Builder();

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentRequest.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentRequest.java
@@ -94,7 +94,8 @@ record GeminiGenerateContentRequest(
         record GeminiGoogleSearchRetrieval() {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
-        record GeminiGoogleMaps(@JsonProperty("enableWidget") Boolean enableWidget) {}
+        record GeminiGoogleMaps(
+                @JsonProperty("enableWidget") Boolean enableWidget) {}
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentRequest.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentRequest.java
@@ -6,13 +6,13 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 record GeminiGenerateContentRequest(
-        String model,
-        List<GeminiContent> contents,
-        List<GeminiTool> tools,
-        GeminiToolConfig toolConfig,
-        List<GeminiSafetySetting> safetySettings,
-        GeminiContent systemInstruction,
-        GeminiGenerationConfig generationConfig) {
+        @JsonProperty("model") String model,
+        @JsonProperty("contents") List<GeminiContent> contents,
+        @JsonProperty("tools") List<GeminiTool> tools,
+        @JsonProperty("toolConfig") GeminiToolConfig toolConfig,
+        @JsonProperty("safetySettings") List<GeminiSafetySetting> safetySettings,
+        @JsonProperty("systemInstruction") GeminiContent systemInstruction,
+        @JsonProperty("generationConfig") GeminiGenerationConfig generationConfig) {
 
     static GeminiGenerateContentRequestBuilder builder() {
         return new GeminiGenerateContentRequestBuilder();
@@ -78,11 +78,11 @@ record GeminiGenerateContentRequest(
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     record GeminiTool(
-            List<GeminiFunctionDeclaration> functionDeclarations,
-            GeminiCodeExecution codeExecution,
+            @JsonProperty("functionDeclarations") List<GeminiFunctionDeclaration> functionDeclarations,
+            @JsonProperty("codeExecution") GeminiCodeExecution codeExecution,
             @JsonProperty("google_search") GeminiGoogleSearchRetrieval googleSearch,
-            GeminiUrlContext urlContext,
-            GeminiGoogleMaps googleMaps) {
+            @JsonProperty("urlContext") GeminiUrlContext urlContext,
+            @JsonProperty("googleMaps") GeminiGoogleMaps googleMaps) {
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         record GeminiCodeExecution() {}
@@ -94,9 +94,10 @@ record GeminiGenerateContentRequest(
         record GeminiGoogleSearchRetrieval() {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
-        record GeminiGoogleMaps(Boolean enableWidget) {}
+        record GeminiGoogleMaps(@JsonProperty("enableWidget") Boolean enableWidget) {}
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record GeminiToolConfig(GeminiFunctionCallingConfig functionCallingConfig) {}
+    record GeminiToolConfig(
+            @JsonProperty("functionCallingConfig") GeminiFunctionCallingConfig functionCallingConfig) {}
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentResponse.java
@@ -1,22 +1,23 @@
 package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 record GeminiGenerateContentResponse(
-        String responseId,
-        String modelVersion,
-        List<GeminiCandidate> candidates,
-        GeminiUsageMetadata usageMetadata,
-        GroundingMetadata groundingMetadata) {
+        @JsonProperty("responseId") String responseId,
+        @JsonProperty("modelVersion") String modelVersion,
+        @JsonProperty("candidates") List<GeminiCandidate> candidates,
+        @JsonProperty("usageMetadata") GeminiUsageMetadata usageMetadata,
+        @JsonProperty("groundingMetadata") GroundingMetadata groundingMetadata) {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     record GeminiCandidate(
-            GeminiContent content,
-            GeminiFinishReason finishReason,
-            GeminiUrlContextMetadata urlContextMetadata,
-            GroundingMetadata groundingMetadata) {
+            @JsonProperty("content") GeminiContent content,
+            @JsonProperty("finishReason") GeminiFinishReason finishReason,
+            @JsonProperty("urlContextMetadata") GeminiUrlContextMetadata urlContextMetadata,
+            @JsonProperty("groundingMetadata") GroundingMetadata groundingMetadata) {
         enum GeminiFinishReason {
             FINISH_REASON_UNSPECIFIED,
             STOP,
@@ -33,10 +34,12 @@ record GeminiGenerateContentResponse(
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record GeminiUrlContextMetadata(List<GeminiUrlMetadata> urlMetadata) {}
+    record GeminiUrlContextMetadata(@JsonProperty("urlMetadata") List<GeminiUrlMetadata> urlMetadata) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record GeminiUrlMetadata(String retrievedUrl, GeminiUrlRetrievalStatus urlRetrievalStatus) {}
+    record GeminiUrlMetadata(
+            @JsonProperty("retrievedUrl") String retrievedUrl,
+            @JsonProperty("urlRetrievalStatus") GeminiUrlRetrievalStatus urlRetrievalStatus) {}
 
     enum GeminiUrlRetrievalStatus {
         URL_RETRIEVAL_STATUS_UNSPECIFIED,
@@ -47,7 +50,10 @@ record GeminiGenerateContentResponse(
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record GeminiUsageMetadata(Integer promptTokenCount, Integer candidatesTokenCount, Integer totalTokenCount) {
+    record GeminiUsageMetadata(
+            @JsonProperty("promptTokenCount") Integer promptTokenCount,
+            @JsonProperty("candidatesTokenCount") Integer candidatesTokenCount,
+            @JsonProperty("totalTokenCount") Integer totalTokenCount) {
 
         public static Builder builder() {
             return new Builder();

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentResponse.java
@@ -34,7 +34,8 @@ record GeminiGenerateContentResponse(
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record GeminiUrlContextMetadata(@JsonProperty("urlMetadata") List<GeminiUrlMetadata> urlMetadata) {}
+    record GeminiUrlContextMetadata(
+            @JsonProperty("urlMetadata") List<GeminiUrlMetadata> urlMetadata) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     record GeminiUrlMetadata(

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiModelInfo.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiModelInfo.java
@@ -1,19 +1,20 @@
 package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 record GeminiModelInfo(
-        String name,
-        String baseModelId,
-        String version,
-        String displayName,
-        String description,
-        Integer inputTokenLimit,
-        Integer outputTokenLimit,
-        List<String> supportedGenerationMethods,
-        Double temperature,
-        Double maxTemperature,
-        Double topP,
-        Integer topK) {}
+        @JsonProperty("name") String name,
+        @JsonProperty("baseModelId") String baseModelId,
+        @JsonProperty("version") String version,
+        @JsonProperty("displayName") String displayName,
+        @JsonProperty("description") String description,
+        @JsonProperty("inputTokenLimit") Integer inputTokenLimit,
+        @JsonProperty("outputTokenLimit") Integer outputTokenLimit,
+        @JsonProperty("supportedGenerationMethods") List<String> supportedGenerationMethods,
+        @JsonProperty("temperature") Double temperature,
+        @JsonProperty("maxTemperature") Double maxTemperature,
+        @JsonProperty("topP") Double topP,
+        @JsonProperty("topK") Integer topK) {}

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiModelsListResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiModelsListResponse.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 record GeminiModelsListResponse(
-        @JsonProperty("models") List<GeminiModelInfo> models, @JsonProperty("nextPageToken") String nextPageToken) {}
+        @JsonProperty("models") List<GeminiModelInfo> models,
+        @JsonProperty("nextPageToken") String nextPageToken) {}

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiModelsListResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiModelsListResponse.java
@@ -1,7 +1,9 @@
 package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-record GeminiModelsListResponse(List<GeminiModelInfo> models, String nextPageToken) {}
+record GeminiModelsListResponse(
+        @JsonProperty("models") List<GeminiModelInfo> models, @JsonProperty("nextPageToken") String nextPageToken) {}

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiThinkingConfig.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiThinkingConfig.java
@@ -1,9 +1,13 @@
 package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record GeminiThinkingConfig(Boolean includeThoughts, Integer thinkingBudget, String thinkingLevel) {
+public record GeminiThinkingConfig(
+        @JsonProperty("includeThoughts") Boolean includeThoughts,
+        @JsonProperty("thinkingBudget") Integer thinkingBudget,
+        @JsonProperty("thinkingLevel") String thinkingLevel) {
 
     public enum GeminiThinkingLevel {
         MINIMAL,

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GroundingMetadata.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GroundingMetadata.java
@@ -72,7 +72,9 @@ public record GroundingMetadata(
             @JsonProperty("retrievedContext") RetrievedContext retrievedContext,
             @JsonProperty("maps") Maps maps) {
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public record Web(@JsonProperty("uri") String uri, @JsonProperty("title") String title) {}
+        public record Web(
+                @JsonProperty("uri") String uri,
+                @JsonProperty("title") String title) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         public record RetrievedContext(
@@ -88,7 +90,8 @@ public record GroundingMetadata(
                 @JsonProperty("placeId") String placeId,
                 @JsonProperty("placeAnswerSources") PlaceAnswerSources placeAnswerSources) {
             @JsonIgnoreProperties(ignoreUnknown = true)
-            public record PlaceAnswerSources(@JsonProperty("reviewSnippets") List<ReviewSnippet> reviewSnippets) {}
+            public record PlaceAnswerSources(
+                    @JsonProperty("reviewSnippets") List<ReviewSnippet> reviewSnippets) {}
 
             @JsonIgnoreProperties(ignoreUnknown = true)
             public record ReviewSnippet(
@@ -113,9 +116,11 @@ public record GroundingMetadata(
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record SearchEntryPoint(
-            @JsonProperty("renderedContent") String renderedContent, @JsonProperty("sdkBlob") String sdkBlob) {}
+            @JsonProperty("renderedContent") String renderedContent,
+            @JsonProperty("sdkBlob") String sdkBlob) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record RetrievalMetadata(
-            @JsonProperty("googleSearchDynamicRetrievalScore") Double googleSearchDynamicRetrievalScore) {}
+            @JsonProperty("googleSearchDynamicRetrievalScore")
+            Double googleSearchDynamicRetrievalScore) {}
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GroundingMetadata.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GroundingMetadata.java
@@ -1,16 +1,17 @@
 package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record GroundingMetadata(
-        List<GroundingChunk> groundingChunks,
-        List<GroundingSupport> groundingSupports,
-        List<String> webSearchQueries,
-        SearchEntryPoint searchEntryPoint,
-        RetrievalMetadata retrievalMetadata,
-        String googleMapsWidgetContextToken) {
+        @JsonProperty("groundingChunks") List<GroundingChunk> groundingChunks,
+        @JsonProperty("groundingSupports") List<GroundingSupport> groundingSupports,
+        @JsonProperty("webSearchQueries") List<String> webSearchQueries,
+        @JsonProperty("searchEntryPoint") SearchEntryPoint searchEntryPoint,
+        @JsonProperty("retrievalMetadata") RetrievalMetadata retrievalMetadata,
+        @JsonProperty("googleMapsWidgetContextToken") String googleMapsWidgetContextToken) {
 
     public static Builder builder() {
         return new Builder();
@@ -66,34 +67,55 @@ public record GroundingMetadata(
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record GroundingChunk(Web web, RetrievedContext retrievedContext, Maps maps) {
+    public record GroundingChunk(
+            @JsonProperty("web") Web web,
+            @JsonProperty("retrievedContext") RetrievedContext retrievedContext,
+            @JsonProperty("maps") Maps maps) {
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public record Web(String uri, String title) {}
+        public record Web(@JsonProperty("uri") String uri, @JsonProperty("title") String title) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public record RetrievedContext(String uri, String title, String text) {}
+        public record RetrievedContext(
+                @JsonProperty("uri") String uri,
+                @JsonProperty("title") String title,
+                @JsonProperty("text") String text) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         public record Maps(
-                String uri, String title, String text, String placeId, PlaceAnswerSources placeAnswerSources) {
+                @JsonProperty("uri") String uri,
+                @JsonProperty("title") String title,
+                @JsonProperty("text") String text,
+                @JsonProperty("placeId") String placeId,
+                @JsonProperty("placeAnswerSources") PlaceAnswerSources placeAnswerSources) {
             @JsonIgnoreProperties(ignoreUnknown = true)
-            public record PlaceAnswerSources(List<ReviewSnippet> reviewSnippets) {}
+            public record PlaceAnswerSources(@JsonProperty("reviewSnippets") List<ReviewSnippet> reviewSnippets) {}
 
             @JsonIgnoreProperties(ignoreUnknown = true)
-            public record ReviewSnippet(String reviewId, String googleMapsUri, String title) {}
+            public record ReviewSnippet(
+                    @JsonProperty("reviewId") String reviewId,
+                    @JsonProperty("googleMapsUri") String googleMapsUri,
+                    @JsonProperty("title") String title) {}
         }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record GroundingSupport(
-            List<Integer> groundingChunkIndices, List<Double> confidenceScores, Segment segment) {}
+            @JsonProperty("groundingChunkIndices") List<Integer> groundingChunkIndices,
+            @JsonProperty("confidenceScores") List<Double> confidenceScores,
+            @JsonProperty("segment") Segment segment) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record Segment(Integer partIndex, Integer startIndex, Integer endIndex, String text) {}
+    public record Segment(
+            @JsonProperty("partIndex") Integer partIndex,
+            @JsonProperty("startIndex") Integer startIndex,
+            @JsonProperty("endIndex") Integer endIndex,
+            @JsonProperty("text") String text) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record SearchEntryPoint(String renderedContent, String sdkBlob) {}
+    public record SearchEntryPoint(
+            @JsonProperty("renderedContent") String renderedContent, @JsonProperty("sdkBlob") String sdkBlob) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record RetrievalMetadata(Double googleSearchDynamicRetrievalScore) {}
+    public record RetrievalMetadata(
+            @JsonProperty("googleSearchDynamicRetrievalScore") Double googleSearchDynamicRetrievalScore) {}
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/UrlContextMetadata.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/UrlContextMetadata.java
@@ -1,11 +1,14 @@
 package dev.langchain4j.model.googleai;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record UrlContextMetadata(List<UrlMetadata> urlMetadata) {
+public record UrlContextMetadata(@JsonProperty("urlMetadata") List<UrlMetadata> urlMetadata) {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record UrlMetadata(String retrievedUrl, String urlRetrievalStatus) {}
+    public record UrlMetadata(
+            @JsonProperty("retrievedUrl") String retrievedUrl,
+            @JsonProperty("urlRetrievalStatus") String urlRetrievalStatus) {}
 }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/UrlContextMetadata.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/UrlContextMetadata.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record UrlContextMetadata(@JsonProperty("urlMetadata") List<UrlMetadata> urlMetadata) {
+public record UrlContextMetadata(
+        @JsonProperty("urlMetadata") List<UrlMetadata> urlMetadata) {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record UrlMetadata(


### PR DESCRIPTION
## Issue
Closes #4845

## Change
On Android, the DEX compiler does not preserve Java record constructor parameter names at runtime. This causes Jackson to fail to serialize/deserialize record components, resulting in empty request bodies (`{}`) being sent to the Gemini API.

This PR adds explicit `@JsonProperty` annotations to all record components in the `langchain4j-google-ai-gemini` module that were previously missing them.

This follows the same pattern already established by:
- `GeminiGenerationConfig` (already fully annotated in this module)
- The entire `langchain4j-open-ai` module (211 `@JsonProperty` annotations)

### Files changed (14)
- `GeminiContent.java` — `GeminiContent`, `GeminiPart`, `GeminiBlob`, `GeminiFunctionCall`, `GeminiFunctionResponse`, `GeminiFileData`, `GeminiExecutableCode`, `GeminiCodeExecutionResult`
- `GeminiGenerateContentRequest.java` — `GeminiGenerateContentRequest`, `GeminiTool`, `GeminiGoogleMaps`, `GeminiToolConfig`
- `GeminiGenerateContentResponse.java` — `GeminiGenerateContentResponse`, `GeminiCandidate`, `GeminiUrlContextMetadata`, `GeminiUrlMetadata`, `GeminiUsageMetadata`
- `GeminiFunctionDeclaration.java`, `GeminiCountTokensRequest.java`, `GeminiCountTokensResponse.java`, `GeminiModelsListResponse.java`, `GeminiModelInfo.java`, `GeminiThinkingConfig.java`
- `GroundingMetadata.java` — `GroundingMetadata` and all nested records
- `UrlContextMetadata.java`, `GeminiEmbeddingRequestResponse.java`, `BatchRequestResponse.java`, `GeminiFiles.java`

## General checklist
- [X] There are no breaking changes (API, behaviour)