### PR TITLE
feat(anthropic): add thinking display setting support

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -53,6 +53,7 @@ AnthropicChatModel model = AnthropicChatModel.builder()
     .cacheTools(...)
     .thinkingType(...)
     .thinkingBudgetTokens(...)
+    .thinkingDisplay(...)
     .returnThinking(...)
     .sendThinking(...)
     .timeout(...)
@@ -428,6 +429,8 @@ Both `AnthropicChatModel` and `AnthropicStreamingChatModel` support
 It is controlled by the following parameters:
 - `thinkingType` and `thinkingBudgetTokens`: enable thinking,
   see more details [here](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking).
+- `thinkingDisplay`: controls how thinking content is returned. Accepts `"summarized"` or `"omitted"`.
+  On Claude Opus 4.7+, the default is `"omitted"`. Set to `"summarized"` to receive thinking summaries.
 - `returnThinking`: controls whether to return thinking (if available) inside `AiMessage.thinking()`
   and whether to invoke `StreamingChatResponseHandler.onPartialThinking()` and `TokenStream.onPartialThinking()`
   callbacks when using `BedrockStreamingChatModel`.
@@ -442,6 +445,7 @@ ChatModel model = AnthropicChatModel.builder()
         .modelName("claude-sonnet-4-5-20250929")
         .thinkingType("enabled")
         .thinkingBudgetTokens(1024)
