### PR TITLE
Add guardrailName() to GuardrailExecutedEvent for observability

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/AbstractGuardrailExecutor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/AbstractGuardrailExecutor.java
@@ -125,6 +125,7 @@ public abstract sealed class AbstractGuardrailExecutor<
                         .request(request)
                         .result(result)
                         .guardrailClass((Class<G>) guardrail.getClass())
+                        .guardrailName(guardrail.name())
                         .duration(duration)
                         .build());
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/Guardrail.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/Guardrail.java
@@ -10,6 +10,18 @@ package dev.langchain4j.guardrail;
  *            The type of the {@link GuardrailResult}
  */
 public interface Guardrail<P extends GuardrailRequest, R extends GuardrailResult<R>> {
+
+    /**
+     * Returns the logical name of this guardrail.
+     *
+     * Wrappers/decorators can override this method to expose the wrapped guardrail's name.
+     *
+     * @return the logical guardrail name
+     */
+    default String name() {
+        return getClass().getSimpleName();
+    }
+
     /**
      * Validate the interaction between the model and the user in one of the two directions.
      *

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
@@ -45,14 +45,12 @@ public interface GuardrailExecutedEvent<
     Class<G> guardrailClass();
 
     /**
-     * Retrieves the guardrail name associated with the validation process.
-     *
-     * @return the guardrail name. Defaults to {@code guardrailClass().getSimpleName()} when not explicitly set.
-     */
-    default String guardrailName() {
-        return guardrailClass().getSimpleName();
-    }
-
+    * Retrieves the guardrail name associated with the validation process.
+    *
+    * @return the guardrail name, as set by the executor (see {@link Guardrail#name()}).
+    */
+    String guardrailName();
+    
     /**
      * Retrieves the duration of the guardrail execution.
      *

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
@@ -45,6 +45,15 @@ public interface GuardrailExecutedEvent<
     Class<G> guardrailClass();
 
     /**
+     * Retrieves the guardrail name associated with the validation process.
+     *
+     * @return the guardrail name. Defaults to {@code guardrailClass().getSimpleName()} when not explicitly set.
+     */
+    default String guardrailName() {
+        return guardrailClass().getSimpleName();
+    }
+
+    /**
      * Retrieves the duration of the guardrail execution.
      *
      * @return the duration of the guardrail validation process.
@@ -61,6 +70,7 @@ public interface GuardrailExecutedEvent<
         private P request;
         private R result;
         private Class<G> guardrailClass;
+        private String guardrailName;
         private Duration duration;
 
         protected GuardrailExecutedEventBuilder() {}
@@ -70,6 +80,7 @@ public interface GuardrailExecutedEvent<
             request(src.request());
             result(src.result());
             guardrailClass(src.guardrailClass());
+            guardrailName(src.guardrailName());
             duration(src.duration());
         }
 
@@ -79,6 +90,10 @@ public interface GuardrailExecutedEvent<
 
         public P request() {
             return request;
+        }
+
+        public String guardrailName() {
+            return guardrailName;
         }
 
         public R result() {
@@ -105,6 +120,11 @@ public interface GuardrailExecutedEvent<
 
         public <C extends G> GuardrailExecutedEventBuilder<P, R, G, T> guardrailClass(Class<C> guardrailClass) {
             this.guardrailClass = (Class<G>) guardrailClass;
+            return this;
+        }
+
+        public GuardrailExecutedEventBuilder<P, R, G, T> guardrailName(String guardrailName) {
+            this.guardrailName = guardrailName;
             return this;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
@@ -45,12 +45,14 @@ public interface GuardrailExecutedEvent<
     Class<G> guardrailClass();
 
     /**
-    * Retrieves the guardrail name associated with the validation process.
-    *
-    * @return the guardrail name, as set by the executor (see {@link Guardrail#name()}).
-    */
-    String guardrailName();
-    
+     * Retrieves the guardrail name associated with the validation process.
+     *
+     * @return the guardrail name. Defaults to {@code guardrailClass().getSimpleName()} when not explicitly set.
+     */
+    default String guardrailName() {
+        return guardrailClass().getSimpleName();
+    }
+
     /**
      * Retrieves the duration of the guardrail execution.
      *

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultGuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultGuardrailExecutedEvent.java
@@ -27,6 +27,7 @@ public abstract class DefaultGuardrailExecutedEvent<
     private final P request;
     private final R result;
     private final Class<G> guardrailClass;
+    private final String guardrailName;
     private final Duration duration;
 
     protected DefaultGuardrailExecutedEvent(GuardrailExecutedEventBuilder<P, R, G, E> builder) {
@@ -34,6 +35,8 @@ public abstract class DefaultGuardrailExecutedEvent<
         this.request = ensureNotNull(builder.request(), "request");
         this.result = ensureNotNull(builder.result(), "result");
         this.guardrailClass = ensureNotNull(builder.guardrailClass(), "guardrailClass");
+        this.guardrailName =
+                (builder.guardrailName() != null) ? builder.guardrailName() : this.guardrailClass.getSimpleName();
         this.duration = ensureNotNull(builder.duration(), "duration");
     }
 
@@ -50,6 +53,11 @@ public abstract class DefaultGuardrailExecutedEvent<
     @Override
     public Class<G> guardrailClass() {
         return this.guardrailClass;
+    }
+
+    @Override
+    public String guardrailName() {
+        return this.guardrailName;
     }
 
     @Override

--- a/langchain4j-core/src/test/java/dev/langchain4j/guardrail/InputGuardrailExecutorTests.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/guardrail/InputGuardrailExecutorTests.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.guardrail;
 
 import static dev.langchain4j.test.guardrail.GuardrailAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/langchain4j-core/src/test/java/dev/langchain4j/guardrail/InputGuardrailExecutorTests.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/guardrail/InputGuardrailExecutorTests.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.guardrail;
 
 import static dev.langchain4j.test.guardrail.GuardrailAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -8,7 +9,11 @@ import static org.mockito.Mockito.verify;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.guardrail.config.InputGuardrailsConfig;
 import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.observability.api.AiServiceListenerRegistrar;
+import dev.langchain4j.observability.api.event.InputGuardrailExecutedEvent;
+import dev.langchain4j.observability.api.listener.InputGuardrailExecutedListener;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -69,6 +74,98 @@ class InputGuardrailExecutorTests {
         var result = executor.execute(request);
 
         assertThat(result).isSuccessful();
+    }
+
+    @Test
+    void wrappedGuardrailShouldUseInnerGuardrailNameInObservabilityEvent() {
+        var eventRef = new AtomicReference<InputGuardrailExecutedEvent>();
+        var registrar = AiServiceListenerRegistrar.newInstance();
+        registrar.register((InputGuardrailExecutedListener) eventRef::set);
+
+        var request = InputGuardrailRequest.builder()
+                .userMessage(UserMessage.from("test"))
+                .commonParams(GuardrailRequestParams.builder()
+                        .chatMemory(null)
+                        .augmentationResult(null)
+                        .userMessageTemplate("")
+                        .variables(Map.of())
+                        .invocationContext(DEFAULT_INVOCATION_CONTEXT)
+                        .aiServiceListenerRegistrar(registrar)
+                        .build())
+                .build();
+
+        var executor = InputGuardrailExecutor.builder()
+                .guardrails(new WrappedInputGuardrail(new InnerFailingInputGuardrail()))
+                .config(InputGuardrailsConfig.builder().build())
+                .build();
+
+        assertThatExceptionOfType(InputGuardrailException.class).isThrownBy(() -> executor.execute(request));
+
+        assertThat(eventRef.get()).isNotNull();
+        assertThat(eventRef.get().guardrailClass()).isEqualTo(WrappedInputGuardrail.class);
+        assertThat(eventRef.get().guardrailName()).isEqualTo(InnerFailingInputGuardrail.class.getSimpleName());
+    }
+
+    @Test
+    void wrappedGuardrailShouldUseInnerGuardrailNameInObservabilityEventOnSuccess() {
+        var eventRef = new AtomicReference<InputGuardrailExecutedEvent>();
+        var registrar = AiServiceListenerRegistrar.newInstance();
+        registrar.register((InputGuardrailExecutedListener) eventRef::set);
+
+        var request = InputGuardrailRequest.builder()
+                .userMessage(UserMessage.from("test"))
+                .commonParams(GuardrailRequestParams.builder()
+                        .chatMemory(null)
+                        .augmentationResult(null)
+                        .userMessageTemplate("")
+                        .variables(Map.of())
+                        .invocationContext(DEFAULT_INVOCATION_CONTEXT)
+                        .aiServiceListenerRegistrar(registrar)
+                        .build())
+                .build();
+
+        var executor = InputGuardrailExecutor.builder()
+                .guardrails(new WrappedInputGuardrail(new InnerSuccessInputGuardrail()))
+                .config(InputGuardrailsConfig.builder().build())
+                .build();
+
+        var result = executor.execute(request);
+
+        assertThat(result).isSuccessful();
+        assertThat(eventRef.get()).isNotNull();
+        assertThat(eventRef.get().guardrailClass()).isEqualTo(WrappedInputGuardrail.class);
+        assertThat(eventRef.get().guardrailName()).isEqualTo(InnerSuccessInputGuardrail.class.getSimpleName());
+    }
+
+    @Test
+    void shouldFallbackToClassNameWhenNoCustomNameProvided() {
+        var eventRef = new AtomicReference<InputGuardrailExecutedEvent>();
+        var registrar = AiServiceListenerRegistrar.newInstance();
+        registrar.register((InputGuardrailExecutedListener) eventRef::set);
+
+        var request = InputGuardrailRequest.builder()
+                .userMessage(UserMessage.from("test"))
+                .commonParams(GuardrailRequestParams.builder()
+                        .chatMemory(null)
+                        .augmentationResult(null)
+                        .userMessageTemplate("")
+                        .variables(Map.of())
+                        .invocationContext(DEFAULT_INVOCATION_CONTEXT)
+                        .aiServiceListenerRegistrar(registrar)
+                        .build())
+                .build();
+
+        var executor = InputGuardrailExecutor.builder()
+                .guardrails(new InnerSuccessInputGuardrail())
+                .config(InputGuardrailsConfig.builder().build())
+                .build();
+
+        var result = executor.execute(request);
+
+        assertThat(result).isSuccessful();
+        assertThat(eventRef.get()).isNotNull();
+        assertThat(eventRef.get().guardrailClass()).isEqualTo(InnerSuccessInputGuardrail.class);
+        assertThat(eventRef.get().guardrailName()).isEqualTo(InnerSuccessInputGuardrail.class.getSimpleName());
     }
 
     @ParameterizedTest(name = "{0}")
@@ -258,6 +355,39 @@ class InputGuardrailExecutorTests {
         @Override
         public InputGuardrailResult validate(final UserMessage userMessage) {
             return InputGuardrailResult.success();
+        }
+    }
+
+    private static class InnerFailingInputGuardrail implements InputGuardrail {
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            return failure("wrapped failure");
+        }
+    }
+
+    private static class InnerSuccessInputGuardrail implements InputGuardrail {
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            return success();
+        }
+    }
+
+    private static class WrappedInputGuardrail implements InputGuardrail {
+
+        private final InputGuardrail delegate;
+
+        private WrappedInputGuardrail(InputGuardrail delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String name() {
+            return delegate.name();
+        }
+
+        @Override
+        public InputGuardrailResult validate(InputGuardrailRequest request) {
+            return delegate.validate(request);
         }
     }
 


### PR DESCRIPTION
## Issue
Closes #4938

## Change

Adds `guardrailName()` to `GuardrailExecutedEvent` to improve observability, especially when guardrails are wrapped using decorators.

### Details

- Added `guardrailName()` to `GuardrailExecutedEvent` with a default implementation returning `guardrailClass().getSimpleName()`
- Propagated guardrail name from execution layer to observability events
- Added a default `name()` method to `Guardrail` interface to represent logical guardrail identity
- Updated event builder and default implementation to carry `guardrailName`
- Added tests covering wrapped guardrails for both success and failure scenarios

This allows listeners to distinguish logical guardrails (e.g. `PromptInjectionGuardrail`) instead of only seeing adapter classes (e.g. `InputGuardrailAdapter`).

Related discussion: https://github.com/langchain4j/langchain4j/discussions/4914


## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [x] I have added/updated the documentation (Javadoc on Guardrail.name() andGuardrailExecutedEvent.guardrailName())
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)


## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j