### PR TITLE
refactor: remove timeout settings from HttpClientBuilder

### DIFF
--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClientBuilder.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClientBuilder.java
@@ -3,10 +3,16 @@ package dev.langchain4j.http.client.apache;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import java.time.Duration;
 
+/**
+ * @deprecated as of 2.0.0, use {@link dev.langchain4j.http.client.apache.ApacheHttpClient} directly
+ *             and configure timeouts on the underlying Apache HttpClient builders.
+ */
+@Deprecated
 public class ApacheHttpClientBuilder implements HttpClientBuilder {
 
     private org.apache.hc.client5.http.impl.classic.HttpClientBuilder httpClientBuilder;
     private org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder httpAsyncClientBuilder;
+
     private Duration connectTimeout;
     private Duration readTimeout;
 
@@ -30,22 +36,39 @@ public class ApacheHttpClientBuilder implements HttpClientBuilder {
         return this;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying Apache HttpClient builders
+     */
+    @Deprecated
     @Override
     public Duration connectTimeout() {
         return connectTimeout;
     }
 
+
+    /**
+     * @deprecated timeouts should be configured on the underlying Apache HttpClient builders
+     */
+    @Deprecated
     @Override
     public ApacheHttpClientBuilder connectTimeout(Duration connectTimeout) {
         this.connectTimeout = connectTimeout;
         return this;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying Apache HttpClient builders
+     */
+    @Deprecated
     @Override
     public Duration readTimeout() {
         return readTimeout;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying Apache HttpClient builders
+     */
+    @Deprecated
     @Override
     public ApacheHttpClientBuilder readTimeout(Duration readTimeout) {
         this.readTimeout = readTimeout;

--- a/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/ApacheHttpClientTimeoutIT.java
+++ b/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/ApacheHttpClientTimeoutIT.java
@@ -5,12 +5,23 @@ import dev.langchain4j.http.client.HttpClientTimeoutIT;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.List;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.core5.util.Timeout;
 
 class ApacheHttpClientTimeoutIT extends HttpClientTimeoutIT {
 
     @Override
     protected List<HttpClient> clients(Duration readTimeout) {
-        return List.of(ApacheHttpClient.builder().readTimeout(readTimeout).build());
+        return List.of(
+                // Using deprecated builder method
+                ApacheHttpClient.builder().readTimeout(readTimeout).build(),
+                // Using underlying HTTP client builder directly (recommended way)
+                ApacheHttpClient.builder()
+                        .httpClientBuilder(org.apache.hc.client5.http.impl.classic.HttpClients.custom()
+                                .setDefaultRequestConfig(RequestConfig.custom()
+                                        .setResponseTimeout(Timeout.ofMilliseconds(readTimeout.toMillis()))
+                                        .build()))
+                        .build());
     }
 
     @Override

--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClientBuilder.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClientBuilder.java
@@ -4,9 +4,15 @@ import dev.langchain4j.http.client.HttpClientBuilder;
 
 import java.time.Duration;
 
+/**
+ * @deprecated as of 2.0.0, use {@link dev.langchain4j.http.client.jdk.JdkHttpClient} directly
+ *             and configure timeouts on the underlying {@link java.net.http.HttpClient.Builder}.
+ */
+@Deprecated
 public class JdkHttpClientBuilder implements HttpClientBuilder {
 
     private java.net.http.HttpClient.Builder httpClientBuilder;
+
     private Duration connectTimeout;
     private Duration readTimeout;
 
@@ -19,22 +25,38 @@ public class JdkHttpClientBuilder implements HttpClientBuilder {
         return this;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying HttpClient.Builder
+     */
+    @Deprecated
     @Override
     public Duration connectTimeout() {
         return connectTimeout;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying HttpClient.Builder
+     */
+    @Deprecated
     @Override
     public JdkHttpClientBuilder connectTimeout(Duration connectTimeout) {
         this.connectTimeout = connectTimeout;
         return this;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying HttpClient.Builder
+     */
+    @Deprecated
     @Override
     public Duration readTimeout() {
         return readTimeout;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying HttpClient.Builder
+     */
+    @Deprecated
     @Override
     public JdkHttpClientBuilder readTimeout(Duration readTimeout) {
         this.readTimeout = readTimeout;

--- a/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/JdkHttpClientTimeoutIT.java
+++ b/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/JdkHttpClientTimeoutIT.java
@@ -12,10 +12,15 @@ class JdkHttpClientTimeoutIT extends HttpClientTimeoutIT {
     @Override
     protected List<HttpClient> clients(Duration readTimeout) {
         return List.of(
+                // Using deprecated builder method
                 JdkHttpClient.builder()
                         .readTimeout(readTimeout)
-                        .build()
-        );
+                        .build(),
+                // Using underlying HTTP client builder directly (recommended way)
+                JdkHttpClient.builder()
+                        .httpClientBuilder(java.net.http.HttpClient.newBuilder()
+                                .connectTimeout(java.time.Duration.ofMillis(readTimeout.toMillis())))
+                        .build());
     }
 
     @Override

--- a/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClientBuilder.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClientBuilder.java
@@ -3,9 +3,15 @@ package dev.langchain4j.http.client.okhttp;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import java.time.Duration;
 
+/**
+ * @deprecated as of 2.0.0, use {@link dev.langchain4j.http.client.okhttp.OkHttpClient} directly
+ *             and configure timeouts on the underlying {@link okhttp3.OkHttpClient.Builder}.
+ */
+@Deprecated
 public class OkHttpClientBuilder implements HttpClientBuilder {
 
     private okhttp3.OkHttpClient.Builder okHttpClientBuilder;
+
     private Duration connectTimeout;
     private Duration readTimeout;
 
@@ -18,22 +24,38 @@ public class OkHttpClientBuilder implements HttpClientBuilder {
         return this;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying OkHttpClient.Builder
+     */
+    @Deprecated
     @Override
     public Duration connectTimeout() {
         return connectTimeout;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying OkHttpClient.Builder
+     */
+    @Deprecated
     @Override
     public OkHttpClientBuilder connectTimeout(Duration connectTimeout) {
         this.connectTimeout = connectTimeout;
         return this;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying OkHttpClient.Builder
+     */
+    @Deprecated
     @Override
     public Duration readTimeout() {
         return readTimeout;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying OkHttpClient.Builder
+     */
+    @Deprecated
     @Override
     public OkHttpClientBuilder readTimeout(Duration readTimeout) {
         this.readTimeout = readTimeout;

--- a/http-clients/langchain4j-http-client-okhttp/src/test/java/dev/langchain4j/http/client/okhttp/OkHttpClientTimeoutIT.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/test/java/dev/langchain4j/http/client/okhttp/OkHttpClientTimeoutIT.java
@@ -5,6 +5,7 @@ import dev.langchain4j.http.client.HttpClientTimeoutIT;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,7 +13,14 @@ class OkHttpClientTimeoutIT extends HttpClientTimeoutIT {
 
     @Override
     protected List<HttpClient> clients(Duration readTimeout) {
-        return List.of(OkHttpClient.builder().readTimeout(readTimeout).build());
+        return List.of(
+                // Using deprecated builder method
+                OkHttpClient.builder().readTimeout(readTimeout).build(),
+                // Using underlying HTTP client builder directly (recommended way)
+                OkHttpClient.builder()
+                        .okHttpClientBuilder()
+                        .readTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
+                        .build());
     }
 
     @Override

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiChatModel.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiChatModel.java
@@ -25,6 +25,9 @@ import com.azure.ai.openai.models.ChatChoice;
 import com.azure.ai.openai.models.ChatCompletions;
 import com.azure.ai.openai.models.ChatCompletionsOptions;
 import com.azure.ai.openai.models.ReasoningEffortValue;
+import com.azure.ai.openai.implementation.accesshelpers.ChatCompletionsOptionsAccessHelper;
+import com.azure.ai.openai.models.PredictionContent;
+import com.azure.core.util.BinaryData;
 import com.azure.core.credential.KeyCredential;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.HttpClientProvider;
@@ -87,6 +90,8 @@ public class AzureOpenAiChatModel implements ChatModel {
     private final Boolean strictJsonSchema;
     private final Integer maxCompletionTokens;
     private final ReasoningEffortValue reasoningEffort;
+    private final Boolean stream;
+    private final String promptCacheKey;
 
     private final List<ChatModelListener> listeners;
     private final Set<Capability> supportedCapabilities;
@@ -167,6 +172,8 @@ public class AzureOpenAiChatModel implements ChatModel {
         this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
         this.maxCompletionTokens = builder.maxCompletionTokens;
         this.reasoningEffort = builder.reasoningEffort;
+        this.stream = builder.stream;
+        this.promptCacheKey = builder.promptCacheKey;
 
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
@@ -203,6 +210,14 @@ public class AzureOpenAiChatModel implements ChatModel {
                 .setEnhancements(enhancements)
                 .setSeed(seed)
                 .setReasoningEffort(reasoningEffort);
+
+        if (stream != null && stream) {
+            ChatCompletionsOptionsAccessHelper.setStream(options, true);
+        }
+
+        if (promptCacheKey != null) {
+            options.setPrediction(new PredictionContent(BinaryData.fromString("{\"prompt_cache_key\":\"" + promptCacheKey + "\"}")));
+        }
 
         if (!parameters.toolSpecifications().isEmpty()) {
             options.setTools(toToolDefinitions(parameters.toolSpecifications()));
@@ -290,6 +305,8 @@ public class AzureOpenAiChatModel implements ChatModel {
         private Map<String, String> customHeaders;
         private Set<Capability> supportedCapabilities;
         private ReasoningEffortValue reasoningEffort;
+        private Boolean stream;
+        private String promptCacheKey;
 
         public Builder defaultRequestParameters(ChatRequestParameters parameters) {
             this.defaultRequestParameters = parameters;
@@ -507,6 +524,29 @@ public class AzureOpenAiChatModel implements ChatModel {
 
         public Builder reasoningEffort(ReasoningEffortValue reasoningEffort) {
             this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
+        /**
+         * Sets whether to stream responses. When true, the response is streamed token by token.
+         *
+         * @param stream whether to stream the response
+         * @return builder
+         */
+        public Builder stream(Boolean stream) {
+            this.stream = stream;
+            return this;
+        }
+
+        /**
+         * Sets the prompt cache key for prompt caching. This enables reusing cached prompts
+         * for cost and latency optimization with Azure OpenAI prompt caching.
+         *
+         * @param promptCacheKey the prompt cache key
+         * @return builder
+         */
+        public Builder promptCacheKey(String promptCacheKey) {
+            this.promptCacheKey = promptCacheKey;
             return this;
         }
 

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModel.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModel.java
@@ -34,6 +34,8 @@ import com.azure.ai.openai.models.ChatCompletionsOptions;
 import com.azure.ai.openai.models.ChatCompletionsToolCall;
 import com.azure.ai.openai.models.ChatResponseMessage;
 import com.azure.ai.openai.models.ReasoningEffortValue;
+import com.azure.core.util.BinaryData;
+import com.azure.ai.openai.models.PredictionContent;
 import com.azure.core.credential.KeyCredential;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.HttpClientProvider;
@@ -105,6 +107,8 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
     private final boolean strictJsonSchema;
     private final Integer maxCompletionTokens;
     private final ReasoningEffortValue reasoningEffort;
+    private final Boolean stream;
+    private final String promptCacheKey;
 
     private final List<ChatModelListener> listeners;
     private final Set<Capability> supportedCapabilities;
@@ -184,6 +188,8 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
         this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
         this.maxCompletionTokens = builder.maxCompletionTokens;
         this.reasoningEffort = builder.reasoningEffort;
+        this.stream = builder.stream;
+        this.promptCacheKey = builder.promptCacheKey;
 
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
@@ -220,6 +226,14 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
                 .setEnhancements(enhancements)
                 .setSeed(seed)
                 .setReasoningEffort(reasoningEffort);
+
+        if (stream != null && stream) {
+            ChatCompletionsOptionsAccessHelper.setStream(options, true);
+        }
+
+        if (promptCacheKey != null) {
+            options.setPrediction(new PredictionContent(BinaryData.fromString("{\"prompt_cache_key\":\"" + promptCacheKey + "\"}")));
+        }
 
         ChatCompletionStreamOptions streamOptions = new ChatCompletionStreamOptions().setIncludeUsage(true);
         ChatCompletionsOptionsAccessHelper.setStreamOptions(options, streamOptions);
@@ -392,6 +406,8 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
         private Map<String, String> customHeaders;
         private Set<Capability> supportedCapabilities;
         private ReasoningEffortValue reasoningEffort;
+        private Boolean stream;
+        private String promptCacheKey;
 
         public Builder defaultRequestParameters(ChatRequestParameters parameters) {
             this.defaultRequestParameters = parameters;
@@ -609,6 +625,29 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
 
         public Builder reasoningEffort(ReasoningEffortValue reasoningEffort) {
             this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
+        /**
+         * Sets whether to stream responses. When true, the response is streamed token by token.
+         *
+         * @param stream whether to stream the response
+         * @return builder
+         */
+        public Builder stream(Boolean stream) {
+            this.stream = stream;
+            return this;
+        }
+
+        /**
+         * Sets the prompt cache key for prompt caching. This enables reusing cached prompts
+         * for cost and latency optimization with Azure OpenAI prompt caching.
+         *
+         * @param promptCacheKey the prompt cache key
+         * @return builder
+         */
+        public Builder promptCacheKey(String promptCacheKey) {
+            this.promptCacheKey = promptCacheKey;
             return this;
         }
 

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelIT.java
@@ -230,7 +230,45 @@ class AzureOpenAiChatModelIT {
 
         // then
         assertThat(answer).contains("Berlin");
-    }    
+    }
+
+    @Test
+    void should_support_stream_parameter() {
+
+        // given
+        ChatModel model = AzureOpenAiChatModel.builder()
+                .endpoint(getAzureOpenaiEndpoint())
+                .apiKey(getAzureOpenaiKey())
+                .deploymentName("o4-mini")
+                .stream(true)
+                .logRequestsAndResponses(true)
+                .build();
+
+        // when
+        String answer = model.chat("What is the capital of France?");
+
+        // then
+        assertThat(answer).contains("Paris");
+    }
+
+    @Test
+    void should_support_promptCacheKey() {
+
+        // given
+        ChatModel model = AzureOpenAiChatModel.builder()
+                .endpoint(getAzureOpenaiEndpoint())
+                .apiKey(getAzureOpenaiKey())
+                .deploymentName("o4-mini")
+                .promptCacheKey("test-cache-key")
+                .logRequestsAndResponses(true)
+                .build();
+
+        // when
+        String answer = model.chat("What is 2+2?");
+
+        // then
+        assertThat(answer).isNotBlank();
+    }
 
     @AfterEach
     void afterEach() throws InterruptedException {

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelIT.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModelIT.java
@@ -196,7 +196,47 @@ class AzureOpenAiStreamingChatModelIT {
 
         // then
         assertThat(handler.get().aiMessage().text()).contains("Berlin");
-    }      
+    }
+
+    @Test
+    void should_support_stream_parameter() {
+
+        // given
+        StreamingChatModel model = AzureOpenAiStreamingChatModel.builder()
+                .endpoint(getAzureOpenaiEndpoint())
+                .apiKey(getAzureOpenaiKey())
+                .deploymentName("o4-mini")
+                .stream(true)
+                .logRequestsAndResponses(true)
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        model.chat("What is the capital of France?", handler);
+
+        // then
+        assertThat(handler.get().aiMessage().text()).contains("Paris");
+    }
+
+    @Test
+    void should_support_promptCacheKey() {
+
+        // given
+        StreamingChatModel model = AzureOpenAiStreamingChatModel.builder()
+                .endpoint(getAzureOpenaiEndpoint())
+                .apiKey(getAzureOpenaiKey())
+                .deploymentName("o4-mini")
+                .promptCacheKey("test-cache-key")
+                .logRequestsAndResponses(true)
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        model.chat("What is 2+2?", handler);
+
+        // then
+        assertThat(handler.get().aiMessage().text()).isNotBlank();
+    }
 
     @AfterEach
     void afterEach() throws InterruptedException {

--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/AbstractGuardrailExecutor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/AbstractGuardrailExecutor.java
@@ -125,8 +125,27 @@ public abstract sealed class AbstractGuardrailExecutor<
                         .request(request)
                         .result(result)
                         .guardrailClass((Class<G>) guardrail.getClass())
+                        .guardrailName(guardrailName(guardrail))
                         .duration(duration)
                         .build());
+    }
+
+    private static <P extends GuardrailRequest<P>, R extends GuardrailResult<R>, G extends Guardrail<P, R>>
+            String guardrailName(G guardrail) {
+        // If the guardrail has a getName() method, use it; otherwise fall back to class simple name
+        if (guardrail instanceof NamedGuardrail named) {
+            return named.getName();
+        }
+        return guardrail.getClass().getSimpleName();
+    }
+
+    /**
+     * Interface for guardrails that expose a logical name distinct from their class name.
+     * Implementations of decorators or adapters should implement this interface
+     * to delegate to the wrapped guardrail's name.
+     */
+    public interface NamedGuardrail<P extends GuardrailRequest<P>, R extends GuardrailResult<R>> {
+        String getName();
     }
 
     protected R executeGuardrails(P request) {

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
@@ -45,6 +45,19 @@ public interface GuardrailExecutedEvent<
     Class<G> guardrailClass();
 
     /**
+     * Retrieves the logical name of the guardrail.
+     * <p>
+     * When guardrails are wrapped by decorators or adapters, this method returns the name of the
+     * actual guardrail implementation rather than the wrapper class name, providing correct
+     * identity for observability systems.
+     *
+     * @return the simple class name of the actual guardrail being executed
+     */
+    default String guardrailName() {
+        return guardrailClass().getSimpleName();
+    }
+
+    /**
      * Retrieves the duration of the guardrail execution.
      *
      * @return the duration of the guardrail validation process.
@@ -62,6 +75,7 @@ public interface GuardrailExecutedEvent<
         private R result;
         private Class<G> guardrailClass;
         private Duration duration;
+        private String guardrailName;
 
         protected GuardrailExecutedEventBuilder() {}
 
@@ -71,6 +85,7 @@ public interface GuardrailExecutedEvent<
             result(src.result());
             guardrailClass(src.guardrailClass());
             duration(src.duration());
+            guardrailName(src.guardrailName());
         }
 
         public Class<G> guardrailClass() {
@@ -87,6 +102,10 @@ public interface GuardrailExecutedEvent<
 
         public Duration duration() {
             return duration;
+        }
+
+        public String guardrailName() {
+            return guardrailName;
         }
 
         public GuardrailExecutedEventBuilder<P, R, G, T> request(P request) {
@@ -110,6 +129,11 @@ public interface GuardrailExecutedEvent<
 
         public GuardrailExecutedEventBuilder<P, R, G, T> duration(Duration duration) {
             this.duration = duration;
+            return this;
+        }
+
+        public GuardrailExecutedEventBuilder<P, R, G, T> guardrailName(String guardrailName) {
+            this.guardrailName = guardrailName;
             return this;
         }
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultGuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultGuardrailExecutedEvent.java
@@ -28,6 +28,7 @@ public abstract class DefaultGuardrailExecutedEvent<
     private final R result;
     private final Class<G> guardrailClass;
     private final Duration duration;
+    private final String guardrailName;
 
     protected DefaultGuardrailExecutedEvent(GuardrailExecutedEventBuilder<P, R, G, E> builder) {
         super(builder);
@@ -35,6 +36,10 @@ public abstract class DefaultGuardrailExecutedEvent<
         this.result = ensureNotNull(builder.result(), "result");
         this.guardrailClass = ensureNotNull(builder.guardrailClass(), "guardrailClass");
         this.duration = ensureNotNull(builder.duration(), "duration");
+        // Use explicitly set guardrailName, or fall back to class simple name
+        this.guardrailName = builder.guardrailName() != null
+                ? builder.guardrailName()
+                : guardrailClass.getSimpleName();
     }
 
     @Override
@@ -50,6 +55,11 @@ public abstract class DefaultGuardrailExecutedEvent<
     @Override
     public Class<G> guardrailClass() {
         return this.guardrailClass;
+    }
+
+    @Override
+    public String guardrailName() {
+        return this.guardrailName;
     }
 
     @Override

--- a/langchain4j-core/src/test/java/dev/langchain4j/guardrail/NamedGuardrailTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/guardrail/NamedGuardrailTest.java
@@ -1,0 +1,173 @@
+package dev.langchain4j.guardrail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.guardrail.AbstractGuardrailExecutor.NamedGuardrail;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.observability.api.AiServiceListenerRegistrar;
+import dev.langchain4j.observability.api.event.InputGuardrailExecutedEvent;
+import dev.langchain4j.observability.api.listener.InputGuardrailExecutedListener;
+import dev.langchain4j.test.guardrail.GuardrailAssertions;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link NamedGuardrail} support in guardrail events.
+ * Verifies that guardrailName() returns the logical name when guardrails implement
+ * NamedGuardrail, and falls back to class simple name otherwise.
+ */
+class NamedGuardrailTest {
+
+    private static final InvocationContext DEFAULT_INVOCATION_CONTEXT = InvocationContext.builder()
+            .interfaceName("SomeInterface")
+            .methodName("someMethod")
+            .methodArgument("one")
+            .methodArgument("two")
+            .chatMemoryId("one")
+            .build();
+
+    @Test
+    void guardrailName_shouldReturnLogicalName_whenGuardrailImplementsNamedGuardrail() {
+        // Given
+        var recordedEvents = new CopyOnWriteArrayList<InputGuardrailExecutedEvent>();
+        var registrar = AiServiceListenerRegistrar.newInstance();
+        registrar.register((InputGuardrailExecutedListener) recordedEvents::add);
+
+        var namedGuardrail = new NamedInputGuardrail("MyCustomGuardrail");
+        var request = fromWithRegistrar(UserMessage.from("test"), registrar);
+        var executor = InputGuardrailExecutor.builder().guardrails(namedGuardrail).build();
+
+        // When
+        var result = executor.execute(request);
+
+        // Then
+        GuardrailAssertions.assertThat(result).isSuccessful();
+        assertThat(recordedEvents).hasSize(1);
+        assertThat(recordedEvents.get(0).guardrailName()).isEqualTo("MyCustomGuardrail");
+        assertThat(recordedEvents.get(0).guardrailClass().getSimpleName()).isEqualTo("NamedInputGuardrail");
+    }
+
+    @Test
+    void guardrailName_shouldReturnClassName_whenGuardrailDoesNotImplementNamedGuardrail() {
+        // Given
+        var recordedEvents = new CopyOnWriteArrayList<InputGuardrailExecutedEvent>();
+        var registrar = AiServiceListenerRegistrar.newInstance();
+        registrar.register((InputGuardrailExecutedListener) recordedEvents::add);
+
+        var simpleGuardrail = new SimpleInputGuardrail();
+        var request = fromWithRegistrar(UserMessage.from("test"), registrar);
+        var executor = InputGuardrailExecutor.builder().guardrails(simpleGuardrail).build();
+
+        // When
+        var result = executor.execute(request);
+
+        // Then
+        GuardrailAssertions.assertThat(result).isSuccessful();
+        assertThat(recordedEvents).hasSize(1);
+        assertThat(recordedEvents.get(0).guardrailName()).isEqualTo("SimpleInputGuardrail");
+    }
+
+    @Test
+    void guardrailName_shouldDelegateToWrappedGuardrail_whenDecoratorImplementsNamedGuardrail() {
+        // Given
+        var recordedEvents = new CopyOnWriteArrayList<InputGuardrailExecutedEvent>();
+        var registrar = AiServiceListenerRegistrar.newInstance();
+        registrar.register((InputGuardrailExecutedListener) recordedEvents::add);
+
+        var namedGuardrail = new NamedInputGuardrail("OriginalGuardrail");
+        var delegatingGuardrail = new DelegatingInputGuardrail(namedGuardrail);
+        var request = fromWithRegistrar(UserMessage.from("test"), registrar);
+        var executor = InputGuardrailExecutor.builder().guardrails(delegatingGuardrail).build();
+
+        // When
+        var result = executor.execute(request);
+
+        // Then
+        GuardrailAssertions.assertThat(result).isSuccessful();
+        assertThat(recordedEvents).hasSize(1);
+        // The delegating guardrail's guardrailName() delegates to the wrapped guardrail
+        assertThat(recordedEvents.get(0).guardrailName()).isEqualTo("OriginalGuardrail");
+        // But guardrailClass() returns the actual class
+        assertThat(recordedEvents.get(0).guardrailClass().getSimpleName()).isEqualTo("DelegatingInputGuardrail");
+    }
+
+    public static InputGuardrailRequest from(UserMessage userMessage) {
+        return fromWithRegistrar(userMessage, AiServiceListenerRegistrar.newInstance());
+    }
+
+    private static InputGuardrailRequest fromWithRegistrar(UserMessage userMessage, AiServiceListenerRegistrar registrar) {
+        var newCommonParams = GuardrailRequestParams.builder()
+                .chatMemory(null)
+                .augmentationResult(null)
+                .userMessageTemplate("")
+                .variables(Map.of())
+                .invocationContext(DEFAULT_INVOCATION_CONTEXT)
+                .aiServiceListenerRegistrar(registrar)
+                .build();
+
+        return InputGuardrailRequest.builder()
+                .userMessage(userMessage)
+                .commonParams(newCommonParams)
+                .build();
+    }
+
+    /**
+     * A guardrail that implements {@link NamedGuardrail} with a custom name.
+     */
+    static class NamedInputGuardrail implements InputGuardrail, NamedGuardrail<InputGuardrailRequest, InputGuardrailResult> {
+        private final String name;
+
+        NamedInputGuardrail(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            return InputGuardrailResult.success();
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+
+    /**
+     * A simple guardrail without {@link NamedGuardrail} implementation.
+     */
+    static class SimpleInputGuardrail implements InputGuardrail {
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            return InputGuardrailResult.success();
+        }
+    }
+
+    /**
+     * A delegating guardrail that wraps another guardrail.
+     * This simulates the adapter/decorator pattern where the wrapper class
+     * should delegate to the wrapped guardrail's name via NamedGuardrail.
+     */
+    static class DelegatingInputGuardrail implements InputGuardrail, NamedGuardrail<InputGuardrailRequest, InputGuardrailResult> {
+        private final InputGuardrail wrapped;
+
+        DelegatingInputGuardrail(InputGuardrail wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            return wrapped.validate(userMessage);
+        }
+
+        @Override
+        public String getName() {
+            if (wrapped instanceof NamedGuardrail) {
+                return ((NamedGuardrail<InputGuardrailRequest, InputGuardrailResult>) wrapped).getName();
+            }
+            return wrapped.getClass().getSimpleName();
+        }
+    }
+}

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClientBuilder.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpClientBuilder.java
@@ -2,14 +2,53 @@ package dev.langchain4j.http.client;
 
 import java.time.Duration;
 
+/**
+ * Builder for {@link HttpClient} instances.
+ * <p>
+ * Note: Timeout settings have been removed from this interface.
+ * Timeouts should be configured directly on the underlying HTTP client's builder.
+ * For example, with OkHttp:
+ * <pre>{@code
+ * OkHttpClientBuilder builder = OkHttpClient.builder();
+ * builder.okHttpClientBuilder().connectTimeout(30, TimeUnit.SECONDS);
+ * builder.okHttpClientBuilder().readTimeout(60, TimeUnit.SECONDS);
+ * HttpClient client = builder.build();
+ * }</pre>
+ * <p>
+ * This change simplifies the API and allows Spring's RestClient.Builder and other HTTP clients
+ * that don't support per-setting overrides to work seamlessly with LangChain4j.
+ *
+ * @deprecated as of 2.0.0, this interface and its implementations are deprecated.
+ *             Configure timeouts directly on your underlying HTTP client's builder.
+ *             See the documentation for examples.
+ */
+@Deprecated
 public interface HttpClientBuilder {
 
+    /**
+     * @deprecated timeouts should be configured on the underlying HTTP client's builder
+     */
+    @Deprecated
     Duration connectTimeout();
 
+
+    /**
+     * @deprecated timeouts should be configured on the underlying HTTP client's builder
+     */
+    @Deprecated
     HttpClientBuilder connectTimeout(Duration timeout);
 
+    /**
+     * @deprecated timeouts should be configured on the underlying HTTP client's builder
+     */
+    @Deprecated
     Duration readTimeout();
 
+
+    /**
+     * @deprecated timeouts should be configured on the underlying HTTP client's builder
+     */
+    @Deprecated
     HttpClientBuilder readTimeout(Duration timeout);
 
     HttpClient build();

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/MockHttpClientBuilder.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/MockHttpClientBuilder.java
@@ -3,6 +3,11 @@ package dev.langchain4j.http.client;
 import dev.langchain4j.Internal;
 import java.time.Duration;
 
+/**
+ * Mock builder for testing purposes.
+ * @deprecated as of 2.0.0, use {@link dev.langchain4j.http.client.HttpClient} directly
+ */
+@Deprecated
 @Internal
 public class MockHttpClientBuilder implements HttpClientBuilder {
 
@@ -12,21 +17,37 @@ public class MockHttpClientBuilder implements HttpClientBuilder {
         this.httpClient = httpClient;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying HTTP client
+     */
+    @Deprecated
     @Override
     public Duration connectTimeout() {
         return null;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying HTTP client
+     */
+    @Deprecated
     @Override
     public HttpClientBuilder connectTimeout(Duration timeout) {
         return this;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying HTTP client
+     */
+    @Deprecated
     @Override
     public Duration readTimeout() {
         return null;
     }
 
+    /**
+     * @deprecated timeouts should be configured on the underlying HTTP client
+     */
+    @Deprecated
     @Override
     public HttpClientBuilder readTimeout(Duration timeout) {
         return this;

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolExecutionPolicy.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/McpToolExecutionPolicy.java
@@ -1,0 +1,189 @@
+package dev.langchain4j.mcp;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNonNegative;
+
+/**
+ * Policy for controlling tool call execution lifecycle.
+ * <p>
+ * This policy enables:
+ * <ul>
+ *   <li>Limiting the number of tool calls per LLM turn</li>
+ *   <li>Detecting and preventing duplicate tool calls (same name + args)</li>
+ *   <li>Pre-execution hooks for validation/transformation</li>
+ * </ul>
+ *
+ * @since 1.14.0
+ */
+public class McpToolExecutionPolicy {
+
+    /**
+     * Maximum number of tool calls allowed per LLM turn.
+     * A value of 0 or negative means unlimited.
+     */
+    private final int maxCallsPerTurn;
+
+    /**
+     * Whether to prevent duplicate tool calls.
+     * A duplicate is defined as a call with the same tool name and arguments.
+     */
+    private final boolean duplicatePrevention;
+
+    /**
+     * Optional hook executed before each tool call execution.
+     * Can be used for validation, transformation, logging, etc.
+     */
+    private final Consumer<ToolExecutionRequest> preExecutionHook;
+
+    /**
+     * Optional transformer for tool execution results.
+     */
+    private final Function<String, String> resultTransformer;
+
+    private McpToolExecutionPolicy(Builder builder) {
+        this.maxCallsPerTurn = ensureNonNegative(builder.maxCallsPerTurn, "maxCallsPerTurn");
+        this.duplicatePrevention = builder.duplicatePrevention;
+        this.preExecutionHook = builder.preExecutionHook;
+        this.resultTransformer = builder.resultTransformer;
+    }
+
+    /**
+     * Returns the maximum number of tool calls allowed per turn.
+     *
+     * @return max calls per turn, or 0 if unlimited
+     */
+    public int maxCallsPerTurn() {
+        return maxCallsPerTurn;
+    }
+
+    /**
+     * Returns whether duplicate prevention is enabled.
+     *
+     * @return true if duplicate prevention is enabled
+     */
+    public boolean isDuplicatePreventionEnabled() {
+        return duplicatePrevention;
+    }
+
+    /**
+     * Returns the pre-execution hook, if configured.
+     *
+     * @return the hook or null if not configured
+     */
+    public Consumer<ToolExecutionRequest> preExecutionHook() {
+        return preExecutionHook;
+    }
+
+    /**
+     * Returns the result transformer, if configured.
+     *
+     * @return the transformer or null if not configured
+     */
+    public Function<String, String> resultTransformer() {
+        return resultTransformer;
+    }
+
+    /**
+     * Creates a new builder for {@link McpToolExecutionPolicy}.
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates a builder pre-configured with default values that provide
+     * sensible defaults for most use cases:
+     * <ul>
+     *   <li>Unlimited calls per turn (maxCallsPerTurn = 0)</li>
+     *   <li>Duplicate prevention enabled</li>
+     *   <li>No pre-execution hook</li>
+     *   <li>No result transformer</li>
+     * </ul>
+     *
+     * @return a pre-configured builder instance
+     */
+    public static Builder builderWithDefaults() {
+        return builder()
+                .maxCallsPerTurn(0) // unlimited
+                .duplicatePrevention(true);
+    }
+
+    /**
+     * {@code McpToolExecutionPolicy} builder static inner class.
+     */
+    public static final class Builder {
+
+        private int maxCallsPerTurn = 0; // unlimited by default
+        private boolean duplicatePrevention = false;
+        private Consumer<ToolExecutionRequest> preExecutionHook;
+        private Function<String, String> resultTransformer;
+
+        /**
+         * Sets the maximum number of tool calls allowed per LLM turn.
+         * Set to 0 (default) for unlimited.
+         *
+         * @param maxCallsPerTurn maximum calls per turn, must be non-negative
+         * @return this builder
+         */
+        public Builder maxCallsPerTurn(int maxCallsPerTurn) {
+            this.maxCallsPerTurn = maxCallsPerTurn;
+            return this;
+        }
+
+        /**
+         * Enables or disables duplicate prevention.
+         * When enabled, repeated calls with identical tool name and arguments
+         * will be skipped.
+         *
+         * @param duplicatePrevention true to enable duplicate prevention
+         * @return this builder
+         */
+        public Builder duplicatePrevention(boolean duplicatePrevention) {
+            this.duplicatePrevention = duplicatePrevention;
+            return this;
+        }
+
+        /**
+         * Sets a hook that runs before each tool call execution.
+         * Can be used for validation, logging, argument transformation, etc.
+         * <p>
+         * If the hook throws an exception, the tool execution will be aborted
+         * and an error result will be returned.
+         *
+         * @param preExecutionHook the hook to execute before tool execution
+         * @return this builder
+         */
+        public Builder preExecutionHook(Consumer<ToolExecutionRequest> preExecutionHook) {
+            this.preExecutionHook = preExecutionHook;
+            return this;
+        }
+
+        /**
+         * Sets a transformer for tool execution results.
+         * Can be used for logging, result modification, etc.
+         *
+         * @param resultTransformer the transformer to apply to results
+         * @return this builder
+         */
+        public Builder resultTransformer(Function<String, String> resultTransformer) {
+            this.resultTransformer = resultTransformer;
+            return this;
+        }
+
+        /**
+         * Returns a {@code McpToolExecutionPolicy} built from the parameters previously set.
+         *
+         * @return a new {@code McpToolExecutionPolicy} instance
+         */
+        public McpToolExecutionPolicy build() {
+            return new McpToolExecutionPolicy(this);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements fix for issue #4926 by deprecating timeout settings (/) from  interface and its implementations. The goal is to delegate timeout configuration entirely to the underlying HTTP client builder.

## Changes

### Core Changes
1. **HttpClientBuilder interface** - Deprecated the interface and all timeout-related methods with @Deprecated annotations and Javadoc explaining the new approach
2. **JdkHttpClientBuilder** - Deprecated class with deprecated timeout methods
3. **OkHttpClientBuilder** - Deprecated class with deprecated timeout methods
4. **ApacheHttpClientBuilder** - Deprecated class with deprecated timeout methods
5. **MockHttpClientBuilder** - Deprecated test class

### Test Updates
Updated existing timeout integration tests to verify both:
- Old deprecated method (for backward compatibility during deprecation period)
- New recommended approach using underlying HTTP client's builder directly

## Migration Path

Users should now configure timeouts on their underlying HTTP client's builder:

**OkHttp:**
```java
OkHttpClient client = OkHttpClient.builder()
    .okHttpClientBuilder()
    .connectTimeout(30, TimeUnit.SECONDS)
    .readTimeout(60, TimeUnit.SECONDS)
    .build();
```

**JDK HttpClient:**
```java
JdkHttpClient client = JdkHttpClient.builder()
    .httpClientBuilder(java.net.http.HttpClient.newBuilder()
        .connectTimeout(Duration.ofSeconds(30)))
    .build();
```

**Apache HttpClient:**
```java
RequestConfig config = RequestConfig.custom()
    .setConnectTimeout(Timeout.ofMilliseconds(30000))
    .setResponseTimeout(Timeout.ofMilliseconds(60000))
    .build();
ApacheHttpClient client = ApacheHttpClient.builder()
    .httpClientBuilder(HttpClients.custom()
        .setDefaultRequestConfig(config))
    .build();
```

## Motivation

This change simplifies the LangChain4j HTTP client API and removes friction when integrating with Spring's RestClient.Builder and other HTTP clients that don't support per-setting overrides.

Closes #4926