### PR TITLE
fix: use skipMain/skip instead of phase=none in maven-compiler-plugin to fix Eclipse/VSCode Java version detection

### DIFF
--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -571,15 +571,20 @@
                     <annotationProcessorPaths></annotationProcessorPaths>
                 </configuration>
                 <executions>
-                    <!-- Replacing default-compile as it is treated specially by Maven -->
+                    <!-- Disabling default-compile/testCompile via skipMain/skip so that
+                         Kotlin compiles first. Using skip instead of phase=none so that
+                         m2e/Eclipse JDT can still read compiler settings from this execution. -->
                     <execution>
                         <id>default-compile</id>
-                        <phase>none</phase>
+                        <configuration>
+                            <skipMain>true</skipMain>
+                        </configuration>
                     </execution>
-                    <!-- Replacing default-testCompile as it is treated specially by Maven -->
                     <execution>
                         <id>default-testCompile</id>
-                        <phase>none</phase>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>java-compile</id>


### PR DESCRIPTION
## Problem

When opening this project in VSCode (or Eclipse), the Java Language Server (Red Hat) reports 11K+ compilation errors because it detects all modules as Java 1.8 instead of Java 17. IntelliJ IDEA is not affected.

**Root cause**: m2e's `AbstractJavaProjectConfigurator.addJavaProjectOptions()` reads compiler settings exclusively from the `default-compile` execution. When `default-compile` has `phase=none`, it is excluded from the Maven lifecycle execution plan, so `getMojoExecutions()` does not return it. m2e then falls back to the default Java 1.8.

    maven-compiler-plugin default-compile has phase=none
        → m2e getMojoExecutions() does not return phase=none executions
        → addJavaProjectOptions() only looks for executionId="default-compile"
        → not found → cannot read maven.compiler.release=17
        → falls back to Java 1.8

## Solution

Replace `phase=none` with `skipMain=true` / `skip=true` for `default-compile` and `default-testCompile` executions in `langchain4j-parent/pom.xml`.

Before (execution not in lifecycle plan, m2e can't find it):

    <execution>
        <id>default-compile</id>
        <phase>none</phase>
    </execution>

After (execution stays in lifecycle plan but skips compilation):

    <execution>
        <id>default-compile</id>
        <configuration>
            <skipMain>true</skipMain>
        </configuration>
    </execution>

Both approaches have the same Maven build behavior (Kotlin compiles first, default Java compilation is skipped), but `skipMain=true` keeps the execution visible to m2e.

## Impact

- **Maven builds**: No change — `skipMain=true` and `phase=none` both prevent `default-compile` from actually compiling
- **IntelliJ IDEA**: No change — IDEA reads `maven.compiler.release` directly
- **Eclipse/VSCode**: Fixed — m2e can now find `default-compile` and correctly detect `maven.compiler.release=17`

## Verification

- Verified by decompiling `org.eclipse.m2e.jdt` (v2.5.0) that `addJavaProjectOptions()` only processes executions with id `default-compile`
- `mvn compile -pl langchain4j-core -am` passes
- VSCode Java Language Server correctly shows Java 17 compliance after reload

## Checklist

- [x] N/A (no existing issue, discovered during development)
- [x] Changed `default-compile` from `<phase>none</phase>` to `<skipMain>true</skipMain>`; Changed `default-testCompile` from `<phase>none</phase>` to `<skip>true</skip>`
- [x] Build config change, verified manually with Maven build and VSCode reload
- [x] Existing tests still pass
