### PR TITLE
Chroma: support custom HTTP client builder and headers

### DIFF
--- a/langchain4j-chroma/revapi.json
+++ b/langchain4j-chroma/revapi.json
@@ -1,0 +1,15 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.http.client.HttpClientBuilder",
+          "justification": "HttpClientBuilder is intentionally exposed by the Chroma integration for custom HTTP client configuration"
+        }
+      ]
+    }
+  }
+]

--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaClientV1.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaClientV1.java
@@ -1,9 +1,12 @@
 package dev.langchain4j.store.embedding.chroma;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.internal.Utils;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Map;
+import java.util.function.Supplier;
 
 @Internal
 class ChromaClientV1 implements ChromaClient {
@@ -15,7 +18,9 @@ class ChromaClientV1 implements ChromaClient {
                 Utils.ensureTrailingForwardSlash(builder.baseUrl),
                 builder.timeout,
                 builder.logRequests,
-                builder.logResponses);
+                builder.logResponses,
+                builder.httpClientBuilder,
+                builder.customHeadersSupplier);
 
         this.chromaApi = new ChromaApiImpl(httpClient);
     }
@@ -24,6 +29,8 @@ class ChromaClientV1 implements ChromaClient {
 
         private String baseUrl;
         private Duration timeout;
+        private HttpClientBuilder httpClientBuilder;
+        private Supplier<Map<String, String>> customHeadersSupplier;
         private boolean logRequests;
         private boolean logResponses;
 
@@ -34,6 +41,16 @@ class ChromaClientV1 implements ChromaClient {
 
         public Builder timeout(Duration timeout) {
             this.timeout = timeout;
+            return this;
+        }
+
+        public Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
+        public Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaClientV2.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaClientV2.java
@@ -3,9 +3,12 @@ package dev.langchain4j.store.embedding.chroma;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.internal.Utils;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Map;
+import java.util.function.Supplier;
 
 @Internal
 class ChromaClientV2 implements ChromaClient {
@@ -22,7 +25,9 @@ class ChromaClientV2 implements ChromaClient {
                 Utils.ensureTrailingForwardSlash(builder.baseUrl),
                 builder.timeout,
                 builder.logRequests,
-                builder.logResponses);
+                builder.logResponses,
+                builder.httpClientBuilder,
+                builder.customHeadersSupplier);
 
         this.chromaApi = new ChromaApiV2Impl(httpClient);
     }
@@ -31,6 +36,8 @@ class ChromaClientV2 implements ChromaClient {
 
         private String baseUrl;
         private Duration timeout;
+        private HttpClientBuilder httpClientBuilder;
+        private Supplier<Map<String, String>> customHeadersSupplier;
         private boolean logRequests;
         private boolean logResponses;
         private String tenantName;
@@ -43,6 +50,16 @@ class ChromaClientV2 implements ChromaClient {
 
         public Builder timeout(Duration timeout) {
             this.timeout = timeout;
+            return this;
+        }
+
+        public Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
+        public Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStore.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStore.java
@@ -12,6 +12,7 @@ import static java.util.stream.Collectors.toList;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.internal.Utils;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
@@ -23,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Represents a store for embeddings using the Chroma backend.
@@ -47,6 +49,8 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
             this.chromaClient = new ChromaClientV1.Builder()
                     .baseUrl(builder.baseUrl)
                     .timeout(getOrDefault(builder.timeout, ofSeconds(5)))
+                    .httpClientBuilder(builder.httpClientBuilder)
+                    .customHeaders(builder.customHeadersSupplier)
                     .logRequests(builder.logRequests)
                     .logResponses(builder.logResponses)
                     .build();
@@ -57,6 +61,8 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
                     .tenantName(builder.tenantName)
                     .databaseName(builder.databaseName)
                     .timeout(getOrDefault(builder.timeout, ofSeconds(5)))
+                    .httpClientBuilder(builder.httpClientBuilder)
+                    .customHeaders(builder.customHeadersSupplier)
                     .logRequests(builder.logRequests)
                     .logResponses(builder.logResponses)
                     .build();
@@ -106,6 +112,8 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
         private String databaseName;
         private String collectionName;
         private Duration timeout;
+        private HttpClientBuilder httpClientBuilder;
+        private Supplier<Map<String, String>> customHeadersSupplier;
         private boolean logRequests;
         private boolean logResponses;
 
@@ -159,6 +167,44 @@ public class ChromaEmbeddingStore implements EmbeddingStore<TextSegment> {
          */
         public Builder timeout(Duration timeout) {
             this.timeout = timeout;
+            return this;
+        }
+
+        /**
+         * Sets the {@link HttpClientBuilder} that will be used to create the HTTP client
+         * that will be used to communicate with Chroma.
+         * <p>
+         * NOTE: {@link #timeout(Duration)} overrides timeouts set on the {@link HttpClientBuilder}.
+         *
+         * @param httpClientBuilder The HTTP client builder.
+         * @return builder
+         */
+        public Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
+        /**
+         * Sets custom HTTP headers.
+         *
+         * @param customHeaders The custom HTTP headers.
+         * @return builder
+         */
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets a supplier for custom HTTP headers.
+         * The supplier is called before each request, allowing dynamic header values.
+         * For example, this is useful for OAuth2 tokens that expire and need refreshing.
+         *
+         * @param customHeadersSupplier The custom HTTP headers supplier.
+         * @return builder
+         */
+        public Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaHttpClient.java
+++ b/langchain4j-chroma/src/main/java/dev/langchain4j/store/embedding/chroma/ChromaHttpClient.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.store.embedding.chroma;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -9,6 +11,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import dev.langchain4j.Internal;
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.http.client.HttpClientBuilderLoader;
 import dev.langchain4j.http.client.HttpMethod;
 import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
@@ -19,6 +23,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,21 +35,37 @@ class ChromaHttpClient {
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
     private final String baseUrl;
+    private final Supplier<Map<String, String>> customHeadersSupplier;
 
     public ChromaHttpClient(String baseUrl, Duration timeout, boolean logRequests, boolean logResponses) {
+        this(baseUrl, timeout, logRequests, logResponses, null, null);
+    }
+
+    public ChromaHttpClient(
+            String baseUrl,
+            Duration timeout,
+            boolean logRequests,
+            boolean logResponses,
+            HttpClientBuilder httpClientBuilder,
+            Supplier<Map<String, String>> customHeadersSupplier) {
         this.baseUrl = Utils.ensureTrailingForwardSlash(baseUrl);
-        dev.langchain4j.http.client.HttpClientBuilder httpClientBuilder =
-                dev.langchain4j.http.client.HttpClientBuilderLoader.loadHttpClientBuilder();
+        HttpClientBuilder clientBuilder =
+                httpClientBuilder == null ? HttpClientBuilderLoader.loadHttpClientBuilder() : httpClientBuilder;
         // Configure HTTP/1.1 for Chroma compatibility if using JDK HTTP client
         if ("dev.langchain4j.http.client.jdk.JdkHttpClientBuilder"
-                .equals(httpClientBuilder.getClass().getCanonicalName())) {
+                .equals(clientBuilder.getClass().getCanonicalName())) {
             try {
-                Method method = httpClientBuilder
-                        .getClass()
-                        .getMethod("httpClientBuilder", java.net.http.HttpClient.Builder.class);
-                method.invoke(
-                        httpClientBuilder,
-                        java.net.http.HttpClient.newBuilder()
+                Method getter = clientBuilder.getClass().getMethod("httpClientBuilder");
+                Method setter =
+                        clientBuilder.getClass().getMethod("httpClientBuilder", java.net.http.HttpClient.Builder.class);
+                java.net.http.HttpClient.Builder jdkHttpClientBuilder =
+                        (java.net.http.HttpClient.Builder) getter.invoke(clientBuilder);
+                if (jdkHttpClientBuilder == null) {
+                    jdkHttpClientBuilder = java.net.http.HttpClient.newBuilder();
+                }
+                setter.invoke(
+                        clientBuilder,
+                        jdkHttpClientBuilder
                                 .connectTimeout(timeout)
                                 .version(java.net.http.HttpClient.Version.HTTP_1_1));
             } catch (NoSuchMethodException
@@ -56,7 +77,8 @@ class ChromaHttpClient {
         }
 
         this.httpClient = new LoggingHttpClient(
-                httpClientBuilder.connectTimeout(timeout).readTimeout(timeout).build(), logRequests, logResponses);
+                clientBuilder.connectTimeout(timeout).readTimeout(timeout).build(), logRequests, logResponses);
+        this.customHeadersSupplier = getOrDefault(customHeadersSupplier, () -> Map::of);
 
         this.objectMapper = new ObjectMapper()
                 .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
@@ -76,6 +98,7 @@ class ChromaHttpClient {
                 .method(HttpMethod.GET)
                 .url(url)
                 .addHeader("Content-Type", "application/json")
+                .addHeaders(customHeadersSupplier.get())
                 .build();
 
         return executeRequest(request, responseType);
@@ -94,6 +117,7 @@ class ChromaHttpClient {
                 .method(HttpMethod.POST)
                 .url(url)
                 .addHeader("Content-Type", "application/json")
+                .addHeaders(customHeadersSupplier.get())
                 .body(jsonBody)
                 .build();
 
@@ -111,6 +135,7 @@ class ChromaHttpClient {
                 .method(HttpMethod.DELETE)
                 .url(url)
                 .addHeader("Content-Type", "application/json")
+                .addHeaders(customHeadersSupplier.get())
                 .build();
 
         executeRequest(request, Void.class);

--- a/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreHttpClientBuilderTest.java
+++ b/langchain4j-chroma/src/test/java/dev/langchain4j/store/embedding/chroma/ChromaEmbeddingStoreHttpClientBuilderTest.java
@@ -1,0 +1,193 @@
+package dev.langchain4j.store.embedding.chroma;
+
+import static dev.langchain4j.http.client.HttpMethod.DELETE;
+import static dev.langchain4j.http.client.HttpMethod.GET;
+import static dev.langchain4j.http.client.HttpMethod.POST;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ChromaEmbeddingStoreHttpClientBuilderTest {
+
+    @Test
+    void should_preserve_custom_jdk_http_client_builder() {
+        // given
+        java.net.http.HttpClient.Builder jdkHttpClientBuilder = java.net.http.HttpClient.newBuilder();
+        JdkHttpClientBuilder httpClientBuilder = new JdkHttpClientBuilder().httpClientBuilder(jdkHttpClientBuilder);
+
+        // when
+        new ChromaHttpClient("http://localhost:8000", Duration.ofSeconds(5), false, false, httpClientBuilder, null);
+
+        // then
+        assertThat(httpClientBuilder.httpClientBuilder()).isSameAs(jdkHttpClientBuilder);
+    }
+
+    @Test
+    void should_use_custom_http_client_builder_and_headers_for_v1() {
+        // given
+        CapturingHttpClient httpClient = new CapturingHttpClient();
+        TestHttpClientBuilder httpClientBuilder = new TestHttpClientBuilder(httpClient);
+
+        // when
+        ChromaEmbeddingStore embeddingStore = ChromaEmbeddingStore.builder()
+                .baseUrl("http://localhost:8000")
+                .collectionName("test")
+                .httpClientBuilder(httpClientBuilder)
+                .customHeaders(Map.of("X-Chroma-Token", "test-token"))
+                .build();
+        embeddingStore.add("id", Embedding.from(List.of(1.0f)));
+        embeddingStore.removeAll();
+
+        // then
+        assertThat(httpClient.requests()).hasSize(4);
+        assertThat(httpClient.requests()).extracting(HttpRequest::method).containsExactly(GET, POST, DELETE, POST);
+
+        HttpRequest request = httpClient.requests().get(0);
+        assertThat(request.url()).isEqualTo("http://localhost:8000/api/v1/collections/test");
+        assertThat(httpClient.requests()).allSatisfy(this::assertStaticHeaders);
+    }
+
+    @Test
+    void should_use_custom_http_client_builder_and_dynamic_headers_for_v2() {
+        // given
+        AtomicInteger headerCalls = new AtomicInteger();
+        CapturingHttpClient httpClient = new CapturingHttpClient();
+        TestHttpClientBuilder httpClientBuilder = new TestHttpClientBuilder(httpClient);
+
+        // when
+        ChromaEmbeddingStore.builder()
+                .apiVersion(ChromaApiVersion.V2)
+                .baseUrl("http://localhost:8000")
+                .tenantName("default")
+                .databaseName("default")
+                .collectionName("test")
+                .httpClientBuilder(httpClientBuilder)
+                .customHeaders(() -> Map.of("Authorization", "Bearer token-" + headerCalls.incrementAndGet()))
+                .build();
+
+        // then
+        assertThat(httpClient.requests()).isNotEmpty();
+        assertThat(headerCalls.get()).isEqualTo(httpClient.requests().size());
+
+        for (int i = 0; i < httpClient.requests().size(); i++) {
+            assertThat(httpClient.requests().get(i).headers())
+                    .containsEntry("Content-Type", List.of("application/json"))
+                    .containsEntry("Authorization", List.of("Bearer token-" + (i + 1)));
+        }
+    }
+
+    @Test
+    void should_handle_null_from_custom_headers_supplier() {
+        // given
+        CapturingHttpClient httpClient = new CapturingHttpClient();
+        TestHttpClientBuilder httpClientBuilder = new TestHttpClientBuilder(httpClient);
+
+        // when
+        ChromaEmbeddingStore.builder()
+                .baseUrl("http://localhost:8000")
+                .collectionName("test")
+                .httpClientBuilder(httpClientBuilder)
+                .customHeaders(() -> null)
+                .build();
+
+        // then
+        assertThat(httpClient.requests()).hasSize(1);
+    }
+
+    private static class TestHttpClientBuilder implements HttpClientBuilder {
+
+        private final HttpClient httpClient;
+
+        private TestHttpClientBuilder(HttpClient httpClient) {
+            this.httpClient = httpClient;
+        }
+
+        @Override
+        public Duration connectTimeout() {
+            return null;
+        }
+
+        @Override
+        public HttpClientBuilder connectTimeout(Duration timeout) {
+            return this;
+        }
+
+        @Override
+        public Duration readTimeout() {
+            return null;
+        }
+
+        @Override
+        public HttpClientBuilder readTimeout(Duration timeout) {
+            return this;
+        }
+
+        @Override
+        public HttpClient build() {
+            return httpClient;
+        }
+    }
+
+    private static class CapturingHttpClient implements HttpClient {
+
+        private final List<HttpRequest> requests = new ArrayList<>();
+
+        private List<HttpRequest> requests() {
+            return requests;
+        }
+
+        @Override
+        public SuccessfulHttpResponse execute(HttpRequest request) {
+            requests.add(request);
+            return SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .headers(emptyMap())
+                    .body(bodyFor(request.url()))
+                    .build();
+        }
+
+        @Override
+        public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+            throw new UnsupportedOperationException("SSE is not used by ChromaEmbeddingStore");
+        }
+
+        private static String bodyFor(String url) {
+            if (url.endsWith("/api/v2/tenants/default")) {
+                return "{\"name\":\"default\"}";
+            }
+            if (url.endsWith("/api/v2/tenants/default/databases/default")) {
+                return "{\"name\":\"default\"}";
+            }
+            if (url.endsWith("/add")) {
+                return "true";
+            }
+            if (url.endsWith("/api/v1/collections")) {
+                return "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{}}";
+            }
+            if (url.contains("/collections/test")) {
+                return "{\"id\":\"collection-id\",\"name\":\"test\",\"metadata\":{}}";
+            }
+            throw new IllegalArgumentException("Unexpected URL: " + url);
+        }
+    }
+
+    private void assertStaticHeaders(HttpRequest request) {
+        assertThat(request.headers())
+                .containsEntry("Content-Type", List.of("application/json"))
+                .containsEntry("X-Chroma-Token", List.of("test-token"));
+    }
+}


### PR DESCRIPTION
## Issue
Addresses #4594

## Change
- Added `httpClientBuilder(...)` to `ChromaEmbeddingStore.Builder`, allowing users to provide an explicit HTTP client builder instead of relying on ServiceLoader discovery.
- Added static and supplier-based `customHeaders(...)` support for Chroma API v1 and v2 requests.
- Preserved the default HTTP client discovery path when no custom builder or headers are configured.

Chroma token authentication is header-based, including `Authorization: Bearer <token>` and `X-Chroma-Token`, so custom headers cover secured Chroma deployments without adding Chroma-specific auth options for each header style.

Reference: https://github.com/chroma-core/docs/blob/main/docs/usage-guide.md#authentication

Tested with:
- `./mvnw -pl langchain4j-chroma -am -Dtest=ChromaEmbeddingStoreHttpClientBuilderTest -DskipITs -Dsurefire.failIfNoSpecifiedTests=false test`

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for \"big\" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
Not applicable.

## Checklist for adding new embedding store integration
Not applicable.

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `ChromaEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j