### PR TITLE
refactor: move timeout settings to underlying HTTP client layer

### DIFF
--- a/docs/docs/tutorials/customizable-http-client.md
+++ b/docs/docs/tutorials/customizable-http-client.md
@@ -2,10 +2,9 @@
 sidebar_position: 33
 ---
 
-# Customizable HTTP Client
+# Customizing HTTP Client
 
-Some LangChain4j modules (currently OpenAI and Ollama) support customizing the HTTP clients used
-to call the LLM provider API.
+## Overview
 
 The `langchain4j-http-client` module implements an `HttpClient` SPI, which is used
 by those modules to call the LLM provider's REST API.
@@ -19,6 +18,93 @@ It is used by default when a supported module (e.g., `langchain4j-open-ai`) is u
 It is used by default when a supported module's Spring Boot starter (e.g., `langchain4j-open-ai-spring-boot-starter`/`langchain4j-open-ai-spring-boot4-starter`) is used.
 - `ApacheHttpClient` from the `langchain4j-http-client-apache` module.
 - `OkHttpClient` from the `langchain4j-http-client-okhttp` module.
+
+## Timeout Configuration
+
+### Migration from 1.x to 2.0
+
+**Important:** As of 2.0, timeout configuration has been moved from `HttpClientBuilder` to the underlying HTTP client builder directly.
+This change simplifies the API and makes it compatible with HTTP clients like Spring's `RestClient.Builder` that do not support setting timeouts as separate properties.
+
+#### Before (deprecated in 2.0)
+
+```java
+ApacheHttpClientBuilder httpClientBuilder = ApacheHttpClient.builder()
+    .connectTimeout(Duration.ofSeconds(30))
+    .readTimeout(Duration.ofSeconds(60))
+    .build();
+```
+
+#### After (2.0+)
+
+Configure timeouts directly on the underlying HTTP client builder, then pass it to the `HttpClientBuilder`:
+
+##### OkHttp
+
+```java
+OkHttpClient.Builder okBuilder = new OkHttpClient.Builder()
+    .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+    .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS);
+
+OkHttpClientBuilder httpClientBuilder = OkHttpClient.builder()
+    .okHttpClientBuilder(okBuilder)
+    .build();
+```
+
+##### Apache HttpClient
+
+```java
+org.apache.hc.client5.http.impl.classic.HttpClientBuilder apacheBuilder =
+    org.apache.hc.client5.http.impl.classic.HttpClientBuilder.create();
+apacheBuilder.setConnectTimeout(30_000, java.util.concurrent.TimeUnit.MILLISECONDS);
+apacheBuilder.setDefaultSocketConfig(
+    org.apache.hc.client5.http.config.SocketConfig.custom()
+        .setSoTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+        .build());
+
+ApacheHttpClientBuilder httpClientBuilder = ApacheHttpClient.builder()
+    .httpClientBuilder(apacheBuilder)
+    .build();
+```
+
+##### JDK HttpClient
+
+```java
+java.net.http.HttpClient.Builder jdkBuilder = java.net.http.HttpClient.newBuilder()
+    .connectTimeout(Duration.ofSeconds(30))
+    .timeout(Duration.ofSeconds(60));
+
+JdkHttpClientBuilder httpClientBuilder = JdkHttpClient.builder()
+    .httpClientBuilder(jdkBuilder)
+    .build();
+```
+
+##### Spring RestClient
+
+```java
+RestClient.Builder restBuilder = RestClient.builder()
+    .requestConfigurer(request -> {
+        RequestConfig config = RequestConfig.custom()
+            .setConnectTimeout(30_000, java.util.concurrent.TimeUnit.MILLISECONDS)
+            .setSocketTimeout(60_000, java.util.concurrent.TimeUnit.MILLISECONDS)
+            .build();
+        request.setConfig(config);
+    });
+
+SpringRestClientBuilder httpClientBuilder = SpringRestClient.builder()
+    .restClientBuilder(restBuilder)
+    .build();
+```
+
+#### Deprecated builder methods
+
+The following methods on `HttpClientBuilder` are deprecated as of 2.0 (for removal):
+- `HttpClientBuilder.connectTimeout(Duration)` — configure on underlying client instead
+- `HttpClientBuilder.readTimeout(Duration)` — configure on underlying client instead
+- `HttpClientBuilder.connectTimeout()` — getter, no longer needed
+- `HttpClientBuilder.readTimeout()` — getter, no longer needed
+
+These methods are kept for backward source compatibility but will be removed in a future version.
 
 ## Customizing JDK's `HttpClient`
 

