### PR TITLE
Fix race condition in planner loop

### DIFF
--- a/langchain4j-agentic-patterns/src/test/java/dev/langchain4j/agentic/patterns/p2p/P2PPlannerComposeActionsIT.java
+++ b/langchain4j-agentic-patterns/src/test/java/dev/langchain4j/agentic/patterns/p2p/P2PPlannerComposeActionsIT.java
@@ -1,0 +1,109 @@
+package dev.langchain4j.agentic.patterns.p2p;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.declarative.K;
+import dev.langchain4j.agentic.declarative.TypedKey;
+import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class P2PPlannerComposeActionsIT {
+
+    // ── Typed keys ──────────────────────────────────────────────────────
+
+    public static class Key1 implements TypedKey<String> {
+        @Override public String name() { return "key1"; }
+    }
+
+    public static class Result2 implements TypedKey<String> {
+        @Override public String name() { return "result2"; }
+    }
+
+    public static class Result3 implements TypedKey<String> {
+        @Override public String name() { return "result3"; }
+    }
+
+    // ── Agent wrapper interfaces ────────────────────────────────────────
+    // The @K parameter on Consumer agents tells P2PPlanner to wait until
+    // key1 is present in scope before activating them.
+
+    public interface ProducerAgent {
+        @Agent
+        void produce();
+    }
+
+    public interface Consumer2Agent {
+        @Agent
+        void consume(@K(Key1.class) String key1);
+    }
+
+    public interface Consumer3Agent {
+        @Agent
+        void consume(@K(Key1.class) String key1);
+    }
+
+    @Test
+    void p2p_should_not_freeze_when_parallel_agents_complete() throws Exception {
+        Object agent1 = AgenticServices.conditionalBuilder(ProducerAgent.class)
+                .subAgents(
+                        "Run when key1 absent",
+                        scope -> !scope.hasState("key1"),
+                        AgenticServices.agentAction(scope -> scope.writeState("key1", "hello")))
+                .name("agent1")
+                .build();
+
+        Object agent2 = AgenticServices.conditionalBuilder(Consumer2Agent.class)
+                .subAgents(
+                        "Run when result2 absent",
+                        scope -> !scope.hasState("result2"),
+                        AgenticServices.agentAction(scope -> {
+                            Thread.sleep(ThreadLocalRandom.current().nextInt(1, 10));
+                            scope.writeState("result2", "analyzed-" + scope.readState("key1", ""));
+                        }))
+                .name("agent2")
+                .build();
+
+        Object agent3 = AgenticServices.conditionalBuilder(Consumer3Agent.class)
+                .subAgents(
+                        "Run when result3 absent",
+                        scope -> !scope.hasState("result3"),
+                        AgenticServices.agentAction(scope -> {
+                            Thread.sleep(ThreadLocalRandom.current().nextInt(1, 10));
+                            scope.writeState("result3", "poem-about-" + scope.readState("key1", ""));
+                        }))
+                .name("agent3")
+                .build();
+
+        UntypedAgent p2p = AgenticServices.plannerBuilder()
+                .subAgents(agent1, agent2, agent3)
+                .planner(() -> new P2PPlanner(15, (scope, invocations) ->
+                        scope.hasState("result2") && scope.hasState("result3")))
+                .name("p2p-test")
+                .build();
+
+        // Run on a daemon thread so the test doesn't hang forever if the bug triggers
+        CompletableFuture<ResultWithAgenticScope<String>> future = CompletableFuture.supplyAsync(
+                () -> p2p.invokeWithAgenticScope(Map.of()));
+
+        try {
+            ResultWithAgenticScope<String> result = future.get(5, TimeUnit.SECONDS);
+
+            assertThat(result.agenticScope().readState("key1", "")).isEqualTo("hello");
+            assertThat(result.agenticScope().readState("result2", "")).isEqualTo("analyzed-hello");
+            assertThat(result.agenticScope().readState("result3", "")).isEqualTo("poem-about-hello");
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            fail("P2P planner froze: composeActions likely dropped a done() action in favor of an empty call()");
+        }
+    }
+}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
@@ -346,7 +346,7 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         private final AgenticScopeRegistry registry;
         private final ReentrantLock lock = new ReentrantLock();
 
-        private Action nextAction = null;
+        private volatile Action nextAction = null;
 
         private PlannerLoop(Planner planner, DefaultAgenticScope agenticScope, AgenticScopeRegistry registry) {
             this.planner = planner;
@@ -402,9 +402,9 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
                 throw new RuntimeException(e);
             }
         }
