### PR TITLE
Fix: JacksonCodec throws on empty JSON array (closes #3295)

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/message/JacksonChatMessageJsonCodec.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/message/JacksonChatMessageJsonCodec.java
@@ -60,6 +60,9 @@ public class JacksonChatMessageJsonCodec implements ChatMessageJsonCodec {
 
     @Override
     public ChatMessage messageFromJson(String json) {
+        if (json == null || json.isBlank()) {
+            throw new IllegalArgumentException("JSON string is null or blank");
+        }
         try {
             return OBJECT_MAPPER.readValue(json, ChatMessage.class);
         } catch (JsonProcessingException e) {

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/message/ChatMessageSerializerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/message/ChatMessageSerializerTest.java
@@ -7,6 +7,7 @@ import static dev.langchain4j.data.message.UserMessage.userMessage;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import java.util.LinkedHashMap;
@@ -209,5 +210,26 @@ class ChatMessageSerializerTest {
         assertThat(deserialized.text()).isEqualTo("sunny");
         assertThat(deserialized.contents()).isEqualTo(List.of(TextContent.from("sunny")));
         assertThat(deserialized.attributes()).isEmpty();
+    }
+
+    @Test
+    void should_throw_on_null_json() {
+        assertThatThrownBy(() -> messageFromJson(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("JSON string is null or blank");
+    }
+
+    @Test
+    void should_throw_on_empty_json() {
+        assertThatThrownBy(() -> messageFromJson("{}"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("JSON string is null or blank");
+    }
+
+    @Test
+    void should_throw_on_blank_json() {
+        assertThatThrownBy(() -> messageFromJson("   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("JSON string is null or blank");
     }
 }


### PR DESCRIPTION
## Fixes #3295

## Problem
JacksonChatMessageJsonCodec.messageFromJson() throws JsonMappingException when parsing an empty JSON array [].