### PR TITLE
Support format in JsonStringSchema

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementJsonUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementJsonUtils.java
@@ -39,7 +39,7 @@ public class JsonSchemaElementJsonUtils {
     // that cannot be represented by the corresponding JsonSchemaElement subtype.
     // When a map contains keys outside this set, fromMap() falls back to JsonRawSchema.
     // NOTE: When adding new JsonSchemaElement subtypes, update these sets accordingly.
-    private static final Set<String> STRING_KEYS = Set.of("type", "description");
+    private static final Set<String> STRING_KEYS = Set.of("type", "description", "format");
     private static final Set<String> INTEGER_KEYS = Set.of("type", "description");
     private static final Set<String> NUMBER_KEYS = Set.of("type", "description");
     private static final Set<String> BOOLEAN_KEYS = Set.of("type", "description");
@@ -74,7 +74,7 @@ public class JsonSchemaElementJsonUtils {
         }
 
         // Simple typed schemas: type + description
-        if (element instanceof JsonStringSchema s) return typedSchema("string", s.description());
+        if (element instanceof JsonStringSchema s) return stringSchemaToMap(s);
         if (element instanceof JsonIntegerSchema i) return typedSchema("integer", i.description());
         if (element instanceof JsonNumberSchema n) return typedSchema("number", n.description());
         if (element instanceof JsonBooleanSchema b) return typedSchema("boolean", b.description());
@@ -104,6 +104,14 @@ public class JsonSchemaElementJsonUtils {
         map.put("type", type);
         if (description != null) {
             map.put("description", description);
+        }
+        return map;
+    }
+
+    private static Map<String, Object> stringSchemaToMap(JsonStringSchema schema) {
+        Map<String, Object> map = typedSchema("string", schema.description());
+        if (schema.format() != null) {
+            map.put("format", schema.format());
         }
         return map;
     }
@@ -162,11 +170,11 @@ public class JsonSchemaElementJsonUtils {
      * Converts a standard JSON Schema {@link Map} representation back to a {@link JsonSchemaElement}.
      * <p>
      * Only the subset of JSON Schema expressible by {@link JsonSchemaElement} subtypes is supported.
-     * When a map contains additional JSON Schema keywords (e.g., {@code format}, {@code pattern},
-     * {@code minimum}, schema-valued {@code additionalProperties}) that cannot be represented by
-     * the corresponding typed schema, the entire node falls back to {@link JsonRawSchema} to
-     * preserve round-trip fidelity. The fallback granularity is per-node: a parent
-     * {@link JsonObjectSchema} can still be typed even if a child property falls back to raw.
+     * When a map contains additional JSON Schema keywords (e.g., {@code pattern}, {@code minimum},
+     * schema-valued {@code additionalProperties}) that cannot be represented by the corresponding
+     * typed schema, the entire node falls back to {@link JsonRawSchema} to preserve round-trip fidelity.
+     * The fallback granularity is per-node: a parent {@link JsonObjectSchema} can still be typed
+     * even if a child property falls back to raw.
      *
      * @throws IllegalArgumentException if the map contains structurally invalid values
      *                                  (e.g., {@code $ref} is not a string, {@code anyOf} is not a list,
@@ -246,6 +254,7 @@ public class JsonSchemaElementJsonUtils {
                 isRepresentable(map, STRING_KEYS)
                         ? JsonStringSchema.builder()
                                 .description(optionalString(map, "description"))
+                                .format(optionalString(map, "format"))
                                 .build()
                         : rawFallback(map);
             case "integer" ->

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -24,6 +24,9 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -45,6 +48,7 @@ public class JsonSchemaElementUtils {
         if (isJsonString(clazz)) {
             return JsonStringSchema.builder()
                     .description(Optional.ofNullable(fieldDescription).orElse(descriptionFrom(clazz)))
+                    .format(formatFrom(clazz))
                     .build();
         }
 
@@ -180,6 +184,22 @@ public class JsonSchemaElementUtils {
         return String.join(" ", description.value());
     }
 
+    private static String formatFrom(Class<?> type) {
+        if (type == UUID.class) {
+            return "uuid";
+        }
+        if (type == LocalDate.class) {
+            return "date";
+        }
+        if (type == LocalTime.class) {
+            return "time";
+        }
+        if (type == Duration.class) {
+            return "duration";
+        }
+        return null;
+    }
+
     private static Class<?> getActualType(Type type) {
         if (type instanceof final ParameterizedType parameterizedType) {
             Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
@@ -297,6 +317,9 @@ public class JsonSchemaElementUtils {
             if (jsonStringSchema.description() != null) {
                 map.put("description", jsonStringSchema.description());
             }
+            if (jsonStringSchema.format() != null) {
+                map.put("format", jsonStringSchema.format());
+            }
             return map;
         } else if (jsonSchemaElement instanceof JsonIntegerSchema jsonIntegerSchema) {
             Map<String, Object> map = new LinkedHashMap<>();
@@ -387,7 +410,10 @@ public class JsonSchemaElementUtils {
                 || type == char.class
                 || type == Character.class
                 || CharSequence.class.isAssignableFrom(type)
-                || type == UUID.class;
+                || type == UUID.class
+                || type == LocalDate.class
+                || type == LocalTime.class
+                || type == Duration.class;
     }
 
     static boolean isJsonArray(Class<?> type) {

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -33,6 +33,9 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -54,6 +57,7 @@ public class JsonSchemaElementUtils {
         if (isJsonString(clazz)) {
             return JsonStringSchema.builder()
                     .description(Optional.ofNullable(fieldDescription).orElse(descriptionFrom(clazz)))
+                    .format(formatFrom(clazz))
                     .build();
         }
 
@@ -323,6 +327,22 @@ public class JsonSchemaElementUtils {
         return String.join(" ", description.value());
     }
 
+    private static String formatFrom(Class<?> type) {
+        if (type == UUID.class) {
+            return "uuid";
+        }
+        if (type == LocalDate.class) {
+            return "date";
+        }
+        if (type == LocalTime.class) {
+            return "time";
+        }
+        if (type == Duration.class) {
+            return "duration";
+        }
+        return null;
+    }
+
     /**
      * Returns the single type argument of a {@code Collection<E>}-shaped type, preserving its full
      * generic shape so callers can recurse into nested generics like {@code List<List<X>>} or {@code List<Foo<Bar>>}.
@@ -479,6 +499,9 @@ public class JsonSchemaElementUtils {
             if (jsonStringSchema.description() != null) {
                 map.put("description", jsonStringSchema.description());
             }
+            if (jsonStringSchema.format() != null) {
+                map.put("format", jsonStringSchema.format());
+            }
             return map;
         } else if (jsonSchemaElement instanceof JsonIntegerSchema jsonIntegerSchema) {
             Map<String, Object> map = new LinkedHashMap<>();
@@ -569,7 +592,10 @@ public class JsonSchemaElementUtils {
                 || type == char.class
                 || type == Character.class
                 || CharSequence.class.isAssignableFrom(type)
-                || type == UUID.class;
+                || type == UUID.class
+                || type == LocalDate.class
+                || type == LocalTime.class
+                || type == Duration.class;
     }
 
     static boolean isJsonArray(Class<?> type) {

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonStringSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonStringSchema.java
@@ -7,18 +7,25 @@ import static dev.langchain4j.internal.Utils.quoted;
 public class JsonStringSchema implements JsonSchemaElement {
 
     private final String description;
+    private final String format;
 
     public JsonStringSchema() {
         this.description = null;
+        this.format = null;
     }
 
     public JsonStringSchema(Builder builder) {
         this.description = builder.description;
+        this.format = builder.format;
     }
 
     @Override
     public String description() {
         return description;
+    }
+
+    public String format() {
+        return format;
     }
 
     public static Builder builder() {
@@ -28,9 +35,15 @@ public class JsonStringSchema implements JsonSchemaElement {
     public static class Builder {
 
         private String description;
+        private String format;
 
         public Builder description(String description) {
             this.description = description;
+            return this;
+        }
+
+        public Builder format(String format) {
+            this.format = format;
             return this;
         }
 
@@ -44,18 +57,20 @@ public class JsonStringSchema implements JsonSchemaElement {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         JsonStringSchema that = (JsonStringSchema) o;
-        return Objects.equals(this.description, that.description);
+        return Objects.equals(this.description, that.description)
+                && Objects.equals(this.format, that.format);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(description);
+        return Objects.hash(description, format);
     }
 
     @Override
     public String toString() {
         return "JsonStringSchema {" +
                 "description = " + quoted(description) +
+                ", format = " + quoted(format) +
                 " }";
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonStringSchema.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/json/JsonStringSchema.java
@@ -1,24 +1,31 @@
 package dev.langchain4j.model.chat.request.json;
 
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.quoted;
+
+import java.util.Objects;
 
 public class JsonStringSchema implements JsonSchemaElement {
 
     private final String description;
+    private final String format;
 
     public JsonStringSchema() {
         this.description = null;
+        this.format = null;
     }
 
     public JsonStringSchema(Builder builder) {
         this.description = builder.description;
+        this.format = builder.format;
     }
 
     @Override
     public String description() {
         return description;
+    }
+
+    public String format() {
+        return format;
     }
 
     public static Builder builder() {
@@ -28,9 +35,15 @@ public class JsonStringSchema implements JsonSchemaElement {
     public static class Builder {
 
         private String description;
+        private String format;
 
         public Builder description(String description) {
             this.description = description;
+            return this;
+        }
+
+        public Builder format(String format) {
+            this.format = format;
             return this;
         }
 
@@ -44,18 +57,16 @@ public class JsonStringSchema implements JsonSchemaElement {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         JsonStringSchema that = (JsonStringSchema) o;
-        return Objects.equals(this.description, that.description);
+        return Objects.equals(this.description, that.description) && Objects.equals(this.format, that.format);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(description);
+        return Objects.hash(description, format);
     }
 
     @Override
     public String toString() {
-        return "JsonStringSchema {" +
-                "description = " + quoted(description) +
-                " }";
+        return "JsonStringSchema {" + "description = " + quoted(description) + ", format = " + quoted(format) + " }";
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementJsonUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementJsonUtilsTest.java
@@ -36,6 +36,7 @@ class JsonSchemaElementJsonUtilsTest {
     @Test
     void should_round_trip_scalar_types() {
         assertRoundTrip(JsonStringSchema.builder().description("a name").build());
+        assertRoundTrip(JsonStringSchema.builder().description("a date").format("date").build());
         assertRoundTrip(new JsonStringSchema());
         assertRoundTrip(JsonIntegerSchema.builder().description("count").build());
         assertRoundTrip(new JsonIntegerSchema());
@@ -269,11 +270,12 @@ class JsonSchemaElementJsonUtilsTest {
     // ---- raw fallback for extra keywords ----
 
     @Test
-    void should_fallback_to_raw_for_string_with_format() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "string");
-        map.put("format", "date-time");
-        assertRawFallback(map);
+    void should_round_trip_string_with_format() {
+        JsonStringSchema schema = JsonStringSchema.builder()
+                .description("timestamp")
+                .format("date-time")
+                .build();
+        assertRoundTrip(schema);
     }
 
     @Test
@@ -309,7 +311,7 @@ class JsonSchemaElementJsonUtilsTest {
 
     @Test
     void should_round_trip_nested_with_raw_fallback_child() {
-        // outer object is typed, child with format falls back to raw
+        // outer object is typed, child with format remains typed string schema
         Map<String, Object> childMap = new LinkedHashMap<>();
         childMap.put("type", "string");
         childMap.put("format", "date-time");
@@ -327,7 +329,8 @@ class JsonSchemaElementJsonUtilsTest {
         assertThat(element).isInstanceOf(JsonObjectSchema.class);
         JsonObjectSchema obj = (JsonObjectSchema) element;
         assertThat(obj.properties().get("name")).isInstanceOf(JsonStringSchema.class);
-        assertThat(obj.properties().get("timestamp")).isInstanceOf(JsonRawSchema.class);
+        assertThat(obj.properties().get("timestamp"))
+                .isEqualTo(JsonStringSchema.builder().format("date-time").build());
 
         // round-trip should preserve structure
         Map<String, Object> restored = JsonSchemaElementJsonUtils.toMap(element);
@@ -380,6 +383,14 @@ class JsonSchemaElementJsonUtilsTest {
         assertThatThrownBy(() -> JsonSchemaElementJsonUtils.fromMap(map))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("description");
+    }
+
+    @Test
+    void should_reject_non_string_format_in_string() {
+        Map<String, Object> map = Map.of("type", "string", "format", 99);
+        assertThatThrownBy(() -> JsonSchemaElementJsonUtils.fromMap(map))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("format");
     }
 
     // ---- enum type validation ----

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementJsonUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementJsonUtilsTest.java
@@ -36,6 +36,8 @@ class JsonSchemaElementJsonUtilsTest {
     @Test
     void should_round_trip_scalar_types() {
         assertRoundTrip(JsonStringSchema.builder().description("a name").build());
+        assertRoundTrip(
+                JsonStringSchema.builder().description("a date").format("date").build());
         assertRoundTrip(new JsonStringSchema());
         assertRoundTrip(JsonIntegerSchema.builder().description("count").build());
         assertRoundTrip(new JsonIntegerSchema());
@@ -269,11 +271,12 @@ class JsonSchemaElementJsonUtilsTest {
     // ---- raw fallback for extra keywords ----
 
     @Test
-    void should_fallback_to_raw_for_string_with_format() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "string");
-        map.put("format", "date-time");
-        assertRawFallback(map);
+    void should_round_trip_string_with_format() {
+        JsonStringSchema schema = JsonStringSchema.builder()
+                .description("timestamp")
+                .format("date-time")
+                .build();
+        assertRoundTrip(schema);
     }
 
     @Test
@@ -309,7 +312,7 @@ class JsonSchemaElementJsonUtilsTest {
 
     @Test
     void should_round_trip_nested_with_raw_fallback_child() {
-        // outer object is typed, child with format falls back to raw
+        // outer object is typed, child with format remains typed string schema
         Map<String, Object> childMap = new LinkedHashMap<>();
         childMap.put("type", "string");
         childMap.put("format", "date-time");
@@ -327,7 +330,8 @@ class JsonSchemaElementJsonUtilsTest {
         assertThat(element).isInstanceOf(JsonObjectSchema.class);
         JsonObjectSchema obj = (JsonObjectSchema) element;
         assertThat(obj.properties().get("name")).isInstanceOf(JsonStringSchema.class);
-        assertThat(obj.properties().get("timestamp")).isInstanceOf(JsonRawSchema.class);
+        assertThat(obj.properties().get("timestamp"))
+                .isEqualTo(JsonStringSchema.builder().format("date-time").build());
 
         // round-trip should preserve structure
         Map<String, Object> restored = JsonSchemaElementJsonUtils.toMap(element);
@@ -380,6 +384,14 @@ class JsonSchemaElementJsonUtilsTest {
         assertThatThrownBy(() -> JsonSchemaElementJsonUtils.fromMap(map))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("description");
+    }
+
+    @Test
+    void should_reject_non_string_format_in_string() {
+        Map<String, Object> map = Map.of("type", "string", "format", 99);
+        assertThatThrownBy(() -> JsonSchemaElementJsonUtils.fromMap(map))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("format");
     }
 
     // ---- enum type validation ----

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
@@ -17,6 +17,9 @@ import dev.langchain4j.model.chat.request.json.JsonRawSchema;
 import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import dev.langchain4j.model.output.structured.Description;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -94,6 +97,7 @@ class JsonSchemaElementUtilsTest {
         assertThat(jsonSchemaElement)
                 .isEqualTo(JsonStringSchema.builder()
                         .description("String in a UUID format")
+                        .format("uuid")
                         .build());
     }
 
@@ -114,7 +118,12 @@ class JsonSchemaElementUtilsTest {
         // then
         assertThat(jsonSchemaElement)
                 .isEqualTo(JsonObjectSchema.builder()
-                        .addStringProperty("uuid", "String in a UUID format")
+                        .addProperty(
+                                "uuid",
+                                JsonStringSchema.builder()
+                                        .description("String in a UUID format")
+                                        .format("uuid")
+                                        .build())
                         .required("uuid")
                         .build());
     }
@@ -137,9 +146,27 @@ class JsonSchemaElementUtilsTest {
         // then
         assertThat(jsonSchemaElement)
                 .isEqualTo(JsonObjectSchema.builder()
-                        .addStringProperty("uuid", "My UUID")
+                        .addProperty(
+                                "uuid",
+                                JsonStringSchema.builder()
+                                        .description("My UUID")
+                                        .format("uuid")
+                                        .build())
                         .required("uuid")
                         .build());
+    }
+
+    @Test
+    void should_set_date_time_formats() {
+
+        assertThat(jsonSchemaElementFrom(LocalDate.class, null, null, true, new LinkedHashMap<>()))
+                .isEqualTo(JsonStringSchema.builder().format("date").build());
+
+        assertThat(jsonSchemaElementFrom(LocalTime.class, null, null, true, new LinkedHashMap<>()))
+                .isEqualTo(JsonStringSchema.builder().format("time").build());
+
+        assertThat(jsonSchemaElementFrom(Duration.class, null, null, true, new LinkedHashMap<>()))
+                .isEqualTo(JsonStringSchema.builder().format("duration").build());
     }
 
     @Test
@@ -337,13 +364,15 @@ class JsonSchemaElementUtilsTest {
     void shouldConvertJsonStringSchemaToMap() {
         JsonStringSchema schema = JsonStringSchema.builder()
                 .description("string description")
+                .format("date-time")
                 .build();
 
         Map<String, Object> map = JsonSchemaElementUtils.toMap(schema);
 
         assertThat(map)
                 .containsEntry("type", "string")
-                .containsEntry("description", "string description");
+                .containsEntry("description", "string description")
+                .containsEntry("format", "date-time");
     }
 
     @Test

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
@@ -18,7 +18,10 @@ import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.model.output.structured.Description;
+import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
@@ -94,6 +97,7 @@ class JsonSchemaElementUtilsTest {
         assertThat(jsonSchemaElement)
                 .isEqualTo(JsonStringSchema.builder()
                         .description("String in a UUID format")
+                        .format("uuid")
                         .build());
     }
 
@@ -114,7 +118,12 @@ class JsonSchemaElementUtilsTest {
         // then
         assertThat(jsonSchemaElement)
                 .isEqualTo(JsonObjectSchema.builder()
-                        .addStringProperty("uuid", "String in a UUID format")
+                        .addProperty(
+                                "uuid",
+                                JsonStringSchema.builder()
+                                        .description("String in a UUID format")
+                                        .format("uuid")
+                                        .build())
                         .required("uuid")
                         .build());
     }
@@ -137,9 +146,27 @@ class JsonSchemaElementUtilsTest {
         // then
         assertThat(jsonSchemaElement)
                 .isEqualTo(JsonObjectSchema.builder()
-                        .addStringProperty("uuid", "My UUID")
+                        .addProperty(
+                                "uuid",
+                                JsonStringSchema.builder()
+                                        .description("My UUID")
+                                        .format("uuid")
+                                        .build())
                         .required("uuid")
                         .build());
+    }
+
+    @Test
+    void should_set_date_time_formats() {
+
+        assertThat(jsonSchemaElementFrom(LocalDate.class, null, null, true, new LinkedHashMap<>()))
+                .isEqualTo(JsonStringSchema.builder().format("date").build());
+
+        assertThat(jsonSchemaElementFrom(LocalTime.class, null, null, true, new LinkedHashMap<>()))
+                .isEqualTo(JsonStringSchema.builder().format("time").build());
+
+        assertThat(jsonSchemaElementFrom(Duration.class, null, null, true, new LinkedHashMap<>()))
+                .isEqualTo(JsonStringSchema.builder().format("duration").build());
     }
 
     @Test
@@ -448,12 +475,17 @@ class JsonSchemaElementUtilsTest {
 
     @Test
     void shouldConvertJsonStringSchemaToMap() {
-        JsonStringSchema schema =
-                JsonStringSchema.builder().description("string description").build();
+        JsonStringSchema schema = JsonStringSchema.builder()
+                .description("string description")
+                .format("date-time")
+                .build();
 
         Map<String, Object> map = JsonSchemaElementUtils.toMap(schema);
 
-        assertThat(map).containsEntry("type", "string").containsEntry("description", "string description");
+        assertThat(map)
+                .containsEntry("type", "string")
+                .containsEntry("description", "string description")
+                .containsEntry("format", "date-time");
     }
 
     @Test


### PR DESCRIPTION
## Issue
Closes #4934

## Change
Adds format to JsonStringSchema and maps the four types requested in the issue:

- UUID to uuid
- LocalDate to date
- LocalTime to time
- Duration to duration

The existing schema map conversions preserve the new field in both directions.

## Testing
- JsonSchemaElementJsonUtilsTest and JsonSchemaElementUtilsTest: 75 tests passed
- git diff --check