### PR TITLE
feat(ollama): add support for dimensions in embedding request payload

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/ValidationUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/ValidationUtils.java
@@ -275,4 +275,19 @@ public class ValidationUtils {
         }
         return i;
     }
+    
+    /**
+     * Ensures that the given integer is either null or greater than zero.
+     *
+     * @param i The integer to check.
+     * @param name The logical name of the integer, used in the exception message.
+     * @return The value if it is null or greater than zero.
+     * @throws IllegalArgumentException if the value is zero or negative.
+     */
+    public static Integer ensureGreaterThanZeroIfNotNull(Integer i, String name) {
+        if (i != null && i <= 0) {
+            throw illegalArgument("%s must be greater than zero, but is: %s", name, i);
+        }
+        return i;
+    }
 }

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/EmbeddingRequest.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/EmbeddingRequest.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.model.ollama;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-import static dev.langchain4j.internal.Exceptions.illegalArgument;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -101,13 +100,6 @@ class EmbeddingRequest {
      */
     private Integer dimensions;
 
-    private static Integer validateDimensions(Integer dimensions) {
-        if (dimensions != null && dimensions < 1) {
-            throw illegalArgument("`dimensions` must be a positive integer.");
-        }
-        return dimensions;
-    }
-
     EmbeddingRequest() {}
 
     EmbeddingRequest(String model, List<String> input) {
@@ -117,7 +109,7 @@ class EmbeddingRequest {
     EmbeddingRequest(String model, List<String> input, Integer dimensions) {
         this.model = model;
         this.input = input;
-        this.dimensions = validateDimensions(dimensions);
+        this.dimensions = dimensions;
     }
 
     static Builder builder() {

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/EmbeddingRequest.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/EmbeddingRequest.java
@@ -1,14 +1,65 @@
 package dev.langchain4j.model.ollama;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.util.List;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-
+/**
+ * Request payload for Ollama's embedding generation API.
+ *
+ * <p>
+ * This class represents the JSON request body sent to the
+ * {@code POST /api/embed} endpoint for generating vector embeddings
+ * from one or more input texts.
+ * </p>
+ *
+ * <p>
+ * Example request:
+ * </p>
+ *
+ * <pre>
+ * curl http://localhost:11434/api/embed -d '{
+ *   "model": "all-minilm",
+ *   "input": [
+ *     "Why is the sky blue?",
+ *     "What is the best place to visit in summer"
+ *   ],
+ *   "dimensions": 2
+ * }'
+ * </pre>
+ *
+ * <p>
+ * Example response:
+ * </p>
+ *
+ * <pre>
+ * {
+ *   "model": "all-minilm",
+ *   "embeddings": [
+ *     [0.98507947, -0.1721],
+ *     [0.9774056, -0.21137223]
+ *   ],
+ *   "total_duration": 9305867458,
+ *   "load_duration": 9067644458,
+ *   "prompt_eval_count": 19
+ * }
+ * </pre>
+ *
+ * <p>
+ * The {@code dimensions} field is optional and controls the number of
+ * dimensions in the returned embedding vectors for models that support
+ * configurable output dimensionality.
+ * </p>
+ *
+ * @see <a href="https://github.com/ollama/ollama/blob/main/docs/api.md">
+ * Ollama API Documentation
+ * </a>
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
 @JsonNaming(SnakeCaseStrategy.class)
@@ -17,12 +68,56 @@ class EmbeddingRequest {
     private String model;
     private List<String> input;
 
-    EmbeddingRequest() {
+    /**
+     * Sets the number of dimensions for the generated embedding vector.
+     * <p>
+     * This value is sent as the {@code dimensions} field in the JSON request
+     * payload to Ollama's {@code /api/embed} endpoint.
+     * </p>
+     *
+     * <p>
+     * When specified, Ollama may return embedding vectors with the requested
+     * number of dimensions, depending on whether the selected embedding model
+     * supports configurable output dimensions.
+     * </p>
+     *
+     * <p>
+     * If {@code null}, the model's default embedding size is used.
+     * </p>
+     *
+     * <p>
+     * Example:
+     * <pre>
+     * {
+     *   "model": "all-minilm",
+     *   "input": ["Why is the sky blue?", "What is the best place to visit in summer"],
+     *   "dimensions": 256
+     * }
+     * </pre>
+     * </p>
+     *
+     * @param dimensions the requested output embedding vector size
+     * @return this builder instance
+     */
+    private Integer dimensions;
+
+    private static Integer validateDimensions(Integer dimensions) {
+        if (dimensions != null && dimensions < 1) {
+            throw illegalArgument("`dimensions` must be a positive integer.");
+        }
+        return dimensions;
     }
 
+    EmbeddingRequest() {}
+
     EmbeddingRequest(String model, List<String> input) {
+        this(model, input, null);
+    }
+
+    EmbeddingRequest(String model, List<String> input, Integer dimensions) {
         this.model = model;
         this.input = input;
+        this.dimensions = validateDimensions(dimensions);
     }
 
     static Builder builder() {
@@ -45,10 +140,19 @@ class EmbeddingRequest {
         this.input = input;
     }
 
+    public Integer getDimensions() {
+        return dimensions;
+    }
+
+    public void setDimension(Integer dimensions) {
+        this.dimensions = dimensions;
+    }
+
     static class Builder {
 
         private String model;
         private List<String> input;
+        private Integer dimensions;
 
         Builder model(String model) {
             this.model = model;
@@ -60,8 +164,13 @@ class EmbeddingRequest {
             return this;
         }
 
+        Builder dimensions(Integer dimensions) {
+            this.dimensions = dimensions;
+            return this;
+        }
+
         EmbeddingRequest build() {
-            return new EmbeddingRequest(model, input);
+            return new EmbeddingRequest(model, input, dimensions);
         }
     }
 }

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -260,9 +260,8 @@ class InternalOllamaHelper {
             return aiMessage.text();
         } else if (chatMessage instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
             if (!toolExecutionResultMessage.hasSingleText()) {
-                throw new UnsupportedFeatureException(
-                        "Ollama does not support non-text content in tool results. "
-                                + "Only text content is supported.");
+                throw new UnsupportedFeatureException("Ollama does not support non-text content in tool results. "
+                        + "Only text content is supported.");
             }
             return toolExecutionResultMessage.text();
         } else {

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaEmbeddingModel.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaEmbeddingModel.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.ollama;
 
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureGreaterThanZeroIfNotNull;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 
@@ -26,6 +27,7 @@ public class OllamaEmbeddingModel extends DimensionAwareEmbeddingModel {
     private final OllamaClient client;
     private final String modelName;
     private final Integer maxRetries;
+    private final Integer dimensions;
 
     public OllamaEmbeddingModel(OllamaEmbeddingModelBuilder builder) {
         this.client = OllamaClient.builder()
@@ -38,6 +40,7 @@ public class OllamaEmbeddingModel extends DimensionAwareEmbeddingModel {
                 .build();
         this.modelName = ensureNotBlank(builder.modelName, "modelName");
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
+        this.dimensions = ensureGreaterThanZeroIfNotNull(builder.dimensions, "dimensions");
     }
 
     public static OllamaEmbeddingModelBuilder builder() {
@@ -51,8 +54,11 @@ public class OllamaEmbeddingModel extends DimensionAwareEmbeddingModel {
     public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
         List<String> input = textSegments.stream().map(TextSegment::text).collect(Collectors.toList());
 
-        EmbeddingRequest request =
-                EmbeddingRequest.builder().model(modelName).input(input).build();
+        EmbeddingRequest request = EmbeddingRequest.builder()
+                .model(modelName)
+                .input(input)
+                .dimensions(dimensions)
+                .build();
         EmbeddingResponse response = withRetryMappingExceptions(() -> client.embed(request), maxRetries);
         List<Embedding> embeddings =
                 response.getEmbeddings().stream().map(Embedding::from).collect(Collectors.toList());
@@ -65,6 +71,11 @@ public class OllamaEmbeddingModel extends DimensionAwareEmbeddingModel {
         return this.modelName;
     }
 
+    @Override
+    protected Integer knownDimension() {
+        return dimensions;
+    }
+
     public static class OllamaEmbeddingModelBuilder {
 
         private HttpClientBuilder httpClientBuilder;
@@ -75,6 +86,7 @@ public class OllamaEmbeddingModel extends DimensionAwareEmbeddingModel {
         private Boolean logRequests;
         private Boolean logResponses;
         private Supplier<Map<String, String>> customHeadersSupplier;
+        private Integer dimensions;
 
         public OllamaEmbeddingModelBuilder() {
             // This is public so it can be extended
@@ -136,6 +148,20 @@ public class OllamaEmbeddingModel extends DimensionAwareEmbeddingModel {
          */
         public OllamaEmbeddingModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
             this.customHeadersSupplier = customHeadersSupplier;
+            return this;
+        }
+
+        /**
+         * Sets the number of dimensions for the generated embeddings.
+         * <p>
+         * If provided, the embedding vector will be truncated or projected
+         * to the specified size by the Ollama embedding model.
+         *
+         * @param dimensions the embedding dimension size, must be positive
+         * @return builder
+         */
+        public OllamaEmbeddingModelBuilder dimensions(Integer dimensions) {
+            this.dimensions = dimensions;
             return this;
         }
 

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaEmbeddingModelIT.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaEmbeddingModelIT.java
@@ -1,17 +1,17 @@
 package dev.langchain4j.model.ollama;
 
-import dev.langchain4j.data.embedding.Embedding;
-import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.model.output.Response;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
 import static dev.langchain4j.model.ollama.AbstractOllamaLanguageModelInfrastructure.ollamaBaseUrl;
 import static dev.langchain4j.model.ollama.OllamaImage.ALL_MINILM_MODEL;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import java.util.List;
+import org.junit.jupiter.api.Test;
 
 class OllamaEmbeddingModelIT extends AbstractOllamaEmbeddingModelInfrastructure {
 
@@ -41,10 +41,7 @@ class OllamaEmbeddingModelIT extends AbstractOllamaEmbeddingModelInfrastructure 
     void should_embed_multiple_segments() {
 
         // given
-        List<TextSegment> segments = asList(
-                TextSegment.from("hello"),
-                TextSegment.from("world")
-        );
+        List<TextSegment> segments = asList(TextSegment.from("hello"), TextSegment.from("world"));
 
         // when
         Response<List<Embedding>> response = model.embedAll(segments);
@@ -68,5 +65,56 @@ class OllamaEmbeddingModelIT extends AbstractOllamaEmbeddingModelInfrastructure 
 
         // then
         assertThat(model.dimension()).isEqualTo(response.content().dimension());
+    }
+
+    @Test
+    void should_embed_with_custom_dimensions() {
+
+        // given
+        EmbeddingModel model = OllamaEmbeddingModel.builder()
+                .baseUrl(ollamaBaseUrl(ollama))
+                .modelName(ALL_MINILM_MODEL)
+                .dimensions(2)
+                .build();
+
+        // when
+        Response<Embedding> response = model.embed("hello world");
+
+        // then
+        assertThat(response.content().dimension()).isEqualTo(2);
+        assertThat(response.content().vector()).hasSize(2);
+    }
+
+    @Test
+    void should_embed_multiple_segments_with_custom_dimensions() {
+
+        // given
+        EmbeddingModel model = OllamaEmbeddingModel.builder()
+                .baseUrl(ollamaBaseUrl(ollama))
+                .modelName(ALL_MINILM_MODEL)
+                .dimensions(2)
+                .build();
+
+        List<TextSegment> segments = asList(TextSegment.from("hello"), TextSegment.from("world"));
+
+        // when
+        Response<List<Embedding>> response = model.embedAll(segments);
+
+        // then
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.content().get(0).dimension()).isEqualTo(2);
+        assertThat(response.content().get(1).dimension()).isEqualTo(2);
+    }
+
+    @Test
+    void should_fail_when_dimensions_is_not_positive() {
+
+        assertThatThrownBy(() -> OllamaEmbeddingModel.builder()
+                        .baseUrl(ollamaBaseUrl(ollama))
+                        .modelName(ALL_MINILM_MODEL)
+                        .dimensions(0)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("dimensions");
     }
 }


### PR DESCRIPTION
## Summary

Adds support for the `dimensions` field in Ollama embedding requests.

This change enhances `EmbeddingRequest` to include an optional `dimensions` property, allowing callers to request embeddings with a custom output vector size for models that support configurable dimensions.

Example request payload:

```json
{
  "model": "all-minilm",
  "input": [
    "Why is the sky blue?",
    "What is the best place to visit in summer"
  ],
  "dimensions": 2
}