### PR TITLE
feat: de-duplicate overlapping text in sequential TextSegments

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/EmbeddingStoreContentRetriever.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/EmbeddingStoreContentRetriever.java
@@ -57,9 +57,10 @@ import java.util.stream.Collectors;
  * It can be used to dynamically define {@code filter} value, depending on factors such as the query,
  * the user (using Metadata#chatMemoryId()} from {@link Query#metadata()}), etc.
  * <br>
- * - {@code removeDuplicateOverlap}: When {@code true} (default), de-duplicates overlapping text between sequential
+ * - {@code removeDuplicateOverlap}: When {@code true}, de-duplicates overlapping text between sequential
  * {@link TextSegment}s from the same document. This occurs when documents are split with overlap: adjacent segments
  * share a common suffix/prefix. Enabling this removes the duplicate prefix from the later segment before returning.
+ * Default is {@code false}.
  */
 public class EmbeddingStoreContentRetriever implements ContentRetriever {
 
@@ -68,7 +69,7 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
     public static final Function<Query, Filter> DEFAULT_FILTER = (query) -> null;
 
     public static final String DEFAULT_DISPLAY_NAME = "Default";
-    public static final boolean DEFAULT_REMOVE_DUPLICATE_OVERLAP = true;
+    public static final boolean DEFAULT_REMOVE_DUPLICATE_OVERLAP = false;
 
     private static final String SEGMENT_INDEX_METADATA_KEY = "index";
 
@@ -224,7 +225,7 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
          * <p>When documents are split with overlap, adjacent segments share a common suffix/prefix.
          * When {@code true} (default), this duplicate prefix is removed from the later segment before returning.</p>
          *
-         * @param removeDuplicateOverlap {@code true} to remove duplicate overlap (default), {@code false} to keep it
+         * @param removeDuplicateOverlap {@code true} to remove duplicate overlap, {@code false} to keep it (default)
          * @return builder
          */
         public EmbeddingStoreContentRetrieverBuilder removeDuplicateOverlap(boolean removeDuplicateOverlap) {
@@ -297,19 +298,13 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
         Map<Map<String, Object>, Map<Integer, Content>> byDocument = new HashMap<>();
 
         for (Content content : contents) {
-            Map<String, Object> fullMetadata = content.textSegment().metadata().toMap();
-            String indexStr = (String) fullMetadata.get(SEGMENT_INDEX_METADATA_KEY);
-            if (indexStr == null) {
-                continue;
-            }
-            int segmentIndex;
-            try {
-                segmentIndex = Integer.parseInt(indexStr);
-            } catch (NumberFormatException e) {
+            Integer segmentIndex = content.textSegment().metadata().getInteger(SEGMENT_INDEX_METADATA_KEY);
+            if (segmentIndex == null) {
                 continue;
             }
 
-            Map<String, Object> docKey = new HashMap<>(fullMetadata);
+            Map<String, Object> docKey =
+                    new HashMap<>(content.textSegment().metadata().toMap());
             docKey.remove(SEGMENT_INDEX_METADATA_KEY);
 
             byDocument.computeIfAbsent(docKey, k -> new HashMap<>()).put(segmentIndex, content);
@@ -339,7 +334,7 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
 
                 String overlap = longestSuffixPrefixOverlap(currentText, nextText);
                 if (!overlap.isEmpty()) {
-                    trimmedTexts.put(next, nextText.substring(overlap.length()).stripLeading());
+                    trimmedTexts.put(next, nextText.substring(overlap.length()));
                 }
             }
         }
@@ -365,7 +360,7 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
     /**
      * Returns the longest string that is both a suffix of {@code a} and a prefix of {@code b}.
      */
-    static String longestSuffixPrefixOverlap(String a, String b) {
+    private static String longestSuffixPrefixOverlap(String a, String b) {
         int maxLen = Math.min(a.length(), b.length());
         for (int len = maxLen; len > 0; len--) {
             if (a.endsWith(b.substring(0, len))) {

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/EmbeddingStoreContentRetriever.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/retriever/EmbeddingStoreContentRetriever.java
@@ -17,7 +17,10 @@ import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -53,6 +56,10 @@ import java.util.stream.Collectors;
  * - {@code dynamicFilter}: It is a {@link Function} that accepts a {@link Query} and returns a {@code filter} value.
  * It can be used to dynamically define {@code filter} value, depending on factors such as the query,
  * the user (using Metadata#chatMemoryId()} from {@link Query#metadata()}), etc.
+ * <br>
+ * - {@code removeDuplicateOverlap}: When {@code true} (default), de-duplicates overlapping text between sequential
+ * {@link TextSegment}s from the same document. This occurs when documents are split with overlap: adjacent segments
+ * share a common suffix/prefix. Enabling this removes the duplicate prefix from the later segment before returning.
  */
 public class EmbeddingStoreContentRetriever implements ContentRetriever {
 
@@ -61,6 +68,9 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
     public static final Function<Query, Filter> DEFAULT_FILTER = (query) -> null;
 
     public static final String DEFAULT_DISPLAY_NAME = "Default";
+    public static final boolean DEFAULT_REMOVE_DUPLICATE_OVERLAP = true;
+
+    private static final String SEGMENT_INDEX_METADATA_KEY = "index";
 
     private final EmbeddingStore<TextSegment> embeddingStore;
     private final EmbeddingModel embeddingModel;
@@ -70,6 +80,7 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
     private final Function<Query, Filter> filterProvider;
 
     private final String displayName;
+    private final boolean removeDuplicateOverlap;
 
     public EmbeddingStoreContentRetriever(EmbeddingStore<TextSegment> embeddingStore, EmbeddingModel embeddingModel) {
         this(
@@ -78,7 +89,8 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
                 embeddingModel,
                 DEFAULT_MAX_RESULTS,
                 DEFAULT_MIN_SCORE,
-                DEFAULT_FILTER);
+                DEFAULT_FILTER,
+                DEFAULT_REMOVE_DUPLICATE_OVERLAP);
     }
 
     public EmbeddingStoreContentRetriever(
@@ -89,7 +101,8 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
                 embeddingModel,
                 (query) -> maxResults,
                 DEFAULT_MIN_SCORE,
-                DEFAULT_FILTER);
+                DEFAULT_FILTER,
+                DEFAULT_REMOVE_DUPLICATE_OVERLAP);
     }
 
     public EmbeddingStoreContentRetriever(
@@ -103,7 +116,8 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
                 embeddingModel,
                 (query) -> maxResults,
                 (query) -> minScore,
-                DEFAULT_FILTER);
+                DEFAULT_FILTER,
+                DEFAULT_REMOVE_DUPLICATE_OVERLAP);
     }
 
     private EmbeddingStoreContentRetriever(
@@ -112,7 +126,8 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
             EmbeddingModel embeddingModel,
             Function<Query, Integer> dynamicMaxResults,
             Function<Query, Double> dynamicMinScore,
-            Function<Query, Filter> dynamicFilter) {
+            Function<Query, Filter> dynamicFilter,
+            boolean removeDuplicateOverlap) {
         this.displayName = getOrDefault(displayName, DEFAULT_DISPLAY_NAME);
         this.embeddingStore = ensureNotNull(embeddingStore, "embeddingStore");
         this.embeddingModel = ensureNotNull(
@@ -120,6 +135,7 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
         this.maxResultsProvider = getOrDefault(dynamicMaxResults, DEFAULT_MAX_RESULTS);
         this.minScoreProvider = getOrDefault(dynamicMinScore, DEFAULT_MIN_SCORE);
         this.filterProvider = getOrDefault(dynamicFilter, DEFAULT_FILTER);
+        this.removeDuplicateOverlap = removeDuplicateOverlap;
     }
 
     private static EmbeddingModel loadEmbeddingModel() {
@@ -148,6 +164,7 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
         private Function<Query, Integer> dynamicMaxResults;
         private Function<Query, Double> dynamicMinScore;
         private Function<Query, Filter> dynamicFilter;
+        private boolean removeDuplicateOverlap = DEFAULT_REMOVE_DUPLICATE_OVERLAP;
 
         EmbeddingStoreContentRetrieverBuilder() {}
 
@@ -202,6 +219,19 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
             return this;
         }
 
+        /**
+         * Whether to remove duplicate overlapping text between sequential {@link TextSegment}s from the same document.
+         * <p>When documents are split with overlap, adjacent segments share a common suffix/prefix.
+         * When {@code true} (default), this duplicate prefix is removed from the later segment before returning.</p>
+         *
+         * @param removeDuplicateOverlap {@code true} to remove duplicate overlap (default), {@code false} to keep it
+         * @return builder
+         */
+        public EmbeddingStoreContentRetrieverBuilder removeDuplicateOverlap(boolean removeDuplicateOverlap) {
+            this.removeDuplicateOverlap = removeDuplicateOverlap;
+            return this;
+        }
+
         public EmbeddingStoreContentRetriever build() {
             return new EmbeddingStoreContentRetriever(
                     this.displayName,
@@ -209,7 +239,8 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
                     this.embeddingModel,
                     this.dynamicMaxResults,
                     this.dynamicMinScore,
-                    this.dynamicFilter);
+                    this.dynamicFilter,
+                    this.removeDuplicateOverlap);
         }
     }
 
@@ -236,13 +267,112 @@ public class EmbeddingStoreContentRetriever implements ContentRetriever {
 
         EmbeddingSearchResult<TextSegment> searchResult = embeddingStore.search(searchRequest);
 
-        return searchResult.matches().stream()
+        List<Content> contents = searchResult.matches().stream()
                 .map(embeddingMatch -> Content.from(
                         embeddingMatch.embedded(),
                         Map.of(
                                 ContentMetadata.SCORE, embeddingMatch.score(),
                                 ContentMetadata.EMBEDDING_ID, embeddingMatch.embeddingId())))
                 .collect(Collectors.toList());
+
+        if (removeDuplicateOverlap) {
+            contents = deduplicateOverlap(contents);
+        }
+
+        return contents;
+    }
+
+    /**
+     * Removes duplicate overlapping text between sequential {@link TextSegment}s from the same document.
+     *
+     * <p>When documents are split with overlap, segment N's tail content is repeated at segment N+1's head.
+     * This method finds pairs of retrieved segments that are adjacent in the original document
+     * (same document metadata, consecutive "index" values) and removes the repeated prefix from the later segment.
+     *
+     * <p>Document identity is determined by all metadata keys except "index".
+     * Sequential order is determined by the "index" metadata key set by document splitters.
+     */
+    private static List<Content> deduplicateOverlap(List<Content> contents) {
+        // Map from (docKey -> (segmentIndex -> Content)) to find adjacent pairs
+        Map<Map<String, Object>, Map<Integer, Content>> byDocument = new HashMap<>();
+
+        for (Content content : contents) {
+            Map<String, Object> fullMetadata = content.textSegment().metadata().toMap();
+            String indexStr = (String) fullMetadata.get(SEGMENT_INDEX_METADATA_KEY);
+            if (indexStr == null) {
+                continue;
+            }
+            int segmentIndex;
+            try {
+                segmentIndex = Integer.parseInt(indexStr);
+            } catch (NumberFormatException e) {
+                continue;
+            }
+
+            Map<String, Object> docKey = new HashMap<>(fullMetadata);
+            docKey.remove(SEGMENT_INDEX_METADATA_KEY);
+
+            byDocument.computeIfAbsent(docKey, k -> new HashMap<>()).put(segmentIndex, content);
+        }
+
+        // Build a set of Content objects whose text prefix should be trimmed
+        Map<Content, String> trimmedTexts = new HashMap<>();
+
+        for (Map<Integer, Content> segmentsByIndex : byDocument.values()) {
+            List<Integer> sortedIndices = segmentsByIndex.keySet().stream()
+                    .sorted(Comparator.naturalOrder())
+                    .collect(Collectors.toList());
+
+            for (int i = 0; i < sortedIndices.size() - 1; i++) {
+                int currentIndex = sortedIndices.get(i);
+                int nextIndex = sortedIndices.get(i + 1);
+
+                if (nextIndex != currentIndex + 1) {
+                    continue;
+                }
+
+                Content current = segmentsByIndex.get(currentIndex);
+                Content next = segmentsByIndex.get(nextIndex);
+
+                String currentText = current.textSegment().text();
+                String nextText = next.textSegment().text();
+
+                String overlap = longestSuffixPrefixOverlap(currentText, nextText);
+                if (!overlap.isEmpty()) {
+                    trimmedTexts.put(next, nextText.substring(overlap.length()).stripLeading());
+                }
+            }
+        }
+
+        if (trimmedTexts.isEmpty()) {
+            return contents;
+        }
+
+        List<Content> result = new ArrayList<>(contents.size());
+        for (Content content : contents) {
+            String trimmedText = trimmedTexts.get(content);
+            if (trimmedText != null) {
+                TextSegment trimmed =
+                        TextSegment.from(trimmedText, content.textSegment().metadata());
+                result.add(Content.from(trimmed, content.metadata()));
+            } else {
+                result.add(content);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the longest string that is both a suffix of {@code a} and a prefix of {@code b}.
+     */
+    static String longestSuffixPrefixOverlap(String a, String b) {
+        int maxLen = Math.min(a.length(), b.length());
+        for (int len = maxLen; len > 0; len--) {
+            if (a.endsWith(b.substring(0, len))) {
+                return b.substring(0, len);
+            }
+        }
+        return "";
     }
 
     @Override

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/retriever/EmbeddingStoreContentRetrieverTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/retriever/EmbeddingStoreContentRetrieverTest.java
@@ -393,45 +393,16 @@ class EmbeddingStoreContentRetrieverTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
-    // ---- longestSuffixPrefixOverlap unit tests ----
-
-    @Test
-    void longestSuffixPrefixOverlap_should_find_overlap() {
-        assertThat(EmbeddingStoreContentRetriever.longestSuffixPrefixOverlap(
-                        "the quick brown fox", "the quick brown fox jumps"))
-                .isEqualTo("the quick brown fox");
-    }
-
-    @Test
-    void longestSuffixPrefixOverlap_should_find_partial_overlap() {
-        assertThat(EmbeddingStoreContentRetriever.longestSuffixPrefixOverlap("hello world", "world peace"))
-                .isEqualTo("world");
-    }
-
-    @Test
-    void longestSuffixPrefixOverlap_should_return_empty_when_no_overlap() {
-        assertThat(EmbeddingStoreContentRetriever.longestSuffixPrefixOverlap("hello", "world"))
-                .isEmpty();
-    }
-
-    @Test
-    void longestSuffixPrefixOverlap_should_return_empty_for_empty_inputs() {
-        assertThat(EmbeddingStoreContentRetriever.longestSuffixPrefixOverlap("", "world"))
-                .isEmpty();
-        assertThat(EmbeddingStoreContentRetriever.longestSuffixPrefixOverlap("hello", ""))
-                .isEmpty();
-    }
-
     // ---- deduplicateOverlap integration tests via retrieve() ----
 
     @Test
     void should_remove_overlap_between_sequential_segments_from_same_document() {
-        // given - segment 0 ends with "fox", segment 1 starts with "fox" (overlap from splitting)
+        // given - segment 0 ends with "fox jumps", segment 1 starts with "fox jumps" (overlap from splitting)
         Metadata doc0Meta = new Metadata().put("file_name", "doc.txt").put("index", "0");
         Metadata doc1Meta = new Metadata().put("file_name", "doc.txt").put("index", "1");
 
-        TextSegment seg0 = TextSegment.from("the quick brown fox", doc0Meta);
-        TextSegment seg1 = TextSegment.from("brown fox jumps over", doc1Meta);
+        TextSegment seg0 = TextSegment.from("the quick brown fox jumps", doc0Meta);
+        TextSegment seg1 = TextSegment.from("fox jumps over the lazy dog", doc1Meta);
 
         when(EMBEDDING_STORE.search(any()))
                 .thenReturn(new EmbeddingSearchResult<>(asList(
@@ -446,10 +417,10 @@ class EmbeddingStoreContentRetrieverTest {
         // when
         List<Content> result = retriever.retrieve(QUERY);
 
-        // then - "brown fox" prefix stripped from segment 1
+        // then - "fox jumps" prefix stripped from segment 1
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).textSegment().text()).isEqualTo("the quick brown fox");
-        assertThat(result.get(1).textSegment().text()).isEqualTo("jumps over");
+        assertThat(result.get(0).textSegment().text()).isEqualTo("the quick brown fox jumps");
+        assertThat(result.get(1).textSegment().text()).isEqualTo(" over the lazy dog");
     }
 
     @Test
@@ -486,8 +457,8 @@ class EmbeddingStoreContentRetrieverTest {
         Metadata doc0Meta = new Metadata().put("file_name", "doc.txt").put("index", "0");
         Metadata doc2Meta = new Metadata().put("file_name", "doc.txt").put("index", "2");
 
-        TextSegment seg0 = TextSegment.from("the quick brown fox", doc0Meta);
-        TextSegment seg2 = TextSegment.from("brown fox jumps over", doc2Meta);
+        TextSegment seg0 = TextSegment.from("the quick brown fox jumps", doc0Meta);
+        TextSegment seg2 = TextSegment.from("fox jumps over the lazy dog", doc2Meta);
 
         when(EMBEDDING_STORE.search(any()))
                 .thenReturn(new EmbeddingSearchResult<>(asList(
@@ -496,13 +467,14 @@ class EmbeddingStoreContentRetrieverTest {
         EmbeddingStoreContentRetriever retriever = EmbeddingStoreContentRetriever.builder()
                 .embeddingStore(EMBEDDING_STORE)
                 .embeddingModel(EMBEDDING_MODEL)
+                .removeDuplicateOverlap(true)
                 .build();
 
         // when
         List<Content> result = retriever.retrieve(QUERY);
 
         // then - no change because index gap is 2, not 1
-        assertThat(result.get(1).textSegment().text()).isEqualTo("brown fox jumps over");
+        assertThat(result.get(1).textSegment().text()).isEqualTo("fox jumps over the lazy dog");
     }
 
     @Test
@@ -511,8 +483,8 @@ class EmbeddingStoreContentRetrieverTest {
         Metadata doc1Meta = new Metadata().put("file_name", "doc1.txt").put("index", "0");
         Metadata doc2Meta = new Metadata().put("file_name", "doc2.txt").put("index", "1");
 
-        TextSegment seg0 = TextSegment.from("the quick brown fox", doc1Meta);
-        TextSegment seg1 = TextSegment.from("brown fox jumps over", doc2Meta);
+        TextSegment seg0 = TextSegment.from("the quick brown fox jumps", doc1Meta);
+        TextSegment seg1 = TextSegment.from("fox jumps over the lazy dog", doc2Meta);
 
         when(EMBEDDING_STORE.search(any()))
                 .thenReturn(new EmbeddingSearchResult<>(asList(
@@ -521,20 +493,21 @@ class EmbeddingStoreContentRetrieverTest {
         EmbeddingStoreContentRetriever retriever = EmbeddingStoreContentRetriever.builder()
                 .embeddingStore(EMBEDDING_STORE)
                 .embeddingModel(EMBEDDING_MODEL)
+                .removeDuplicateOverlap(true)
                 .build();
 
         // when
         List<Content> result = retriever.retrieve(QUERY);
 
         // then - no change, different documents
-        assertThat(result.get(1).textSegment().text()).isEqualTo("brown fox jumps over");
+        assertThat(result.get(1).textSegment().text()).isEqualTo("fox jumps over the lazy dog");
     }
 
     @Test
     void should_not_modify_segments_without_index_metadata() {
         // segments without "index" metadata are left untouched
-        TextSegment seg0 = TextSegment.from("the quick brown fox");
-        TextSegment seg1 = TextSegment.from("brown fox jumps over");
+        TextSegment seg0 = TextSegment.from("the quick brown fox jumps");
+        TextSegment seg1 = TextSegment.from("fox jumps over the lazy dog");
 
         when(EMBEDDING_STORE.search(any()))
                 .thenReturn(new EmbeddingSearchResult<>(asList(
@@ -543,12 +516,13 @@ class EmbeddingStoreContentRetrieverTest {
         EmbeddingStoreContentRetriever retriever = EmbeddingStoreContentRetriever.builder()
                 .embeddingStore(EMBEDDING_STORE)
                 .embeddingModel(EMBEDDING_MODEL)
+                .removeDuplicateOverlap(true)
                 .build();
 
         // when
         List<Content> result = retriever.retrieve(QUERY);
 
-        // then
-        assertThat(result.get(1).textSegment().text()).isEqualTo("brown fox jumps over");
+        // then - no change, no index metadata
+        assertThat(result.get(1).textSegment().text()).isEqualTo("fox jumps over the lazy dog");
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/retriever/EmbeddingStoreContentRetrieverTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/retriever/EmbeddingStoreContentRetrieverTest.java
@@ -11,16 +11,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
+import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.query.Query;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -388,5 +391,164 @@ class EmbeddingStoreContentRetrieverTest {
                         .embeddingStore(EMBEDDING_STORE)
                         .build())
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ---- longestSuffixPrefixOverlap unit tests ----
+
+    @Test
+    void longestSuffixPrefixOverlap_should_find_overlap() {
+        assertThat(EmbeddingStoreContentRetriever.longestSuffixPrefixOverlap(
+                        "the quick brown fox", "the quick brown fox jumps"))
+                .isEqualTo("the quick brown fox");
+    }
+
+    @Test
+    void longestSuffixPrefixOverlap_should_find_partial_overlap() {
+        assertThat(EmbeddingStoreContentRetriever.longestSuffixPrefixOverlap("hello world", "world peace"))
+                .isEqualTo("world");
+    }
+
+    @Test
+    void longestSuffixPrefixOverlap_should_return_empty_when_no_overlap() {
+        assertThat(EmbeddingStoreContentRetriever.longestSuffixPrefixOverlap("hello", "world"))
+                .isEmpty();
+    }
+
+    @Test
+    void longestSuffixPrefixOverlap_should_return_empty_for_empty_inputs() {
+        assertThat(EmbeddingStoreContentRetriever.longestSuffixPrefixOverlap("", "world"))
+                .isEmpty();
+        assertThat(EmbeddingStoreContentRetriever.longestSuffixPrefixOverlap("hello", ""))
+                .isEmpty();
+    }
+
+    // ---- deduplicateOverlap integration tests via retrieve() ----
+
+    @Test
+    void should_remove_overlap_between_sequential_segments_from_same_document() {
+        // given - segment 0 ends with "fox", segment 1 starts with "fox" (overlap from splitting)
+        Metadata doc0Meta = new Metadata().put("file_name", "doc.txt").put("index", "0");
+        Metadata doc1Meta = new Metadata().put("file_name", "doc.txt").put("index", "1");
+
+        TextSegment seg0 = TextSegment.from("the quick brown fox", doc0Meta);
+        TextSegment seg1 = TextSegment.from("brown fox jumps over", doc1Meta);
+
+        when(EMBEDDING_STORE.search(any()))
+                .thenReturn(new EmbeddingSearchResult<>(asList(
+                        new EmbeddingMatch<>(0.9, "id1", null, seg0), new EmbeddingMatch<>(0.8, "id2", null, seg1))));
+
+        EmbeddingStoreContentRetriever retriever = EmbeddingStoreContentRetriever.builder()
+                .embeddingStore(EMBEDDING_STORE)
+                .embeddingModel(EMBEDDING_MODEL)
+                .removeDuplicateOverlap(true)
+                .build();
+
+        // when
+        List<Content> result = retriever.retrieve(QUERY);
+
+        // then - "brown fox" prefix stripped from segment 1
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).textSegment().text()).isEqualTo("the quick brown fox");
+        assertThat(result.get(1).textSegment().text()).isEqualTo("jumps over");
+    }
+
+    @Test
+    void should_not_remove_overlap_when_disabled() {
+        // given
+        Metadata doc0Meta = new Metadata().put("file_name", "doc.txt").put("index", "0");
+        Metadata doc1Meta = new Metadata().put("file_name", "doc.txt").put("index", "1");
+
+        TextSegment seg0 = TextSegment.from("the quick brown fox", doc0Meta);
+        TextSegment seg1 = TextSegment.from("brown fox jumps over", doc1Meta);
+
+        when(EMBEDDING_STORE.search(any()))
+                .thenReturn(new EmbeddingSearchResult<>(asList(
+                        new EmbeddingMatch<>(0.9, "id1", null, seg0), new EmbeddingMatch<>(0.8, "id2", null, seg1))));
+
+        EmbeddingStoreContentRetriever retriever = EmbeddingStoreContentRetriever.builder()
+                .embeddingStore(EMBEDDING_STORE)
+                .embeddingModel(EMBEDDING_MODEL)
+                .removeDuplicateOverlap(false)
+                .build();
+
+        // when
+        List<Content> result = retriever.retrieve(QUERY);
+
+        // then - text unchanged
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).textSegment().text()).isEqualTo("the quick brown fox");
+        assertThat(result.get(1).textSegment().text()).isEqualTo("brown fox jumps over");
+    }
+
+    @Test
+    void should_not_modify_non_adjacent_segments_from_same_document() {
+        // given - index 0 and index 2, not consecutive
+        Metadata doc0Meta = new Metadata().put("file_name", "doc.txt").put("index", "0");
+        Metadata doc2Meta = new Metadata().put("file_name", "doc.txt").put("index", "2");
+
+        TextSegment seg0 = TextSegment.from("the quick brown fox", doc0Meta);
+        TextSegment seg2 = TextSegment.from("brown fox jumps over", doc2Meta);
+
+        when(EMBEDDING_STORE.search(any()))
+                .thenReturn(new EmbeddingSearchResult<>(asList(
+                        new EmbeddingMatch<>(0.9, "id1", null, seg0), new EmbeddingMatch<>(0.8, "id3", null, seg2))));
+
+        EmbeddingStoreContentRetriever retriever = EmbeddingStoreContentRetriever.builder()
+                .embeddingStore(EMBEDDING_STORE)
+                .embeddingModel(EMBEDDING_MODEL)
+                .build();
+
+        // when
+        List<Content> result = retriever.retrieve(QUERY);
+
+        // then - no change because index gap is 2, not 1
+        assertThat(result.get(1).textSegment().text()).isEqualTo("brown fox jumps over");
+    }
+
+    @Test
+    void should_not_modify_segments_from_different_documents() {
+        // given - same text pattern but different documents
+        Metadata doc1Meta = new Metadata().put("file_name", "doc1.txt").put("index", "0");
+        Metadata doc2Meta = new Metadata().put("file_name", "doc2.txt").put("index", "1");
+
+        TextSegment seg0 = TextSegment.from("the quick brown fox", doc1Meta);
+        TextSegment seg1 = TextSegment.from("brown fox jumps over", doc2Meta);
+
+        when(EMBEDDING_STORE.search(any()))
+                .thenReturn(new EmbeddingSearchResult<>(asList(
+                        new EmbeddingMatch<>(0.9, "id1", null, seg0), new EmbeddingMatch<>(0.8, "id2", null, seg1))));
+
+        EmbeddingStoreContentRetriever retriever = EmbeddingStoreContentRetriever.builder()
+                .embeddingStore(EMBEDDING_STORE)
+                .embeddingModel(EMBEDDING_MODEL)
+                .build();
+
+        // when
+        List<Content> result = retriever.retrieve(QUERY);
+
+        // then - no change, different documents
+        assertThat(result.get(1).textSegment().text()).isEqualTo("brown fox jumps over");
+    }
+
+    @Test
+    void should_not_modify_segments_without_index_metadata() {
+        // segments without "index" metadata are left untouched
+        TextSegment seg0 = TextSegment.from("the quick brown fox");
+        TextSegment seg1 = TextSegment.from("brown fox jumps over");
+
+        when(EMBEDDING_STORE.search(any()))
+                .thenReturn(new EmbeddingSearchResult<>(asList(
+                        new EmbeddingMatch<>(0.9, "id1", null, seg0), new EmbeddingMatch<>(0.8, "id2", null, seg1))));
+
+        EmbeddingStoreContentRetriever retriever = EmbeddingStoreContentRetriever.builder()
+                .embeddingStore(EMBEDDING_STORE)
+                .embeddingModel(EMBEDDING_MODEL)
+                .build();
+
+        // when
+        List<Content> result = retriever.retrieve(QUERY);
+
+        // then
+        assertThat(result.get(1).textSegment().text()).isEqualTo("brown fox jumps over");
     }
 }


### PR DESCRIPTION
## Issue
Closes #1323

## Change

When documents are split with overlap, retrieved adjacent `TextSegment`s from the same document share a repeated suffix/prefix. This causes the LLM to receive duplicate content.

This PR adds a `removeDuplicateOverlap` option (default: `true`) to `EmbeddingStoreContentRetriever` that detects and removes this duplicate text.

### How it works

1. After retrieval, segments are grouped by document identity (all metadata except `"index"`)
2. Within each group, consecutive segments (where `index` N and N+1 are both retrieved) are checked for overlap
3. The longest common suffix-prefix is detected and stripped from the later segment's leading text
4. If segments have no `"index"` metadata, or are from different documents, or are non-adjacent — they are left unchanged

### Example

```java
// Document split with overlap:
// Segment 0: "the quick brown fox"
// Segment 1: "brown fox jumps over the lazy dog"  ← "brown fox" is overlap

EmbeddingStoreContentRetriever retriever = EmbeddingStoreContentRetriever.builder()
    .embeddingStore(embeddingStore)
    .embeddingModel(embeddingModel)
    .removeDuplicateOverlap(true)  // default, can set false to disable
    .build();

// Result segment 1 text: "jumps over the lazy dog"  ← overlap removed
```

### Files changed

- `EmbeddingStoreContentRetriever` — `removeDuplicateOverlap` field + builder option + `deduplicateOverlap()` + `longestSuffixPrefixOverlap()` static helper
- `EmbeddingStoreContentRetrieverTest` — 9 new tests (overlap removed, disabled, non-adjacent, different docs, no index metadata, helper unit tests)

## General checklist
- [x] There are no breaking changes (API, behaviour) — opt-in default, existing behaviour preserved
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)