### PR TITLE
Add metadata filter support to AstraDbEmbeddingStore

### DIFF
--- a/langchain4j-cassandra/pom.xml
+++ b/langchain4j-cassandra/pom.xml
@@ -42,7 +42,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
-
         <!-- test dependencies -->
 
         <!-- Visibility for EmbeddingStoreIT -->

--- a/langchain4j-cassandra/src/main/java/dev/langchain4j/store/embedding/astradb/AstraDbEmbeddingStore.java
+++ b/langchain4j-cassandra/src/main/java/dev/langchain4j/store/embedding/astradb/AstraDbEmbeddingStore.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.store.embedding.astradb;
 
+import static dev.langchain4j.internal.Utils.randomUUID;
+
 import com.dtsx.astra.sdk.AstraDBCollection;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
@@ -13,16 +15,12 @@ import io.stargate.sdk.data.domain.JsonDocumentMutationResult;
 import io.stargate.sdk.data.domain.JsonDocumentResult;
 import io.stargate.sdk.data.domain.odm.Document;
 import io.stargate.sdk.data.domain.query.Filter;
-import org.jspecify.annotations.NonNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import static dev.langchain4j.internal.Utils.randomUUID;
-import static dev.langchain4j.internal.Utils.toStringValueMap;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Implementation of {@link EmbeddingStore} using AstraDB.
@@ -106,7 +104,8 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
     public String add(Embedding embedding, TextSegment textSegment) {
         return astraDBCollection
                 .insertOne(mapRecord(randomUUID(), embedding, textSegment))
-                .getDocument().getId();
+                .getDocument()
+                .getId();
     }
 
     /**
@@ -125,15 +124,11 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
         if (embeddings == null) return null;
 
         // Map as a JsonDocument list.
-        List<JsonDocument> recordList = embeddings
-                .stream()
-                .map(e -> mapRecord(randomUUID(), e, null))
-                .collect(Collectors.toList());
+        List<JsonDocument> recordList =
+                embeddings.stream().map(e -> mapRecord(randomUUID(), e, null)).collect(Collectors.toList());
 
         // No upsert needed as ids will be generated.
-        return astraDBCollection
-                .insertManyChunkedJsonDocuments(recordList, itemsPerChunk, concurrentThreads)
-                .stream()
+        return astraDBCollection.insertManyChunkedJsonDocuments(recordList, itemsPerChunk, concurrentThreads).stream()
                 .map(JsonDocumentMutationResult::getDocument)
                 .map(Document::getId)
                 .collect(Collectors.toList());
@@ -142,7 +137,8 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
     @Override
     public void addAll(List<String> ids, List<Embedding> embeddingList, List<TextSegment> textSegmentList) {
         if (embeddingList == null || textSegmentList == null || embeddingList.size() != textSegmentList.size()) {
-            throw new IllegalArgumentException("embeddingList and textSegmentList must not be null and have the same size");
+            throw new IllegalArgumentException(
+                    "embeddingList and textSegmentList must not be null and have the same size");
         }
 
         // Map as JsonDocument list
@@ -152,22 +148,20 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         // No upsert needed (ids will be generated)
-        astraDBCollection
-                .insertManyChunkedJsonDocuments(recordList, itemsPerChunk, concurrentThreads);
+        astraDBCollection.insertManyChunkedJsonDocuments(recordList, itemsPerChunk, concurrentThreads);
     }
 
     @Override
     public EmbeddingSearchResult<TextSegment> search(EmbeddingSearchRequest request) {
-        if (request.filter() != null) {
-            throw new UnsupportedOperationException("EmbeddingSearchRequest.Filter is not supported yet.");
-        }
+        Filter filter = request.filter() == null ? null : AstraDbFilterMapper.map(request.filter());
 
         List<EmbeddingMatch<TextSegment>> matches =
-                findRelevant(request.queryEmbedding(), request.maxResults(), request.minScore());
+                findRelevant(request.queryEmbedding(), filter, request.maxResults(), request.minScore());
         return new EmbeddingSearchResult<>(matches);
     }
 
-    public List<EmbeddingMatch<TextSegment>> findRelevant(Embedding referenceEmbedding, int maxResults, double minScore) {
+    public List<EmbeddingMatch<TextSegment>> findRelevant(
+            Embedding referenceEmbedding, int maxResults, double minScore) {
         return findRelevant(referenceEmbedding, (Filter) null, maxResults, minScore);
     }
 
@@ -175,13 +169,15 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
      * Semantic search with metadata filtering.
      *
      * @param referenceEmbedding vector
-     * @param metaDatafilter     fileter for metadata
+     * @param metaDatafilter     filter for metadata
      * @param maxResults         limit
      * @param minScore           threshold
      * @return records
      */
