### PR TITLE
feat: add ReturnBehavior.IMMEDIATE_IF_LAST for agentic halt-tool pattern

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ReturnBehavior.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ReturnBehavior.java
@@ -20,5 +20,18 @@ public enum ReturnBehavior {
      * while a {@code RuntimeException} will be thrown attempting to use a tool with immediate return with an
      * AI service having a different return type.
      */
-    IMMEDIATE;
+    IMMEDIATE,
+
+    /**
+     * Returns immediately to the caller when the annotated tool is the <b>last</b> tool called
+     * in a multi-tool batch response, and it completed without error. When placed last, the model
+     * has intentionally signalled completion after all side-effect tools have run.
+     * <p>
+     * If the tool appears earlier in the batch (not last), execution continues normally as if
+     * {@link #TO_LLM} were used.
+     * <p>
+     * Like {@link #IMMEDIATE}, this is only allowed on AI services returning
+     * {@code dev.langchain4j.service.Result}.
+     */
+    IMMEDIATE_IF_LAST;
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -5,8 +5,6 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.service.AiServiceParamsUtil.chatRequestParameters;
 import static dev.langchain4j.service.tool.ToolService.refreshDynamicProviders;
 
-import dev.langchain4j.service.tool.search.ToolSearchService;
-
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
@@ -42,6 +40,7 @@ import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolServiceContext;
+import dev.langchain4j.service.tool.search.ToolSearchService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -294,6 +293,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
             boolean immediateToolReturn = true;
             List<ToolExecutionResult> toolResults = new ArrayList<>();
+            String lastToolName = null;
+            boolean lastToolErrored = false;
 
             if (toolExecutor != null) {
                 for (Future<ToolRequestResult> toolExecutionFuture : toolExecutionFutures) {
@@ -306,6 +307,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                         ToolExecutionResultMessage toolExecutionResultMessage =
                                 toResultMessage(toolRequest, toolResult);
                         addToMemory(toolExecutionResultMessage);
+                        lastToolName = toolExecutionResultMessage.toolName();
+                        lastToolErrored = toolResult.isError();
                         immediateToolReturn = immediateToolReturn
                                 && !toolResult.isError()
                                 && context.toolService.isImmediateTool(toolExecutionResultMessage.toolName());
@@ -326,13 +329,21 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     toolResults.add(toolResult);
                     ToolRequestResult toolRequestResult = new ToolRequestResult(toolRequest, toolResult);
                     fireToolExecutedEvent(toolRequestResult);
-                    ToolExecutionResultMessage toolExecutionResultMessage =
-                            toResultMessage(toolRequest, toolResult);
+                    ToolExecutionResultMessage toolExecutionResultMessage = toResultMessage(toolRequest, toolResult);
                     addToMemory(toolExecutionResultMessage);
+                    lastToolName = toolRequest.name();
+                    lastToolErrored = toolResult.isError();
                     immediateToolReturn = immediateToolReturn
                             && !toolResult.isError()
                             && context.toolService.isImmediateTool(toolRequest.name());
                 }
+            }
+
+            if (!immediateToolReturn
+                    && lastToolName != null
+                    && !lastToolErrored
+                    && context.toolService.isImmediateIfLastTool(lastToolName)) {
+                immediateToolReturn = true;
             }
 
             if (immediateToolReturn) {
@@ -347,11 +358,12 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
             List<ChatMessage> messages = messagesToSend(invocationContext.chatMemoryId());
 
-            ToolServiceContext updatedToolContext = refreshDynamicProviders(toolServiceContext, messages, invocationContext);
+            ToolServiceContext updatedToolContext =
+                    refreshDynamicProviders(toolServiceContext, messages, invocationContext);
             updatedToolContext = ToolSearchService.addFoundTools(updatedToolContext, toolResults);
 
-            ChatRequestParameters parameters = chatRequestParameters(invocationContext.methodArguments(),
-                    updatedToolContext.effectiveTools());
+            ChatRequestParameters parameters =
+                    chatRequestParameters(invocationContext.methodArguments(), updatedToolContext.effectiveTools());
 
             ChatRequest nextChatRequest = context.chatRequestTransformer.apply(
                     ChatRequest.builder()

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/AiServiceTool.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/AiServiceTool.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.service.tool;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolSpecification;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 /**
  * Represents a tool managed by an AI Service, combining:
@@ -21,11 +21,13 @@ public class AiServiceTool {
     private final ToolSpecification toolSpecification;
     private final ToolExecutor toolExecutor;
     private final boolean immediateReturn;
+    private final boolean immediateIfLastReturn;
 
     private AiServiceTool(Builder builder) {
         this.toolSpecification = ensureNotNull(builder.toolSpecification, "toolSpecification");
         this.toolExecutor = ensureNotNull(builder.toolExecutor, "toolExecutor");
         this.immediateReturn = builder.immediateReturn;
+        this.immediateIfLastReturn = builder.immediateIfLastReturn;
     }
 
     public ToolSpecification toolSpecification() {
@@ -40,6 +42,10 @@ public class AiServiceTool {
         return immediateReturn;
     }
 
+    public boolean immediateIfLastReturn() {
+        return immediateIfLastReturn;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -49,6 +55,7 @@ public class AiServiceTool {
         private ToolSpecification toolSpecification;
         private ToolExecutor toolExecutor;
         private boolean immediateReturn;
+        private boolean immediateIfLastReturn;
 
         public Builder toolSpecification(ToolSpecification toolSpecification) {
             this.toolSpecification = toolSpecification;
@@ -62,6 +69,11 @@ public class AiServiceTool {
 
         public Builder immediateReturn(boolean immediateReturn) {
             this.immediateReturn = immediateReturn;
+            return this;
+        }
+
+        public Builder immediateIfLastReturn(boolean immediateIfLastReturn) {
+            this.immediateIfLastReturn = immediateIfLastReturn;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolProviderResult.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolProviderResult.java
@@ -5,7 +5,6 @@ import static dev.langchain4j.internal.Utils.copy;
 import dev.langchain4j.agent.tool.ReturnBehavior;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.service.IllegalConfigurationException;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -16,22 +15,29 @@ public class ToolProviderResult {
     private final Map<ToolSpecification, ToolExecutor> tools;
     private final Map<String, ToolSpecification> toolsByName;
     private final Set<String> immediateReturnToolNames;
+    private final Set<String> immediateIfLastReturnToolNames;
 
     public ToolProviderResult(Builder builder) {
-        this(builder.tools, builder.toolsByName, builder.immediateReturnToolNames);
+        this(
+                builder.tools,
+                builder.toolsByName,
+                builder.immediateReturnToolNames,
+                builder.immediateIfLastReturnToolNames);
     }
 
     public ToolProviderResult(Map<ToolSpecification, ToolExecutor> tools) {
-        this(tools, indexTools(tools), Set.of());
+        this(tools, indexTools(tools), Set.of(), Set.of());
     }
 
     private ToolProviderResult(
             Map<ToolSpecification, ToolExecutor> tools,
             Map<String, ToolSpecification> toolsByName,
-            Set<String> immediateReturnToolNames) {
+            Set<String> immediateReturnToolNames,
+            Set<String> immediateIfLastReturnToolNames) {
         this.tools = copy(tools);
         this.toolsByName = copy(toolsByName);
         this.immediateReturnToolNames = copy(immediateReturnToolNames);
+        this.immediateIfLastReturnToolNames = copy(immediateIfLastReturnToolNames);
     }
 
     private static Map<String, ToolSpecification> indexTools(Map<ToolSpecification, ToolExecutor> tools) {
@@ -61,10 +67,15 @@ public class ToolProviderResult {
         return immediateReturnToolNames;
     }
 
+    public Set<String> immediateIfLastReturnToolNames() {
+        return immediateIfLastReturnToolNames;
+    }
+
     public Builder toBuilder() {
         return builder()
                 .addAll(tools)
-                .immediateReturnToolNames(immediateReturnToolNames);
+                .immediateReturnToolNames(immediateReturnToolNames)
+                .immediateIfLastReturnToolNames(immediateIfLastReturnToolNames);
     }
 
     public static Builder builder() {
@@ -76,6 +87,7 @@ public class ToolProviderResult {
         private final Map<ToolSpecification, ToolExecutor> tools = new HashMap<>();
         private final Map<String, ToolSpecification> toolsByName = new HashMap<>();
         private final Set<String> immediateReturnToolNames = new HashSet<>();
+        private final Set<String> immediateIfLastReturnToolNames = new HashSet<>();
 
         public Builder add(ToolSpecification tool, ToolExecutor executor) {
             return add(tool, executor, ReturnBehavior.TO_LLM);
@@ -88,6 +100,8 @@ public class ToolProviderResult {
             }
             if (returnBehavior == ReturnBehavior.IMMEDIATE) {
                 immediateReturnToolNames.add(tool.name());
+            } else if (returnBehavior == ReturnBehavior.IMMEDIATE_IF_LAST) {
+                immediateIfLastReturnToolNames.add(tool.name());
             }
             return this;
         }
@@ -100,6 +114,13 @@ public class ToolProviderResult {
         public Builder immediateReturnToolNames(Set<String> immediateReturnToolNames) {
             if (immediateReturnToolNames != null) {
                 this.immediateReturnToolNames.addAll(immediateReturnToolNames);
+            }
+            return this;
+        }
+
+        public Builder immediateIfLastReturnToolNames(Set<String> immediateIfLastReturnToolNames) {
+            if (immediateIfLastReturnToolNames != null) {
+                this.immediateIfLastReturnToolNames.addAll(immediateIfLastReturnToolNames);
             }
             return this;
         }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -48,7 +48,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -71,6 +70,7 @@ public class ToolService {
     private final List<ToolSpecification> toolSpecifications = new ArrayList<>();
     private final Map<String, ToolExecutor> toolExecutors = new HashMap<>();
     private final Set<String> immediateReturnTools = new HashSet<>();
+    private final Set<String> immediateIfLastReturnTools = new HashSet<>();
     private final Set<ToolProvider> toolProviders = new LinkedHashSet<>();
     private Executor executor;
     private int maxSequentialToolsInvocations = 100;
@@ -127,6 +127,9 @@ public class ToolService {
                 if (tool.immediateReturn()) {
                     immediateReturnTools.add(toolName);
                 }
+                if (tool.immediateIfLastReturn()) {
+                    immediateIfLastReturnTools.add(toolName);
+                }
             }
         }
     }
@@ -166,10 +169,13 @@ public class ToolService {
             Optional<Method> annotatedMethod = getAnnotatedMethod(method, Tool.class);
             if (annotatedMethod.isPresent()) {
                 Method toolMethod = annotatedMethod.get();
+                ReturnBehavior returnBehavior =
+                        toolMethod.getAnnotation(Tool.class).returnBehavior();
                 result.add(AiServiceTool.builder()
                         .toolSpecification(toolSpecificationFrom(toolMethod))
                         .toolExecutor(createToolExecutor(objectWithTools, toolMethod))
-                        .immediateReturn(toolMethod.getAnnotation(Tool.class).returnBehavior() == ReturnBehavior.IMMEDIATE)
+                        .immediateReturn(returnBehavior == ReturnBehavior.IMMEDIATE)
+                        .immediateIfLastReturn(returnBehavior == ReturnBehavior.IMMEDIATE_IF_LAST)
                         .build());
             }
         }
@@ -256,9 +262,8 @@ public class ToolService {
         this.toolSearchService = new ToolSearchService(toolSearchStrategy);
     }
 
-    public ToolServiceContext createContext(InvocationContext invocationContext,
-                                            UserMessage userMessage,
-                                            List<ChatMessage> messages) {
+    public ToolServiceContext createContext(
+            InvocationContext invocationContext, UserMessage userMessage, List<ChatMessage> messages) {
         ToolServiceContext context = createContextFromStaticToolsAndProviders(invocationContext, userMessage, messages);
         if (toolSearchService != null) {
             context = toolSearchService.adjust(context, messages, invocationContext);
@@ -267,9 +272,8 @@ public class ToolService {
         return context;
     }
 
-    private ToolServiceContext createContextFromStaticToolsAndProviders(InvocationContext invocationContext,
-                                                                        UserMessage userMessage,
-                                                                        List<ChatMessage> messages) {
+    private ToolServiceContext createContextFromStaticToolsAndProviders(
+            InvocationContext invocationContext, UserMessage userMessage, List<ChatMessage> messages) {
         if (this.toolProviders.isEmpty()) {
             if (this.toolSpecifications.isEmpty()) {
                 return ToolServiceContext.Empty.INSTANCE;
@@ -280,12 +284,14 @@ public class ToolService {
                     .availableTools(this.toolSpecifications)
                     .toolExecutors(this.toolExecutors)
                     .immediateReturnTools(this.immediateReturnTools)
+                    .immediateIfLastReturnTools(this.immediateIfLastReturnTools)
                     .build();
         }
 
         List<ToolSpecification> toolSpecifications = new ArrayList<>(this.toolSpecifications);
         Map<String, ToolExecutor> toolExecutors = new HashMap<>(this.toolExecutors);
         Set<String> immediateReturnTools = new HashSet<>(this.immediateReturnTools);
+        Set<String> immediateIfLastReturnTools = new HashSet<>(this.immediateIfLastReturnTools);
         List<ToolProvider> dynamicToolProviders = new ArrayList<>();
 
         ToolProviderRequest toolProviderRequest = ToolProviderRequest.builder()
@@ -304,13 +310,15 @@ public class ToolService {
                         toolProviderResult.tools().entrySet()) {
                     String toolName = entry.getKey().name();
                     if (toolExecutors.putIfAbsent(toolName, entry.getValue()) != null) {
-                        throw new IllegalConfigurationException(
-                                "Duplicated definition for tool: " + toolName);
+                        throw new IllegalConfigurationException("Duplicated definition for tool: " + toolName);
                     }
                     toolSpecifications.add(entry.getKey());
                 }
                 if (toolProviderResult.immediateReturnToolNames() != null) {
                     immediateReturnTools.addAll(toolProviderResult.immediateReturnToolNames());
+                }
+                if (toolProviderResult.immediateIfLastReturnToolNames() != null) {
+                    immediateIfLastReturnTools.addAll(toolProviderResult.immediateIfLastReturnToolNames());
                 }
             }
         });
@@ -320,6 +328,7 @@ public class ToolService {
                 .availableTools(toolSpecifications)
                 .toolExecutors(toolExecutors)
                 .immediateReturnTools(immediateReturnTools)
+                .immediateIfLastReturnTools(immediateIfLastReturnTools)
                 .dynamicToolProviders(dynamicToolProviders)
                 .build();
     }
@@ -400,6 +409,24 @@ public class ToolService {
                 }
             }
 
+            if (!immediateToolReturn && !toolResults.isEmpty()) {
+                Map.Entry<ToolExecutionRequest, ToolExecutionResult> lastEntry = null;
+                for (Map.Entry<ToolExecutionRequest, ToolExecutionResult> entry : toolResults.entrySet()) {
+                    lastEntry = entry;
+                }
+                if (!lastEntry.getValue().isError()
+                        && toolServiceContext
+                                .immediateIfLastReturnTools()
+                                .contains(lastEntry.getKey().name())) {
+                    if (!isReturnTypeResult) {
+                        throw illegalConfiguration(
+                                "Tool '%s' with immediate return is not allowed on a AI service not returning Result.",
+                                lastEntry.getKey().name());
+                    }
+                    immediateToolReturn = true;
+                }
+            }
+
             if (immediateToolReturn) {
                 ChatResponse finalResponse = intermediateResponses.remove(intermediateResponses.size() - 1);
                 return ToolServiceResult.builder()
@@ -458,9 +485,8 @@ public class ToolService {
      *
      * @since 1.13.0
      */
-    public static ToolServiceContext refreshDynamicProviders(ToolServiceContext toolServiceContext,
-                                                             List<ChatMessage> messages,
-                                                             InvocationContext invocationContext) {
+    public static ToolServiceContext refreshDynamicProviders(
+            ToolServiceContext toolServiceContext, List<ChatMessage> messages, InvocationContext invocationContext) {
         if (toolServiceContext == null) {
             return null;
         }
@@ -481,12 +507,14 @@ public class ToolService {
         List<ToolSpecification> newAvailableTools = new ArrayList<>(toolServiceContext.availableTools());
         Map<String, ToolExecutor> newToolExecutors = new HashMap<>(toolServiceContext.toolExecutors());
         Set<String> newImmediateReturnTools = new HashSet<>(toolServiceContext.immediateReturnTools());
+        Set<String> newImmediateIfLastReturnTools = new HashSet<>(toolServiceContext.immediateIfLastReturnTools());
         boolean changed = false;
 
         for (ToolProvider dynamicProvider : dynamicProviders) {
             ToolProviderResult result = dynamicProvider.provideTools(request);
             if (result != null) {
-                for (Map.Entry<ToolSpecification, ToolExecutor> toolEntry : result.tools().entrySet()) {
+                for (Map.Entry<ToolSpecification, ToolExecutor> toolEntry :
+                        result.tools().entrySet()) {
                     String toolName = toolEntry.getKey().name();
                     if (!newToolExecutors.containsKey(toolName)) {
                         newEffectiveTools.add(toolEntry.getKey());
@@ -496,6 +524,7 @@ public class ToolService {
                     }
                 }
                 newImmediateReturnTools.addAll(result.immediateReturnToolNames());
+                newImmediateIfLastReturnTools.addAll(result.immediateIfLastReturnToolNames());
             }
         }
 
@@ -508,6 +537,7 @@ public class ToolService {
                 .availableTools(newAvailableTools)
                 .toolExecutors(newToolExecutors)
                 .immediateReturnTools(newImmediateReturnTools)
+                .immediateIfLastReturnTools(newImmediateIfLastReturnTools)
                 .build();
     }
 
@@ -752,4 +782,7 @@ public class ToolService {
         return immediateReturnTools.contains(toolName);
     }
 
+    public boolean isImmediateIfLastTool(String toolName) {
+        return immediateIfLastReturnTools.contains(toolName);
+    }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolServiceContext.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolServiceContext.java
@@ -1,17 +1,15 @@
 package dev.langchain4j.service.tool;
 
+import static dev.langchain4j.internal.Utils.copy;
+
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolSpecification;
-
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.service.tool.search.ToolSearchStrategy;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-
-import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.service.tool.search.ToolSearchStrategy;
-
-import static dev.langchain4j.internal.Utils.copy;
 
 @Internal
 public class ToolServiceContext {
@@ -20,6 +18,7 @@ public class ToolServiceContext {
     private final List<ToolSpecification> availableTools;
     private final Map<String, ToolExecutor> toolExecutors;
     private final Set<String> immediateReturnTools;
+    private final Set<String> immediateIfLastReturnTools;
     private final List<ToolProvider> dynamicToolProviders;
 
     public ToolServiceContext(Builder builder) {
@@ -27,6 +26,7 @@ public class ToolServiceContext {
         this.availableTools = copy(builder.availableTools);
         this.toolExecutors = copy(builder.toolExecutors);
         this.immediateReturnTools = copy(builder.immediateReturnTools);
+        this.immediateIfLastReturnTools = copy(builder.immediateIfLastReturnTools);
         this.dynamicToolProviders = copy(builder.dynamicToolProviders);
     }
 
@@ -39,6 +39,7 @@ public class ToolServiceContext {
         this.availableTools = copy(toolSpecifications);
         this.toolExecutors = copy(toolExecutors);
         this.immediateReturnTools = Set.of();
+        this.immediateIfLastReturnTools = Set.of();
         this.dynamicToolProviders = List.of();
     }
 
@@ -82,6 +83,10 @@ public class ToolServiceContext {
         return immediateReturnTools;
     }
 
+    public Set<String> immediateIfLastReturnTools() {
+        return immediateIfLastReturnTools;
+    }
+
     /**
      * Returns dynamic tool providers that are re-evaluated before each LLM call.
      *
@@ -97,6 +102,7 @@ public class ToolServiceContext {
                 .availableTools(availableTools)
                 .toolExecutors(toolExecutors)
                 .immediateReturnTools(immediateReturnTools)
+                .immediateIfLastReturnTools(immediateIfLastReturnTools)
                 .dynamicToolProviders(dynamicToolProviders);
     }
 
@@ -108,23 +114,30 @@ public class ToolServiceContext {
                 && Objects.equals(availableTools, that.availableTools)
                 && Objects.equals(toolExecutors, that.toolExecutors)
                 && Objects.equals(immediateReturnTools, that.immediateReturnTools)
+                && Objects.equals(immediateIfLastReturnTools, that.immediateIfLastReturnTools)
                 && Objects.equals(dynamicToolProviders, that.dynamicToolProviders);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(effectiveTools, availableTools, toolExecutors, immediateReturnTools, dynamicToolProviders);
+        return Objects.hash(
+                effectiveTools,
+                availableTools,
+                toolExecutors,
+                immediateReturnTools,
+                immediateIfLastReturnTools,
+                dynamicToolProviders);
     }
 
     @Override
     public String toString() {
-        return "ToolServiceContext{" +
-                "effectiveTools=" + effectiveTools +
-                ", availableTools=" + availableTools +
-                ", toolExecutors=" + toolExecutors +
-                ", immediateReturnTools=" + immediateReturnTools +
-                ", dynamicToolProviders=" + dynamicToolProviders +
-                '}';
+        return "ToolServiceContext{" + "effectiveTools="
+                + effectiveTools + ", availableTools="
+                + availableTools + ", toolExecutors="
+                + toolExecutors + ", immediateReturnTools="
+                + immediateReturnTools + ", immediateIfLastReturnTools="
+                + immediateIfLastReturnTools + ", dynamicToolProviders="
+                + dynamicToolProviders + '}';
     }
 
     public static Builder builder() {
@@ -137,6 +150,7 @@ public class ToolServiceContext {
         private List<ToolSpecification> availableTools;
         private Map<String, ToolExecutor> toolExecutors;
         private Set<String> immediateReturnTools;
+        private Set<String> immediateIfLastReturnTools;
         private List<ToolProvider> dynamicToolProviders;
 
         /**
@@ -181,6 +195,11 @@ public class ToolServiceContext {
 
         public Builder immediateReturnTools(Set<String> immediateReturnTools) {
             this.immediateReturnTools = immediateReturnTools;
+            return this;
+        }
+
+        public Builder immediateIfLastReturnTools(Set<String> immediateIfLastReturnTools) {
+            this.immediateIfLastReturnTools = immediateIfLastReturnTools;
             return this;
         }
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ImmediateIfLastReturnTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ImmediateIfLastReturnTest.java
@@ -1,0 +1,216 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ReturnBehavior;
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.Result;
+import dev.langchain4j.service.TokenStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ImmediateIfLastReturnTest {
+
+    interface Assistant {
+        Result<String> chat(String message);
+    }
+
+    interface StreamingAssistant {
+        TokenStream chat(String message);
+    }
+
+    static class SideEffectThenHaltTools {
+
+        final AtomicInteger sideEffectCalls = new AtomicInteger();
+        final AtomicInteger haltCalls = new AtomicInteger();
+
+        @Tool
+        public String doSideEffect() {
+            sideEffectCalls.incrementAndGet();
+            return "side-effect-done";
+        }
+
+        @Tool(returnBehavior = ReturnBehavior.IMMEDIATE_IF_LAST)
+        public String halt() {
+            haltCalls.incrementAndGet();
+            return "halted";
+        }
+    }
+
+    static class HaltTool {
+
+        final AtomicInteger calls = new AtomicInteger();
+
+        @Tool(returnBehavior = ReturnBehavior.IMMEDIATE_IF_LAST)
+        public String halt() {
+            return "halted-" + calls.incrementAndGet();
+        }
+    }
+
+    static class ThrowingHaltTool {
+
+        @Tool(returnBehavior = ReturnBehavior.IMMEDIATE_IF_LAST)
+        public String halt() {
+            throw new RuntimeException("halt failed");
+        }
+    }
+
+    @Test
+    void should_return_immediately_when_immediate_if_last_tool_is_last_in_batch__sync() {
+        SideEffectThenHaltTools tools = new SideEffectThenHaltTools();
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(batchCall("call-1", "doSideEffect", "call-2", "halt"));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tools)
+                .build();
+
+        Result<String> result = assistant.chat("go");
+
+        assertThat(tools.sideEffectCalls.get()).isEqualTo(1);
+        assertThat(tools.haltCalls.get()).isEqualTo(1);
+        assertThat(model.requests()).hasSize(1);
+        assertThat(result.toolExecutions()).hasSize(2);
+        assertThat(result.toolExecutions().get(1).result()).isEqualTo("halted");
+    }
+
+    @Test
+    void should_not_return_immediately_when_immediate_if_last_tool_is_not_last_in_batch__sync() {
+        SideEffectThenHaltTools tools = new SideEffectThenHaltTools();
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(
+                batchCall("call-1", "halt", "call-2", "doSideEffect"), AiMessage.from("done"));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .tools(tools)
+                .build();
+
+        Result<String> result = assistant.chat("go");
+
+        assertThat(tools.sideEffectCalls.get()).isEqualTo(1);
+        assertThat(tools.haltCalls.get()).isEqualTo(1);
+
+        assertThat(model.requests()).hasSize(2);
+        assertThat(result.content()).isEqualTo("done");
+    }
+
+    @Test
+    void should_return_immediately_when_single_immediate_if_last_tool__sync() {
+        HaltTool tool = new HaltTool();
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(singleCall("call-1", "halt"));
+
+        Assistant assistant =
+                AiServices.builder(Assistant.class).chatModel(model).tools(tool).build();
+
+        Result<String> result = assistant.chat("go");
+
+        assertThat(tool.calls.get()).isEqualTo(1);
+        assertThat(model.requests()).hasSize(1);
+        assertThat(result.toolExecutions()).hasSize(1);
+        assertThat(result.toolExecutions().get(0).result()).isEqualTo("halted-1");
+    }
+
+    @Test
+    void should_not_return_immediately_when_immediate_if_last_tool_throws__sync() {
+        ThrowingHaltTool tool = new ThrowingHaltTool();
+        ChatModelMock model =
+                ChatModelMock.thatAlwaysResponds(singleCall("call-1", "halt"), AiMessage.from("recovered"));
+
+        Assistant assistant =
+                AiServices.builder(Assistant.class).chatModel(model).tools(tool).build();
+
+        Result<String> result = assistant.chat("go");
+
+        assertThat(model.requests()).hasSize(2);
+        assertThat(result.content()).isEqualTo("recovered");
+    }
+
+    @Test
+    void should_return_immediately_when_immediate_if_last_tool_is_last_in_batch__streaming() throws Exception {
+        SideEffectThenHaltTools tools = new SideEffectThenHaltTools();
+        StreamingChatModelMock model =
+                StreamingChatModelMock.thatAlwaysStreams(batchCall("call-1", "doSideEffect", "call-2", "halt"));
+
+        List<ToolExecution> observedExecutions = new ArrayList<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .tools(tools)
+                .build();
+
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onToolExecuted(observedExecutions::add)
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        future.get(10, TimeUnit.SECONDS);
+
+        assertThat(tools.sideEffectCalls.get()).isEqualTo(1);
+        assertThat(tools.haltCalls.get()).isEqualTo(1);
+        assertThat(model.requests()).hasSize(1);
+        assertThat(observedExecutions).hasSize(2);
+    }
+
+    @Test
+    void should_not_return_immediately_when_immediate_if_last_tool_is_not_last_in_batch__streaming() throws Exception {
+        SideEffectThenHaltTools tools = new SideEffectThenHaltTools();
+        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(
+                batchCall("call-1", "halt", "call-2", "doSideEffect"), AiMessage.from("done"));
+
+        List<ToolExecution> observedExecutions = new ArrayList<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .tools(tools)
+                .build();
+
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onToolExecuted(observedExecutions::add)
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        future.get(10, TimeUnit.SECONDS);
+
+        assertThat(tools.sideEffectCalls.get()).isEqualTo(1);
+        assertThat(tools.haltCalls.get()).isEqualTo(1);
+        assertThat(model.requests()).hasSize(2);
+        assertThat(observedExecutions).hasSize(2);
+    }
+
+    private static AiMessage singleCall(String id, String name) {
+        return AiMessage.from(
+                ToolExecutionRequest.builder().id(id).name(name).arguments("{}").build());
+    }
+
+    private static AiMessage batchCall(String id1, String name1, String id2, String name2) {
+        return AiMessage.from(
+                ToolExecutionRequest.builder()
+                        .id(id1)
+                        .name(name1)
+                        .arguments("{}")
+                        .build(),
+                ToolExecutionRequest.builder()
+                        .id(id2)
+                        .name(name2)
+                        .arguments("{}")
+                        .build());
+    }
+}


### PR DESCRIPTION
Fixes #4974

## What changed

Adds `ReturnBehavior.IMMEDIATE_IF_LAST`, a new enum value that halts the AI service execution loop when the annotated tool is the **last** tool called in a multi-tool batch and completed without error.

### Semantics

| Batch order | Behaviour |
|---|---|
| `[regularTool, IMMEDIATE_IF_LAST_tool]` | **Halt** — last tool signals completion ✓ |
| `[IMMEDIATE_IF_LAST_tool, regularTool]` | **Continue** — last is regular, treat as non-final ✓ |
| `[IMMEDIATE_IF_LAST_tool]` | **Halt** — single tool, same as existing `IMMEDIATE` ✓ |
| Last tool throws | **Continue** — error suppresses halt, same as `IMMEDIATE` ✓ |

### Files changed

- `ReturnBehavior.java` — new `IMMEDIATE_IF_LAST` enum value with Javadoc
- `AiServiceTool.java` — `immediateIfLastReturn` flag + builder method
- `ToolServiceContext.java` — `immediateIfLastReturnTools` set (field, accessor, builder, equals/hashCode/toString)
- `ToolProviderResult.java` — `immediateIfLastReturnToolNames` (field, accessor, builder method, `add(…, ReturnBehavior)` routing)
- `ToolService.java` — populates set from annotations and `ToolProvider`; post-loop check in `executeInferenceAndToolsLoop`; `isImmediateIfLastTool()` helper; `refreshDynamicProviders` propagation
- `AiServiceStreamingResponseHandler.java` — tracks `lastToolName`/`lastToolErrored` across both concurrent and sequential tool branches; post-loop check mirrors sync path
- `ImmediateIfLastReturnTest.java` — 6 unit tests covering all four semantic cases for both sync and streaming paths

## Before submitting this PR I confirmed the following

- [x] I have read the [contribution guidelines](https://github.com/langchain4j/langchain4j/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (6 unit tests)
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the relevant documentation (Javadoc on enum value)
- [x] I confirm that the changes are backward compatible (purely additive, no existing behaviour changed)