+        .thinkingDisplay("summarized")
         .maxTokens(1024 + 100)
         .returnThinking(true)
         .sendThinking(true)

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -69,6 +69,7 @@ public class AnthropicChatModel implements ChatModel {
     private final boolean cacheTools;
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
+    private final String thinkingDisplay;
     private final boolean returnThinking;
     private final boolean sendThinking;
     private final int maxRetries;
@@ -101,6 +102,7 @@ public class AnthropicChatModel implements ChatModel {
         this.cacheTools = getOrDefault(builder.cacheTools, false);
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
+        this.thinkingDisplay = builder.thinkingDisplay;
         this.returnThinking = getOrDefault(builder.returnThinking, false);
         this.sendThinking = getOrDefault(builder.sendThinking, true);
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
@@ -166,6 +168,7 @@ public class AnthropicChatModel implements ChatModel {
         private Boolean cacheTools;
         private String thinkingType;
         private Integer thinkingBudgetTokens;
+        private String thinkingDisplay;
         private Boolean returnThinking;
         private Boolean sendThinking;
         private Duration timeout;
@@ -357,6 +360,24 @@ public class AnthropicChatModel implements ChatModel {
         }
 
         /**
+         * Controls how thinking content is returned in API responses.
+         * <p>
+         * Accepts {@code "summarized"} or {@code "omitted"}.
+         * On Claude Opus 4.7+, the default is {@code "omitted"} (thinking text is suppressed),
+         * which reduces time-to-first-text-token but hides the reasoning trace.
+         * Set to {@code "summarized"} to receive a summary of the model's reasoning.
+         * <p>
+         * Note: you are still charged for the full thinking tokens regardless of this setting.
+         *
+         * @param thinkingDisplay the display mode: {@code "summarized"} or {@code "omitted"}
+         * @see #thinkingType(String)
+         */
+        public AnthropicChatModelBuilder thinkingDisplay(String thinkingDisplay) {
+            this.thinkingDisplay = thinkingDisplay;
+            return this;
+        }
+
+        /**
          * Controls whether to return thinking/reasoning text (if available) inside {@link AiMessage#thinking()}.
          * Please note that this does not enable thinking/reasoning for the LLM;
          * it only controls whether to parse the {@code thinking} field from the API response
@@ -479,7 +500,7 @@ public class AnthropicChatModel implements ChatModel {
 
         AnthropicCreateMessageRequest anthropicRequest = createAnthropicRequest(
                 chatRequest,
-                toThinking(thinkingType, thinkingBudgetTokens),
+                toThinking(thinkingType, thinkingBudgetTokens, thinkingDisplay),
                 sendThinking,
                 cacheSystemMessages ? EPHEMERAL : NO_CACHE,
                 cacheTools ? EPHEMERAL : NO_CACHE,
@@ -514,11 +535,12 @@ public class AnthropicChatModel implements ChatModel {
                 .build();
     }
 
-    static AnthropicThinking toThinking(String thinkingType, Integer thinkingBudgetTokens) {
+    static AnthropicThinking toThinking(String thinkingType, Integer thinkingBudgetTokens, String thinkingDisplay) {
         if (thinkingType != null || thinkingBudgetTokens != null) {
             return AnthropicThinking.builder()
                     .type(thinkingType)
                     .budgetTokens(thinkingBudgetTokens)
+                    .display(thinkingDisplay)
                     .build();
         }
         return null;

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -66,6 +66,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
     private final boolean cacheTools;
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
+    private final String thinkingDisplay;
     private final boolean returnThinking;
     private final boolean sendThinking;
     private final List<ChatModelListener> listeners;
@@ -115,6 +116,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         this.cacheTools = getOrDefault(builder.cacheTools, false);
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
+        this.thinkingDisplay = builder.thinkingDisplay;
         this.returnThinking = getOrDefault(builder.returnThinking, false);
         this.sendThinking = getOrDefault(builder.sendThinking, true);
         this.listeners = copy(builder.listeners);
@@ -152,6 +154,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         private Boolean cacheTools;
         private String thinkingType;
         private Integer thinkingBudgetTokens;
+        private String thinkingDisplay;
         private Boolean returnThinking;
         private Boolean sendThinking;
         private Duration timeout;
@@ -267,6 +270,24 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
          */
         public AnthropicStreamingChatModelBuilder thinkingBudgetTokens(Integer thinkingBudgetTokens) {
             this.thinkingBudgetTokens = thinkingBudgetTokens;
+            return this;
+        }
+
+        /**
+         * Controls how thinking content is returned in API responses.
+         * <p>
+         * Accepts {@code "summarized"} or {@code "omitted"}.
+         * On Claude Opus 4.7+, the default is {@code "omitted"} (thinking text is suppressed),
+         * which reduces time-to-first-text-token but hides the reasoning trace.
+         * Set to {@code "summarized"} to receive a summary of the model's reasoning.
+         * <p>
+         * Note: you are still charged for the full thinking tokens regardless of this setting.
+         *
+         * @param thinkingDisplay the display mode: {@code "summarized"} or {@code "omitted"}
+         * @see #thinkingType(String)
+         */
+        public AnthropicStreamingChatModelBuilder thinkingDisplay(String thinkingDisplay) {
+            this.thinkingDisplay = thinkingDisplay;
             return this;
         }
 
@@ -460,7 +481,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         validate(chatRequest.parameters());
         AnthropicCreateMessageRequest anthropicRequest = createAnthropicRequest(
                 chatRequest,
-                toThinking(thinkingType, thinkingBudgetTokens),
+                toThinking(thinkingType, thinkingBudgetTokens, thinkingDisplay),
                 sendThinking,
                 cacheSystemMessages ? EPHEMERAL : NO_CACHE,
                 cacheTools ? EPHEMERAL : NO_CACHE,

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicThinking.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicThinking.java
@@ -34,8 +34,7 @@ public class AnthropicThinking {
         private Integer budgetTokens;
         private String display;
 
-        private Builder() {
-        }
+        private Builder() {}
 
         public Builder type(String type) {
             this.type = type;

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicThinking.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicThinking.java
@@ -15,9 +15,13 @@ public class AnthropicThinking {
     @JsonProperty
     private final Integer budgetTokens;
 
+    @JsonProperty
+    private final String display;
+
     public AnthropicThinking(Builder builder) {
         this.type = builder.type;
         this.budgetTokens = builder.budgetTokens;
+        this.display = builder.display;
     }
 
     public static Builder builder() {
@@ -28,6 +32,7 @@ public class AnthropicThinking {
 
         private String type;
         private Integer budgetTokens;
+        private String display;
 
         private Builder() {
         }
@@ -39,6 +44,17 @@ public class AnthropicThinking {
 
         public Builder budgetTokens(Integer budgetTokens) {
             this.budgetTokens = budgetTokens;
+            return this;
+        }
+
+        /**
+         * Controls how thinking content is returned in API responses.
+         *
+         * @param display {@code "summarized"} to receive summarized thinking text,
+         *                {@code "omitted"} to suppress thinking text (default on Opus 4.7+).
+         */
+        public Builder display(String display) {
+            this.display = display;
             return this;
         }
 

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelTest.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.model.anthropic;
 
 import static dev.langchain4j.model.anthropic.AnthropicChatModel.toThinking;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelTest.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.model.anthropic;
+
+import static dev.langchain4j.model.anthropic.AnthropicChatModel.toThinking;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import dev.langchain4j.model.anthropic.internal.api.AnthropicThinking;
+import org.junit.jupiter.api.Test;
+
+class AnthropicChatModelTest {
+
+    @Test
+    void toThinking_with_display_summarized() {
+        AnthropicThinking thinking = toThinking("adaptive", null, "summarized");
+
+        assertNotNull(thinking);
+    }
+
+    @Test
+    void toThinking_with_display_omitted() {
+        AnthropicThinking thinking = toThinking("adaptive", null, "omitted");
+
+        assertNotNull(thinking);
+    }
+
+    @Test
+    void toThinking_without_display() {
+        AnthropicThinking thinking = toThinking("enabled", 10000, null);
+
+        assertNotNull(thinking);
+    }
+
+    @Test
+    void toThinking_returns_null_when_all_null() {
+        AnthropicThinking thinking = toThinking(null, null, null);
+
+        assertNull(thinking);
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelThinkingDisplayIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelThinkingDisplayIT.java
@@ -28,7 +28,8 @@ class AnthropicChatModelThinkingDisplayIT {
     void should_return_thinking_when_display_is_summarized() {
 
         // given
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         ChatModel model = AnthropicChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
@@ -91,7 +92,8 @@ class AnthropicChatModelThinkingDisplayIT {
     void should_send_display_field_in_request_body() {
 
         // given
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         ChatModel model = AnthropicChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelThinkingDisplayIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelThinkingDisplayIT.java
@@ -1,0 +1,117 @@
+package dev.langchain4j.model.anthropic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SpyingHttpClient;
+import dev.langchain4j.http.client.jdk.JdkHttpClient;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+@Disabled("Run manually. Requires ANTHROPIC_API_KEY and costs real tokens.")
+class AnthropicChatModelThinkingDisplayIT {
+
+    private static String apiKey() {
+        return System.getenv("ANTHROPIC_API_KEY");
+    }
+
+    private static String baseUrl() {
+        String url = System.getenv("ANTHROPIC_BASE_URL");
+        return url != null ? url : "https://api.anthropic.com/v1/";
+    }
+
+    @Test
+    void should_return_thinking_when_display_is_summarized() {
+
+        // given
+        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        ChatModel model = AnthropicChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .baseUrl(baseUrl())
+                .apiKey(apiKey())
+                .modelName("claude-opus-4-6")
+                .thinkingType("adaptive")
+                .thinkingDisplay("summarized")
+                .maxTokens(4096)
+                .returnThinking(true)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("What is 15 * 37? Think step by step.");
+
+        // when
+        ChatResponse chatResponse = model.chat(userMessage);
+
+        // then
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).contains("555");
+        assertThat(aiMessage.thinking()).isNotBlank();
+
+        // verify display field was sent in the request
+        assertThat(spyingHttpClient.requests().get(0).body())
+                .contains("\"display\"")
+                .contains("summarized");
+    }
+
+    @Test
+    void should_return_empty_thinking_when_display_is_omitted() {
+
+        // given
+        ChatModel model = AnthropicChatModel.builder()
+                .baseUrl(baseUrl())
+                .apiKey(apiKey())
+                .modelName("claude-opus-4-6")
+                .thinkingType("adaptive")
+                .thinkingDisplay("omitted")
+                .maxTokens(4096)
+                .returnThinking(true)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("What is 15 * 37? Think step by step.");
+
+        // when
+        ChatResponse chatResponse = model.chat(userMessage);
+
+        // then
+        AiMessage aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.text()).contains("555");
+        // thinking should be blank or null since display is omitted
+        assertThat(aiMessage.thinking()).isNullOrEmpty();
+    }
+
+    @Test
+    void should_send_display_field_in_request_body() {
+
+        // given
+        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+
+        ChatModel model = AnthropicChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
+                .baseUrl(baseUrl())
+                .apiKey(apiKey())
+                .modelName("claude-opus-4-6")
+                .thinkingType("adaptive")
+                .thinkingDisplay("summarized")
+                .maxTokens(4096)
+                .returnThinking(true)
+                .build();
+
+        UserMessage userMessage = UserMessage.from("Hello");
+
+        // when
+        model.chat(userMessage);
+
+        // then - verify the thinking object in the request contains the display field
+        String requestBody = spyingHttpClient.requests().get(0).body();
+        assertThat(requestBody).contains("\"type\" : \"adaptive\"");
+        assertThat(requestBody).contains("\"display\" : \"summarized\"");
+    }
+}


### PR DESCRIPTION
## Issue

Anthropic Claude Opus 4.7 changed the default value of `thinking.display` from `"summarized"` to `"omitted"`, which silently suppresses reasoning traces in API responses. LangChain4j's `AnthropicThinking` currently has no `display` field, making it impossible to opt back into summarized thinking on 4.7+.

## Change

Add `display` field to `AnthropicThinking` and expose `thinkingDisplay(String)` on both `AnthropicChatModel` and `AnthropicStreamingChatModel` builders.

Usage:
```java
AnthropicChatModel.builder()
    .thinkingType("adaptive")
    .thinkingDisplay("summarized")  // new
    .build();
```

**Reference implementations:**
- LangChain Python: [`chat_models.py#L833-L848`](https://github.com/langchain-ai/langchain/blob/master/libs/partners/anthropic/langchain_anthropic/chat_models.py#L833-L848)
- Spring AI (merged): [spring-projects/spring-ai#5643](https://github.com/spring-projects/spring-ai/pull/5643)
- Anthropic docs: [Controlling thinking display](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#controlling-thinking-display)

**Follow-up:** Spring Boot starter in `langchain4j-spring` needs a matching `thinkingDisplay` property in `ChatModelProperties` — will submit separately after this merges.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)