-    public List<EmbeddingMatch<TextSegment>> findRelevant(Embedding referenceEmbedding, Filter metaDatafilter, int maxResults, double minScore) {
-        return astraDBCollection.findVector(referenceEmbedding.vector(), metaDatafilter, maxResults)
+    public List<EmbeddingMatch<TextSegment>> findRelevant(
+            Embedding referenceEmbedding, Filter metaDatafilter, int maxResults, double minScore) {
+        return astraDBCollection
+                .findVector(referenceEmbedding.vector(), metaDatafilter, maxResults)
                 .filter(r -> r.getSimilarity() >= minScore)
                 .map(this::mapJsonResult)
                 .collect(Collectors.toList());
@@ -203,9 +199,11 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
             Object body = properties.get(KEY_ATTRIBUTES_BLOB);
             if (body != null) {
                 Metadata metadata = new Metadata(properties.entrySet().stream()
-                        .collect(Collectors.toMap(Map.Entry::getKey,
-                                entry -> entry.getValue() == null ? "" : entry.getValue().toString()
-                        )));
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                entry -> entry.getValue() == null
+                                        ? ""
+                                        : entry.getValue().toString())));
                 metadata.remove(KEY_ATTRIBUTES_BLOB);
                 metadata.remove(KEY_SIMILARITY);
                 embedded = new TextSegment(body.toString(), metadata);
@@ -225,7 +223,7 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
         JsonDocument record = new JsonDocument().id(id).vector(embedding.vector());
         if (textSegment != null) {
             record.put(KEY_ATTRIBUTES_BLOB, textSegment.text());
-            toStringValueMap(textSegment.metadata().toMap()).forEach(record::put);
+            textSegment.metadata().toMap().forEach(record::put);
         }
         return record;
     }

--- a/langchain4j-cassandra/src/main/java/dev/langchain4j/store/embedding/astradb/AstraDbEmbeddingStore.java
+++ b/langchain4j-cassandra/src/main/java/dev/langchain4j/store/embedding/astradb/AstraDbEmbeddingStore.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.store.embedding.astradb;
 
+import static dev.langchain4j.internal.Utils.randomUUID;
+
 import com.dtsx.astra.sdk.AstraDBCollection;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
@@ -13,16 +15,12 @@ import io.stargate.sdk.data.domain.JsonDocumentMutationResult;
 import io.stargate.sdk.data.domain.JsonDocumentResult;
 import io.stargate.sdk.data.domain.odm.Document;
 import io.stargate.sdk.data.domain.query.Filter;
