### PR TITLE
OpenAI Responses API: Support reasoning summaries and encrypted reasoning

### DIFF
--- a/docs/docs/integrations/language-models/open-ai.md
+++ b/docs/docs/integrations/language-models/open-ai.md
@@ -423,7 +423,7 @@ StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
 `OpenAiResponsesChatRequestParameters` extends `DefaultChatRequestParameters` with Responses API-specific fields:
 `previousResponseId`, `maxToolCalls`, `parallelToolCalls`, `topLogprobs`, `truncation`, `include`,
 `serviceTier`, `safetyIdentifier`, `promptCacheKey`, `promptCacheRetention`, `reasoningEffort`,
-`textVerbosity`, `streamIncludeObfuscation`, `store`, `strictTools`, `strictJsonSchema`.
+`reasoningSummary`, `textVerbosity`, `streamIncludeObfuscation`, `store`, `strictTools`, `strictJsonSchema`.
 
 These parameters can be configured as defaults when creating the model (via `defaultRequestParameters` on the builder),
 or passed per-request via `ChatRequest` (per-request parameters override the defaults):
@@ -437,6 +437,44 @@ ChatRequest chatRequest = ChatRequest.builder()
                 .build())
         .build();
 ```
+
+### Thinking / Reasoning
+OpenAI reasoning models (e.g. `gpt-5.4`, `gpt-5-mini`) support
+[reasoning summaries](https://developers.openai.com/api/docs/guides/reasoning#reasoning-summaries)
+that expose a summary of the model's internal reasoning.
+
+To enable reasoning summaries, set `reasoningSummary` to `"auto"` on the builder
+(or via `OpenAiResponsesChatRequestParameters`).
+You can also control how much effort the model puts into reasoning with `reasoningEffort`.
+
+```java
+ChatModel model = OpenAiResponsesChatModel.builder()
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .modelName("gpt-5-mini")
+        .reasoningEffort("low")
+        .reasoningSummary("auto")
+        .build();
+
+ChatResponse response = model.chat("What is the capital of Germany?");
+response.aiMessage().text();     // "The capital of Germany is Berlin."
+response.aiMessage().thinking(); // reasoning summary text
+```
+
+When `reasoningSummary` is set for `OpenAiResponsesStreamingChatModel`,
+the `StreamingChatResponseHandler.onPartialThinking()` callback will be invoked
+as reasoning summary tokens are streamed:
+
+```java
+StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .modelName("gpt-5-mini")
+        .reasoningEffort("low")
+        .reasoningSummary("auto")
+        .build();
+```
+
+Unlike some other providers (e.g. DeepSeek), OpenAI reasoning tokens do not persist
+across conversation turns, so there is no need to send thinking back in follow-up requests.
 
 ### `OpenAiResponsesChatResponseMetadata`
 

--- a/docs/docs/integrations/language-models/open-ai.md
+++ b/docs/docs/integrations/language-models/open-ai.md
@@ -474,7 +474,57 @@ StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
 ```
 
 Unlike some other providers (e.g. DeepSeek), OpenAI reasoning tokens do not persist
