### PR TITLE
feat: add guardrailName() to GuardrailExecutedEvent and name() to Guardrail

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/Guardrail.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/Guardrail.java
@@ -19,4 +19,30 @@ public interface Guardrail<P extends GuardrailRequest, R extends GuardrailResult
      * @return The result of the validation
      */
     R validate(P request);
+
+    /**
+     * Returns the logical name of this guardrail, used for observability and reporting.
+     *
+     * <p>The default implementation returns the simple class name of the guardrail. Decorator or
+     * adapter implementations should override this method to return the name of the underlying
+     * guardrail they wrap, so that observability systems (e.g. {@code GuardrailExecutedEvent})
+     * correctly identify the logical guardrail rather than the wrapper.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * public class PromptInjectionGuardrailAdapter implements InputGuardrail {
+     *     private final PromptInjectionGuardrail delegate;
+     *
+     *     @Override
+     *     public String name() {
+     *         return delegate.name();
+     *     }
+     * }
+     * }</pre>
+     *
+     * @return the logical name of this guardrail; never {@code null}
+     */
+    default String name() {
+        return getClass().getSimpleName();
+    }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
@@ -45,6 +45,30 @@ public interface GuardrailExecutedEvent<
     Class<G> guardrailClass();
 
     /**
+     * Returns the logical name of the guardrail that was executed.
+     *
+     * <p>This is a convenience method for observability integrations (e.g. OpenInference
+     * {@code validator_name} attribute). The default implementation delegates to
+     * {@link Guardrail#name()}, which returns the simple class name. When guardrails are
+     * wrapped by adapters or decorators, the adapter should override {@link Guardrail#name()}
+     * to expose the underlying guardrail's name, so that this method correctly identifies
+     * the logical guardrail rather than the wrapper class.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * listener.onEvent(event -> {
+     *     // "PromptInjectionGuardrail" rather than "InputGuardrailAdapter"
+     *     String name = event.guardrailName();
+     * });
+     * }</pre>
+     *
+     * @return the logical name of the executed guardrail; never {@code null}
+     */
+    default String guardrailName() {
+        return guardrailClass().getSimpleName();
+    }
+
+    /**
      * Retrieves the duration of the guardrail execution.
      *
      * @return the duration of the guardrail validation process.


### PR DESCRIPTION
## Issue

Closes #4938

## Change

Adds two backward-compatible default methods to improve guardrail observability when guardrails are wrapped by adapters or decorators.

### `Guardrail.name()`

A new default method on the `Guardrail` interface that returns the logical name of the guardrail. The default implementation returns `getClass().getSimpleName()`. Decorator/adapter implementations should override this to expose the underlying guardrail's identity:

```java
public class PromptInjectionGuardrailAdapter implements InputGuardrail {
    private final PromptInjectionGuardrail delegate;

    @Override
    public String name() {
        return delegate.name(); // "PromptInjectionGuardrail", not "PromptInjectionGuardrailAdapter"
    }
}
```

### `GuardrailExecutedEvent.guardrailName()`

A new default method on `GuardrailExecutedEvent` for use in observability listeners (e.g. OpenInference `validator_name`). The default returns `guardrailClass().getSimpleName()`:

```java
// Before — when guardrails are wrapped, all executions report the adapter class:
event.guardrailClass().getSimpleName() // → "InputGuardrailAdapter"

// After — correctly reports the logical guardrail name:
event.guardrailName() // → "PromptInjectionGuardrail"
```

## Notes

- **Zero breaking changes** — both methods are `default` implementations on existing interfaces
- **Zero new dependencies** — uses only types already present in each interface
- Existing implementations of `Guardrail` and `GuardrailExecutedEvent` compile without modification
- Decorator pattern is supported: override `Guardrail.name()` in the wrapper, `guardrailName()` picks it up automatically