### PR TITLE
OpenAI: guard against empty choices in ChatCompletionResponse

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.openai;
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.model.ModelProvider.OPEN_AI;
 import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_OPENAI_URL;
@@ -31,6 +32,7 @@ import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.openai.internal.OpenAiClient;
 import dev.langchain4j.model.openai.internal.ParsedAndRawResponse;
+import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
 import dev.langchain4j.model.openai.spi.OpenAiChatModelBuilderFactory;
@@ -158,16 +160,22 @@ public class OpenAiChatModel implements ChatModel {
 
         ChatCompletionResponse openAiResponse = parsedAndRawResponse.parsedResponse();
 
+        if (isNullOrEmpty(openAiResponse.choices())) {
+            throw new IllegalArgumentException("OpenAI response contains no choices. "
+                    + "This can happen on content filtering, quota errors, or malformed upstream responses.");
+        }
+        ChatCompletionChoice firstChoice = openAiResponse.choices().get(0);
+
         OpenAiChatResponseMetadata responseMetadata = OpenAiChatResponseMetadata.builder()
                 .id(openAiResponse.id())
                 .modelName(openAiResponse.model())
                 .tokenUsage(tokenUsageFrom(openAiResponse.usage()))
-                .finishReason(finishReasonFrom(openAiResponse.choices().get(0).finishReason()))
+                .finishReason(finishReasonFrom(firstChoice.finishReason()))
                 .created(openAiResponse.created())
                 .serviceTier(openAiResponse.serviceTier())
                 .systemFingerprint(openAiResponse.systemFingerprint())
                 .rawHttpResponse(parsedAndRawResponse.rawHttpResponse())
-                .logProbs(logProbsFrom(openAiResponse.choices().get(0).logprobs()))
+                .logProbs(logProbsFrom(firstChoice.logprobs()))
                 .build();
 
         return ChatResponse.builder()

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
@@ -348,6 +348,10 @@ public class OpenAiUtils {
     }
 
     public static AiMessage aiMessageFrom(ChatCompletionResponse response, boolean returnThinking) {
+        if (isNullOrEmpty(response.choices())) {
+            throw illegalArgument("OpenAI response contains no choices. "
+                    + "This can happen on content filtering, quota errors, or malformed upstream responses.");
+        }
         AssistantMessage assistantMessage = response.choices().get(0).message();
 
         String refusal = assistantMessage.refusal();

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiChatModelErrorsTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiChatModelErrorsTest.java
@@ -16,8 +16,8 @@ import io.ktor.http.HttpStatusCode;
 import java.time.Duration;
 import java.util.stream.Stream;
 import me.kpavlov.aimocks.openai.MockOpenai;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -145,6 +145,31 @@ class OpenAiChatModelErrorsTest {
         assertThatThrownBy(() -> model.chat(userMessage))
                 .isExactlyInstanceOf(dev.langchain4j.exception.ContentFilteredException.class)
                 .hasMessage("I'm sorry, I cannot assist with that request.");
+    }
+
+    @Test
+    void should_throw_on_empty_choices() {
+
+        // given
+        final var userMessage = "empty choices";
+        MOCK.completion(req -> req.userMessageContains(userMessage)).respondsError(res -> {
+            res.setHttpStatus(HttpStatusCode.Companion.fromValue(200));
+            // language=json
+            res.setBody("""
+                    {
+                      "id": "chatcmpl-empty",
+                      "object": "chat.completion",
+                      "created": 1721596428,
+                      "model": "gpt-4o-2024-08-06",
+                      "choices": []
+                    }
+                    """);
+        });
+
+        // when-then
+        assertThatThrownBy(() -> model.chat(userMessage))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no choices");
     }
 
     @AfterEach

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/OpenAiUtilsTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/OpenAiUtilsTest.java
@@ -3,8 +3,10 @@ package dev.langchain4j.model.openai.internal;
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.aiMessageFrom;
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.toOpenAiToolChoice;
 import static dev.langchain4j.model.openai.internal.chat.ToolType.FUNCTION;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
@@ -245,5 +247,25 @@ class OpenAiUtilsTest {
         // then
         assertThat(aiMessage.text()).isNull();
         assertThat(aiMessage.toolExecutionRequests()).isEmpty();
+    }
+
+    @Test
+    void should_throw_when_choices_is_null() {
+        ChatCompletionResponse response =
+                ChatCompletionResponse.builder().choices(null).build();
+
+        assertThatThrownBy(() -> aiMessageFrom(response))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no choices");
+    }
+
+    @Test
+    void should_throw_when_choices_is_empty() {
+        ChatCompletionResponse response =
+                ChatCompletionResponse.builder().choices(emptyList()).build();
+
+        assertThatThrownBy(() -> aiMessageFrom(response))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no choices");
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesModerationTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesModerationTest.java
@@ -99,7 +99,9 @@ class AiServicesModerationTest {
                 .build();
 
         // when/then
-        assertThatThrownBy(() -> aiMessageFrom(response)).isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> aiMessageFrom(response))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no choices");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `OpenAiChatModel.doChat` and `OpenAiUtils.aiMessageFrom` dereferenced `choices().get(0)` without checking for null or empty lists, producing `NullPointerException` / `IndexOutOfBoundsException` on responses that contain no choices (content filtering, quota errors, malformed upstream responses).
- Added an explicit guard that throws `IllegalArgumentException` with a descriptive message, mirroring the guard already present in `OpenAiStreamingChatModel`.
- Cached `choices().get(0)` into a local `firstChoice` in `doChat` to avoid the duplicated dereference.

Fixes #4810.

## Test plan

- [x] New unit tests in `OpenAiUtilsTest` cover `choices == null` and `choices == []`.
- [x] New integration-style test in `OpenAiChatModelErrorsTest` uses `MockOpenai` to return a 200 with `"choices": []` and asserts `IllegalArgumentException`.
- [x] Full `langchain4j-open-ai` module suite passes: 137/137.
- [x] `spotless:apply` clean.