-
         private Object result() {
             Object result = output != null ? output.apply(agenticScope) : nextAction.result();
+
             if (outputKey != null) {
                 if (result != null) {
                     agenticScope.writeState(outputKey, result);

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -343,6 +344,7 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         private final Planner planner;
         private final DefaultAgenticScope agenticScope;
         private final AgenticScopeRegistry registry;
+        private final ReentrantLock lock = new ReentrantLock();
 
         private Action nextAction = null;
 
@@ -416,16 +418,21 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
 
         @Override
         public void onSubagentInvoked(AgentInvocation agentInvocation) {
-            this.nextAction = composeActions(this.nextAction, planner.nextAction(new PlanningContext(agenticScope, agentInvocation)));
+            lock.lock();
+            try {
+                this.nextAction = composeActions(this.nextAction, planner.nextAction(new PlanningContext(agenticScope, agentInvocation)));
 
-            // Save planner execution state after each agent invocation
-            Map<String, Object> execState = planner.executionState();
-            if (!execState.isEmpty()) {
-                agenticScope.writeState(executionStateId(), execState);
-            }
+                // Save planner execution state after each agent invocation
+                Map<String, Object> execState = planner.executionState();
+                if (!execState.isEmpty()) {
+                    agenticScope.writeState(executionStateId(), execState);
+                }
 
-            if (registry != null) {
-                agenticScope.checkpoint(registry);
+                if (registry != null) {
+                    agenticScope.checkpoint(registry);
+                }
+            } finally {
+                lock.unlock();
             }
         }
 
@@ -435,10 +442,10 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         }
 
         private static Action composeActions(Action first, Action second) {
-            if (first == null || first.isDone()) {
+            if (first == null || first.isDone() || isEmptyCall(first)) {
                 return second;
             }
-            if (second == null || second.isDone()) {
+            if (second == null || second.isDone() || isEmptyCall(second)) {
                 return first;
             }
 
@@ -446,6 +453,10 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
             agentsToCall.addAll(((Action.AgentCallAction) first).agentsToCall());
             agentsToCall.addAll(((Action.AgentCallAction) second).agentsToCall());
             return new Action.AgentCallAction(agentsToCall);
+        }
+
+        private static boolean isEmptyCall(Action action) {
+            return action instanceof Action.AgentCallAction aca && aca.agentsToCall().isEmpty();
         }
     }
 

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/CustomPlannerIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/CustomPlannerIT.java
@@ -8,7 +8,6 @@ import dev.langchain4j.agentic.planner.PlanningContext;
 import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.locks.ReentrantLock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,8 +24,6 @@ public class CustomPlannerIT {
         private int cursor = 0;
         private int onGoingRequests = 1;
 
-        private final ReentrantLock lock = new ReentrantLock();
-
         private final List<Integer> invocations;
 
         public ParallelInPairsPlanner(List<Integer> invocations) {
@@ -40,24 +37,21 @@ public class CustomPlannerIT {
 
         @Override
         public Action nextAction(PlanningContext planningContext) {
-            lock.lock();
-            try {
-                if (--onGoingRequests == 0) {
-                    int missingRequests = agents.size() - cursor;
-                    int requestsToMake = Math.min(2, missingRequests);
-                    if (requestsToMake == 0) {
-                        return done();
-                    }
-                    onGoingRequests = requestsToMake;
-                    List<AgentInstance> toCall = agents.subList(cursor, cursor + requestsToMake);
-                    cursor += requestsToMake;
-                    invocations.add(requestsToMake);
-                    return call(toCall);
+            // No lock needed here: PlannerLoop.onSubagentInvoked serializes
+            // calls to nextAction() via its own ReentrantLock.
+            if (--onGoingRequests == 0) {
+                int missingRequests = agents.size() - cursor;
+                int requestsToMake = Math.min(2, missingRequests);
+                if (requestsToMake == 0) {
+                    return done();
                 }
-                return noOp();
-            } finally {
-                lock.unlock();
+                onGoingRequests = requestsToMake;
+                List<AgentInstance> toCall = agents.subList(cursor, cursor + requestsToMake);
+                cursor += requestsToMake;
+                invocations.add(requestsToMake);
+                return call(toCall);
             }
+            return noOp();
         }
     }
 

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/PlannerLoopThreadSafetyIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/PlannerLoopThreadSafetyIT.java
@@ -1,0 +1,119 @@
+package dev.langchain4j.agentic;
+
+import dev.langchain4j.agentic.planner.Action;
+import dev.langchain4j.agentic.planner.AgentInstance;
+import dev.langchain4j.agentic.planner.InitPlanningContext;
+import dev.langchain4j.agentic.planner.Planner;
+import dev.langchain4j.agentic.planner.PlanningContext;
+import dev.langchain4j.agentic.scope.AgentInvocation;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlannerLoopThreadSafetyIT {
+
+    interface CountingAgent {
+        @Agent
+        int count();
+    }
+
+    /**
+     * A planner that tracks per-agent follow-ups to expose the lost-update race
+     * in {@code composeActions}:
+     *
+     * Phase 1: Launch all agents in parallel (firstAction).
+     *          As each completes, the planner checks by agent ID whether it
+     *          already triggered a follow-up. If not, it schedules one.
+     *          All N callbacks race on the unsynchronized {@code nextAction} field
+     *          in {@code onSubagentInvoked}.
+     *
+     * Phase 2: Execute whatever follow-ups survived the race.
+     *          Each follow-up completion is tracked. Once all agents that
+     *          need a follow-up have completed both phases, return done().
+     *
+     * The per-agent tracking ensures the planner always terminates (no hang
+     * on lost actions) and allows precise counting of dropped follow-ups.
+     */
+    public static class ParallelBurstPlanner implements Planner {
+
+        private Map<String, AgentInstance> agentsById;
+
+        private final Set<String> phase1Completed = ConcurrentHashMap.newKeySet();
+
+        @Override
+        public void init(InitPlanningContext ctx) {
+            this.agentsById = ctx.subagents().stream()
+                    .collect(Collectors.toMap(AgentInstance::agentId, Function.identity()));
+        }
+
+        @Override
+        public Action firstAction(PlanningContext ctx) {
+            return call(new ArrayList<>(agentsById.values()));
+        }
+
+        @Override
+        public Action nextAction(PlanningContext ctx) {
+            AgentInvocation prev = ctx.previousAgentInvocation();
+            String agentId = prev.agentId();
+
+            if (phase1Completed.add(agentId)) {
+                // First time this agent completed — phase 1 done, schedule follow-up.
+                // All N phase-1 callbacks arrive concurrently from parallel threads.
+                // Each returns a call() action that composeActions should merge,
+                // but the lost-update race silently drops some.
+                return call(agentsById.get(agentId));
+            }
+
+            // This agent already completed phase 1, so this is a follow-up
+            // completion. All surviving follow-ups run in a single
+            // parallelExecution batch. Returning done() from each is safe:
+            // composeActions(done(), done()) = done(), so the loop terminates
+            // after the batch completes regardless of how many survived.
+            return done();
+        }
+    }
+
+    /**
+     * Launches 8 agents in parallel. Each completion schedules a follow-up
+     * for that specific agent via {@code onSubagentInvoked → composeActions}.
+     * All 8 callbacks race on the unsynchronized {@code nextAction} field.
+     */
+    @Test
+    void parallel_burst_should_execute_all_followups() {
+        int batchSize = 8;
+        AtomicInteger executionCount = new AtomicInteger(0);
+
+        Object[] subAgents = new Object[batchSize];
+        for (int i = 0; i < batchSize; i++) {
+            subAgents[i] = AgenticServices.agentAction(agenticScope -> {
+                // Random sleep to increase interleaving and widen the race window
+                Thread.sleep(ThreadLocalRandom.current().nextInt(1, 5));
+                executionCount.incrementAndGet();
+            });
+        }
+
+        CountingAgent agent = AgenticServices.plannerBuilder(CountingAgent.class)
+                .subAgents(subAgents)
+                .planner(ParallelBurstPlanner::new)
+                .output(scope -> executionCount.get())
+                .build();
+
+        int result = agent.count();
+
+        // Each of the N agents should run once in phase 1, then once more as
+        // a follow-up in phase 2, for a total of 2*N executions.
+        // If the race condition triggers, some follow-ups are lost and result < 2*batchSize.
+        assertThat(result)
+                .as("All %d phase-1 agents and their %d follow-ups should have executed", batchSize, batchSize)
+                .isEqualTo(2 * batchSize);
+    }
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #4862

## Change

As suggested in the bug report there are two distinct bugs, a more generic one causing a race condition when multiple agents are executed in parallel, and another one, still relatively generic, but specifically triggered by the P2P architecture.                                                                                                                                                
                                                                                                                                                                                                                                                                                        
In particular the first bug is a lost-update race on `nextAction`, where multiple threads calling `onSubagentInvoked` concurrently performed a non-atomic read-modify-write on the nextAction field, causing follow-up actions to be silently lost. The fix is simply making that operation atomic, by wrapping `onSubagentInvoked` body with a `ReentrantLock` (chosen over synchronized to avoid virtual thread pinning). This fix also simplifies the implementation of new Planners, making redundant the user-side lock from `CustomPlannerIT.ParallelInPairsPlanner`, that has been simplified accodingly.                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                          
The second bug is in the fact that `composeActions` drops `done()` in favor of empty call(). When two parallel agents finish and one returns done() while the other returns an empty `call()` (no new agents to schedule), `composeActions` always preferred the non-done action, even when it carried no work. This caused the planner loop to spin forever and it has been fixed by adding an `isEmptyCall()` check so empty `AgentCallActions` are treated as transparent, allowing `done()` to propagate.                                                                                                                                                                    

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
