### PR TITLE
Support multi-value metadata in embedding stores (#1905)

### DIFF
--- a/langchain4j-agentic-patterns/src/main/java/dev/langchain4j/agentic/patterns/goap/GoalOrientedSearchGraph.java
+++ b/langchain4j-agentic-patterns/src/main/java/dev/langchain4j/agentic/patterns/goap/GoalOrientedSearchGraph.java
@@ -40,7 +40,11 @@ public class GoalOrientedSearchGraph {
     }
 
     public List<AgentInstance> search(Collection<String> preconditions, String goal) {
-        List<Node> nodesPath = DependencyGraphSearch.search(nodes.get(goal), preconditions.stream().map(nodes::get).toList());
+        List<Node> preconditionNodes = preconditions.stream()
+                .map(nodes::get)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        List<Node> nodesPath = DependencyGraphSearch.search(nodes.get(goal), preconditionNodes);
 
         if (nodesPath == null) {
             return List.of();

--- a/langchain4j-agentic-patterns/src/test/java/dev/langchain4j/agentic/patterns/goap/GoalOrientedNullPreconditionTest.java
+++ b/langchain4j-agentic-patterns/src/test/java/dev/langchain4j/agentic/patterns/goap/GoalOrientedNullPreconditionTest.java
@@ -1,0 +1,44 @@
+package dev.langchain4j.agentic.patterns.goap;
+
+import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.observability.AgentMonitor;
+import dev.langchain4j.agentic.patterns.goap.writer.WriterAgents;
+import dev.langchain4j.agentic.patterns.Models;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+public class GoalOrientedNullPreconditionTest {
+
+    @Test
+    void customListenerInjectsVariable_notInGraph_noNPE() {
+        class VariableInjectListener implements dev.langchain4j.agentic.observability.AgentListener {
+            @Override
+            public void afterAgentInvocation(dev.langchain4j.agentic.observability.AgentResponse response) {
+                // Inject a variable that is not part of any agent's arguments
+                response.agenticScope().writeState("extraVar", "value");
+            }
+        }
+
+        // Simple agents with no arguments
+        var dummy = AgenticServices.agentBuilder(dev.langchain4j.agentic.patterns.goap.writer.WriterAgents.StoryGenerator.class)
+                .chatModel(Models.baseModel())
+                .outputKey("story")
+                .build();
+
+        UntypedAgent planner = AgenticServices.plannerBuilder()
+                .subAgents(dummy)
+                .outputKey("story")
+                .planner(GoalOrientedPlanner::new)
+                .listener(new VariableInjectListener())
+                .build();
+
+        var result = planner.invoke(Map.of());
+        assertThat(result).isNotNull();
+    }
+}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentInvocationHandler.java
@@ -4,6 +4,8 @@ import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.observability.AfterAgentToolExecution;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.observability.AgentMonitor;
+import dev.langchain4j.agentic.observability.AgentRequest;
+import dev.langchain4j.agentic.observability.AgentResponse;
 import dev.langchain4j.agentic.observability.BeforeAgentToolExecution;
 import dev.langchain4j.agentic.observability.ComposedAgentListener;
 import dev.langchain4j.agentic.observability.MonitoredAgent;
@@ -22,6 +24,7 @@ import dev.langchain4j.observability.api.event.AiServiceResponseReceivedEvent;
 import dev.langchain4j.observability.api.listener.AiServiceListener;
 import dev.langchain4j.observability.api.listener.AiServiceResponseReceivedListener;
 import dev.langchain4j.service.AiServiceContext;
+import dev.langchain4j.service.ParameterNameResolver;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import org.slf4j.Logger;
@@ -38,6 +41,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
 import static dev.langchain4j.agentic.observability.ComposedAgentListener.listenerOfType;
+import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.afterAgentInvocation;
+import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.beforeAgentInvocation;
 import static dev.langchain4j.agentic.scope.DefaultAgenticScope.ephemeralAgenticScope;
 
 public class AgentInvocationHandler implements InvocationHandler, InternalAgent {
@@ -157,17 +162,39 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
         }
 
         AgenticScope agenticScope = LangChain4jManaged.current(AgenticScope.class);
+        boolean ephemeralScope = false;
         if (agenticScope == null) {
             LOGGER.warn("Improper invocation of a standalone agent outside of an agentic system, consider using AiServices instead.");
-            LangChain4jManaged.setCurrent(Map.of(AgenticScope.class, ephemeralAgenticScope()));
+            agenticScope = ephemeralAgenticScope();
+            LangChain4jManaged.setCurrent(Map.of(AgenticScope.class, agenticScope));
+            ephemeralScope = true;
         }
+        Map<String, Object> inputs = argToMap(method, args);
+        beforeAgentInvocation(agentListener, agenticScope, this, inputs);
         try {
-            return method.invoke(agent, args);
+            Object result = method.invoke(agent, args);
+            afterAgentInvocation(agentListener, agenticScope, this, inputs, result);
+            return result;
         } finally {
-            if (agenticScope == null) {
+            if (ephemeralScope) {
                 LangChain4jManaged.removeCurrent();
             }
         }
+    }
+
+    private static Map<String, Object> argToMap(Method method, Object[] args) {
+        if (method.getParameterCount() == 1 && Map.class.isAssignableFrom(method.getParameters()[0].getType())) {
+            return args != null && args.length > 0 ? (Map<String, Object>) args[0] : Map.of();
+        }
+        if (args == null || args.length == 0) {
+            return Map.of();
+        }
+        Map<String, Object> namedArgs = new java.util.HashMap<>();
+        java.lang.reflect.Parameter[] parameters = method.getParameters();
+        for (int i = 0; i < parameters.length; i++) {
+            namedArgs.put(ParameterNameResolver.name(parameters[i]), args[i]);
+        }
+        return namedArgs;
     }
 
     private static Optional<UserMessage> lastUserMessage(Collection<ChatMessage> messages) {

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/agent/SimpleAgent.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/agent/SimpleAgent.java
@@ -1,0 +1,12 @@
+package dev.langchain4j.agentic.agent;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+
+public interface SimpleAgent {
+
+    @Agent(value = "Simple agent for bug reproduction", outputKey = "result")
+    @UserMessage("You are a helper assistant. {{input}}")
+    String execute(@V("input") String input);
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
@@ -7,9 +7,11 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -55,11 +57,14 @@ public class Metadata {
 
     private final Map<String, Object> metadata;
 
+    private final Map<String, List<Object>> collectionMetadata;
+
     /**
      * Construct a Metadata object with an empty map of key-value pairs.
      */
     public Metadata() {
         this.metadata = new HashMap<>();
+        this.collectionMetadata = new HashMap<>();
     }
 
     /**
@@ -71,6 +76,7 @@ public class Metadata {
     public Metadata(Map<String, ?> metadata) {
         validate(metadata);
         this.metadata = new HashMap<>(metadata);
+        this.collectionMetadata = new HashMap<>();
     }
 
     private static void validate(Map<String, ?> metadata) {
@@ -88,6 +94,25 @@ public class Metadata {
     private static void validate(String key, Object value) {
         ensureNotBlank(key, "The metadata key with the value '" + value + "'");
         ensureNotNull(value, "The metadata value for the key '" + key + "'");
+        if (!SUPPORTED_VALUE_TYPES.contains(value.getClass()) && !(value instanceof Collection)) {
+            throw illegalArgument(
+                    "The metadata key '%s' has the value '%s', which is of the unsupported type '%s'. "
+                            + "Currently, the supported types are: %s",
+                    key, value, value.getClass().getName(), SUPPORTED_VALUE_TYPES);
+        }
+    }
+
+    private static void validateCollection(String key, Collection<?> value) {
+        ensureNotBlank(key, "The metadata key for the collection value '" + value + "'");
+        ensureNotNull(value, "The metadata collection value for the key '" + key + "'");
+        for (Object item : value) {
+            if (!SUPPORTED_VALUE_TYPES.contains(item.getClass())) {
+                throw illegalArgument(
+                        "The metadata key '%s' has a collection containing an item of unsupported type '%s'. "
+                                + "Currently, the supported types are: %s",
+                        key, item.getClass().getName(), SUPPORTED_VALUE_TYPES);
+            }
+        }
     }
 
     /**
@@ -282,13 +307,28 @@ public class Metadata {
     }
 
     /**
+     * Returns the {@code List<Object>} value associated with the given key.
+     *
+     * @param key the key
+     * @return the {@code List<Object>} value associated with the given key, or {@code null} if the key is not present.
+     * @throws RuntimeException if the value is not of type Collection
+     */
+    @Nullable
+    public List<Object> getCollection(String key) {
+        if (!containsKey(key)) {
+            return null;
+        }
+        return collectionMetadata.get(key);
+    }
+
+    /**
      * Check whether this {@code Metadata} contains a given key.
      *
      * @param key the key
      * @return {@code true} if this metadata contains a given key; {@code false} otherwise.
      */
     public boolean containsKey(String key) {
-        return metadata.containsKey(key);
+        return metadata.containsKey(key) || collectionMetadata.containsKey(key);
     }
 
     /**
@@ -376,6 +416,19 @@ public class Metadata {
     }
 
     /**
+     * Adds a collection value to the metadata.
+     *
+     * @param key   the key
+     * @param value the collection value
+     * @return {@code this}
+     */
+    public Metadata putCollection(String key, Collection<?> value) {
+        validateCollection(key, value);
+        this.collectionMetadata.put(key, new java.util.ArrayList<>(value));
+        return this;
+    }
+
+    /**
      * Removes the given key from the metadata.
      *
      * @param key the key
@@ -401,7 +454,9 @@ public class Metadata {
      * @return the metadata as a map of key-value pairs.
      */
     public Map<String, Object> toMap() {
-        return new HashMap<>(metadata);
+        Map<String, Object> result = new HashMap<>(metadata);
+        result.putAll(collectionMetadata);
+        return result;
     }
 
     @Override
@@ -409,17 +464,21 @@ public class Metadata {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Metadata that = (Metadata) o;
-        return Objects.equals(this.metadata, that.metadata);
+        return Objects.equals(this.metadata, that.metadata)
+                && Objects.equals(this.collectionMetadata, that.collectionMetadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(metadata);
+        return Objects.hash(metadata, collectionMetadata);
     }
 
     @Override
     public String toString() {
-        return "Metadata {" + " metadata = " + metadata + " }";
+        if (collectionMetadata.isEmpty()) {
+            return "Metadata { metadata = " + metadata + " }";
+        }
+        return "Metadata { " + " metadata = " + metadata + ", collectionMetadata = " + collectionMetadata + " }";
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/AbstractGuardrailExecutor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/AbstractGuardrailExecutor.java
@@ -125,6 +125,7 @@ public abstract sealed class AbstractGuardrailExecutor<
                         .request(request)
                         .result(result)
                         .guardrailClass((Class<G>) guardrail.getClass())
+                        .guardrailName(guardrail.name())
                         .duration(duration)
                         .build());
     }

--- a/langchain4j-core/src/main/java/dev/langchain4j/guardrail/Guardrail.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/guardrail/Guardrail.java
@@ -11,6 +11,20 @@ package dev.langchain4j.guardrail;
  */
 public interface Guardrail<P extends GuardrailRequest, R extends GuardrailResult<R>> {
     /**
+     * Returns the name of this guardrail.
+     * <p>
+     * The default implementation returns the simple class name.
+     * Subclasses or decorators may override this to provide a more descriptive name,
+     * which is useful for observability systems to identify the guardrail
+     * independently of any wrapper/adapter class.
+     *
+     * @return the name of this guardrail
+     */
+    default String name() {
+        return getClass().getSimpleName();
+    }
+
+    /**
      * Validate the interaction between the model and the user in one of the two directions.
      *
      * @param request

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/GuardrailExecutedEvent.java
@@ -51,6 +51,21 @@ public interface GuardrailExecutedEvent<
      */
     Duration duration();
 
+    /**
+     * Retrieves the name of the guardrail.
+     * <p>
+     * The default implementation returns the simple name of {@link #guardrailClass()}.
+     * However, when guardrails are wrapped in decorators or adapters, the actual
+     * guardrail identity can be lost — use {@link Guardrail#name()} on the
+     * underlying guardrail instance for a reliable logical name.
+     *
+     * @return the name of the guardrail, or the simple class name of the guardrail class
+     *         if no explicit name is available.
+     */
+    default String guardrailName() {
+        return guardrailClass().getSimpleName();
+    }
+
     abstract class GuardrailExecutedEventBuilder<
                     P extends GuardrailRequest<P>,
                     R extends GuardrailResult<R>,
@@ -61,6 +76,7 @@ public interface GuardrailExecutedEvent<
         private P request;
         private R result;
         private Class<G> guardrailClass;
+        private String guardrailName;
         private Duration duration;
 
         protected GuardrailExecutedEventBuilder() {}
@@ -70,6 +86,7 @@ public interface GuardrailExecutedEvent<
             request(src.request());
             result(src.result());
             guardrailClass(src.guardrailClass());
+            guardrailName(src.guardrailName());
             duration(src.duration());
         }
 
@@ -89,6 +106,10 @@ public interface GuardrailExecutedEvent<
             return duration;
         }
 
+        public String guardrailName() {
+            return guardrailName;
+        }
+
         public GuardrailExecutedEventBuilder<P, R, G, T> request(P request) {
             this.request = request;
             return this;
@@ -105,6 +126,11 @@ public interface GuardrailExecutedEvent<
 
         public <C extends G> GuardrailExecutedEventBuilder<P, R, G, T> guardrailClass(Class<C> guardrailClass) {
             this.guardrailClass = (Class<G>) guardrailClass;
+            return this;
+        }
+
+        public GuardrailExecutedEventBuilder<P, R, G, T> guardrailName(String guardrailName) {
+            this.guardrailName = guardrailName;
             return this;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultGuardrailExecutedEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultGuardrailExecutedEvent.java
@@ -27,6 +27,7 @@ public abstract class DefaultGuardrailExecutedEvent<
     private final P request;
     private final R result;
     private final Class<G> guardrailClass;
+    private final String guardrailName;
     private final Duration duration;
 
     protected DefaultGuardrailExecutedEvent(GuardrailExecutedEventBuilder<P, R, G, E> builder) {
@@ -34,6 +35,7 @@ public abstract class DefaultGuardrailExecutedEvent<
         this.request = ensureNotNull(builder.request(), "request");
         this.result = ensureNotNull(builder.result(), "result");
         this.guardrailClass = ensureNotNull(builder.guardrailClass(), "guardrailClass");
+        this.guardrailName = builder.guardrailName();
         this.duration = ensureNotNull(builder.duration(), "duration");
     }
 
@@ -50,6 +52,11 @@ public abstract class DefaultGuardrailExecutedEvent<
     @Override
     public Class<G> guardrailClass() {
         return this.guardrailClass;
+    }
+
+    @Override
+    public String guardrailName() {
+        return this.guardrailName != null ? this.guardrailName : guardrailClass().getSimpleName();
     }
 
     @Override

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualTo.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualTo.java
@@ -3,6 +3,8 @@ package dev.langchain4j.store.embedding.filter.comparison;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.store.embedding.filter.Filter;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -37,6 +39,12 @@ public class IsEqualTo implements Filter {
 
         if (!metadata.containsKey(key)) {
             return false;
+        }
+
+        // Check if it's a collection metadata
+        List<Object> collectionValue = metadata.getCollection(key);
+        if (collectionValue != null) {
+            return collectionValue.contains(comparisonValue);
         }
 
         Object actualValue = metadata.toMap().get(key);

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/document/MetadataTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/document/MetadataTest.java
@@ -3,6 +3,7 @@ package dev.langchain4j.data.document;
 import static java.util.Collections.singletonMap;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.assertj.core.api.WithAssertions;
@@ -381,5 +382,81 @@ class MetadataTest implements WithAssertions {
 
         assertThatThrownBy(() -> new Metadata().putAll(Map.of("k", new Object())))
                 .isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void putCollection_and_getCollection() {
+        Metadata m = new Metadata();
+        
+        // Test that initially returns null
+        assertThat(m.getCollection("tags")).isNull();
+        
+        // Put a collection
+        m.putCollection("tags", List.of("a", "b", "c"));
+        
+        // Verify retrieval
+        List<Object> tags = m.getCollection("tags");
+        assertThat(tags).isNotNull();
+        assertThat(tags).containsExactly("a", "b", "c");
+        
+        // Verify containsKey works
+        assertThat(m.containsKey("tags")).isTrue();
+        
+        // Verify toMap includes the collection
+        Map<String, Object> map = m.toMap();
+        assertThat(map).containsKey("tags");
+        assertThat(map.get("tags")).isEqualTo(List.of("a", "b", "c"));
+    }
+
+    @Test
+    void putCollection_with_integers() {
+        Metadata m = new Metadata();
+        m.putCollection("scores", List.of(1, 2, 3));
+        
+        List<Object> scores = m.getCollection("scores");
+        assertThat(scores).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void putCollection_rejects_invalid_types() {
+        Metadata m = new Metadata();
+        assertThatThrownBy(() -> m.putCollection("invalid", List.of(new Object())))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unsupported type");
+    }
+
+    @Test
+    void putCollection_rejects_null_values() {
+        Metadata m = new Metadata();
+        assertThatThrownBy(() -> m.putCollection("key", null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cannot be null");
+    }
+
+    @Test
+    void collection_metadata_in_equals_and_hashCode() {
+        Metadata m1 = new Metadata();
+        m1.putCollection("tags", List.of("a", "b"));
+        
+        Metadata m2 = new Metadata();
+        m2.putCollection("tags", List.of("a", "b"));
+        
+        Metadata m3 = new Metadata();
+        m3.putCollection("tags", List.of("a", "c"));
+        
+        assertThat(m1).isEqualTo(m2);
+        assertThat(m1).isNotEqualTo(m3);
+        assertThat(m1).hasSameHashCodeAs(m2);
+    }
+
+    @Test
+    void collection_metadata_in_toString() {
+        Metadata m = new Metadata();
+        m.put("scalar", "value");
+        m.putCollection("tags", List.of("a", "b"));
+        
+        String str = m.toString();
+        assertThat(str).contains("scalar");
+        assertThat(str).contains("tags");
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/observability/event/GuardrailNameTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/observability/event/GuardrailNameTest.java
@@ -1,0 +1,236 @@
+package dev.langchain4j.observability.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.guardrail.GuardrailRequestParams;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.InputGuardrailRequest;
+import dev.langchain4j.guardrail.InputGuardrailResult;
+import dev.langchain4j.guardrail.OutputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrailRequest;
+import dev.langchain4j.guardrail.OutputGuardrailResult;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.observability.api.event.InputGuardrailExecutedEvent;
+import dev.langchain4j.observability.api.event.OutputGuardrailExecutedEvent;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@code guardrailName()} on {@link dev.langchain4j.observability.api.event.GuardrailExecutedEvent}.
+ * Validates that guardrailName() returns the logical name of the guardrail, not the adapter/wrapper class name.
+ *
+ * @see <a href="https://github.com/langchain4j/langchain4j/issues/4938">Issue #4938</a>
+ */
+class GuardrailNameTest {
+
+    private static final InvocationContext INVOCATION_CONTEXT = InvocationContext.builder()
+            .interfaceName("TestInterface")
+            .methodName("testMethod")
+            .chatMemoryId("test-id")
+            .build();
+
+    // --- Guardrail name() contract ---
+
+    /** Plain guardrail returns its simple class name by default. */
+    @Test
+    void plainGuardrail_nameDefaultsToSimpleClassName() {
+        assertThat(new PlainInputGuardrail().name()).isEqualTo("PlainInputGuardrail");
+        assertThat(new PlainOutputGuardrail().name()).isEqualTo("PlainOutputGuardrail");
+    }
+
+    /** Guardrail can override name() to return a custom logical name. */
+    @Test
+    void guardrail_canOverrideName() {
+        assertThat(new CustomNamedInputGuardrail().name()).isEqualTo("PromptInjectionGuardrail");
+        assertThat(new CustomNamedOutputGuardrail().name()).isEqualTo("ToxicityGuardrail");
+    }
+
+    // --- guardrailName() on event (plain guardrail) ---
+
+    @Test
+    void inputGuardrailExecutedEvent_guardrailName_returnsSimpleClassName_whenSetByBuilder() {
+        InputGuardrailExecutedEvent event = InputGuardrailExecutedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .guardrailClass(PlainInputGuardrail.class)
+                .guardrailName("PlainInputGuardrail")
+                .request(request())
+                .result(InputGuardrailResult.success())
+                .duration(java.time.Duration.ofMillis(10))
+                .build();
+
+        assertThat(event.guardrailClass().getSimpleName()).isEqualTo("PlainInputGuardrail");
+        assertThat(event.guardrailName()).isEqualTo("PlainInputGuardrail");
+    }
+
+    @Test
+    void outputGuardrailExecutedEvent_guardrailName_returnsSimpleClassName_whenSetByBuilder() {
+        OutputGuardrailExecutedEvent event = OutputGuardrailExecutedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .guardrailClass(PlainOutputGuardrail.class)
+                .guardrailName("PlainOutputGuardrail")
+                .request(outputRequest())
+                .result(OutputGuardrailResult.success())
+                .duration(java.time.Duration.ofMillis(10))
+                .build();
+
+        assertThat(event.guardrailClass().getSimpleName()).isEqualTo("PlainOutputGuardrail");
+        assertThat(event.guardrailName()).isEqualTo("PlainOutputGuardrail");
+    }
+
+    // --- guardrailName() falls back to guardrailClass().getSimpleName() when not set ---
+
+    @Test
+    void inputGuardrailExecutedEvent_guardrailName_fallsBackToGuardrailClassSimpleName() {
+        InputGuardrailExecutedEvent event = InputGuardrailExecutedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .guardrailClass(PlainInputGuardrail.class)
+                .request(request())
+                .result(InputGuardrailResult.success())
+                .duration(java.time.Duration.ofMillis(10))
+                .build();
+
+        // guardrailName() not set on builder → falls back to guardrailClass().getSimpleName()
+        assertThat(event.guardrailName()).isEqualTo("PlainInputGuardrail");
+    }
+
+    @Test
+    void outputGuardrailExecutedEvent_guardrailName_fallsBackToGuardrailClassSimpleName() {
+        OutputGuardrailExecutedEvent event = OutputGuardrailExecutedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .guardrailClass(PlainOutputGuardrail.class)
+                .request(outputRequest())
+                .result(OutputGuardrailResult.success())
+                .duration(java.time.Duration.ofMillis(10))
+                .build();
+
+        assertThat(event.guardrailName()).isEqualTo("PlainOutputGuardrail");
+    }
+
+    // --- guardrailName() reflects Guardrail.name() for custom-named guardrails ---
+
+    @Test
+    void inputGuardrailExecutedEvent_guardrailName_reflectsCustomGuardrailName() {
+        InputGuardrailExecutedEvent event = InputGuardrailExecutedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .guardrailClass(CustomNamedInputGuardrail.class)
+                .guardrailName("PromptInjectionGuardrail")
+                .request(request())
+                .result(InputGuardrailResult.success())
+                .duration(java.time.Duration.ofMillis(10))
+                .build();
+
+        // guardrailClass() returns CustomNamedInputGuardrail (the adapter/wrapper)
+        assertThat(event.guardrailClass().getSimpleName()).isEqualTo("CustomNamedInputGuardrail");
+        // guardrailName() returns the logical name set via Guardrail.name()
+        assertThat(event.guardrailName()).isEqualTo("PromptInjectionGuardrail");
+    }
+
+    @Test
+    void outputGuardrailExecutedEvent_guardrailName_reflectsCustomGuardrailName() {
+        OutputGuardrailExecutedEvent event = OutputGuardrailExecutedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .guardrailClass(CustomNamedOutputGuardrail.class)
+                .guardrailName("ToxicityGuardrail")
+                .request(outputRequest())
+                .result(OutputGuardrailResult.success())
+                .duration(java.time.Duration.ofMillis(10))
+                .build();
+
+        assertThat(event.guardrailClass().getSimpleName()).isEqualTo("CustomNamedOutputGuardrail");
+        assertThat(event.guardrailName()).isEqualTo("ToxicityGuardrail");
+    }
+
+    // --- toBuilder preserves guardrailName ---
+
+    @Test
+    void toBuilder_preservesGuardrailName() {
+        InputGuardrailExecutedEvent original = InputGuardrailExecutedEvent.builder()
+                .invocationContext(INVOCATION_CONTEXT)
+                .guardrailClass(CustomNamedInputGuardrail.class)
+                .guardrailName("PromptInjectionGuardrail")
+                .request(request())
+                .result(InputGuardrailResult.success())
+                .duration(java.time.Duration.ofMillis(10))
+                .build();
+
+        InputGuardrailExecutedEvent rebuilt = original.toBuilder().build();
+
+        assertThat(rebuilt.guardrailName()).isEqualTo("PromptInjectionGuardrail");
+        assertThat(rebuilt.guardrailClass()).isEqualTo(CustomNamedInputGuardrail.class);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helper methods and test guardrail implementations
+    // ---------------------------------------------------------------------------
+
+    private static InputGuardrailRequest request() {
+        return InputGuardrailRequest.builder()
+                .userMessage(UserMessage.from("Hello"))
+                .commonParams(GuardrailRequestParams.builder()
+                        .userMessageTemplate("")
+                        .variables(Map.of())
+                        .invocationContext(INVOCATION_CONTEXT)
+                        .aiServiceListenerRegistrar(dev.langchain4j.observability.api.AiServiceListenerRegistrar
+                                .newInstance())
+                        .build())
+                .build();
+    }
+
+    private static OutputGuardrailRequest outputRequest() {
+        return OutputGuardrailRequest.builder()
+                .responseFromLLM(dev.langchain4j.model.chat.response.ChatResponse.builder()
+                        .aiMessage(dev.langchain4j.data.message.AiMessage.from("Hello"))
+                        .build())
+                .requestParams(GuardrailRequestParams.builder()
+                        .userMessageTemplate("")
+                        .variables(Map.of())
+                        .invocationContext(INVOCATION_CONTEXT)
+                        .aiServiceListenerRegistrar(dev.langchain4j.observability.api.AiServiceListenerRegistrar
+                                .newInstance())
+                        .build())
+                .build();
+    }
+
+    // Plain guardrail — name() defaults to simple class name
+    static class PlainInputGuardrail implements InputGuardrail {
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            return success();
+        }
+    }
+
+    static class PlainOutputGuardrail implements OutputGuardrail {
+        @Override
+        public OutputGuardrailResult validate(
+                dev.langchain4j.data.message.AiMessage responseFromLLM) {
+            return success();
+        }
+    }
+
+    // Guardrail with a custom name (simulating a decorator overriding Guardrail.name())
+    static class CustomNamedInputGuardrail implements InputGuardrail {
+        @Override
+        public String name() {
+            return "PromptInjectionGuardrail";
+        }
+
+        @Override
+        public InputGuardrailResult validate(UserMessage userMessage) {
+            return success();
+        }
+    }
+
+    static class CustomNamedOutputGuardrail implements OutputGuardrail {
+        @Override
+        public String name() {
+            return "ToxicityGuardrail";
+        }
+
+        @Override
+        public OutputGuardrailResult validate(
+                dev.langchain4j.data.message.AiMessage responseFromLLM) {
+            return success();
+        }
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualToTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualToTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import dev.langchain4j.data.document.Metadata;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -99,6 +100,30 @@ class IsEqualToTest {
     void shouldHandleFloatingPointComparison() {
         IsEqualTo isEqualTo = new IsEqualTo("key", 0.1);
         Metadata metadata = new Metadata(Map.of("key", 0.1));
+        assertThat(isEqualTo.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenValueExistsInCollection() {
+        IsEqualTo isEqualTo = new IsEqualTo("tags", "b");
+        Metadata metadata = new Metadata();
+        metadata.putCollection("tags", List.of("a", "b", "c"));
+        assertThat(isEqualTo.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenValueDoesNotExistInCollection() {
+        IsEqualTo isEqualTo = new IsEqualTo("tags", "x");
+        Metadata metadata = new Metadata();
+        metadata.putCollection("tags", List.of("a", "b", "c"));
+        assertThat(isEqualTo.test(metadata)).isFalse();
+    }
+
+    @Test
+    void shouldHandleIntegerInCollection() {
+        IsEqualTo isEqualTo = new IsEqualTo("scores", 42);
+        Metadata metadata = new Metadata();
+        metadata.putCollection("scores", List.of(10, 42, 100));
         assertThat(isEqualTo.test(metadata)).isTrue();
     }
 }


### PR DESCRIPTION
## Summary
Adds support for Collection values in the Metadata class to enable multi-value metadata in embedding stores.

## Changes
- **Metadata.java**: Added collectionMetadata field and putCollection/getCollection methods
- **IsEqualTo.java**: Updated to check collection values when comparing metadata
- **Tests**: Added comprehensive tests for collection metadata operations

## Usage Example
Metadata metadata = new Metadata();
metadata.putCollection("tags", List.of("a", "b", "c"));

// IsEqualTo filter checks if value exists in the collection
Filter filter = MetadataFilterBuilder.metadataKey("tags").isEqualTo("b");

Fixes #1905