-import org.jspecify.annotations.NonNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import static dev.langchain4j.internal.Utils.randomUUID;
-import static dev.langchain4j.internal.Utils.toStringValueMap;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Implementation of {@link EmbeddingStore} using AstraDB.
@@ -106,7 +104,8 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
     public String add(Embedding embedding, TextSegment textSegment) {
         return astraDBCollection
                 .insertOne(mapRecord(randomUUID(), embedding, textSegment))
-                .getDocument().getId();
+                .getDocument()
+                .getId();
     }
 
     /**
@@ -125,15 +124,11 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
         if (embeddings == null) return null;
 
         // Map as a JsonDocument list.
-        List<JsonDocument> recordList = embeddings
-                .stream()
-                .map(e -> mapRecord(randomUUID(), e, null))
-                .collect(Collectors.toList());
+        List<JsonDocument> recordList =
+                embeddings.stream().map(e -> mapRecord(randomUUID(), e, null)).collect(Collectors.toList());
 
         // No upsert needed as ids will be generated.
-        return astraDBCollection
-                .insertManyChunkedJsonDocuments(recordList, itemsPerChunk, concurrentThreads)
-                .stream()
+        return astraDBCollection.insertManyChunkedJsonDocuments(recordList, itemsPerChunk, concurrentThreads).stream()
                 .map(JsonDocumentMutationResult::getDocument)
                 .map(Document::getId)
                 .collect(Collectors.toList());
@@ -142,7 +137,8 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
     @Override
     public void addAll(List<String> ids, List<Embedding> embeddingList, List<TextSegment> textSegmentList) {
         if (embeddingList == null || textSegmentList == null || embeddingList.size() != textSegmentList.size()) {
-            throw new IllegalArgumentException("embeddingList and textSegmentList must not be null and have the same size");
+            throw new IllegalArgumentException(
+                    "embeddingList and textSegmentList must not be null and have the same size");
         }
 
         // Map as JsonDocument list
@@ -152,22 +148,20 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         // No upsert needed (ids will be generated)
-        astraDBCollection
-                .insertManyChunkedJsonDocuments(recordList, itemsPerChunk, concurrentThreads);
+        astraDBCollection.insertManyChunkedJsonDocuments(recordList, itemsPerChunk, concurrentThreads);
     }
 
     @Override
     public EmbeddingSearchResult<TextSegment> search(EmbeddingSearchRequest request) {
-        if (request.filter() != null) {
-            throw new UnsupportedOperationException("EmbeddingSearchRequest.Filter is not supported yet.");
-        }
+        Filter filter = request.filter() == null ? null : AstraDbFilterMapper.map(request.filter());
 
         List<EmbeddingMatch<TextSegment>> matches =
-                findRelevant(request.queryEmbedding(), request.maxResults(), request.minScore());
+                findRelevant(request.queryEmbedding(), filter, request.maxResults(), request.minScore());
         return new EmbeddingSearchResult<>(matches);
     }
 
-    public List<EmbeddingMatch<TextSegment>> findRelevant(Embedding referenceEmbedding, int maxResults, double minScore) {
+    public List<EmbeddingMatch<TextSegment>> findRelevant(
+            Embedding referenceEmbedding, int maxResults, double minScore) {
         return findRelevant(referenceEmbedding, (Filter) null, maxResults, minScore);
     }
 
@@ -180,8 +174,10 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
      * @param minScore           threshold
      * @return records
      */
-    public List<EmbeddingMatch<TextSegment>> findRelevant(Embedding referenceEmbedding, Filter metaDatafilter, int maxResults, double minScore) {
-        return astraDBCollection.findVector(referenceEmbedding.vector(), metaDatafilter, maxResults)
+    public List<EmbeddingMatch<TextSegment>> findRelevant(
+            Embedding referenceEmbedding, Filter metaDatafilter, int maxResults, double minScore) {
+        return astraDBCollection
+                .findVector(referenceEmbedding.vector(), metaDatafilter, maxResults)
                 .filter(r -> r.getSimilarity() >= minScore)
                 .map(this::mapJsonResult)
                 .collect(Collectors.toList());
@@ -203,9 +199,11 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
             Object body = properties.get(KEY_ATTRIBUTES_BLOB);
             if (body != null) {
                 Metadata metadata = new Metadata(properties.entrySet().stream()
-                        .collect(Collectors.toMap(Map.Entry::getKey,
-                                entry -> entry.getValue() == null ? "" : entry.getValue().toString()
-                        )));
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                entry -> entry.getValue() == null
+                                        ? ""
+                                        : entry.getValue().toString())));
                 metadata.remove(KEY_ATTRIBUTES_BLOB);
                 metadata.remove(KEY_SIMILARITY);
                 embedded = new TextSegment(body.toString(), metadata);
