### PR TITLE
fix: correct spelling of 'outputAssessments' in GuardrailAssessmentSummary

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
@@ -1010,7 +1010,7 @@ abstract class AbstractBedrockChatModel {
                 }
             }
 
-            builder.ouputAssessments(outputAssessments);
+            builder.outputAssessments(outputAssessments);
         }
 
         return builder.build();

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/GuardrailAssessmentSummary.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/GuardrailAssessmentSummary.java
@@ -20,6 +20,11 @@ public class GuardrailAssessmentSummary {
         return outputAssessments;
     }
 
+    @Deprecated
+    public List<GuardrailAssessment> ouputAssessments() {
+        return outputAssessments();
+    }
+
     public boolean hasAssessments() {
         return (inputAssessments != null && !inputAssessments.isEmpty())
                 || (outputAssessments != null && !outputAssessments.isEmpty());
@@ -62,6 +67,11 @@ public class GuardrailAssessmentSummary {
         public Builder outputAssessments(List<GuardrailAssessment> outputAssessments) {
             this.outputAssessments = outputAssessments;
             return this;
+        }
+
+        @Deprecated
+        public Builder ouputAssessments(List<GuardrailAssessment> ouputAssessments) {
+            return outputAssessments(ouputAssessments);
         }
 
         public GuardrailAssessmentSummary build() {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/GuardrailAssessmentSummary.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/GuardrailAssessmentSummary.java
@@ -5,24 +5,24 @@ import java.util.Objects;
 
 public class GuardrailAssessmentSummary {
     private final List<GuardrailAssessment> inputAssessments;
-    private final List<GuardrailAssessment> ouputAssessments;
+    private final List<GuardrailAssessment> outputAssessments;
 
     public GuardrailAssessmentSummary(Builder builder) {
         this.inputAssessments = builder.inputAssessments;
-        this.ouputAssessments = builder.ouputAssessments;
+        this.outputAssessments = builder.outputAssessments;
     }
 
     public List<GuardrailAssessment> inputAssessments() {
         return inputAssessments;
     }
 
-    public List<GuardrailAssessment> ouputAssessments() {
-        return ouputAssessments;
+    public List<GuardrailAssessment> outputAssessments() {
+        return outputAssessments;
     }
 
     public boolean hasAssessments() {
         return (inputAssessments != null && !inputAssessments.isEmpty())
-                || (ouputAssessments != null && !ouputAssessments.isEmpty());
+                || (outputAssessments != null && !outputAssessments.isEmpty());
     }
 
     public static Builder builder() {
@@ -36,31 +36,31 @@ public class GuardrailAssessmentSummary {
         }
         GuardrailAssessmentSummary that = (GuardrailAssessmentSummary) o;
         return Objects.equals(inputAssessments, that.inputAssessments)
-                && Objects.equals(ouputAssessments, that.ouputAssessments);
+                && Objects.equals(outputAssessments, that.outputAssessments);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(inputAssessments, ouputAssessments);
+        return Objects.hash(inputAssessments, outputAssessments);
     }
 
     @Override
     public String toString() {
-        return "GuardrailAssessmentSummary{" + "inputAssessments=" + inputAssessments + ", ouputAssessments="
-                + ouputAssessments + '}';
+        return "GuardrailAssessmentSummary{" + "inputAssessments=" + inputAssessments + ", outputAssessments="
+                + outputAssessments + '}';
     }
 
     public static class Builder {
         private List<GuardrailAssessment> inputAssessments;
-        private List<GuardrailAssessment> ouputAssessments;
+        private List<GuardrailAssessment> outputAssessments;
 
         public Builder inputAssessments(List<GuardrailAssessment> inputAssessments) {
             this.inputAssessments = inputAssessments;
             return this;
         }
 
-        public Builder ouputAssessments(List<GuardrailAssessment> ouputAssessments) {
-            this.ouputAssessments = ouputAssessments;
+        public Builder outputAssessments(List<GuardrailAssessment> outputAssessments) {
+            this.outputAssessments = outputAssessments;
             return this;
         }
 

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardrailIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockGuardrailIT.java
@@ -235,12 +235,12 @@ public class BedrockGuardrailIT {
         BedrockChatResponseMetadata metadata = (BedrockChatResponseMetadata) response.metadata();
         assertThat(metadata.guardrailAssessmentSummary()).isNotNull();
 
-        assertThat(metadata.guardrailAssessmentSummary().ouputAssessments()).isNotNull();
-        assertThat(metadata.guardrailAssessmentSummary().ouputAssessments()).isNotEmpty();
-        assertThat(metadata.guardrailAssessmentSummary().ouputAssessments().size())
+        assertThat(metadata.guardrailAssessmentSummary().outputAssessments()).isNotNull();
+        assertThat(metadata.guardrailAssessmentSummary().outputAssessments()).isNotEmpty();
+        assertThat(metadata.guardrailAssessmentSummary().outputAssessments().size())
                 .isEqualTo(1);
 
-        metadata.guardrailAssessmentSummary().ouputAssessments().stream()
+        metadata.guardrailAssessmentSummary().outputAssessments().stream()
                 .filter(i -> i.action() == GuardrailAssessment.Action.ANONYMIZED
                         && i.policy() == GuardrailAssessment.Policy.SENSITIVE
                         && i.name().equals("EMAIL"))

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockStreamingGuardrailIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockStreamingGuardrailIT.java
@@ -243,12 +243,12 @@ public class BedrockStreamingGuardrailIT {
         BedrockChatResponseMetadata metadata = (BedrockChatResponseMetadata) response.metadata();
         assertThat(metadata.guardrailAssessmentSummary()).isNotNull();
 
-        assertThat(metadata.guardrailAssessmentSummary().ouputAssessments()).isNotNull();
-        assertThat(metadata.guardrailAssessmentSummary().ouputAssessments()).isNotEmpty();
-        assertThat(metadata.guardrailAssessmentSummary().ouputAssessments().size())
+        assertThat(metadata.guardrailAssessmentSummary().outputAssessments()).isNotNull();
+        assertThat(metadata.guardrailAssessmentSummary().outputAssessments()).isNotEmpty();
+        assertThat(metadata.guardrailAssessmentSummary().outputAssessments().size())
                 .isEqualTo(1);
 
-        metadata.guardrailAssessmentSummary().ouputAssessments().stream()
+        metadata.guardrailAssessmentSummary().outputAssessments().stream()
                 .filter(i -> i.action() == GuardrailAssessment.Action.ANONYMIZED
                         && i.policy() == GuardrailAssessment.Policy.SENSITIVE
                         && i.name().equals("EMAIL"))


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change
<!-- Please describe the changes you made. -->
This PR corrects the misspelled `ouputAssessments` name in the Bedrock guardrail assessment summary API by renaming it to `outputAssessments`.

The change updates:
- `GuardrailAssessmentSummary` field, getter, builder setter, and related `equals`, `hashCode`, and `toString` methods
- `AbstractBedrockChatModel` so the mapped metadata uses the corrected builder method
- `BedrockGuardrailIT` and `BedrockStreamingGuardrailIT` to assert against the corrected accessor

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)