### PR TITLE
fix(ollama): include tool_name and is_error fields in tool result messages

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -251,6 +251,17 @@ class InternalOllamaHelper {
                             .collect(Collectors.toList()))
                     .orElse(null);
         }
+
+        // Handle ToolExecutionResultMessage with full field support
+        if (chatMessage instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+            return Message.builder()
+                    .role(Role.TOOL)
+                    .content(toText(chatMessage))
+                    .toolName(toolExecutionResultMessage.toolName())
+                    .isError(toolExecutionResultMessage.isError())
+                    .build();
+        }
+
         return Message.builder()
                 .role(toOllamaRole(chatMessage.type()))
                 .content(toText(chatMessage))

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/Message.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/Message.java
@@ -21,6 +21,8 @@ class Message {
     private String thinking;
     private List<String> images;
     private List<ToolCall> toolCalls;
+    private String toolName;
+    private Boolean isError;
     private Map<String, Object> additionalFields;
 
     Message() {}
@@ -31,6 +33,8 @@ class Message {
         this.thinking = builder.thinking;
         this.images = builder.images;
         this.toolCalls = builder.toolCalls;
+        this.toolName = builder.toolName;
+        this.isError = builder.isError;
         this.additionalFields = builder.additionalFields;
     }
 
@@ -70,6 +74,22 @@ class Message {
         this.toolCalls = toolCalls;
     }
 
+    public String getToolName() {
+        return toolName;
+    }
+
+    public void setToolName(String toolName) {
+        this.toolName = toolName;
+    }
+
+    public Boolean getIsError() {
+        return isError;
+    }
+
+    public void setIsError(Boolean isError) {
+        this.isError = isError;
+    }
+
     @JsonAnyGetter
     public Map<String, Object> getAdditionalFields() {
         return additionalFields;
@@ -95,6 +115,8 @@ class Message {
         private String thinking;
         private List<String> images;
         private List<ToolCall> toolCalls;
+        private String toolName;
+        private Boolean isError;
         private Map<String, Object> additionalFields;
 
         Builder role(Role role) {
@@ -119,6 +141,16 @@ class Message {
 
         Builder toolCalls(List<ToolCall> toolCalls) {
             this.toolCalls = toolCalls;
+            return this;
+        }
+
+        Builder toolName(String toolName) {
+            this.toolName = toolName;
+            return this;
+        }
+
+        Builder isError(Boolean isError) {
+            this.isError = isError;
             return this;
         }
 

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
@@ -2,12 +2,27 @@ package dev.langchain4j.model.ollama;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class InternalOllamaHelperTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new com.fasterxml.jackson.databind.module.SimpleModule()
+                    .addSerializer(Role.class, new com.fasterxml.jackson.databind.JsonSerializer<Role>() {
+                        @Override
+                        public void serialize(Role role, com.fasterxml.jackson.core.JsonGenerator gen,
+                                com.fasterxml.jackson.databind.SerializerProvider serializers) throws java.io.IOException {
+                            gen.writeString(role.name().toLowerCase(java.util.Locale.ROOT));
+                        }
+                    }));
 
     @Test
     void toToolExecutionRequests_mapsToolCalls() {
@@ -34,5 +49,49 @@ class InternalOllamaHelperTest {
         List<ToolExecutionRequest> result = InternalOllamaHelper.toToolExecutionRequests(List.of());
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void toOllamaMessages_includesToolNameAndIsError_onToolExecutionResultMessage() throws Exception {
+        ToolExecutionResultMessage toolResult = ToolExecutionResultMessage.builder()
+                .id("call_abc123")
+                .toolName("getWeather")
+                .text("Sunny, 22°C")
+                .isError(false)
+                .build();
+
+        List<ChatMessage> messages = List.of(toolResult);
+        List<Message> ollamaMessages = InternalOllamaHelper.toOllamaMessages(messages);
+
+        assertThat(ollamaMessages).hasSize(1);
+        Message msg = ollamaMessages.get(0);
+        assertThat(msg.getRole()).isEqualTo(Role.TOOL);
+        assertThat(msg.getContent()).isEqualTo("Sunny, 22°C");
+        assertThat(msg.getToolName()).isEqualTo("getWeather");
+        assertThat(msg.getIsError()).isEqualTo(false);
+
+        // Verify JSON serialization includes tool_name and is_error
+        String json = OBJECT_MAPPER.writeValueAsString(msg);
+        assertThat(json).contains("\"tool_name\"");
+        assertThat(json).contains("\"is_error\"");
+    }
+
+    @Test
+    void toOllamaMessages_includesIsErrorTrue_onToolExecutionResultMessage() throws Exception {
+        ToolExecutionResultMessage toolResult = ToolExecutionResultMessage.builder()
+                .id("call_def456")
+                .toolName("getWeather")
+                .text("Error: location not found")
+                .isError(true)
+                .build();
+
+        List<ChatMessage> messages = List.of(toolResult);
+        List<Message> ollamaMessages = InternalOllamaHelper.toOllamaMessages(messages);
+
+        assertThat(ollamaMessages).hasSize(1);
+        Message msg = ollamaMessages.get(0);
+        assertThat(msg.getRole()).isEqualTo(Role.TOOL);
+        assertThat(msg.getToolName()).isEqualTo("getWeather");
+        assertThat(msg.getIsError()).isEqualTo(true);
     }
 }


### PR DESCRIPTION
## Fixes langchain4j/langchain4j#4742

### Problem
ToolExecutionResultMessage was not serializing `tool_name` and `is_error` when converted to Ollama's Message format. Per the Ollama API spec, tool result messages must include `role:"tool"`, `tool_name`, and `content` fields — but the adapter was dropping the tool name and isError flag.

### Changes

- **Message.java**: Added `toolName` and `isError` fields with snake_case JSON serialization
- **InternalOllamaHelper.java**: Added explicit `ToolExecutionResultMessage` handling in `otherMessages()` that sets all three fields (`role: tool`, `tool_name`, `content`, `is_error`)
- **InternalOllamaHelperTest.java**: Added regression tests verifying the full serialization including `tool_name` and `is_error` in the JSON output

### Testing
Unit tests added in `InternalOllamaHelperTest.java` cover:
- Basic tool result with `toolName` and `isError=false`
- Tool result with `isError=true`