### PR TITLE
Add built-in tools support to unofficial OpenAI Responses

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatModel.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.openai;
 
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.util.Arrays.asList;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.exception.UnsupportedFeatureException;
@@ -14,14 +19,9 @@ import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
-
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-
-import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static java.util.Arrays.asList;
 
 @Experimental
 public class OpenAiResponsesChatModel implements ChatModel {
@@ -54,7 +54,6 @@ public class OpenAiResponsesChatModel implements ChatModel {
                         : OpenAiResponsesChatRequestParameters.EMPTY;
 
         this.defaultRequestParameters = OpenAiResponsesChatRequestParameters.builder()
-
                 .modelName(ensureNotNull(getOrDefault(builder.modelName, commonParameters.modelName()), "modelName"))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -62,7 +61,6 @@ public class OpenAiResponsesChatModel implements ChatModel {
                 .toolSpecifications(getOrDefault(builder.toolSpecifications, commonParameters.toolSpecifications()))
                 .toolChoice(getOrDefault(builder.toolChoice, commonParameters.toolChoice()))
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
-
                 .previousResponseId(getOrDefault(builder.previousResponseId, responsesParameters.previousResponseId()))
                 .maxToolCalls(getOrDefault(builder.maxToolCalls, responsesParameters.maxToolCalls()))
                 .parallelToolCalls(getOrDefault(builder.parallelToolCalls, responsesParameters.parallelToolCalls()))
@@ -72,13 +70,15 @@ public class OpenAiResponsesChatModel implements ChatModel {
                 .serviceTier(getOrDefault(builder.serviceTier, responsesParameters.serviceTier()))
                 .safetyIdentifier(getOrDefault(builder.safetyIdentifier, responsesParameters.safetyIdentifier()))
                 .promptCacheKey(getOrDefault(builder.promptCacheKey, responsesParameters.promptCacheKey()))
-                .promptCacheRetention(getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
+                .promptCacheRetention(
+                        getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
                 .reasoningEffort(getOrDefault(builder.reasoningEffort, responsesParameters.reasoningEffort()))
                 .reasoningSummary(getOrDefault(builder.reasoningSummary, responsesParameters.reasoningSummary()))
                 .textVerbosity(getOrDefault(builder.textVerbosity, responsesParameters.textVerbosity()))
                 .store(getOrDefault(builder.store, getOrDefault(responsesParameters.store(), false)))
                 .strictTools(getOrDefault(builder.strictTools, responsesParameters.strictTools()))
                 .strictJsonSchema(getOrDefault(builder.strictJsonSchema, responsesParameters.strictJsonSchema()))
+                .serverTools(getOrDefault(builder.serverTools, responsesParameters.serverTools()))
                 .build();
 
         this.listeners = copy(builder.listeners);
@@ -101,10 +101,12 @@ public class OpenAiResponsesChatModel implements ChatModel {
             throw new UnsupportedFeatureException("'topK' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.frequencyPenalty() != null) {
-            throw new UnsupportedFeatureException("'frequencyPenalty' parameter is not supported by OpenAI Responses API");
+            throw new UnsupportedFeatureException(
+                    "'frequencyPenalty' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.presencePenalty() != null) {
-            throw new UnsupportedFeatureException("'presencePenalty' parameter is not supported by OpenAI Responses API");
+            throw new UnsupportedFeatureException(
+                    "'presencePenalty' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.stopSequences() != null && !parameters.stopSequences().isEmpty()) {
             throw new UnsupportedFeatureException("'stopSequences' parameter is not supported by OpenAI Responses API");
@@ -159,6 +161,7 @@ public class OpenAiResponsesChatModel implements ChatModel {
         private Boolean strictJsonSchema;
         private ResponseFormat responseFormat;
         private List<ToolSpecification> toolSpecifications;
+        private List<Map<String, Object>> serverTools;
         private ToolChoice toolChoice;
         private Boolean logRequests;
         private Boolean logResponses;
@@ -297,6 +300,11 @@ public class OpenAiResponsesChatModel implements ChatModel {
 
         public Builder toolSpecifications(ToolSpecification... toolSpecifications) {
             return toolSpecifications(asList(toolSpecifications));
+        }
+
+        public Builder serverTools(List<Map<String, Object>> serverTools) {
+            this.serverTools = serverTools;
+            return this;
         }
 
         public Builder toolChoice(ToolChoice toolChoice) {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatRequestParameters.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesChatRequestParameters.java
@@ -1,13 +1,13 @@
 package dev.langchain4j.model.openai;
 
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
-import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
-
-import java.util.List;
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestParameters {
 
@@ -31,6 +31,7 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
     private final Boolean store;
     private final Boolean strictTools;
     private final Boolean strictJsonSchema;
+    private final List<Map<String, Object>> serverTools;
 
     private OpenAiResponsesChatRequestParameters(Builder builder) {
         super(builder);
@@ -51,6 +52,7 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
         this.store = builder.store;
         this.strictTools = builder.strictTools;
         this.strictJsonSchema = builder.strictJsonSchema;
+        this.serverTools = copy(builder.serverTools);
     }
 
     public String previousResponseId() {
@@ -121,6 +123,10 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
         return strictJsonSchema;
     }
 
+    public List<Map<String, Object>> serverTools() {
+        return serverTools;
+    }
+
     @Override
     public OpenAiResponsesChatRequestParameters overrideWith(ChatRequestParameters that) {
         return OpenAiResponsesChatRequestParameters.builder()
@@ -159,7 +165,8 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
                 && Objects.equals(streamIncludeObfuscation, that.streamIncludeObfuscation)
                 && Objects.equals(store, that.store)
                 && Objects.equals(strictTools, that.strictTools)
-                && Objects.equals(strictJsonSchema, that.strictJsonSchema);
+                && Objects.equals(strictJsonSchema, that.strictJsonSchema)
+                && Objects.equals(serverTools, that.serverTools);
     }
 
     @Override
@@ -182,7 +189,8 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
                 streamIncludeObfuscation,
                 store,
                 strictTools,
-                strictJsonSchema);
+                strictJsonSchema,
+                serverTools);
     }
 
     public static Builder builder() {
@@ -208,6 +216,7 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
         private Boolean store;
         private Boolean strictTools;
         private Boolean strictJsonSchema;
+        private List<Map<String, Object>> serverTools;
 
         @Override
         public Builder overrideWith(ChatRequestParameters parameters) {
@@ -230,6 +239,7 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
                 store(getOrDefault(p.store(), store));
                 strictTools(getOrDefault(p.strictTools(), strictTools));
                 strictJsonSchema(getOrDefault(p.strictJsonSchema(), strictJsonSchema));
+                serverTools(getOrDefault(p.serverTools(), serverTools));
             }
             return this;
         }
@@ -316,6 +326,11 @@ public class OpenAiResponsesChatRequestParameters extends DefaultChatRequestPara
 
         public Builder strictJsonSchema(Boolean strictJsonSchema) {
             this.strictJsonSchema = strictJsonSchema;
+            return this;
+        }
+
+        public Builder serverTools(List<Map<String, Object>> serverTools) {
+            this.serverTools = serverTools;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -57,8 +57,7 @@ import java.util.Set;
 
 class OpenAiResponsesClient {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .enable(INDENT_OUTPUT);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().enable(INDENT_OUTPUT);
 
     private static final String DEFAULT_BASE_URL = "https://api.openai.com/v1";
     private static final String OPENAI_ORGANIZATION_HEADER = "OpenAI-Organization";
@@ -149,7 +148,8 @@ class OpenAiResponsesClient {
     private static final String ROLE_USER = "user";
     private static final String ROLE_ASSISTANT = "assistant";
 
-    static final String ENCRYPTED_REASONING_KEY = "encrypted_reasoning"; // do not change, will break backward compatibility!
+    static final String ENCRYPTED_REASONING_KEY =
+            "encrypted_reasoning"; // do not change, will break backward compatibility!
 
     private static final String TYPE_FUNCTION = "function";
     private static final String TYPE_FUNCTION_CALL = "function_call";
@@ -198,9 +198,10 @@ class OpenAiResponsesClient {
         }
     }
 
-    void streamingChat(ChatRequest chatRequest,
-                       OpenAiResponsesChatRequestParameters parameters,
-                       StreamingChatResponseHandler handler) {
+    void streamingChat(
+            ChatRequest chatRequest,
+            OpenAiResponsesChatRequestParameters parameters,
+            StreamingChatResponseHandler handler) {
         try {
             Map<String, Object> payload = buildRequestPayload(chatRequest, parameters, true);
             HttpRequest request = buildHttpRequest(payload, true);
@@ -212,9 +213,8 @@ class OpenAiResponsesClient {
         }
     }
 
-    private Map<String, Object> buildRequestPayload(ChatRequest chatRequest,
-                                                    OpenAiResponsesChatRequestParameters parameters,
-                                                    boolean stream) {
+    private Map<String, Object> buildRequestPayload(
+            ChatRequest chatRequest, OpenAiResponsesChatRequestParameters parameters, boolean stream) {
         List<Map<String, Object>> input = new ArrayList<>();
         for (ChatMessage message : chatRequest.messages()) {
             input.addAll(toResponsesMessages(message));
@@ -296,9 +296,9 @@ class OpenAiResponsesClient {
         }
 
         boolean strictTools = Boolean.TRUE.equals(parameters.strictTools());
+        List<Map<String, Object>> tools = new ArrayList<>();
         List<ToolSpecification> toolSpecifications = parameters.toolSpecifications();
         if (toolSpecifications != null && !toolSpecifications.isEmpty()) {
-            List<Map<String, Object>> tools = new ArrayList<>();
             for (ToolSpecification toolSpec : toolSpecifications) {
                 Map<String, Object> tool = new LinkedHashMap<>();
                 tool.put(FIELD_TYPE, TYPE_FUNCTION);
@@ -327,6 +327,11 @@ class OpenAiResponsesClient {
 
                 tools.add(tool);
             }
+        }
+        if (parameters.serverTools() != null) {
+            tools.addAll(parameters.serverTools());
+        }
+        if (!tools.isEmpty()) {
             payload.put(FIELD_TOOLS, tools);
 
             if (parameters.toolChoice() != null) {
@@ -401,7 +406,8 @@ class OpenAiResponsesClient {
                 JsonNode summaryArray = item.path(FIELD_SUMMARY);
                 if (summaryArray.isArray()) {
                     for (JsonNode summaryItem : summaryArray) {
-                        if (FIELD_SUMMARY_TEXT.equals(summaryItem.path(FIELD_TYPE).asText())) {
+                        if (FIELD_SUMMARY_TEXT.equals(
+                                summaryItem.path(FIELD_TYPE).asText())) {
                             summaryBuilder.append(summaryItem.path(FIELD_TEXT).asText());
                         }
                     }
@@ -473,7 +479,8 @@ class OpenAiResponsesClient {
         JsonNode outputDetailsNode = usageNode.path(FIELD_OUTPUT_TOKENS_DETAILS);
         if (!outputDetailsNode.isMissingNode()) {
             usageBuilder.outputTokensDetails(OpenAiTokenUsage.OutputTokensDetails.builder()
-                    .reasoningTokens(outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
+                    .reasoningTokens(
+                            outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
                     .build());
         }
 
@@ -499,18 +506,14 @@ class OpenAiResponsesClient {
         String text = extractText(outputNode);
         String thinking = extractReasoningSummary(outputNode);
         String encryptedContent = extractReasoningEncryptedContent(outputNode);
-        List<ToolExecutionRequest> toolExecutionRequests =
-                extractToolExecutionRequests(outputNode);
+        List<ToolExecutionRequest> toolExecutionRequests = extractToolExecutionRequests(outputNode);
 
-        AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                .text(text)
-                .thinking(thinking)
-                .toolExecutionRequests(toolExecutionRequests);
+        AiMessage.Builder aiMessageBuilder =
+                AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(toolExecutionRequests);
         if (encryptedContent != null) {
             aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
         }
         AiMessage aiMessage = aiMessageBuilder.build();
-
 
         OpenAiResponsesChatResponseMetadata.Builder metadataBuilder = OpenAiResponsesChatResponseMetadata.builder()
                 .id(responseNode.path(FIELD_ID).asText(null))
@@ -685,8 +688,9 @@ class OpenAiResponsesClient {
             case LOW -> "low";
             case HIGH -> "high";
             case AUTO -> "auto";
-            default -> throw new UnsupportedFeatureException(
-                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default ->
+                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
+                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
@@ -974,10 +978,8 @@ class OpenAiResponsesClient {
             String thinking = extractReasoningSummary(outputNode);
             String encryptedContent = extractReasoningEncryptedContent(outputNode);
 
-            AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                    .text(text)
-                    .thinking(thinking)
-                    .toolExecutionRequests(completedToolCalls);
+            AiMessage.Builder aiMessageBuilder =
+                    AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(completedToolCalls);
             if (encryptedContent != null) {
                 aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
             }
@@ -992,8 +994,8 @@ class OpenAiResponsesClient {
                 metadataBuilder.tokenUsage(tokenUsage);
             }
 
-            FinishReason finishReason = finishReasonFromStatus(
-                    responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
+            FinishReason finishReason =
+                    finishReasonFromStatus(responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
             if (finishReason != null) {
                 metadataBuilder.finishReason(finishReason);
             }
@@ -1002,10 +1004,12 @@ class OpenAiResponsesClient {
                 metadataBuilder.createdAt(responseNode.path(FIELD_CREATED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_COMPLETED_AT)) {
-                metadataBuilder.completedAt(responseNode.path(FIELD_COMPLETED_AT).asLong());
+                metadataBuilder.completedAt(
+                        responseNode.path(FIELD_COMPLETED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_SERVICE_TIER)) {
-                metadataBuilder.serviceTier(responseNode.path(FIELD_SERVICE_TIER).asText());
+                metadataBuilder.serviceTier(
+                        responseNode.path(FIELD_SERVICE_TIER).asText());
             }
             if (rawHttpResponse != null) {
                 metadataBuilder.rawHttpResponse(rawHttpResponse);
@@ -1014,9 +1018,7 @@ class OpenAiResponsesClient {
                 metadataBuilder.rawServerSentEvents(new ArrayList<>(rawServerSentEvents));
             }
 
-            var responseBuilder = ChatResponse.builder()
-                    .aiMessage(aiMessage)
-                    .metadata(metadataBuilder.build());
+            var responseBuilder = ChatResponse.builder().aiMessage(aiMessage).metadata(metadataBuilder.build());
 
             if (!isCancelled()) {
                 try {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesStreamingChatModel.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.openai;
 
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.util.Arrays.asList;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.exception.UnsupportedFeatureException;
@@ -14,14 +19,9 @@ import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
-
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-
-import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static java.util.Arrays.asList;
 
 @Experimental
 public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
@@ -54,7 +54,6 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
                         : OpenAiResponsesChatRequestParameters.EMPTY;
 
         this.defaultRequestParameters = OpenAiResponsesChatRequestParameters.builder()
-
                 .modelName(ensureNotNull(getOrDefault(builder.modelName, commonParameters.modelName()), "modelName"))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -62,7 +61,6 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
                 .toolSpecifications(getOrDefault(builder.toolSpecifications, commonParameters.toolSpecifications()))
                 .toolChoice(getOrDefault(builder.toolChoice, commonParameters.toolChoice()))
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
-
                 .previousResponseId(getOrDefault(builder.previousResponseId, responsesParameters.previousResponseId()))
                 .maxToolCalls(getOrDefault(builder.maxToolCalls, responsesParameters.maxToolCalls()))
                 .parallelToolCalls(getOrDefault(builder.parallelToolCalls, responsesParameters.parallelToolCalls()))
@@ -72,14 +70,17 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
                 .serviceTier(getOrDefault(builder.serviceTier, responsesParameters.serviceTier()))
                 .safetyIdentifier(getOrDefault(builder.safetyIdentifier, responsesParameters.safetyIdentifier()))
                 .promptCacheKey(getOrDefault(builder.promptCacheKey, responsesParameters.promptCacheKey()))
-                .promptCacheRetention(getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
+                .promptCacheRetention(
+                        getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
                 .reasoningEffort(getOrDefault(builder.reasoningEffort, responsesParameters.reasoningEffort()))
                 .reasoningSummary(getOrDefault(builder.reasoningSummary, responsesParameters.reasoningSummary()))
                 .textVerbosity(getOrDefault(builder.textVerbosity, responsesParameters.textVerbosity()))
-                .streamIncludeObfuscation(getOrDefault(builder.streamIncludeObfuscation, responsesParameters.streamIncludeObfuscation()))
+                .streamIncludeObfuscation(
+                        getOrDefault(builder.streamIncludeObfuscation, responsesParameters.streamIncludeObfuscation()))
                 .store(getOrDefault(builder.store, getOrDefault(responsesParameters.store(), false)))
                 .strictTools(getOrDefault(builder.strictTools, responsesParameters.strictTools()))
                 .strictJsonSchema(getOrDefault(builder.strictJsonSchema, responsesParameters.strictJsonSchema()))
+                .serverTools(getOrDefault(builder.serverTools, responsesParameters.serverTools()))
                 .build();
 
         this.listeners = copy(builder.listeners);
@@ -102,10 +103,12 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
             throw new UnsupportedFeatureException("'topK' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.frequencyPenalty() != null) {
-            throw new UnsupportedFeatureException("'frequencyPenalty' parameter is not supported by OpenAI Responses API");
+            throw new UnsupportedFeatureException(
+                    "'frequencyPenalty' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.presencePenalty() != null) {
-            throw new UnsupportedFeatureException("'presencePenalty' parameter is not supported by OpenAI Responses API");
+            throw new UnsupportedFeatureException(
+                    "'presencePenalty' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.stopSequences() != null && !parameters.stopSequences().isEmpty()) {
             throw new UnsupportedFeatureException("'stopSequences' parameter is not supported by OpenAI Responses API");
@@ -161,6 +164,7 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
         private Boolean strictJsonSchema;
         private ResponseFormat responseFormat;
         private List<ToolSpecification> toolSpecifications;
+        private List<Map<String, Object>> serverTools;
         private ToolChoice toolChoice;
         private Boolean logRequests;
         private Boolean logResponses;
@@ -314,6 +318,11 @@ public class OpenAiResponsesStreamingChatModel implements StreamingChatModel {
 
         public Builder toolSpecifications(ToolSpecification... toolSpecifications) {
             return toolSpecifications(asList(toolSpecifications));
+        }
+
+        public Builder serverTools(List<Map<String, Object>> serverTools) {
+            this.serverTools = serverTools;
+            return this;
         }
 
         public Builder toolChoice(ToolChoice toolChoice) {

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesChatRequestParametersTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesChatRequestParametersTest.java
@@ -1,0 +1,89 @@
+package dev.langchain4j.model.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OpenAiResponsesChatRequestParametersTest {
+
+    @Test
+    void should_store_server_tools() {
+        List<Map<String, Object>> serverTools = List.of(Map.of("type", "web_search"));
+
+        OpenAiResponsesChatRequestParameters parameters = OpenAiResponsesChatRequestParameters.builder()
+                .serverTools(serverTools)
+                .build();
+
+        assertThat(parameters.serverTools()).containsExactlyElementsOf(serverTools);
+    }
+
+    @Test
+    void should_override_server_tools() {
+        OpenAiResponsesChatRequestParameters defaults = OpenAiResponsesChatRequestParameters.builder()
+                .modelName("gpt-5.4-mini")
+                .serverTools(List.of(Map.of("type", "web_search")))
+                .build();
+
+        OpenAiResponsesChatRequestParameters override = OpenAiResponsesChatRequestParameters.builder()
+                .serverTools(List.of(Map.of("type", "file_search", "vector_store_ids", List.of("vs_1"))))
+                .build();
+
+        OpenAiResponsesChatRequestParameters merged = defaults.overrideWith(override);
+
+        assertThat(merged.serverTools())
+                .containsExactly(Map.of("type", "file_search", "vector_store_ids", List.of("vs_1")));
+    }
+
+    @Test
+    void should_include_server_tools_in_equals_and_hash_code() {
+        OpenAiResponsesChatRequestParameters first = OpenAiResponsesChatRequestParameters.builder()
+                .serverTools(List.of(Map.of("type", "web_search")))
+                .build();
+
+        OpenAiResponsesChatRequestParameters second = OpenAiResponsesChatRequestParameters.builder()
+                .serverTools(List.of(Map.of("type", "web_search")))
+                .build();
+
+        OpenAiResponsesChatRequestParameters third = OpenAiResponsesChatRequestParameters.builder()
+                .serverTools(List.of(Map.of("type", "file_search")))
+                .build();
+
+        assertThat(first).isEqualTo(second);
+        assertThat(first.hashCode()).isEqualTo(second.hashCode());
+        assertThat(first).isNotEqualTo(third);
+    }
+
+    @Test
+    void should_store_server_tools_in_chat_model_default_request_parameters() {
+        List<Map<String, Object>> serverTools = List.of(Map.of("type", "web_search"));
+
+        OpenAiResponsesChatModel model = OpenAiResponsesChatModel.builder()
+                .modelName("gpt-5.4-mini")
+                .apiKey("banana")
+                .serverTools(serverTools)
+                .build();
+
+        OpenAiResponsesChatRequestParameters parameters =
+                (OpenAiResponsesChatRequestParameters) model.defaultRequestParameters();
+
+        assertThat(parameters.serverTools()).containsExactlyElementsOf(serverTools);
+    }
+
+    @Test
+    void should_store_server_tools_in_streaming_model_default_request_parameters() {
+        List<Map<String, Object>> serverTools = List.of(Map.of("type", "file_search"));
+
+        OpenAiResponsesStreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+                .modelName("gpt-5.4-mini")
+                .apiKey("banana")
+                .serverTools(serverTools)
+                .build();
+
+        OpenAiResponsesChatRequestParameters parameters =
+                (OpenAiResponsesChatRequestParameters) model.defaultRequestParameters();
+
+        assertThat(parameters.serverTools()).containsExactlyElementsOf(serverTools);
+    }
+}

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesStreamingChatModelPayloadTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiResponsesStreamingChatModelPayloadTest.java
@@ -1,0 +1,126 @@
+package dev.langchain4j.model.openai;
+
+import static dev.langchain4j.model.chat.request.ToolChoice.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OpenAiResponsesStreamingChatModelPayloadTest {
+
+    private static final String MODEL_NAME = "gpt-5.4-mini";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ToolSpecification WEATHER_TOOL = ToolSpecification.builder()
+            .name("getWeather")
+            .description("Returns the current weather for a given city")
+            .parameters(JsonObjectSchema.builder()
+                    .addStringProperty("city")
+                    .required("city")
+                    .build())
+            .build();
+
+    @Test
+    void should_send_only_server_tools() throws Exception {
+        MockHttpClient mockHttpClient = new MockHttpClient();
+        Map<String, Object> webSearchTool = new LinkedHashMap<>();
+        webSearchTool.put("type", "web_search");
+        webSearchTool.put("user_location", Map.of("type", "approximate", "country", "US"));
+
+        OpenAiResponsesStreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+                .apiKey("test-key")
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .modelName(MODEL_NAME)
+                .serverTools(List.of(webSearchTool))
+                .build();
+
+        try {
+            model.chat("Hello", new TestStreamingChatResponseHandler());
+        } catch (Exception ignored) {
+        }
+
+        JsonNode payload = OBJECT_MAPPER.readTree(mockHttpClient.request().body());
+        assertThat(payload.get("tools")).hasSize(1);
+        assertThat(payload.get("tools").get(0).get("type").asText()).isEqualTo("web_search");
+        assertThat(payload.get("tools")
+                        .get(0)
+                        .get("user_location")
+                        .get("country")
+                        .asText())
+                .isEqualTo("US");
+    }
+
+    @Test
+    void should_send_function_and_server_tools_together() throws Exception {
+        MockHttpClient mockHttpClient = new MockHttpClient();
+        Map<String, Object> webSearchTool = new LinkedHashMap<>();
+        webSearchTool.put("type", "web_search");
+
+        OpenAiResponsesStreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+                .apiKey("test-key")
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .modelName(MODEL_NAME)
+                .toolSpecifications(WEATHER_TOOL)
+                .serverTools(List.of(webSearchTool))
+                .toolChoice(REQUIRED)
+                .build();
+
+        try {
+            model.chat("Hello", new TestStreamingChatResponseHandler());
+        } catch (Exception ignored) {
+        }
+
+        JsonNode payload = OBJECT_MAPPER.readTree(mockHttpClient.request().body());
+        assertThat(payload.get("tools")).hasSize(2);
+        assertThat(payload.get("tools").get(0).get("type").asText()).isEqualTo("function");
+        assertThat(payload.get("tools").get(0).get("name").asText()).isEqualTo("getWeather");
+        assertThat(payload.get("tools").get(1).get("type").asText()).isEqualTo("web_search");
+        assertThat(payload.get("tool_choice").asText()).isEqualTo("required");
+    }
+
+    @Test
+    void should_override_default_server_tools_with_request_server_tools() throws Exception {
+        MockHttpClient mockHttpClient = new MockHttpClient();
+        Map<String, Object> defaultTool = new LinkedHashMap<>();
+        defaultTool.put("type", "web_search");
+        Map<String, Object> requestTool = new LinkedHashMap<>();
+        requestTool.put("type", "file_search");
+        requestTool.put("vector_store_ids", List.of("vs_1"));
+
+        OpenAiResponsesStreamingChatModel model = OpenAiResponsesStreamingChatModel.builder()
+                .apiKey("test-key")
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .defaultRequestParameters(OpenAiResponsesChatRequestParameters.builder()
+                        .modelName(MODEL_NAME)
+                        .serverTools(List.of(defaultTool))
+                        .build())
+                .build();
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
+                .parameters(OpenAiResponsesChatRequestParameters.builder()
+                        .serverTools(List.of(requestTool))
+                        .build())
+                .build();
+
+        try {
+            model.chat(chatRequest, new TestStreamingChatResponseHandler());
+        } catch (Exception ignored) {
+        }
+
+        JsonNode payload = OBJECT_MAPPER.readTree(mockHttpClient.request().body());
+        assertThat(payload.get("tools")).hasSize(1);
+        assertThat(payload.get("tools").get(0).get("type").asText()).isEqualTo("file_search");
+        assertThat(payload.get("tools").get(0).get("vector_store_ids").get(0).asText())
+                .isEqualTo("vs_1");
+    }
+}


### PR DESCRIPTION
## Issue

## Change
- add serverTools to OpenAiResponsesChatRequestParameters using List<Map<String, Object>>
- expose serverTools(...) on unofficial OpenAiResponsesChatModel and OpenAiResponsesStreamingChatModel
- merge built-in tools and existing function tools into the same outgoing Responses API tools array
- add focused tests for parameter storage, builder propagation, payload construction, and request-level override behavior

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for big features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root pom.xml and langchain4j-bom/pom.xml

## Checklist for adding new embedding store integration
- [ ] I have added a {NameOfIntegration}EmbeddingStoreIT that extends from either EmbeddingStoreIT or EmbeddingStoreWithFilteringIT
- [ ] I have added a {NameOfIntegration}EmbeddingStoreRemovalIT that extends from EmbeddingStoreWithRemovalIT

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the {NameOfIntegration}EmbeddingStore works correctly with the data persisted using the latest released version of LangChain4j

## Verification
- ran ./mvnw -o -nsu -Dmaven.repo.local=/Users/leocham/.m2/repository -pl langchain4j-open-ai spotless:apply
- ran ./mvnw -o -nsu -Dmaven.repo.local=/Users/leocham/.m2/repository -pl langchain4j-open-ai -Dtest=OpenAiResponsesChatRequestParametersTest,OpenAiResponsesStreamingChatModelPayloadTest test
