### PR TITLE
fix: make DateOutputParser thread-safe by using DateTimeFormatter

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/output/DateOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/DateOutputParser.java
@@ -15,8 +15,15 @@ class DateOutputParser implements OutputParser<Date> {
 
     @Override
     public Date parse(String string) {
-        LocalDate localDate = LocalDate.parse(string.trim(), FORMATTER);
-        return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        if (string == null) {
+            throw new OutputParsingException("Cannot parse null into java.util.Date", null);
+        }
+        try {
+            LocalDate localDate = LocalDate.parse(string.trim(), FORMATTER);
+            return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        } catch (Exception e) {
+            throw new OutputParsingException("Cannot parse '%s' into java.util.Date".formatted(string), e);
+        }
     }
 
     @Override

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/DateOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/DateOutputParser.java
@@ -1,29 +1,33 @@
 package dev.langchain4j.service.output;
 
 import dev.langchain4j.Internal;
-
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 
 @Internal
 class DateOutputParser implements OutputParser<Date> {
 
     private static final String DATE_PATTERN = "yyyy-MM-dd";
-    private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat(DATE_PATTERN);
+    // DateTimeFormatter is immutable and thread-safe, unlike SimpleDateFormat.
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
 
     @Override
     public Date parse(String string) {
         string = string.trim();
 
-        // SimpleDateFormat silently accepts dd-MM-yyyy; but parses it strangely.
+        // Guard against inputs like "dd-MM-yyyy" so the error message stays consistent
+        // with previous behavior (and independent of formatter-specific exceptions).
         if (string.indexOf("-") != 4 || string.indexOf("-", 5) != 7) {
             throw new RuntimeException("Invalid date format: " + string);
         }
 
         try {
-            return SIMPLE_DATE_FORMAT.parse(string);
-        } catch (ParseException e) {
+            LocalDate localDate = LocalDate.parse(string, FORMATTER);
+            return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        } catch (DateTimeParseException e) {
             throw new RuntimeException(e);
         }
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/DateOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/DateOutputParser.java
@@ -1,35 +1,22 @@
 package dev.langchain4j.service.output;
 
 import dev.langchain4j.Internal;
+
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Date;
 
 @Internal
 class DateOutputParser implements OutputParser<Date> {
 
     private static final String DATE_PATTERN = "yyyy-MM-dd";
-    // DateTimeFormatter is immutable and thread-safe, unlike SimpleDateFormat.
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
 
     @Override
     public Date parse(String string) {
-        string = string.trim();
-
-        // Guard against inputs like "dd-MM-yyyy" so the error message stays consistent
-        // with previous behavior (and independent of formatter-specific exceptions).
-        if (string.indexOf("-") != 4 || string.indexOf("-", 5) != 7) {
-            throw new RuntimeException("Invalid date format: " + string);
-        }
-
-        try {
-            LocalDate localDate = LocalDate.parse(string, FORMATTER);
-            return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
-        } catch (DateTimeParseException e) {
-            throw new RuntimeException(e);
-        }
+        LocalDate localDate = LocalDate.parse(string.trim(), FORMATTER);
+        return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
 
     @Override

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/DateOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/DateOutputParserTest.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.format.DateTimeParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.stream.Stream;
@@ -42,12 +42,13 @@ class DateOutputParserTest {
         );
     }
 
-    @ParameterizedTest
-    @NullSource
-    void should_fail_to_parse_null_input(String input) {
+    @Test
+    void should_fail_to_parse_null_input() {
 
-        assertThatThrownBy(() -> parser.parse(input))
-                .isInstanceOf(Exception.class);
+        assertThatThrownBy(() -> parser.parse(null))
+                .isExactlyInstanceOf(OutputParsingException.class)
+                .hasMessage("Cannot parse null into java.util.Date")
+                .hasNoCause();
     }
 
     @ParameterizedTest
@@ -64,7 +65,9 @@ class DateOutputParserTest {
     void should_fail_to_parse_invalid_input(String input) {
 
         assertThatThrownBy(() -> parser.parse(input))
-                .isInstanceOf(RuntimeException.class);
+                .isExactlyInstanceOf(OutputParsingException.class)
+                .hasMessageContainingAll("Cannot parse", input, "into java.util.Date")
+                .hasCauseExactlyInstanceOf(DateTimeParseException.class);
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/DateOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/DateOutputParserTest.java
@@ -1,0 +1,79 @@
+package dev.langchain4j.service.output;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DateOutputParserTest {
+
+    private final DateOutputParser parser = new DateOutputParser();
+
+    @ParameterizedTest
+    @MethodSource
+    void should_parse_valid_input(String input, int year, int month, int day) {
+
+        // when
+        Date actual = parser.parse(input);
+
+        // then
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(actual);
+        assertThat(calendar.get(Calendar.YEAR)).isEqualTo(year);
+        assertThat(calendar.get(Calendar.MONTH)).isEqualTo(month - 1);
+        assertThat(calendar.get(Calendar.DAY_OF_MONTH)).isEqualTo(day);
+    }
+
+    static Stream<Arguments> should_parse_valid_input() {
+        return Stream.of(
+                Arguments.of("2024-01-15", 2024, 1, 15),
+                Arguments.of("2000-12-31", 2000, 12, 31),
+                Arguments.of("1999-06-01", 1999, 6, 1),
+                Arguments.of("  2024-01-15  ", 2024, 1, 15)
+        );
+    }
+
+    @ParameterizedTest
+    @NullSource
+    void should_fail_to_parse_null_input(String input) {
+
+        assertThatThrownBy(() -> parser.parse(input))
+                .isInstanceOf(Exception.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            " ",
+            "15-01-2024",
+            "01-15-2024",
+            "2024/01/15",
+            "20240115",
+            "not-a-date",
+            "2024-1-5"
+    })
+    void should_fail_to_parse_invalid_input(String input) {
+
+        assertThatThrownBy(() -> parser.parse(input))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void format_instructions() {
+
+        // when
+        String instructions = parser.formatInstructions();
+
+        // then
+        assertThat(instructions).isEqualTo("yyyy-MM-dd");
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/OutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/OutputParserTest.java
@@ -6,6 +6,11 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +64,45 @@ class OutputParserTest implements WithAssertions {
         assertThatExceptionOfType(RuntimeException.class)
                 .isThrownBy(() -> parser.parse("01-12-2020"))
                 .withMessage("Invalid date format: 01-12-2020");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void date_parser_is_thread_safe() throws InterruptedException {
+        DateOutputParser parser = new DateOutputParser();
+        Date expected = new Date(120, Calendar.JANUARY, 12);
+
+        int threads = 16;
+        int iterationsPerThread = 500;
+
+        CountDownLatch latch = new CountDownLatch(threads);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            for (int i = 0; i < threads; i++) {
+                executor.submit(() -> {
+                    try {
+                        for (int j = 0; j < iterationsPerThread; j++) {
+                            Date result = parser.parse("2020-01-12");
+                            if (!expected.equals(result)) {
+                                failure.compareAndSet(null, new AssertionError("Got unexpected date: " + result));
+                                return;
+                            }
+                        }
+                    } catch (Throwable t) {
+                        failure.compareAndSet(null, t);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(failure.get()).isNull();
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/OutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/OutputParserTest.java
@@ -4,13 +4,6 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
@@ -48,61 +41,6 @@ class OutputParserTest implements WithAssertions {
         assertThat(parser.parse("-42")).isEqualTo((byte) -42);
 
         assertThatExceptionOfType(NumberFormatException.class).isThrownBy(() -> parser.parse("42.0"));
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    void date() {
-        DateOutputParser parser = new DateOutputParser();
-        assertThat(parser.formatInstructions()).isEqualTo("yyyy-MM-dd");
-
-        assertThat(parser.parse("2020-01-12"))
-                .isEqualTo(parser.parse("2020-01-12"))
-                .isEqualTo(parser.parse(" 2020-01-12 "))
-                .isEqualTo(new Date(120, Calendar.JANUARY, 12));
-
-        assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(() -> parser.parse("01-12-2020"))
-                .withMessage("Invalid date format: 01-12-2020");
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    void date_parser_is_thread_safe() throws InterruptedException {
-        DateOutputParser parser = new DateOutputParser();
-        Date expected = new Date(120, Calendar.JANUARY, 12);
-
-        int threads = 16;
-        int iterationsPerThread = 500;
-
-        CountDownLatch latch = new CountDownLatch(threads);
-        AtomicReference<Throwable> failure = new AtomicReference<>();
-
-        ExecutorService executor = Executors.newFixedThreadPool(threads);
-        try {
-            for (int i = 0; i < threads; i++) {
-                executor.submit(() -> {
-                    try {
-                        for (int j = 0; j < iterationsPerThread; j++) {
-                            Date result = parser.parse("2020-01-12");
-                            if (!expected.equals(result)) {
-                                failure.compareAndSet(null, new AssertionError("Got unexpected date: " + result));
-                                return;
-                            }
-                        }
-                    } catch (Throwable t) {
-                        failure.compareAndSet(null, t);
-                    } finally {
-                        latch.countDown();
-                    }
-                });
-            }
-            assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
-        } finally {
-            executor.shutdownNow();
-        }
-
-        assertThat(failure.get()).isNull();
     }
 
     @Test


### PR DESCRIPTION
Fixes #4901.

## Summary

`DateOutputParser` used a `static final SimpleDateFormat` instance shared
across all threads (and shared across the whole application via
`DefaultOutputParserFactory`). `SimpleDateFormat` is
[documented as not thread-safe](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/text/SimpleDateFormat.html),
so concurrent AI Service calls returning `Date` can produce silently
corrupt results or throw `NumberFormatException` /
`ArrayIndexOutOfBoundsException`.

This PR replaces `SimpleDateFormat` with the thread-safe
`DateTimeFormatter.ISO_LOCAL_DATE`, aligning the implementation with
the sibling `LocalDateOutputParser`.

## Changes

- `DateOutputParser`: use `DateTimeFormatter` + `LocalDate.parse(...)` +
  `Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant())`
- `OutputParserTest`: add `date_parser_is_thread_safe` — a concurrent
  regression test (16 threads × 500 iterations). Fails on the current
  `main` (`NumberFormatException: multiple points`) and passes with
  this fix.

## Behavior preservation

- Same format pattern (`yyyy-MM-dd`) and `formatInstructions()` output
- Same default-timezone semantics (`ZoneId.systemDefault()` matches what
  `SimpleDateFormat` did without explicit TZ configuration)
- Same `RuntimeException` surface and exact message for malformed input —
  the `indexOf("-")` validation is intentionally kept so the pre-existing
  `date()` test assertion
  (`.withMessage("Invalid date format: 01-12-2020")`) still holds

## Open questions raised in the issue

I left three questions in #4901 and chose the most conservative defaults
here; happy to adjust based on maintainer preference:

1. `DateTimeFormatter` vs `ThreadLocal<SimpleDateFormat>` → chose
   `DateTimeFormatter` to match `LocalDateOutputParser`
2. `ZoneId.systemDefault()` vs `ZoneOffset.UTC` → chose
   `systemDefault()` for behavior preservation
3. Remove the `indexOf("-")` pre-check → kept it to preserve the
   existing error-message assertion

Marking as **draft** until the direction is confirmed.

## Test plan

- [x] Existing `OutputParserTest` tests pass (9/9)
- [x] New concurrent test fails on current `main` and passes with this fix
- [x] `./mvnw -pl langchain4j spotless:check` passes
