### PR TITLE
feat: pass UserMessage to systemMessageProvider for dynamic system prompts

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceContext.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceContext.java
@@ -3,6 +3,7 @@ package dev.langchain4j.service;
 import static dev.langchain4j.spi.ServiceHelper.loadFactory;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
@@ -25,7 +26,8 @@ import java.util.function.Function;
 public class AiServiceContext {
 
     private static final Function<Object, Optional<String>> DEFAULT_USER_MESSAGE_PROVIDER = x -> Optional.empty();
-    private static final Function<Object, Optional<String>> DEFAULT_SYSTEM_MESSAGE_PROVIDER = x -> Optional.empty();
+    private static final BiFunction<Object, UserMessage, Optional<String>> DEFAULT_SYSTEM_MESSAGE_PROVIDER =
+            (memoryId, userMessage) -> Optional.empty();
 
     public final Class<?> aiServiceClass;
     public final AiServiceListenerRegistrar eventListenerRegistrar = AiServiceListenerRegistrar.newInstance();
@@ -49,7 +51,7 @@ public class AiServiceContext {
     public boolean storeRetrievedContentInChatMemory = true;
 
     public Function<Object, Optional<String>> userMessageProvider = DEFAULT_USER_MESSAGE_PROVIDER;
-    public Function<Object, Optional<String>> systemMessageProvider = DEFAULT_SYSTEM_MESSAGE_PROVIDER;
+    public BiFunction<Object, UserMessage, Optional<String>> systemMessageProvider = DEFAULT_SYSTEM_MESSAGE_PROVIDER;
 
     public BiFunction<String, InvocationContext, String> systemMessageTransformer = null;
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -13,6 +13,7 @@ import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.exception.ToolArgumentsException;
@@ -271,8 +272,32 @@ public abstract class AiServices<T> {
      *                              or a system message template containing unresolved template variables (e.g. "{{name}}"),
      *                              which will be resolved using the values of method parameters annotated with @{@link V}.
      * @return builder
+     * @deprecated Use {@link #systemMessageProvider(BiFunction)} instead to also receive the in-flight {@link dev.langchain4j.data.message.UserMessage}.
      */
+    @Deprecated
     public AiServices<T> systemMessageProvider(Function<Object, String> systemMessageProvider) {
+        return systemMessageProvider((memoryId, userMessage) -> systemMessageProvider.apply(memoryId));
+    }
+
+    /**
+     * Configures the system message provider, which provides a system message to be used each time an AI service is invoked.
+     * <br>
+     * When both {@code @SystemMessage} and the system message provider are configured,
+     * {@code @SystemMessage} takes precedence.
+     *
+     * @param systemMessageProvider A {@link BiFunction} that accepts a chat memory ID
+     *                              (a value of a method parameter annotated with @{@link MemoryId})
+     *                              and the current in-flight {@link dev.langchain4j.data.message.UserMessage},
+     *                              and returns a system message to be used.
+     *                              If there is no parameter annotated with {@code @MemoryId},
+     *                              the value of memory ID is "default".
+     *                              The returned {@link String} can be either a complete system message
+     *                              or a system message template containing unresolved template variables (e.g. "{{name}}"),
+     *                              which will be resolved using the values of method parameters annotated with @{@link V}.
+     * @return builder
+     * @since 1.14.0
+     */
+    public AiServices<T> systemMessageProvider(BiFunction<Object, UserMessage, String> systemMessageProvider) {
         context.systemMessageProvider = systemMessageProvider.andThen(Optional::ofNullable);
         return this;
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -169,7 +169,13 @@ class DefaultAiServices<T> extends AiServices<T> {
                                 ? context.chatMemoryService.getOrCreateChatMemory(memoryId)
                                 : null;
 
-                        Optional<SystemMessage> systemMessage = prepareSystemMessage(memoryId, method, args);
+                        var userMessageTemplate = getUserMessageTemplate(memoryId, method, args);
+                        var variables = InternalReflectionVariableResolver.findTemplateVariables(
+                                userMessageTemplate, method, args);
+                        UserMessage originalUserMessage =
+                                prepareUserMessage(method, args, userMessageTemplate, variables);
+
+                        Optional<SystemMessage> systemMessage = prepareSystemMessage(memoryId, method, args, originalUserMessage);
                         if (context.systemMessageTransformer != null) {
                             String transformedSystemMessage = context.systemMessageTransformer.apply(
                                     systemMessage.map(SystemMessage::text).orElse(null), invocationContext);
@@ -177,11 +183,6 @@ class DefaultAiServices<T> extends AiServices<T> {
                                     ? Optional.of(SystemMessage.from(transformedSystemMessage))
                                     : Optional.empty();
                         }
-                        var userMessageTemplate = getUserMessageTemplate(memoryId, method, args);
-                        var variables = InternalReflectionVariableResolver.findTemplateVariables(
-                                userMessageTemplate, method, args);
-                        UserMessage originalUserMessage =
-                                prepareUserMessage(method, args, userMessageTemplate, variables);
 
                         context.eventListenerRegistrar.fireEvent(AiServiceStartedEvent.builder()
                                 .invocationContext(invocationContext)
@@ -531,14 +532,14 @@ class DefaultAiServices<T> extends AiServices<T> {
         return (T) responseFromLLM;
     }
 
-    private Optional<SystemMessage> prepareSystemMessage(Object memoryId, Method method, Object[] args) {
-        return findSystemMessageTemplate(memoryId, method).map(systemMessageTemplate -> PromptTemplate.from(
+    private Optional<SystemMessage> prepareSystemMessage(Object memoryId, Method method, Object[] args, UserMessage userMessage) {
+        return findSystemMessageTemplate(memoryId, method, userMessage).map(systemMessageTemplate -> PromptTemplate.from(
                         systemMessageTemplate)
                 .apply(InternalReflectionVariableResolver.findTemplateVariables(systemMessageTemplate, method, args))
                 .toSystemMessage());
     }
 
-    private Optional<String> findSystemMessageTemplate(Object memoryId, Method method) {
+    private Optional<String> findSystemMessageTemplate(Object memoryId, Method method, UserMessage userMessage) {
         dev.langchain4j.service.SystemMessage annotation =
                 method.getAnnotation(dev.langchain4j.service.SystemMessage.class);
         if (annotation != null) {
@@ -546,7 +547,7 @@ class DefaultAiServices<T> extends AiServices<T> {
                     method, "System", annotation.fromResource(), annotation.value(), annotation.delimiter()));
         }
 
-        return context.systemMessageProvider.apply(memoryId);
+        return context.systemMessageProvider.apply(memoryId, userMessage);
     }
 
     private static UserMessage prepareUserMessage(

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesSystemAndUserMessageConfigsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesSystemAndUserMessageConfigsTest.java
@@ -583,4 +583,65 @@ class AiServicesSystemAndUserMessageConfigsTest {
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("The parameter 'arg1' in the method 'illegalChat2' of the class dev.langchain4j.service.AiServicesSystemAndUserMessageConfigsTest$AiService" + VALIDATION_ERROR_MESSAGE_SUFFIX);
     }
+
+    /**
+     * Tests that systemMessageProvider receives the current UserMessage,
+     * enabling dynamic system prompt customization based on user input.
+     */
+    @Test
+    void system_message_provider_receives_user_message() {
+
+        // given
+        AiService aiService = AiServices.builder(AiService.class)
+                .chatModel(model)
+                .systemMessageProvider((memoryId, userMessage) -> {
+                    String userText = userMessage.contents().stream()
+                            .filter(c -> c instanceof dev.langchain4j.data.message.TextContent)
+                            .map(c -> ((dev.langchain4j.data.message.TextContent) c).text())
+                            .findFirst()
+                            .orElse("");
+                    // Customize system prompt based on user message content
+                    if (userText.contains("Germany")) {
+                        return "You are a German geography expert. Answer in capital letters.";
+                    } else if (userText.contains("France")) {
+                        return "You are a French culture expert. Answer with Haiku.";
+                    }
+                    return "You are a helpful assistant.";
+                })
+                .build();
+
+        // when-then - Germany path
+        assertThat(aiService.chat11("What is the capital of Germany?"))
+                .containsIgnoringCase("Berlin");
+        verify(model)
+                .chat(ChatRequest.builder()
+                        .messages(
+                                systemMessage("You are a German geography expert. Answer in capital letters."),
+                                userMessage("What is the capital of Germany?"))
+                        .build());
+    }
+
+    /**
+     * Tests backward compatibility: the deprecated Function-based systemMessageProvider
+     * still works and is auto-wrapped to the new BiFunction signature.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    void deprecated_function_based_system_message_provider_still_works() {
+
+        // given - using deprecated API
+        AiService aiService = AiServices.builder(AiService.class)
+                .chatModel(model)
+                .systemMessageProvider(chatMemoryId -> "Static fallback system message")
+                .build();
+
+        // when-then
+        assertThat(aiService.chat11("Hello")).containsIgnoringCase("Berlin");
+        verify(model)
+                .chat(ChatRequest.builder()
+                        .messages(
+                                systemMessage("Static fallback system message"),
+                                userMessage("Hello"))
+                        .build());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #4909 — systemMessageProvider contract only passed memoryId, preventing AI services from customizing system prompts based on user input.

## Changes

- **AiServiceContext**: Changed systemMessageProvider from Function<Object, Optional<String>> to BiFunction<Object, UserMessage, Optional<String>> to receive the in-flight UserMessage
- **AiServices**: Added new systemMessageProvider(BiFunction) method; deprecated the old systemMessageProvider(Function) with a backward-compatible adapter
- **DefaultAiServices**: Updated prepareSystemMessage() and findSystemMessageTemplate() to construct and pass the UserMessage to the provider
- **Tests**: Added regression tests verifying the new behavior and backward compatibility

## API Migration

**Before (still works, deprecated):**
.systemMessageProvider(memoryId -> "You are a helpful assistant")

**After (recommended):**
.systemMessageProvider((memoryId, userMessage) -> {
    String text = userMessage.contents().stream()
        .filter(c -> c instanceof TextContent)
        .map(c -> ((TextContent) c).text())
        .findFirst().orElse("");
    return text.contains("expert") ? "You are an expert" : "You are helpful";
})

## Verification

All AiServicesSystemAndUserMessageConfigsTest and AiServicesTest tests pass.