### PR TITLE
Fix multi-choice tool_calls extraction in OpenAiUtils

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
@@ -51,11 +51,11 @@ import dev.langchain4j.model.openai.OpenAiTokenUsage;
 import dev.langchain4j.model.openai.OpenAiTokenUsage.InputTokensDetails;
 import dev.langchain4j.model.openai.OpenAiTokenUsage.OutputTokensDetails;
 import dev.langchain4j.model.openai.internal.chat.AssistantMessage;
+import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
 import dev.langchain4j.model.openai.internal.chat.ContentType;
 import dev.langchain4j.model.openai.internal.chat.Function;
-import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.FunctionCall;
 import dev.langchain4j.model.openai.internal.chat.FunctionMessage;
 import dev.langchain4j.model.openai.internal.chat.ImageDetail;
@@ -371,8 +371,7 @@ public class OpenAiUtils {
                 if (isNotNullOrBlank(assistantMessage.content())) {
                     content = assistantMessage.content();
                 }
-            } else if (isNotNullOrBlank(assistantMessage.content())
-                    && isNullOrEmpty(assistantMessage.toolCalls())) {
+            } else if (isNotNullOrBlank(assistantMessage.content()) && isNullOrEmpty(assistantMessage.toolCalls())) {
                 // content already set; only overwrite if this choice has content but no tool_calls
                 content = assistantMessage.content();
             }

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
@@ -55,6 +55,7 @@ import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
 import dev.langchain4j.model.openai.internal.chat.ContentType;
 import dev.langchain4j.model.openai.internal.chat.Function;
+import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.FunctionCall;
 import dev.langchain4j.model.openai.internal.chat.FunctionMessage;
 import dev.langchain4j.model.openai.internal.chat.ImageDetail;
