### PR TITLE
Add opt-in error ignoring to EmbeddingStoreIngestor

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestor.java
@@ -15,6 +15,7 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.data.segment.TextSegmentTransformer;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.spi.data.document.splitter.DocumentSplitterFactory;
 import dev.langchain4j.spi.model.embedding.EmbeddingModelFactory;
 import java.util.Collection;
@@ -57,6 +58,7 @@ public class EmbeddingStoreIngestor {
     private final TextSegmentTransformer textSegmentTransformer;
     private final EmbeddingModel embeddingModel;
     private final EmbeddingStore<TextSegment> embeddingStore;
+    private final boolean ignoreErrors;
 
     /**
      * Creates an instance of an {@code EmbeddingStoreIngestor}.
@@ -75,12 +77,23 @@ public class EmbeddingStoreIngestor {
             TextSegmentTransformer textSegmentTransformer,
             EmbeddingModel embeddingModel,
             EmbeddingStore<TextSegment> embeddingStore) {
+        this(documentTransformer, documentSplitter, textSegmentTransformer, embeddingModel, embeddingStore, false);
+    }
+
+    private EmbeddingStoreIngestor(
+            DocumentTransformer documentTransformer,
+            DocumentSplitter documentSplitter,
+            TextSegmentTransformer textSegmentTransformer,
+            EmbeddingModel embeddingModel,
+            EmbeddingStore<TextSegment> embeddingStore,
+            boolean ignoreErrors) {
         this.documentTransformer = documentTransformer;
         this.documentSplitter = getOrDefault(documentSplitter, EmbeddingStoreIngestor::loadDocumentSplitter);
         this.textSegmentTransformer = textSegmentTransformer;
         this.embeddingModel = ensureNotNull(
                 getOrDefault(embeddingModel, EmbeddingStoreIngestor::loadEmbeddingModel), "embeddingModel");
         this.embeddingStore = ensureNotNull(embeddingStore, "embeddingStore");
+        this.ignoreErrors = ignoreErrors;
     }
 
     private static DocumentSplitter loadDocumentSplitter() {
@@ -178,6 +191,10 @@ public class EmbeddingStoreIngestor {
 
         log.debug("Starting to ingest {} documents", documents.size());
 
+        if (ignoreErrors) {
+            return ingestIgnoringErrors(documents);
+        }
+
         if (documentTransformer != null) {
             documents = documentTransformer.transformAll(documents);
             log.debug("Documents were transformed into {} documents", documents.size());
@@ -189,6 +206,7 @@ public class EmbeddingStoreIngestor {
         } else {
             segments = documents.stream().map(Document::toTextSegment).collect(toList());
         }
+
         if (textSegmentTransformer != null) {
             segments = textSegmentTransformer.transformAll(segments);
             log.debug("{} documents were transformed into {} text segments", documents.size(), segments.size());
@@ -203,6 +221,66 @@ public class EmbeddingStoreIngestor {
         log.debug("Finished storing {} text segments into the embedding store", segments.size());
 
         return new IngestionResult(embeddingsResponse.tokenUsage());
+    }
+
+    private IngestionResult ingestIgnoringErrors(List<Document> documents) {
+        TokenUsage tokenUsage = null;
+
+        for (Document document : documents) {
+            try {
+                List<Document> documentsToIngest = singletonList(document);
+                if (documentTransformer != null) {
+                    documentsToIngest = documentTransformer.transformAll(documentsToIngest);
+                    log.debug("Document was transformed into {} documents", documentsToIngest.size());
+                }
+
+                List<TextSegment> segments;
+                if (documentSplitter != null) {
+                    segments = documentSplitter.splitAll(documentsToIngest);
+                    log.debug(
+                            "{} documents were split into {} text segments", documentsToIngest.size(), segments.size());
+                } else {
+                    segments = documentsToIngest.stream()
+                            .map(Document::toTextSegment)
+                            .collect(toList());
+                }
+
+                if (segments.isEmpty()) {
+                    log.debug("Skipping embedding because no text segments were produced");
+                    continue;
+                }
+
+                if (textSegmentTransformer != null) {
+                    segments = textSegmentTransformer.transformAll(segments);
+                    log.debug(
+                            "{} documents were transformed into {} text segments",
+                            documentsToIngest.size(),
+                            segments.size());
+                }
+
+                if (segments.isEmpty()) {
+                    log.debug("Skipping embedding because no text segments were produced");
+                    continue;
+                }
+
+                log.debug("Starting to embed {} text segments", segments.size());
+                Response<List<Embedding>> embeddingsResponse = embeddingModel.embedAll(segments);
+                log.debug("Finished embedding {} text segments", segments.size());
+
+                log.debug("Starting to store {} text segments into the embedding store", segments.size());
+                embeddingStore.addAll(embeddingsResponse.content(), segments);
+                log.debug("Finished storing {} text segments into the embedding store", segments.size());
+
+                tokenUsage = TokenUsage.sum(tokenUsage, embeddingsResponse.tokenUsage());
+            } catch (RuntimeException e) {
+                log.debug(
+                        "Skipping document because ingestion failed: {}: {}",
+                        e.getClass().getSimpleName(),
+                        e.getMessage());
+            }
+        }
+
+        return new IngestionResult(tokenUsage);
     }
 
     /**
@@ -224,6 +302,7 @@ public class EmbeddingStoreIngestor {
         private TextSegmentTransformer textSegmentTransformer;
         private EmbeddingModel embeddingModel;
         private EmbeddingStore<TextSegment> embeddingStore;
+        private boolean ignoreErrors;
 
         /**
          * Creates a new EmbeddingStoreIngestor builder.
@@ -290,13 +369,30 @@ public class EmbeddingStoreIngestor {
         }
 
         /**
+         * Configures whether ingestion should ignore {@link RuntimeException}s and continue with the rest of the
+         * documents. When enabled, documents that produce no text segments are also skipped.
+         *
+         * @param ignoreErrors whether to ignore errors.
+         * @return {@code this}
+         */
+        public Builder ignoreErrors(boolean ignoreErrors) {
+            this.ignoreErrors = ignoreErrors;
+            return this;
+        }
+
+        /**
          * Builds the EmbeddingStoreIngestor.
          *
          * @return the EmbeddingStoreIngestor.
          */
         public EmbeddingStoreIngestor build() {
             return new EmbeddingStoreIngestor(
-                    documentTransformer, documentSplitter, textSegmentTransformer, embeddingModel, embeddingStore);
+                    documentTransformer,
+                    documentSplitter,
+                    textSegmentTransformer,
+                    embeddingModel,
+                    embeddingStore,
+                    ignoreErrors);
         }
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestor.java
@@ -18,6 +18,7 @@ import dev.langchain4j.model.embedding.request.EmbeddingInputType;
 import dev.langchain4j.model.embedding.request.EmbeddingRequest;
 import dev.langchain4j.model.embedding.response.EmbeddingResponse;
 import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.spi.data.document.splitter.DocumentSplitterFactory;
 import dev.langchain4j.spi.model.embedding.EmbeddingModelFactory;
 import java.util.Collection;
