### PR TITLE
Fix copy-paste errors in Guardrail Javadoc

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/InputGuardrail.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/InputGuardrail.java
@@ -22,7 +22,7 @@ public interface InputGuardrail extends Guardrail<InputGuardrailRequest, InputGu
      * <p>
      *
      * @param userMessage
-     *            the response from the LLM
+     *            the user message to be sent to the LLM
      */
     default InputGuardrailResult validate(UserMessage userMessage) {
         return failure("Validation not implemented");
@@ -105,7 +105,7 @@ public interface InputGuardrail extends Guardrail<InputGuardrailRequest, InputGu
     }
 
     /**
-     * Produces a non-fatal failure
+     * Produces a fatal failure
      *
      * @param message
      *            A message describing the failure.

--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/OutputGuardrail.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/OutputGuardrail.java
@@ -60,7 +60,7 @@ public interface OutputGuardrail extends Guardrail<OutputGuardrailRequest, Outpu
     }
 
     /**
-     * Produces a non-fatal failure
+     * Produces a successful result with specific success text and result object
      *
      * @return The result of a successful output guardrail validation with a specific text.
      *
@@ -86,7 +86,7 @@ public interface OutputGuardrail extends Guardrail<OutputGuardrailRequest, Outpu
     }
 
     /**
-     * Produces a non-fatal failure
+     * Produces a successful result with specific AiMessage and result object
      *
      * @param successfulAiMessage
      *            The AiMessage successful result.

--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/OutputGuardrailResult.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/OutputGuardrailResult.java
@@ -85,7 +85,7 @@ public final class OutputGuardrailResult implements GuardrailResult<OutputGuardr
     }
 
     /**
-     * Produces a non-fatal failure
+     * Produces a successful result with specific success text and result object
      *
      * @param successfulText
      *            The text of the successful result.
@@ -110,7 +110,7 @@ public final class OutputGuardrailResult implements GuardrailResult<OutputGuardr
     }
 
     /**
-     * Produces a non-fatal failure
+     * Produces a successful result with specific AiMessage and result object
      *
      * @param successfulAiMessage
      *            The AiMessage successful result.


### PR DESCRIPTION
Fixed 6 incorrect Javadoc comments in guardrail classes caused by copy-paste:

- InputGuardrail#validate(UserMessage): @param userMessage was described as "the response from the LLM" instead of "the user message to be sent to the LLM"
- InputGuardrail#fatal(String, Throwable): described as "Produces a non-fatal failure" instead of "Produces a fatal failure"
- OutputGuardrail#successWith(String, Object) and successWith(AiMessage, Object): described as "Produces a non-fatal failure" instead of producing a successful result
- OutputGuardrailResult#successWith(String, Object) and successWith(AiMessage, Object): same issue