@@ -225,7 +223,7 @@ public class AstraDbEmbeddingStore implements EmbeddingStore<TextSegment> {
         JsonDocument record = new JsonDocument().id(id).vector(embedding.vector());
         if (textSegment != null) {
             record.put(KEY_ATTRIBUTES_BLOB, textSegment.text());
-            toStringValueMap(textSegment.metadata().toMap()).forEach(record::put);
+            textSegment.metadata().toMap().forEach(record::put);
         }
         return record;
     }

--- a/langchain4j-cassandra/src/main/java/dev/langchain4j/store/embedding/astradb/AstraDbFilterMapper.java
+++ b/langchain4j-cassandra/src/main/java/dev/langchain4j/store/embedding/astradb/AstraDbFilterMapper.java
@@ -1,0 +1,108 @@
+package dev.langchain4j.store.embedding.astradb;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsGreaterThan;
+import dev.langchain4j.store.embedding.filter.comparison.IsGreaterThanOrEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsIn;
+import dev.langchain4j.store.embedding.filter.comparison.IsLessThan;
+import dev.langchain4j.store.embedding.filter.comparison.IsLessThanOrEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsNotEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsNotIn;
+import dev.langchain4j.store.embedding.filter.logical.And;
+import dev.langchain4j.store.embedding.filter.logical.Not;
+import dev.langchain4j.store.embedding.filter.logical.Or;
+import io.stargate.sdk.utils.JsonUtils;
+import java.util.ArrayList;
+import java.util.Map;
+
+class AstraDbFilterMapper {
+
+    private AstraDbFilterMapper() {}
+
+    static io.stargate.sdk.data.domain.query.Filter map(Filter filter) {
+        return new io.stargate.sdk.data.domain.query.Filter(JsonUtils.marshallForDataApi(mapToObject(filter)));
+    }
+
+    private static Map<String, Object> mapToObject(Filter filter) {
+        if (filter instanceof IsEqualTo) {
+            return mapEqual((IsEqualTo) filter);
+        } else if (filter instanceof IsNotEqualTo) {
+            return mapNotEqual((IsNotEqualTo) filter);
+        } else if (filter instanceof IsGreaterThan) {
+            return mapGreaterThan((IsGreaterThan) filter);
+        } else if (filter instanceof IsGreaterThanOrEqualTo) {
+            return mapGreaterThanOrEqual((IsGreaterThanOrEqualTo) filter);
+        } else if (filter instanceof IsLessThan) {
+            return mapLessThan((IsLessThan) filter);
+        } else if (filter instanceof IsLessThanOrEqualTo) {
+            return mapLessThanOrEqual((IsLessThanOrEqualTo) filter);
+        } else if (filter instanceof IsIn) {
+            return mapIn((IsIn) filter);
+        } else if (filter instanceof IsNotIn) {
+            return mapNotIn((IsNotIn) filter);
+        } else if (filter instanceof And) {
+            return mapAnd((And) filter);
+        } else if (filter instanceof Or) {
+            return mapOr((Or) filter);
+        } else if (filter instanceof Not) {
+            return mapNot((Not) filter);
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported filter type: " + filter.getClass().getName());
+        }
+    }
+
+    private static Map<String, Object> mapEqual(IsEqualTo filter) {
+        return singletonMap(escapeFieldName(filter.key()), filter.comparisonValue());
+    }
+
+    private static Map<String, Object> mapNotEqual(IsNotEqualTo filter) {
+        return singletonMap(escapeFieldName(filter.key()), singletonMap("$ne", filter.comparisonValue()));
+    }
+
+    private static Map<String, Object> mapGreaterThan(IsGreaterThan filter) {
+        return singletonMap(escapeFieldName(filter.key()), singletonMap("$gt", filter.comparisonValue()));
+    }
+
+    private static Map<String, Object> mapGreaterThanOrEqual(IsGreaterThanOrEqualTo filter) {
+        return singletonMap(escapeFieldName(filter.key()), singletonMap("$gte", filter.comparisonValue()));
+    }
+
+    private static Map<String, Object> mapLessThan(IsLessThan filter) {
+        return singletonMap(escapeFieldName(filter.key()), singletonMap("$lt", filter.comparisonValue()));
+    }
+
+    private static Map<String, Object> mapLessThanOrEqual(IsLessThanOrEqualTo filter) {
+        return singletonMap(escapeFieldName(filter.key()), singletonMap("$lte", filter.comparisonValue()));
+    }
+
+    private static Map<String, Object> mapIn(IsIn filter) {
+        return singletonMap(
+                escapeFieldName(filter.key()), singletonMap("$in", new ArrayList<>(filter.comparisonValues())));
+    }
+
+    private static Map<String, Object> mapNotIn(IsNotIn filter) {
+        return singletonMap(
+                escapeFieldName(filter.key()), singletonMap("$nin", new ArrayList<>(filter.comparisonValues())));
+    }
+
+    private static Map<String, Object> mapAnd(And filter) {
+        return singletonMap("$and", asList(mapToObject(filter.left()), mapToObject(filter.right())));
+    }
+
+    private static Map<String, Object> mapOr(Or filter) {
+        return singletonMap("$or", asList(mapToObject(filter.left()), mapToObject(filter.right())));
+    }
+
+    private static Map<String, Object> mapNot(Not filter) {
+        return singletonMap("$not", mapToObject(filter.expression()));
+    }
+
+    private static String escapeFieldName(String fieldName) {
+        return fieldName.replace("&", "&&").replace(".", "&.");
+    }
+}

