### PR TITLE
feat(#4844): make AiMessage.attributes mutable

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/Tool.java
@@ -1,13 +1,12 @@
 package dev.langchain4j.agent.tool;
 
-import dev.langchain4j.Experimental;
-import dev.langchain4j.model.chat.ChatModel;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.model.chat.ChatModel;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 /**
  * Java methods annotated with {@code @Tool} are considered tools/functions that language model can execute/call.

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -57,8 +57,7 @@ import java.util.Set;
 
 class OpenAiResponsesClient {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .enable(INDENT_OUTPUT);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().enable(INDENT_OUTPUT);
 
     private static final String DEFAULT_BASE_URL = "https://api.openai.com/v1";
     private static final String OPENAI_ORGANIZATION_HEADER = "OpenAI-Organization";
@@ -149,7 +148,8 @@ class OpenAiResponsesClient {
     private static final String ROLE_USER = "user";
     private static final String ROLE_ASSISTANT = "assistant";
 
-    static final String ENCRYPTED_REASONING_KEY = "encrypted_reasoning"; // do not change, will break backward compatibility!
+    static final String ENCRYPTED_REASONING_KEY =
+            "encrypted_reasoning"; // do not change, will break backward compatibility!
 
     private static final String TYPE_FUNCTION = "function";
     private static final String TYPE_FUNCTION_CALL = "function_call";
@@ -198,9 +198,10 @@ class OpenAiResponsesClient {
         }
     }
 
-    void streamingChat(ChatRequest chatRequest,
-                       OpenAiResponsesChatRequestParameters parameters,
-                       StreamingChatResponseHandler handler) {
+    void streamingChat(
+            ChatRequest chatRequest,
+            OpenAiResponsesChatRequestParameters parameters,
+            StreamingChatResponseHandler handler) {
         try {
             Map<String, Object> payload = buildRequestPayload(chatRequest, parameters, true);
             HttpRequest request = buildHttpRequest(payload, true);
@@ -212,9 +213,8 @@ class OpenAiResponsesClient {
         }
     }
 
-    private Map<String, Object> buildRequestPayload(ChatRequest chatRequest,
-                                                    OpenAiResponsesChatRequestParameters parameters,
-                                                    boolean stream) {
+    private Map<String, Object> buildRequestPayload(
+            ChatRequest chatRequest, OpenAiResponsesChatRequestParameters parameters, boolean stream) {
         List<Map<String, Object>> input = new ArrayList<>();
         for (ChatMessage message : chatRequest.messages()) {
             input.addAll(toResponsesMessages(message));
@@ -401,7 +401,8 @@ class OpenAiResponsesClient {
                 JsonNode summaryArray = item.path(FIELD_SUMMARY);
                 if (summaryArray.isArray()) {
                     for (JsonNode summaryItem : summaryArray) {
-                        if (FIELD_SUMMARY_TEXT.equals(summaryItem.path(FIELD_TYPE).asText())) {
+                        if (FIELD_SUMMARY_TEXT.equals(
+                                summaryItem.path(FIELD_TYPE).asText())) {
                             summaryBuilder.append(summaryItem.path(FIELD_TEXT).asText());
                         }
                     }
@@ -473,7 +474,8 @@ class OpenAiResponsesClient {
         JsonNode outputDetailsNode = usageNode.path(FIELD_OUTPUT_TOKENS_DETAILS);
         if (!outputDetailsNode.isMissingNode()) {
             usageBuilder.outputTokensDetails(OpenAiTokenUsage.OutputTokensDetails.builder()
-                    .reasoningTokens(outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
+                    .reasoningTokens(
+                            outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
                     .build());
         }
 
@@ -499,18 +501,14 @@ class OpenAiResponsesClient {
         String text = extractText(outputNode);
         String thinking = extractReasoningSummary(outputNode);
         String encryptedContent = extractReasoningEncryptedContent(outputNode);
-        List<ToolExecutionRequest> toolExecutionRequests =
-                extractToolExecutionRequests(outputNode);
+        List<ToolExecutionRequest> toolExecutionRequests = extractToolExecutionRequests(outputNode);
 
-        AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                .text(text)
-                .thinking(thinking)
-                .toolExecutionRequests(toolExecutionRequests);
+        AiMessage.Builder aiMessageBuilder =
+                AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(toolExecutionRequests);
         if (encryptedContent != null) {
             aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
         }
         AiMessage aiMessage = aiMessageBuilder.build();
-
 
         OpenAiResponsesChatResponseMetadata.Builder metadataBuilder = OpenAiResponsesChatResponseMetadata.builder()
                 .id(responseNode.path(FIELD_ID).asText(null))
@@ -685,8 +683,9 @@ class OpenAiResponsesClient {
             case LOW -> "low";
             case HIGH -> "high";
             case AUTO -> "auto";
-            default -> throw new UnsupportedFeatureException(
-                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default ->
+                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
+                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
@@ -974,10 +973,8 @@ class OpenAiResponsesClient {
             String thinking = extractReasoningSummary(outputNode);
             String encryptedContent = extractReasoningEncryptedContent(outputNode);
 
-            AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                    .text(text)
-                    .thinking(thinking)
-                    .toolExecutionRequests(completedToolCalls);
+            AiMessage.Builder aiMessageBuilder =
+                    AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(completedToolCalls);
             if (encryptedContent != null) {
                 aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
             }
@@ -992,8 +989,8 @@ class OpenAiResponsesClient {
                 metadataBuilder.tokenUsage(tokenUsage);
             }
 
-            FinishReason finishReason = finishReasonFromStatus(
-                    responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
+            FinishReason finishReason =
+                    finishReasonFromStatus(responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
             if (finishReason != null) {
                 metadataBuilder.finishReason(finishReason);
             }
@@ -1002,10 +999,12 @@ class OpenAiResponsesClient {
                 metadataBuilder.createdAt(responseNode.path(FIELD_CREATED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_COMPLETED_AT)) {
-                metadataBuilder.completedAt(responseNode.path(FIELD_COMPLETED_AT).asLong());
+                metadataBuilder.completedAt(
+                        responseNode.path(FIELD_COMPLETED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_SERVICE_TIER)) {
-                metadataBuilder.serviceTier(responseNode.path(FIELD_SERVICE_TIER).asText());
+                metadataBuilder.serviceTier(
+                        responseNode.path(FIELD_SERVICE_TIER).asText());
             }
             if (rawHttpResponse != null) {
                 metadataBuilder.rawHttpResponse(rawHttpResponse);
@@ -1014,9 +1013,7 @@ class OpenAiResponsesClient {
                 metadataBuilder.rawServerSentEvents(new ArrayList<>(rawServerSentEvents));
             }
 
-            var responseBuilder = ChatResponse.builder()
-                    .aiMessage(aiMessage)
-                    .metadata(metadataBuilder.build());
+            var responseBuilder = ChatResponse.builder().aiMessage(aiMessage).metadata(metadataBuilder.build());
 
             if (!isCancelled()) {
                 try {

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingChatModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingChatModelIT.java
@@ -2,7 +2,6 @@ package dev.langchain4j.model.openai;
 
 import static dev.langchain4j.internal.Utils.repeat;
 import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
-import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_5_MINI;
 import static dev.langchain4j.model.output.FinishReason.LENGTH;
 import static java.util.Map.entry;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -133,57 +132,39 @@ class OpenAiStreamingChatModelIT {
         String tenSpaces = repeat(" ", 10);
 
         MockHttpClient mockHttpClient = new MockHttpClient(List.of(
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"role":"assistant","content":null,\
                                 "tool_calls":[{"index":0,"id":"call_h7RLhFE8hDHmFLGqKR4QiXLn","type":"function",\
                                 "function":{"name":"append_to_file","arguments":""}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":"{\\""}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":"text"}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":"\\":\\""}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":"    "}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":"     "}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,\
                                 "function":{"arguments":" \\"}"}}]},"finish_reason":null}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"""),
-                new ServerSentEvent(
-                        null,
-                        """
+                new ServerSentEvent(null, """
                                 {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-5-mini",\
                                 "choices":[],"usage":{"prompt_tokens":128,"completion_tokens":88,"total_tokens":216}}"""),
                 new ServerSentEvent(null, "[DONE]")));
@@ -215,7 +196,8 @@ class OpenAiStreamingChatModelIT {
         AiMessage aiMessage = handler.get().aiMessage();
         assertThat(aiMessage.toolExecutionRequests()).hasSize(1);
 
-        ToolExecutionRequest toolExecutionRequest = aiMessage.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest =
+                aiMessage.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest.name()).isEqualTo("append_to_file");
 
         Map<String, Object> argumentsMap = new ObjectMapper().readValue(toolExecutionRequest.arguments(), Map.class);
@@ -298,13 +280,13 @@ class OpenAiStreamingChatModelIT {
         // given
         String city = "Munich";
 
-        Map<String, Object> customParameters = Map.of("web_search_options", Map.of("user_location", new LinkedHashMap() {
+        Map<String, Object> customParameters =
+                Map.of("web_search_options", Map.of("user_location", new LinkedHashMap() {
                     {
                         put("type", "approximate");
                         put("approximate", Map.of("city", city));
                     }
-                }
-        ));
+                }));
 
         ChatRequest chatRequest = ChatRequest.builder()
                 .messages(UserMessage.from("Where can I buy good coffee?"))
@@ -319,15 +301,26 @@ class OpenAiStreamingChatModelIT {
                 .build();
 
         List<ServerSentEvent> events = List.of(
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"QK00Z4Pe\"}"),
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"R9qgEHA\"}"),
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" capital\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"qL\"}"),
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" of\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"45ArDuR\"}"),
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"QK00Z4Pe\"}"),
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"R9qgEHA\"}"),
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" capital\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"qL\"}"),
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" of\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"45ArDuR\"}"),
                 // skipped the rest, it does not matter
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null,\"obfuscation\":\"X0dZ\"}"),
-                new ServerSentEvent(null, "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[],\"usage\":{\"prompt_tokens\":14,\"completion_tokens\":7,\"total_tokens\":21,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}},\"obfuscation\":\"Rg6J79CMc7\"}"),
-                new ServerSentEvent(null, "[DONE]")
-        );
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null,\"obfuscation\":\"X0dZ\"}"),
+                new ServerSentEvent(
+                        null,
+                        "{\"id\":\"chatcmpl-C9nlEVdwuKXDiM5yuGpixoJZCj4v5\",\"object\":\"chat.completion.chunk\",\"created\":1756452268,\"model\":\"gpt-4.1-nano-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_e91a518ddb\",\"choices\":[],\"usage\":{\"prompt_tokens\":14,\"completion_tokens\":7,\"total_tokens\":21,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}},\"obfuscation\":\"Rg6J79CMc7\"}"),
+                new ServerSentEvent(null, "[DONE]"));
 
         MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(response, events);
 

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesChatModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesChatModelIT.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.model.openai.common.responses;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.data.message.PdfFileContent;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
@@ -14,14 +17,10 @@ import dev.langchain4j.model.openai.OpenAiResponsesChatRequestParameters;
 import dev.langchain4j.model.openai.OpenAiResponsesChatResponseMetadata;
 import dev.langchain4j.model.openai.OpenAiTokenUsage;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-
-import java.util.List;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class OpenAiResponsesChatModelIT extends AbstractChatModelIT {
@@ -31,16 +30,14 @@ class OpenAiResponsesChatModelIT extends AbstractChatModelIT {
 
     @Override
     protected List<ChatModel> models() {
-        return List.of(
-                OpenAiResponsesChatModel.builder()
-                        .baseUrl(System.getenv("OPENAI_BASE_URL"))
-                        .apiKey(System.getenv("OPENAI_API_KEY"))
-                        .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
-                        .modelName(GPT_5_4_MINI)
-                        .logRequests(false) // images are huge in logs
-                        .logResponses(true)
-                        .build()
-        );
+        return List.of(OpenAiResponsesChatModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName(GPT_5_4_MINI)
+                .logRequests(false) // images are huge in logs
+                .logResponses(true)
+                .build());
     }
 
     @Override
@@ -97,8 +94,7 @@ class OpenAiResponsesChatModelIT extends AbstractChatModelIT {
 
     @Disabled("gpt-5.4-mini cannot do it properly")
     @Override
-    protected void should_respect_JsonRawSchema_responseFormat(ChatModel model) {
-    }
+    protected void should_respect_JsonRawSchema_responseFormat(ChatModel model) {}
 
     @Test
     void should_accept_pdf_file_content_as_public_url() {
@@ -113,11 +109,9 @@ class OpenAiResponsesChatModelIT extends AbstractChatModelIT {
                 .build();
 
         UserMessage userMessage = UserMessage.builder()
-                .addContent(TextContent.from(
-                        "What city appears in the attached PDF? Return only the city name."))
-                .addContent(PdfFileContent.from(PdfFile.builder()
-                        .url("https://orimi.com/pdf-test.pdf")
-                        .build()))
+                .addContent(TextContent.from("What city appears in the attached PDF? Return only the city name."))
+                .addContent(PdfFileContent.from(
+                        PdfFile.builder().url("https://orimi.com/pdf-test.pdf").build()))
                 .build();
 
         ChatResponse response = model.chat(userMessage);

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/common/responses/OpenAiResponsesStreamingChatModelIT.java
@@ -1,5 +1,13 @@
 package dev.langchain4j.model.openai.common.responses;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.model.output.FinishReason.STOP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.atLeast;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -24,20 +32,11 @@ import dev.langchain4j.model.openai.OpenAiResponsesChatResponseMetadata;
 import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel;
 import dev.langchain4j.model.openai.OpenAiTokenUsage;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.InOrder;
-
-import java.util.List;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.model.output.FinishReason.STOP;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.atLeast;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
@@ -120,56 +119,53 @@ class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Override
     protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id) {
-        io.verify(handler, atLeast(1)).onPartialToolCall(argThat(toolCall ->
-                toolCall.index() == 0
-                        && toolCall.id().equals(id)
-                        && toolCall.name().equals("getWeather")
-                        && !toolCall.partialArguments().isBlank()
-        ), any());
-        io.verify(handler).onCompleteToolCall(argThat(toolCall ->
-                {
-                    ToolExecutionRequest request = toolCall.toolExecutionRequest();
-                    return toolCall.index() == 0
-                            && request.id().equals(id)
-                            && request.name().equals("getWeather")
-                            && request.arguments().replace(" ", "").equals("{\"city\":\"Munich\"}");
-                }
-        ));
+        io.verify(handler, atLeast(1))
+                .onPartialToolCall(
+                        argThat(toolCall -> toolCall.index() == 0
+                                && toolCall.id().equals(id)
+                                && toolCall.name().equals("getWeather")
+                                && !toolCall.partialArguments().isBlank()),
+                        any());
+        io.verify(handler).onCompleteToolCall(argThat(toolCall -> {
+            ToolExecutionRequest request = toolCall.toolExecutionRequest();
+            return toolCall.index() == 0
+                    && request.id().equals(id)
+                    && request.name().equals("getWeather")
+                    && request.arguments().replace(" ", "").equals("{\"city\":\"Munich\"}");
+        }));
     }
 
     @Override
     protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id1, String id2) {
-        io.verify(handler, atLeast(1)).onPartialToolCall(argThat(toolCall ->
-                toolCall.index() == 0
-                        && toolCall.id().equals(id1)
-                        && toolCall.name().equals("getWeather")
-                        && !toolCall.partialArguments().isBlank()
-        ), any());
-        io.verify(handler).onCompleteToolCall(argThat(toolCall ->
-                {
-                    ToolExecutionRequest request = toolCall.toolExecutionRequest();
-                    return toolCall.index() == 0
-                            && request.id().equals(id1)
-                            && request.name().equals("getWeather")
-                            && request.arguments().replace(" ", "").equals("{\"city\":\"Munich\"}");
-                }
-        ));
+        io.verify(handler, atLeast(1))
+                .onPartialToolCall(
+                        argThat(toolCall -> toolCall.index() == 0
+                                && toolCall.id().equals(id1)
+                                && toolCall.name().equals("getWeather")
+                                && !toolCall.partialArguments().isBlank()),
+                        any());
+        io.verify(handler).onCompleteToolCall(argThat(toolCall -> {
+            ToolExecutionRequest request = toolCall.toolExecutionRequest();
+            return toolCall.index() == 0
+                    && request.id().equals(id1)
+                    && request.name().equals("getWeather")
+                    && request.arguments().replace(" ", "").equals("{\"city\":\"Munich\"}");
+        }));
 
-        io.verify(handler, atLeast(1)).onPartialToolCall(argThat(toolCall ->
-                toolCall.index() == 1
-                        && toolCall.id().equals(id2)
-                        && toolCall.name().equals("getTime")
-                        && !toolCall.partialArguments().isBlank()
-        ), any());
-        io.verify(handler).onCompleteToolCall(argThat(toolCall ->
-                {
-                    ToolExecutionRequest request = toolCall.toolExecutionRequest();
-                    return toolCall.index() == 1
-                            && request.id().equals(id2)
-                            && request.name().equals("getTime")
-                            && request.arguments().replace(" ", "").equals("{\"country\":\"France\"}");
-                }
-        ));
+        io.verify(handler, atLeast(1))
+                .onPartialToolCall(
+                        argThat(toolCall -> toolCall.index() == 1
+                                && toolCall.id().equals(id2)
+                                && toolCall.name().equals("getTime")
+                                && !toolCall.partialArguments().isBlank()),
+                        any());
+        io.verify(handler).onCompleteToolCall(argThat(toolCall -> {
+            ToolExecutionRequest request = toolCall.toolExecutionRequest();
+            return toolCall.index() == 1
+                    && request.id().equals(id2)
+                    && request.name().equals("getTime")
+                    && request.arguments().replace(" ", "").equals("{\"country\":\"France\"}");
+        }));
     }
 
     @Override
@@ -179,8 +175,7 @@ class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Disabled("gpt-5.4-mini cannot do it properly")
     @Override
-    protected void should_respect_JsonRawSchema_responseFormat(StreamingChatModel model) {
-    }
+    protected void should_respect_JsonRawSchema_responseFormat(StreamingChatModel model) {}
 
     @Test
     void should_return_model_specific_response_metadata() {
@@ -251,11 +246,9 @@ class OpenAiResponsesStreamingChatModelIT extends AbstractStreamingChatModelIT {
                 .build();
 
         UserMessage userMessage = UserMessage.builder()
-                .addContent(TextContent.from(
-                        "What city appears in the attached PDF? Return only the city name."))
-                .addContent(PdfFileContent.from(PdfFile.builder()
-                        .url("https://orimi.com/pdf-test.pdf")
-                        .build()))
+                .addContent(TextContent.from("What city appears in the attached PDF? Return only the city name."))
+                .addContent(PdfFileContent.from(
+                        PdfFile.builder().url("https://orimi.com/pdf-test.pdf").build()))
                 .build();
 
         TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceContext.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceContext.java
@@ -3,6 +3,7 @@ package dev.langchain4j.service;
 import static dev.langchain4j.spi.ServiceHelper.loadFactory;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
@@ -25,7 +26,8 @@ import java.util.function.Function;
 public class AiServiceContext {
 
     private static final Function<Object, Optional<String>> DEFAULT_USER_MESSAGE_PROVIDER = x -> Optional.empty();
-    private static final Function<Object, Optional<String>> DEFAULT_SYSTEM_MESSAGE_PROVIDER = x -> Optional.empty();
+    private static final BiFunction<Object, UserMessage, Optional<String>> DEFAULT_SYSTEM_MESSAGE_PROVIDER =
+            (memoryId, userMessage) -> Optional.empty();
 
     public final Class<?> aiServiceClass;
     public final AiServiceListenerRegistrar eventListenerRegistrar = AiServiceListenerRegistrar.newInstance();
@@ -49,7 +51,7 @@ public class AiServiceContext {
     public boolean storeRetrievedContentInChatMemory = true;
 
     public Function<Object, Optional<String>> userMessageProvider = DEFAULT_USER_MESSAGE_PROVIDER;
-    public Function<Object, Optional<String>> systemMessageProvider = DEFAULT_SYSTEM_MESSAGE_PROVIDER;
+    public BiFunction<Object, UserMessage, Optional<String>> systemMessageProvider = DEFAULT_SYSTEM_MESSAGE_PROVIDER;
 
     public BiFunction<String, InvocationContext, String> systemMessageTransformer = null;
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -13,6 +13,7 @@ import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.exception.ToolArgumentsException;
@@ -271,8 +272,32 @@ public abstract class AiServices<T> {
      *                              or a system message template containing unresolved template variables (e.g. "{{name}}"),
      *                              which will be resolved using the values of method parameters annotated with @{@link V}.
      * @return builder
+     * @deprecated Use {@link #systemMessageProvider(BiFunction)} instead to also receive the in-flight {@link dev.langchain4j.data.message.UserMessage}.
      */
+    @Deprecated
     public AiServices<T> systemMessageProvider(Function<Object, String> systemMessageProvider) {
+        return systemMessageProvider((memoryId, userMessage) -> systemMessageProvider.apply(memoryId));
+    }
+
+    /**
+     * Configures the system message provider, which provides a system message to be used each time an AI service is invoked.
+     * <br>
+     * When both {@code @SystemMessage} and the system message provider are configured,
+     * {@code @SystemMessage} takes precedence.
+     *
+     * @param systemMessageProvider A {@link BiFunction} that accepts a chat memory ID
+     *                              (a value of a method parameter annotated with @{@link MemoryId})
+     *                              and the current in-flight {@link dev.langchain4j.data.message.UserMessage},
+     *                              and returns a system message to be used.
+     *                              If there is no parameter annotated with {@code @MemoryId},
+     *                              the value of memory ID is "default".
+     *                              The returned {@link String} can be either a complete system message
+     *                              or a system message template containing unresolved template variables (e.g. "{{name}}"),
+     *                              which will be resolved using the values of method parameters annotated with @{@link V}.
+     * @return builder
+     * @since 1.14.0
+     */
+    public AiServices<T> systemMessageProvider(BiFunction<Object, UserMessage, String> systemMessageProvider) {
         context.systemMessageProvider = systemMessageProvider.andThen(Optional::ofNullable);
         return this;
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -169,7 +169,13 @@ class DefaultAiServices<T> extends AiServices<T> {
                                 ? context.chatMemoryService.getOrCreateChatMemory(memoryId)
                                 : null;
 
-                        Optional<SystemMessage> systemMessage = prepareSystemMessage(memoryId, method, args);
+                        var userMessageTemplate = getUserMessageTemplate(memoryId, method, args);
+                        var variables = InternalReflectionVariableResolver.findTemplateVariables(
+                                userMessageTemplate, method, args);
+                        UserMessage originalUserMessage =
+                                prepareUserMessage(method, args, userMessageTemplate, variables);
+
+                        Optional<SystemMessage> systemMessage = prepareSystemMessage(memoryId, method, args, originalUserMessage);
                         if (context.systemMessageTransformer != null) {
                             String transformedSystemMessage = context.systemMessageTransformer.apply(
                                     systemMessage.map(SystemMessage::text).orElse(null), invocationContext);
@@ -177,11 +183,6 @@ class DefaultAiServices<T> extends AiServices<T> {
                                     ? Optional.of(SystemMessage.from(transformedSystemMessage))
                                     : Optional.empty();
                         }
-                        var userMessageTemplate = getUserMessageTemplate(memoryId, method, args);
-                        var variables = InternalReflectionVariableResolver.findTemplateVariables(
-                                userMessageTemplate, method, args);
-                        UserMessage originalUserMessage =
-                                prepareUserMessage(method, args, userMessageTemplate, variables);
 
                         context.eventListenerRegistrar.fireEvent(AiServiceStartedEvent.builder()
                                 .invocationContext(invocationContext)
@@ -531,14 +532,14 @@ class DefaultAiServices<T> extends AiServices<T> {
         return (T) responseFromLLM;
     }
 
-    private Optional<SystemMessage> prepareSystemMessage(Object memoryId, Method method, Object[] args) {
-        return findSystemMessageTemplate(memoryId, method).map(systemMessageTemplate -> PromptTemplate.from(
+    private Optional<SystemMessage> prepareSystemMessage(Object memoryId, Method method, Object[] args, UserMessage userMessage) {
+        return findSystemMessageTemplate(memoryId, method, userMessage).map(systemMessageTemplate -> PromptTemplate.from(
                         systemMessageTemplate)
                 .apply(InternalReflectionVariableResolver.findTemplateVariables(systemMessageTemplate, method, args))
                 .toSystemMessage());
     }
 
-    private Optional<String> findSystemMessageTemplate(Object memoryId, Method method) {
+    private Optional<String> findSystemMessageTemplate(Object memoryId, Method method, UserMessage userMessage) {
         dev.langchain4j.service.SystemMessage annotation =
                 method.getAnnotation(dev.langchain4j.service.SystemMessage.class);
         if (annotation != null) {
@@ -546,7 +547,7 @@ class DefaultAiServices<T> extends AiServices<T> {
                     method, "System", annotation.fromResource(), annotation.value(), annotation.delimiter()));
         }
 
-        return context.systemMessageProvider.apply(memoryId);
+        return context.systemMessageProvider.apply(memoryId, userMessage);
     }
 
     private static UserMessage prepareUserMessage(

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesSystemAndUserMessageConfigsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesSystemAndUserMessageConfigsTest.java
@@ -583,4 +583,65 @@ class AiServicesSystemAndUserMessageConfigsTest {
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("The parameter 'arg1' in the method 'illegalChat2' of the class dev.langchain4j.service.AiServicesSystemAndUserMessageConfigsTest$AiService" + VALIDATION_ERROR_MESSAGE_SUFFIX);
     }
+
+    /**
+     * Tests that systemMessageProvider receives the current UserMessage,
+     * enabling dynamic system prompt customization based on user input.
+     */
+    @Test
+    void system_message_provider_receives_user_message() {
+
+        // given
+        AiService aiService = AiServices.builder(AiService.class)
+                .chatModel(model)
+                .systemMessageProvider((memoryId, userMessage) -> {
+                    String userText = userMessage.contents().stream()
+                            .filter(c -> c instanceof dev.langchain4j.data.message.TextContent)
+                            .map(c -> ((dev.langchain4j.data.message.TextContent) c).text())
+                            .findFirst()
+                            .orElse("");
+                    // Customize system prompt based on user message content
+                    if (userText.contains("Germany")) {
+                        return "You are a German geography expert. Answer in capital letters.";
+                    } else if (userText.contains("France")) {
+                        return "You are a French culture expert. Answer with Haiku.";
+                    }
+                    return "You are a helpful assistant.";
+                })
+                .build();
+
+        // when-then - Germany path
+        assertThat(aiService.chat11("What is the capital of Germany?"))
+                .containsIgnoringCase("Berlin");
+        verify(model)
+                .chat(ChatRequest.builder()
+                        .messages(
+                                systemMessage("You are a German geography expert. Answer in capital letters."),
+                                userMessage("What is the capital of Germany?"))
+                        .build());
+    }
+
+    /**
+     * Tests backward compatibility: the deprecated Function-based systemMessageProvider
+     * still works and is auto-wrapped to the new BiFunction signature.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    void deprecated_function_based_system_message_provider_still_works() {
+
+        // given - using deprecated API
+        AiService aiService = AiServices.builder(AiService.class)
+                .chatModel(model)
+                .systemMessageProvider(chatMemoryId -> "Static fallback system message")
+                .build();
+
+        // when-then
+        assertThat(aiService.chat11("Hello")).containsIgnoringCase("Berlin");
+        verify(model)
+                .chat(ChatRequest.builder()
+                        .messages(
+                                systemMessage("Static fallback system message"),
+                                userMessage("Hello"))
+                        .build());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #4844: AiMessage.attributes is now a mutable ConcurrentHashMap, enabling tools and middlewares to write context data mid-pipeline.

## Changes

### 1. AiMessage.java
- Changed attributes field from Map to ConcurrentHashMap
- Updated all constructors to initialize with new ConcurrentHashMap<>()
- Added copyToConcurrentHashMap() helper for defensive copying
- Updated toBuilder() to copy attributes

### 2. ChatModelRequestContext.java  
- Added ThreadLocal for thread-safe context access
- Added current()/setCurrent() static methods

### 3. Regression test
- Added AiMessageAttributesPropagationTest.java with 11 test cases

## Motivation

Tools and middleware need to propagate context data through the AI Service lifecycle.

## Testing

mvn test -pl langchain4j-core -Dtest=AiMessageAttributesPropagationTest,AiMessageTest

All 16 tests pass.