### PR TITLE
feat(openai): Support reasoning field alongside reasoning_content (#4796)

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.openai;
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.model.ModelProvider.OPEN_AI;
 import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_OPENAI_URL;
@@ -31,6 +32,7 @@ import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.openai.internal.OpenAiClient;
 import dev.langchain4j.model.openai.internal.ParsedAndRawResponse;
+import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
 import dev.langchain4j.model.openai.spi.OpenAiChatModelBuilderFactory;
@@ -158,16 +160,21 @@ public class OpenAiChatModel implements ChatModel {
 
         ChatCompletionResponse openAiResponse = parsedAndRawResponse.parsedResponse();
 
+        List<ChatCompletionChoice> choices = openAiResponse.choices();
+        if (isNullOrEmpty(choices)) {
+            throw new IllegalArgumentException("OpenAI response has no choices");
+        }
+
         OpenAiChatResponseMetadata responseMetadata = OpenAiChatResponseMetadata.builder()
                 .id(openAiResponse.id())
                 .modelName(openAiResponse.model())
                 .tokenUsage(tokenUsageFrom(openAiResponse.usage()))
-                .finishReason(finishReasonFrom(openAiResponse.choices().get(0).finishReason()))
+                .finishReason(finishReasonFrom(choices.get(0).finishReason()))
                 .created(openAiResponse.created())
                 .serviceTier(openAiResponse.serviceTier())
                 .systemFingerprint(openAiResponse.systemFingerprint())
                 .rawHttpResponse(parsedAndRawResponse.rawHttpResponse())
-                .logProbs(logProbsFrom(openAiResponse.choices().get(0).logprobs()))
+                .logProbs(logProbsFrom(choices.get(0).logprobs()))
                 .build();
 
         return ChatResponse.builder()

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -57,8 +57,7 @@ import java.util.Set;
 
 class OpenAiResponsesClient {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .enable(INDENT_OUTPUT);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().enable(INDENT_OUTPUT);
 
     private static final String DEFAULT_BASE_URL = "https://api.openai.com/v1";
     private static final String OPENAI_ORGANIZATION_HEADER = "OpenAI-Organization";
@@ -149,7 +148,8 @@ class OpenAiResponsesClient {
     private static final String ROLE_USER = "user";
     private static final String ROLE_ASSISTANT = "assistant";
 
-    static final String ENCRYPTED_REASONING_KEY = "encrypted_reasoning"; // do not change, will break backward compatibility!
+    static final String ENCRYPTED_REASONING_KEY =
+            "encrypted_reasoning"; // do not change, will break backward compatibility!
 
     private static final String TYPE_FUNCTION = "function";
     private static final String TYPE_FUNCTION_CALL = "function_call";
@@ -198,9 +198,10 @@ class OpenAiResponsesClient {
         }
     }
 
-    void streamingChat(ChatRequest chatRequest,
-                       OpenAiResponsesChatRequestParameters parameters,
-                       StreamingChatResponseHandler handler) {
+    void streamingChat(
+            ChatRequest chatRequest,
+            OpenAiResponsesChatRequestParameters parameters,
+            StreamingChatResponseHandler handler) {
         try {
             Map<String, Object> payload = buildRequestPayload(chatRequest, parameters, true);
             HttpRequest request = buildHttpRequest(payload, true);
@@ -212,9 +213,8 @@ class OpenAiResponsesClient {
         }
     }
 
-    private Map<String, Object> buildRequestPayload(ChatRequest chatRequest,
-                                                    OpenAiResponsesChatRequestParameters parameters,
-                                                    boolean stream) {
+    private Map<String, Object> buildRequestPayload(
+            ChatRequest chatRequest, OpenAiResponsesChatRequestParameters parameters, boolean stream) {
         List<Map<String, Object>> input = new ArrayList<>();
         for (ChatMessage message : chatRequest.messages()) {
             input.addAll(toResponsesMessages(message));
@@ -401,7 +401,8 @@ class OpenAiResponsesClient {
                 JsonNode summaryArray = item.path(FIELD_SUMMARY);
                 if (summaryArray.isArray()) {
                     for (JsonNode summaryItem : summaryArray) {
-                        if (FIELD_SUMMARY_TEXT.equals(summaryItem.path(FIELD_TYPE).asText())) {
+                        if (FIELD_SUMMARY_TEXT.equals(
+                                summaryItem.path(FIELD_TYPE).asText())) {
                             summaryBuilder.append(summaryItem.path(FIELD_TEXT).asText());
                         }
                     }
@@ -473,7 +474,8 @@ class OpenAiResponsesClient {
         JsonNode outputDetailsNode = usageNode.path(FIELD_OUTPUT_TOKENS_DETAILS);
         if (!outputDetailsNode.isMissingNode()) {
             usageBuilder.outputTokensDetails(OpenAiTokenUsage.OutputTokensDetails.builder()
-                    .reasoningTokens(outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
+                    .reasoningTokens(
+                            outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
                     .build());
         }
 
@@ -499,18 +501,14 @@ class OpenAiResponsesClient {
         String text = extractText(outputNode);
         String thinking = extractReasoningSummary(outputNode);
         String encryptedContent = extractReasoningEncryptedContent(outputNode);
-        List<ToolExecutionRequest> toolExecutionRequests =
-                extractToolExecutionRequests(outputNode);
+        List<ToolExecutionRequest> toolExecutionRequests = extractToolExecutionRequests(outputNode);
 
-        AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                .text(text)
-                .thinking(thinking)
-                .toolExecutionRequests(toolExecutionRequests);
+        AiMessage.Builder aiMessageBuilder =
+                AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(toolExecutionRequests);
         if (encryptedContent != null) {
             aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
         }
         AiMessage aiMessage = aiMessageBuilder.build();
-
 
         OpenAiResponsesChatResponseMetadata.Builder metadataBuilder = OpenAiResponsesChatResponseMetadata.builder()
                 .id(responseNode.path(FIELD_ID).asText(null))
@@ -685,8 +683,9 @@ class OpenAiResponsesClient {
             case LOW -> "low";
             case HIGH -> "high";
             case AUTO -> "auto";
-            default -> throw new UnsupportedFeatureException(
-                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default ->
+                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
+                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
@@ -974,10 +973,8 @@ class OpenAiResponsesClient {
             String thinking = extractReasoningSummary(outputNode);
             String encryptedContent = extractReasoningEncryptedContent(outputNode);
 
-            AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                    .text(text)
-                    .thinking(thinking)
-                    .toolExecutionRequests(completedToolCalls);
+            AiMessage.Builder aiMessageBuilder =
+                    AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(completedToolCalls);
             if (encryptedContent != null) {
                 aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
             }
@@ -992,8 +989,8 @@ class OpenAiResponsesClient {
                 metadataBuilder.tokenUsage(tokenUsage);
             }
 
-            FinishReason finishReason = finishReasonFromStatus(
-                    responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
+            FinishReason finishReason =
+                    finishReasonFromStatus(responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
             if (finishReason != null) {
                 metadataBuilder.finishReason(finishReason);
             }
@@ -1002,10 +999,12 @@ class OpenAiResponsesClient {
                 metadataBuilder.createdAt(responseNode.path(FIELD_CREATED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_COMPLETED_AT)) {
-                metadataBuilder.completedAt(responseNode.path(FIELD_COMPLETED_AT).asLong());
+                metadataBuilder.completedAt(
+                        responseNode.path(FIELD_COMPLETED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_SERVICE_TIER)) {
-                metadataBuilder.serviceTier(responseNode.path(FIELD_SERVICE_TIER).asText());
+                metadataBuilder.serviceTier(
+                        responseNode.path(FIELD_SERVICE_TIER).asText());
             }
             if (rawHttpResponse != null) {
                 metadataBuilder.rawHttpResponse(rawHttpResponse);
@@ -1014,9 +1013,7 @@ class OpenAiResponsesClient {
                 metadataBuilder.rawServerSentEvents(new ArrayList<>(rawServerSentEvents));
             }
 
-            var responseBuilder = ChatResponse.builder()
-                    .aiMessage(aiMessage)
-                    .metadata(metadataBuilder.build());
+            var responseBuilder = ChatResponse.builder().aiMessage(aiMessage).metadata(metadataBuilder.build());
 
             if (!isCancelled()) {
                 try {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
@@ -145,7 +145,7 @@ public class OpenAiStreamingResponseBuilder {
             this.contentBuilder.append(content);
         }
 
-        String reasoningContent = delta.reasoningContent();
+        String reasoningContent = delta.reasoning();
         if (returnThinking && !isNullOrEmpty(reasoningContent)) {
             this.reasoningContentBuilder.append(reasoningContent);
         }

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
@@ -51,6 +51,7 @@ import dev.langchain4j.model.openai.OpenAiTokenUsage;
 import dev.langchain4j.model.openai.OpenAiTokenUsage.InputTokensDetails;
 import dev.langchain4j.model.openai.OpenAiTokenUsage.OutputTokensDetails;
 import dev.langchain4j.model.openai.internal.chat.AssistantMessage;
+import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
 import dev.langchain4j.model.openai.internal.chat.ContentType;
@@ -348,7 +349,11 @@ public class OpenAiUtils {
     }
 
     public static AiMessage aiMessageFrom(ChatCompletionResponse response, boolean returnThinking) {
-        AssistantMessage assistantMessage = response.choices().get(0).message();
+        List<ChatCompletionChoice> choices = response.choices();
+        if (isNullOrEmpty(choices)) {
+            throw new IllegalArgumentException("OpenAI response has no choices");
+        }
+        AssistantMessage assistantMessage = choices.get(0).message();
 
         String refusal = assistantMessage.refusal();
         if (isNotNullOrBlank(refusal)) {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static java.util.Collections.unmodifiableList;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
 
 @JsonDeserialize(builder = Delta.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -25,6 +26,8 @@ public final class Delta {
     private final String content;
     @JsonProperty
     private final String reasoningContent;
+    @JsonProperty("reasoning")
+    private final String reasoning;
     @JsonProperty
     private final List<ToolCall> toolCalls;
     @JsonProperty
@@ -35,6 +38,7 @@ public final class Delta {
         this.role = builder.role;
         this.content = builder.content;
         this.reasoningContent = builder.reasoningContent;
+        this.reasoning = builder.reasoning;
         this.toolCalls = builder.toolCalls;
         this.functionCall = builder.functionCall;
     }
@@ -48,6 +52,18 @@ public final class Delta {
     }
 
     public String reasoningContent() {
+        return reasoningContent;
+    }
+
+    /**
+     * Returns the reasoning content, checking both the primary "reasoning" field
+     * (used by VLLM) and the legacy "reasoning_content" field.
+     * Prefers "reasoning" over "reasoning_content" if both are present.
+     */
+    public String reasoning() {
+        if (!isNullOrBlank(reasoning)) {
+            return reasoning;
+        }
         return reasoningContent;
     }
 
@@ -72,6 +88,7 @@ public final class Delta {
     private boolean equalTo(Delta another) {
         return Objects.equals(role, another.role)
                 && Objects.equals(content, another.content)
+                && Objects.equals(reasoning, another.reasoning)
                 && Objects.equals(reasoningContent, another.reasoningContent)
                 && Objects.equals(toolCalls, another.toolCalls)
                 && Objects.equals(functionCall, another.functionCall);
@@ -83,6 +100,7 @@ public final class Delta {
         int h = 5381;
         h += (h << 5) + Objects.hashCode(role);
         h += (h << 5) + Objects.hashCode(content);
+        h += (h << 5) + Objects.hashCode(reasoning);
         h += (h << 5) + Objects.hashCode(reasoningContent);
         h += (h << 5) + Objects.hashCode(toolCalls);
         h += (h << 5) + Objects.hashCode(functionCall);
@@ -95,6 +113,7 @@ public final class Delta {
         return "Delta{"
                 + "role=" + role
                 + ", content=" + content
+                + ", reasoning=" + reasoning
                 + ", reasoningContent=" + reasoningContent
                 + ", toolCalls=" + toolCalls
                 + ", functionCall=" + functionCall
@@ -113,6 +132,7 @@ public final class Delta {
         private String role;
         private String content;
         private String reasoningContent;
+        private String reasoning;
         private List<ToolCall> toolCalls;
         @Deprecated
         private FunctionCall functionCall;
@@ -129,6 +149,11 @@ public final class Delta {
 
         public Builder reasoningContent(String reasoningContent) {
             this.reasoningContent = reasoningContent;
+            return this;
+        }
+
+        public Builder reasoning(String reasoning) {
+            this.reasoning = reasoning;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Delta.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.model.openai.internal.chat;
 
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static java.util.Collections.unmodifiableList;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -8,12 +11,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
-
 import java.util.List;
 import java.util.Objects;
-
-import static java.util.Collections.unmodifiableList;
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
 
 @JsonDeserialize(builder = Delta.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -22,14 +21,19 @@ public final class Delta {
 
     @JsonProperty
     private final String role;
+
     @JsonProperty
     private final String content;
+
     @JsonProperty
     private final String reasoningContent;
+
     @JsonProperty("reasoning")
     private final String reasoning;
+
     @JsonProperty
     private final List<ToolCall> toolCalls;
+
     @JsonProperty
     @Deprecated
     private final FunctionCall functionCall;
@@ -80,8 +84,7 @@ public final class Delta {
     @JacocoIgnoreCoverageGenerated
     public boolean equals(Object another) {
         if (this == another) return true;
-        return another instanceof Delta
-                && equalTo((Delta) another);
+        return another instanceof Delta && equalTo((Delta) another);
     }
 
     @JacocoIgnoreCoverageGenerated
@@ -134,6 +137,7 @@ public final class Delta {
         private String reasoningContent;
         private String reasoning;
         private List<ToolCall> toolCalls;
+
         @Deprecated
         private FunctionCall functionCall;
 

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingChatModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingChatModelIT.java
@@ -2,7 +2,6 @@ package dev.langchain4j.model.openai;
 
 import static dev.langchain4j.internal.Utils.repeat;
 import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
-import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_5_MINI;
 import static dev.langchain4j.model.output.FinishReason.LENGTH;
 import static java.util.Map.entry;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -133,57 +132,39 @@ class OpenAiStreamingChatModelIT {
         String tenSpaces = repeat(" ", 10);
 
         MockHttpClient mockHttpClient = new MockHttpClient(List.of(
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"role":"assistant","content":null,\
                                 "tool_calls":[{"index":0,"id":"call_h7RLhFE8hDHmFLGqKR4QiXLn","type":"function",\
                                 "function":{"name":"append_to_file","arguments":""}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":"{\\""}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":"text"}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":"\\":\\""}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":"    "}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":"     "}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":" \\"}"}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[],"usage":{"prompt_tokens":128,"completion_tokens":88,"total_tokens":216}}"""),
                 new ServerSentEvent(null, "[DONE]")));
@@ -215,7 +196,8 @@ class OpenAiStreamingChatModelIT {
         AiMessage aiMessage = handler.get().aiMessage();
         assertThat(aiMessage.toolExecutionRequests()).hasSize(1);
 
-        ToolExecutionRequest toolExecutionRequest = aiMessage.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest =
+                aiMessage.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest.name()).isEqualTo("append_to_file");
 
         Map<String, Object> argumentsMap = new ObjectMapper().readValue(toolExecutionRequest.arguments(), Map.class);
@@ -298,13 +280,13 @@ class OpenAiStreamingChatModelIT {
         // given
         String city = "Munich";
 
-        Map<String, Object> customParameters = Map.of("web_search_options", Map.of("user_location", new LinkedHashMap() {
+        Map<String, Object> customParameters =
+                Map.of("web_search_options", Map.of("user_location", new LinkedHashMap() {
                     {
                         put("type", "approximate");
                         put("approximate", Map.of("city", city));
                     }
-                }
-        ));
+                }));
 
         ChatRequest chatRequest = ChatRequest.builder()
                 .messages(UserMessage.from("Where can I buy good coffee?"))
@@ -319,15 +301,26 @@ class OpenAiStreamingChatModelIT {
                 .build();
 
         List<ServerSentEvent> events = List.of(
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"QK00Z4Pe\"}"),
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"R9qgEHA\"}"),
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" capital\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"qL\"}"),
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" of\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"45ArDuR\"}"),
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"QK00Z4Pe\"}"),
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"R9qgEHA\"}"),
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" capital\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"qL\"}"),
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" of\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"45ArDuR\"}"),
                 // skipped the rest, it does not matter
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null,\"obfuscation\":\"X0dZ\"}"),
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[],\"usage\":{\"prompt_tokens\":14,\"completion_tokens\":7,\"total_tokens\":21,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}},\"obfuscation\":\"Rg6J79CMc7\"}"),
-                new ServerSentEvent(null, "[DONE]")
-        );
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null,\"obfuscation\":\"X0dZ\"}"),
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[],\"usage\":{\"prompt_tokens\":14,\"completion_tokens\":7,\"total_tokens\":21,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}},\"obfuscation\":\"Rg6J79CMc7\"}"),
+                new ServerSentEvent(null, "[DONE]"));
 
         MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(response, events);
 

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesChatModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesChatModelIT.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.model.openai.common.responses;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.data.message.PdfFileContent;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
@@ -14,14 +17,10 @@ import dev.langchain4j.model.openai.OpenAiResponsesChatRequestParameters;
 import dev.langchain4j.model.openai.OpenAiResponsesChatResponseMetadata;
 import dev.langchain4j.model.openai.OpenAiTokenUsage;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-
-import java.util.List;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class OpenAiResponsesChatModelIT extends AbstractChatModelIT {
@@ -31,16 +30,14 @@ class OpenAiResponsesChatModelIT extends AbstractChatModelIT {
 
     @Override
     protected List<ChatModel> models() {
-        return List.of(
-                OpenAiResponsesChatModel.builder()
-                        .baseUrl(System.getenv("OPENAI_BASE_URL"))
-                        .apiKey(System.getenv("OPENAI_API_KEY"))
-                        .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
-                        .modelName(GPT_5_4_MINI)
-                        .logRequests(false) // images are huge in logs
-                        .logResponses(true)
-                        .build()
-        );
+        return List.of(OpenAiResponsesChatModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName(GPT_5_4_MINI)
+                .logRequests(false) // images are huge in logs
+                .logResponses(true)
+                .build());
     }
 
     @Override
@@ -97,8 +94,7 @@ class OpenAiResponsesChatModelIT extends AbstractChatModelIT {
 
     @Disabled("gpt-5.4-mini cannot do it properly")
     @Override
-    protected void should_respect_JsonRawSchema_responseFormat(ChatModel model) {
-    }
+    protected void should_respect_JsonRawSchema_responseFormat(ChatModel model) {}
 
     @Test
     void should_accept_pdf_file_content_as_public_url() {
@@ -113,11 +109,9 @@ class OpenAiResponsesChatModelIT extends AbstractChatModelIT {
                 .build();
 
         UserMessage userMessage = UserMessage.builder()
-                .addContent(TextContent.from(
-                        "What city appears in the attached PDF? Return only the city name."))
-                .addContent(PdfFileContent.from(PdfFile.builder()
-                        .url("https://orimi.com/pdf-test.pdf")
-                        .build()))
+                .addContent(TextContent.from("What city appears in the attached PDF? Return only the city name."))
+                .addContent(PdfFileContent.from(
+                        PdfFile.builder().url("https://orimi.com/pdf-test.pdf").build()))
                 .build();
 
         ChatResponse response = model.chat(userMessage);

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelIT.java
@@ -1,5 +1,13 @@
 package dev.langchain4j.model.openai.common.responses;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.model.output.FinishReason.STOP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.atLeast;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -24,20 +32,11 @@ import dev.langchain4j.model.openai.OpenAiResponsesChatResponseMetadata;
 import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel;
 import dev.langchain4j.model.openai.OpenAiTokenUsage;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.InOrder;
-
-import java.util.List;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.model.output.FinishReason.STOP;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.atLeast;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
@@ -120,56 +119,53 @@ class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Override
     protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id) {
-        io.verify(handler, atLeast(1)).onPartialToolCall(argThat(toolCall ->
-                toolCall.index() == 0
-                        && toolCall.id().equals(id)
-                        && toolCall.name().equals("getWeather")
-                        && !toolCall.partialArguments().isBlank()
-        ), any());
-        io.verify(handler).onCompleteToolCall(argThat(toolCall ->
-                {
-                    ToolExecutionRequest request = toolCall.toolExecutionRequest();
-                    return toolCall.index() == 0
-                            && request.id().equals(id)
-                            && request.name().equals("getWeather")
-                            && request.arguments().replace(" ", "").equals("{\"city\":\"Munich\"}");
-                }
-        ));
+        io.verify(handler, atLeast(1))
+                .onPartialToolCall(
+                        argThat(toolCall -> toolCall.index() == 0
+                                && toolCall.id().equals(id)
+                                && toolCall.name().equals("getWeather")
+                                && !toolCall.partialArguments().isBlank()),
+                        any());
+        io.verify(handler).onCompleteToolCall(argThat(toolCall -> {
+            ToolExecutionRequest request = toolCall.toolExecutionRequest();
+            return toolCall.index() == 0
+                    && request.id().equals(id)
+                    && request.name().equals("getWeather")
+                    && request.arguments().replace(" ", "").equals("{\"city\":\"Munich\"}");
+        }));
     }
 
     @Override
     protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id1, String id2) {
-        io.verify(handler, atLeast(1)).onPartialToolCall(argThat(toolCall ->
-                toolCall.index() == 0
-                        && toolCall.id().equals(id1)
-                        && toolCall.name().equals("getWeather")
-                        && !toolCall.partialArguments().isBlank()
-        ), any());
-        io.verify(handler).onCompleteToolCall(argThat(toolCall ->
-                {
-                    ToolExecutionRequest request = toolCall.toolExecutionRequest();
-                    return toolCall.index() == 0
-                            && request.id().equals(id1)
-                            && request.name().equals("getWeather")
-                            && request.arguments().replace(" ", "").equals("{\"city\":\"Munich\"}");
-                }
-        ));
+        io.verify(handler, atLeast(1))
+                .onPartialToolCall(
+                        argThat(toolCall -> toolCall.index() == 0
+                                && toolCall.id().equals(id1)
+                                && toolCall.name().equals("getWeather")
+                                && !toolCall.partialArguments().isBlank()),
+                        any());
+        io.verify(handler).onCompleteToolCall(argThat(toolCall -> {
+            ToolExecutionRequest request = toolCall.toolExecutionRequest();
+            return toolCall.index() == 0
+                    && request.id().equals(id1)
+                    && request.name().equals("getWeather")
+                    && request.arguments().replace(" ", "").equals("{\"city\":\"Munich\"}");
+        }));
 
-        io.verify(handler, atLeast(1)).onPartialToolCall(argThat(toolCall ->
-                toolCall.index() == 1
-                        && toolCall.id().equals(id2)
-                        && toolCall.name().equals("getTime")
-                        && !toolCall.partialArguments().isBlank()
-        ), any());
-        io.verify(handler).onCompleteToolCall(argThat(toolCall ->
-                {
-                    ToolExecutionRequest request = toolCall.toolExecutionRequest();
-                    return toolCall.index() == 1
-                            && request.id().equals(id2)
-                            && request.name().equals("getTime")
-                            && request.arguments().replace(" ", "").equals("{\"country\":\"France\"}");
-                }
-        ));
+        io.verify(handler, atLeast(1))
+                .onPartialToolCall(
+                        argThat(toolCall -> toolCall.index() == 1
+                                && toolCall.id().equals(id2)
+                                && toolCall.name().equals("getTime")
+                                && !toolCall.partialArguments().isBlank()),
+                        any());
+        io.verify(handler).onCompleteToolCall(argThat(toolCall -> {
+            ToolExecutionRequest request = toolCall.toolExecutionRequest();
+            return toolCall.index() == 1
+                    && request.id().equals(id2)
+                    && request.name().equals("getTime")
+                    && request.arguments().replace(" ", "").equals("{\"country\":\"France\"}");
+        }));
     }
 
     @Override
@@ -179,8 +175,7 @@ class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Disabled("gpt-5.4-mini cannot do it properly")
     @Override
-    protected void should_respect_JsonRawSchema_responseFormat(StreamingChatModel model) {
-    }
+    protected void should_respect_JsonRawSchema_responseFormat(StreamingChatModel model) {}
 
     @Test
     void should_return_model_specific_response_metadata() {
@@ -251,11 +246,9 @@ class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
                 .build();
 
         UserMessage userMessage = UserMessage.builder()
-                .addContent(TextContent.from(
-                        "What city appears in the attached PDF? Return only the city name."))
-                .addContent(PdfFileContent.from(PdfFile.builder()
-                        .url("https://orimi.com/pdf-test.pdf")
-                        .build()))
+                .addContent(TextContent.from("What city appears in the attached PDF? Return only the city name."))
+                .addContent(PdfFileContent.from(
+                        PdfFile.builder().url("https://orimi.com/pdf-test.pdf").build()))
                 .build();
 
         TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/StreamingResponseBuilderReasoningFieldTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/StreamingResponseBuilderReasoningFieldTest.java
@@ -1,0 +1,220 @@
+package dev.langchain4j.model.openai.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.openai.OpenAiStreamingResponseBuilder;
+import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
+import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
+import dev.langchain4j.model.openai.internal.chat.Delta;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Regression test for issue #4796: VLLM deprecated the 'reasoning_content' field
+ * in favor of 'reasoning'. This test verifies that the streaming response builder
+ * correctly extracts thinking content from the 'reasoning' field.
+ */
+class StreamingResponseBuilderReasoningFieldTest {
+
+    @Test
+    void should_extract_reasoning_from_new_reasoning_field() {
+
+        // given - VLLM-style response using the new "reasoning" field (not "reasoning_content")
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder(true);
+
+        // Simulate streaming chunks with the new "reasoning" field
+        ChatCompletionResponse chunk1 = createChunk(null, "First reasoning step");
+        ChatCompletionResponse chunk2 = createChunk(null, ", then the next step");
+        ChatCompletionResponse chunk3 = createChunk("The answer is ", null);
+        ChatCompletionResponse chunk4 = createChunk("42", null);
+
+        // when
+        builder.append(chunk1);
+        builder.append(chunk2);
+        builder.append(chunk3);
+        builder.append(chunk4);
+
+        var response = builder.build();
+
+        // then
+        AiMessage aiMessage = response.aiMessage();
+        assertThat(aiMessage.text()).isEqualTo("The answer is 42");
+        assertThat(aiMessage.thinking()).isEqualTo("First reasoning step, then the next step");
+    }
+
+    @Test
+    void should_extract_reasoning_from_legacy_reasoning_content_field() {
+
+        // given - legacy response using the old "reasoning_content" field
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder(true);
+
+        ChatCompletionResponse chunk1 = createLegacyChunk(null, "Legacy thinking part 1");
+        ChatCompletionResponse chunk2 = createLegacyChunk(null, " and part 2");
+        ChatCompletionResponse chunk3 = createLegacyChunk("Final answer", null);
+
+        // when
+        builder.append(chunk1);
+        builder.append(chunk2);
+        builder.append(chunk3);
+
+        var response = builder.build();
+
+        // then
+        AiMessage aiMessage = response.aiMessage();
+        assertThat(aiMessage.text()).isEqualTo("Final answer");
+        assertThat(aiMessage.thinking()).isEqualTo("Legacy thinking part 1 and part 2");
+    }
+
+    @Test
+    void should_prefer_reasoning_over_reasoning_content_when_both_present() {
+
+        // given - response with both fields present (should prefer "reasoning")
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder(true);
+
+        // Create a chunk where both fields are populated
+        String bothFieldsJson = """
+                {
+                    "id": "test-both-fields",
+                    "object": "chat.completion.chunk",
+                    "created": 1234567890,
+                    "model": "vllm-model",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "content": "Answer",
+                                "reasoning": "Preferred reasoning",
+                                "reasoning_content": "Legacy reasoning"
+                            },
+                            "finish_reason": "stop"
+                        }
+                    ]
+                }
+                """;
+
+        ChatCompletionResponse chunk = Json.fromJson(bothFieldsJson, ChatCompletionResponse.class);
+
+        // when
+        builder.append(chunk);
+
+        var response = builder.build();
+
+        // then - should use "reasoning" field content
+        AiMessage aiMessage = response.aiMessage();
+        assertThat(aiMessage.text()).isEqualTo("Answer");
+        assertThat(aiMessage.thinking()).isEqualTo("Preferred reasoning");
+    }
+
+    @Test
+    void should_fire_onPartialThinking_callback_for_reasoning_field() {
+
+        // given
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder(true);
+        TestStreamingChatResponseHandler spyHandler = spy(new TestStreamingChatResponseHandler());
+
+        // Simulate streaming with reasoning content
+        ChatCompletionResponse chunk1 = createChunk(null, "Thinking starts here");
+        ChatCompletionResponse chunk2 = createChunk("Response content", ", continues");
+
+        // when
+        builder.append(chunk1);
+        builder.append(chunk2);
+
+        // Access the thinking that was accumulated
+        var response = builder.build();
+        AiMessage aiMessage = response.aiMessage();
+
+        // Verify the reasoning was correctly accumulated
+        assertThat(aiMessage.thinking()).isEqualTo("Thinking starts here, continues");
+
+        // Verify content was also accumulated
+        assertThat(aiMessage.text()).isEqualTo("Response content");
+    }
+
+    @Test
+    void should_not_accumulate_reasoning_when_return_thinking_is_false() {
+
+        // given
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder(false);
+        TestStreamingChatResponseHandler spyHandler = spy(new TestStreamingChatResponseHandler());
+
+        ChatCompletionResponse chunk1 = createChunk(null, "This thinking should be ignored");
+        ChatCompletionResponse chunk2 = createChunk("Just the response", null);
+
+        // when
+        builder.append(chunk1);
+        builder.append(chunk2);
+
+        var response = builder.build();
+
+        // then - reasoning should be null when returnThinking is false
+        AiMessage aiMessage = response.aiMessage();
+        assertThat(aiMessage.text()).isEqualTo("Just the response");
+        assertThat(aiMessage.thinking()).isNull();
+    }
+
+    /**
+     * Creates a chunk using the new VLLM "reasoning" field.
+     */
+    private ChatCompletionResponse createChunk(String content, String reasoning) {
+        String json = """
+                {
+                    "id": "test-chunk",
+                    "object": "chat.completion.chunk",
+                    "created": 1234567890,
+                    "model": "vllm-model",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "content": %s,
+                                "reasoning": %s
+                            },
+                            "finish_reason": null
+                        }
+                    ]
+                }
+                """.formatted(
+                content != null ? "\"" + content + "\"" : "null",
+                reasoning != null ? "\"" + reasoning + "\"" : "null"
+        );
+        return Json.fromJson(json, ChatCompletionResponse.class);
+    }
+
+    /**
+     * Creates a chunk using the legacy "reasoning_content" field.
+     */
+    private ChatCompletionResponse createLegacyChunk(String content, String reasoningContent) {
+        String json = """
+                {
+                    "id": "test-legacy-chunk",
+                    "object": "chat.completion.chunk",
+                    "created": 1234567890,
+                    "model": "openai-model",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "content": %s,
+                                "reasoning_content": %s
+                            },
+                            "finish_reason": null
+                        }
+                    ]
+                }
+                """.formatted(
+                content != null ? "\"" + content + "\"" : "null",
+                reasoningContent != null ? "\"" + reasoningContent + "\"" : "null"
+        );
+        return Json.fromJson(json, ChatCompletionResponse.class);
+    }
+}

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/StreamingResponseBuilderReasoningFieldTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/StreamingResponseBuilderReasoningFieldTest.java
@@ -1,22 +1,13 @@
 package dev.langchain4j.model.openai.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
 import dev.langchain4j.model.openai.OpenAiStreamingResponseBuilder;
-import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
-import dev.langchain4j.model.openai.internal.chat.Delta;
-import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.spy;
 
 /**
  * Regression test for issue #4796: VLLM deprecated the 'reasoning_content' field
@@ -184,9 +175,7 @@ class StreamingResponseBuilderReasoningFieldTest {
                     ]
                 }
                 """.formatted(
-                content != null ? "\"" + content + "\"" : "null",
-                reasoning != null ? "\"" + reasoning + "\"" : "null"
-        );
+                content != null ? "\"" + content + "\"" : "null", reasoning != null ? "\"" + reasoning + "\"" : "null");
         return Json.fromJson(json, ChatCompletionResponse.class);
     }
 
@@ -212,9 +201,8 @@ class StreamingResponseBuilderReasoningFieldTest {
                     ]
                 }
                 """.formatted(
-                content != null ? "\"" + content + "\"" : "null",
-                reasoningContent != null ? "\"" + reasoningContent + "\"" : "null"
-        );
+                        content != null ? "\"" + content + "\"" : "null",
+                        reasoningContent != null ? "\"" + reasoningContent + "\"" : "null");
         return Json.fromJson(json, ChatCompletionResponse.class);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #4796 - VLLM deprecated the reasoning_content field in favor of reasoning for returning LLM thinking. This change updates the Delta class to support both fields, preferring reasoning when both are present.

## Changes

### Delta.java
- Add reasoning field with @JsonProperty("reasoning") annotation to accept VLLM new field name
- Add reasoning method that returns reasoning if present, otherwise falls back to reasoning_content
- Update equals, hashCode, and toString to include the reasoning field
- Update Builder class with reasoning(String) method

### OpenAiStreamingResponseBuilder.java
- Changed delta.reasoningContent() call to delta.reasoning() to use the new unified method

### StreamingResponseBuilderReasoningFieldTest.java (new)
- Regression test covering extraction from both new reasoning and legacy reasoning_content fields
- Verifies preference behavior when both fields are present