-across conversation turns, so there is no need to send thinking back in follow-up requests.
+across conversation turns, so there is no need to send the reasoning summary back in follow-up requests.
+
+#### Encrypted Reasoning (Keeping Reasoning in Context)
+
+When `store` is `false` (by default) or your organization has zero data retention,
+the model's reasoning context is lost between turns.
+To preserve it, request [encrypted reasoning content](https://developers.openai.com/api/docs/guides/reasoning#keeping-reasoning-items-in-context)
+via the `include` parameter:
+
+```java
+ChatModel model = OpenAiResponsesChatModel.builder()
+        .apiKey(System.getenv("OPENAI_API_KEY"))
+        .modelName("gpt-5-mini")
+        .reasoningEffort("medium")
+        .include(List.of("reasoning.encrypted_content"))
+        .build();
+```
+
+When `include` contains `"reasoning.encrypted_content"`, the response's reasoning items
+will contain an opaque encrypted blob. This is automatically stored in
+`AiMessage.attributes()` under the key `"encrypted_reasoning"`.
+
+When you pass that `AiMessage` back in a follow-up request (e.g. after a tool call),
+the encrypted reasoning is automatically included in the request,
+allowing the model to resume its reasoning context:
+
+```java
+// Turn 1: model calls a tool
+ChatResponse response1 = model.chat(ChatRequest.builder()
+        .messages(userMessage)
+        .parameters(ChatRequestParameters.builder()
+                .toolSpecifications(weatherTool)
+                .build())
+        .build());
+
+AiMessage aiMessage1 = response1.aiMessage();
+// aiMessage1.attribute("encrypted_reasoning", String.class) is not null
+
+// Turn 2: send tool result back — encrypted reasoning is sent automatically
+ChatResponse response2 = model.chat(ChatRequest.builder()
+        .messages(
+                userMessage,
+                aiMessage1, // contains encrypted reasoning in attributes
+                ToolExecutionResultMessage.from(aiMessage1.toolExecutionRequests().get(0), "sunny"))
+        .parameters(ChatRequestParameters.builder()
+                .toolSpecifications(weatherTool)
+                .build())
+        .build());
+```
+
+This works identically for `OpenAiResponsesStreamingChatModel`.
 
 ### `OpenAiResponsesChatResponseMetadata`
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatModel.java
@@ -74,6 +74,7 @@ public class OpenAiResponsesChatModel implements ChatModel {
                 .promptCacheKey(getOrDefault(builder.promptCacheKey, responsesParameters.promptCacheKey()))
                 .promptCacheRetention(getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
                 .reasoningEffort(getOrDefault(builder.reasoningEffort, responsesParameters.reasoningEffort()))
+                .reasoningSummary(getOrDefault(builder.reasoningSummary, responsesParameters.reasoningSummary()))
                 .textVerbosity(getOrDefault(builder.textVerbosity, responsesParameters.textVerbosity()))
                 .store(getOrDefault(builder.store, getOrDefault(responsesParameters.store(), false)))
                 .strictTools(getOrDefault(builder.strictTools, responsesParameters.strictTools()))
@@ -151,6 +152,7 @@ public class OpenAiResponsesChatModel implements ChatModel {
         private String promptCacheKey;
         private String promptCacheRetention;
         private String reasoningEffort;
+        private String reasoningSummary;
         private String textVerbosity;
         private Boolean store;
         private Boolean strictTools;
@@ -255,6 +257,11 @@ public class OpenAiResponsesChatModel implements ChatModel {
 
         public Builder reasoningEffort(String reasoningEffort) {
             this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
+        public Builder reasoningSummary(String reasoningSummary) {
+            this.reasoningSummary = reasoningSummary;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatRequestParameters.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatRequestParameters.java
@@ -25,6 +25,7 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
     private final String promptCacheKey;
     private final String promptCacheRetention;
     private final String reasoningEffort;
+    private final String reasoningSummary;
     private final String textVerbosity;
     private final Boolean streamIncludeObfuscation;
     private final Boolean store;
@@ -44,6 +45,7 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
         this.promptCacheKey = builder.promptCacheKey;
         this.promptCacheRetention = builder.promptCacheRetention;
         this.reasoningEffort = builder.reasoningEffort;
+        this.reasoningSummary = builder.reasoningSummary;
         this.textVerbosity = builder.textVerbosity;
         this.streamIncludeObfuscation = builder.streamIncludeObfuscation;
         this.store = builder.store;
@@ -93,6 +95,10 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
 
     public String reasoningEffort() {
         return reasoningEffort;
+    }
+
+    public String reasoningSummary() {
+        return reasoningSummary;
     }
 
     public String textVerbosity() {
@@ -148,6 +154,7 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
                 && Objects.equals(promptCacheKey, that.promptCacheKey)
                 && Objects.equals(promptCacheRetention, that.promptCacheRetention)
                 && Objects.equals(reasoningEffort, that.reasoningEffort)
+                && Objects.equals(reasoningSummary, that.reasoningSummary)
                 && Objects.equals(textVerbosity, that.textVerbosity)
                 && Objects.equals(streamIncludeObfuscation, that.streamIncludeObfuscation)
                 && Objects.equals(store, that.store)
@@ -170,6 +177,7 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
                 promptCacheKey,
                 promptCacheRetention,
                 reasoningEffort,
+                reasoningSummary,
                 textVerbosity,
                 streamIncludeObfuscation,
                 store,
@@ -194,6 +202,7 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
         private String promptCacheKey;
         private String promptCacheRetention;
         private String reasoningEffort;
+        private String reasoningSummary;
         private String textVerbosity;
         private Boolean streamIncludeObfuscation;
         private Boolean store;
@@ -215,6 +224,7 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
                 promptCacheKey(getOrDefault(p.promptCacheKey(), promptCacheKey));
                 promptCacheRetention(getOrDefault(p.promptCacheRetention(), promptCacheRetention));
                 reasoningEffort(getOrDefault(p.reasoningEffort(), reasoningEffort));
+                reasoningSummary(getOrDefault(p.reasoningSummary(), reasoningSummary));
                 textVerbosity(getOrDefault(p.textVerbosity(), textVerbosity));
                 streamIncludeObfuscation(getOrDefault(p.streamIncludeObfuscation(), streamIncludeObfuscation));
                 store(getOrDefault(p.store(), store));
@@ -276,6 +286,11 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
 
         public Builder reasoningEffort(String reasoningEffort) {
             this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
+        public Builder reasoningSummary(String reasoningSummary) {
+            this.reasoningSummary = reasoningSummary;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -125,6 +125,7 @@ class OpenAiResponsesClient {
     private static final String FIELD_EFFORT = "effort";
     private static final String FIELD_SUMMARY = "summary";
     private static final String FIELD_SUMMARY_TEXT = "summary_text";
+    private static final String FIELD_ENCRYPTED_CONTENT = "encrypted_content";
     private static final String FIELD_STRICT = "strict";
     private static final String FIELD_STREAM_OPTIONS = "stream_options";
     private static final String FIELD_INCLUDE_OBFUSCATION = "include_obfuscation";
@@ -141,9 +142,12 @@ class OpenAiResponsesClient {
     private static final String ROLE_USER = "user";
     private static final String ROLE_ASSISTANT = "assistant";
 
+    static final String ENCRYPTED_REASONING_KEY = "encrypted_reasoning"; // do not change, will break backward compatibility!
+
     private static final String TYPE_FUNCTION = "function";
     private static final String TYPE_FUNCTION_CALL = "function_call";
     private static final String TYPE_MESSAGE = "message";
+    private static final String TYPE_REASONING = "reasoning";
     private static final String TYPE_OUTPUT_TEXT = "output_text";
     private static final String TYPE_OBJECT = "object";
     private static final String TYPE_INPUT_TEXT = "input_text";
@@ -385,7 +389,7 @@ class OpenAiResponsesClient {
 
         StringBuilder summaryBuilder = new StringBuilder();
         for (JsonNode item : output) {
-            if (FIELD_REASONING.equals(item.path(FIELD_TYPE).asText())) {
+            if (TYPE_REASONING.equals(item.path(FIELD_TYPE).asText())) {
                 JsonNode summaryArray = item.path(FIELD_SUMMARY);
                 if (summaryArray.isArray()) {
                     for (JsonNode summaryItem : summaryArray) {
@@ -397,6 +401,22 @@ class OpenAiResponsesClient {
             }
         }
         return summaryBuilder.isEmpty() ? null : summaryBuilder.toString();
+    }
+
+    private static String extractReasoningEncryptedContent(JsonNode output) {
+        if (!output.isArray()) {
+            return null;
+        }
+
+        for (JsonNode item : output) {
+            if (TYPE_REASONING.equals(item.path(FIELD_TYPE).asText())) {
+                JsonNode encryptedContent = item.path(FIELD_ENCRYPTED_CONTENT);
+                if (!encryptedContent.isMissingNode() && !encryptedContent.isNull()) {
+                    return encryptedContent.asText();
+                }
+            }
+        }
+        return null;
     }
 
     private static List<ToolExecutionRequest> extractToolExecutionRequests(JsonNode output) {
@@ -466,13 +486,17 @@ class OpenAiResponsesClient {
         JsonNode outputNode = responseNode.path(FIELD_OUTPUT);
         String text = extractText(outputNode);
         String thinking = extractReasoningSummary(outputNode);
+        String encryptedContent = extractReasoningEncryptedContent(outputNode);
         List<ToolExecutionRequest> toolExecutionRequests =
                 extractToolExecutionRequests(outputNode);
 
         AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                .text(!toolExecutionRequests.isEmpty() && text == null ? null : (text == null ? "" : text)) // TODO
+                .text(text)
                 .thinking(thinking)
-                .toolExecutionRequests(toolExecutionRequests.isEmpty() ? null : toolExecutionRequests);
+                .toolExecutionRequests(toolExecutionRequests);
+        if (encryptedContent != null) {
+            aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
+        }
         AiMessage aiMessage = aiMessageBuilder.build();
 
 
@@ -529,6 +553,22 @@ class OpenAiResponsesClient {
             return List.of(createMessageEntry(ROLE_USER, contentEntries));
         } else if (msg instanceof AiMessage aiMessage) {
             List<Map<String, Object>> items = new ArrayList<>();
+
+            String encryptedContent = aiMessage.attribute(ENCRYPTED_REASONING_KEY, String.class);
+            if (encryptedContent != null) {
+                var reasoningItem = new LinkedHashMap<String, Object>();
+                reasoningItem.put(FIELD_TYPE, TYPE_REASONING);
+                reasoningItem.put(FIELD_ENCRYPTED_CONTENT, encryptedContent);
+                List<Map<String, Object>> summaryItems = new ArrayList<>();
+                if (aiMessage.thinking() != null && !aiMessage.thinking().isEmpty()) {
+                    var summaryTextItem = new LinkedHashMap<String, Object>();
+                    summaryTextItem.put(FIELD_TYPE, FIELD_SUMMARY_TEXT);
+                    summaryTextItem.put(FIELD_TEXT, aiMessage.thinking());
+                    summaryItems.add(summaryTextItem);
+                }
+                reasoningItem.put(FIELD_SUMMARY, summaryItems);
+                items.add(reasoningItem);
+            }
 
             var text = aiMessage.text();
             if (text != null && !text.isEmpty()) {
@@ -894,11 +934,15 @@ class OpenAiResponsesClient {
             JsonNode outputNode = responseNode.path(FIELD_OUTPUT);
             String text = extractText(outputNode);
             String thinking = extractReasoningSummary(outputNode);
+            String encryptedContent = extractReasoningEncryptedContent(outputNode);
 
             AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                    .text(!completedToolCalls.isEmpty() && text == null ? null : (text == null ? "" : text)) // TODO
+                    .text(text)
                     .thinking(thinking)
-                    .toolExecutionRequests(completedToolCalls.isEmpty() ? null : completedToolCalls);
+                    .toolExecutionRequests(completedToolCalls);
+            if (encryptedContent != null) {
+                aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
+            }
             var aiMessage = aiMessageBuilder.build();
 
             OpenAiResponsesChatResponseMetadata.Builder metadataBuilder = OpenAiResponsesChatResponseMetadata.builder()

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -123,6 +123,8 @@ class OpenAiResponsesClient {
     private static final String FIELD_PROMPT_CACHE_RETENTION = "prompt_cache_retention";
     private static final String FIELD_REASONING = "reasoning";
     private static final String FIELD_EFFORT = "effort";
+    private static final String FIELD_SUMMARY = "summary";
+    private static final String FIELD_SUMMARY_TEXT = "summary_text";
     private static final String FIELD_STRICT = "strict";
     private static final String FIELD_STREAM_OPTIONS = "stream_options";
     private static final String FIELD_INCLUDE_OBFUSCATION = "include_obfuscation";
@@ -264,9 +266,14 @@ class OpenAiResponsesClient {
             payload.put(FIELD_PROMPT_CACHE_RETENTION, parameters.promptCacheRetention());
         }
 
-        if (parameters.reasoningEffort() != null) {
+        if (parameters.reasoningEffort() != null || parameters.reasoningSummary() != null) {
             Map<String, Object> reasoning = new LinkedHashMap<>();
-            reasoning.put(FIELD_EFFORT, parameters.reasoningEffort());
+            if (parameters.reasoningEffort() != null) {
+                reasoning.put(FIELD_EFFORT, parameters.reasoningEffort());
+            }
+            if (parameters.reasoningSummary() != null) {
+                reasoning.put(FIELD_SUMMARY, parameters.reasoningSummary());
+            }
             payload.put(FIELD_REASONING, reasoning);
         }
 
@@ -371,6 +378,27 @@ class OpenAiResponsesClient {
         return textBuilder.isEmpty() ? null : textBuilder.toString();
     }
 
+    private static String extractReasoningSummary(JsonNode output) {
+        if (!output.isArray()) {
+            return null;
+        }
+
+        StringBuilder summaryBuilder = new StringBuilder();
+        for (JsonNode item : output) {
+            if (FIELD_REASONING.equals(item.path(FIELD_TYPE).asText())) {
+                JsonNode summaryArray = item.path(FIELD_SUMMARY);
+                if (summaryArray.isArray()) {
+                    for (JsonNode summaryItem : summaryArray) {
+                        if (FIELD_SUMMARY_TEXT.equals(summaryItem.path(FIELD_TYPE).asText())) {
+                            summaryBuilder.append(summaryItem.path(FIELD_TEXT).asText());
+                        }
+                    }
+                }
+            }
+        }
+        return summaryBuilder.isEmpty() ? null : summaryBuilder.toString();
+    }
+
     private static List<ToolExecutionRequest> extractToolExecutionRequests(JsonNode output) {
         if (!output.isArray()) {
             return List.of();
@@ -435,15 +463,17 @@ class OpenAiResponsesClient {
     private ChatResponse parseChatResponse(SuccessfulHttpResponse rawHttpResponse) throws Exception {
         JsonNode responseNode = OBJECT_MAPPER.readTree(rawHttpResponse.body());
 
-        String text = extractText(responseNode.path(FIELD_OUTPUT));
+        JsonNode outputNode = responseNode.path(FIELD_OUTPUT);
+        String text = extractText(outputNode);
+        String thinking = extractReasoningSummary(outputNode);
         List<ToolExecutionRequest> toolExecutionRequests =
-                extractToolExecutionRequests(responseNode.path(FIELD_OUTPUT));
+                extractToolExecutionRequests(outputNode);
 
-        AiMessage aiMessage = !toolExecutionRequests.isEmpty() && text != null
-                ? new AiMessage(text, toolExecutionRequests)
-                : !toolExecutionRequests.isEmpty()
-                ? AiMessage.from(toolExecutionRequests)
-                : new AiMessage(text == null ? "" : text);
+        AiMessage.Builder aiMessageBuilder = AiMessage.builder()
+                .text(!toolExecutionRequests.isEmpty() && text == null ? null : (text == null ? "" : text)) // TODO
+                .thinking(thinking)
+                .toolExecutionRequests(toolExecutionRequests.isEmpty() ? null : toolExecutionRequests);
+        AiMessage aiMessage = aiMessageBuilder.build();
 
 
         OpenAiResponsesChatResponseMetadata.Builder metadataBuilder = OpenAiResponsesChatResponseMetadata.builder()
@@ -861,13 +891,15 @@ class OpenAiResponsesClient {
         private void handleResponseCompleted(JsonNode node) {
             var responseNode = node.path(FIELD_RESPONSE);
 
-            String text = extractText(responseNode.path(FIELD_OUTPUT));
+            JsonNode outputNode = responseNode.path(FIELD_OUTPUT);
+            String text = extractText(outputNode);
+            String thinking = extractReasoningSummary(outputNode);
 
-            var aiMessage = !completedToolCalls.isEmpty() && text != null
-                    ? new AiMessage(text, completedToolCalls)
-                    : !completedToolCalls.isEmpty()
-                    ? AiMessage.from(completedToolCalls)
-                    : new AiMessage(text == null ? "" : text);
+            AiMessage.Builder aiMessageBuilder = AiMessage.builder()
+                    .text(!completedToolCalls.isEmpty() && text == null ? null : (text == null ? "" : text)) // TODO
+                    .thinking(thinking)
+                    .toolExecutionRequests(completedToolCalls.isEmpty() ? null : completedToolCalls);
+            var aiMessage = aiMessageBuilder.build();
 
             OpenAiResponsesChatResponseMetadata.Builder metadataBuilder = OpenAiResponsesChatResponseMetadata.builder()
                     .id(responseNode.path(FIELD_ID).asText(null))

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesStreamingChatModel.java
@@ -74,6 +74,7 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
                 .promptCacheKey(getOrDefault(builder.promptCacheKey, responsesParameters.promptCacheKey()))
                 .promptCacheRetention(getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
                 .reasoningEffort(getOrDefault(builder.reasoningEffort, responsesParameters.reasoningEffort()))
+                .reasoningSummary(getOrDefault(builder.reasoningSummary, responsesParameters.reasoningSummary()))
                 .textVerbosity(getOrDefault(builder.textVerbosity, responsesParameters.textVerbosity()))
                 .streamIncludeObfuscation(getOrDefault(builder.streamIncludeObfuscation, responsesParameters.streamIncludeObfuscation()))
                 .store(getOrDefault(builder.store, getOrDefault(responsesParameters.store(), false)))
@@ -152,6 +153,7 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
         private String promptCacheKey;
         private String promptCacheRetention;
         private String reasoningEffort;
+        private String reasoningSummary;
         private String textVerbosity;
         private Boolean streamIncludeObfuscation;
         private Boolean store;
@@ -257,6 +259,11 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
 
         public Builder reasoningEffort(String reasoningEffort) {
             this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
+        public Builder reasoningSummary(String reasoningSummary) {
+            this.reasoningSummary = reasoningSummary;
             return this;
         }
 

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesChatModelThinkingIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesChatModelThinkingIT.java
@@ -1,17 +1,48 @@
 package dev.langchain4j.model.openai.common.responses;
 
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SpyingHttpClient;
+import dev.langchain4j.http.client.jdk.JdkHttpClient;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.openai.OpenAiResponsesChatModel;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class OpenAiResponsesChatModelThinkingIT {
+
+    private static final String ENCRYPTED_REASONING_KEY = "encrypted_reasoning";
+
+    private static final ToolSpecification WEATHER_TOOL = ToolSpecification.builder()
+            .name("getWeather")
+            .description("Returns the current weather for a given city")
+            .parameters(JsonObjectSchema.builder()
+                    .addStringProperty("city")
+                    .required("city")
+                    .build())
+            .build();
+
+    private static final ToolSpecification TIME_TOOL = ToolSpecification.builder()
+            .name("getTime")
+            .description("Returns the current time for a given country")
+            .parameters(JsonObjectSchema.builder()
+                    .addStringProperty("country")
+                    .required("country")
+                    .build())
+            .build();
 
     @Test
     void should_return_reasoning_summary() {
@@ -64,5 +95,134 @@ class OpenAiResponsesChatModelThinkingIT {
         AiMessage aiMessage = chatResponse.aiMessage();
         assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
         assertThat(aiMessage.thinking()).isNull();
+    }
+
+    @Test
+    void should_return_encrypted_reasoning_and_send_it_back__single_tool_call() {
+
+        // given
+        List<String> include = List.of("reasoning.encrypted_content");
+
+        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        ChatModel model = OpenAiResponsesChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName("gpt-5-mini")
+                .reasoningEffort("medium")
+                .include(include)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("What is the weather in Munich?");
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(userMessage)
+                .parameters(ChatRequestParameters.builder()
+                        .toolSpecifications(WEATHER_TOOL)
+                        .build())
+                .build();
+
+        // when
+        ChatResponse chatResponse1 = model.chat(chatRequest);
+
+        // then
+        AiMessage aiMessage1 = chatResponse1.aiMessage();
+        assertThat(aiMessage1.toolExecutionRequests()).hasSize(1);
+        assertThat(aiMessage1.toolExecutionRequests().get(0).name()).isEqualTo("getWeather");
+        String encryptedContent1 = aiMessage1.attribute(ENCRYPTED_REASONING_KEY, String.class);
+        assertThat(encryptedContent1).isNotBlank();
+
+        // when
+        ChatRequest chatRequest2 = ChatRequest.builder()
+                .messages(
+                        userMessage,
+                        aiMessage1,
+                        ToolExecutionResultMessage.from(aiMessage1.toolExecutionRequests().get(0), "sunny, 22°C"))
+                .parameters(ChatRequestParameters.builder()
+                        .toolSpecifications(WEATHER_TOOL)
+                        .build())
+                .build();
+
+        ChatResponse chatResponse2 = model.chat(chatRequest2);
+
+        // then
+        AiMessage aiMessage2 = chatResponse2.aiMessage();
+        assertThat(aiMessage2.text()).containsIgnoringCase("sun");
+        assertThat(aiMessage2.toolExecutionRequests()).isEmpty();
+
+        // verify encrypted_content was sent back in turn 2
+        List<HttpRequest> httpRequests = spyingHttpClient.requests();
+        assertThat(httpRequests).hasSize(2);
+        assertThat(httpRequests.get(1).body())
+                .contains("encrypted_content")
+                .contains(encryptedContent1);
+    }
+
+    @Test
+    void should_return_encrypted_reasoning_and_send_it_back__two_parallel_tool_calls() {
+
+        // given
+        List<String> include = List.of("reasoning.encrypted_content");
+
+        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        ChatModel model = OpenAiResponsesChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName("gpt-5-mini")
+                .reasoningEffort("medium")
+                .include(include)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from(
+                "What is the weather in Munich and the current time in France? Call both tools in parallel.");
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(userMessage)
+                .parameters(ChatRequestParameters.builder()
+                        .toolSpecifications(WEATHER_TOOL, TIME_TOOL)
+                        .build())
+                .build();
+
+        // when
+        ChatResponse chatResponse1 = model.chat(chatRequest);
+
+        // then
+        AiMessage aiMessage1 = chatResponse1.aiMessage();
+        assertThat(aiMessage1.toolExecutionRequests()).hasSize(2);
+        String encryptedContent1 = aiMessage1.attribute(ENCRYPTED_REASONING_KEY, String.class);
+        assertThat(encryptedContent1).isNotBlank();
+
+        // when
+        ChatRequest chatRequest2 = ChatRequest.builder()
+                .messages(
+                        userMessage,
+                        aiMessage1,
+                        ToolExecutionResultMessage.from(aiMessage1.toolExecutionRequests().get(0), "sunny, 22°C"),
+                        ToolExecutionResultMessage.from(aiMessage1.toolExecutionRequests().get(1), "14:35"))
+                .parameters(ChatRequestParameters.builder()
+                        .toolSpecifications(WEATHER_TOOL, TIME_TOOL)
+                        .build())
+                .build();
+
+        ChatResponse chatResponse2 = model.chat(chatRequest2);
+
+        // then
+        AiMessage aiMessage2 = chatResponse2.aiMessage();
+
+        // verify encrypted_content was sent back in turn 2
+        List<HttpRequest> httpRequests = spyingHttpClient.requests();
+        assertThat(httpRequests).hasSize(2);
+        assertThat(httpRequests.get(1).body())
+                .contains("encrypted_content")
+                .contains(encryptedContent1);
     }
 }

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesChatModelThinkingIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesChatModelThinkingIT.java
@@ -1,0 +1,68 @@
+package dev.langchain4j.model.openai.common.responses;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openai.OpenAiResponsesChatModel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class OpenAiResponsesChatModelThinkingIT {
+
+    @Test
+    void should_return_reasoning_summary() {
+
+        // given
+        String reasoningSummary = "auto";
+
+        ChatModel model = OpenAiResponsesChatModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName("gpt-5-mini")
+                .reasoningEffort("low")
+                .reasoningSummary(reasoningSummary)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("What is the capital of Germany?");
+
+        // when
+        ChatResponse chatResponse = model.chat(userMessage);
+
+        // then
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
+        assertThat(aiMessage.thinking()).isNotBlank();
+    }
+
+    @Test
+    void should_not_return_reasoning_summary_when_not_requested() {
+
+        // given
+        ChatModel model = OpenAiResponsesChatModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName("gpt-5-mini")
+                .reasoningEffort("low")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("What is the capital of Germany?");
+
+        // when
+        ChatResponse chatResponse = model.chat(userMessage);
+
+        // then
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
+        assertThat(aiMessage.thinking()).isNull();
+    }
+}

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelIT.java
@@ -373,6 +373,38 @@ class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
     }
 
     @Test
+    void should_set_thinking_on_ai_message_from_reasoning_summary_in_completed_response() {
+        MockHttpClient mockHttpClient = new MockHttpClient(List.of(
+                new ServerSentEvent(null, "{\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"let me\"}"),
+                new ServerSentEvent(null, "{\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\" think\"}"),
+                new ServerSentEvent(null, "{\"type\":\"response.output_text.delta\",\"delta\":\"Berlin\"}"),
+                new ServerSentEvent(
+                        null,
+                        "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp_123\",\"model\":\"o4-mini\",\"status\":\"completed\","
+                                + "\"output\":["
+                                + "{\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"let me think\"}]},"
+                                + "{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Berlin\"}]}"
+                                + "],\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"total_tokens\":15}}}"),
+                new ServerSentEvent(null, "[DONE]")));
+
+        StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+                .apiKey("test-key")
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .modelName("o4-mini")
+                .reasoningSummary("auto")
+                .build();
+
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        model.chat("Hello", handler);
+
+        ChatResponse response = handler.get();
+        assertThat(response.aiMessage().text()).isEqualTo("Berlin");
+        assertThat(response.aiMessage().thinking()).isEqualTo("let me think");
+        assertThat(handler.getThinking()).isEqualTo("let me think");
+        assertThat(response.aiMessage().thinking()).isEqualTo(handler.getThinking());
+    }
+
+    @Test
     void should_complete_response_when_completed_event_has_no_text_or_tool_calls() {
         MockHttpClient mockHttpClient = new MockHttpClient(List.of(
                 new ServerSentEvent(

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelIT.java
@@ -230,27 +230,6 @@ class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
     }
 
     @Test
-    void should_support_reasoning_effort() {
-        StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
-                .baseUrl(System.getenv("OPENAI_BASE_URL"))
-                .apiKey(System.getenv("OPENAI_API_KEY"))
-                .modelName("o4-mini")
-                .reasoningEffort("medium")
-                .build();
-
-        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
-        model.chat("What is the capital of France?", handler);
-
-        ChatResponse response = handler.get();
-        assertThat(response.aiMessage().text()).contains("Paris");
-        assertThat(response.metadata()).isInstanceOf(OpenAiResponsesChatResponseMetadata.class);
-        OpenAiResponsesChatResponseMetadata metadata = (OpenAiResponsesChatResponseMetadata) response.metadata();
-        assertThat(metadata.id()).isNotBlank();
-        assertThat(metadata.modelName()).isNotBlank();
-        assertThat(metadata.finishReason()).isNotNull();
-    }
-
-    @Test
     void should_propagate_all_Responses_API_specific_parameters() {
         MockHttpClient mockHttpClient = new MockHttpClient();
 
@@ -350,83 +329,6 @@ class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
     }
 
     @Test
-    void should_emit_partial_thinking_for_reasoning_deltas() {
-        MockHttpClient mockHttpClient = new MockHttpClient(List.of(
-                new ServerSentEvent(null, "{\"type\":\"response.reasoning_text.delta\",\"delta\":\"let me\"}"),
-                new ServerSentEvent(null, "{\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\" think\"}"),
-                new ServerSentEvent(
-                        null,
-                        "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp_123\",\"model\":\"gpt-4.1-nano\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":0,\"total_tokens\":1}}}"),
-                new ServerSentEvent(null, "[DONE]")));
-
-        StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
-                .apiKey("test-key")
-                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
-                .modelName(GPT_5_4_MINI)
-                .build();
-
-        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
-        model.chat("Hello", handler);
-
-        handler.get();
-        assertThat(handler.getThinking()).isEqualTo("let me think");
-    }
-
-    @Test
-    void should_set_thinking_on_ai_message_from_reasoning_summary_in_completed_response() {
-        MockHttpClient mockHttpClient = new MockHttpClient(List.of(
-                new ServerSentEvent(null, "{\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"let me\"}"),
-                new ServerSentEvent(null, "{\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\" think\"}"),
-                new ServerSentEvent(null, "{\"type\":\"response.output_text.delta\",\"delta\":\"Berlin\"}"),
-                new ServerSentEvent(
-                        null,
-                        "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp_123\",\"model\":\"o4-mini\",\"status\":\"completed\","
-                                + "\"output\":["
-                                + "{\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"let me think\"}]},"
-                                + "{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Berlin\"}]}"
-                                + "],\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"total_tokens\":15}}}"),
-                new ServerSentEvent(null, "[DONE]")));
-
-        StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
-                .apiKey("test-key")
-                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
-                .modelName("o4-mini")
-                .reasoningSummary("auto")
-                .build();
-
-        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
-        model.chat("Hello", handler);
-
-        ChatResponse response = handler.get();
-        assertThat(response.aiMessage().text()).isEqualTo("Berlin");
-        assertThat(response.aiMessage().thinking()).isEqualTo("let me think");
-        assertThat(handler.getThinking()).isEqualTo("let me think");
-        assertThat(response.aiMessage().thinking()).isEqualTo(handler.getThinking());
-    }
-
-    @Test
-    void should_complete_response_when_completed_event_has_no_text_or_tool_calls() {
-        MockHttpClient mockHttpClient = new MockHttpClient(List.of(
-                new ServerSentEvent(
-                        null,
-                        "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp_123\",\"model\":\"gpt-4.1-nano\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":0,\"total_tokens\":1}}}"),
-                new ServerSentEvent(null, "[DONE]")));
-
-        StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
-                .apiKey("test-key")
-                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
-                .modelName(GPT_5_4_MINI)
-                .build();
-
-        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
-        model.chat("Hello", handler);
-
-        ChatResponse response = handler.get();
-        assertThat(response.aiMessage().text()).isEmpty();
-        assertThat(response.metadata().finishReason()).isEqualTo(STOP);
-    }
-
-    @Test
     void should_surface_response_failed_message_from_error_node() {
         MockHttpClient mockHttpClient = new MockHttpClient(List.of(
                 new ServerSentEvent(
@@ -462,27 +364,5 @@ class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
         model.chat("Hello", handler);
 
         assertThatThrownBy(handler::get).rootCause().hasMessage("Response failed: request rejected");
-    }
-
-    @Test
-    void should_map_incomplete_status_to_length_for_completed_callback() {
-        MockHttpClient mockHttpClient = new MockHttpClient(List.of(
-                new ServerSentEvent(
-                        null,
-                        "{\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp_123\",\"model\":\"gpt-4.1-nano\",\"status\":\"incomplete\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":0,\"total_tokens\":1}}}"),
-                new ServerSentEvent(null, "[DONE]")));
-
-        StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
-                .apiKey("test-key")
-                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
-                .modelName(GPT_5_4_MINI)
-                .build();
-
-        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
-        model.chat("Hello", handler);
-
-        ChatResponse response = handler.get();
-        assertThat(response.aiMessage().text()).isEmpty();
-        assertThat(response.metadata().finishReason()).isEqualTo(dev.langchain4j.model.output.FinishReason.LENGTH);
     }
 }

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelThinkingIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelThinkingIT.java
@@ -1,5 +1,26 @@
 package dev.langchain4j.model.openai.common.responses;
 
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SpyingHttpClient;
+import dev.langchain4j.http.client.jdk.JdkHttpClient;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.mockito.InOrder;
+
+import java.util.List;
+
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -10,21 +31,31 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.StreamingChatModel;
-import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
-import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.mockito.InOrder;
-
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class OpenAiResponsesStreamingChatModelThinkingIT {
 
+    private static final String ENCRYPTED_REASONING_KEY = "encrypted_reasoning";
+
+    private static final ToolSpecification WEATHER_TOOL = ToolSpecification.builder()
+            .name("getWeather")
+            .description("Returns the current weather for a given city")
+            .parameters(JsonObjectSchema.builder()
+                    .addStringProperty("city")
+                    .required("city")
+                    .build())
+            .build();
+
+    private static final ToolSpecification TIME_TOOL = ToolSpecification.builder()
+            .name("getTime")
+            .description("Returns the current time for a given country")
+            .parameters(JsonObjectSchema.builder()
+                    .addStringProperty("country")
+                    .required("country")
+                    .build())
+            .build();
+
     @Test
-    void should_stream_reasoning_summary() {
+    void should_return_reasoning_summary() {
 
         // given
         String reasoningSummary = "auto";
@@ -64,7 +95,7 @@ class OpenAiResponsesStreamingChatModelThinkingIT {
     }
 
     @Test
-    void should_not_stream_reasoning_summary_when_not_requested() {
+    void should_not_return_reasoning_summary_when_not_requested() {
 
         // given
         StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
@@ -91,5 +122,138 @@ class OpenAiResponsesStreamingChatModelThinkingIT {
 
         verify(spyHandler, never()).onPartialThinking(any());
         verify(spyHandler, never()).onPartialThinking(any(), any());
+    }
+
+    @Test
+    void should_return_encrypted_reasoning_and_send_it_back__single_tool_call() {
+
+        // given
+        List<String> include = List.of("reasoning.encrypted_content");
+
+        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName("gpt-5-mini")
+                .reasoningEffort("medium")
+                .include(include)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("What is the weather in Munich?");
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(userMessage)
+                .parameters(ChatRequestParameters.builder()
+                        .toolSpecifications(WEATHER_TOOL)
+                        .build())
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler1 = new TestStreamingChatResponseHandler();
+        model.chat(chatRequest, handler1);
+
+        // then
+        AiMessage aiMessage1 = handler1.get().aiMessage();
+        assertThat(aiMessage1.toolExecutionRequests()).hasSize(1);
+        assertThat(aiMessage1.toolExecutionRequests().get(0).name()).isEqualTo("getWeather");
+        String encryptedContent1 = aiMessage1.attribute(ENCRYPTED_REASONING_KEY, String.class);
+        assertThat(encryptedContent1).isNotBlank();
+
+        // when
+        ChatRequest chatRequest2 = ChatRequest.builder()
+                .messages(
+                        userMessage,
+                        aiMessage1,
+                        ToolExecutionResultMessage.from(aiMessage1.toolExecutionRequests().get(0), "sunny, 22°C"))
+                .parameters(ChatRequestParameters.builder()
+                        .toolSpecifications(WEATHER_TOOL)
+                        .build())
+                .build();
+
+        TestStreamingChatResponseHandler handler2 = new TestStreamingChatResponseHandler();
+        model.chat(chatRequest2, handler2);
+
+        // then
+        AiMessage aiMessage2 = handler2.get().aiMessage();
+        assertThat(aiMessage2.text()).containsIgnoringCase("sun");
+        assertThat(aiMessage2.toolExecutionRequests()).isEmpty();
+
+        // verify encrypted_content was sent back in turn 2
+        List<HttpRequest> httpRequests = spyingHttpClient.requests();
+        assertThat(httpRequests).hasSize(2);
+        assertThat(httpRequests.get(1).body())
+                .contains("encrypted_content")
+                .contains(encryptedContent1);
+    }
+
+    @Test
+    void should_return_encrypted_reasoning_and_send_it_back__two_parallel_tool_calls() {
+
+        // given
+        List<String> include = List.of("reasoning.encrypted_content");
+
+        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName("gpt-5-mini")
+                .reasoningEffort("medium")
+                .include(include)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from(
+                "What is the weather in Munich and the current time in France? Call both tools in parallel.");
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(userMessage)
+                .parameters(ChatRequestParameters.builder()
+                        .toolSpecifications(WEATHER_TOOL, TIME_TOOL)
+                        .build())
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler1 = new TestStreamingChatResponseHandler();
+        model.chat(chatRequest, handler1);
+
+        // then
+        AiMessage aiMessage1 = handler1.get().aiMessage();
+        assertThat(aiMessage1.toolExecutionRequests()).hasSize(2);
+        String encryptedContent1 = aiMessage1.attribute(ENCRYPTED_REASONING_KEY, String.class);
+        assertThat(encryptedContent1).isNotBlank();
+
+        // when
+        ChatRequest chatRequest2 = ChatRequest.builder()
+                .messages(
+                        userMessage,
+                        aiMessage1,
+                        ToolExecutionResultMessage.from(aiMessage1.toolExecutionRequests().get(0), "sunny, 22°C"),
+                        ToolExecutionResultMessage.from(aiMessage1.toolExecutionRequests().get(1), "14:35"))
+                .parameters(ChatRequestParameters.builder()
+                        .toolSpecifications(WEATHER_TOOL, TIME_TOOL)
+                        .build())
+                .build();
+
+        TestStreamingChatResponseHandler handler2 = new TestStreamingChatResponseHandler();
+        model.chat(chatRequest2, handler2);
+
+        // then
+        AiMessage aiMessage2 = handler2.get().aiMessage();
+
+        // verify encrypted_content was sent back in turn 2
+        List<HttpRequest> httpRequests = spyingHttpClient.requests();
+        assertThat(httpRequests).hasSize(2);
+        assertThat(httpRequests.get(1).body())
+                .contains("encrypted_content")
+                .contains(encryptedContent1);
     }
 }

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelThinkingIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelThinkingIT.java
@@ -1,0 +1,95 @@
+package dev.langchain4j.model.openai.common.responses;
+
+import static java.util.List.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.mockito.InOrder;
+
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class OpenAiResponsesStreamingChatModelThinkingIT {
+
+    @Test
+    void should_stream_reasoning_summary() {
+
+        // given
+        String reasoningSummary = "auto";
+
+        StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName("gpt-5-mini")
+                .reasoningEffort("low")
+                .reasoningSummary(reasoningSummary)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("What is the capital of Germany?");
+
+        // when
+        TestStreamingChatResponseHandler spyHandler = spy(new TestStreamingChatResponseHandler());
+        model.chat(of(userMessage), spyHandler);
+
+        // then
+        ChatResponse chatResponse = spyHandler.get();
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
+        assertThat(aiMessage.thinking()).isNotBlank();
+        assertThat(aiMessage.thinking()).isEqualTo(spyHandler.getThinking());
+
+        InOrder inOrder = inOrder(spyHandler);
+        inOrder.verify(spyHandler).get();
+        inOrder.verify(spyHandler, atLeastOnce()).onPartialThinking(any(), any());
+        inOrder.verify(spyHandler, atLeastOnce()).onPartialResponse(any(), any());
+        inOrder.verify(spyHandler).onCompleteResponse(any());
+        inOrder.verify(spyHandler).getThinking();
+        inOrder.verifyNoMoreInteractions();
+        verifyNoMoreInteractions(spyHandler);
+    }
+
+    @Test
+    void should_not_stream_reasoning_summary_when_not_requested() {
+
+        // given
+        StreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName("gpt-5-mini")
+                .reasoningEffort("low")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("What is the capital of Germany?");
+
+        // when
+        TestStreamingChatResponseHandler spyHandler = spy(new TestStreamingChatResponseHandler());
+        model.chat(of(userMessage), spyHandler);
+
+        // then
+        ChatResponse chatResponse = spyHandler.get();
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).containsIgnoringCase("Berlin");
+        assertThat(aiMessage.thinking()).isNull();
+
+        verify(spyHandler, never()).onPartialThinking(any());
+        verify(spyHandler, never()).onPartialThinking(any(), any());
+    }
+}


### PR DESCRIPTION
## Change
- Add `reasoningSummary` parameter to `OpenAiResponsesChatModel` and `OpenAiResponsesStreamingChatModel` to request reasoning summaries via the Responses API (`reasoning.summary` field)
- Parse reasoning summary from response output items and expose via `AiMessage.thinking()`
- For streaming, `onPartialThinking()` is called when reasoning summary text is streamed
- Support round-tripping of encrypted reasoning content (`reasoning.encrypted_content`) for stateless conversations: extracted from responses into `AiMessage.attributes()` and automatically sent back in follow-up requests

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)