### PR TITLE
fix(AzureOpenAiChatModel): throw clear exception when choices is empty

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiChatModel.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiChatModel.java
@@ -4,6 +4,7 @@ import static com.azure.ai.openai.models.CompletionsFinishReason.CONTENT_FILTERE
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.copyIfNotNull;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.model.ModelProvider.AZURE_OPEN_AI;
 import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.aiMessageFrom;
@@ -214,7 +215,13 @@ public class AzureOpenAiChatModel implements ChatModel {
         ChatCompletions chatCompletions = AzureOpenAiExceptionMapper.INSTANCE.withExceptionMapper(
                 () -> client.getChatCompletions(parameters.modelName(), options));
 
-        ChatChoice chatChoice = chatCompletions.getChoices().get(0);
+        List<ChatChoice> choices = chatCompletions.getChoices();
+        if (isNullOrEmpty(choices)) {
+            throw new IllegalArgumentException(
+                    "Azure OpenAI returned an empty choices list. "
+                            + "This may be due to content filtering, quota limits, or a malformed response.");
+        }
+        ChatChoice chatChoice = choices.get(0);
 
         if (chatChoice.getFinishReason() == CONTENT_FILTERED) {
             String details;


### PR DESCRIPTION
## Fix AzureOpenAiChatModel crash on empty choices

### Root Cause

`AzureOpenAiChatModel.doChat()` accesses `chatCompletions.getChoices().get(0)` at line 217 without checking if the list is null or empty. When Azure OpenAI returns an empty choices list (e.g. content filtering, quota errors, malformed response), this causes:

- `NullPointerException` if `getChoices()` is null
- `IndexOutOfBoundsException` if `getChoices()` is an empty list

The streaming counterpart `AzureOpenAiStreamingChatModel` already has this guard.

### Fix

Add null/empty check on choices before accessing index 0, throwing `IllegalArgumentException` with a descriptive message instead of a cryptic NPE.

```java
List<ChatChoice> choices = chatCompletions.getChoices();
if (isNullOrEmpty(choices)) {
    throw new IllegalArgumentException(
            "Azure OpenAI returned an empty choices list. "
                    + "This may be due to content filtering, quota limits, or a malformed response.");
}
```

Fixes #4814