### PR TITLE
Add guardrailName() to GuardrailExecutedEvent for observability

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/AbstractGuardrailExecutor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/AbstractGuardrailExecutor.java
@@ -125,6 +125,7 @@ public abstract sealed class AbstractGuardrailExecutor<
                         .request(request)
                         .result(result)
                         .guardrailClass((Class<G>) guardrail.getClass())
+                        .guardrailName(guardrail.name())
                         .duration(duration)
                         .build());
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/Guardrail.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/Guardrail.java
@@ -11,6 +11,16 @@ package dev.langchain4j.guardrail;
  */
 public interface Guardrail<P extends GuardrailRequest, R extends GuardrailResult<R>> {
     /**
+     * Returns the name of this guardrail for observability purposes.
+     * Decorators should override this method to return the name of the wrapped guardrail.
+     *
+     * @return the simple class name by default, or a custom name if overridden
+     */
+    default String name() {
+        return getClass().getSimpleName();
+    }
+
+    /**
      * Validate the interaction between the model and the user in one of the two directions.
      *
      * @param request

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
@@ -51,6 +51,17 @@ public interface GuardrailExecutedEvent<
      */
     Duration duration();
 
+    /**
+     * Retrieves the name of the guardrail for observability purposes.
+     * This returns the logical name rather than the class, allowing decorators
+     * to expose the wrapped guardrail's name.
+     *
+     * @return the name of the guardrail
+     */
+    default String guardrailName() {
+        return guardrailClass().getSimpleName();
+    }
+
     abstract class GuardrailExecutedEventBuilder<
                     P extends GuardrailRequest<P>,
                     R extends GuardrailResult<R>,
@@ -61,6 +72,7 @@ public interface GuardrailExecutedEvent<
         private P request;
         private R result;
         private Class<G> guardrailClass;
+        private String guardrailName;
         private Duration duration;
 
         protected GuardrailExecutedEventBuilder() {}
@@ -75,6 +87,10 @@ public interface GuardrailExecutedEvent<
 
         public Class<G> guardrailClass() {
             return guardrailClass;
+        }
+
+        public String guardrailName() {
+            return guardrailName;
         }
 
         public P request() {
@@ -105,6 +121,11 @@ public interface GuardrailExecutedEvent<
 
         public <C extends G> GuardrailExecutedEventBuilder<P, R, G, T> guardrailClass(Class<C> guardrailClass) {
             this.guardrailClass = (Class<G>) guardrailClass;
+            return this;
+        }
+
+        public GuardrailExecutedEventBuilder<P, R, G, T> guardrailName(String guardrailName) {
+            this.guardrailName = guardrailName;
             return this;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultGuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultGuardrailExecutedEvent.java
@@ -27,6 +27,7 @@ public abstract class DefaultGuardrailExecutedEvent<
     private final P request;
     private final R result;
     private final Class<G> guardrailClass;
+    private final String guardrailName;
     private final Duration duration;
 
     protected DefaultGuardrailExecutedEvent(GuardrailExecutedEventBuilder<P, R, G, E> builder) {
@@ -34,6 +35,7 @@ public abstract class DefaultGuardrailExecutedEvent<
         this.request = ensureNotNull(builder.request(), "request");
         this.result = ensureNotNull(builder.result(), "result");
         this.guardrailClass = ensureNotNull(builder.guardrailClass(), "guardrailClass");
+        this.guardrailName = builder.guardrailName();
         this.duration = ensureNotNull(builder.duration(), "duration");
     }
 
@@ -50,6 +52,11 @@ public abstract class DefaultGuardrailExecutedEvent<
     @Override
     public Class<G> guardrailClass() {
         return this.guardrailClass;
+    }
+
+    @Override
+    public String guardrailName() {
+        return this.guardrailName;
     }
 
     @Override

--- a/langchain4j-core/src/test/java/dev/langchain4j/observability/api/event/GuardrailExecutedEventGuardrailNameTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/observability/api/event/GuardrailExecutedEventGuardrailNameTest.java
@@ -1,0 +1,58 @@
+package dev.langchain4j.observability.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.guardrail.Guardrail;
+import dev.langchain4j.guardrail.GuardrailRequest;
+import dev.langchain4j.guardrail.GuardrailResult;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.InputGuardrailRequest;
+import dev.langchain4j.guardrail.InputGuardrailResult;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link GuardrailExecutedEvent#guardrailName()} to verify that decorators
+ * expose the logical name of the wrapped guardrail rather than the decorator class name.
+ */
+class GuardrailExecutedEventGuardrailNameTest {
+
+    @Test
+    void guardrailName_should_return_simple_class_name_by_default() {
+        // given
+        var event = InputGuardrailExecutedEvent.builder()
+                .guardrailClass(MyGuardrail.class)
+                .build();
+
+        // when
+        String name = event.guardrailName();
+
+        // then
+        assertThat(name).isEqualTo("MyGuardrail");
+    }
+
+    @Test
+    void guardrailName_should_return_decorator_overridden_name() {
+        // given
+        var event = InputGuardrailExecutedEvent.builder()
+                .guardrailClass(MyGuardrailDecorator.class)
+                .guardrailName("MyLogicalGuardrail")
+                .build();
+
+        // when
+        String name = event.guardrailName();
+
+        // then
+        assertThat(name).isEqualTo("MyLogicalGuardrail");
+    }
+
+    // --- Test guardrail classes ---
+
+    private static class MyGuardrail implements InputGuardrail {}
+
+    private static class MyGuardrailDecorator implements InputGuardrail {
+        @Override
+        public String name() {
+            return "MyLogicalGuardrail";
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4938 — decorators now expose logical guardrail name via GuardrailExecutedEvent.guardrailName()

## Changes

### Guardrail.java
Added `default String name()` method returning `getClass().getSimpleName()` — decorators can override to expose the wrapped guardrail's logical name.

### GuardrailExecutedEvent.java
- Added `default String guardrailName()` interface method (returns `guardrailClass().getSimpleName()` as fallback)
- Added `private String guardrailName` field to builder
- Added `guardrailName()` getter and setter to `GuardrailExecutedEventBuilder`

### DefaultGuardrailExecutedEvent.java
- Added `guardrailName` field
- Constructor now captures `guardrailName` from builder
- Added `guardrailName()` implementation

### AbstractGuardrailExecutor.java
`fireObservabilityEvent()` now calls `guardrail.name()` at construction time instead of relying on class-based fallback.

### Test
Added `GuardrailExecutedEventGuardrailNameTest` verifying:
- Default guardrail returns its own simple class name
- Decorator with overridden `name()` passes logical name through to event