@@ -348,34 +349,54 @@ public class OpenAiUtils {
     }
 
     public static AiMessage aiMessageFrom(ChatCompletionResponse response, boolean returnThinking) {
-        AssistantMessage assistantMessage = response.choices().get(0).message();
-
-        String refusal = assistantMessage.refusal();
-        if (isNotNullOrBlank(refusal)) {
-            throw new ContentFilteredException(refusal);
-        }
-
-        String content = assistantMessage.content();
-
+        // Some OpenAI-compatible providers split text and tool_calls across multiple choices.
+        // For example: choices[0] has content="...", choices[1] has tool_calls=[...].
+        // We must iterate all choices and merge tool_calls from any choice.
+        List<ToolExecutionRequest> toolExecutionRequests = new ArrayList<>();
+        String content = null;
         String reasoningContent = null;
-        if (returnThinking) {
-            reasoningContent = assistantMessage.reasoningContent();
-        }
 
-        List<ToolExecutionRequest> toolExecutionRequests =
-                getOrDefault(assistantMessage.toolCalls(), List.of()).stream()
-                        .filter(toolCall -> toolCall.type() == FUNCTION)
-                        .map(OpenAiUtils::toToolExecutionRequest)
-                        .collect(toList());
+        for (ChatCompletionChoice choice : response.choices()) {
+            AssistantMessage assistantMessage = choice.message();
 
-        // legacy
-        FunctionCall functionCall = assistantMessage.functionCall();
-        if (functionCall != null) {
-            ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
-                    .name(functionCall.name())
-                    .arguments(functionCall.arguments())
-                    .build();
-            toolExecutionRequests.add(toolExecutionRequest);
+            String refusal = assistantMessage.refusal();
+            if (isNotNullOrBlank(refusal)) {
+                throw new ContentFilteredException(refusal);
+            }
+
+            // Prefer content from a choice that does NOT have tool_calls,
+            // to avoid silently dropping text when providers split them across choices.
+            // If a choice has both content and tool_calls in the same message, still take it.
+            if (content == null) {
+                if (isNotNullOrBlank(assistantMessage.content())) {
+                    content = assistantMessage.content();
+                }
+            } else if (isNotNullOrBlank(assistantMessage.content())
+                    && isNullOrEmpty(assistantMessage.toolCalls())) {
+                // content already set; only overwrite if this choice has content but no tool_calls
+                content = assistantMessage.content();
+            }
+
+            if (returnThinking && reasoningContent == null) {
+                reasoningContent = assistantMessage.reasoningContent();
+            }
+
+            // Extract tool_calls from every choice
+            List<ToolCall> toolCalls = getOrDefault(assistantMessage.toolCalls(), List.of());
+            for (ToolCall toolCall : toolCalls) {
+                if (toolCall.type() == FUNCTION) {
+                    toolExecutionRequests.add(toToolExecutionRequest(toolCall));
+                }
+            }
+
+            // legacy
+            FunctionCall functionCall = assistantMessage.functionCall();
+            if (functionCall != null) {
+                toolExecutionRequests.add(ToolExecutionRequest.builder()
+                        .name(functionCall.name())
+                        .arguments(functionCall.arguments())
+                        .build());
+            }
         }
 
         return AiMessage.builder()

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/OpenAiUtilsTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/OpenAiUtilsTest.java
@@ -246,4 +246,100 @@ class OpenAiUtilsTest {
         assertThat(aiMessage.text()).isNull();
         assertThat(aiMessage.toolExecutionRequests()).isEmpty();
     }
+
+    /**
+     * Regression test for <a href="https://github.com/langchain4j/langchain4j/issues/4931">Issue #4931</a>.
+     * Some OpenAI-compatible providers split text and tool_calls across multiple choices.
+     * For example, choices[0] has content and choices[1] has tool_calls.
+     * All tool_calls must be extracted regardless of which choice they appear in.
+     */
+    @Test
+    void should_extract_tool_calls_from_all_choices_when_text_and_tools_are_split_across_choices() {
+        // given
+        // choices[0] returns text content, choices[1] returns tool_calls
+        String textContent = "Let me look that up for you.";
+        String functionName = "current_time";
+        String functionArguments = "{}";
+
+        ChatCompletionChoice textChoice = ChatCompletionChoice.builder()
+                .message(AssistantMessage.builder()
+                        .content(textContent)
+                        .build())
+                .build();
+
+        ChatCompletionChoice toolCallChoice = ChatCompletionChoice.builder()
+                .message(AssistantMessage.builder()
+                        .toolCalls(ToolCall.builder()
+                                .type(FUNCTION)
+                                .function(FunctionCall.builder()
+                                        .name(functionName)
+                                        .arguments(functionArguments)
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        ChatCompletionResponse response = ChatCompletionResponse.builder()
+                .choices(java.util.List.of(textChoice, toolCallChoice))
+                .build();
+
+        // when
+        AiMessage aiMessage = aiMessageFrom(response);
+
+
+        // then
+        assertThat(aiMessage.text()).isEqualTo(textContent);
+        assertThat(aiMessage.toolExecutionRequests()).hasSize(1);
+        assertThat(aiMessage.toolExecutionRequests().get(0).name()).isEqualTo(functionName);
+        assertThat(aiMessage.toolExecutionRequests().get(0).arguments()).isEqualTo(functionArguments);
+    }
+
+    @Test
+    void should_merge_tool_calls_when_multiple_choices_have_tool_calls() {
+        // given
+        String functionName1 = "get_weather";
+        String functionArguments1 = "{\"city\":\"Toronto\"}";
+        String functionName2 = "get_time";
+        String functionArguments2 = "{}";
+
+        ChatCompletionChoice choice1 = ChatCompletionChoice.builder()
+                .message(AssistantMessage.builder()
+                        .toolCalls(ToolCall.builder()
+                                .id("call_1")
+                                .type(FUNCTION)
+                                .function(FunctionCall.builder()
+                                        .name(functionName1)
+                                        .arguments(functionArguments1)
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        ChatCompletionChoice choice2 = ChatCompletionChoice.builder()
+                .message(AssistantMessage.builder()
+                        .toolCalls(ToolCall.builder()
+                                .id("call_2")
+                                .type(FUNCTION)
+                                .function(FunctionCall.builder()
+                                        .name(functionName2)
+                                        .arguments(functionArguments2)
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        ChatCompletionResponse response = ChatCompletionResponse.builder()
+                .choices(java.util.List.of(choice1, choice2))
+                .build();
+
+        // when
+        AiMessage aiMessage = aiMessageFrom(response);
+
+        // then
+        assertThat(aiMessage.toolExecutionRequests()).hasSize(2);
+        assertThat(aiMessage.toolExecutionRequests().get(0).id()).isEqualTo("call_1");
+        assertThat(aiMessage.toolExecutionRequests().get(0).name()).isEqualTo(functionName1);
+        assertThat(aiMessage.toolExecutionRequests().get(1).id()).isEqualTo("call_2");
+        assertThat(aiMessage.toolExecutionRequests().get(1).name()).isEqualTo(functionName2);
+    }
 }

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/OpenAiUtilsTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/OpenAiUtilsTest.java
@@ -262,9 +262,7 @@ class OpenAiUtilsTest {
         String functionArguments = "{}";
 
         ChatCompletionChoice textChoice = ChatCompletionChoice.builder()
-                .message(AssistantMessage.builder()
-                        .content(textContent)
-                        .build())
+                .message(AssistantMessage.builder().content(textContent).build())
                 .build();
 
         ChatCompletionChoice toolCallChoice = ChatCompletionChoice.builder()
@@ -285,7 +283,6 @@ class OpenAiUtilsTest {
 
         // when
         AiMessage aiMessage = aiMessageFrom(response);
-
 
         // then
         assertThat(aiMessage.text()).isEqualTo(textContent);


### PR DESCRIPTION
## Fix multi-choice tool_calls extraction in OpenAiUtils

Fixes https://github.com/langchain4j/langchain4j/issues/4931

### Problem
`OpenAiUtils.aiMessageFrom(...)` only parsed `choices.get(0)`, silently dropping tool_calls from later choices. This breaks OpenAI-compatible providers (e.g. gpt-5.4) that split text and tool_calls across multiple choices.

### Solution
`aiMessageFrom` now iterates **all** choices and merges:
- `tool_calls` from every choice that has them
- `content` from the first choice that has it (preferring choices without tool_calls)
- `reasoningContent` from the first choice that has it
- legacy `functionCall` from every choice

### Changes
- `OpenAiUtils.java`: loop over all choices instead of just `choices.get(0)`
- `OpenAiUtilsTest.java`: two new regression tests:
  - `should_extract_tool_calls_from_all_choices_when_text_and_tools_are_split_across_choices`
  - `should_merge_tool_calls_when_multiple_choices_have_tool_calls`

### Testing
`mvn test -pl langchain4j-open-ai -Dtest=OpenAiUtilsTest` → 14 tests pass (all existing + 2 new)