--- a/langchain4j-cassandra/src/test/java/dev/langchain4j/store/embedding/astradb/AstraDbEmbeddingStoreTest.java
+++ b/langchain4j-cassandra/src/test/java/dev/langchain4j/store/embedding/astradb/AstraDbEmbeddingStoreTest.java
@@ -1,0 +1,80 @@
+package dev.langchain4j.store.embedding.astradb;
+
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dtsx.astra.sdk.AstraDBCollection;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import io.stargate.sdk.data.domain.JsonDocument;
+import io.stargate.sdk.data.domain.JsonDocumentMutationResult;
+import io.stargate.sdk.data.domain.query.Filter;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AstraDbEmbeddingStoreTest {
+
+    @Test
+    void should_pass_mapped_filter_to_astra_vector_search() {
+        AstraDBCollection collection = mock(AstraDBCollection.class);
+        when(collection.findVector(any(float[].class), any(Filter.class), eq(5)))
+                .thenReturn(Stream.empty());
+        AstraDbEmbeddingStore store = new AstraDbEmbeddingStore(collection);
+        Embedding queryEmbedding = Embedding.from(new float[] {0.1f, 0.2f});
+
+        store.search(EmbeddingSearchRequest.builder()
+                .queryEmbedding(queryEmbedding)
+                .filter(metadataKey("age").isGreaterThan(18))
+                .maxResults(5)
+                .build());
+
+        ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+        verify(collection).findVector(eq(queryEmbedding.vector()), filterCaptor.capture(), eq(5));
+        assertThat(filterCaptor.getValue().getFilter()).isEqualTo(Map.of("age", Map.of("$gt", 18)));
+    }
+
+    @Test
+    void should_pass_null_filter_to_astra_vector_search_when_request_filter_is_null() {
+        AstraDBCollection collection = mock(AstraDBCollection.class);
+        when(collection.findVector(any(float[].class), isNull(), eq(5))).thenReturn(Stream.empty());
+        AstraDbEmbeddingStore store = new AstraDbEmbeddingStore(collection);
+        Embedding queryEmbedding = Embedding.from(new float[] {0.1f, 0.2f});
+
+        store.search(EmbeddingSearchRequest.builder()
+                .queryEmbedding(queryEmbedding)
+                .maxResults(5)
+                .build());
+
+        verify(collection).findVector(eq(queryEmbedding.vector()), isNull(), eq(5));
+    }
+
+    @Test
+    void should_store_metadata_values_without_stringifying_them() {
+        AstraDBCollection collection = mock(AstraDBCollection.class);
+        ArgumentCaptor<JsonDocument> documentCaptor = ArgumentCaptor.forClass(JsonDocument.class);
+        when(collection.insertOne(any(JsonDocument.class)))
+                .thenReturn(new JsonDocumentMutationResult(new JsonDocument().id("id")));
+        AstraDbEmbeddingStore store = new AstraDbEmbeddingStore(collection);
+
+        store.add(
+                Embedding.from(new float[] {0.1f}),
+                TextSegment.from(
+                        "text", new Metadata().put("age", 18).put("score", 0.7d).put("source", "test")));
+
+        verify(collection).insertOne(documentCaptor.capture());
+        Map<String, Object> data = documentCaptor.getValue().getData();
+        assertThat(data.get("age")).isEqualTo(18);
+        assertThat(data.get("score")).isEqualTo(0.7d);
+        assertThat(data.get("source")).isEqualTo("test");
+    }
+}

