### PR TITLE
feat: add User-Agent header to Ollama, HuggingFace, and Nomic clients

### DIFF
--- a/langchain4j-hugging-face/src/main/java/dev/langchain4j/model/huggingface/ApiKeyInsertingInterceptor.java
+++ b/langchain4j-hugging-face/src/main/java/dev/langchain4j/model/huggingface/ApiKeyInsertingInterceptor.java
@@ -1,12 +1,11 @@
 package dev.langchain4j.model.huggingface;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
+import java.io.IOException;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
-
-import java.io.IOException;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 
 class ApiKeyInsertingInterceptor implements Interceptor {
 
@@ -22,6 +21,7 @@ class ApiKeyInsertingInterceptor implements Interceptor {
         Request request = chain.request()
                 .newBuilder()
                 .addHeader("Authorization", "Bearer " + apiKey)
+                .addHeader("User-Agent", "langchain4j-hugging-face")
                 .build();
 
         return chain.proceed(request);

--- a/langchain4j-nomic/src/main/java/dev/langchain4j/model/nomic/NomicClient.java
+++ b/langchain4j-nomic/src/main/java/dev/langchain4j/model/nomic/NomicClient.java
@@ -1,20 +1,19 @@
 package dev.langchain4j.model.nomic;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import dev.langchain4j.internal.Utils;
+import java.io.IOException;
+import java.time.Duration;
 import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
-
-import java.io.IOException;
-import java.time.Duration;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 
 class NomicClient {
 
@@ -27,13 +26,18 @@ class NomicClient {
     private final NomicApi nomicApi;
     private final String authorizationHeader;
 
-    NomicClient(String baseUrl, String apiKey, Duration timeout, Boolean logRequests, Boolean logResponses, Logger logger) {
+    NomicClient(
+            String baseUrl, String apiKey, Duration timeout, Boolean logRequests, Boolean logResponses, Logger logger) {
 
         OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
                 .callTimeout(timeout)
                 .connectTimeout(timeout)
                 .readTimeout(timeout)
-                .writeTimeout(timeout);
+                .writeTimeout(timeout)
+                .addInterceptor(chain -> chain.proceed(chain.request()
+                        .newBuilder()
+                        .addHeader("User-Agent", "langchain4j-nomic")
+                        .build()));
 
         if (logRequests) {
             okHttpClientBuilder.addInterceptor(new RequestLoggingInterceptor(logger));
@@ -58,8 +62,8 @@ class NomicClient {
 
     public EmbeddingResponse embed(EmbeddingRequest request) {
         try {
-            retrofit2.Response<EmbeddingResponse> retrofitResponse
-                    = nomicApi.embed(request, authorizationHeader).execute();
+            retrofit2.Response<EmbeddingResponse> retrofitResponse =
+                    nomicApi.embed(request, authorizationHeader).execute();
 
             if (retrofitResponse.isSuccessful()) {
                 return retrofitResponse.body();
@@ -86,8 +90,7 @@ class NomicClient {
         private Boolean logResponses;
         private Logger logger;
 
-        NomicClientBuilder() {
-        }
+        NomicClientBuilder() {}
 
         public NomicClientBuilder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
@@ -120,11 +123,13 @@ class NomicClient {
         }
 
         public NomicClient build() {
-            return new NomicClient(this.baseUrl, this.apiKey, this.timeout, this.logRequests, this.logResponses, this.logger);
+            return new NomicClient(
+                    this.baseUrl, this.apiKey, this.timeout, this.logRequests, this.logResponses, this.logger);
         }
 
         public String toString() {
-            return "NomicClient.NomicClientBuilder(baseUrl=" + this.baseUrl + ", apiKey=" + this.apiKey + ", timeout=" + this.timeout + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
+            return "NomicClient.NomicClientBuilder(baseUrl=" + this.baseUrl + ", apiKey=" + this.apiKey + ", timeout="
+                    + this.timeout + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
         }
     }
 }

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
@@ -42,6 +42,7 @@ import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -77,11 +78,13 @@ class OllamaClient {
     }
 
     private Map<String, String> buildRequestHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("User-Agent", "langchain4j-ollama");
         Map<String, String> dynamicHeaders = customHeadersSupplier.get();
-        if (isNullOrEmpty(dynamicHeaders)) {
-            return Map.of();
+        if (!isNullOrEmpty(dynamicHeaders)) {
+            headers.putAll(dynamicHeaders);
         }
-        return dynamicHeaders;
+        return headers;
     }
 
     static Builder builder() {

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaCustomHeadersSupplierTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaCustomHeadersSupplierTest.java
@@ -13,6 +13,28 @@ import org.junit.jupiter.api.Test;
 class OllamaCustomHeadersSupplierTest {
 
     @Test
+    void should_send_user_agent_header() {
+        // given
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        OllamaChatModel model = OllamaChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost:11434")
+                .modelName("llama3")
+                .maxRetries(0)
+                .build();
+
+        // when
+        try {
+            model.chat("test");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.request().headers()).containsEntry("User-Agent", List.of("langchain4j-ollama"));
+    }
+
+    @Test
     void should_invoke_supplier_and_propagate_headers() {
         // given
         AtomicInteger callCount = new AtomicInteger(0);


### PR DESCRIPTION
## Issue
Addresses #967

## Change

Adds `User-Agent: langchain4j-<provider>` to all outbound HTTP requests for three providers that were missing it:

| Module | File changed | Approach |
|--------|-------------|----------|
| `langchain4j-ollama` | `OllamaClient.java` | Added to `buildRequestHeaders()` so it is present on every request alongside custom headers |
| `langchain4j-hugging-face` | `ApiKeyInsertingInterceptor.java` | Added alongside the existing `Authorization` header in the OkHttp interceptor |
| `langchain4j-nomic` | `NomicClient.java` | Added via a new OkHttp interceptor in the client builder |

Providers already covered (skipped): `langchain4j-mistral-ai`, `langchain4j-open-ai`, `langchain4j-google-ai-gemini`

Providers that cannot be covered (no HTTP layer access, as noted by @roytruelove in the issue):
- `AbstractBedrockChatModel` and subclasses
- `Qwen*`
- `VertexAiEmbeddingModel`, `VertexAiGeminiChatModel`, `VertexAiGeminiStreamingChatModel`

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)