### PR TITLE
feat: add numThread support to OllamaChatRequestParameters

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -176,6 +176,7 @@ class InternalOllamaHelper {
                         // numPredict and maxOutputTokens are semantically identical
                         .numPredict(requestParameters.maxOutputTokens())
                         .numCtx(requestParameters.numCtx())
+                        .numThread(requestParameters.numThread())
                         .stop(requestParameters.stopSequences())
                         .minP(requestParameters.minP())
                         .build())

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatRequestParameters.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaChatRequestParameters.java
@@ -16,6 +16,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
     private final Double mirostatEta;
     private final Double mirostatTau;
     private final Integer numCtx;
+    private final Integer numThread;
     private final Integer repeatLastN;
     private final Double repeatPenalty;
     private final Integer seed;
@@ -29,6 +30,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
         this.mirostatEta = builder.mirostatEta;
         this.mirostatTau = builder.mirostatTau;
         this.numCtx = builder.numCtx;
+        this.numThread = builder.numThread;
         this.repeatLastN = builder.repeatLastN;
         this.repeatPenalty = builder.repeatPenalty;
         this.seed = builder.seed;
@@ -51,6 +53,10 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
 
     public Integer numCtx() {
         return numCtx;
+    }
+
+    public Integer numThread() {
+        return numThread;
     }
 
     public Integer repeatLastN() {
@@ -86,6 +92,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
                 && Objects.equals(mirostatEta, that.mirostatEta)
                 && Objects.equals(mirostatTau, that.mirostatTau)
                 && Objects.equals(numCtx, that.numCtx)
+                && Objects.equals(numThread, that.numThread)
                 && Objects.equals(repeatLastN, that.repeatLastN)
                 && Objects.equals(repeatPenalty, that.repeatPenalty)
                 && Objects.equals(seed, that.seed)
@@ -102,6 +109,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
                 mirostatEta,
                 mirostatTau,
                 numCtx,
+                numThread,
                 repeatLastN,
                 repeatPenalty,
                 seed,
@@ -128,6 +136,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
                 + ", mirostatEta=" + mirostatEta
                 + ", mirostatTau=" + mirostatTau
                 + ", numCtx=" + numCtx
+                + ", numThread=" + numThread
                 + ", repeatLastN=" + repeatLastN
                 + ", repeatPenalty=" + repeatPenalty
                 + ", seed=" + seed
@@ -163,6 +172,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
         private Double mirostatEta;
         private Double mirostatTau;
         private Integer numCtx;
+        private Integer numThread;
         private Integer repeatLastN;
         private Double repeatPenalty;
         private Integer seed;
@@ -178,6 +188,7 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
                 mirostatEta(getOrDefault(ollamaChatRequestParameters.mirostatEta, mirostatEta));
                 mirostatTau(getOrDefault(ollamaChatRequestParameters.mirostatTau, mirostatTau));
                 numCtx(getOrDefault(ollamaChatRequestParameters.numCtx, numCtx));
+                numThread(getOrDefault(ollamaChatRequestParameters.numThread, numThread));
                 repeatLastN(getOrDefault(ollamaChatRequestParameters.repeatLastN, repeatLastN));
                 repeatPenalty(getOrDefault(ollamaChatRequestParameters.repeatPenalty, repeatPenalty));
                 seed(getOrDefault(ollamaChatRequestParameters.seed, seed));
@@ -226,6 +237,18 @@ public class OllamaChatRequestParameters extends DefaultChatRequestParameters {
 
         public Builder numCtx(Integer numCtx) {
             this.numCtx = numCtx;
+            return this;
+        }
+
+        /**
+         * Sets the number of threads to use during computation.
+         * <p>Useful for CPU-only machines to control CPU utilization.</p>
+         * <p>Default: detected automatically</p>
+         *
+         * @return builder
+         */
+        public Builder numThread(Integer numThread) {
+            this.numThread = numThread;
             return this;
         }
 

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/Options.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/Options.java
@@ -29,6 +29,7 @@ class Options {
     private Integer seed;
     private Integer numPredict;
     private Integer numCtx;
+    private Integer numThread;
     private List<String> stop;
     private Double minP;
 
@@ -46,6 +47,7 @@ class Options {
         this.seed = builder.seed;
         this.numPredict = builder.numPredict;
         this.numCtx = builder.numCtx;
+        this.numThread = builder.numThread;
         this.stop = builder.stop;
         this.minP = builder.minP;
     }
@@ -138,6 +140,14 @@ class Options {
         this.numCtx = numCtx;
     }
 
+    public Integer getNumThread() {
+        return numThread;
+    }
+
+    public void setNumThread(Integer numThread) {
+        this.numThread = numThread;
+    }
+
     public List<String> getStop() {
         return stop;
     }
@@ -171,6 +181,7 @@ class Options {
         private Integer seed;
         private Integer numPredict;
         private Integer numCtx;
+        private Integer numThread;
         private List<String> stop;
         private Double minP;
 
@@ -226,6 +237,11 @@ class Options {
 
         Builder numCtx(Integer numCtx) {
             this.numCtx = numCtx;
+            return this;
+        }
+
+        Builder numThread(Integer numThread) {
+            this.numThread = numThread;
             return this;
         }
 

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaChatRequestParametersTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaChatRequestParametersTest.java
@@ -1,0 +1,73 @@
+package dev.langchain4j.model.ollama;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import org.junit.jupiter.api.Test;
+
+class OllamaChatRequestParametersTest {
+
+    @Test
+    void should_build_with_numThread() {
+        OllamaChatRequestParameters params =
+                OllamaChatRequestParameters.builder().numThread(4).build();
+
+        assertThat(params.numThread()).isEqualTo(4);
+    }
+
+    @Test
+    void numThread_should_be_null_when_not_set() {
+        OllamaChatRequestParameters params =
+                OllamaChatRequestParameters.builder().build();
+
+        assertThat(params.numThread()).isNull();
+    }
+
+    @Test
+    void overrideWith_should_apply_numThread_from_override() {
+        OllamaChatRequestParameters original =
+                OllamaChatRequestParameters.builder().numThread(2).build();
+        OllamaChatRequestParameters override =
+                OllamaChatRequestParameters.builder().numThread(8).build();
+
+        ChatRequestParameters result = original.overrideWith(override);
+
+        assertThat(result).isInstanceOf(OllamaChatRequestParameters.class);
+        assertThat(((OllamaChatRequestParameters) result).numThread()).isEqualTo(8);
+    }
+
+    @Test
+    void overrideWith_should_keep_original_numThread_when_override_is_null() {
+        OllamaChatRequestParameters original =
+                OllamaChatRequestParameters.builder().numThread(4).build();
+        OllamaChatRequestParameters override =
+                OllamaChatRequestParameters.builder().build();
+
+        ChatRequestParameters result = original.overrideWith(override);
+
+        assertThat(result).isInstanceOf(OllamaChatRequestParameters.class);
+        assertThat(((OllamaChatRequestParameters) result).numThread()).isEqualTo(4);
+    }
+
+    @Test
+    void equals_and_hashCode_should_include_numThread() {
+        OllamaChatRequestParameters params1 =
+                OllamaChatRequestParameters.builder().numThread(4).build();
+        OllamaChatRequestParameters params2 =
+                OllamaChatRequestParameters.builder().numThread(4).build();
+        OllamaChatRequestParameters params3 =
+                OllamaChatRequestParameters.builder().numThread(8).build();
+
+        assertThat(params1).isEqualTo(params2);
+        assertThat(params1.hashCode()).isEqualTo(params2.hashCode());
+        assertThat(params1).isNotEqualTo(params3);
+    }
+
+    @Test
+    void toString_should_include_numThread() {
+        OllamaChatRequestParameters params =
+                OllamaChatRequestParameters.builder().numThread(4).build();
+
+        assertThat(params.toString()).contains("numThread=4");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #4967

## Change
Adds `numThread` parameter to `OllamaChatRequestParameters` so users on CPU-only machines can control the number of threads used during inference.

Changes:
- `OllamaChatRequestParameters` — added `numThread` field, accessor, builder method with Javadoc, `equals`/`hashCode`/`toString`, and `overrideWith` support
- `Options` — added `numThread` field, getter/setter, and builder method (this is the DTO serialized to the Ollama REST API)
- `InternalOllamaHelper` — wired `numThread` from `OllamaChatRequestParameters` into `Options`
- `OllamaChatRequestParametersTest` — added 6 unit tests covering builder, null default, `overrideWith` (both directions), `equals`/`hashCode`, and `toString`

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)