--- a/langchain4j-cassandra/src/test/java/dev/langchain4j/store/embedding/astradb/AstraDbFilterMapperTest.java
+++ b/langchain4j-cassandra/src/test/java/dev/langchain4j/store/embedding/astradb/AstraDbFilterMapperTest.java
@@ -1,0 +1,141 @@
+package dev.langchain4j.store.embedding.astradb;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.store.embedding.filter.comparison.ContainsString;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsGreaterThan;
+import dev.langchain4j.store.embedding.filter.comparison.IsGreaterThanOrEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsIn;
+import dev.langchain4j.store.embedding.filter.comparison.IsLessThan;
+import dev.langchain4j.store.embedding.filter.comparison.IsLessThanOrEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsNotEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsNotIn;
+import dev.langchain4j.store.embedding.filter.logical.And;
+import dev.langchain4j.store.embedding.filter.logical.Not;
+import dev.langchain4j.store.embedding.filter.logical.Or;
+import io.stargate.sdk.data.domain.query.Filter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AstraDbFilterMapperTest {
+
+    @Test
+    void should_map_equal() {
+        assertThat(AstraDbFilterMapper.map(new IsEqualTo("key", "value")).getFilter())
+                .isEqualTo(singletonMap("key", "value"));
+    }
+
+    @Test
+    void should_map_not_equal() {
+        assertThat(AstraDbFilterMapper.map(new IsNotEqualTo("key", "value")).getFilter())
+                .isEqualTo(singletonMap("key", singletonMap("$ne", "value")));
+    }
+
+    @Test
+    void should_map_greater_than() {
+        assertThat(AstraDbFilterMapper.map(new IsGreaterThan("age", 18)).getFilter())
+                .isEqualTo(singletonMap("age", singletonMap("$gt", 18)));
+    }
+
+    @Test
+    void should_map_greater_than_or_equal_to() {
+        assertThat(AstraDbFilterMapper.map(new IsGreaterThanOrEqualTo("age", 18))
+                        .getFilter())
+                .isEqualTo(singletonMap("age", singletonMap("$gte", 18)));
+    }
+
+    @Test
+    void should_map_less_than() {
+        assertThat(AstraDbFilterMapper.map(new IsLessThan("age", 65)).getFilter())
+                .isEqualTo(singletonMap("age", singletonMap("$lt", 65)));
+    }
+
+    @Test
+    void should_map_less_than_or_equal_to() {
+        assertThat(AstraDbFilterMapper.map(new IsLessThanOrEqualTo("age", 65)).getFilter())
+                .isEqualTo(singletonMap("age", singletonMap("$lte", 65)));
+    }
+
+    @Test
+    void should_map_in_filters() {
+        Map<String, Object> inFilter = AstraDbFilterMapper.map(new IsIn("status", asList("active", "pending")))
+                .getFilter();
+        assertThat(operatorValues(inFilter, "status", "$in")).containsExactlyInAnyOrder("active", "pending");
+
+        Map<String, Object> notInFilter = AstraDbFilterMapper.map(new IsNotIn("status", asList("deleted", "archived")))
+                .getFilter();
+        assertThat(operatorValues(notInFilter, "status", "$nin")).containsExactlyInAnyOrder("deleted", "archived");
+    }
+
+    @Test
+    void should_map_logical_filters() {
+        Filter andFilter =
+                AstraDbFilterMapper.map(new And(new IsEqualTo("status", "active"), new IsGreaterThan("age", 18)));
+
+        assertThat(andFilter.getFilter())
+                .isEqualTo(singletonMap(
+                        "$and",
+                        asList(singletonMap("status", "active"), singletonMap("age", singletonMap("$gt", 18)))));
+
+        Filter orFilter =
+                AstraDbFilterMapper.map(new Or(new IsEqualTo("status", "active"), new IsEqualTo("status", "pending")));
+
+        assertThat(orFilter.getFilter())
+                .isEqualTo(singletonMap(
+                        "$or", asList(singletonMap("status", "active"), singletonMap("status", "pending"))));
+
+        Filter notFilter = AstraDbFilterMapper.map(new Not(new IsEqualTo("status", "inactive")));
+
+        assertThat(notFilter.getFilter()).isEqualTo(singletonMap("$not", singletonMap("status", "inactive")));
+
+        Filter notRangeFilter = AstraDbFilterMapper.map(new Not(new IsGreaterThan("age", 18)));
+
+        assertThat(notRangeFilter.getFilter())
+                .isEqualTo(singletonMap("$not", singletonMap("age", singletonMap("$gt", 18))));
+
+        Filter notAndFilter = AstraDbFilterMapper.map(
+                new Not(new And(new IsEqualTo("status", "inactive"), new IsLessThan("age", 18))));
+
+        assertThat(notAndFilter.getFilter())
+                .isEqualTo(singletonMap(
+                        "$not",
+                        singletonMap(
+                                "$and",
+                                asList(
+                                        singletonMap("status", "inactive"),
+                                        singletonMap("age", singletonMap("$lt", 18))))));
+    }
+
+    @Test
+    void should_escape_field_names_for_filters() {
+        assertThat(AstraDbFilterMapper.map(new IsLessThan("costs.price.usd", 300))
+                        .getFilter())
+                .isEqualTo(singletonMap("costs&.price&.usd", singletonMap("$lt", 300)));
+        assertThat(AstraDbFilterMapper.map(new IsEqualTo("areas.r&d", "active")).getFilter())
+                .isEqualTo(singletonMap("areas&.r&&d", "active"));
+    }
+
+    @Test
+    void should_throw_for_contains_string() {
+        assertThatThrownBy(() -> AstraDbFilterMapper.map(new ContainsString("key", "value")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Unsupported filter type");
+    }
+
+    private static List<Object> operatorValues(Map<String, Object> filter, String field, String operator) {
+        Object operatorFilter = filter.get(field);
+        assertThat(operatorFilter).isInstanceOf(Map.class);
+
+        Map<?, ?> operators = (Map<?, ?>) operatorFilter;
+        Object values = operators.get(operator);
+        assertThat(values).isInstanceOf(List.class);
+
+        return new ArrayList<>((List<?>) values);
+    }
+}


### PR DESCRIPTION
## Issue
Fixes #4819

## Change
Maps LangChain4j embedding filters to Astra DB Data API filters and passes them to vector search. Equality, range, in/not-in, and logical filters are supported; unsupported filter types fail explicitly.

Metadata values are stored without stringifying them so numeric filters retain their type. Unrelated formatting changes were removed.

## Testing
- AstraDbFilterMapperTest and AstraDbEmbeddingStoreTest: 13 tests passed
- git diff --check