### PR TITLE
MCP: expose session id on StreamableHttpMcpTransport (#4757)

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -174,7 +174,7 @@ public class StreamableHttpMcpTransport implements McpTransport {
      * captured from the {@code Mcp-Session-Id} response header during initialization
      * and reused on subsequent requests via the same header.
      */
-    public String mcpSessionId() {
+    public String getMcpSessionId() {
         return mcpSessionId.get();
     }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/StreamableHttpMcpTransport.java
@@ -168,6 +168,26 @@ public class StreamableHttpMcpTransport implements McpTransport {
         this.onFailureCallback = actionOnFailure;
     }
 
+    /**
+     * Returns the MCP session ID assigned by the server, or {@code null} if no session
+     * has been established yet (or the server does not use sessions). The session ID is
+     * captured from the {@code Mcp-Session-Id} response header during initialization
+     * and reused on subsequent requests via the same header.
+     */
+    public String mcpSessionId() {
+        return mcpSessionId.get();
+    }
+
+    /**
+     * Sets the MCP session ID to be sent on subsequent requests via the
+     * {@code Mcp-Session-Id} header. This is intended for scenarios where a session
+     * obtained elsewhere (for example, in another process or pod) needs to be resumed
+     * by this transport, allowing stateless deployments without sticky sessions.
+     */
+    public void setMcpSessionId(String mcpSessionId) {
+        this.mcpSessionId.set(mcpSessionId);
+    }
+
     private CompletableFuture<JsonNode> execute(McpCallContext context, boolean isRetry) {
         Long id = context.message().getId();
         if (!(context.message() instanceof McpInitializeRequest)) {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
@@ -64,7 +64,7 @@ class StreamableHttpMcpTransportTest {
         StreamableHttpMcpTransport transport =
                 StreamableHttpMcpTransport.builder().url("http://localhost/mcp").build();
 
-        assertThat(transport.mcpSessionId()).isNull();
+        assertThat(transport.getMcpSessionId()).isNull();
     }
 
     @Test
@@ -73,10 +73,10 @@ class StreamableHttpMcpTransportTest {
                 StreamableHttpMcpTransport.builder().url("http://localhost/mcp").build();
 
         transport.setMcpSessionId("session-123");
-        assertThat(transport.mcpSessionId()).isEqualTo("session-123");
+        assertThat(transport.getMcpSessionId()).isEqualTo("session-123");
 
         transport.setMcpSessionId(null);
-        assertThat(transport.mcpSessionId()).isNull();
+        assertThat(transport.getMcpSessionId()).isNull();
     }
 
     private static SSLContext extractSslContext(StreamableHttpMcpTransport transport) throws Exception {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/StreamableHttpMcpTransportTest.java
@@ -59,6 +59,26 @@ class StreamableHttpMcpTransportTest {
         assertThat(extractHttpClient(transport).version()).isEqualTo(HttpClient.Version.HTTP_1_1);
     }
 
+    @Test
+    void mcpSessionIdShouldBeNullByDefault() {
+        StreamableHttpMcpTransport transport =
+                StreamableHttpMcpTransport.builder().url("http://localhost/mcp").build();
+
+        assertThat(transport.mcpSessionId()).isNull();
+    }
+
+    @Test
+    void shouldExposeAndAcceptMcpSessionId() {
+        StreamableHttpMcpTransport transport =
+                StreamableHttpMcpTransport.builder().url("http://localhost/mcp").build();
+
+        transport.setMcpSessionId("session-123");
+        assertThat(transport.mcpSessionId()).isEqualTo("session-123");
+
+        transport.setMcpSessionId(null);
+        assertThat(transport.mcpSessionId()).isNull();
+    }
+
     private static SSLContext extractSslContext(StreamableHttpMcpTransport transport) throws Exception {
         Field field = StreamableHttpMcpTransport.class.getDeclaredField("sslContext");
         field.setAccessible(true);


### PR DESCRIPTION
## Summary
- Add `mcpSessionId()` getter and `setMcpSessionId(String)` setter to `StreamableHttpMcpTransport`, allowing callers to read the server-assigned session ID and inject one obtained elsewhere (e.g. from another pod) for stateless deployments without sticky sessions.

Closes #4757.

## Test plan
- [x] New unit tests in `StreamableHttpMcpTransportTest` cover the default-null state and getter/setter round-trip
- [x] `mvn -pl langchain4j-mcp test -Dtest=StreamableHttpMcpTransportTest` passes (7/7)