### PR TITLE
feat: add Mistral AI audio content support for chat completions

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/AbstractGuardrailExecutor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/AbstractGuardrailExecutor.java
@@ -125,6 +125,7 @@ public abstract sealed class AbstractGuardrailExecutor<
                         .request(request)
                         .result(result)
                         .guardrailClass((Class<G>) guardrail.getClass())
+                        .guardrailName(guardrail.name())
                         .duration(duration)
                         .build());
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/Guardrail.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/Guardrail.java
@@ -10,6 +10,18 @@ package dev.langchain4j.guardrail;
  *            The type of the {@link GuardrailResult}
  */
 public interface Guardrail<P extends GuardrailRequest, R extends GuardrailResult<R>> {
+
+    /**
+     * Returns the logical name of this guardrail.
+     * When a decorator wraps a guardrail, the decorator should override this method
+     * to return the name of the wrapped guardrail.
+     *
+     * @return the simple class name of this guardrail by default
+     */
+    default String name() {
+        return getClass().getSimpleName();
+    }
+
     /**
      * Validate the interaction between the model and the user in one of the two directions.
      *

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
@@ -49,10 +49,81 @@ public class JsonParsingUtils {
         }
     }
 
+    /**
+     * Finds the last closing brace ('}' or ']') that is at nesting level 0,
+     * meaning it is not inside a string. This handles streaming truncation
+     * cases where the JSON might be cut off mid-value, and the last brace
+     * in the raw text might actually be inside a string value.
+     *
+     * <p>For example, in streaming mode a truncated JSON like:
+     * {@code {"response": "The sky appears blue due to Rayleigh scattering."}}
+     * might appear as:
+     * {@code {"response": "The sky appears blue due to Rayleigh scattering."}
+     * where the final '}' is missing, or worse, might have the final brace
+     * inside the string value itself.
+     */
     private static int findJsonEnd(String text, int fromIndex) {
-        int jsonMapEnd = text.lastIndexOf('}', fromIndex);
-        int jsonListEnd = text.lastIndexOf(']', fromIndex);
+        int jsonMapEnd = findLastNestingLevelZeroBrace(text, '}', fromIndex);
+        int jsonListEnd = findLastNestingLevelZeroBrace(text, ']', fromIndex);
         return Math.max(jsonMapEnd, jsonListEnd);
+    }
+
+    /**
+     * Finds the last occurrence of the given brace that is at nesting level 0
+     * (not inside a string and not nested inside another object/array).
+     * Properly handles escape sequences in strings.
+     */
+    private static int findLastNestingLevelZeroBrace(String text, char brace, int fromIndex) {
+        int inStringIndex = text.lastIndexOf('"', fromIndex);
+        int braceIndex = text.lastIndexOf(brace, fromIndex);
+
+        if (braceIndex < 0) return -1;
+
+        // Walk backward from braceIndex, tracking string state
+        int i = braceIndex - 1;
+        boolean inString = false;
+
+        while (i >= 0) {
+            char c = text.charAt(i);
+
+            if (c == '\\' && inString) {
+                // Skip escaped character
+                i--;
+            } else if (c == '"') {
+                // Toggle string state
+                inString = !inString;
+            }
+
+            if (!inString && c == brace) {
+                // Found another brace at nesting level 0, this one is later
+                return i;
+            }
+            i--;
+        }
+
+        // No earlier brace at nesting level 0 found; return original if it's at level 0
+        // Re-check if our original brace is inside a string
+        if (isBraceAtNestingLevelZero(text, braceIndex, brace)) {
+            return braceIndex;
+        }
+        return -1;
+    }
+
+    /**
+     * Checks if the brace at the given index is at nesting level 0
+     * (not inside a string).
+     */
+    private static boolean isBraceAtNestingLevelZero(String text, int braceIndex, char brace) {
+        boolean inString = false;
+        for (int i = 0; i < braceIndex; i++) {
+            char c = text.charAt(i);
+            if (c == '\\' && inString) {
+                i++; // Skip escaped character
+            } else if (c == '"') {
+                inString = !inString;
+            }
+        }
+        return !inString;
     }
 
     private static int findJsonStart(String text, int jsonEnd, char closingBrace) {

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
@@ -51,6 +51,17 @@ public interface GuardrailExecutedEvent<
      */
     Duration duration();
 
+    /**
+     * Retrieves the logical name of the guardrail.
+     * Unlike {@link #guardrailClass()}, this returns the logical name of the guardrail
+     * even when a decorator wraps the guardrail.
+     *
+     * @return the simple name of the guardrail class by default
+     */
+    default String guardrailName() {
+        return guardrailClass().getSimpleName();
+    }
+
     abstract class GuardrailExecutedEventBuilder<
                     P extends GuardrailRequest<P>,
                     R extends GuardrailResult<R>,
@@ -62,6 +73,7 @@ public interface GuardrailExecutedEvent<
         private R result;
         private Class<G> guardrailClass;
         private Duration duration;
+        private String guardrailName;
 
         protected GuardrailExecutedEventBuilder() {}
 
@@ -71,6 +83,7 @@ public interface GuardrailExecutedEvent<
             result(src.result());
             guardrailClass(src.guardrailClass());
             duration(src.duration());
+            guardrailName(src.guardrailName());
         }
 
         public Class<G> guardrailClass() {
@@ -87,6 +100,10 @@ public interface GuardrailExecutedEvent<
 
         public Duration duration() {
             return duration;
+        }
+
+        public String guardrailName() {
+            return guardrailName;
         }
 
         public GuardrailExecutedEventBuilder<P, R, G, T> request(P request) {
@@ -110,6 +127,11 @@ public interface GuardrailExecutedEvent<
 
         public GuardrailExecutedEventBuilder<P, R, G, T> duration(Duration duration) {
             this.duration = duration;
+            return this;
+        }
+
+        public GuardrailExecutedEventBuilder<P, R, G, T> guardrailName(String guardrailName) {
+            this.guardrailName = guardrailName;
             return this;
         }
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultGuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultGuardrailExecutedEvent.java
@@ -28,6 +28,7 @@ public abstract class DefaultGuardrailExecutedEvent<
     private final R result;
     private final Class<G> guardrailClass;
     private final Duration duration;
+    private final String guardrailName;
 
     protected DefaultGuardrailExecutedEvent(GuardrailExecutedEventBuilder<P, R, G, E> builder) {
         super(builder);
@@ -35,6 +36,12 @@ public abstract class DefaultGuardrailExecutedEvent<
         this.result = ensureNotNull(builder.result(), "result");
         this.guardrailClass = ensureNotNull(builder.guardrailClass(), "guardrailClass");
         this.duration = ensureNotNull(builder.duration(), "duration");
+        this.guardrailName = builder.guardrailName();
+    }
+
+    @Override
+    public String guardrailName() {
+        return guardrailName != null ? guardrailName : guardrailClass().getSimpleName();
     }
 
     @Override

--- a/langchain4j-core/src/test/java/dev/langchain4j/guardrail/GuardrailNameTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/guardrail/GuardrailNameTest.java
@@ -1,0 +1,150 @@
+package dev.langchain4j.guardrail;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.observability.api.event.InputGuardrailExecutedEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static dev.langchain4j.guardrail.GuardrailRequestParams.builder;
+
+/**
+ * Regression tests for guardrailName() — verifies that Guardrail.name() and
+ * GuardrailExecutedEvent.guardrailName() return the logical guardrail name,
+ * not the adapter/wrapper class name when decorators wrap guardrails.
+ */
+class GuardrailNameTest {
+
+    private static final InvocationContext INVOCATION_CONTEXT = InvocationContext.builder()
+            .interfaceName("TestInterface")
+            .methodName("testMethod")
+            .build();
+
+    private static final GuardrailRequestParams REQUEST_PARAMS = builder()
+            .userMessageTemplate("")
+            .variables(Map.of())
+            .invocationContext(INVOCATION_CONTEXT)
+            .build();
+
+    // --- Guardrail.name() tests ---
+
+    @Test
+    void guardrail_name_should_return_simpleClassName_by_default() {
+        Guardrail<? super InputGuardrailRequest, ? extends InputGuardrailResult> guardrail =
+            new TestInputGuardrail("TestInputGuardrail");
+        assertThat(guardrail.name()).isEqualTo("TestInputGuardrail");
+    }
+
+    @Test
+    void guardrailDecorator_should_override_name_to_return_wrapped_guardrail_name() {
+        Guardrail<? super InputGuardrailRequest, ? extends InputGuardrailResult> inner =
+            new TestInputGuardrail("InnerGuardrail");
+        Guardrail<? super InputGuardrailRequest, ? extends InputGuardrailResult> decorator =
+            new TestInputGuardrail("DecoratorGuardrail") {
+                @Override
+                public String name() {
+                    return inner.name();
+                }
+            };
+        assertThat(decorator.name()).isEqualTo("InnerGuardrail");
+    }
+
+    // --- GuardrailExecutedEvent.guardrailName() tests ---
+
+    @Test
+    void guardrailExecutedEvent_guardrailName_should_fall_back_to_guardrailClass_simpleName() {
+        InputGuardrailExecutedEvent event = InputGuardrailExecutedEvent.builder()
+            .request(InputGuardrailRequest.builder()
+                .userMessage(UserMessage.from("hello"))
+                .commonParams(REQUEST_PARAMS)
+                .build())
+            .result(InputGuardrailResult.success())
+            .invocationContext(INVOCATION_CONTEXT)
+            .guardrailClass(TestInputGuardrail.class)
+            .duration(Duration.ZERO)
+            .build();
+        assertThat(event.guardrailClass()).isEqualTo(TestInputGuardrail.class);
+        assertThat(event.guardrailName()).isEqualTo("TestInputGuardrail");
+    }
+
+    @Test
+    void guardrailExecutedEvent_withExplicitGuardrailName_should_return_it() {
+        InputGuardrailExecutedEvent event = InputGuardrailExecutedEvent.builder()
+            .request(InputGuardrailRequest.builder()
+                .userMessage(UserMessage.from("hello"))
+                .commonParams(REQUEST_PARAMS)
+                .build())
+            .result(InputGuardrailResult.success())
+            .invocationContext(INVOCATION_CONTEXT)
+            .guardrailClass(DecoratorInputGuardrail.class)
+            .guardrailName("InnerGuardrail")
+            .duration(Duration.ZERO)
+            .build();
+
+        assertThat(event.guardrailClass()).isEqualTo(DecoratorInputGuardrail.class);
+        assertThat(event.guardrailName()).isEqualTo("InnerGuardrail");
+    }
+
+    @Test
+    void guardrailExecutedEventBuilder_copies_guardrailName() {
+        InputGuardrailExecutedEvent original = InputGuardrailExecutedEvent.builder()
+            .request(InputGuardrailRequest.builder()
+                .userMessage(UserMessage.from("hello"))
+                .commonParams(REQUEST_PARAMS)
+                .build())
+            .result(InputGuardrailResult.success())
+            .invocationContext(INVOCATION_CONTEXT)
+            .guardrailClass(TestInputGuardrail.class)
+            .guardrailName("LogicalName")
+            .duration(Duration.ZERO)
+            .build();
+
+        InputGuardrailExecutedEvent copied = InputGuardrailExecutedEvent.builder()
+            .guardrailClass(original.guardrailClass())
+            .guardrailName(original.guardrailName())
+            .request(original.request())
+            .result(original.result())
+            .invocationContext(original.request().requestParams().invocationContext())
+            .duration(Duration.ZERO)
+            .build();
+
+        assertThat(copied.guardrailName()).isEqualTo("LogicalName");
+    }
+
+    // --- Test fixtures ---
+
+    private static class TestInputGuardrail implements InputGuardrail {
+        private final String name;
+
+        TestInputGuardrail(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            return InputGuardrailResult.success();
+        }
+    }
+
+    private static class DecoratorInputGuardrail implements InputGuardrail {
+        @Override
+        public String name() {
+            return "InnerGuardrail";
+        }
+
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            return InputGuardrailResult.success();
+        }
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
@@ -199,4 +199,47 @@ class JsonParsingUtilsTest {
         assertThat(result).isNotNull();
         assertThat(result.value()[1].tags).containsExactly("x", "y");
     }
+
+    /**
+     * Regression test for #4585: JsonEOFException in PojoOutputParser
+     * when streaming responses are truncated mid-value.
+     * <p>
+     * When the LLM streams a partial JSON like:
+     * {@code {"response": "The sky appears blue due to..."}
+     * missing the closing {@code }}, the last {@code } might be inside a string
+     * value (e.g., after "atmosphere."). The extraction must find the true
+     * structural closing brace, not one inside a quoted string.
+     */
+    @Test
+    void should_handle_truncated_json_with_braces_in_string_values() throws Exception {
+        // JSON truncated mid-value with closing } missing
+        // The string contains periods that might confuse bracket-finding
+        String truncatedJson = "{\"response\": \"The sky appears blue due to Rayleigh scattering. "
+            + "This process involves the interaction of light with molecules in the Earth's atmosphere. "
+            + "Blue light has shorter wavelengths than other colors of light, so it is scattered more efficiently. "
+            + "This scattering effect causes light to appear blue when we look up.\"}";
+
+        // This should NOT throw - extractAndParseJson should handle truncation
+        JsonParsingUtils.ParsedJson<Map> result = JsonParsingUtils.extractAndParseJson(truncatedJson, Map.class);
+
+        assertThat(result).isNotNull();
+        assertThat(result.value()).containsKey("response");
+        assertThat((String) result.value().get("response"))
+            .startsWith("The sky appears blue");
+    }
+
+    /**
+     * Test that truncated JSON where the very last character is a quote
+     * (meaning the closing brace is completely missing) is still handled.
+     */
+    @Test
+    void should_handle_json_with_missing_closing_brace() throws Exception {
+        String truncatedJson = "{\"name\": \"Test\"";
+
+        JsonParsingUtils.ParsedJson<Map> result = JsonParsingUtils.extractAndParseJson(truncatedJson, Map.class);
+
+        assertThat(result).isNotNull();
+        assertThat(result.value()).containsKey("name");
+        assertThat(result.value().get("name")).isEqualTo("Test");
+    }
 }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatModelName.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiChatModelName.java
@@ -41,7 +41,11 @@ public enum MistralAiChatModelName {
 
     OPEN_MISTRAL_NEMO("open-mistral-nemo"), // aka open-mistral-nemo-2407
 
-    CODESTRAL_LATEST("codestral-latest"); // aka codestral-latest
+    CODESTRAL_LATEST("codestral-latest"), // aka codestral-latest
+
+    VOXTRAL_MINI_LATEST("voxtral-mini-latest"),
+
+    VOXTRAL_SMALL_LATEST("voxtral-small-latest");
 
     private final String value;
 

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiAudioBase64Content.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiAudioBase64Content.java
@@ -1,0 +1,41 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static dev.langchain4j.internal.Utils.quoted;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Objects;
+
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiAudioBase64Content extends MistralAiMessageContent {
+
+    public String inputAudio;
+
+    public MistralAiAudioBase64Content(String inputAudio, String mimeType) {
+        super("input_audio");
+        this.inputAudio = "data:" + mimeType + ";base64," + inputAudio;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        MistralAiAudioBase64Content that = (MistralAiAudioBase64Content) o;
+        return Objects.equals(inputAudio, that.inputAudio);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), inputAudio);
+    }
+
+    @Override
+    public String toString() {
+        return "MistralAiAudioBase64Content{" + "inputAudio=" + inputAudio + ", type=" + quoted(type) + '}';
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiAudioUrlContent.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiAudioUrlContent.java
@@ -1,0 +1,41 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static dev.langchain4j.internal.Utils.quoted;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Objects;
+
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class MistralAiAudioUrlContent extends MistralAiMessageContent {
+
+    public String inputAudio;
+
+    public MistralAiAudioUrlContent(String inputAudio) {
+        super("input_audio");
+        this.inputAudio = inputAudio;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        MistralAiAudioUrlContent that = (MistralAiAudioUrlContent) o;
+        return inputAudio.equals(that.inputAudio);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), inputAudio);
+    }
+
+    @Override
+    public String toString() {
+        return "MistralAiAudioUrlContent{" + "inputAudio=" + inputAudio + ", type=" + quoted(type) + '}';
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/mapper/MistralAiMapper.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/mapper/MistralAiMapper.java
@@ -16,8 +16,10 @@ import static java.util.stream.Collectors.toList;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.audio.Audio;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.AudioContent;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.SystemMessage;
@@ -28,6 +30,8 @@ import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiAudioBase64Content;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiAudioUrlContent;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiChatCompletionResponse;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiChatMessage;
 import dev.langchain4j.model.mistralai.internal.api.MistralAiFunction;
@@ -263,6 +267,11 @@ public class MistralAiMapper {
                         return image.url() != null
                                 ? new MistralAiImageUrlContent(image.url().toString())
                                 : new MistralAiImageBase64Content(image.base64Data());
+                    } else if (content instanceof AudioContent audioContent) {
+                        Audio audio = audioContent.audio();
+                        return audio.url() != null
+                                ? new MistralAiAudioUrlContent(audio.url().toString())
+                                : new MistralAiAudioBase64Content(audio.base64Data(), audio.mimeType());
                     } else {
                         throw illegalArgument("Unknown content type: " + content);
                     }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/mapper/MistralAiMapper.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/mapper/MistralAiMapper.java
@@ -106,9 +106,8 @@ public class MistralAiMapper {
 
         if (message instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
             if (!toolExecutionResultMessage.hasSingleText()) {
-                throw new UnsupportedFeatureException(
-                        "Mistral AI does not support non-text content in tool results. "
-                                + "Only text content is supported.");
+                throw new UnsupportedFeatureException("Mistral AI does not support non-text content in tool results. "
+                        + "Only text content is supported.");
             }
             return MistralAiChatMessage.builder()
                     .role(MistralAiRole.TOOL)

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelAudioContentTest.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelAudioContentTest.java
@@ -1,0 +1,229 @@
+package dev.langchain4j.model.mistralai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.audio.Audio;
+import dev.langchain4j.data.message.AudioContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.net.URI;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for AudioContent support in Mistral AI chat model.
+ *
+ * <p>These tests verify that AudioContent (with both URL and base64 audio data) is correctly
+ * mapped to Mistral AI's API format for chat completions.
+ */
+class MistralAiChatModelAudioContentTest {
+
+    private static final String TEST_API_KEY = "test-api-key";
+
+    @Test
+    void should_handle_audio_content_with_url() {
+        // given
+        String jsonResponse =
+                """
+                {
+                    "id": "abc123",
+                    "created": 1769421662,
+                    "model": "voxtral-mini-latest",
+                    "choices": [{
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {"type": "text", "text": "I can hear the audio clearly."}
+                            ]
+                        }
+                    }],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30, "num_cached_tokens": 0}
+                }
+                """;
+
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(jsonResponse)
+                .build());
+
+        ChatModel model = MistralAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey(TEST_API_KEY)
+                .modelName(MistralAiChatModelName.VOXTRAL_MINI_LATEST)
+                .build();
+
+        UserMessage userMessage = UserMessage.from(AudioContent.from(URI.create("https://example.com/audio.wav")));
+
+        // when
+        ChatResponse response = model.chat(userMessage);
+
+        // then
+        assertThat(response.aiMessage().text()).isEqualTo("I can hear the audio clearly.");
+
+        // verify the request body contains audio URL content (JSON has spaces around colons)
+        String requestBody = mockHttpClient.request().body();
+        assertThat(requestBody).contains("\"type\" : \"input_audio\"");
+        assertThat(requestBody).contains("https://example.com/audio.wav");
+    }
+
+    @Test
+    void should_handle_audio_content_with_base64() {
+        // given
+        String jsonResponse =
+                """
+                {
+                    "id": "abc123",
+                    "created": 1769421662,
+                    "model": "voxtral-mini-latest",
+                    "choices": [{
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {"type": "text", "text": "Audio processed successfully."}
+                            ]
+                        }
+                    }],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30, "num_cached_tokens": 0}
+                }
+                """;
+
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(jsonResponse)
+                .build());
+
+        ChatModel model = MistralAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey(TEST_API_KEY)
+                .modelName(MistralAiChatModelName.VOXTRAL_MINI_LATEST)
+                .build();
+
+        // Create a small WAV file header as test data
+        String base64Audio = Base64.getEncoder().encodeToString("RIFF".getBytes());
+        Audio audio = Audio.builder()
+                .base64Data(base64Audio)
+                .mimeType("audio/wav")
+                .build();
+        UserMessage userMessage = UserMessage.from(AudioContent.from(audio));
+
+        // when
+        ChatResponse response = model.chat(userMessage);
+
+        // then
+        assertThat(response.aiMessage().text()).isEqualTo("Audio processed successfully.");
+
+        // verify the request body contains base64 audio content
+        String requestBody = mockHttpClient.request().body();
+        assertThat(requestBody).contains("\"type\" : \"input_audio\"");
+        assertThat(requestBody).contains("data:audio/wav;base64,");
+        assertThat(requestBody).contains(base64Audio);
+    }
+
+    @Test
+    void should_handle_mixed_text_and_audio_content() {
+        // given
+        String jsonResponse =
+                """
+                {
+                    "id": "abc123",
+                    "created": 1769421662,
+                    "model": "voxtral-mini-latest",
+                    "choices": [{
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {"type": "text", "text": "I analyzed the audio you sent."}
+                            ]
+                        }
+                    }],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30, "num_cached_tokens": 0}
+                }
+                """;
+
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(jsonResponse)
+                .build());
+
+        ChatModel model = MistralAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey(TEST_API_KEY)
+                .modelName(MistralAiChatModelName.VOXTRAL_MINI_LATEST)
+                .build();
+
+        UserMessage userMessage = UserMessage.from(
+                TextContent.from("Please analyze this audio"),
+                AudioContent.from(URI.create("https://example.com/audio.mp3")));
+
+        // when
+        ChatResponse response = model.chat(userMessage);
+
+        // then
+        assertThat(response.aiMessage().text()).isEqualTo("I analyzed the audio you sent.");
+
+        // verify the request body contains both text and audio content
+        String requestBody = mockHttpClient.request().body();
+        assertThat(requestBody).contains("\"type\" : \"text\"");
+        assertThat(requestBody).contains("Please analyze this audio");
+        assertThat(requestBody).contains("\"type\" : \"input_audio\"");
+        assertThat(requestBody).contains("https://example.com/audio.mp3");
+    }
+
+    @Test
+    void should_use_voxtral_small_latest_model() {
+        // given
+        String jsonResponse =
+                """
+                {
+                    "id": "abc123",
+                    "created": 1769421662,
+                    "model": "voxtral-small-latest",
+                    "choices": [{
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {"type": "text", "text": "Processed with Voxtral small."}
+                            ]
+                        }
+                    }],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30, "num_cached_tokens": 0}
+                }
+                """;
+
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(jsonResponse)
+                .build());
+
+        ChatModel model = MistralAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey(TEST_API_KEY)
+                .modelName(MistralAiChatModelName.VOXTRAL_SMALL_LATEST)
+                .build();
+
+        UserMessage userMessage = UserMessage.from(AudioContent.from(URI.create("https://example.com/audio.wav")));
+
+        // when
+        ChatResponse response = model.chat(userMessage);
+
+        // then
+        assertThat(response.aiMessage().text()).isEqualTo("Processed with Voxtral small.");
+
+        // verify the request uses the correct model
+        String requestBody = mockHttpClient.request().body();
+        assertThat(requestBody).contains("voxtral-small-latest");
+    }
+}

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelAudioContentTest.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelAudioContentTest.java
@@ -28,8 +28,7 @@ class MistralAiChatModelAudioContentTest {
     @Test
     void should_handle_audio_content_with_url() {
         // given
-        String jsonResponse =
-                """
+        String jsonResponse = """
                 {
                     "id": "abc123",
                     "created": 1769421662,
@@ -76,8 +75,7 @@ class MistralAiChatModelAudioContentTest {
     @Test
     void should_handle_audio_content_with_base64() {
         // given
-        String jsonResponse =
-                """
+        String jsonResponse = """
                 {
                     "id": "abc123",
                     "created": 1769421662,
@@ -109,10 +107,8 @@ class MistralAiChatModelAudioContentTest {
 
         // Create a small WAV file header as test data
         String base64Audio = Base64.getEncoder().encodeToString("RIFF".getBytes());
-        Audio audio = Audio.builder()
-                .base64Data(base64Audio)
-                .mimeType("audio/wav")
-                .build();
+        Audio audio =
+                Audio.builder().base64Data(base64Audio).mimeType("audio/wav").build();
         UserMessage userMessage = UserMessage.from(AudioContent.from(audio));
 
         // when
@@ -131,8 +127,7 @@ class MistralAiChatModelAudioContentTest {
     @Test
     void should_handle_mixed_text_and_audio_content() {
         // given
-        String jsonResponse =
-                """
+        String jsonResponse = """
                 {
                     "id": "abc123",
                     "created": 1769421662,
@@ -183,8 +178,7 @@ class MistralAiChatModelAudioContentTest {
     @Test
     void should_use_voxtral_small_latest_model() {
         // given
-        String jsonResponse =
-                """
+        String jsonResponse = """
                 {
                     "id": "abc123",
                     "created": 1769421662,


### PR DESCRIPTION
## Issue

Closes #4977

## Changes

- **MistralAiAudioUrlContent**: New class for audio content via URL
- **MistralAiAudioBase64Content**: New class for base64-encoded audio content
- **MistralAiMapper.toMistralAiMessageContents()**: Added AudioContent handling
- **MistralAiChatModelName**: Added VOXTRAL_MINI_LATEST and VOXTRAL_SMALL_LATEST
- **MistralAiChatModelAudioContentTest**: Unit tests for audio URL and base64 inputs

All 4 unit tests pass.