### PR TITLE
MCP: label stderr logs as STDERR

### DIFF
--- a/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallback.java
+++ b/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallback.java
@@ -1,18 +1,18 @@
 package dev.langchain4j.mcp.client.transport.docker;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.StreamType;
 import dev.langchain4j.mcp.client.transport.McpOperationHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class DockerResultCallback extends ResultCallback.Adapter<Frame> {
     private static final Logger LOG = LoggerFactory.getLogger(DockerResultCallback.class);
@@ -41,7 +41,7 @@ class DockerResultCallback extends ResultCallback.Adapter<Frame> {
     public void onNext(Frame frame) {
         String frameStr = new String(frame.getPayload());
         if (frame.getStreamType() == StreamType.STDERR) {
-            LOG.debug("[ERROR] {}", frameStr);
+            LOG.debug("[STDERR] {}", frameStr);
         } else if (frame.getStreamType() == StreamType.STDOUT) {
             this.send(frameStr);
         }
@@ -59,7 +59,7 @@ class DockerResultCallback extends ResultCallback.Adapter<Frame> {
     }
 
     private void send(String line) {
-        if (line !=null && !line.isBlank()) {
+        if (line != null && !line.isBlank()) {
             logAggregator.append(line);
 
             // we aggregate until we have a newline char at then end of the line

--- a/langchain4j-mcp-docker/src/test/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallbackTest.java
+++ b/langchain4j-mcp-docker/src/test/java/dev/langchain4j/mcp/client/transport/docker/DockerResultCallbackTest.java
@@ -1,0 +1,37 @@
+package dev.langchain4j.mcp.client.transport.docker;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.StreamType;
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class DockerResultCallbackTest {
+
+    @Test
+    void shouldLabelDockerStderrFramesAsStderr() {
+        try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+            Logger logger = mock(Logger.class);
+            loggerFactory
+                    .when(() -> LoggerFactory.getLogger(DockerResultCallback.class))
+                    .thenReturn(logger);
+            McpOperationHandler messageHandler = mock(McpOperationHandler.class);
+            DockerResultCallback callback = new DockerResultCallback(false, messageHandler);
+
+            callback.onNext(new Frame(StreamType.STDERR, "server log".getBytes(UTF_8)));
+
+            verify(logger).debug("[STDERR] {}", "server log");
+            verify(logger, never()).debug("[ERROR] {}", "server log");
+            verifyNoInteractions(messageHandler);
+        }
+    }
+}

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandler.java
@@ -23,7 +23,7 @@ class ProcessStderrHandler implements Runnable, Closeable {
             try (BufferedReader reader = new BufferedReader(inputStreamReader)) {
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    log.debug("[ERROR] {}", line);
+                    log.debug("[STDERR] {}", line);
                 }
             } catch (IOException e) {
                 // If this handler was closed, it means the MCP server process is shutting down,

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandlerTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandlerTest.java
@@ -1,0 +1,36 @@
+package dev.langchain4j.mcp.client.transport.stdio;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ProcessStderrHandlerTest {
+
+    @Test
+    void shouldLabelProcessStderrOutputAsStderr() {
+        try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+            Logger logger = mock(Logger.class);
+            loggerFactory
+                    .when(() -> LoggerFactory.getLogger(ProcessStderrHandler.class))
+                    .thenReturn(logger);
+
+            Process process = mock(Process.class);
+            when(process.getErrorStream())
+                    .thenReturn(new ByteArrayInputStream(("server log" + System.lineSeparator()).getBytes()));
+            when(process.pid()).thenReturn(123L);
+
+            new ProcessStderrHandler(process).run();
+
+            verify(logger).debug("[STDERR] {}", "server log");
+            verify(logger, never()).debug("[ERROR] {}", "server log");
+        }
+    }
+}


### PR DESCRIPTION
## Issue
Closes #4873

## Change
- Label MCP stdio and Docker stderr output as `[STDERR]` instead of `[ERROR]`.
- Preserve the existing DEBUG log level and stdout/stderr transport behavior.
- Add regression tests for the stdio stderr handler and Docker STDERR frames.

This follows the maintainer discussion in https://github.com/langchain4j/langchain4j/issues/4873#issuecomment-4212291920.

Verification:
- `./mvnw -pl langchain4j-mcp,langchain4j-mcp-docker -am test`
- `git diff --check origin/main..HEAD`

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j