### PR TITLE
feat(bedrock): add guardContent placement support

### DIFF
--- a/docs/docs/integrations/language-models/amazon-bedrock.md
+++ b/docs/docs/integrations/language-models/amazon-bedrock.md
@@ -19,10 +19,6 @@ In order to use Amazon Bedrock models, you need to configure AWS credentials.
 One of the options is to set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. More information can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html). Alternatively, set the `AWS_BEARER_TOKEN_BEDROCK` environment variable locally for API Key authentication. For additional API key details, refer to [docs](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html).
 
 ## BedrockChatModel
-:::note
-Guardrails is not supported by the current implementation.
-:::
-
 Supported models and their features can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html).
 
 Models ids can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html).
@@ -61,11 +57,6 @@ ChatModel model = BedrockChatModel.builder()
 - [BedrockChatModelExample](https://github.com/langchain4j/langchain4j-examples/blob/main/bedrock-examples/src/main/java/converse/BedrockChatModelExample.java)
 
 ## BedrockStreamingChatModel
-
-:::note
-Guardrails is not supported by the current implementation.
-:::
-
 Supported models and their features can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html).
 
 Models ids can be found [here](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html).
@@ -102,6 +93,23 @@ StreamingChatModel model = BedrockStreamingChatModel.builder()
 
 - [BedrockStreamingChatModelExample](https://github.com/langchain4j/langchain4j-examples/blob/main/bedrock-examples/src/main/java/converse/BedrockStreamingChatModelExample.java)
 
+## Guardrails
+
+`BedrockChatModel` and `BedrockStreamingChatModel` support [Amazon Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html). Configure a guardrail through `BedrockChatRequestParameters`:
+
+```java
+BedrockChatRequestParameters parameters = BedrockChatRequestParameters.builder()
+        .guardrailConfiguration(BedrockGuardrailConfiguration.builder()
+                .guardrailIdentifier("guardrail-id")
+                .guardrailVersion("1")
+                .guardContentPlacement(BedrockGuardContentPlacement.LAST_USER_MESSAGE)
+                .build())
+        .build();
+```
+
+Set these parameters as the model's `defaultRequestParameters`. Without `guardContentPlacement`, the guardrail applies to the entire request. Use `LAST_USER_MESSAGE` to guard only the last user message or `ALL_USER_MESSAGES` to guard all user messages.
+
+Selective guarding supports text and PNG/JPEG images. If a selected message contains content that cannot be represented as Bedrock `guardContent`, the model falls back to applying the guardrail to the entire request and logs a warning.
 
 ## Additional Model Request Fields
 

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
@@ -312,9 +312,8 @@ abstract class AbstractBedrockChatModel {
             if (msg instanceof ToolExecutionResultMessage toolResult) {
                 handleToolResult(toolResult, currentBlocks, bedrockMessages, i, messages);
             } else if ((msg instanceof UserMessage) || (msg instanceof AiMessage)) {
-                boolean shouldApplyGuardContent =
-                        shouldUseGuardContent
-                                && shouldApplyGuardContent(msg, guardContentPlacement, i, lastUserMessageIndex);
+                boolean shouldApplyGuardContent = shouldUseGuardContent
+                        && shouldApplyGuardContent(msg, guardContentPlacement, i, lastUserMessageIndex);
                 Message bedrockMessage = shouldApplyGuardContent
                         ? createGuardedUserMessage((UserMessage) msg)
                         : convertToBedRockMessage(msg);
@@ -352,42 +351,73 @@ abstract class AbstractBedrockChatModel {
     }
 
     private boolean shouldUseGuardContent(
-            List<ChatMessage> messages,
-            BedrockGuardContentPlacement guardContentPlacement,
-            int lastUserMessageIndex) {
+            List<ChatMessage> messages, BedrockGuardContentPlacement guardContentPlacement, int lastUserMessageIndex) {
         if (guardContentPlacement == null) {
             return false;
+        }
+
+        String fallbackReason = guardContentFallbackReason(messages, guardContentPlacement, lastUserMessageIndex);
+        if (fallbackReason != null) {
+            log.warn(fallbackReason);
+            return false;
+        }
+        return true;
+    }
+
+    private String guardContentFallbackReason(
+            List<ChatMessage> messages, BedrockGuardContentPlacement guardContentPlacement, int lastUserMessageIndex) {
+        if (guardContentPlacement == null || messages == null) {
+            return null;
         }
 
         for (int i = 0; i < messages.size(); i++) {
             ChatMessage message = messages.get(i);
             // Avoid partial selective guarding; regular content lets Bedrock apply guardrailConfig to all messages.
-            if (shouldApplyGuardContent(message, guardContentPlacement, i, lastUserMessageIndex)
-                    && !supportsGuardContent(((UserMessage) message).contents())) {
-                return false;
+            if (shouldApplyGuardContent(message, guardContentPlacement, i, lastUserMessageIndex)) {
+                String unsupportedContentReason = unsupportedGuardContentReason(((UserMessage) message).contents());
+                if (unsupportedContentReason != null) {
+                    return String.format(
+                            "BedrockGuardContentPlacement.%s is configured but ignored because selected user "
+                                    + "message at index %d contains %s that cannot be represented as guardContent.",
+                            guardContentPlacement, i, unsupportedContentReason);
+                }
             }
         }
 
-        return true;
+        return null;
     }
 
-    private boolean supportsGuardContent(List<Content> contents) {
+    private String unsupportedGuardContentReason(List<Content> contents) {
         if (isNullOrEmpty(contents)) {
-            return true;
+            return null;
         }
 
-        return contents.stream().allMatch(this::supportsGuardContent);
+        for (Content content : contents) {
+            String unsupportedContentReason = unsupportedGuardContentReason(content);
+            if (unsupportedContentReason != null) {
+                return unsupportedContentReason;
+            }
+        }
+
+        return null;
     }
 
-    private boolean supportsGuardContent(Content content) {
+    private String unsupportedGuardContentReason(Content content) {
+        if (content == null) {
+            return "null content";
+        }
         if (content instanceof TextContent) {
-            return true;
+            return null;
         }
         if (content instanceof ImageContent imageContent) {
-            return isGuardContentImageFormatSupported(extractAndValidateFormat(imageContent.image()));
+            String imgFormat = extractAndValidateFormat(imageContent.image());
+            if (isGuardContentImageFormatSupported(imgFormat)) {
+                return null;
+            }
+            return "unsupported image format '" + imgFormat + "'";
         }
 
-        return false;
+        return "content type '" + content.type() + "'";
     }
 
     private boolean shouldApplyGuardContent(
@@ -612,7 +642,9 @@ abstract class AbstractBedrockChatModel {
                 .guardContent(GuardrailConverseContentBlock.builder()
                         .image(GuardrailConverseImageBlock.builder()
                                 .format(guardContentImageFormat(imgFormat, imageContent))
-                                .source(GuardrailConverseImageSource.builder().bytes(bytes).build())
+                                .source(GuardrailConverseImageSource.builder()
+                                        .bytes(bytes)
+                                        .build())
                                 .build())
                         .build())
                 .build();

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
@@ -80,6 +80,11 @@ import software.amazon.awssdk.services.bedrockruntime.model.DocumentBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.DocumentFormat;
 import software.amazon.awssdk.services.bedrockruntime.model.DocumentSource;
 import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConfiguration;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConverseContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConverseImageBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConverseImageFormat;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConverseImageSource;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConverseTextBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.GuardrailStreamConfiguration;
 import software.amazon.awssdk.services.bedrockruntime.model.GuardrailStreamProcessingMode;
 import software.amazon.awssdk.services.bedrockruntime.model.GuardrailTrace;
@@ -269,6 +274,14 @@ abstract class AbstractBedrockChatModel {
 
     protected List<Message> extractRegularMessages(
             List<ChatMessage> messages, BedrockCachePointPlacement cachePointPlacement, CacheTTL cacheTtl) {
+        return extractRegularMessages(messages, cachePointPlacement, cacheTtl, null);
+    }
+
+    protected List<Message> extractRegularMessages(
+            List<ChatMessage> messages,
+            BedrockCachePointPlacement cachePointPlacement,
+            CacheTTL cacheTtl,
+            BedrockGuardContentPlacement guardContentPlacement) {
         if (messages == null) {
             return new ArrayList<>();
         }
@@ -277,9 +290,10 @@ abstract class AbstractBedrockChatModel {
         List<ContentBlock> currentBlocks = new ArrayList<>();
         boolean firstUserMessageProcessed = false;
 
-        // Find the index of the last user message for AFTER_LAST_USER_MESSAGE placement
+        // Find the index of the last user message for AFTER_LAST_USER_MESSAGE and LAST_USER_MESSAGE placements
         int lastUserMessageIndex = -1;
-        if (cachePointPlacement == BedrockCachePointPlacement.AFTER_LAST_USER_MESSAGE) {
+        if (cachePointPlacement == BedrockCachePointPlacement.AFTER_LAST_USER_MESSAGE
+                || guardContentPlacement == BedrockGuardContentPlacement.LAST_USER_MESSAGE) {
             for (int i = messages.size() - 1; i >= 0; i--) {
                 if (messages.get(i) instanceof UserMessage) {
                     lastUserMessageIndex = i;
@@ -287,6 +301,8 @@ abstract class AbstractBedrockChatModel {
                 }
             }
         }
+
+        boolean shouldUseGuardContent = shouldUseGuardContent(messages, guardContentPlacement, lastUserMessageIndex);
 
         for (int i = 0; i < messages.size(); i++) {
             ChatMessage msg = messages.get(i);
@@ -296,7 +312,12 @@ abstract class AbstractBedrockChatModel {
             if (msg instanceof ToolExecutionResultMessage toolResult) {
                 handleToolResult(toolResult, currentBlocks, bedrockMessages, i, messages);
             } else if ((msg instanceof UserMessage) || (msg instanceof AiMessage)) {
-                Message bedrockMessage = convertToBedRockMessage(msg);
+                boolean shouldApplyGuardContent =
+                        shouldUseGuardContent
+                                && shouldApplyGuardContent(msg, guardContentPlacement, i, lastUserMessageIndex);
+                Message bedrockMessage = shouldApplyGuardContent
+                        ? createGuardedUserMessage((UserMessage) msg)
+                        : convertToBedRockMessage(msg);
 
                 boolean shouldAddCachePoint = false;
 
@@ -328,6 +349,59 @@ abstract class AbstractBedrockChatModel {
         }
 
         return bedrockMessages;
+    }
+
+    private boolean shouldUseGuardContent(
+            List<ChatMessage> messages,
+            BedrockGuardContentPlacement guardContentPlacement,
+            int lastUserMessageIndex) {
+        if (guardContentPlacement == null) {
+            return false;
+        }
+
+        for (int i = 0; i < messages.size(); i++) {
+            ChatMessage message = messages.get(i);
+            // Avoid partial selective guarding; regular content lets Bedrock apply guardrailConfig to all messages.
+            if (shouldApplyGuardContent(message, guardContentPlacement, i, lastUserMessageIndex)
+                    && !supportsGuardContent(((UserMessage) message).contents())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean supportsGuardContent(List<Content> contents) {
+        if (isNullOrEmpty(contents)) {
+            return true;
+        }
+
+        return contents.stream().allMatch(this::supportsGuardContent);
+    }
+
+    private boolean supportsGuardContent(Content content) {
+        if (content instanceof TextContent) {
+            return true;
+        }
+        if (content instanceof ImageContent imageContent) {
+            return isGuardContentImageFormatSupported(extractAndValidateFormat(imageContent.image()));
+        }
+
+        return false;
+    }
+
+    private boolean shouldApplyGuardContent(
+            ChatMessage message,
+            BedrockGuardContentPlacement guardContentPlacement,
+            int messageIndex,
+            int lastUserMessageIndex) {
+        if (!(message instanceof UserMessage) || guardContentPlacement == null) {
+            return false;
+        }
+
+        return guardContentPlacement == BedrockGuardContentPlacement.ALL_USER_MESSAGES
+                || (guardContentPlacement == BedrockGuardContentPlacement.LAST_USER_MESSAGE
+                        && messageIndex == lastUserMessageIndex);
     }
 
     protected void handleToolResult(
@@ -410,6 +484,13 @@ abstract class AbstractBedrockChatModel {
                 .build();
     }
 
+    protected Message createGuardedUserMessage(UserMessage message) {
+        return Message.builder()
+                .role(ConversationRole.USER)
+                .content(convertContentsWithGuardContent(message.contents()))
+                .build();
+    }
+
     protected Message createAiMessage(AiMessage message) {
         List<ContentBlock> blocks = new ArrayList<>();
 
@@ -459,6 +540,14 @@ abstract class AbstractBedrockChatModel {
         return contents.stream().map(this::convertContent).toList();
     }
 
+    protected List<ContentBlock> convertContentsWithGuardContent(List<Content> contents) {
+        if (isNullOrEmpty(contents)) {
+            return emptyList();
+        }
+
+        return contents.stream().map(this::convertContentWithGuardContent).toList();
+    }
+
     protected ContentBlock convertContent(Content content) {
         if (content instanceof TextContent text) {
             return ContentBlock.builder().text(text.text()).build();
@@ -482,6 +571,22 @@ abstract class AbstractBedrockChatModel {
         throw new IllegalArgumentException("Unsupported content type: " + content.getClass());
     }
 
+    protected ContentBlock convertContentWithGuardContent(Content content) {
+        if (content instanceof TextContent text) {
+            return ContentBlock.builder()
+                    .guardContent(GuardrailConverseContentBlock.builder()
+                            .text(GuardrailConverseTextBlock.builder()
+                                    .text(text.text())
+                                    .build())
+                            .build())
+                    .build();
+        } else if (content instanceof ImageContent image) {
+            return createGuardedImageBlock(image);
+        }
+
+        return convertContent(content);
+    }
+
     protected ContentBlock createImageBlock(ImageContent imageContent) {
         final SdkBytes bytes = fromByteArray(
                 nonNull(imageContent.image().base64Data())
@@ -494,6 +599,41 @@ abstract class AbstractBedrockChatModel {
                         .source(ImageSource.builder().bytes(bytes).build())
                         .build())
                 .build();
+    }
+
+    protected ContentBlock createGuardedImageBlock(ImageContent imageContent) {
+        final SdkBytes bytes = fromByteArray(
+                nonNull(imageContent.image().base64Data())
+                        ? Base64.getDecoder().decode(imageContent.image().base64Data())
+                        : readBytes(String.valueOf(imageContent.image().url())));
+        final String imgFormat = extractAndValidateFormat(imageContent.image());
+
+        return ContentBlock.builder()
+                .guardContent(GuardrailConverseContentBlock.builder()
+                        .image(GuardrailConverseImageBlock.builder()
+                                .format(guardContentImageFormat(imgFormat, imageContent))
+                                .source(GuardrailConverseImageSource.builder().bytes(bytes).build())
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private GuardrailConverseImageFormat guardContentImageFormat(String imgFormat, ImageContent imageContent) {
+        if (GuardrailConverseImageFormat.PNG.toString().equals(imgFormat)) {
+            return GuardrailConverseImageFormat.PNG;
+        }
+        if (GuardrailConverseImageFormat.JPEG.toString().equals(imgFormat)) {
+            return GuardrailConverseImageFormat.JPEG;
+        }
+
+        throw new UnsupportedFeatureException(String.format(
+                "Bedrock guardContent image supports only png | jpeg. Image format: %s, Mime type: %s, URI: %s",
+                imgFormat, imageContent.image().mimeType(), imageContent.image().url()));
+    }
+
+    private boolean isGuardContentImageFormatSupported(String imgFormat) {
+        return GuardrailConverseImageFormat.PNG.toString().equals(imgFormat)
+                || GuardrailConverseImageFormat.JPEG.toString().equals(imgFormat);
     }
 
     protected ToolConfiguration extractToolConfigurationFrom(ChatRequest chatRequest) {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
@@ -80,6 +80,11 @@ import software.amazon.awssdk.services.bedrockruntime.model.DocumentBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.DocumentFormat;
 import software.amazon.awssdk.services.bedrockruntime.model.DocumentSource;
 import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConfiguration;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConverseContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConverseImageBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConverseImageFormat;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConverseImageSource;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConverseTextBlock;
 import software.amazon.awssdk.services.bedrockruntime.model.GuardrailStreamConfiguration;
 import software.amazon.awssdk.services.bedrockruntime.model.GuardrailStreamProcessingMode;
 import software.amazon.awssdk.services.bedrockruntime.model.GuardrailTrace;
@@ -271,6 +276,14 @@ abstract class AbstractBedrockChatModel {
 
     protected List<Message> extractRegularMessages(
             List<ChatMessage> messages, BedrockCachePointPlacement cachePointPlacement, CacheTTL cacheTtl) {
+        return extractRegularMessages(messages, cachePointPlacement, cacheTtl, null);
+    }
+
+    protected List<Message> extractRegularMessages(
+            List<ChatMessage> messages,
+            BedrockCachePointPlacement cachePointPlacement,
+            CacheTTL cacheTtl,
+            BedrockGuardContentPlacement guardContentPlacement) {
         if (messages == null) {
             return new ArrayList<>();
         }
@@ -279,9 +292,10 @@ abstract class AbstractBedrockChatModel {
         List<ContentBlock> currentBlocks = new ArrayList<>();
         boolean firstUserMessageProcessed = false;
 
-        // Find the index of the last user message for AFTER_LAST_USER_MESSAGE placement
+        // Find the index of the last user message for AFTER_LAST_USER_MESSAGE and LAST_USER_MESSAGE placements
         int lastUserMessageIndex = -1;
-        if (cachePointPlacement == BedrockCachePointPlacement.AFTER_LAST_USER_MESSAGE) {
+        if (cachePointPlacement == BedrockCachePointPlacement.AFTER_LAST_USER_MESSAGE
+                || guardContentPlacement == BedrockGuardContentPlacement.LAST_USER_MESSAGE) {
             for (int i = messages.size() - 1; i >= 0; i--) {
                 if (messages.get(i) instanceof UserMessage) {
                     lastUserMessageIndex = i;
@@ -289,6 +303,8 @@ abstract class AbstractBedrockChatModel {
                 }
             }
         }
+
+        boolean shouldUseGuardContent = shouldUseGuardContent(messages, guardContentPlacement, lastUserMessageIndex);
 
         for (int i = 0; i < messages.size(); i++) {
             ChatMessage msg = messages.get(i);
@@ -298,7 +314,12 @@ abstract class AbstractBedrockChatModel {
             if (msg instanceof ToolExecutionResultMessage toolResult) {
                 handleToolResult(toolResult, currentBlocks, bedrockMessages, i, messages);
             } else if ((msg instanceof UserMessage) || (msg instanceof AiMessage)) {
-                Message bedrockMessage = convertToBedRockMessage(msg);
+                boolean shouldApplyGuardContent =
+                        shouldUseGuardContent
+                                && shouldApplyGuardContent(msg, guardContentPlacement, i, lastUserMessageIndex);
+                Message bedrockMessage = shouldApplyGuardContent
+                        ? createGuardedUserMessage((UserMessage) msg)
+                        : convertToBedRockMessage(msg);
 
                 boolean shouldAddCachePoint = false;
 
@@ -330,6 +351,59 @@ abstract class AbstractBedrockChatModel {
         }
 
         return bedrockMessages;
+    }
+
+    private boolean shouldUseGuardContent(
+            List<ChatMessage> messages,
+            BedrockGuardContentPlacement guardContentPlacement,
+            int lastUserMessageIndex) {
+        if (guardContentPlacement == null) {
+            return false;
+        }
+
+        for (int i = 0; i < messages.size(); i++) {
+            ChatMessage message = messages.get(i);
+            // Avoid partial selective guarding; regular content lets Bedrock apply guardrailConfig to all messages.
+            if (shouldApplyGuardContent(message, guardContentPlacement, i, lastUserMessageIndex)
+                    && !supportsGuardContent(((UserMessage) message).contents())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean supportsGuardContent(List<Content> contents) {
+        if (isNullOrEmpty(contents)) {
+            return true;
+        }
+
+        return contents.stream().allMatch(this::supportsGuardContent);
+    }
+
+    private boolean supportsGuardContent(Content content) {
+        if (content instanceof TextContent) {
+            return true;
+        }
+        if (content instanceof ImageContent imageContent) {
+            return isGuardContentImageFormatSupported(extractAndValidateFormat(imageContent.image()));
+        }
+
+        return false;
+    }
+
+    private boolean shouldApplyGuardContent(
+            ChatMessage message,
+            BedrockGuardContentPlacement guardContentPlacement,
+            int messageIndex,
+            int lastUserMessageIndex) {
+        if (!(message instanceof UserMessage) || guardContentPlacement == null) {
+            return false;
+        }
+
+        return guardContentPlacement == BedrockGuardContentPlacement.ALL_USER_MESSAGES
+                || (guardContentPlacement == BedrockGuardContentPlacement.LAST_USER_MESSAGE
+                        && messageIndex == lastUserMessageIndex);
     }
 
     protected void handleToolResult(
@@ -412,6 +486,13 @@ abstract class AbstractBedrockChatModel {
                 .build();
     }
 
+    protected Message createGuardedUserMessage(UserMessage message) {
+        return Message.builder()
+                .role(ConversationRole.USER)
+                .content(convertContentsWithGuardContent(message.contents()))
+                .build();
+    }
+
     protected Message createAiMessage(AiMessage message) {
         List<ContentBlock> blocks = new ArrayList<>();
 
@@ -461,6 +542,14 @@ abstract class AbstractBedrockChatModel {
         return contents.stream().map(this::convertContent).toList();
     }
 
+    protected List<ContentBlock> convertContentsWithGuardContent(List<Content> contents) {
+        if (isNullOrEmpty(contents)) {
+            return emptyList();
+        }
+
+        return contents.stream().map(this::convertContentWithGuardContent).toList();
+    }
+
     protected ContentBlock convertContent(Content content) {
         if (content instanceof TextContent text) {
             return ContentBlock.builder().text(text.text()).build();
@@ -484,6 +573,22 @@ abstract class AbstractBedrockChatModel {
         throw new IllegalArgumentException("Unsupported content type: " + content.getClass());
     }
 
+    protected ContentBlock convertContentWithGuardContent(Content content) {
+        if (content instanceof TextContent text) {
+            return ContentBlock.builder()
+                    .guardContent(GuardrailConverseContentBlock.builder()
+                            .text(GuardrailConverseTextBlock.builder()
+                                    .text(text.text())
+                                    .build())
+                            .build())
+                    .build();
+        } else if (content instanceof ImageContent image) {
+            return createGuardedImageBlock(image);
+        }
+
+        return convertContent(content);
+    }
+
     protected ContentBlock createImageBlock(ImageContent imageContent) {
         final SdkBytes bytes = fromByteArray(
                 nonNull(imageContent.image().base64Data())
@@ -496,6 +601,41 @@ abstract class AbstractBedrockChatModel {
                         .source(ImageSource.builder().bytes(bytes).build())
                         .build())
                 .build();
+    }
+
+    protected ContentBlock createGuardedImageBlock(ImageContent imageContent) {
+        final SdkBytes bytes = fromByteArray(
+                nonNull(imageContent.image().base64Data())
+                        ? Base64.getDecoder().decode(imageContent.image().base64Data())
+                        : readBytes(String.valueOf(imageContent.image().url())));
+        final String imgFormat = extractAndValidateFormat(imageContent.image());
+
+        return ContentBlock.builder()
+                .guardContent(GuardrailConverseContentBlock.builder()
+                        .image(GuardrailConverseImageBlock.builder()
+                                .format(guardContentImageFormat(imgFormat, imageContent))
+                                .source(GuardrailConverseImageSource.builder().bytes(bytes).build())
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private GuardrailConverseImageFormat guardContentImageFormat(String imgFormat, ImageContent imageContent) {
+        if (GuardrailConverseImageFormat.PNG.toString().equals(imgFormat)) {
+            return GuardrailConverseImageFormat.PNG;
+        }
+        if (GuardrailConverseImageFormat.JPEG.toString().equals(imgFormat)) {
+            return GuardrailConverseImageFormat.JPEG;
+        }
+
+        throw new UnsupportedFeatureException(String.format(
+                "Bedrock guardContent image supports only png | jpeg. Image format: %s, Mime type: %s, URI: %s",
+                imgFormat, imageContent.image().mimeType(), imageContent.image().url()));
+    }
+
+    private boolean isGuardContentImageFormatSupported(String imgFormat) {
+        return GuardrailConverseImageFormat.PNG.toString().equals(imgFormat)
+                || GuardrailConverseImageFormat.JPEG.toString().equals(imgFormat);
     }
 
     protected ToolConfiguration extractToolConfigurationFrom(ChatRequest chatRequest) {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
@@ -314,9 +314,8 @@ abstract class AbstractBedrockChatModel {
             if (msg instanceof ToolExecutionResultMessage toolResult) {
                 handleToolResult(toolResult, currentBlocks, bedrockMessages, i, messages);
             } else if ((msg instanceof UserMessage) || (msg instanceof AiMessage)) {
-                boolean shouldApplyGuardContent =
-                        shouldUseGuardContent
-                                && shouldApplyGuardContent(msg, guardContentPlacement, i, lastUserMessageIndex);
+                boolean shouldApplyGuardContent = shouldUseGuardContent
+                        && shouldApplyGuardContent(msg, guardContentPlacement, i, lastUserMessageIndex);
                 Message bedrockMessage = shouldApplyGuardContent
                         ? createGuardedUserMessage((UserMessage) msg)
                         : convertToBedRockMessage(msg);
@@ -354,42 +353,73 @@ abstract class AbstractBedrockChatModel {
     }
 
     private boolean shouldUseGuardContent(
-            List<ChatMessage> messages,
-            BedrockGuardContentPlacement guardContentPlacement,
-            int lastUserMessageIndex) {
+            List<ChatMessage> messages, BedrockGuardContentPlacement guardContentPlacement, int lastUserMessageIndex) {
         if (guardContentPlacement == null) {
             return false;
+        }
+
+        String fallbackReason = guardContentFallbackReason(messages, guardContentPlacement, lastUserMessageIndex);
+        if (fallbackReason != null) {
+            log.warn(fallbackReason);
+            return false;
+        }
+        return true;
+    }
+
+    private String guardContentFallbackReason(
+            List<ChatMessage> messages, BedrockGuardContentPlacement guardContentPlacement, int lastUserMessageIndex) {
+        if (guardContentPlacement == null || messages == null) {
+            return null;
         }
 
         for (int i = 0; i < messages.size(); i++) {
             ChatMessage message = messages.get(i);
             // Avoid partial selective guarding; regular content lets Bedrock apply guardrailConfig to all messages.
-            if (shouldApplyGuardContent(message, guardContentPlacement, i, lastUserMessageIndex)
-                    && !supportsGuardContent(((UserMessage) message).contents())) {
-                return false;
+            if (shouldApplyGuardContent(message, guardContentPlacement, i, lastUserMessageIndex)) {
+                String unsupportedContentReason = unsupportedGuardContentReason(((UserMessage) message).contents());
+                if (unsupportedContentReason != null) {
+                    return String.format(
+                            "BedrockGuardContentPlacement.%s is configured but ignored because selected user "
+                                    + "message at index %d contains %s that cannot be represented as guardContent.",
+                            guardContentPlacement, i, unsupportedContentReason);
+                }
             }
         }
 
-        return true;
+        return null;
     }
 
-    private boolean supportsGuardContent(List<Content> contents) {
+    private String unsupportedGuardContentReason(List<Content> contents) {
         if (isNullOrEmpty(contents)) {
-            return true;
+            return null;
         }
 
-        return contents.stream().allMatch(this::supportsGuardContent);
+        for (Content content : contents) {
+            String unsupportedContentReason = unsupportedGuardContentReason(content);
+            if (unsupportedContentReason != null) {
+                return unsupportedContentReason;
+            }
+        }
+
+        return null;
     }
 
-    private boolean supportsGuardContent(Content content) {
+    private String unsupportedGuardContentReason(Content content) {
+        if (content == null) {
+            return "null content";
+        }
         if (content instanceof TextContent) {
-            return true;
+            return null;
         }
         if (content instanceof ImageContent imageContent) {
-            return isGuardContentImageFormatSupported(extractAndValidateFormat(imageContent.image()));
+            String imgFormat = extractAndValidateFormat(imageContent.image());
+            if (isGuardContentImageFormatSupported(imgFormat)) {
+                return null;
+            }
+            return "unsupported image format '" + imgFormat + "'";
         }
 
-        return false;
+        return "content type '" + content.type() + "'";
     }
 
     private boolean shouldApplyGuardContent(
@@ -614,7 +644,9 @@ abstract class AbstractBedrockChatModel {
                 .guardContent(GuardrailConverseContentBlock.builder()
                         .image(GuardrailConverseImageBlock.builder()
                                 .format(guardContentImageFormat(imgFormat, imageContent))
-                                .source(GuardrailConverseImageSource.builder().bytes(bytes).build())
+                                .source(GuardrailConverseImageSource.builder()
+                                        .bytes(bytes)
+                                        .build())
                                 .build())
                         .build())
                 .build();

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatModel.java
@@ -77,6 +77,9 @@ public class BedrockChatModel extends AbstractBedrockChatModel implements ChatMo
         BedrockCachePointPlacement cachePointPlacement = parameters.cachePointPlacement();
         CacheTTL cacheTtl = parameters.cacheTtl();
         BedrockGuardrailConfiguration bedrockGuardrailConfiguration = parameters.bedrockGuardrailConfiguration();
+        BedrockGuardContentPlacement guardContentPlacement = bedrockGuardrailConfiguration == null
+                ? null
+                : bedrockGuardrailConfiguration.guardContentPlacement();
         BedrockServiceTier bedrockServiceTier = parameters.serviceTier();
 
         // Validate total cache points don't exceed AWS limit
@@ -88,7 +91,8 @@ public class BedrockChatModel extends AbstractBedrockChatModel implements ChatMo
                 .modelId(chatRequest.modelName())
                 .inferenceConfig(inferenceConfigFrom(chatRequest.parameters()))
                 .system(extractSystemMessages(chatRequest.messages(), cachePointPlacement, cacheTtl))
-                .messages(extractRegularMessages(chatRequest.messages(), cachePointPlacement, cacheTtl))
+                .messages(extractRegularMessages(
+                        chatRequest.messages(), cachePointPlacement, cacheTtl, guardContentPlacement))
                 .toolConfig(extractToolConfigurationFrom(chatRequest, cachePointPlacement, cacheTtl))
                 .additionalModelRequestFields(additionalRequestModelFieldsFrom(chatRequest.parameters()))
                 .guardrailConfig(guardrailConfigFrom(bedrockGuardrailConfiguration))

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatModel.java
@@ -77,9 +77,8 @@ public class BedrockChatModel extends AbstractBedrockChatModel implements ChatMo
         BedrockCachePointPlacement cachePointPlacement = parameters.cachePointPlacement();
         CacheTTL cacheTtl = parameters.cacheTtl();
         BedrockGuardrailConfiguration bedrockGuardrailConfiguration = parameters.bedrockGuardrailConfiguration();
-        BedrockGuardContentPlacement guardContentPlacement = bedrockGuardrailConfiguration == null
-                ? null
-                : bedrockGuardrailConfiguration.guardContentPlacement();
+        BedrockGuardContentPlacement guardContentPlacement =
+                bedrockGuardrailConfiguration == null ? null : bedrockGuardrailConfiguration.guardContentPlacement();
         BedrockServiceTier bedrockServiceTier = parameters.serviceTier();
 
         // Validate total cache points don't exceed AWS limit

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockGuardContentPlacement.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockGuardContentPlacement.java
@@ -1,0 +1,17 @@
+package dev.langchain4j.model.bedrock;
+
+/**
+ * Defines which user messages should be wrapped in Bedrock Converse {@code guardContent} blocks.
+ */
+public enum BedrockGuardContentPlacement {
+
+    /**
+     * Wraps supported content blocks in the last user message.
+     */
+    LAST_USER_MESSAGE,
+
+    /**
+     * Wraps supported content blocks in all user messages.
+     */
+    ALL_USER_MESSAGES
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockGuardrailConfiguration.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockGuardrailConfiguration.java
@@ -8,12 +8,22 @@ public class BedrockGuardrailConfiguration {
     private final String guardrailIdentifier;
     private final String guardrailVersion;
     private final ProcessingMode streamProcessingMode;
+    private final BedrockGuardContentPlacement guardContentPlacement;
 
     public BedrockGuardrailConfiguration(
             String guardrailIdentifier, String guardrailVersion, ProcessingMode streamProcessingMode) {
+        this(guardrailIdentifier, guardrailVersion, streamProcessingMode, null);
+    }
+
+    public BedrockGuardrailConfiguration(
+            String guardrailIdentifier,
+            String guardrailVersion,
+            ProcessingMode streamProcessingMode,
+            BedrockGuardContentPlacement guardContentPlacement) {
         this.guardrailIdentifier = guardrailIdentifier;
         this.guardrailVersion = guardrailVersion;
         this.streamProcessingMode = streamProcessingMode;
+        this.guardContentPlacement = guardContentPlacement;
     }
 
     public String guardrailIdentifier() {
@@ -28,6 +38,10 @@ public class BedrockGuardrailConfiguration {
         return streamProcessingMode;
     }
 
+    public BedrockGuardContentPlacement guardContentPlacement() {
+        return guardContentPlacement;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -36,6 +50,7 @@ public class BedrockGuardrailConfiguration {
     public String toString() {
         return "BedrockGuardrailConfiguration{" + "guardrailIdentifier='" + guardrailIdentifier + '\''
                 + ", guardrailVersion='" + guardrailVersion + '\'' + ", streamProcessingMode=" + streamProcessingMode
+                + ", guardContentPlacement=" + guardContentPlacement
                 + '}';
     }
 
@@ -49,6 +64,7 @@ public class BedrockGuardrailConfiguration {
         private String guardrailIdentifier;
         private String guardrailVersion;
         private ProcessingMode streamProcessingMode;
+        private BedrockGuardContentPlacement guardContentPlacement;
 
         /**
          * Sets the identifier for the guardrail.
@@ -83,8 +99,20 @@ public class BedrockGuardrailConfiguration {
             return this;
         }
 
+        /**
+         * Sets which user messages should be wrapped in Bedrock Converse {@code guardContent} blocks.
+         *
+         * @param guardContentPlacement the guard content placement strategy; null disables guardContent wrapping
+         * @return this builder
+         */
+        public Builder guardContentPlacement(BedrockGuardContentPlacement guardContentPlacement) {
+            this.guardContentPlacement = guardContentPlacement;
+            return this;
+        }
+
         public BedrockGuardrailConfiguration build() {
-            return new BedrockGuardrailConfiguration(guardrailIdentifier, guardrailVersion, streamProcessingMode);
+            return new BedrockGuardrailConfiguration(
+                    guardrailIdentifier, guardrailVersion, streamProcessingMode, guardContentPlacement);
         }
     }
 }

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockGuardrailConfiguration.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockGuardrailConfiguration.java
@@ -55,12 +55,13 @@ public class BedrockGuardrailConfiguration {
         BedrockGuardrailConfiguration that = (BedrockGuardrailConfiguration) o;
         return Objects.equals(guardrailIdentifier, that.guardrailIdentifier)
                 && Objects.equals(guardrailVersion, that.guardrailVersion)
-                && Objects.equals(streamProcessingMode, that.streamProcessingMode);
+                && Objects.equals(streamProcessingMode, that.streamProcessingMode)
+                && Objects.equals(guardContentPlacement, that.guardContentPlacement);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(guardrailIdentifier, guardrailVersion, streamProcessingMode);
+        return Objects.hash(guardrailIdentifier, guardrailVersion, streamProcessingMode, guardContentPlacement);
     }
 
     @Override

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockGuardrailConfiguration.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockGuardrailConfiguration.java
@@ -10,12 +10,22 @@ public class BedrockGuardrailConfiguration {
     private final String guardrailIdentifier;
     private final String guardrailVersion;
     private final ProcessingMode streamProcessingMode;
+    private final BedrockGuardContentPlacement guardContentPlacement;
 
     public BedrockGuardrailConfiguration(
             String guardrailIdentifier, String guardrailVersion, ProcessingMode streamProcessingMode) {
+        this(guardrailIdentifier, guardrailVersion, streamProcessingMode, null);
+    }
+
+    public BedrockGuardrailConfiguration(
+            String guardrailIdentifier,
+            String guardrailVersion,
+            ProcessingMode streamProcessingMode,
+            BedrockGuardContentPlacement guardContentPlacement) {
         this.guardrailIdentifier = guardrailIdentifier;
         this.guardrailVersion = guardrailVersion;
         this.streamProcessingMode = streamProcessingMode;
+        this.guardContentPlacement = guardContentPlacement;
     }
 
     public String guardrailIdentifier() {
@@ -28,6 +38,10 @@ public class BedrockGuardrailConfiguration {
 
     public ProcessingMode streamProcessingMode() {
         return streamProcessingMode;
+    }
+
+    public BedrockGuardContentPlacement guardContentPlacement() {
+        return guardContentPlacement;
     }
 
     public static Builder builder() {
@@ -53,6 +67,7 @@ public class BedrockGuardrailConfiguration {
     public String toString() {
         return "BedrockGuardrailConfiguration{" + "guardrailIdentifier='" + guardrailIdentifier + '\''
                 + ", guardrailVersion='" + guardrailVersion + '\'' + ", streamProcessingMode=" + streamProcessingMode
+                + ", guardContentPlacement=" + guardContentPlacement
                 + '}';
     }
 
@@ -66,6 +81,7 @@ public class BedrockGuardrailConfiguration {
         private String guardrailIdentifier;
         private String guardrailVersion;
         private ProcessingMode streamProcessingMode;
+        private BedrockGuardContentPlacement guardContentPlacement;
 
         /**
          * Sets the identifier for the guardrail.
@@ -100,8 +116,20 @@ public class BedrockGuardrailConfiguration {
             return this;
         }
 
+        /**
+         * Sets which user messages should be wrapped in Bedrock Converse {@code guardContent} blocks.
+         *
+         * @param guardContentPlacement the guard content placement strategy; null disables guardContent wrapping
+         * @return this builder
+         */
+        public Builder guardContentPlacement(BedrockGuardContentPlacement guardContentPlacement) {
+            this.guardContentPlacement = guardContentPlacement;
+            return this;
+        }
+
         public BedrockGuardrailConfiguration build() {
-            return new BedrockGuardrailConfiguration(guardrailIdentifier, guardrailVersion, streamProcessingMode);
+            return new BedrockGuardrailConfiguration(
+                    guardrailIdentifier, guardrailVersion, streamProcessingMode, guardContentPlacement);
         }
     }
 }

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
@@ -190,9 +190,8 @@ public class BedrockStreamingChatModel extends AbstractBedrockChatModel implemen
         BedrockCachePointPlacement cachePointPlacement = parameters.cachePointPlacement();
         CacheTTL cacheTtl = parameters.cacheTtl();
         BedrockGuardrailConfiguration bedrockGuardrailConfiguration = parameters.bedrockGuardrailConfiguration();
-        BedrockGuardContentPlacement guardContentPlacement = bedrockGuardrailConfiguration == null
-                ? null
-                : bedrockGuardrailConfiguration.guardContentPlacement();
+        BedrockGuardContentPlacement guardContentPlacement =
+                bedrockGuardrailConfiguration == null ? null : bedrockGuardrailConfiguration.guardContentPlacement();
         BedrockServiceTier bedrockServiceTier = parameters.serviceTier();
 
         // Validate total cache points don't exceed AWS limit

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
@@ -190,6 +190,9 @@ public class BedrockStreamingChatModel extends AbstractBedrockChatModel implemen
         BedrockCachePointPlacement cachePointPlacement = parameters.cachePointPlacement();
         CacheTTL cacheTtl = parameters.cacheTtl();
         BedrockGuardrailConfiguration bedrockGuardrailConfiguration = parameters.bedrockGuardrailConfiguration();
+        BedrockGuardContentPlacement guardContentPlacement = bedrockGuardrailConfiguration == null
+                ? null
+                : bedrockGuardrailConfiguration.guardContentPlacement();
         BedrockServiceTier bedrockServiceTier = parameters.serviceTier();
 
         // Validate total cache points don't exceed AWS limit
@@ -201,7 +204,8 @@ public class BedrockStreamingChatModel extends AbstractBedrockChatModel implemen
                 .modelId(chatRequest.modelName())
                 .inferenceConfig(inferenceConfigFrom(chatRequest.parameters()))
                 .system(extractSystemMessages(chatRequest.messages(), cachePointPlacement, cacheTtl))
-                .messages(extractRegularMessages(chatRequest.messages(), cachePointPlacement, cacheTtl))
+                .messages(extractRegularMessages(
+                        chatRequest.messages(), cachePointPlacement, cacheTtl, guardContentPlacement))
                 .toolConfig(extractToolConfigurationFrom(chatRequest, cachePointPlacement, cacheTtl))
                 .additionalModelRequestFields(additionalRequestModelFieldsFrom(chatRequest.parameters()))
                 .guardrailConfig(guardrailStreamConfigFrom(bedrockGuardrailConfiguration))

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
@@ -202,9 +202,8 @@ public class BedrockStreamingChatModel extends AbstractBedrockChatModel implemen
         BedrockCachePointPlacement cachePointPlacement = parameters.cachePointPlacement();
         CacheTTL cacheTtl = parameters.cacheTtl();
         BedrockGuardrailConfiguration bedrockGuardrailConfiguration = parameters.bedrockGuardrailConfiguration();
-        BedrockGuardContentPlacement guardContentPlacement = bedrockGuardrailConfiguration == null
-                ? null
-                : bedrockGuardrailConfiguration.guardContentPlacement();
+        BedrockGuardContentPlacement guardContentPlacement =
+                bedrockGuardrailConfiguration == null ? null : bedrockGuardrailConfiguration.guardContentPlacement();
         BedrockServiceTier bedrockServiceTier = parameters.serviceTier();
 
         // Validate total cache points don't exceed AWS limit

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
@@ -202,6 +202,9 @@ public class BedrockStreamingChatModel extends AbstractBedrockChatModel implemen
         BedrockCachePointPlacement cachePointPlacement = parameters.cachePointPlacement();
         CacheTTL cacheTtl = parameters.cacheTtl();
         BedrockGuardrailConfiguration bedrockGuardrailConfiguration = parameters.bedrockGuardrailConfiguration();
+        BedrockGuardContentPlacement guardContentPlacement = bedrockGuardrailConfiguration == null
+                ? null
+                : bedrockGuardrailConfiguration.guardContentPlacement();
         BedrockServiceTier bedrockServiceTier = parameters.serviceTier();
 
         // Validate total cache points don't exceed AWS limit
@@ -213,7 +216,8 @@ public class BedrockStreamingChatModel extends AbstractBedrockChatModel implemen
                 .modelId(chatRequest.modelName())
                 .inferenceConfig(inferenceConfigFrom(chatRequest.parameters()))
                 .system(extractSystemMessages(chatRequest.messages(), cachePointPlacement, cacheTtl))
-                .messages(extractRegularMessages(chatRequest.messages(), cachePointPlacement, cacheTtl))
+                .messages(extractRegularMessages(
+                        chatRequest.messages(), cachePointPlacement, cacheTtl, guardContentPlacement))
                 .toolConfig(extractToolConfigurationFrom(chatRequest, cachePointPlacement, cacheTtl))
                 .additionalModelRequestFields(additionalRequestModelFieldsFrom(chatRequest.parameters()))
                 .guardrailConfig(guardrailStreamConfigFrom(bedrockGuardrailConfiguration))

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatRequestParametersTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatRequestParametersTest.java
@@ -173,6 +173,7 @@ class BedrockChatRequestParametersTest {
                 .guardrailConfiguration(BedrockGuardrailConfiguration.builder()
                         .guardrailIdentifier("12345")
                         .guardrailVersion("DRAFT")
+                        .guardContentPlacement(BedrockGuardContentPlacement.LAST_USER_MESSAGE)
                         .build())
                 .build();
 
@@ -180,6 +181,7 @@ class BedrockChatRequestParametersTest {
                 .guardrailConfiguration(BedrockGuardrailConfiguration.builder()
                         .guardrailIdentifier("67890")
                         .guardrailVersion("LIVE")
+                        .guardContentPlacement(BedrockGuardContentPlacement.ALL_USER_MESSAGES)
                         .build())
                 .build();
 
@@ -189,6 +191,24 @@ class BedrockChatRequestParametersTest {
         // Then
         assertThat(merged.bedrockGuardrailConfiguration().guardrailIdentifier()).isEqualTo("67890");
         assertThat(merged.bedrockGuardrailConfiguration().guardrailVersion()).isEqualTo("LIVE");
+        assertThat(merged.bedrockGuardrailConfiguration().guardContentPlacement())
+                .isEqualTo(BedrockGuardContentPlacement.ALL_USER_MESSAGES);
+    }
+
+    @Test
+    void should_build_guardrail_configuration_with_guard_content_placement() {
+        // Given & When
+        BedrockChatRequestParameters params = BedrockChatRequestParameters.builder()
+                .guardrailConfiguration(BedrockGuardrailConfiguration.builder()
+                        .guardrailIdentifier("12345")
+                        .guardrailVersion("DRAFT")
+                        .guardContentPlacement(BedrockGuardContentPlacement.LAST_USER_MESSAGE)
+                        .build())
+                .build();
+
+        // Then
+        assertThat(params.bedrockGuardrailConfiguration().guardContentPlacement())
+                .isEqualTo(BedrockGuardContentPlacement.LAST_USER_MESSAGE);
     }
 
     @Test

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatRequestParametersTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatRequestParametersTest.java
@@ -175,6 +175,7 @@ class BedrockChatRequestParametersTest {
                 .guardrailConfiguration(BedrockGuardrailConfiguration.builder()
                         .guardrailIdentifier("12345")
                         .guardrailVersion("DRAFT")
+                        .guardContentPlacement(BedrockGuardContentPlacement.LAST_USER_MESSAGE)
                         .build())
                 .build();
 
@@ -182,6 +183,7 @@ class BedrockChatRequestParametersTest {
                 .guardrailConfiguration(BedrockGuardrailConfiguration.builder()
                         .guardrailIdentifier("67890")
                         .guardrailVersion("LIVE")
+                        .guardContentPlacement(BedrockGuardContentPlacement.ALL_USER_MESSAGES)
                         .build())
                 .build();
 
@@ -191,6 +193,24 @@ class BedrockChatRequestParametersTest {
         // Then
         assertThat(merged.bedrockGuardrailConfiguration().guardrailIdentifier()).isEqualTo("67890");
         assertThat(merged.bedrockGuardrailConfiguration().guardrailVersion()).isEqualTo("LIVE");
+        assertThat(merged.bedrockGuardrailConfiguration().guardContentPlacement())
+                .isEqualTo(BedrockGuardContentPlacement.ALL_USER_MESSAGES);
+    }
+
+    @Test
+    void should_build_guardrail_configuration_with_guard_content_placement() {
+        // Given & When
+        BedrockChatRequestParameters params = BedrockChatRequestParameters.builder()
+                .guardrailConfiguration(BedrockGuardrailConfiguration.builder()
+                        .guardrailIdentifier("12345")
+                        .guardrailVersion("DRAFT")
+                        .guardContentPlacement(BedrockGuardContentPlacement.LAST_USER_MESSAGE)
+                        .build())
+                .build();
+
+        // Then
+        assertThat(params.bedrockGuardrailConfiguration().guardContentPlacement())
+                .isEqualTo(BedrockGuardContentPlacement.LAST_USER_MESSAGE);
     }
 
     @Test

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatRequestParametersTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatRequestParametersTest.java
@@ -393,14 +393,16 @@ class BedrockChatRequestParametersTest {
     void should_not_be_equal_when_guardrail_configuration_differs() {
         BedrockChatRequestParameters first = BedrockChatRequestParameters.builder()
                 .guardrailConfiguration(BedrockGuardrailConfiguration.builder()
-                        .guardrailIdentifier("first")
+                        .guardrailIdentifier("guardrail")
                         .guardrailVersion("1")
+                        .guardContentPlacement(BedrockGuardContentPlacement.LAST_USER_MESSAGE)
                         .build())
                 .build();
         BedrockChatRequestParameters second = BedrockChatRequestParameters.builder()
                 .guardrailConfiguration(BedrockGuardrailConfiguration.builder()
-                        .guardrailIdentifier("second")
+                        .guardrailIdentifier("guardrail")
                         .guardrailVersion("1")
+                        .guardContentPlacement(BedrockGuardContentPlacement.ALL_USER_MESSAGES)
                         .build())
                 .build();
 

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardContentExtractionTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardContentExtractionTest.java
@@ -1,0 +1,346 @@
+package dev.langchain4j.model.bedrock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.PdfFileContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.pdf.PdfFile;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.DefaultAwsResponseMetadata;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.CacheTTL;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ConversationRole;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseOutput;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamResponseHandler;
+import software.amazon.awssdk.services.bedrockruntime.model.Message;
+import software.amazon.awssdk.services.bedrockruntime.model.StopReason;
+import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
+
+class BedrockGuardContentExtractionTest {
+
+    private static final String BASE64_IMAGE = "aW1hZ2U=";
+    private static final String BASE64_PDF = "JVBERi0xLjQ=";
+
+    private final TestableExtractor extractor = new TestableExtractor();
+
+    @Test
+    void should_keep_user_text_and_image_unchanged_without_guard_content_placement() {
+        List<Message> messages = extractor.testExtractRegularMessages(
+                List.of(userMessage("hello", pngImage())),
+                null,
+                null,
+                null);
+
+        List<ContentBlock> content = messages.get(0).content();
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0).text()).isEqualTo("hello");
+        assertThat(content.get(0).guardContent()).isNull();
+        assertThat(content.get(1).image()).isNotNull();
+        assertThat(content.get(1).guardContent()).isNull();
+    }
+
+    @Test
+    void should_wrap_only_last_user_message_text_and_image_in_guard_content() {
+        List<Message> messages = extractor.testExtractRegularMessages(
+                List.of(
+                        userMessage("first", pngImage()),
+                        userMessage("last", jpegImage())),
+                null,
+                null,
+                BedrockGuardContentPlacement.LAST_USER_MESSAGE);
+
+        List<ContentBlock> firstUserContent = messages.get(0).content();
+        assertThat(firstUserContent.get(0).text()).isEqualTo("first");
+        assertThat(firstUserContent.get(1).image()).isNotNull();
+        assertThat(firstUserContent)
+                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+
+        List<ContentBlock> lastUserContent = messages.get(1).content();
+        assertThat(lastUserContent).hasSize(2);
+        assertThat(lastUserContent.get(0).text()).isNull();
+        assertThat(lastUserContent.get(0).guardContent().text().text()).isEqualTo("last");
+        assertThat(lastUserContent.get(1).image()).isNull();
+        assertThat(lastUserContent.get(1).guardContent().image().formatAsString()).isEqualTo("jpeg");
+        assertThat(lastUserContent.get(1).guardContent().image().source().bytes().asUtf8String())
+                .isEqualTo("image");
+    }
+
+    @Test
+    void should_wrap_all_user_messages_text_and_supported_images_in_guard_content() {
+        List<Message> messages = extractor.testExtractRegularMessages(
+                List.of(
+                        userMessage("first", pngImage()),
+                        userMessage("second", jpegImage())),
+                null,
+                null,
+                BedrockGuardContentPlacement.ALL_USER_MESSAGES);
+
+        assertThat(messages.get(0).content().get(0).guardContent().text().text())
+                .isEqualTo("first");
+        assertThat(messages.get(0).content().get(1).guardContent().image().formatAsString())
+                .isEqualTo("png");
+        assertThat(messages.get(1).content().get(0).guardContent().text().text())
+                .isEqualTo("second");
+        assertThat(messages.get(1).content().get(1).guardContent().image().formatAsString())
+                .isEqualTo("jpeg");
+    }
+
+    @Test
+    void should_fallback_all_messages_to_regular_content_when_targeted_pdf_content_cannot_be_guarded() {
+        List<Message> messages = extractor.testExtractRegularMessages(
+                List.of(
+                        userMessage("first", pngImage()),
+                        new UserMessage(
+                                TextContent.from("inspect this"),
+                                PdfFileContent.from(PdfFile.builder()
+                                        .url("file:///tmp/sample.pdf")
+                                        .base64Data(BASE64_PDF)
+                                        .mimeType(PdfFile.DEFAULT_MIME_TYPE)
+                                        .build()))),
+                null,
+                null,
+                BedrockGuardContentPlacement.ALL_USER_MESSAGES);
+
+        List<ContentBlock> firstContent = messages.get(0).content();
+        assertThat(firstContent.get(0).text()).isEqualTo("first");
+        assertThat(firstContent.get(1).image()).isNotNull();
+
+        List<ContentBlock> secondContent = messages.get(1).content();
+        assertThat(secondContent).hasSize(2);
+        assertThat(secondContent.get(0).text()).isEqualTo("inspect this");
+        assertThat(secondContent.get(1).document()).isNotNull();
+
+        assertThat(messages)
+                .flatExtracting(Message::content)
+                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+    }
+
+    @Test
+    void should_fallback_to_regular_content_when_targeted_image_format_cannot_be_guarded() {
+        List<Message> messages = extractor.testExtractRegularMessages(
+                List.of(userMessage("look", gifImage())),
+                null,
+                null,
+                BedrockGuardContentPlacement.LAST_USER_MESSAGE);
+
+        List<ContentBlock> content = messages.get(0).content();
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0).text()).isEqualTo("look");
+        assertThat(content.get(0).guardContent()).isNull();
+        assertThat(content.get(1).image().formatAsString()).isEqualTo("gif");
+        assertThat(content.get(1).guardContent()).isNull();
+    }
+
+    @Test
+    void should_not_fallback_when_unsupported_content_is_not_targeted_for_guard_content() {
+        List<Message> messages = extractor.testExtractRegularMessages(
+                List.of(
+                        userMessage("historical", gifImage()),
+                        userMessage("current", pngImage())),
+                null,
+                null,
+                BedrockGuardContentPlacement.LAST_USER_MESSAGE);
+
+        List<ContentBlock> historicalContent = messages.get(0).content();
+        assertThat(historicalContent.get(0).text()).isEqualTo("historical");
+        assertThat(historicalContent.get(1).image().formatAsString()).isEqualTo("gif");
+        assertThat(historicalContent)
+                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+
+        List<ContentBlock> currentContent = messages.get(1).content();
+        assertThat(currentContent.get(0).guardContent().text().text()).isEqualTo("current");
+        assertThat(currentContent.get(1).guardContent().image().formatAsString()).isEqualTo("png");
+    }
+
+    @Test
+    void should_keep_cache_point_after_guard_content_when_both_are_enabled() {
+        List<Message> messages = extractor.testExtractRegularMessages(
+                List.of(userMessage("cache and guard", pngImage())),
+                BedrockCachePointPlacement.AFTER_LAST_USER_MESSAGE,
+                CacheTTL.VALUE_5_M,
+                BedrockGuardContentPlacement.LAST_USER_MESSAGE);
+
+        List<ContentBlock> content = messages.get(0).content();
+        assertThat(content).hasSize(3);
+        assertThat(content.get(0).guardContent().text().text()).isEqualTo("cache and guard");
+        assertThat(content.get(1).guardContent().image().formatAsString()).isEqualTo("png");
+        assertThat(content.get(2).cachePoint()).isNotNull();
+    }
+
+    @Test
+    void should_apply_guard_content_placement_when_building_sync_request() {
+        AtomicReference<ConverseRequest> capturedRequest = new AtomicReference<>();
+        BedrockChatModel model = BedrockChatModel.builder()
+                .modelId("test-model")
+                .client(new BedrockRuntimeClient() {
+
+                    @Override
+                    public ConverseResponse converse(ConverseRequest request) {
+                        capturedRequest.set(request);
+                        return minimalConverseResponse();
+                    }
+
+                    @Override
+                    public String serviceName() {
+                        return "bedrock-runtime";
+                    }
+
+                    @Override
+                    public void close() {}
+                })
+                .build();
+
+        model.doChat(chatRequestWithGuardContentPlacement(BedrockGuardContentPlacement.LAST_USER_MESSAGE));
+
+        ConverseRequest request = capturedRequest.get();
+        assertThat(request.guardrailConfig().guardrailIdentifier()).isEqualTo("guardrail-id");
+        assertThat(request.guardrailConfig().guardrailVersion()).isEqualTo("1");
+
+        List<Message> messages = request.messages();
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0).content())
+                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+
+        List<ContentBlock> content = messages.get(1).content();
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0).guardContent().text().text()).isEqualTo("guard me");
+        assertThat(content.get(1).guardContent().image().formatAsString()).isEqualTo("png");
+    }
+
+    @Test
+    void should_apply_guard_content_placement_when_building_streaming_request() {
+        AtomicReference<ConverseStreamRequest> capturedRequest = new AtomicReference<>();
+        BedrockStreamingChatModel model = BedrockStreamingChatModel.builder()
+                .modelId("test-model")
+                .client(new BedrockRuntimeAsyncClient() {
+
+                    @Override
+                    public CompletableFuture<Void> converseStream(
+                            ConverseStreamRequest request, ConverseStreamResponseHandler responseHandler) {
+                        capturedRequest.set(request);
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    @Override
+                    public String serviceName() {
+                        return "bedrock-runtime";
+                    }
+
+                    @Override
+                    public void close() {}
+                })
+                .build();
+
+        model.doChat(
+                chatRequestWithGuardContentPlacement(BedrockGuardContentPlacement.LAST_USER_MESSAGE),
+                new TestStreamingChatResponseHandler());
+
+        ConverseStreamRequest request = capturedRequest.get();
+        assertThat(request.guardrailConfig().guardrailIdentifier()).isEqualTo("guardrail-id");
+        assertThat(request.guardrailConfig().guardrailVersion()).isEqualTo("1");
+
+        List<Message> messages = request.messages();
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0).content())
+                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+
+        List<ContentBlock> content = messages.get(1).content();
+        assertThat(content).hasSize(2);
+        assertThat(content.get(0).guardContent().text().text()).isEqualTo("guard me");
+        assertThat(content.get(1).guardContent().image().formatAsString()).isEqualTo("png");
+    }
+
+    private static UserMessage userMessage(String text, ImageContent imageContent) {
+        return new UserMessage(TextContent.from(text), imageContent);
+    }
+
+    private static ImageContent pngImage() {
+        return imageContent("image/png");
+    }
+
+    private static ImageContent jpegImage() {
+        return imageContent("image/jpeg");
+    }
+
+    private static ImageContent gifImage() {
+        return imageContent("image/gif");
+    }
+
+    private static ImageContent imageContent(String mimeType) {
+        return ImageContent.from(Image.builder()
+                .base64Data(BASE64_IMAGE)
+                .mimeType(mimeType)
+                .build());
+    }
+
+    private static ChatRequest chatRequestWithGuardContentPlacement(BedrockGuardContentPlacement placement) {
+        return ChatRequest.builder()
+                // Keep one historical user message so LAST_USER_MESSAGE can prove only the last user message is guarded.
+                .messages(
+                        userMessage("history", jpegImage()),
+                        userMessage("guard me", pngImage()))
+                .parameters(BedrockChatRequestParameters.builder()
+                        .modelName("test-model")
+                        .guardrailConfiguration(BedrockGuardrailConfiguration.builder()
+                                .guardrailIdentifier("guardrail-id")
+                                .guardrailVersion("1")
+                                .guardContentPlacement(placement)
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private static ConverseResponse minimalConverseResponse() {
+        ConverseResponse.Builder builder = ConverseResponse.builder();
+        builder.output(ConverseOutput.fromMessage(Message.builder()
+                .role(ConversationRole.ASSISTANT)
+                .content(ContentBlock.builder().text("ok").build())
+                .build()));
+        builder.stopReason(StopReason.END_TURN);
+        builder.usage(TokenUsage.builder()
+                .inputTokens(1)
+                .outputTokens(1)
+                .totalTokens(2)
+                .build());
+        builder.responseMetadata(DefaultAwsResponseMetadata.create(Map.of("AWS_REQUEST_ID", "request-id")));
+        return builder.build();
+    }
+
+    private static class TestableExtractor extends AbstractBedrockChatModel {
+
+        TestableExtractor() {
+            super(new TestBuilder());
+        }
+
+        List<Message> testExtractRegularMessages(
+                List<ChatMessage> messages,
+                BedrockCachePointPlacement cachePointPlacement,
+                CacheTTL cacheTtl,
+                BedrockGuardContentPlacement guardContentPlacement) {
+            return extractRegularMessages(messages, cachePointPlacement, cacheTtl, guardContentPlacement);
+        }
+
+        private static class TestBuilder extends AbstractBuilder<TestBuilder> {
+
+            @Override
+            public TestBuilder self() {
+                return this;
+            }
+        }
+    }
+}

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardContentExtractionTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardContentExtractionTest.java
@@ -40,11 +40,8 @@ class BedrockGuardContentExtractionTest {
 
     @Test
     void should_keep_user_text_and_image_unchanged_without_guard_content_placement() {
-        List<Message> messages = extractor.testExtractRegularMessages(
-                List.of(userMessage("hello", pngImage())),
-                null,
-                null,
-                null);
+        List<Message> messages =
+                extractor.testExtractRegularMessages(List.of(userMessage("hello", pngImage())), null, null, null);
 
         List<ContentBlock> content = messages.get(0).content();
         assertThat(content).hasSize(2);
@@ -57,9 +54,7 @@ class BedrockGuardContentExtractionTest {
     @Test
     void should_wrap_only_last_user_message_text_and_image_in_guard_content() {
         List<Message> messages = extractor.testExtractRegularMessages(
-                List.of(
-                        userMessage("first", pngImage()),
-                        userMessage("last", jpegImage())),
+                List.of(userMessage("first", pngImage()), userMessage("last", jpegImage())),
                 null,
                 null,
                 BedrockGuardContentPlacement.LAST_USER_MESSAGE);
@@ -68,24 +63,30 @@ class BedrockGuardContentExtractionTest {
         assertThat(firstUserContent.get(0).text()).isEqualTo("first");
         assertThat(firstUserContent.get(1).image()).isNotNull();
         assertThat(firstUserContent)
-                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+                .allSatisfy(
+                        contentBlock -> assertThat(contentBlock.guardContent()).isNull());
 
         List<ContentBlock> lastUserContent = messages.get(1).content();
         assertThat(lastUserContent).hasSize(2);
         assertThat(lastUserContent.get(0).text()).isNull();
         assertThat(lastUserContent.get(0).guardContent().text().text()).isEqualTo("last");
         assertThat(lastUserContent.get(1).image()).isNull();
-        assertThat(lastUserContent.get(1).guardContent().image().formatAsString()).isEqualTo("jpeg");
-        assertThat(lastUserContent.get(1).guardContent().image().source().bytes().asUtf8String())
+        assertThat(lastUserContent.get(1).guardContent().image().formatAsString())
+                .isEqualTo("jpeg");
+        assertThat(lastUserContent
+                        .get(1)
+                        .guardContent()
+                        .image()
+                        .source()
+                        .bytes()
+                        .asUtf8String())
                 .isEqualTo("image");
     }
 
     @Test
     void should_wrap_all_user_messages_text_and_supported_images_in_guard_content() {
         List<Message> messages = extractor.testExtractRegularMessages(
-                List.of(
-                        userMessage("first", pngImage()),
-                        userMessage("second", jpegImage())),
+                List.of(userMessage("first", pngImage()), userMessage("second", jpegImage())),
                 null,
                 null,
                 BedrockGuardContentPlacement.ALL_USER_MESSAGES);
@@ -127,16 +128,14 @@ class BedrockGuardContentExtractionTest {
 
         assertThat(messages)
                 .flatExtracting(Message::content)
-                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+                .allSatisfy(
+                        contentBlock -> assertThat(contentBlock.guardContent()).isNull());
     }
 
     @Test
     void should_fallback_to_regular_content_when_targeted_image_format_cannot_be_guarded() {
         List<Message> messages = extractor.testExtractRegularMessages(
-                List.of(userMessage("look", gifImage())),
-                null,
-                null,
-                BedrockGuardContentPlacement.LAST_USER_MESSAGE);
+                List.of(userMessage("look", gifImage())), null, null, BedrockGuardContentPlacement.LAST_USER_MESSAGE);
 
         List<ContentBlock> content = messages.get(0).content();
         assertThat(content).hasSize(2);
@@ -149,9 +148,7 @@ class BedrockGuardContentExtractionTest {
     @Test
     void should_not_fallback_when_unsupported_content_is_not_targeted_for_guard_content() {
         List<Message> messages = extractor.testExtractRegularMessages(
-                List.of(
-                        userMessage("historical", gifImage()),
-                        userMessage("current", pngImage())),
+                List.of(userMessage("historical", gifImage()), userMessage("current", pngImage())),
                 null,
                 null,
                 BedrockGuardContentPlacement.LAST_USER_MESSAGE);
@@ -160,11 +157,13 @@ class BedrockGuardContentExtractionTest {
         assertThat(historicalContent.get(0).text()).isEqualTo("historical");
         assertThat(historicalContent.get(1).image().formatAsString()).isEqualTo("gif");
         assertThat(historicalContent)
-                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+                .allSatisfy(
+                        contentBlock -> assertThat(contentBlock.guardContent()).isNull());
 
         List<ContentBlock> currentContent = messages.get(1).content();
         assertThat(currentContent.get(0).guardContent().text().text()).isEqualTo("current");
-        assertThat(currentContent.get(1).guardContent().image().formatAsString()).isEqualTo("png");
+        assertThat(currentContent.get(1).guardContent().image().formatAsString())
+                .isEqualTo("png");
     }
 
     @Test
@@ -214,7 +213,8 @@ class BedrockGuardContentExtractionTest {
         List<Message> messages = request.messages();
         assertThat(messages).hasSize(2);
         assertThat(messages.get(0).content())
-                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+                .allSatisfy(
+                        contentBlock -> assertThat(contentBlock.guardContent()).isNull());
 
         List<ContentBlock> content = messages.get(1).content();
         assertThat(content).hasSize(2);
@@ -257,7 +257,8 @@ class BedrockGuardContentExtractionTest {
         List<Message> messages = request.messages();
         assertThat(messages).hasSize(2);
         assertThat(messages.get(0).content())
-                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+                .allSatisfy(
+                        contentBlock -> assertThat(contentBlock.guardContent()).isNull());
 
         List<ContentBlock> content = messages.get(1).content();
         assertThat(content).hasSize(2);
@@ -282,18 +283,15 @@ class BedrockGuardContentExtractionTest {
     }
 
     private static ImageContent imageContent(String mimeType) {
-        return ImageContent.from(Image.builder()
-                .base64Data(BASE64_IMAGE)
-                .mimeType(mimeType)
-                .build());
+        return ImageContent.from(
+                Image.builder().base64Data(BASE64_IMAGE).mimeType(mimeType).build());
     }
 
     private static ChatRequest chatRequestWithGuardContentPlacement(BedrockGuardContentPlacement placement) {
         return ChatRequest.builder()
-                // Keep one historical user message so LAST_USER_MESSAGE can prove only the last user message is guarded.
-                .messages(
-                        userMessage("history", jpegImage()),
-                        userMessage("guard me", pngImage()))
+                // Keep one historical user message so LAST_USER_MESSAGE can prove only the last user message is
+                // guarded.
+                .messages(userMessage("history", jpegImage()), userMessage("guard me", pngImage()))
                 .parameters(BedrockChatRequestParameters.builder()
                         .modelName("test-model")
                         .guardrailConfiguration(BedrockGuardrailConfiguration.builder()

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardContentExtractionTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardContentExtractionTest.java
@@ -39,27 +39,9 @@ class BedrockGuardContentExtractionTest {
     private final TestableExtractor extractor = new TestableExtractor();
 
     @Test
-    void should_keep_user_text_and_image_unchanged_without_guard_content_placement() {
-        List<Message> messages = extractor.testExtractRegularMessages(
-                List.of(userMessage("hello", pngImage())),
-                null,
-                null,
-                null);
-
-        List<ContentBlock> content = messages.get(0).content();
-        assertThat(content).hasSize(2);
-        assertThat(content.get(0).text()).isEqualTo("hello");
-        assertThat(content.get(0).guardContent()).isNull();
-        assertThat(content.get(1).image()).isNotNull();
-        assertThat(content.get(1).guardContent()).isNull();
-    }
-
-    @Test
     void should_wrap_only_last_user_message_text_and_image_in_guard_content() {
         List<Message> messages = extractor.testExtractRegularMessages(
-                List.of(
-                        userMessage("first", pngImage()),
-                        userMessage("last", jpegImage())),
+                List.of(userMessage("first", pngImage()), userMessage("last", jpegImage())),
                 null,
                 null,
                 BedrockGuardContentPlacement.LAST_USER_MESSAGE);
@@ -68,36 +50,38 @@ class BedrockGuardContentExtractionTest {
         assertThat(firstUserContent.get(0).text()).isEqualTo("first");
         assertThat(firstUserContent.get(1).image()).isNotNull();
         assertThat(firstUserContent)
-                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+                .allSatisfy(
+                        contentBlock -> assertThat(contentBlock.guardContent()).isNull());
 
         List<ContentBlock> lastUserContent = messages.get(1).content();
         assertThat(lastUserContent).hasSize(2);
         assertThat(lastUserContent.get(0).text()).isNull();
         assertThat(lastUserContent.get(0).guardContent().text().text()).isEqualTo("last");
         assertThat(lastUserContent.get(1).image()).isNull();
-        assertThat(lastUserContent.get(1).guardContent().image().formatAsString()).isEqualTo("jpeg");
-        assertThat(lastUserContent.get(1).guardContent().image().source().bytes().asUtf8String())
+        assertThat(lastUserContent.get(1).guardContent().image().formatAsString())
+                .isEqualTo("jpeg");
+        assertThat(lastUserContent
+                        .get(1)
+                        .guardContent()
+                        .image()
+                        .source()
+                        .bytes()
+                        .asUtf8String())
                 .isEqualTo("image");
     }
 
     @Test
-    void should_wrap_all_user_messages_text_and_supported_images_in_guard_content() {
+    void should_wrap_all_user_messages() {
         List<Message> messages = extractor.testExtractRegularMessages(
-                List.of(
-                        userMessage("first", pngImage()),
-                        userMessage("second", jpegImage())),
+                List.of(UserMessage.from("first"), UserMessage.from("second")),
                 null,
                 null,
                 BedrockGuardContentPlacement.ALL_USER_MESSAGES);
 
-        assertThat(messages.get(0).content().get(0).guardContent().text().text())
-                .isEqualTo("first");
-        assertThat(messages.get(0).content().get(1).guardContent().image().formatAsString())
-                .isEqualTo("png");
-        assertThat(messages.get(1).content().get(0).guardContent().text().text())
-                .isEqualTo("second");
-        assertThat(messages.get(1).content().get(1).guardContent().image().formatAsString())
-                .isEqualTo("jpeg");
+        assertThat(messages)
+                .extracting(message ->
+                        message.content().get(0).guardContent().text().text())
+                .containsExactly("first", "second");
     }
 
     @Test
@@ -127,16 +111,14 @@ class BedrockGuardContentExtractionTest {
 
         assertThat(messages)
                 .flatExtracting(Message::content)
-                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+                .allSatisfy(
+                        contentBlock -> assertThat(contentBlock.guardContent()).isNull());
     }
 
     @Test
     void should_fallback_to_regular_content_when_targeted_image_format_cannot_be_guarded() {
         List<Message> messages = extractor.testExtractRegularMessages(
-                List.of(userMessage("look", gifImage())),
-                null,
-                null,
-                BedrockGuardContentPlacement.LAST_USER_MESSAGE);
+                List.of(userMessage("look", gifImage())), null, null, BedrockGuardContentPlacement.LAST_USER_MESSAGE);
 
         List<ContentBlock> content = messages.get(0).content();
         assertThat(content).hasSize(2);
@@ -149,9 +131,7 @@ class BedrockGuardContentExtractionTest {
     @Test
     void should_not_fallback_when_unsupported_content_is_not_targeted_for_guard_content() {
         List<Message> messages = extractor.testExtractRegularMessages(
-                List.of(
-                        userMessage("historical", gifImage()),
-                        userMessage("current", pngImage())),
+                List.of(userMessage("historical", gifImage()), userMessage("current", pngImage())),
                 null,
                 null,
                 BedrockGuardContentPlacement.LAST_USER_MESSAGE);
@@ -160,11 +140,13 @@ class BedrockGuardContentExtractionTest {
         assertThat(historicalContent.get(0).text()).isEqualTo("historical");
         assertThat(historicalContent.get(1).image().formatAsString()).isEqualTo("gif");
         assertThat(historicalContent)
-                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+                .allSatisfy(
+                        contentBlock -> assertThat(contentBlock.guardContent()).isNull());
 
         List<ContentBlock> currentContent = messages.get(1).content();
         assertThat(currentContent.get(0).guardContent().text().text()).isEqualTo("current");
-        assertThat(currentContent.get(1).guardContent().image().formatAsString()).isEqualTo("png");
+        assertThat(currentContent.get(1).guardContent().image().formatAsString())
+                .isEqualTo("png");
     }
 
     @Test
@@ -214,7 +196,8 @@ class BedrockGuardContentExtractionTest {
         List<Message> messages = request.messages();
         assertThat(messages).hasSize(2);
         assertThat(messages.get(0).content())
-                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+                .allSatisfy(
+                        contentBlock -> assertThat(contentBlock.guardContent()).isNull());
 
         List<ContentBlock> content = messages.get(1).content();
         assertThat(content).hasSize(2);
@@ -257,7 +240,8 @@ class BedrockGuardContentExtractionTest {
         List<Message> messages = request.messages();
         assertThat(messages).hasSize(2);
         assertThat(messages.get(0).content())
-                .allSatisfy(contentBlock -> assertThat(contentBlock.guardContent()).isNull());
+                .allSatisfy(
+                        contentBlock -> assertThat(contentBlock.guardContent()).isNull());
 
         List<ContentBlock> content = messages.get(1).content();
         assertThat(content).hasSize(2);
@@ -282,18 +266,15 @@ class BedrockGuardContentExtractionTest {
     }
 
     private static ImageContent imageContent(String mimeType) {
-        return ImageContent.from(Image.builder()
-                .base64Data(BASE64_IMAGE)
-                .mimeType(mimeType)
-                .build());
+        return ImageContent.from(
+                Image.builder().base64Data(BASE64_IMAGE).mimeType(mimeType).build());
     }
 
     private static ChatRequest chatRequestWithGuardContentPlacement(BedrockGuardContentPlacement placement) {
         return ChatRequest.builder()
-                // Keep one historical user message so LAST_USER_MESSAGE can prove only the last user message is guarded.
-                .messages(
-                        userMessage("history", jpegImage()),
-                        userMessage("guard me", pngImage()))
+                // Keep one historical user message so LAST_USER_MESSAGE can prove only the last user message is
+                // guarded.
+                .messages(userMessage("history", jpegImage()), userMessage("guard me", pngImage()))
                 .parameters(BedrockChatRequestParameters.builder()
                         .modelName("test-model")
                         .guardrailConfiguration(BedrockGuardrailConfiguration.builder()

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardContentExtractionTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardContentExtractionTest.java
@@ -1,6 +1,9 @@
 package dev.langchain4j.model.bedrock;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.ChatMessage;
@@ -167,25 +170,13 @@ class BedrockGuardContentExtractionTest {
     @Test
     void should_apply_guard_content_placement_when_building_sync_request() {
         AtomicReference<ConverseRequest> capturedRequest = new AtomicReference<>();
-        BedrockChatModel model = BedrockChatModel.builder()
-                .modelId("test-model")
-                .client(new BedrockRuntimeClient() {
-
-                    @Override
-                    public ConverseResponse converse(ConverseRequest request) {
-                        capturedRequest.set(request);
-                        return minimalConverseResponse();
-                    }
-
-                    @Override
-                    public String serviceName() {
-                        return "bedrock-runtime";
-                    }
-
-                    @Override
-                    public void close() {}
-                })
-                .build();
+        BedrockRuntimeClient client = mock(BedrockRuntimeClient.class);
+        when(client.converse(any(ConverseRequest.class))).thenAnswer(invocation -> {
+            capturedRequest.set(invocation.getArgument(0));
+            return minimalConverseResponse();
+        });
+        BedrockChatModel model =
+                BedrockChatModel.builder().modelId("test-model").client(client).build();
 
         model.doChat(chatRequestWithGuardContentPlacement(BedrockGuardContentPlacement.LAST_USER_MESSAGE));
 
@@ -208,25 +199,15 @@ class BedrockGuardContentExtractionTest {
     @Test
     void should_apply_guard_content_placement_when_building_streaming_request() {
         AtomicReference<ConverseStreamRequest> capturedRequest = new AtomicReference<>();
+        BedrockRuntimeAsyncClient client = mock(BedrockRuntimeAsyncClient.class);
+        when(client.converseStream(any(ConverseStreamRequest.class), any(ConverseStreamResponseHandler.class)))
+                .thenAnswer(invocation -> {
+                    capturedRequest.set(invocation.getArgument(0));
+                    return CompletableFuture.completedFuture(null);
+                });
         BedrockStreamingChatModel model = BedrockStreamingChatModel.builder()
                 .modelId("test-model")
-                .client(new BedrockRuntimeAsyncClient() {
-
-                    @Override
-                    public CompletableFuture<Void> converseStream(
-                            ConverseStreamRequest request, ConverseStreamResponseHandler responseHandler) {
-                        capturedRequest.set(request);
-                        return CompletableFuture.completedFuture(null);
-                    }
-
-                    @Override
-                    public String serviceName() {
-                        return "bedrock-runtime";
-                    }
-
-                    @Override
-                    public void close() {}
-                })
+                .client(client)
                 .build();
 
         model.doChat(

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardrailConfigurationTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardrailConfigurationTest.java
@@ -27,8 +27,10 @@ class BedrockGuardrailConfigurationTest {
 
     @Test
     void should_not_be_equal_when_guardrail_version_differs() {
-        BedrockGuardrailConfiguration first = fullyPopulated().guardrailVersion("1").build();
-        BedrockGuardrailConfiguration second = fullyPopulated().guardrailVersion("2").build();
+        BedrockGuardrailConfiguration first =
+                fullyPopulated().guardrailVersion("1").build();
+        BedrockGuardrailConfiguration second =
+                fullyPopulated().guardrailVersion("2").build();
 
         assertThat(first).isNotEqualTo(second);
     }

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardrailConfigurationTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardrailConfigurationTest.java
@@ -54,6 +54,7 @@ class BedrockGuardrailConfigurationTest {
         return BedrockGuardrailConfiguration.builder()
                 .guardrailIdentifier("guardrail")
                 .guardrailVersion("1")
-                .streamProcessingMode(ProcessingMode.SYNC);
+                .streamProcessingMode(ProcessingMode.SYNC)
+                .guardContentPlacement(BedrockGuardContentPlacement.LAST_USER_MESSAGE);
     }
 }


### PR DESCRIPTION
## Issue
Closes #4982

## Change
Adds optional Bedrock Converse `guardContent` placement for the last user message or all user messages. Text and supported PNG/JPEG images are wrapped; when selected content cannot be represented, the request falls back to the existing whole-request guardrail behavior and logs a warning.

The default request behavior is unchanged. Sync and streaming models use the same conversion path. The Bedrock documentation now covers guardrail configuration and selective guard content placement.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [x] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for big features)
- [ ] I have added/updated Spring Boot starters (if applicable)

## Testing
- Targeted Bedrock tests: 35 passed
- Bedrock module Spotless check and unit tests: passed
- Core and main module verification: passed
- Docusaurus production build: passed
