### PR TITLE
PgVector: parenthesize isNotIn/isNotEqualTo to fix AND/OR precedence (#2513)

### DIFF
--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorFilterMapper.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorFilterMapper.java
@@ -73,7 +73,7 @@ abstract class PgVectorFilterMapper {
     private String mapNotEqual(IsNotEqualTo isNotEqualTo) {
         String key =
                 formatKey(isNotEqualTo.key(), isNotEqualTo.comparisonValue().getClass());
-        return format("%s is null or %s != %s", key, key, formatValue(isNotEqualTo.comparisonValue()));
+        return format("(%s is null or %s != %s)", key, key, formatValue(isNotEqualTo.comparisonValue()));
     }
 
     private String mapGreaterThan(IsGreaterThan isGreaterThan) {
@@ -114,7 +114,7 @@ abstract class PgVectorFilterMapper {
 
     private String mapNotIn(IsNotIn isNotIn) {
         String key = formatKeyAsString(isNotIn.key());
-        return format("%s is null or %s not in %s", key, key, formatValuesAsString(isNotIn.comparisonValues()));
+        return format("(%s is null or %s not in %s)", key, key, formatValuesAsString(isNotIn.comparisonValues()));
     }
 
     private String mapAnd(And and) {

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorFilterMapperTest.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorFilterMapperTest.java
@@ -1,0 +1,73 @@
+package dev.langchain4j.store.embedding.pgvector;
+
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.store.embedding.filter.Filter;
+import org.junit.jupiter.api.Test;
+
+class PgVectorFilterMapperTest {
+
+    private final JSONFilterMapper jsonMapper = new JSONFilterMapper("metadata");
+    private final ColumnFilterMapper columnMapper = new ColumnFilterMapper();
+
+    @Test
+    void mapNotEqual_shouldWrapNullCheckInParentheses_jsonMapper() {
+        Filter filter = metadataKey("id").isNotEqualTo("A");
+
+        String sql = jsonMapper.map(filter);
+
+        assertThat(sql).isEqualTo("((metadata->>'id')::text is null or (metadata->>'id')::text != 'A')");
+    }
+
+    @Test
+    void mapNotIn_shouldWrapNullCheckInParentheses_jsonMapper() {
+        Filter filter = metadataKey("id").isNotIn("A", "B", "C");
+
+        String sql = jsonMapper.map(filter);
+
+        assertThat(sql).isEqualTo("(metadata->>'id' is null or metadata->>'id' not in ('A','B','C'))");
+    }
+
+    @Test
+    void mapNotEqual_shouldWrapNullCheckInParentheses_columnMapper() {
+        Filter filter = metadataKey("id").isNotEqualTo("A");
+
+        String sql = columnMapper.map(filter);
+
+        assertThat(sql).isEqualTo("(id::text is null or id::text != 'A')");
+    }
+
+    @Test
+    void mapNotIn_shouldWrapNullCheckInParentheses_columnMapper() {
+        Filter filter = metadataKey("id").isNotIn("A", "B", "C");
+
+        String sql = columnMapper.map(filter);
+
+        assertThat(sql).isEqualTo("(id is null or id not in ('A','B','C'))");
+    }
+
+    @Test
+    void notIn_combinedWithAnd_shouldPreserveAndPrecedence() {
+        Filter filter =
+                metadataKey("type").isEqualTo("user").and(metadataKey("id").isNotIn("A", "B"));
+
+        String sql = jsonMapper.map(filter);
+
+        assertThat(sql)
+                .isEqualTo(
+                        "(metadata->>'type')::text is not null and (metadata->>'type')::text = 'user' and (metadata->>'id' is null or metadata->>'id' not in ('A','B'))");
+    }
+
+    @Test
+    void notEqual_combinedWithAnd_shouldPreserveAndPrecedence() {
+        Filter filter =
+                metadataKey("type").isEqualTo("user").and(metadataKey("id").isNotEqualTo("A"));
+
+        String sql = jsonMapper.map(filter);
+
+        assertThat(sql)
+                .isEqualTo(
+                        "(metadata->>'type')::text is not null and (metadata->>'type')::text = 'user' and ((metadata->>'id')::text is null or (metadata->>'id')::text != 'A')");
+    }
+}


### PR DESCRIPTION
## Summary
- Wrap the `is null or ...` clauses produced by `mapNotIn` and `mapNotEqual` in parentheses. Without them, `someFilter.and(metadataKey("id").isNotIn(...))` rendered as `something AND id is null OR id not in (...)`, which SQL parses as `(something AND id is null) OR (id not in (...))` — silently matching rows that should be filtered out.
- Matches the parenthesization already used in `MariaDbFilterMapper`.

Closes #2513.

## Test plan
- [x] New `PgVectorFilterMapperTest` asserts the parens for both `JSONFilterMapper` and `ColumnFilterMapper`, and that AND-combined queries keep correct precedence
- [x] `mvn -pl langchain4j-pgvector test` passes (10/10 unit tests)