--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClientBuilder.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClientBuilder.java
@@ -3,6 +3,12 @@ package dev.langchain4j.http.client.apache;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import java.time.Duration;
 
+/**
+ * @deprecated as of 2.0. Timeout configuration should be performed on the underlying
+ * Apache {@code HttpClientBuilder} directly. This class now stores the timeout values
+ * only for backward compatibility and logs a deprecation warning when used.
+ */
+@Deprecated(forRemoval = true)
 public class ApacheHttpClientBuilder implements HttpClientBuilder {
 
     private org.apache.hc.client5.http.impl.classic.HttpClientBuilder httpClientBuilder;
@@ -31,29 +37,45 @@ public class ApacheHttpClientBuilder implements HttpClientBuilder {
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public Duration connectTimeout() {
         return connectTimeout;
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public ApacheHttpClientBuilder connectTimeout(Duration connectTimeout) {
+        System.err.println("[DEPRECATION] HttpClientBuilder.connectTimeout(Duration) is deprecated. Set timeout on the underlying HttpClientBuilder.");
         this.connectTimeout = connectTimeout;
         return this;
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public Duration readTimeout() {
         return readTimeout;
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public ApacheHttpClientBuilder readTimeout(Duration readTimeout) {
+        System.err.println("[DEPRECATION] HttpClientBuilder.readTimeout(Duration) is deprecated. Set timeout on the underlying HttpClientBuilder.");
         this.readTimeout = readTimeout;
         return this;
     }
 
     @Override
     public ApacheHttpClient build() {
+        // Apply stored timeouts to the underlying builder for backward compatibility
+        if (connectTimeout != null && httpClientBuilder != null) {
+            httpClientBuilder.setConnectionTimeToLive(connectTimeout.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+        }
+        if (readTimeout != null && httpClientBuilder != null) {
+            // Apache HttpClient does not have a direct read timeout; we set socket timeout
+            httpClientBuilder.setDefaultSocketConfig(org.apache.hc.client5.http.config.SocketConfig.custom()
+                    .setSoTimeout(readTimeout)
+                    .build());
+        }
         return new ApacheHttpClient(this);
     }
 }

--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
@@ -30,11 +30,9 @@ public class JdkHttpClient implements HttpClient {
     private final Duration readTimeout;
 
     public JdkHttpClient(JdkHttpClientBuilder builder) {
+        // Timeouts are applied by JdkHttpClientBuilder.build() on the underlying builder.
         java.net.http.HttpClient.Builder httpClientBuilder =
                 getOrDefault(builder.httpClientBuilder(), java.net.http.HttpClient::newBuilder);
-        if (builder.connectTimeout() != null) {
-            httpClientBuilder.connectTimeout(builder.connectTimeout());
-        }
         this.delegate = httpClientBuilder.build();
         this.readTimeout = builder.readTimeout();
     }

--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClientBuilder.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClientBuilder.java
@@ -1,10 +1,19 @@
 package dev.langchain4j.http.client.jdk;
 
 import dev.langchain4j.http.client.HttpClientBuilder;
-
 import java.time.Duration;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+/**
+ * @deprecated as of 2.0. Timeout configuration should be performed on the underlying
+ * {@code HttpClient.Builder} directly. This class now stores the timeout values only
+ * for backward compatibility and logs a deprecation warning when used.
+ */
+@Deprecated(forRemoval = true)
 public class JdkHttpClientBuilder implements HttpClientBuilder {
+
+    private static final Logger logger = Logger.getLogger(JdkHttpClientBuilder.class.getName());
 
     private java.net.http.HttpClient.Builder httpClientBuilder;
     private Duration connectTimeout;
@@ -20,29 +29,42 @@ public class JdkHttpClientBuilder implements HttpClientBuilder {
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public Duration connectTimeout() {
         return connectTimeout;
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public JdkHttpClientBuilder connectTimeout(Duration connectTimeout) {
+        logger.warning("[DEPRECATION] HttpClientBuilder.connectTimeout(Duration) is deprecated. Set timeout on the underlying HttpClient.Builder.");
         this.connectTimeout = connectTimeout;
         return this;
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public Duration readTimeout() {
         return readTimeout;
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public JdkHttpClientBuilder readTimeout(Duration readTimeout) {
+        logger.warning("[DEPRECATION] HttpClientBuilder.readTimeout(Duration) is deprecated. Set timeout on the underlying HttpClient.Builder.");
         this.readTimeout = readTimeout;
         return this;
     }
 
     @Override
     public JdkHttpClient build() {
+        // Apply stored timeouts to the underlying builder for backward compatibility
+        if (httpClientBuilder == null) {
+            httpClientBuilder = java.net.http.HttpClient.newBuilder();
+        }
+        if (connectTimeout != null) {
+            httpClientBuilder.connectTimeout(connectTimeout);
+        }
         return new JdkHttpClient(this);
     }
 }

--- a/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
@@ -32,16 +32,10 @@ public class OkHttpClient implements HttpClient {
     private final okhttp3.OkHttpClient client;
 
     public OkHttpClient(OkHttpClientBuilder builder) {
+        // Timeouts are applied by OkHttpClientBuilder.build() on the underlying builder.
+        // OkHttpClient now uses the pre-configured okHttpClientBuilder.
         okhttp3.OkHttpClient.Builder okBuilder =
                 getOrDefault(builder.okHttpClientBuilder(), okhttp3.OkHttpClient.Builder::new);
-
-        if (builder.connectTimeout() != null) {
-            okBuilder.connectTimeout(builder.connectTimeout().toMillis(), TimeUnit.MILLISECONDS);
-        }
-        if (builder.readTimeout() != null) {
-            okBuilder.readTimeout(builder.readTimeout().toMillis(), TimeUnit.MILLISECONDS);
-        }
-
         this.client = okBuilder.build();
     }
 

--- a/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClientBuilder.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClientBuilder.java
@@ -3,6 +3,12 @@ package dev.langchain4j.http.client.okhttp;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import java.time.Duration;
 
+/**
+ * @deprecated as of 2.0. Timeout configuration should be performed on the underlying
+ * OkHttp {@code OkHttpClient.Builder} directly. This class now stores the timeout values
+ * only for backward compatibility and logs a deprecation warning when used.
+ */
+@Deprecated(forRemoval = true)
 public class OkHttpClientBuilder implements HttpClientBuilder {
 
     private okhttp3.OkHttpClient.Builder okHttpClientBuilder;
@@ -19,29 +25,45 @@ public class OkHttpClientBuilder implements HttpClientBuilder {
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public Duration connectTimeout() {
         return connectTimeout;
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public OkHttpClientBuilder connectTimeout(Duration connectTimeout) {
+        System.err.println("[DEPRECATION] HttpClientBuilder.connectTimeout(Duration) is deprecated. Set timeout on the underlying OkHttpClient.Builder.");
         this.connectTimeout = connectTimeout;
         return this;
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public Duration readTimeout() {
         return readTimeout;
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public OkHttpClientBuilder readTimeout(Duration readTimeout) {
+        System.err.println("[DEPRECATION] HttpClientBuilder.readTimeout(Duration) is deprecated. Set timeout on the underlying OkHttpClient.Builder.");
         this.readTimeout = readTimeout;
         return this;
     }
 
     @Override
     public OkHttpClient build() {
+        // Apply stored timeouts to the underlying builder for backward compatibility
+        if (okHttpClientBuilder == null) {
+            okHttpClientBuilder = new okhttp3.OkHttpClient.Builder();
+        }
+        if (connectTimeout != null) {
+            okHttpClientBuilder.connectTimeout(connectTimeout.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+        }
+        if (readTimeout != null) {
+            okHttpClientBuilder.readTimeout(readTimeout.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+        }
         return new OkHttpClient(this);
     }
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
@@ -159,9 +159,6 @@ public class DefaultAnthropicClient extends AnthropicClient {
     /**
      * Constructs a new {@link DefaultAnthropicClient} using the provided builder configuration.
      *
-     * <p>Initializes the HTTP client with configured timeouts (defaulting to 15s connect, 60s read)
-     * and optionally wraps it with {@link LoggingHttpClient} if request/response logging is enabled.</p>
-     *
      * @param builder the builder containing configuration parameters
      * @throws IllegalArgumentException if {@code baseUrl}, {@code apiKey}, or {@code version} are blank
      */
@@ -170,12 +167,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
         HttpClientBuilder httpClientBuilder =
                 getOrDefault(builder.httpClientBuilder, HttpClientBuilderLoader::loadHttpClientBuilder);
 
-        HttpClient httpClient = httpClientBuilder
-                .connectTimeout(getOrDefault(
-                        getOrDefault(builder.timeout, httpClientBuilder.connectTimeout()), Duration.ofSeconds(15)))
-                .readTimeout(getOrDefault(
-                        getOrDefault(builder.timeout, httpClientBuilder.readTimeout()), Duration.ofSeconds(60)))
-                .build();
+        HttpClient httpClient = httpClientBuilder.build();
 
         if (builder.logRequests != null && builder.logRequests
                 || builder.logResponses != null && builder.logResponses) {

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClientBuilder.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClientBuilder.java
@@ -2,14 +2,45 @@ package dev.langchain4j.http.client;
 
 import java.time.Duration;
 
+/**
+ * Builder for {@link HttpClient} instances.
+ * <p>
+ * Note: {@code connectTimeout} and {@code readTimeout} settings on this builder
+ * are deprecated as of 2.0. Timeouts should be configured directly on the
+ * underlying HTTP client. Some HTTP clients (e.g. Spring's {@code RestClient.Builder})
+ * do not support customizing timeouts without overriding other properties.
+ * <p>
+ * To set timeouts, configure them on your underlying HTTP client:
+ * <ul>
+ *   <li>OkHttp: {@code new OkHttpClient.Builder().connectTimeout(...).readTimeout(...)}</li>
+ *   <li>Apache HttpClient: configure via {@code RequestConfig}</li>
+ *   <li>JDK HttpClient: {@code HttpClient.newBuilder().connectTimeout(...).timeout(...)}</li>
+ * </ul>
+ */
 public interface HttpClientBuilder {
 
+    /**
+     * @deprecated as of 2.0. Configure connect timeout on the underlying HTTP client instead.
+     */
+    @Deprecated(forRemoval = true)
     Duration connectTimeout();
 
+    /**
+     * @deprecated as of 2.0. Configure connect timeout on the underlying HTTP client instead.
+     */
+    @Deprecated(forRemoval = true)
     HttpClientBuilder connectTimeout(Duration timeout);
 
+    /**
+     * @deprecated as of 2.0. Configure read timeout on the underlying HTTP client instead.
+     */
+    @Deprecated(forRemoval = true)
     Duration readTimeout();
 
+    /**
+     * @deprecated as of 2.0. Configure read timeout on the underlying HTTP client instead.
+     */
+    @Deprecated(forRemoval = true)
     HttpClientBuilder readTimeout(Duration timeout);
 
     HttpClient build();

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
@@ -45,12 +45,7 @@ public class DefaultMistralAiClient extends MistralAiClient {
         HttpClientBuilder httpClientBuilder =
                 getOrDefault(builder.httpClientBuilder, HttpClientBuilderLoader::loadHttpClientBuilder);
 
-        HttpClient httpClient = httpClientBuilder
-                .connectTimeout(getOrDefault(
-                        getOrDefault(builder.timeout, httpClientBuilder.connectTimeout()), Duration.ofSeconds(15)))
-                .readTimeout(getOrDefault(
-                        getOrDefault(builder.timeout, httpClientBuilder.readTimeout()), Duration.ofSeconds(60)))
-                .build();
+        HttpClient httpClient = httpClientBuilder.build();
 
         if (builder.logRequests != null && builder.logRequests
                 || builder.logResponses != null && builder.logResponses) {

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
@@ -57,12 +57,7 @@ class OllamaClient {
         HttpClientBuilder httpClientBuilder =
                 getOrDefault(builder.httpClientBuilder, HttpClientBuilderLoader::loadHttpClientBuilder);
 
-        HttpClient httpClient = httpClientBuilder
-                .connectTimeout(
-                        getOrDefault(getOrDefault(builder.timeout, httpClientBuilder.connectTimeout()), ofSeconds(15)))
-                .readTimeout(
-                        getOrDefault(getOrDefault(builder.timeout, httpClientBuilder.readTimeout()), ofSeconds(60)))
-                .build();
+        HttpClient httpClient = httpClientBuilder.build();
 
         if (builder.logRequests || builder.logResponses) {
             this.httpClient =
@@ -325,8 +320,6 @@ class OllamaClient {
         /**
          * Sets the {@link HttpClientBuilder} that will be used to create the {@link HttpClient}
          * that will be used to communicate with Ollama.
-         * <p>
-         * NOTE: {@link #timeout(Duration)} overrides timeouts set on the {@link HttpClientBuilder}.
          */
         Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
             this.httpClientBuilder = httpClientBuilder;
@@ -338,6 +331,10 @@ class OllamaClient {
             return this;
         }
 
+        /**
+         * @deprecated as of 2.0. Configure timeouts directly on the {@link HttpClientBuilder} instead.
+         */
+        @Deprecated(forRemoval = true)
         Builder timeout(Duration timeout) {
             this.timeout = timeout;
             return this;

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/DefaultOpenAiClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/DefaultOpenAiClient.java
@@ -43,12 +43,7 @@ public class DefaultOpenAiClient extends OpenAiClient {
         HttpClientBuilder httpClientBuilder =
                 getOrDefault(builder.httpClientBuilder, HttpClientBuilderLoader::loadHttpClientBuilder);
 
-        HttpClient httpClient = httpClientBuilder
-                .connectTimeout(getOrDefault(
-                        getOrDefault(builder.connectTimeout, httpClientBuilder.connectTimeout()), ofSeconds(15)))
-                .readTimeout(
-                        getOrDefault(getOrDefault(builder.readTimeout, httpClientBuilder.readTimeout()), ofSeconds(60)))
-                .build();
+        HttpClient httpClient = httpClientBuilder.build();
 
         if (builder.logRequests || builder.logResponses) {
             this.httpClient =

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiClient.java
@@ -113,11 +113,19 @@ public abstract class OpenAiClient {
             return (B) this;
         }
 
+        /**
+         * @deprecated as of 2.0. Configure connect timeout on the underlying HTTP client builder instead.
+         */
+        @Deprecated(forRemoval = true)
         public B connectTimeout(Duration connectTimeout) {
             this.connectTimeout = connectTimeout;
             return (B) this;
         }
 
+        /**
+         * @deprecated as of 2.0. Configure read timeout on the underlying HTTP client builder instead.
+         */
+        @Deprecated(forRemoval = true)
         public B readTimeout(Duration readTimeout) {
             this.readTimeout = readTimeout;
             return (B) this;

--- a/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiClient.java
+++ b/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiClient.java
@@ -34,12 +34,7 @@ class VoyageAiClient {
         HttpClientBuilder httpClientBuilder =
                 getOrDefault(builder.httpClientBuilder, HttpClientBuilderLoader::loadHttpClientBuilder);
 
-        HttpClient httpClient = httpClientBuilder
-                .connectTimeout(
-                        getOrDefault(getOrDefault(builder.timeout, httpClientBuilder.connectTimeout()), ofSeconds(15)))
-                .readTimeout(
-                        getOrDefault(getOrDefault(builder.timeout, httpClientBuilder.readTimeout()), ofSeconds(60)))
-                .build();
+        HttpClient httpClient = httpClientBuilder.build();
 
         if (builder.logRequests != null && builder.logRequests
                 || builder.logResponses != null && builder.logResponses) {


### PR DESCRIPTION
## Summary

Addresses #4926: Move `connectTimeout`/`readTimeout` from `HttpClientBuilder` to the underlying HTTP client layer.

### Changes

- `HttpClientBuilder` interface: Marked timeout methods as `@Deprecated(forRemoval = true)` with Javadoc guidance.
- Concrete builders: Added deprecation annotations and warnings; stored timeouts applied in `build()` for backward compatibility.
- ChatModel clients: Removed calls to timeout setters on `HttpClientBuilder`; now call only `.build()`.
- OpenAI/Ollama builders: Added `@Deprecated(forRemoval = true)` to timeout builder methods.

### Migration guide

Updated `docs/docs/tutorials/customizable-http-client.md` with a migration section covering OkHttp, Apache, JDK, and Spring RestClient timeout configuration.

Closes #4926