@@ -61,6 +62,7 @@ public class EmbeddingStoreIngestor {
     private final EmbeddingModel embeddingModel;
     private final EmbeddingStore<TextSegment> embeddingStore;
     private final EmbeddingInputType embeddingInputType;
+    private final boolean ignoreErrors;
 
     /**
      * Creates an instance of an {@code EmbeddingStoreIngestor}.
@@ -79,7 +81,14 @@ public class EmbeddingStoreIngestor {
             TextSegmentTransformer textSegmentTransformer,
             EmbeddingModel embeddingModel,
             EmbeddingStore<TextSegment> embeddingStore) {
-        this(documentTransformer, documentSplitter, textSegmentTransformer, embeddingModel, embeddingStore, null);
+        this(
+                documentTransformer,
+                documentSplitter,
+                textSegmentTransformer,
+                embeddingModel,
+                embeddingStore,
+                null,
+                false);
     }
 
     private EmbeddingStoreIngestor(
@@ -88,7 +97,8 @@ public class EmbeddingStoreIngestor {
             TextSegmentTransformer textSegmentTransformer,
             EmbeddingModel embeddingModel,
             EmbeddingStore<TextSegment> embeddingStore,
-            EmbeddingInputType embeddingInputType) {
+            EmbeddingInputType embeddingInputType,
+            boolean ignoreErrors) {
         this.documentTransformer = documentTransformer;
         this.documentSplitter = getOrDefault(documentSplitter, EmbeddingStoreIngestor::loadDocumentSplitter);
         this.textSegmentTransformer = textSegmentTransformer;
@@ -96,6 +106,7 @@ public class EmbeddingStoreIngestor {
                 getOrDefault(embeddingModel, EmbeddingStoreIngestor::loadEmbeddingModel), "embeddingModel");
         this.embeddingStore = ensureNotNull(embeddingStore, "embeddingStore");
         this.embeddingInputType = embeddingInputType;
+        this.ignoreErrors = ignoreErrors;
     }
 
     private static DocumentSplitter loadDocumentSplitter() {
@@ -193,6 +204,10 @@ public class EmbeddingStoreIngestor {
 
         log.debug("Starting to ingest {} documents", documents.size());
 
+        if (ignoreErrors) {
+            return ingestIgnoringErrors(documents);
+        }
+
         if (documentTransformer != null) {
             documents = documentTransformer.transformAll(documents);
             log.debug("Documents were transformed into {} documents", documents.size());
@@ -218,6 +233,39 @@ public class EmbeddingStoreIngestor {
         log.debug("Finished storing {} text segments into the embedding store", segments.size());
 
         return new IngestionResult(embeddingsResponse.tokenUsage());
+    }
+
+    private IngestionResult ingestIgnoringErrors(List<Document> documents) {
+        TokenUsage tokenUsage = null;
+
+        for (Document document : documents) {
+            try {
+                List<Document> transformedDocuments = singletonList(document);
+                if (documentTransformer != null) {
+                    transformedDocuments = documentTransformer.transformAll(transformedDocuments);
+                }
+
+                List<TextSegment> segments = documentSplitter == null
+                        ? transformedDocuments.stream()
+                                .map(Document::toTextSegment)
+                                .collect(toList())
+                        : documentSplitter.splitAll(transformedDocuments);
+                if (textSegmentTransformer != null) {
+                    segments = textSegmentTransformer.transformAll(segments);
+                }
+                if (segments.isEmpty()) {
+                    continue;
+                }
+
+                Response<List<Embedding>> embeddingsResponse = embedSegments(segments);
+                embeddingStore.addAll(embeddingsResponse.content(), segments);
+                tokenUsage = TokenUsage.sum(tokenUsage, embeddingsResponse.tokenUsage());
+            } catch (RuntimeException e) {
+                log.debug("Skipping document because ingestion failed", e);
+            }
+        }
+
+        return new IngestionResult(tokenUsage);
     }
 
     private Response<List<Embedding>> embedSegments(List<TextSegment> segments) {
@@ -251,6 +299,7 @@ public class EmbeddingStoreIngestor {
         private EmbeddingModel embeddingModel;
         private EmbeddingStore<TextSegment> embeddingStore;
         private EmbeddingInputType embeddingInputType;
+        private boolean ignoreErrors;
 
         /**
          * Creates a new EmbeddingStoreIngestor builder.
@@ -334,6 +383,17 @@ public class EmbeddingStoreIngestor {
         }
 
         /**
+         * Configures whether failures and documents that produce no text segments should be skipped. Disabled by default.
+         *
+         * @param ignoreErrors whether to continue ingesting after a document fails.
+         * @return {@code this}
+         */
+        public Builder ignoreErrors(boolean ignoreErrors) {
+            this.ignoreErrors = ignoreErrors;
+            return this;
+        }
+
+        /**
          * Builds the EmbeddingStoreIngestor.
          *
          * @return the EmbeddingStoreIngestor.
@@ -345,7 +405,8 @@ public class EmbeddingStoreIngestor {
                     textSegmentTransformer,
                     embeddingModel,
                     embeddingStore,
-                    embeddingInputType);
+                    embeddingInputType,
+                    ignoreErrors);
         }
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestorTest.java
@@ -2,9 +2,12 @@ package dev.langchain4j.store.embedding;
 
 import static dev.langchain4j.data.segment.TextSegment.textSegment;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -191,5 +194,248 @@ class EmbeddingStoreIngestorTest {
         verifyNoMoreInteractions(embeddingStore);
 
         assertThat(ingestionResult.tokenUsage()).isEqualTo(tokenUsage);
+    }
+
+    @Test
+    void should_ignore_empty_segments_when_ignore_errors_is_enabled() {
+
+        // given
+        Document document = Document.from("Malformed document");
+
+        DocumentSplitter documentSplitter = mock(DocumentSplitter.class);
+        when(documentSplitter.splitAll(singletonList(document))).thenReturn(emptyList());
+
+        TextSegmentTransformer textSegmentTransformer = mock(TextSegmentTransformer.class);
+
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+
+        EmbeddingStore<TextSegment> embeddingStore = mock(EmbeddingStore.class);
+
+        EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
+                .documentSplitter(documentSplitter)
+                .textSegmentTransformer(textSegmentTransformer)
+                .embeddingModel(embeddingModel)
+                .embeddingStore(embeddingStore)
+                .ignoreErrors(true)
+                .build();
+
+        // when
+        IngestionResult ingestionResult = ingestor.ingest(document);
+
+        // then
+        assertThat(ingestionResult.tokenUsage()).isNull();
+
+        verify(documentSplitter).splitAll(singletonList(document));
+        verifyNoMoreInteractions(textSegmentTransformer);
+        verify(embeddingModel, never()).embedAll(emptyList());
+        verifyNoMoreInteractions(embeddingModel);
+        verifyNoMoreInteractions(embeddingStore);
+    }
+
+    @Test
+    void should_ignore_empty_transformed_segments_when_ignore_errors_is_enabled() {
+
+        // given
+        Document document = Document.from("Malformed document");
+        TextSegment segment = textSegment("Malformed document");
+
+        DocumentSplitter documentSplitter = mock(DocumentSplitter.class);
+        when(documentSplitter.splitAll(singletonList(document))).thenReturn(singletonList(segment));
+
+        TextSegmentTransformer textSegmentTransformer = mock(TextSegmentTransformer.class);
+        when(textSegmentTransformer.transformAll(singletonList(segment))).thenReturn(emptyList());
+
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+
+        EmbeddingStore<TextSegment> embeddingStore = mock(EmbeddingStore.class);
+
+        EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
+                .documentSplitter(documentSplitter)
+                .textSegmentTransformer(textSegmentTransformer)
+                .embeddingModel(embeddingModel)
+                .embeddingStore(embeddingStore)
+                .ignoreErrors(true)
+                .build();
+
+        // when
+        IngestionResult ingestionResult = ingestor.ingest(document);
+
+        // then
+        assertThat(ingestionResult.tokenUsage()).isNull();
+
+        verify(documentSplitter).splitAll(singletonList(document));
+        verify(textSegmentTransformer).transformAll(singletonList(segment));
+        verifyNoMoreInteractions(textSegmentTransformer);
+        verify(embeddingModel, never()).embedAll(emptyList());
+        verifyNoMoreInteractions(embeddingModel);
+        verifyNoMoreInteractions(embeddingStore);
+    }
+
+    @Test
+    void should_ingest_non_empty_segments_when_ignore_errors_is_enabled() {
+
+        // given
+        Document malformedDocument = Document.from("Malformed document");
+        Document firstValidDocument = Document.from("First valid document");
+        Document secondValidDocument = Document.from("Second valid document");
+        TextSegment firstValidSegment = textSegment("First valid document");
+        TextSegment secondValidSegment = textSegment("Second valid document");
+        TokenUsage firstTokenUsage = new TokenUsage(1, 2, 3);
+        TokenUsage secondTokenUsage = new TokenUsage(3, 5, 8);
+
+        DocumentSplitter documentSplitter = document -> {
+            if (document == malformedDocument) {
+                return emptyList();
+            }
+            if (document == firstValidDocument) {
+                return singletonList(firstValidSegment);
+            }
+            return singletonList(secondValidSegment);
+        };
+
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+        when(embeddingModel.embedAll(singletonList(firstValidSegment)))
+                .thenReturn(Response.from(singletonList(Embedding.from(new float[] {1})), firstTokenUsage));
+        when(embeddingModel.embedAll(singletonList(secondValidSegment)))
+                .thenReturn(Response.from(singletonList(Embedding.from(new float[] {2})), secondTokenUsage));
+
+        EmbeddingStore<TextSegment> embeddingStore = mock(EmbeddingStore.class);
+
+        EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
+                .documentSplitter(documentSplitter)
+                .embeddingModel(embeddingModel)
+                .embeddingStore(embeddingStore)
+                .ignoreErrors(true)
+                .build();
+
+        // when
+        IngestionResult ingestionResult =
+                ingestor.ingest(asList(malformedDocument, firstValidDocument, secondValidDocument));
+
+        // then
+        assertThat(ingestionResult.tokenUsage()).isEqualTo(new TokenUsage(4, 7, 11));
+
+        verify(embeddingModel).embedAll(singletonList(firstValidSegment));
+        verify(embeddingModel).embedAll(singletonList(secondValidSegment));
+        verifyNoMoreInteractions(embeddingModel);
+        verify(embeddingStore).addAll(singletonList(Embedding.from(new float[] {1})), singletonList(firstValidSegment));
+        verify(embeddingStore)
+                .addAll(singletonList(Embedding.from(new float[] {2})), singletonList(secondValidSegment));
+        verifyNoMoreInteractions(embeddingStore);
+    }
+
+    @Test
+    void should_continue_ingesting_when_ignore_errors_is_enabled() {
+
+        // given
+        Document malformedDocument = Document.from("Malformed document");
+        Document validDocument = Document.from("Valid document");
+        TextSegment validSegment = textSegment("Valid document");
+        TokenUsage tokenUsage = new TokenUsage(1, 2, 3);
+
+        DocumentSplitter documentSplitter = document -> {
+            if (document == malformedDocument) {
+                throw new RuntimeException("Cannot split document");
+            }
+            return singletonList(validSegment);
+        };
+
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+        when(embeddingModel.embedAll(singletonList(validSegment)))
+                .thenReturn(Response.from(singletonList(Embedding.from(new float[] {1})), tokenUsage));
+
+        EmbeddingStore<TextSegment> embeddingStore = mock(EmbeddingStore.class);
+
+        EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
+                .documentSplitter(documentSplitter)
+                .embeddingModel(embeddingModel)
+                .embeddingStore(embeddingStore)
+                .ignoreErrors(true)
+                .build();
+
+        // when
+        IngestionResult ingestionResult = ingestor.ingest(asList(malformedDocument, validDocument));
+
+        // then
+        assertThat(ingestionResult.tokenUsage()).isEqualTo(tokenUsage);
+
+        verify(embeddingModel).embedAll(singletonList(validSegment));
+        verifyNoMoreInteractions(embeddingModel);
+        verify(embeddingStore).addAll(singletonList(Embedding.from(new float[] {1})), singletonList(validSegment));
+        verifyNoMoreInteractions(embeddingStore);
+    }
+
+    @Test
+    void should_continue_ingesting_when_embedding_fails_and_ignore_errors_is_enabled() {
+
+        // given
+        Document malformedDocument = Document.from("Malformed document");
+        Document validDocument = Document.from("Valid document");
+        TextSegment malformedSegment = textSegment("Malformed document");
+        TextSegment validSegment = textSegment("Valid document");
+        TokenUsage tokenUsage = new TokenUsage(1, 2, 3);
+
+        DocumentSplitter documentSplitter = document -> {
+            if (document == malformedDocument) {
+                return singletonList(malformedSegment);
+            }
+            return singletonList(validSegment);
+        };
+
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+        when(embeddingModel.embedAll(singletonList(malformedSegment))).thenThrow(new RuntimeException("Cannot embed"));
+        when(embeddingModel.embedAll(singletonList(validSegment)))
+                .thenReturn(Response.from(singletonList(Embedding.from(new float[] {1})), tokenUsage));
+
+        EmbeddingStore<TextSegment> embeddingStore = mock(EmbeddingStore.class);
+
+        EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
+                .documentSplitter(documentSplitter)
+                .embeddingModel(embeddingModel)
+                .embeddingStore(embeddingStore)
+                .ignoreErrors(true)
+                .build();
+
+        // when
+        IngestionResult ingestionResult = ingestor.ingest(asList(malformedDocument, validDocument));
+
+        // then
+        assertThat(ingestionResult.tokenUsage()).isEqualTo(tokenUsage);
+
+        verify(embeddingModel).embedAll(singletonList(malformedSegment));
+        verify(embeddingModel).embedAll(singletonList(validSegment));
+        verifyNoMoreInteractions(embeddingModel);
+        verify(embeddingStore).addAll(singletonList(Embedding.from(new float[] {1})), singletonList(validSegment));
+        verifyNoMoreInteractions(embeddingStore);
+    }
+
+    @Test
+    void should_not_skip_empty_segments_by_default() {
+
+        // given
+        Document document = Document.from("Malformed document");
+
+        DocumentSplitter documentSplitter = mock(DocumentSplitter.class);
+        when(documentSplitter.splitAll(singletonList(document))).thenReturn(emptyList());
+
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+        RuntimeException exception = new RuntimeException("Empty input");
+        when(embeddingModel.embedAll(emptyList())).thenThrow(exception);
+
+        EmbeddingStore<TextSegment> embeddingStore = mock(EmbeddingStore.class);
+
+        EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
+                .documentSplitter(documentSplitter)
+                .embeddingModel(embeddingModel)
+                .embeddingStore(embeddingStore)
+                .build();
+
+        // when/then
+        assertThatThrownBy(() -> ingestor.ingest(document)).isSameAs(exception);
+
+        verify(documentSplitter).splitAll(singletonList(document));
+        verify(embeddingModel).embedAll(emptyList());
+        verifyNoMoreInteractions(embeddingModel);
+        verifyNoMoreInteractions(embeddingStore);
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestorTest.java
@@ -2,11 +2,14 @@ package dev.langchain4j.store.embedding;
 
 import static dev.langchain4j.data.segment.TextSegment.textSegment;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -232,5 +235,60 @@ class EmbeddingStoreIngestorTest {
         verify(embeddingModel).embed(captor.capture());
         assertThat(captor.getValue().inputType()).isEqualTo(EmbeddingInputType.DOCUMENT);
         verify(embeddingModel, never()).embedAll(any());
+    }
+
+    @Test
+    void should_ignore_errors_and_empty_segments_when_configured() {
+
+        Document emptyDocument = Document.from("empty");
+        Document brokenDocument = Document.from("broken");
+        Document validDocument = Document.from("valid");
+        Document anotherValidDocument = Document.from("also valid");
+        TextSegment validSegment = textSegment("valid");
+        TokenUsage tokenUsage = new TokenUsage(1, 2, 3);
+
+        DocumentSplitter splitter = document -> {
+            if (document == emptyDocument) {
+                return emptyList();
+            }
+            if (document == brokenDocument) {
+                throw new RuntimeException("cannot split");
+            }
+            return singletonList(validSegment);
+        };
+        EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
+        when(embeddingModel.embedAll(singletonList(validSegment)))
+                .thenReturn(Response.from(singletonList(Embedding.from(new float[] {1})), tokenUsage));
+        EmbeddingStore<TextSegment> embeddingStore = mock(EmbeddingStore.class);
+        EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
+                .documentSplitter(splitter)
+                .embeddingModel(embeddingModel)
+                .embeddingStore(embeddingStore)
+                .ignoreErrors(true)
+                .build();
+
+        IngestionResult result =
+                ingestor.ingest(asList(emptyDocument, brokenDocument, validDocument, anotherValidDocument));
+
+        assertThat(result.tokenUsage()).isEqualTo(new TokenUsage(2, 4, 6));
+        verify(embeddingStore, times(2))
+                .addAll(singletonList(Embedding.from(new float[] {1})), singletonList(validSegment));
+        verifyNoMoreInteractions(embeddingStore);
+    }
+
+    @Test
+    void should_fail_fast_by_default() {
+
+        RuntimeException failure = new RuntimeException("cannot split");
+        DocumentSplitter splitter = document -> {
+            throw failure;
+        };
+        EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
+                .documentSplitter(splitter)
+                .embeddingModel(mock(EmbeddingModel.class))
+                .embeddingStore(mock(EmbeddingStore.class))
+                .build();
+
+        assertThatThrownBy(() -> ingestor.ingest(Document.from("broken"))).isSameAs(failure);
     }
 }


### PR DESCRIPTION
## Issue
Closes #2273

## Change
Adds an opt-in ignoreErrors flag to EmbeddingStoreIngestor.

The default remains fail-fast. When enabled, documents are processed independently, documents that produce no segments or throw a RuntimeException are skipped, successful documents continue to storage, and their token usage is aggregated. The path reuses the current embedSegments method, including configured embedding input types.

## Testing
- EmbeddingStoreIngestorTest: 5 tests passed
- git diff --check