### PR TITLE
fix: PojoOutputParser includes inherited fields in format instructions

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
@@ -11,8 +11,10 @@ import dev.langchain4j.Internal;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.output.structured.Description;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -62,13 +64,8 @@ class PojoOutputParser<T> implements OutputParser<T> {
         StringBuilder jsonSchema = new StringBuilder();
 
         jsonSchema.append("{\n");
-        for (Field field : type.getDeclaredFields()) {
-            String name = field.getName();
-            if (name.equals("__$hits$__") || java.lang.reflect.Modifier.isStatic(field.getModifiers())) {
-                // Skip coverage instrumentation field.
-                continue;
-            }
-            jsonSchema.append(format("\"%s\": (%s),\n", name, descriptionFor(field, visited)));
+        for (Field field : allNonStaticFields(type)) {
+            jsonSchema.append(format("\"%s\": (%s),\n", field.getName(), descriptionFor(field, visited)));
         }
 
         int trailingCommaIndex = jsonSchema.lastIndexOf(",");
@@ -77,6 +74,26 @@ class PojoOutputParser<T> implements OutputParser<T> {
         }
         jsonSchema.append("}");
         return jsonSchema.toString();
+    }
+
+    private static List<Field> allNonStaticFields(Class<?> type) {
+        List<Field> fields = new ArrayList<>();
+        Set<String> seenNames = new HashSet<>();
+        Class<?> current = type;
+        while (current != null && current != Object.class) {
+            for (Field field : current.getDeclaredFields()) {
+                String name = field.getName();
+                if (name.equals("__$hits$__") || Modifier.isStatic(field.getModifiers())) {
+                    // Skip coverage instrumentation field.
+                    continue;
+                }
+                if (seenNames.add(name)) {
+                    fields.add(field);
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return fields;
     }
 
     private static String descriptionFor(Field field, Set<Class<?>> visited) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/PojoOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/PojoOutputParserTest.java
@@ -2,10 +2,53 @@ package dev.langchain4j.service.output;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.langchain4j.model.output.structured.Description;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class PojoOutputParserTest {
+
+    abstract static class Parent {
+        @Description("status")
+        String status;
+
+        String message;
+    }
+
+    static class Child extends Parent {
+        String payload;
+    }
+
+    static class GrandChild extends Child {
+        // shadow parent field; subclass value should win (and no duplicate entry)
+        String status;
+    }
+
+    @Test
+    void should_include_inherited_fields_in_format_instructions() {
+
+        PojoOutputParser<Child> parser = new PojoOutputParser<>(Child.class);
+
+        String formatInstructions = parser.formatInstructions();
+
+        assertThat(formatInstructions)
+                .contains("\"payload\":")
+                .contains("\"status\":")
+                .contains("\"message\":");
+    }
+
+    @Test
+    void should_not_duplicate_shadowed_fields() {
+
+        PojoOutputParser<GrandChild> parser = new PojoOutputParser<>(GrandChild.class);
+
+        String formatInstructions = parser.formatInstructions();
+
+        int firstStatus = formatInstructions.indexOf("\"status\":");
+        int lastStatus = formatInstructions.lastIndexOf("\"status\":");
+        assertThat(firstStatus).isGreaterThanOrEqualTo(0);
+        assertThat(firstStatus).isEqualTo(lastStatus);
+    }
 
     @Test
     void should_create_schema_for_enum_with_custom_toString() {


### PR DESCRIPTION
Closes #3186.

`PojoOutputParser.jsonStructure` used `type.getDeclaredFields()`, which skips fields inherited from superclasses. For a POJO whose fields all come from an abstract parent (e.g. `status`, `message` on a shared DTO base class), the generated JSON structure was `{}`, so `validateJsonStructure` threw `IllegalConfigurationException: Illegal method return type: ...`. Even when the subclass declared some fields of its own, inherited fields were silently omitted from the prompt sent to the LLM.

The fix walks the class hierarchy (stopping at `Object`) and collects all non-static declared fields, deduping by name so a shadowed field in a subclass wins over the parent's. Existing filters (`__$hits$__`, static) are preserved.

Two tests are added: one verifies inherited fields appear in `formatInstructions()`, one verifies that a field shadowed by a subclass appears only once.

Note: the schema path via `JsonSchemaElementUtils.jsonObjectOrReferenceSchemaFrom` has the same `getDeclaredFields()` limitation but is out of scope here since it is shared with tool-spec generation; #3515 / #3516 already address that path.