### PR TITLE
AI Services: support polymorphic return types and tool parameters

### DIFF
--- a/docs/docs/tutorials/structured-outputs.md
+++ b/docs/docs/tutorials/structured-outputs.md
@@ -683,7 +683,7 @@ class names.
 | Attribute | Supported values |
 |---|---|
 | `use` | `Id.NAME`, `Id.SIMPLE_NAME` |
-| `include` | `As.PROPERTY` (default) |
+| `include` | `As.PROPERTY` (default), `As.EXISTING_PROPERTY` |
 | `property` | Any explicit value; defaults to `"@type"` when blank |
 | `defaultImpl` | Any concrete subclass — used when the LLM's discriminator is missing or unknown |
 | `visible` | `true` keeps the discriminator field on the deserialized bean (and bypasses the field-collision check) |
@@ -729,10 +729,13 @@ When `@Description` is omitted, descriptions fall back to the simple class name
 **Discriminator field collisions:**
 
 If a subtype declares a field with the same name as the discriminator (e.g., a `type` field
-on a sealed-only base), schema generation fails with a clear message. The fix options are
-to rename the field, choose a different discriminator name with
-`@JsonTypeInfo(property = "...")`, or set `@JsonTypeInfo(visible = true)` if the field is
-intentionally part of the subtype.
+on a sealed-only base), schema generation fails with a clear message. Fix options:
+
+- Rename the field, or
+- Choose a different discriminator name with `@JsonTypeInfo(property = "...")`, or
+- Set `@JsonTypeInfo(visible = true)` if the field is intentionally part of the subtype, or
+- Use `@JsonTypeInfo(include = As.EXISTING_PROPERTY)` when the field on the subtype is the
+  source of truth for the discriminator.
 
 #### Limitations
 

--- a/docs/docs/tutorials/structured-outputs.md
+++ b/docs/docs/tutorials/structured-outputs.md
@@ -618,9 +618,9 @@ the LLM emits `{"value":{"type":"Dog","name":"Rex","breed":"Labrador"}}`, which 
 back into a `Dog` instance.
 
 :::note
-Because JSON schemas cannot have `anyOf` at the root, the schema wraps the polymorphic
-choice under a `value` property (or `values` for collections). The wrapper is an
-implementation detail — your AI Service method still returns the unwrapped subtype.
+Because many LLM providers do not support JSON schemas with `anyOf` at the root,
+the schema wraps the polymorphic choice under a `value` property (or `values` for collections).
+The wrapper is an implementation detail — your AI Service method still returns the unwrapped subtype.
 :::
 
 **Collections of polymorphic types:**
@@ -670,15 +670,15 @@ it on the base:
 ```java
 sealed interface Bird permits Eagle, Sparrow {}
 
-@JsonTypeName("eagle")
+@JsonTypeName("bird_eagle")
 record Eagle(double wingspanMeters) implements Bird {}
 
-@JsonTypeName("sparrow")
+@JsonTypeName("bird_sparrow")
 record Sparrow(boolean migratory) implements Bird {}
 ```
 
-The LLM will see `"eagle"` / `"sparrow"` as the discriminator values rather than the simple
-class names.
+The LLM will see `"bird_eagle"` / `"bird_sparrow"` as the discriminator values rather than the simple
+class names (`"Eagle"`/`"Sparrow"`).
 
 **Supported `@JsonTypeInfo` configuration:**
 
@@ -730,7 +730,7 @@ When `@Description` is omitted, descriptions fall back to the simple class name
 
 **Recursive polymorphic types:**
 
-A polymorphic base whose subtypes contain it as a field works out of the box:
+A polymorphic base whose subtypes contain it as a field works as well:
 
 ```java
 sealed interface ExpressionNode permits Literal, BinaryOp {}
@@ -741,7 +741,7 @@ record BinaryOp(String operator, ExpressionNode left, ExpressionNode right) impl
 ```
 
 Recursive polymorphic schemas require a model that supports `$ref` / `$defs`
-(currently OpenAI, Azure OpenAI, and Google AI Gemini in strict mode).
+(currently Azure OpenAI, Mistral and OpenAI).
 
 **Discriminator field collisions:**
 

--- a/docs/docs/tutorials/structured-outputs.md
+++ b/docs/docs/tutorials/structured-outputs.md
@@ -573,6 +573,161 @@ enum Priority {
 ```
 :::
 
+#### Polymorphic Types
+
+AI Service methods can return polymorphic types: a base type (sealed interface, sealed class,
+abstract class, or interface) whose concrete subtype is decided by the LLM at runtime.
+Polymorphic return types work for the type itself, for collections (`List<T>`, `Set<T>`),
+and for fields nested inside other POJOs.
+
+A discriminator property (defaulting to `"type"`) is added to each subtype so the LLM
+can communicate which concrete type it produced; the parser then dispatches to the
+right subtype automatically.
+
+**Sealed interfaces and classes — no annotations needed:**
+
+```java
+sealed interface Animal permits Dog, Cat {}
+
+record Dog(String name, String breed) implements Animal {}
+
+record Cat(String name, boolean indoor) implements Animal {}
+
+interface AnimalExtractor {
+
+    Animal extractAnimalFrom(String text);
+}
+```
+
+The LLM is shown a schema with `anyOf` over `Dog` and `Cat`, each constrained to emit
+its simple class name in the `type` property. Given:
+
+```
+Rex is a Labrador.
+```
+
+the LLM emits `{"value":{"type":"Dog","name":"Rex","breed":"Labrador"}}`, which is parsed
+back into a `Dog` instance.
+
+:::note
+Because JSON schemas cannot have `anyOf` at the root, the schema wraps the polymorphic
+choice under a `value` property (or `values` for collections). The wrapper is an
+implementation detail — your AI Service method still returns the unwrapped subtype.
+:::
+
+**Collections of polymorphic types:**
+
+```java
+interface AnimalsExtractor {
+
+    List<Animal> extractAnimalsFrom(String text);
+}
+```
+
+**Polymorphic fields inside another POJO:**
+
+```java
+record Owner(String name, Animal pet) {}
+
+interface OwnerExtractor {
+
+    Owner extractOwnerFrom(String text);
+}
+```
+
+**Jackson `@JsonSubTypes` / `@JsonTypeInfo`** are also supported and let you decouple wire
+names from Java class names:
+
+```java
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Square.class, name = "square"),
+    @JsonSubTypes.Type(value = Circle.class, name = "circle")
+})
+interface Shape {}
+
+class Square implements Shape { double side; }
+
+class Circle implements Shape { double radius; }
+```
+
+Resolution order for the discriminator value:
+1. `@JsonSubTypes.Type(name = "...")` on the base type
+2. `@JsonTypeName` on the subtype
+3. `Class.getSimpleName()` (the default)
+
+So `@JsonTypeName` is a convenient way to set a wire name when you don't want to declare
+it on the base:
+
+```java
+sealed interface Bird permits Eagle, Sparrow {}
+
+@JsonTypeName("eagle")
+record Eagle(double wingspanMeters) implements Bird {}
+
+@JsonTypeName("sparrow")
+record Sparrow(boolean migratory) implements Bird {}
+```
+
+The LLM will see `"eagle"` / `"sparrow"` as the discriminator values rather than the simple
+class names.
+
+**Supported `@JsonTypeInfo` configuration:**
+
+| Attribute | Supported values |
+|---|---|
+| `use` | `Id.NAME`, `Id.SIMPLE_NAME` |
+| `include` | `As.PROPERTY` (default) |
+| `property` | Any explicit value; defaults to `"@type"` when blank |
+| `defaultImpl` | Any concrete subclass — used when the LLM's discriminator is missing or unknown |
+| `visible` | `true` keeps the discriminator field on the deserialized bean (and bypasses the field-collision check) |
+
+Anything else (e.g., `Id.CLASS`, `As.WRAPPER_OBJECT`) is rejected at schema-generation time
+with an `UnsupportedFeatureException`.
+
+**`defaultImpl` for hallucination tolerance:**
+
+```java
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, defaultImpl = UnknownTool.class)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Hammer.class, name = "hammer"),
+    @JsonSubTypes.Type(value = Wrench.class, name = "wrench")
+})
+interface Tool {}
+```
+
+If the LLM emits an unknown discriminator (e.g., `"saw"`) or omits it entirely, the parser
+returns an `UnknownTool` instead of failing, so your code can detect and handle the
+hallucination.
+
+**Adding descriptions:**
+
+You can guide the LLM by annotating the base type and/or subtypes with `@Description`.
+The base-type description is attached to the `anyOf` element, and each subtype's
+description is attached to its individual option:
+
+```java
+@Description("A pet that lives in your home")
+sealed interface Pet permits Hamster, Parrot {}
+
+@Description("A small caged rodent kept as a pet")
+record Hamster(String name, double weightGrams) implements Pet {}
+
+@Description("A talking bird that can mimic human speech")
+record Parrot(String name, int vocabulary) implements Pet {}
+```
+
+When `@Description` is omitted, descriptions fall back to the simple class name
+(e.g., `"Hamster"`) so the LLM still has a label per option.
+
+**Discriminator field collisions:**
+
+If a subtype declares a field with the same name as the discriminator (e.g., a `type` field
+on a sealed-only base), schema generation fails with a clear message. The fix options are
+to rename the field, choose a different discriminator name with
+`@JsonTypeInfo(property = "...")`, or set `@JsonTypeInfo(visible = true)` if the field is
+intentionally part of the subtype.
+
 #### Limitations
 
 When using JSON Schema with AI Services, there are some limitations:
@@ -585,9 +740,9 @@ When using JSON Schema with AI Services, there are some limitations:
   - `enum`s
   - Nested POJOs
   - `List<T>`, `Set<T>` and `T[]`, where `T` is a scalar, an `enum` or a POJO
+  - Polymorphic types (sealed interfaces/classes or types annotated with Jackson `@JsonSubTypes`)
 - Recursion is currently supported only by Azure OpenAI, Mistral and OpenAI.
-- Polymorphism is not supported yet. The returned POJO and its nested POJOs must be concrete classes;
-interfaces or abstract classes are not supported.
+- Polymorphic types require an LLM that supports `anyOf` in the JSON schema.
 - When LLM does not support JSON Schema feature, or it is not enabled, or type is not supported,
   AI Service will fall back to [prompting](/tutorials/structured-outputs#prompting).
 
@@ -616,27 +771,28 @@ If LLM and LLM provider supports the methods described above, it is better to us
 
 ## Supported Types
 
-| Type                          | JSON Schema | Prompting |
-|-------------------------------|-------------|-----------|
-| `POJO`                        | ✅           | ✅         |
-| `List<POJO>`, `Set<POJO>`     | ✅           | ❌         |
-| `Enum`                        | ✅           | ✅         |
-| `List<Enum>`, `Set<Enum>`     | ✅           | ✅         |
-| `List<String>`, `Set<String>` | ✅           | ✅         |
-| `boolean`, `Boolean`          | ✅           | ✅         |
-| `int`, `Integer`              | ✅           | ✅         |
-| `long`, `Long`                | ✅           | ✅         |
-| `float`, `Float`              | ✅           | ✅         |
-| `double`, `Double`            | ✅           | ✅         |
-| `byte`, `Byte`                | ❌           | ✅         |
-| `short`, `Short`              | ❌           | ✅         |
-| `BigInteger`                  | ❌           | ✅         |
-| `BigDecimal`                  | ❌           | ✅         |
-| `Date`                        | ❌           | ✅         |
-| `LocalDate`                   | ❌           | ✅         |
-| `LocalTime`                   | ❌           | ✅         |
-| `LocalDateTime`               | ❌           | ✅         |
-| `Map<?, ?>`                   | ❌           | ✅         |
+| Type                                                       | JSON Schema | Prompting |
+|------------------------------------------------------------|-------------|-----------|
+| `POJO`                                                     | ✅           | ✅         |
+| `List<POJO>`, `Set<POJO>`                                  | ✅           | ❌         |
+| `Enum`                                                     | ✅           | ✅         |
+| `List<Enum>`, `Set<Enum>`                                  | ✅           | ✅         |
+| `List<String>`, `Set<String>`                              | ✅           | ✅         |
+| Polymorphic (sealed / `@JsonSubTypes`), incl. `List`/`Set` | ✅           | ❌         |
+| `boolean`, `Boolean`                                       | ✅           | ✅         |
+| `int`, `Integer`                                           | ✅           | ✅         |
+| `long`, `Long`                                             | ✅           | ✅         |
+| `float`, `Float`                                           | ✅           | ✅         |
+| `double`, `Double`                                         | ✅           | ✅         |
+| `byte`, `Byte`                                             | ❌           | ✅         |
+| `short`, `Short`                                           | ❌           | ✅         |
+| `BigInteger`                                               | ❌           | ✅         |
+| `BigDecimal`                                               | ❌           | ✅         |
+| `Date`                                                     | ❌           | ✅         |
+| `LocalDate`                                                | ❌           | ✅         |
+| `LocalTime`                                                | ❌           | ✅         |
+| `LocalDateTime`                                            | ❌           | ✅         |
+| `Map<?, ?>`                                                | ❌           | ✅         |
 
 A few examples:
 ```java

--- a/docs/docs/tutorials/structured-outputs.md
+++ b/docs/docs/tutorials/structured-outputs.md
@@ -575,8 +575,14 @@ enum Priority {
 
 #### Polymorphic Types
 
-AI Service methods can return polymorphic types: a base type (sealed interface, sealed class,
-abstract class, or interface) whose concrete subtype is decided by the LLM at runtime.
+AI Service methods can return polymorphic types — a base type whose concrete subtype is
+decided by the LLM at runtime. Two flavors are supported:
+
+- **Sealed interfaces and sealed classes** — no annotations needed; subtypes are
+  discovered via `Class.getPermittedSubclasses()`.
+- **Plain abstract classes and interfaces** — must declare their subtypes explicitly
+  with Jackson's `@JsonSubTypes`.
+
 Polymorphic return types work for the type itself, for collections (`List<T>`, `Set<T>`),
 and for fields nested inside other POJOs.
 

--- a/docs/docs/tutorials/structured-outputs.md
+++ b/docs/docs/tutorials/structured-outputs.md
@@ -584,7 +584,9 @@ decided by the LLM at runtime. Two flavors are supported:
   with Jackson's `@JsonSubTypes`.
 
 Polymorphic return types work for the type itself, for collections (`List<T>`, `Set<T>`),
-and for fields nested inside other POJOs.
+for fields nested inside other POJOs, and for recursive hierarchies where a subtype
+contains the base type as a field (e.g., `BinaryOp(left: ExpressionNode, right: ExpressionNode)`
+where `ExpressionNode` is the sealed base).
 
 A discriminator property (defaulting to `"type"`) is added to each subtype so the LLM
 can communicate which concrete type it produced; the parser then dispatches to the
@@ -725,6 +727,21 @@ record Parrot(String name, int vocabulary) implements Pet {}
 
 When `@Description` is omitted, descriptions fall back to the simple class name
 (e.g., `"Hamster"`) so the LLM still has a label per option.
+
+**Recursive polymorphic types:**
+
+A polymorphic base whose subtypes contain it as a field works out of the box:
+
+```java
+sealed interface ExpressionNode permits Literal, BinaryOp {}
+
+record Literal(int value) implements ExpressionNode {}
+
+record BinaryOp(String operator, ExpressionNode left, ExpressionNode right) implements ExpressionNode {}
+```
+
+Recursive polymorphic schemas require a model that supports `$ref` / `$defs`
+(currently OpenAI, Azure OpenAI, and Google AI Gemini in strict mode).
 
 **Discriminator field collisions:**
 

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -450,8 +450,10 @@ are currently supported only by OpenAI.
 
 #### Polymorphic Tool Parameters
 
-A tool parameter can be a polymorphic type — a base type (sealed interface, sealed class,
-abstract class, or interface) whose concrete subtype is decided by the LLM at call time.
+A tool parameter can be a polymorphic type — a base type whose concrete subtype is decided
+by the LLM at call time. Sealed interfaces and sealed classes work without annotations;
+plain abstract classes and interfaces must declare their subtypes with Jackson's
+`@JsonSubTypes`.
 The schema sent to the LLM contains an `anyOf` over the permitted subtypes, each with a
 discriminator property (defaulting to `"type"`) so the LLM can communicate which concrete
 type it produced; the framework deserializes the LLM's argument into the right subtype

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -369,6 +369,8 @@ Methods annotated with `@Tool` can accept any number of parameters of various ty
 - Object types: `String`, `Integer`, `Double`, etc
 - Custom POJOs (can contain nested POJOs)
 - `enum`s
+- Polymorphic types (sealed interfaces/classes or types annotated with Jackson
+  `@JsonSubTypes` / `@JsonTypeInfo`) — see [Polymorphic Tool Parameters](#polymorphic-tool-parameters)
 - `List<T>`/`Set<T>` where `T` is one of the above-mentioned types
 - `Map<K,V>` (you need to manually specify the types of `K` and `V` in the parameter description with `@P`)
 
@@ -445,6 +447,65 @@ all fields and sub-fields are considered **_optional_** by default.
 
 Recursive parameters (e.g., a `Person` class having a `Set<Person> children` field)
 are currently supported only by OpenAI.
+
+#### Polymorphic Tool Parameters
+
+A tool parameter can be a polymorphic type — a base type (sealed interface, sealed class,
+abstract class, or interface) whose concrete subtype is decided by the LLM at call time.
+The schema sent to the LLM contains an `anyOf` over the permitted subtypes, each with a
+discriminator property (defaulting to `"type"`) so the LLM can communicate which concrete
+type it produced; the framework deserializes the LLM's argument into the right subtype
+before invoking your tool method.
+
+This works for the polymorphic type as a parameter, for `List<T>` / `Set<T>` of polymorphic
+types, and for polymorphic types nested inside another POJO parameter.
+
+**Sealed interfaces and classes — no annotations needed:**
+
+```java
+sealed interface Animal permits Dog, Cat {}
+
+record Dog(String name, String breed) implements Animal {}
+
+record Cat(String name, boolean indoor) implements Animal {}
+
+class AnimalRegistry {
+
+    @Tool("Registers a single animal")
+    void registerAnimal(Animal animal) { /* dispatched to Dog or Cat */ }
+
+    @Tool("Registers a batch of animals")
+    void registerAnimals(List<Animal> animals) { /* mixed Dog / Cat */ }
+
+    @Tool("Registers an owner with their pet")
+    void registerOwner(Owner owner) { /* Owner.pet is dispatched */ }
+}
+
+record Owner(String name, Animal pet) {}
+```
+
+**Jackson `@JsonSubTypes` / `@JsonTypeInfo`** are also supported and let you decouple wire
+names from Java class names:
+
+```java
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Square.class, name = "square"),
+    @JsonSubTypes.Type(value = Circle.class, name = "circle")
+})
+interface Shape {}
+
+class ShapeRegistry {
+
+    @Tool("Registers a shape")
+    void registerShape(Shape shape) { /* dispatched to Square or Circle */ }
+}
+```
+
+The set of supported `@JsonTypeInfo` options, the discriminator-name resolution order,
+`defaultImpl` behavior, the `visible` flag, and field-collision detection are described in
+detail in [Polymorphic Types](/tutorials/structured-outputs#polymorphic-types) under
+Structured Outputs — they apply identically to tool parameters.
 
 ### Tool Method Return Types
 Methods annotated with `@Tool` can return any type, including `void`.

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
@@ -13,17 +13,21 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
+import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
+import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import dev.langchain4j.Internal;
 import java.io.IOException;
@@ -31,6 +35,7 @@ import java.lang.reflect.Type;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -130,24 +135,7 @@ class JacksonJsonCodec implements Json.JsonCodec {
             }
         });
 
-        // Dispatcher for sealed interfaces/classes that carry no @JsonTypeInfo. This lets such
-        // types appear as fields nested in other beans (Jackson can't otherwise instantiate them).
-        // Top-level dispatch is still done by ServiceOutputParser; this only kicks in when Jackson
-        // encounters a sealed type during normal bean traversal.
-        module.setDeserializerModifier(new BeanDeserializerModifier() {
-            @Override
-            public JsonDeserializer<?> modifyDeserializer(
-                    DeserializationConfig config, BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
-                Class<?> beanClass = beanDesc.getBeanClass();
-                if (beanClass.getAnnotation(JsonTypeInfo.class) == null
-                        && PolymorphicTypes.isPolymorphic(beanClass)) {
-                    return new SealedPolymorphicDeserializer(beanClass);
-                }
-                return deserializer;
-            }
-        });
-
-        return JsonMapper.builder()
+        ObjectMapper mapper = JsonMapper.builder()
                 .visibility(FIELD, ANY)
                 .disable(INDENT_OUTPUT) // disabled on purpose to save tokens when sending tool results to LLM
                 .enable(FAIL_ON_UNKNOWN_PROPERTIES) // enabled on purpose to prevent issues caused by LLM hallucinations
@@ -155,43 +143,13 @@ class JacksonJsonCodec implements Json.JsonCodec {
                 .build()
                 .findAndRegisterModules()
                 .registerModule(module);
-    }
 
-    private static final class SealedPolymorphicDeserializer extends JsonDeserializer<Object> {
-
-        private final Class<?> baseType;
-        private final String discriminatorProperty;
-
-        SealedPolymorphicDeserializer(Class<?> baseType) {
-            this.baseType = baseType;
-            this.discriminatorProperty = PolymorphicTypes.discriminatorPropertyName(baseType);
-        }
-
-        @Override
-        public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-            JsonNode node = p.readValueAsTree();
-            if (!(node instanceof ObjectNode)) {
-                throw ctxt.weirdStringException(
-                        node.toString(), baseType, "expected an object for polymorphic type " + baseType.getName());
-            }
-            ObjectNode object = (ObjectNode) node;
-            JsonNode discriminator = object.get(discriminatorProperty);
-            if (discriminator == null || discriminator.isNull()) {
-                throw ctxt.instantiationException(
-                        baseType,
-                        "missing discriminator property '" + discriminatorProperty + "' for polymorphic type "
-                                + baseType.getName());
-            }
-            Class<?> subtype = PolymorphicTypes.findSubtypeByDiscriminator(baseType, discriminator.asText());
-            if (subtype == null) {
-                throw ctxt.instantiationException(
-                        baseType,
-                        "unknown discriminator value '" + discriminator.asText() + "' for polymorphic type "
-                                + baseType.getName());
-            }
-            object.remove(discriminatorProperty);
-            return p.getCodec().treeToValue(object, subtype);
-        }
+        // Make sealed interfaces/classes deserializable as polymorphic types without the user
+        // having to add @JsonTypeInfo+@JsonSubTypes. We synthesize equivalent metadata via a
+        // custom AnnotationIntrospector consulted ahead of Jackson's default one.
+        mapper.setAnnotationIntrospector(AnnotationIntrospectorPair.pair(
+                new SealedTypePolymorphicIntrospector(), mapper.getDeserializationConfig().getAnnotationIntrospector()));
+        return mapper;
     }
 
     /**
@@ -248,5 +206,47 @@ class JacksonJsonCodec implements Json.JsonCodec {
      */
     public ObjectMapper getObjectMapper() {
         return objectMapper;
+    }
+
+    /**
+     * Synthesizes {@code @JsonTypeInfo} + {@code @JsonSubTypes} metadata for sealed types that
+     * carry no Jackson polymorphism annotations of their own. With this introspector consulted
+     * ahead of Jackson's default one, sealed bases dispatch natively via the same discriminator
+     * langchain4j puts in the schema — no custom deserializer needed.
+     */
+    private static final class SealedTypePolymorphicIntrospector extends NopAnnotationIntrospector {
+
+        @Override
+        public TypeResolverBuilder<?> findTypeResolver(
+                MapperConfig<?> config, AnnotatedClass ac, com.fasterxml.jackson.databind.JavaType baseType) {
+            Class<?> raw = ac.getRawType();
+            if (!shouldHandle(raw)) {
+                return null;
+            }
+            StdTypeResolverBuilder builder = new StdTypeResolverBuilder()
+                    .init(JsonTypeInfo.Id.NAME, null)
+                    .inclusion(JsonTypeInfo.As.PROPERTY)
+                    .typeProperty(PolymorphicTypes.discriminatorPropertyName(raw))
+                    .typeIdVisibility(false);
+            return builder;
+        }
+
+        @Override
+        public List<NamedType> findSubtypes(com.fasterxml.jackson.databind.introspect.Annotated a) {
+            Class<?> raw = a.getRawType();
+            if (!shouldHandle(raw)) {
+                return null;
+            }
+            return PolymorphicTypes.findConcreteSubtypes(raw).stream()
+                    .map(sub -> new NamedType(sub, PolymorphicTypes.discriminatorValue(raw, sub)))
+                    .toList();
+        }
+
+        private static boolean shouldHandle(Class<?> raw) {
+            // Step in for any polymorphic base that doesn't already declare its own type-info
+            // strategy via @JsonTypeInfo. This covers both sealed types (no annotations) and
+            // types that only use @JsonSubTypes for subtype enumeration.
+            return raw.getAnnotation(JsonTypeInfo.class) == null && PolymorphicTypes.isPolymorphic(raw);
+        }
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
@@ -9,16 +9,21 @@ import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import dev.langchain4j.Internal;
 import java.io.IOException;
@@ -125,6 +130,23 @@ class JacksonJsonCodec implements Json.JsonCodec {
             }
         });
 
+        // Dispatcher for sealed interfaces/classes that carry no @JsonTypeInfo. This lets such
+        // types appear as fields nested in other beans (Jackson can't otherwise instantiate them).
+        // Top-level dispatch is still done by ServiceOutputParser; this only kicks in when Jackson
+        // encounters a sealed type during normal bean traversal.
+        module.setDeserializerModifier(new BeanDeserializerModifier() {
+            @Override
+            public JsonDeserializer<?> modifyDeserializer(
+                    DeserializationConfig config, BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
+                Class<?> beanClass = beanDesc.getBeanClass();
+                if (beanClass.getAnnotation(JsonTypeInfo.class) == null
+                        && PolymorphicTypes.isPolymorphic(beanClass)) {
+                    return new SealedPolymorphicDeserializer(beanClass);
+                }
+                return deserializer;
+            }
+        });
+
         return JsonMapper.builder()
                 .visibility(FIELD, ANY)
                 .disable(INDENT_OUTPUT) // disabled on purpose to save tokens when sending tool results to LLM
@@ -133,6 +155,43 @@ class JacksonJsonCodec implements Json.JsonCodec {
                 .build()
                 .findAndRegisterModules()
                 .registerModule(module);
+    }
+
+    private static final class SealedPolymorphicDeserializer extends JsonDeserializer<Object> {
+
+        private final Class<?> baseType;
+        private final String discriminatorProperty;
+
+        SealedPolymorphicDeserializer(Class<?> baseType) {
+            this.baseType = baseType;
+            this.discriminatorProperty = PolymorphicTypes.discriminatorPropertyName(baseType);
+        }
+
+        @Override
+        public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            JsonNode node = p.readValueAsTree();
+            if (!(node instanceof ObjectNode)) {
+                throw ctxt.weirdStringException(
+                        node.toString(), baseType, "expected an object for polymorphic type " + baseType.getName());
+            }
+            ObjectNode object = (ObjectNode) node;
+            JsonNode discriminator = object.get(discriminatorProperty);
+            if (discriminator == null || discriminator.isNull()) {
+                throw ctxt.instantiationException(
+                        baseType,
+                        "missing discriminator property '" + discriminatorProperty + "' for polymorphic type "
+                                + baseType.getName());
+            }
+            Class<?> subtype = PolymorphicTypes.findSubtypeByDiscriminator(baseType, discriminator.asText());
+            if (subtype == null) {
+                throw ctxt.instantiationException(
+                        baseType,
+                        "unknown discriminator value '" + discriminator.asText() + "' for polymorphic type "
+                                + baseType.getName());
+            }
+            object.remove(discriminatorProperty);
+            return p.getCodec().treeToValue(object, subtype);
+        }
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -145,24 +145,59 @@ public class JsonSchemaElementUtils {
         return null;
     }
 
+    /**
+     * If recursion was detected for {@code baseType} during schema generation, the polymorphic
+     * body will be emitted in {@code $defs} — return a {@link JsonReferenceSchema} so the body is
+     * not duplicated at the top of the schema. Otherwise return {@code element} unchanged.
+     */
+    public static JsonSchemaElement referenceIfRecursive(
+            JsonSchemaElement element, Class<?> baseType, Map<Class<?>, VisitedClassMetadata> visited) {
+        VisitedClassMetadata metadata = visited.get(baseType);
+        if (metadata != null && metadata.recursionDetected && element instanceof JsonAnyOfSchema) {
+            return JsonReferenceSchema.builder().reference(metadata.reference).build();
+        }
+        return element;
+    }
+
+    /**
+     * Wraps {@code element} as the only required property of a {@link JsonObjectSchema} (the
+     * {@code value}/{@code values} envelope used for polymorphic AI Service return types) and
+     * attaches any recursion-induced definitions collected in {@code visited}.
+     */
+    public static JsonObjectSchema wrapPolymorphic(
+            String propertyName, JsonSchemaElement element, Map<Class<?>, VisitedClassMetadata> visited) {
+        JsonObjectSchema.Builder builder =
+                JsonObjectSchema.builder().addProperty(propertyName, element).required(propertyName);
+        Map<String, JsonSchemaElement> definitions = new LinkedHashMap<>();
+        visited.forEach((clazz, meta) -> {
+            if (meta.recursionDetected) {
+                definitions.put(meta.reference, meta.jsonSchemaElement);
+            }
+        });
+        if (!definitions.isEmpty()) {
+            builder.definitions(definitions);
+        }
+        return builder.build();
+    }
+
     private static JsonSchemaElement addDiscriminator(
             JsonSchemaElement subtypeSchema, Class<?> baseType, Class<?> subtype, String discriminatorProperty) {
         if (!(subtypeSchema instanceof JsonObjectSchema obj)) {
             return subtypeSchema;
         }
 
+        String expectedDiscriminatorValue = PolymorphicTypes.discriminatorValue(baseType, subtype);
+
         // Idempotency: when polymorphic recursion happens, the subtype schema may already carry
         // our injected discriminator from a prior call. Detect that and skip re-augmentation.
-        JsonSchemaElement existing = obj.properties() == null ? null : obj.properties().get(discriminatorProperty);
-        String expectedDiscriminatorValue = PolymorphicTypes.discriminatorValue(baseType, subtype);
-        if (existing instanceof JsonEnumSchema enumSchema
+        if (obj.properties().get(discriminatorProperty) instanceof JsonEnumSchema enumSchema
                 && enumSchema.enumValues() != null
                 && enumSchema.enumValues().size() == 1
                 && expectedDiscriminatorValue.equals(enumSchema.enumValues().get(0))) {
             return obj;
         }
 
-        if (obj.properties() != null && obj.properties().containsKey(discriminatorProperty)) {
+        if (obj.properties().containsKey(discriminatorProperty)) {
             JsonTypeInfo info = baseType.getAnnotation(JsonTypeInfo.class);
             // The user expects the discriminator to be a real field on the subtype when:
             //   - @JsonTypeInfo(visible = true), or
@@ -185,23 +220,18 @@ public class JsonSchemaElementUtils {
             }
         }
 
-        JsonEnumSchema discriminator = JsonEnumSchema.builder()
-                .enumValues(PolymorphicTypes.discriminatorValue(baseType, subtype))
-                .build();
+        JsonEnumSchema discriminator =
+                JsonEnumSchema.builder().enumValues(expectedDiscriminatorValue).build();
 
         Map<String, JsonSchemaElement> properties = new LinkedHashMap<>();
         properties.put(discriminatorProperty, discriminator);
-        if (obj.properties() != null) {
-            obj.properties().forEach(properties::putIfAbsent);
-        }
+        obj.properties().forEach(properties::putIfAbsent);
 
         List<String> required = new ArrayList<>();
         required.add(discriminatorProperty);
-        if (obj.required() != null) {
-            obj.required().forEach(r -> {
-                if (!required.contains(r)) required.add(r);
-            });
-        }
+        obj.required().forEach(r -> {
+            if (!required.contains(r)) required.add(r);
+        });
 
         return JsonObjectSchema.builder()
                 .description(Optional.ofNullable(obj.description()).orElse(subtype.getSimpleName()))

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -100,9 +100,6 @@ public class JsonSchemaElementUtils {
             Map<Class<?>, VisitedClassMetadata> visited) {
         PolymorphicTypes.verifyJsonTypeInfoIsSupported(baseType);
 
-        // If we've already generated the anyOf for this base type during this traversal, emit a
-        // $ref instead of re-inlining the same anyOf and all its subtypes. This keeps recursive
-        // schemas compact (the body lives once in $defs).
         if (visited.containsKey(baseType)) {
             VisitedClassMetadata metadata = visited.get(baseType);
             metadata.recursionDetected = true;
@@ -122,33 +119,78 @@ public class JsonSchemaElementUtils {
             JsonSchemaElement withDiscriminator =
                     addDiscriminator(subtypeSchema, baseType, subtype, discriminatorProperty);
             options.add(withDiscriminator);
-            // Replace the version cached in `visited` (built without the discriminator) with the
-            // augmented one, so any recursive `$ref` to this subtype resolves to a schema that
-            // still constrains the discriminator property.
+            // Refresh the cached entry so any recursive $ref to this subtype keeps the discriminator.
             VisitedClassMetadata subtypeMetadata = visited.get(subtype);
             if (subtypeMetadata != null) {
                 subtypeMetadata.jsonSchemaElement = withDiscriminator;
             }
         }
-        JsonAnyOfSchema anyOf = JsonAnyOfSchema.builder()
-                .description(firstNonNull(description, descriptionFrom(baseType), baseType.getSimpleName()))
-                .anyOf(options)
-                .build();
+        String desc = description != null ? description : Optional.ofNullable(descriptionFrom(baseType))
+                .orElse(baseType.getSimpleName());
+        JsonAnyOfSchema anyOf = JsonAnyOfSchema.builder().description(desc).anyOf(options).build();
         metadata.jsonSchemaElement = anyOf;
         return anyOf;
     }
 
-    private static String firstNonNull(String... values) {
-        for (String v : values) {
-            if (v != null) return v;
+    private static JsonSchemaElement addDiscriminator(
+            JsonSchemaElement subtypeSchema, Class<?> baseType, Class<?> subtype, String discriminatorProperty) {
+        if (!(subtypeSchema instanceof JsonObjectSchema obj)) {
+            return subtypeSchema;
         }
-        return null;
+
+        String discriminatorValue = PolymorphicTypes.discriminatorValue(baseType, subtype);
+
+        // Idempotency: a recursive call may have already augmented this subtype.
+        if (obj.properties().get(discriminatorProperty) instanceof JsonEnumSchema existing
+                && existing.enumValues() != null
+                && existing.enumValues().size() == 1
+                && discriminatorValue.equals(existing.enumValues().get(0))) {
+            return obj;
+        }
+
+        if (obj.properties().containsKey(discriminatorProperty)) {
+            JsonTypeInfo info = baseType.getAnnotation(JsonTypeInfo.class);
+            // The discriminator field is allowed to coexist with a same-named bean field only when
+            // @JsonTypeInfo(visible=true) or @JsonTypeInfo(include=As.EXISTING_PROPERTY).
+            boolean allowed = info != null
+                    && (info.visible() || info.include() == JsonTypeInfo.As.EXISTING_PROPERTY);
+            if (!allowed) {
+                throw new IllegalArgumentException(String.format(
+                        "Polymorphic subtype %s declares a field named '%s', which collides with the discriminator "
+                                + "property used for %s. Either rename the field, specify a different discriminator "
+                                + "name with @JsonTypeInfo(property = \"...\") on %s, set @JsonTypeInfo(visible = true), "
+                                + "or use @JsonTypeInfo(include = As.EXISTING_PROPERTY) if the field is intentionally "
+                                + "part of the subtype.",
+                        subtype.getName(),
+                        discriminatorProperty,
+                        baseType.getName(),
+                        baseType.getName()));
+            }
+        }
+
+        Map<String, JsonSchemaElement> properties = new LinkedHashMap<>();
+        properties.put(
+                discriminatorProperty, JsonEnumSchema.builder().enumValues(discriminatorValue).build());
+        obj.properties().forEach(properties::putIfAbsent);
+
+        List<String> required = new ArrayList<>();
+        required.add(discriminatorProperty);
+        obj.required().forEach(r -> {
+            if (!required.contains(r)) required.add(r);
+        });
+
+        return JsonObjectSchema.builder()
+                .description(Optional.ofNullable(obj.description()).orElse(subtype.getSimpleName()))
+                .addProperties(properties)
+                .required(required)
+                .additionalProperties(obj.additionalProperties())
+                .build();
     }
 
     /**
-     * If recursion was detected for {@code baseType} during schema generation, the polymorphic
-     * body will be emitted in {@code $defs} — return a {@link JsonReferenceSchema} so the body is
-     * not duplicated at the top of the schema. Otherwise return {@code element} unchanged.
+     * If recursion was detected for {@code baseType}, returns a {@link JsonReferenceSchema} to the
+     * polymorphic body (which will be emitted under {@code $defs}); otherwise returns
+     * {@code element} unchanged. Avoids duplicating the body inline next to the {@code $defs} entry.
      */
     public static JsonSchemaElement referenceIfRecursive(
             JsonSchemaElement element, Class<?> baseType, Map<Class<?>, VisitedClassMetadata> visited) {
@@ -160,9 +202,10 @@ public class JsonSchemaElementUtils {
     }
 
     /**
-     * Wraps {@code element} as the only required property of a {@link JsonObjectSchema} (the
-     * {@code value}/{@code values} envelope used for polymorphic AI Service return types) and
-     * attaches any recursion-induced definitions collected in {@code visited}.
+     * Wraps {@code element} as the only required property of an object schema (the
+     * {@code value}/{@code values} envelope used at the root of polymorphic AI Service return types,
+     * since {@code anyOf} is not allowed at the JSON-schema root) and attaches any
+     * recursion-induced definitions collected in {@code visited}.
      */
     public static JsonObjectSchema wrapPolymorphic(
             String propertyName, JsonSchemaElement element, Map<Class<?>, VisitedClassMetadata> visited) {
@@ -178,67 +221,6 @@ public class JsonSchemaElementUtils {
             builder.definitions(definitions);
         }
         return builder.build();
-    }
-
-    private static JsonSchemaElement addDiscriminator(
-            JsonSchemaElement subtypeSchema, Class<?> baseType, Class<?> subtype, String discriminatorProperty) {
-        if (!(subtypeSchema instanceof JsonObjectSchema obj)) {
-            return subtypeSchema;
-        }
-
-        String expectedDiscriminatorValue = PolymorphicTypes.discriminatorValue(baseType, subtype);
-
-        // Idempotency: when polymorphic recursion happens, the subtype schema may already carry
-        // our injected discriminator from a prior call. Detect that and skip re-augmentation.
-        if (obj.properties().get(discriminatorProperty) instanceof JsonEnumSchema enumSchema
-                && enumSchema.enumValues() != null
-                && enumSchema.enumValues().size() == 1
-                && expectedDiscriminatorValue.equals(enumSchema.enumValues().get(0))) {
-            return obj;
-        }
-
-        if (obj.properties().containsKey(discriminatorProperty)) {
-            JsonTypeInfo info = baseType.getAnnotation(JsonTypeInfo.class);
-            // The user expects the discriminator to be a real field on the subtype when:
-            //   - @JsonTypeInfo(visible = true), or
-            //   - @JsonTypeInfo(include = As.EXISTING_PROPERTY).
-            // Otherwise this is a silent shadowing risk.
-            boolean expectedAsRealField = info != null
-                    && (info.visible() || info.include() == JsonTypeInfo.As.EXISTING_PROPERTY);
-            if (!expectedAsRealField) {
-                throw new IllegalArgumentException(String.format(
-                        "Polymorphic subtype %s declares a field named '%s', which collides with the discriminator "
-                                + "property used for %s. Either rename the field, specify a different discriminator "
-                                + "name with @JsonTypeInfo(property = \"...\") on %s, set "
-                                + "@JsonTypeInfo(visible = true), or use "
-                                + "@JsonTypeInfo(include = As.EXISTING_PROPERTY) if the field is intentionally "
-                                + "part of the subtype.",
-                        subtype.getName(),
-                        discriminatorProperty,
-                        baseType.getName(),
-                        baseType.getName()));
-            }
-        }
-
-        JsonEnumSchema discriminator =
-                JsonEnumSchema.builder().enumValues(expectedDiscriminatorValue).build();
-
-        Map<String, JsonSchemaElement> properties = new LinkedHashMap<>();
-        properties.put(discriminatorProperty, discriminator);
-        obj.properties().forEach(properties::putIfAbsent);
-
-        List<String> required = new ArrayList<>();
-        required.add(discriminatorProperty);
-        obj.required().forEach(r -> {
-            if (!required.contains(r)) required.add(r);
-        });
-
-        return JsonObjectSchema.builder()
-                .description(Optional.ofNullable(obj.description()).orElse(subtype.getSimpleName()))
-                .addProperties(properties)
-                .required(required)
-                .additionalProperties(obj.additionalProperties())
-                .build();
     }
 
     public static JsonSchemaElement jsonObjectOrReferenceSchemaFrom(

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -5,6 +5,7 @@ import static java.lang.reflect.Modifier.isStatic;
 import static java.util.Arrays.stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import dev.langchain4j.Internal;
 import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
@@ -85,7 +86,86 @@ public class JsonSchemaElementUtils {
                     .build();
         }
 
+        if (PolymorphicTypes.isPolymorphic(clazz)) {
+            return polymorphicSchemaFrom(clazz, fieldDescription, areSubFieldsRequiredByDefault, visited);
+        }
+
         return jsonObjectOrReferenceSchemaFrom(clazz, fieldDescription, areSubFieldsRequiredByDefault, visited, false);
+    }
+
+    public static JsonAnyOfSchema polymorphicSchemaFrom(
+            Class<?> baseType,
+            String description,
+            boolean areSubFieldsRequiredByDefault,
+            Map<Class<?>, VisitedClassMetadata> visited) {
+        PolymorphicTypes.verifyJsonTypeInfoIsSupported(baseType);
+        String discriminatorProperty = PolymorphicTypes.discriminatorPropertyName(baseType);
+        List<JsonSchemaElement> options = new ArrayList<>();
+        for (Class<?> subtype : PolymorphicTypes.findConcreteSubtypes(baseType)) {
+            JsonSchemaElement subtypeSchema = jsonObjectOrReferenceSchemaFrom(
+                    subtype, null, areSubFieldsRequiredByDefault, visited, false);
+            options.add(addDiscriminator(subtypeSchema, baseType, subtype, discriminatorProperty));
+        }
+        return JsonAnyOfSchema.builder()
+                .description(firstNonNull(description, descriptionFrom(baseType), baseType.getSimpleName()))
+                .anyOf(options)
+                .build();
+    }
+
+    private static String firstNonNull(String... values) {
+        for (String v : values) {
+            if (v != null) return v;
+        }
+        return null;
+    }
+
+    private static JsonSchemaElement addDiscriminator(
+            JsonSchemaElement subtypeSchema, Class<?> baseType, Class<?> subtype, String discriminatorProperty) {
+        if (!(subtypeSchema instanceof JsonObjectSchema obj)) {
+            return subtypeSchema;
+        }
+
+        if (obj.properties() != null && obj.properties().containsKey(discriminatorProperty)) {
+            JsonTypeInfo info = baseType.getAnnotation(JsonTypeInfo.class);
+            // With @JsonTypeInfo(visible = true) the user expects the discriminator to be a real
+            // field on the subtype, so let it through; otherwise this is a silent shadowing risk.
+            if (info == null || !info.visible()) {
+                throw new IllegalArgumentException(String.format(
+                        "Polymorphic subtype %s declares a field named '%s', which collides with the discriminator "
+                                + "property used for %s. Either rename the field, specify a different discriminator "
+                                + "name with @JsonTypeInfo(property = \"...\") on %s, or set "
+                                + "@JsonTypeInfo(visible = true) if the field is intentionally part of the subtype.",
+                        subtype.getName(),
+                        discriminatorProperty,
+                        baseType.getName(),
+                        baseType.getName()));
+            }
+        }
+
+        JsonEnumSchema discriminator = JsonEnumSchema.builder()
+                .enumValues(PolymorphicTypes.discriminatorValue(baseType, subtype))
+                .build();
+
+        Map<String, JsonSchemaElement> properties = new LinkedHashMap<>();
+        properties.put(discriminatorProperty, discriminator);
+        if (obj.properties() != null) {
+            obj.properties().forEach(properties::putIfAbsent);
+        }
+
+        List<String> required = new ArrayList<>();
+        required.add(discriminatorProperty);
+        if (obj.required() != null) {
+            obj.required().forEach(r -> {
+                if (!required.contains(r)) required.add(r);
+            });
+        }
+
+        return JsonObjectSchema.builder()
+                .description(Optional.ofNullable(obj.description()).orElse(subtype.getSimpleName()))
+                .addProperties(properties)
+                .required(required)
+                .additionalProperties(obj.additionalProperties())
+                .build();
     }
 
     public static JsonSchemaElement jsonObjectOrReferenceSchemaFrom(

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -93,23 +93,49 @@ public class JsonSchemaElementUtils {
         return jsonObjectOrReferenceSchemaFrom(clazz, fieldDescription, areSubFieldsRequiredByDefault, visited, false);
     }
 
-    public static JsonAnyOfSchema polymorphicSchemaFrom(
+    public static JsonSchemaElement polymorphicSchemaFrom(
             Class<?> baseType,
             String description,
             boolean areSubFieldsRequiredByDefault,
             Map<Class<?>, VisitedClassMetadata> visited) {
         PolymorphicTypes.verifyJsonTypeInfoIsSupported(baseType);
+
+        // If we've already generated the anyOf for this base type during this traversal, emit a
+        // $ref instead of re-inlining the same anyOf and all its subtypes. This keeps recursive
+        // schemas compact (the body lives once in $defs).
+        if (visited.containsKey(baseType)) {
+            VisitedClassMetadata metadata = visited.get(baseType);
+            metadata.recursionDetected = true;
+            return JsonReferenceSchema.builder().reference(metadata.reference).build();
+        }
+
+        String reference = generateUUIDFrom(baseType.getName());
+        VisitedClassMetadata metadata =
+                new VisitedClassMetadata(JsonReferenceSchema.builder().reference(reference).build(), reference, false);
+        visited.put(baseType, metadata);
+
         String discriminatorProperty = PolymorphicTypes.discriminatorPropertyName(baseType);
         List<JsonSchemaElement> options = new ArrayList<>();
         for (Class<?> subtype : PolymorphicTypes.findConcreteSubtypes(baseType)) {
             JsonSchemaElement subtypeSchema = jsonObjectOrReferenceSchemaFrom(
                     subtype, null, areSubFieldsRequiredByDefault, visited, false);
-            options.add(addDiscriminator(subtypeSchema, baseType, subtype, discriminatorProperty));
+            JsonSchemaElement withDiscriminator =
+                    addDiscriminator(subtypeSchema, baseType, subtype, discriminatorProperty);
+            options.add(withDiscriminator);
+            // Replace the version cached in `visited` (built without the discriminator) with the
+            // augmented one, so any recursive `$ref` to this subtype resolves to a schema that
+            // still constrains the discriminator property.
+            VisitedClassMetadata subtypeMetadata = visited.get(subtype);
+            if (subtypeMetadata != null) {
+                subtypeMetadata.jsonSchemaElement = withDiscriminator;
+            }
         }
-        return JsonAnyOfSchema.builder()
+        JsonAnyOfSchema anyOf = JsonAnyOfSchema.builder()
                 .description(firstNonNull(description, descriptionFrom(baseType), baseType.getSimpleName()))
                 .anyOf(options)
                 .build();
+        metadata.jsonSchemaElement = anyOf;
+        return anyOf;
     }
 
     private static String firstNonNull(String... values) {
@@ -125,16 +151,33 @@ public class JsonSchemaElementUtils {
             return subtypeSchema;
         }
 
+        // Idempotency: when polymorphic recursion happens, the subtype schema may already carry
+        // our injected discriminator from a prior call. Detect that and skip re-augmentation.
+        JsonSchemaElement existing = obj.properties() == null ? null : obj.properties().get(discriminatorProperty);
+        String expectedDiscriminatorValue = PolymorphicTypes.discriminatorValue(baseType, subtype);
+        if (existing instanceof JsonEnumSchema enumSchema
+                && enumSchema.enumValues() != null
+                && enumSchema.enumValues().size() == 1
+                && expectedDiscriminatorValue.equals(enumSchema.enumValues().get(0))) {
+            return obj;
+        }
+
         if (obj.properties() != null && obj.properties().containsKey(discriminatorProperty)) {
             JsonTypeInfo info = baseType.getAnnotation(JsonTypeInfo.class);
-            // With @JsonTypeInfo(visible = true) the user expects the discriminator to be a real
-            // field on the subtype, so let it through; otherwise this is a silent shadowing risk.
-            if (info == null || !info.visible()) {
+            // The user expects the discriminator to be a real field on the subtype when:
+            //   - @JsonTypeInfo(visible = true), or
+            //   - @JsonTypeInfo(include = As.EXISTING_PROPERTY).
+            // Otherwise this is a silent shadowing risk.
+            boolean expectedAsRealField = info != null
+                    && (info.visible() || info.include() == JsonTypeInfo.As.EXISTING_PROPERTY);
+            if (!expectedAsRealField) {
                 throw new IllegalArgumentException(String.format(
                         "Polymorphic subtype %s declares a field named '%s', which collides with the discriminator "
                                 + "property used for %s. Either rename the field, specify a different discriminator "
-                                + "name with @JsonTypeInfo(property = \"...\") on %s, or set "
-                                + "@JsonTypeInfo(visible = true) if the field is intentionally part of the subtype.",
+                                + "name with @JsonTypeInfo(property = \"...\") on %s, set "
+                                + "@JsonTypeInfo(visible = true), or use "
+                                + "@JsonTypeInfo(include = As.EXISTING_PROPERTY) if the field is intentionally "
+                                + "part of the subtype.",
                         subtype.getName(),
                         discriminatorProperty,
                         baseType.getName(),

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.internal;
 
+import static dev.langchain4j.internal.PolymorphicTypes.discriminatorPropertyName;
+import static dev.langchain4j.internal.PolymorphicTypes.discriminatorValue;
+import static dev.langchain4j.internal.PolymorphicTypes.findConcreteSubtypes;
+import static dev.langchain4j.internal.PolymorphicTypes.isPolymorphic;
+import static dev.langchain4j.internal.PolymorphicTypes.verifyJsonTypeInfoIsSupported;
 import static dev.langchain4j.internal.Utils.generateUUIDFrom;
 import static java.lang.reflect.Modifier.isStatic;
 import static java.util.Arrays.stream;
@@ -86,7 +91,7 @@ public class JsonSchemaElementUtils {
                     .build();
         }
 
-        if (PolymorphicTypes.isPolymorphic(clazz)) {
+        if (isPolymorphic(clazz)) {
             return polymorphicSchemaFrom(clazz, fieldDescription, areSubFieldsRequiredByDefault, visited);
         }
 
@@ -98,7 +103,7 @@ public class JsonSchemaElementUtils {
             String description,
             boolean areSubFieldsRequiredByDefault,
             Map<Class<?>, VisitedClassMetadata> visited) {
-        PolymorphicTypes.verifyJsonTypeInfoIsSupported(baseType);
+        verifyJsonTypeInfoIsSupported(baseType);
 
         if (visited.containsKey(baseType)) {
             VisitedClassMetadata metadata = visited.get(baseType);
@@ -111,9 +116,9 @@ public class JsonSchemaElementUtils {
                 new VisitedClassMetadata(JsonReferenceSchema.builder().reference(reference).build(), reference, false);
         visited.put(baseType, metadata);
 
-        String discriminatorProperty = PolymorphicTypes.discriminatorPropertyName(baseType);
+        String discriminatorProperty = discriminatorPropertyName(baseType);
         List<JsonSchemaElement> options = new ArrayList<>();
-        for (Class<?> subtype : PolymorphicTypes.findConcreteSubtypes(baseType)) {
+        for (Class<?> subtype : findConcreteSubtypes(baseType)) {
             JsonSchemaElement subtypeSchema = jsonObjectOrReferenceSchemaFrom(
                     subtype, null, areSubFieldsRequiredByDefault, visited, false);
             JsonSchemaElement withDiscriminator =
@@ -138,7 +143,7 @@ public class JsonSchemaElementUtils {
             return subtypeSchema;
         }
 
-        String discriminatorValue = PolymorphicTypes.discriminatorValue(baseType, subtype);
+        String discriminatorValue = discriminatorValue(baseType, subtype);
 
         // Idempotency: a recursive call may have already augmented this subtype.
         if (obj.properties().get(discriminatorProperty) instanceof JsonEnumSchema existing

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/PolymorphicTypes.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/PolymorphicTypes.java
@@ -1,0 +1,167 @@
+package dev.langchain4j.internal;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import dev.langchain4j.Internal;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+
+/**
+ * Utilities for handling polymorphic types (sealed interfaces/classes, abstract classes/interfaces
+ * annotated with {@link JsonSubTypes}) when generating JSON schemas and parsing structured outputs.
+ */
+@Internal
+public class PolymorphicTypes {
+
+    /**
+     * Default discriminator property name used when no Jackson {@link JsonTypeInfo} is configured
+     * on the polymorphic base type.
+     */
+    public static final String DEFAULT_DISCRIMINATOR_PROPERTY = "type";
+
+    private PolymorphicTypes() {
+    }
+
+    /**
+     * Verifies that the {@link JsonTypeInfo} configuration on {@code baseType} (if present) uses
+     * settings supported by LangChain4j. Throws {@link UnsupportedFeatureException} otherwise so the
+     * user gets a clear failure at schema-generation time rather than a silent mismatch between the
+     * generated schema and Jackson's deserialization.
+     *
+     * <p>Supported {@code use} values: {@code Id.NAME}, {@code Id.SIMPLE_NAME}.<br>
+     * Supported {@code include} value: {@code As.PROPERTY}.</p>
+     */
+    public static void verifyJsonTypeInfoIsSupported(Class<?> baseType) {
+        JsonTypeInfo ann = baseType.getAnnotation(JsonTypeInfo.class);
+        if (ann == null) {
+            return;
+        }
+        JsonTypeInfo.Id use = ann.use();
+        if (use != JsonTypeInfo.Id.NAME && use != JsonTypeInfo.Id.SIMPLE_NAME) {
+            throw new UnsupportedFeatureException(String.format(
+                    "@JsonTypeInfo(use = Id.%s) on %s is not supported for AI Service return types. "
+                            + "Supported values: Id.NAME, Id.SIMPLE_NAME.",
+                    use.name(), baseType.getName()));
+        }
+        if (ann.include() != JsonTypeInfo.As.PROPERTY) {
+            throw new UnsupportedFeatureException(String.format(
+                    "@JsonTypeInfo(include = As.%s) on %s is not supported for AI Service return types. "
+                            + "Supported value: As.PROPERTY.",
+                    ann.include().name(), baseType.getName()));
+        }
+    }
+
+    /**
+     * Returns {@code true} if {@code type} is a polymorphic base type for which concrete subtypes
+     * can be discovered automatically — either a sealed interface/class, or any type annotated
+     * with Jackson's {@link JsonSubTypes}.
+     */
+    public static boolean isPolymorphic(Class<?> type) {
+        if (type == null || type.isPrimitive() || type.isEnum() || type.isArray()) {
+            return false;
+        }
+        if (hasJsonSubTypes(type) || type.isSealed()) {
+            return !findConcreteSubtypes(type).isEmpty();
+        }
+        return false;
+    }
+
+    /**
+     * Returns the list of concrete (instantiable) subtypes for a polymorphic base type. Sealed
+     * hierarchies are flattened recursively. {@link JsonSubTypes} declarations take precedence.
+     */
+    public static List<Class<?>> findConcreteSubtypes(Class<?> type) {
+        Set<Class<?>> result = new LinkedHashSet<>();
+        flattenSubtypes(type, result);
+        return new ArrayList<>(result);
+    }
+
+    private static void flattenSubtypes(Class<?> type, Set<Class<?>> result) {
+        if (hasJsonSubTypes(type)) {
+            JsonSubTypes ann = type.getAnnotation(JsonSubTypes.class);
+            for (JsonSubTypes.Type t : ann.value()) {
+                flattenSubtypes(t.value(), result);
+            }
+            return;
+        }
+        if (type.isSealed()) {
+            for (Class<?> permitted : type.getPermittedSubclasses()) {
+                flattenSubtypes(permitted, result);
+            }
+            return;
+        }
+        if (!type.isInterface() && !Modifier.isAbstract(type.getModifiers())) {
+            result.add(type);
+        }
+    }
+
+    /**
+     * Returns the discriminator property name to use when generating the schema and when parsing
+     * the LLM response. Honors {@link JsonTypeInfo#property()} when set explicitly; otherwise,
+     * when {@code @JsonTypeInfo} is present, returns Jackson's default ({@code "@type"}) for
+     * {@code Id.NAME} / {@code Id.SIMPLE_NAME}; otherwise returns
+     * {@link #DEFAULT_DISCRIMINATOR_PROPERTY}.
+     */
+    public static String discriminatorPropertyName(Class<?> baseType) {
+        JsonTypeInfo ann = baseType.getAnnotation(JsonTypeInfo.class);
+        if (ann != null) {
+            if (!isNullOrBlank(ann.property())) {
+                return ann.property();
+            }
+            return "@type";
+        }
+        return DEFAULT_DISCRIMINATOR_PROPERTY;
+    }
+
+    /**
+     * Returns the discriminator value for a concrete subtype. Resolution order:
+     * <ol>
+     *   <li>{@code @JsonSubTypes.Type(name = "...")} on the base type</li>
+     *   <li>{@code @JsonTypeName} on the subtype</li>
+     *   <li>{@link Class#getSimpleName()}</li>
+     * </ol>
+     */
+    public static String discriminatorValue(Class<?> baseType, Class<?> subtype) {
+        JsonSubTypes ann = baseType.getAnnotation(JsonSubTypes.class);
+        if (ann != null) {
+            for (JsonSubTypes.Type t : ann.value()) {
+                if (t.value() == subtype && !isNullOrBlank(t.name())) {
+                    return t.name();
+                }
+            }
+        }
+        JsonTypeName name = subtype.getAnnotation(JsonTypeName.class);
+        if (name != null && !isNullOrBlank(name.value())) {
+            return name.value();
+        }
+        return subtype.getSimpleName();
+    }
+
+    /**
+     * Resolves a discriminator value back to one of the concrete subtypes of {@code baseType}.
+     * Returns {@code null} when no subtype matches.
+     */
+    public static Class<?> findSubtypeByDiscriminator(Class<?> baseType, String discriminator) {
+        if (isNullOrBlank(discriminator)) {
+            return null;
+        }
+        for (Class<?> subtype : findConcreteSubtypes(baseType)) {
+            if (discriminator.equals(discriminatorValue(baseType, subtype))) {
+                return subtype;
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasJsonSubTypes(Class<?> type) {
+        return type.getAnnotation(JsonSubTypes.class) != null;
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/PolymorphicTypes.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/PolymorphicTypes.java
@@ -37,7 +37,7 @@ public class PolymorphicTypes {
      * generated schema and Jackson's deserialization.
      *
      * <p>Supported {@code use} values: {@code Id.NAME}, {@code Id.SIMPLE_NAME}.<br>
-     * Supported {@code include} value: {@code As.PROPERTY}.</p>
+     * Supported {@code include} values: {@code As.PROPERTY}, {@code As.EXISTING_PROPERTY}.</p>
      */
     public static void verifyJsonTypeInfoIsSupported(Class<?> baseType) {
         JsonTypeInfo ann = baseType.getAnnotation(JsonTypeInfo.class);
@@ -51,11 +51,12 @@ public class PolymorphicTypes {
                             + "Supported values: Id.NAME, Id.SIMPLE_NAME.",
                     use.name(), baseType.getName()));
         }
-        if (ann.include() != JsonTypeInfo.As.PROPERTY) {
+        JsonTypeInfo.As include = ann.include();
+        if (include != JsonTypeInfo.As.PROPERTY && include != JsonTypeInfo.As.EXISTING_PROPERTY) {
             throw new UnsupportedFeatureException(String.format(
                     "@JsonTypeInfo(include = As.%s) on %s is not supported for AI Service return types. "
-                            + "Supported value: As.PROPERTY.",
-                    ann.include().name(), baseType.getName()));
+                            + "Supported values: As.PROPERTY, As.EXISTING_PROPERTY.",
+                    include.name(), baseType.getName()));
         }
     }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/PolymorphicTypes.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/PolymorphicTypes.java
@@ -1,101 +1,66 @@
 package dev.langchain4j.internal;
 
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import dev.langchain4j.Internal;
 import dev.langchain4j.exception.UnsupportedFeatureException;
-
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-
 /**
- * Utilities for handling polymorphic types (sealed interfaces/classes, abstract classes/interfaces
- * annotated with {@link JsonSubTypes}) when generating JSON schemas and parsing structured outputs.
+ * Detection and naming for polymorphic base types — sealed interfaces / classes (no annotations
+ * needed) and types annotated with Jackson's {@link JsonSubTypes}. Used by both schema generation
+ * and the Jackson polymorphic-dispatch hook for sealed types.
  */
 @Internal
-public class PolymorphicTypes {
+public final class PolymorphicTypes {
 
-    /**
-     * Default discriminator property name used when no Jackson {@link JsonTypeInfo} is configured
-     * on the polymorphic base type.
-     */
+    /** Default discriminator property name when {@code @JsonTypeInfo} is not configured. */
     public static final String DEFAULT_DISCRIMINATOR_PROPERTY = "type";
 
-    private PolymorphicTypes() {
-    }
+    private PolymorphicTypes() {}
 
     /**
-     * Verifies that the {@link JsonTypeInfo} configuration on {@code baseType} (if present) uses
-     * settings supported by LangChain4j. Throws {@link UnsupportedFeatureException} otherwise so the
-     * user gets a clear failure at schema-generation time rather than a silent mismatch between the
-     * generated schema and Jackson's deserialization.
-     *
-     * <p>Supported {@code use} values: {@code Id.NAME}, {@code Id.SIMPLE_NAME}.<br>
-     * Supported {@code include} values: {@code As.PROPERTY}, {@code As.EXISTING_PROPERTY}.</p>
-     */
-    public static void verifyJsonTypeInfoIsSupported(Class<?> baseType) {
-        JsonTypeInfo ann = baseType.getAnnotation(JsonTypeInfo.class);
-        if (ann == null) {
-            return;
-        }
-        JsonTypeInfo.Id use = ann.use();
-        if (use != JsonTypeInfo.Id.NAME && use != JsonTypeInfo.Id.SIMPLE_NAME) {
-            throw new UnsupportedFeatureException(String.format(
-                    "@JsonTypeInfo(use = Id.%s) on %s is not supported for AI Service return types. "
-                            + "Supported values: Id.NAME, Id.SIMPLE_NAME.",
-                    use.name(), baseType.getName()));
-        }
-        JsonTypeInfo.As include = ann.include();
-        if (include != JsonTypeInfo.As.PROPERTY && include != JsonTypeInfo.As.EXISTING_PROPERTY) {
-            throw new UnsupportedFeatureException(String.format(
-                    "@JsonTypeInfo(include = As.%s) on %s is not supported for AI Service return types. "
-                            + "Supported values: As.PROPERTY, As.EXISTING_PROPERTY.",
-                    include.name(), baseType.getName()));
-        }
-    }
-
-    /**
-     * Returns {@code true} if {@code type} is a polymorphic base type for which concrete subtypes
-     * can be discovered automatically — either a sealed interface/class, or any type annotated
-     * with Jackson's {@link JsonSubTypes}.
+     * Returns {@code true} if {@code type} is a polymorphic base — sealed, or annotated with
+     * {@link JsonSubTypes} — and has at least one concrete subtype discoverable by langchain4j.
      */
     public static boolean isPolymorphic(Class<?> type) {
         if (type == null || type.isPrimitive() || type.isEnum() || type.isArray()) {
             return false;
         }
-        if (hasJsonSubTypes(type) || type.isSealed()) {
+        if (type.getAnnotation(JsonSubTypes.class) != null || type.isSealed()) {
             return !findConcreteSubtypes(type).isEmpty();
         }
         return false;
     }
 
     /**
-     * Returns the list of concrete (instantiable) subtypes for a polymorphic base type. Sealed
-     * hierarchies are flattened recursively. {@link JsonSubTypes} declarations take precedence.
+     * Concrete (instantiable) subtypes for {@code type}. Sealed hierarchies are flattened
+     * recursively; {@code @JsonSubTypes} on the base takes precedence over sealed permits.
      */
     public static List<Class<?>> findConcreteSubtypes(Class<?> type) {
         Set<Class<?>> result = new LinkedHashSet<>();
-        flattenSubtypes(type, result);
+        flatten(type, result);
         return new ArrayList<>(result);
     }
 
-    private static void flattenSubtypes(Class<?> type, Set<Class<?>> result) {
-        if (hasJsonSubTypes(type)) {
-            JsonSubTypes ann = type.getAnnotation(JsonSubTypes.class);
+    private static void flatten(Class<?> type, Set<Class<?>> result) {
+        JsonSubTypes ann = type.getAnnotation(JsonSubTypes.class);
+        if (ann != null) {
             for (JsonSubTypes.Type t : ann.value()) {
-                flattenSubtypes(t.value(), result);
+                flatten(t.value(), result);
             }
             return;
         }
         if (type.isSealed()) {
             for (Class<?> permitted : type.getPermittedSubclasses()) {
-                flattenSubtypes(permitted, result);
+                flatten(permitted, result);
             }
             return;
         }
@@ -105,30 +70,21 @@ public class PolymorphicTypes {
     }
 
     /**
-     * Returns the discriminator property name to use when generating the schema and when parsing
-     * the LLM response. Honors {@link JsonTypeInfo#property()} when set explicitly; otherwise,
-     * when {@code @JsonTypeInfo} is present, returns Jackson's default ({@code "@type"}) for
-     * {@code Id.NAME} / {@code Id.SIMPLE_NAME}; otherwise returns
-     * {@link #DEFAULT_DISCRIMINATOR_PROPERTY}.
+     * Discriminator property name. Honors {@code @JsonTypeInfo(property=...)} when explicit;
+     * otherwise {@code "@type"} for {@code @JsonTypeInfo}-annotated bases (Jackson's default) and
+     * {@link #DEFAULT_DISCRIMINATOR_PROPERTY} otherwise.
      */
     public static String discriminatorPropertyName(Class<?> baseType) {
         JsonTypeInfo ann = baseType.getAnnotation(JsonTypeInfo.class);
-        if (ann != null) {
-            if (!isNullOrBlank(ann.property())) {
-                return ann.property();
-            }
-            return "@type";
+        if (ann == null) {
+            return DEFAULT_DISCRIMINATOR_PROPERTY;
         }
-        return DEFAULT_DISCRIMINATOR_PROPERTY;
+        return isNullOrBlank(ann.property()) ? "@type" : ann.property();
     }
 
     /**
-     * Returns the discriminator value for a concrete subtype. Resolution order:
-     * <ol>
-     *   <li>{@code @JsonSubTypes.Type(name = "...")} on the base type</li>
-     *   <li>{@code @JsonTypeName} on the subtype</li>
-     *   <li>{@link Class#getSimpleName()}</li>
-     * </ol>
+     * Discriminator value for a subtype. Resolution order: {@code @JsonSubTypes.Type(name=...)}
+     * on the base → {@code @JsonTypeName} on the subtype → {@link Class#getSimpleName()}.
      */
     public static String discriminatorValue(Class<?> baseType, Class<?> subtype) {
         JsonSubTypes ann = baseType.getAnnotation(JsonSubTypes.class);
@@ -139,30 +95,37 @@ public class PolymorphicTypes {
                 }
             }
         }
-        JsonTypeName name = subtype.getAnnotation(JsonTypeName.class);
-        if (name != null && !isNullOrBlank(name.value())) {
-            return name.value();
+        JsonTypeName typeName = subtype.getAnnotation(JsonTypeName.class);
+        if (typeName != null && !isNullOrBlank(typeName.value())) {
+            return typeName.value();
         }
         return subtype.getSimpleName();
     }
 
     /**
-     * Resolves a discriminator value back to one of the concrete subtypes of {@code baseType}.
-     * Returns {@code null} when no subtype matches.
+     * Verifies that the {@code @JsonTypeInfo} configuration on {@code baseType} (if present) uses
+     * settings supported by langchain4j. Throws otherwise so the user gets a clear failure at
+     * schema-generation time rather than a silent mismatch.
+     *
+     * <p>Supported {@code use}: {@code Id.NAME}, {@code Id.SIMPLE_NAME}.<br>
+     * Supported {@code include}: {@code As.PROPERTY}, {@code As.EXISTING_PROPERTY}.</p>
      */
-    public static Class<?> findSubtypeByDiscriminator(Class<?> baseType, String discriminator) {
-        if (isNullOrBlank(discriminator)) {
-            return null;
+    public static void verifyJsonTypeInfoIsSupported(Class<?> baseType) {
+        JsonTypeInfo ann = baseType.getAnnotation(JsonTypeInfo.class);
+        if (ann == null) {
+            return;
         }
-        for (Class<?> subtype : findConcreteSubtypes(baseType)) {
-            if (discriminator.equals(discriminatorValue(baseType, subtype))) {
-                return subtype;
-            }
+        if (ann.use() != JsonTypeInfo.Id.NAME && ann.use() != JsonTypeInfo.Id.SIMPLE_NAME) {
+            throw new UnsupportedFeatureException(String.format(
+                    "@JsonTypeInfo(use = Id.%s) on %s is not supported for AI Service return types. "
+                            + "Supported values: Id.NAME, Id.SIMPLE_NAME.",
+                    ann.use().name(), baseType.getName()));
         }
-        return null;
-    }
-
-    private static boolean hasJsonSubTypes(Class<?> type) {
-        return type.getAnnotation(JsonSubTypes.class) != null;
+        if (ann.include() != JsonTypeInfo.As.PROPERTY && ann.include() != JsonTypeInfo.As.EXISTING_PROPERTY) {
+            throw new UnsupportedFeatureException(String.format(
+                    "@JsonTypeInfo(include = As.%s) on %s is not supported for AI Service return types. "
+                            + "Supported values: As.PROPERTY, As.EXISTING_PROPERTY.",
+                    ann.include().name(), baseType.getName()));
+        }
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/PojoCollectionOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/PojoCollectionOutputParser.java
@@ -1,17 +1,20 @@
 package dev.langchain4j.service.output;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.internal.PolymorphicTypes;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.jsonObjectOrReferenceSchemaFrom;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.polymorphicSchemaFrom;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.service.output.ParsingUtils.parseAsStringOrJson;
 
 @Internal
@@ -40,11 +43,14 @@ abstract class PojoCollectionOutputParser<T, CT extends Collection<T>> implement
 
     @Override
     public Optional<JsonSchema> jsonSchema() {
+        JsonSchemaElement itemSchema = PolymorphicTypes.isPolymorphic(type)
+                ? polymorphicSchemaFrom(type, null, false, new LinkedHashMap<>())
+                : jsonObjectOrReferenceSchemaFrom(type, null, false, new LinkedHashMap<>(), true);
         JsonSchema jsonSchema = JsonSchema.builder()
                 .name(collectionType().getSimpleName() + "_of_" + type.getSimpleName())
                 .rootElement(JsonObjectSchema.builder()
                         .addProperty("values", JsonArraySchema.builder()
-                                .items(jsonObjectOrReferenceSchemaFrom(type, null, false, new LinkedHashMap<>(), true))
+                                .items(itemSchema)
                                 .build())
                         .required("values")
                         .build())

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/PojoCollectionOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/PojoCollectionOutputParser.java
@@ -16,6 +16,8 @@ import java.util.function.Supplier;
 
 import static dev.langchain4j.internal.JsonSchemaElementUtils.jsonObjectOrReferenceSchemaFrom;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.polymorphicSchemaFrom;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.referenceIfRecursive;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.wrapPolymorphic;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.service.output.ParsingUtils.parseAsStringOrJson;
 
@@ -45,26 +47,22 @@ abstract class PojoCollectionOutputParser<T, CT extends Collection<T>> implement
 
     @Override
     public Optional<JsonSchema> jsonSchema() {
+        boolean polymorphic = PolymorphicTypes.isPolymorphic(type);
         Map<Class<?>, VisitedClassMetadata> visited = new LinkedHashMap<>();
-        JsonSchemaElement itemSchema;
-        if (PolymorphicTypes.isPolymorphic(type)) {
-            itemSchema = PojoOutputParser.referenceIfRecursive(
-                    polymorphicSchemaFrom(type, null, false, visited), type, visited);
-        } else {
-            itemSchema = jsonObjectOrReferenceSchemaFrom(type, null, false, visited, true);
-        }
+        JsonSchemaElement itemSchema = polymorphic
+                ? referenceIfRecursive(polymorphicSchemaFrom(type, null, false, visited), type, visited)
+                : jsonObjectOrReferenceSchemaFrom(type, null, false, visited, true);
         JsonArraySchema valuesArray = JsonArraySchema.builder().items(itemSchema).build();
-        JsonObjectSchema rootElement = PolymorphicTypes.isPolymorphic(type)
-                ? PojoOutputParser.wrapPolymorphic("values", valuesArray, visited)
+        JsonObjectSchema rootElement = polymorphic
+                ? wrapPolymorphic("values", valuesArray, visited)
                 : JsonObjectSchema.builder()
                         .addProperty("values", valuesArray)
                         .required("values")
                         .build();
-        JsonSchema jsonSchema = JsonSchema.builder()
+        return Optional.of(JsonSchema.builder()
                 .name(collectionType().getSimpleName() + "_of_" + type.getSimpleName())
                 .rootElement(rootElement)
-                .build();
-        return Optional.of(jsonSchema);
+                .build());
     }
 
     @Override

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/PojoCollectionOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/PojoCollectionOutputParser.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.service.output;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.internal.JsonSchemaElementUtils.VisitedClassMetadata;
 import dev.langchain4j.internal.PolymorphicTypes;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
@@ -9,6 +10,7 @@ import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -43,17 +45,24 @@ abstract class PojoCollectionOutputParser<T, CT extends Collection<T>> implement
 
     @Override
     public Optional<JsonSchema> jsonSchema() {
-        JsonSchemaElement itemSchema = PolymorphicTypes.isPolymorphic(type)
-                ? polymorphicSchemaFrom(type, null, false, new LinkedHashMap<>())
-                : jsonObjectOrReferenceSchemaFrom(type, null, false, new LinkedHashMap<>(), true);
+        Map<Class<?>, VisitedClassMetadata> visited = new LinkedHashMap<>();
+        JsonSchemaElement itemSchema;
+        if (PolymorphicTypes.isPolymorphic(type)) {
+            itemSchema = PojoOutputParser.referenceIfRecursive(
+                    polymorphicSchemaFrom(type, null, false, visited), type, visited);
+        } else {
+            itemSchema = jsonObjectOrReferenceSchemaFrom(type, null, false, visited, true);
+        }
+        JsonArraySchema valuesArray = JsonArraySchema.builder().items(itemSchema).build();
+        JsonObjectSchema rootElement = PolymorphicTypes.isPolymorphic(type)
+                ? PojoOutputParser.wrapPolymorphic("values", valuesArray, visited)
+                : JsonObjectSchema.builder()
+                        .addProperty("values", valuesArray)
+                        .required("values")
+                        .build();
         JsonSchema jsonSchema = JsonSchema.builder()
                 .name(collectionType().getSimpleName() + "_of_" + type.getSimpleName())
-                .rootElement(JsonObjectSchema.builder()
-                        .addProperty("values", JsonArraySchema.builder()
-                                .items(itemSchema)
-                                .build())
-                        .required("values")
-                        .build())
+                .rootElement(rootElement)
                 .build();
         return Optional.of(jsonSchema);
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
@@ -47,6 +47,8 @@ class PojoOutputParser<T> implements OutputParser<T> {
 
         try {
             if (PolymorphicTypes.isPolymorphic(type)) {
+                // Schema wraps the polymorphic value under "value" because anyOf can't be a JSON
+                // schema root. Unwrap, then let Jackson dispatch via the discriminator.
                 @SuppressWarnings("unchecked")
                 Map<String, Object> map = (Map<String, Object>) extractAndParseJson(text, Map.class).value();
                 Object payload = (map != null && map.size() == 1 && map.containsKey("value")) ? map.get("value") : map;

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
@@ -3,6 +3,8 @@ package dev.langchain4j.service.output;
 import static dev.langchain4j.internal.JsonParsingUtils.extractAndParseJson;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.jsonObjectOrReferenceSchemaFrom;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.polymorphicSchemaFrom;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.referenceIfRecursive;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.wrapPolymorphic;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
 import static dev.langchain4j.service.output.ParsingUtils.outputParsingException;
@@ -14,9 +16,7 @@ import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.internal.Json;
 import dev.langchain4j.internal.JsonSchemaElementUtils.VisitedClassMetadata;
 import dev.langchain4j.internal.PolymorphicTypes;
-import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
-import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.output.structured.Description;
@@ -122,32 +122,6 @@ class PojoOutputParser<T> implements OutputParser<T> {
                 .rootElement(rootElement)
                 .build();
         return Optional.of(jsonSchema);
-    }
-
-    static JsonSchemaElement referenceIfRecursive(
-            JsonSchemaElement element, Class<?> baseType, Map<Class<?>, VisitedClassMetadata> visited) {
-        VisitedClassMetadata metadata = visited.get(baseType);
-        if (metadata != null && metadata.recursionDetected && element instanceof JsonAnyOfSchema) {
-            return JsonReferenceSchema.builder().reference(metadata.reference).build();
-        }
-        return element;
-    }
-
-    static JsonObjectSchema wrapPolymorphic(
-            String propertyName, JsonSchemaElement element, Map<Class<?>, VisitedClassMetadata> visited) {
-        JsonObjectSchema.Builder builder = JsonObjectSchema.builder()
-                .addProperty(propertyName, element)
-                .required(propertyName);
-        Map<String, JsonSchemaElement> definitions = new LinkedHashMap<>();
-        visited.forEach((clazz, meta) -> {
-            if (meta.recursionDetected) {
-                definitions.put(meta.reference, meta.jsonSchemaElement);
-            }
-        });
-        if (!definitions.isEmpty()) {
-            builder.definitions(definitions);
-        }
-        return builder.build();
     }
 
     @Override

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
@@ -5,16 +5,17 @@ import static dev.langchain4j.internal.JsonSchemaElementUtils.jsonObjectOrRefere
 import static dev.langchain4j.internal.JsonSchemaElementUtils.polymorphicSchemaFrom;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.referenceIfRecursive;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.wrapPolymorphic;
+import static dev.langchain4j.internal.PolymorphicTypes.isPolymorphic;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
 import static dev.langchain4j.service.output.ParsingUtils.outputParsingException;
 import static java.lang.String.format;
+import static java.lang.reflect.Modifier.isAbstract;
 
 import dev.langchain4j.Internal;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.internal.Json;
 import dev.langchain4j.internal.JsonSchemaElementUtils.VisitedClassMetadata;
-import dev.langchain4j.internal.PolymorphicTypes;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
@@ -46,15 +47,19 @@ class PojoOutputParser<T> implements OutputParser<T> {
         }
 
         try {
-            if (PolymorphicTypes.isPolymorphic(type)) {
-                // Schema wraps the polymorphic value under "value" because anyOf can't be a JSON
-                // schema root. Unwrap, then let Jackson dispatch via the discriminator.
-                @SuppressWarnings("unchecked")
-                Map<String, Object> map = (Map<String, Object>) extractAndParseJson(text, Map.class).value();
-                Object payload = (map != null && map.size() == 1 && map.containsKey("value")) ? map.get("value") : map;
-                return type.cast(Json.fromJson(Json.toJson(payload), type));
+            if (isPolymorphic(type)) {
+                return extractAndParseJson(text, json -> {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> map = Json.fromJson(json, Map.class);
+                    if (map != null && map.size() == 1 && map.containsKey("value")) {
+                        return Json.fromJson(Json.toJson(map.get("value")), type);
+                    } else {
+                        return Json.fromJson(json, type);
+                    }
+                }).value();
+            } else {
+                return extractAndParseJson(text, type).value();
             }
-            return extractAndParseJson(text, type).value();
         } catch (Exception e) {
             throw outputParsingException(text, type.getTypeName(), e);
         }
@@ -62,29 +67,26 @@ class PojoOutputParser<T> implements OutputParser<T> {
 
     @Override
     public Optional<JsonSchema> jsonSchema() {
-        JsonSchemaElement rootElement;
-        if (PolymorphicTypes.isPolymorphic(type)) {
+        JsonSchemaElement root;
+        if (isPolymorphic(type)) {
             Map<Class<?>, VisitedClassMetadata> visited = new LinkedHashMap<>();
             JsonSchemaElement anyOf = polymorphicSchemaFrom(type, null, false, visited);
-            rootElement = wrapPolymorphic("value", referenceIfRecursive(anyOf, type, visited), visited);
+            root = wrapPolymorphic("value", referenceIfRecursive(anyOf, type, visited), visited);
         } else {
-            rootElement = jsonObjectOrReferenceSchemaFrom(type, null, false, new LinkedHashMap<>(), true);
-            // A plain interface or abstract class without sealed-permits or @JsonSubTypes produces
-            // an empty schema that the LLM cannot meaningfully fill in. Fail fast with a clear
-            // remediation message.
-            if (rootElement instanceof JsonObjectSchema obj
-                    && obj.properties().isEmpty()
-                    && java.lang.reflect.Modifier.isAbstract(type.getModifiers())) {
-                throw new UnsupportedFeatureException(String.format(
-                        "Type %s is an interface or abstract class with no permitted subtypes discoverable "
-                                + "by langchain4j, which produced an empty JSON schema. To use it as a "
-                                + "polymorphic return type, either make it sealed or annotate it with @JsonSubTypes.",
-                        type.getName()));
-            }
+            root = jsonObjectOrReferenceSchemaFrom(type, null, false, new LinkedHashMap<>(), true);
         }
+
+        if (root instanceof JsonObjectSchema obj && obj.properties().isEmpty() && isAbstract(type.getModifiers())) {
+            throw new UnsupportedFeatureException(String.format(
+                    "Type %s is an interface or abstract class with no permitted subtypes discoverable "
+                            + "by langchain4j, which produced an empty JSON schema. To use it as a "
+                            + "polymorphic return type, either make it sealed or annotate it with @JsonSubTypes.",
+                    type.getName()));
+        }
+
         return Optional.of(JsonSchema.builder()
                 .name(type.getSimpleName())
-                .rootElement(rootElement)
+                .rootElement(root)
                 .build());
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
@@ -2,13 +2,20 @@ package dev.langchain4j.service.output;
 
 import static dev.langchain4j.internal.JsonParsingUtils.extractAndParseJson;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.jsonObjectOrReferenceSchemaFrom;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.polymorphicSchemaFrom;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
 import static dev.langchain4j.service.output.ParsingUtils.outputParsingException;
 import static java.lang.String.format;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import dev.langchain4j.Internal;
+import dev.langchain4j.internal.Json;
+import dev.langchain4j.internal.PolymorphicTypes;
+import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.output.structured.Description;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
@@ -17,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -36,17 +44,68 @@ class PojoOutputParser<T> implements OutputParser<T> {
         }
 
         try {
+            if (PolymorphicTypes.isPolymorphic(type)) {
+                return parsePolymorphic(text);
+            }
             return extractAndParseJson(text, type).value();
         } catch (Exception e) {
             throw outputParsingException(text, type.getTypeName(), e);
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private T parsePolymorphic(String text) throws Exception {
+        Map<String, Object> map = (Map<String, Object>) extractAndParseJson(text, Map.class).value();
+        Object payload = unwrapValueEnvelope(map);
+        if (!(payload instanceof Map)) {
+            throw outputParsingException(text, type);
+        }
+        return type.cast(deserializePolymorphic(type, (Map<String, Object>) payload));
+    }
+
+    static Object unwrapValueEnvelope(Map<String, Object> map) {
+        if (map != null && map.size() == 1 && map.containsKey("value")) {
+            return map.get("value");
+        }
+        return map;
+    }
+
+    static <T> T deserializePolymorphic(Class<T> baseType, Map<String, Object> payload) {
+        PolymorphicTypes.verifyJsonTypeInfoIsSupported(baseType);
+
+        // For @JsonTypeInfo with defaultImpl, pre-strip a missing or unknown discriminator so
+        // Jackson falls back to defaultImpl without tripping FAIL_ON_UNKNOWN_PROPERTIES on the
+        // unrecognized type id field. Sealed dispatch is handled by Jackson's BeanDeserializerModifier;
+        // Jackson-annotated dispatch is handled natively.
+        JsonTypeInfo info = baseType.getAnnotation(JsonTypeInfo.class);
+        if (info != null && info.defaultImpl() != JsonTypeInfo.None.class && info.defaultImpl() != Void.class) {
+            String discriminatorProperty = PolymorphicTypes.discriminatorPropertyName(baseType);
+            Object discriminatorValue = payload.get(discriminatorProperty);
+            if (discriminatorValue == null
+                    || PolymorphicTypes.findSubtypeByDiscriminator(baseType, discriminatorValue.toString()) == null) {
+                Map<String, Object> stripped = new LinkedHashMap<>(payload);
+                stripped.remove(discriminatorProperty);
+                payload = stripped;
+            }
+        }
+        return Json.fromJson(Json.toJson(payload), baseType);
+    }
+
     @Override
     public Optional<JsonSchema> jsonSchema() {
+        JsonSchemaElement rootElement;
+        if (PolymorphicTypes.isPolymorphic(type)) {
+            JsonAnyOfSchema anyOf = polymorphicSchemaFrom(type, null, false, new LinkedHashMap<>());
+            rootElement = JsonObjectSchema.builder()
+                    .addProperty("value", anyOf)
+                    .required("value")
+                    .build();
+        } else {
+            rootElement = jsonObjectOrReferenceSchemaFrom(type, null, false, new LinkedHashMap<>(), true);
+        }
         JsonSchema jsonSchema = JsonSchema.builder()
                 .name(type.getSimpleName())
-                .rootElement(jsonObjectOrReferenceSchemaFrom(type, null, false, new LinkedHashMap<>(), true))
+                .rootElement(rootElement)
                 .build();
         return Optional.of(jsonSchema);
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
@@ -10,10 +10,13 @@ import static java.lang.String.format;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import dev.langchain4j.Internal;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.internal.Json;
+import dev.langchain4j.internal.JsonSchemaElementUtils.VisitedClassMetadata;
 import dev.langchain4j.internal.PolymorphicTypes;
 import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.output.structured.Description;
@@ -95,19 +98,56 @@ class PojoOutputParser<T> implements OutputParser<T> {
     public Optional<JsonSchema> jsonSchema() {
         JsonSchemaElement rootElement;
         if (PolymorphicTypes.isPolymorphic(type)) {
-            JsonAnyOfSchema anyOf = polymorphicSchemaFrom(type, null, false, new LinkedHashMap<>());
-            rootElement = JsonObjectSchema.builder()
-                    .addProperty("value", anyOf)
-                    .required("value")
-                    .build();
+            Map<Class<?>, VisitedClassMetadata> visited = new LinkedHashMap<>();
+            JsonSchemaElement anyOf = polymorphicSchemaFrom(type, null, false, visited);
+            rootElement = wrapPolymorphic("value", referenceIfRecursive(anyOf, type, visited), visited);
         } else {
             rootElement = jsonObjectOrReferenceSchemaFrom(type, null, false, new LinkedHashMap<>(), true);
+            // Detect a useless empty-object schema: this happens when the user used an interface
+            // or abstract class as a return type without making it sealed or annotating it with
+            // @JsonSubTypes. Fail fast with a clear remediation message.
+            if (rootElement instanceof JsonObjectSchema obj
+                    && (obj.properties() == null || obj.properties().isEmpty())
+                    && java.lang.reflect.Modifier.isAbstract(type.getModifiers())) {
+                throw new UnsupportedFeatureException(String.format(
+                        "Type %s is an interface or abstract class with no permitted subtypes discoverable "
+                                + "by langchain4j, which produced an empty JSON schema. To use it as a "
+                                + "polymorphic return type, either make it sealed or annotate it with "
+                                + "@JsonSubTypes.",
+                        type.getName()));
+            }
         }
         JsonSchema jsonSchema = JsonSchema.builder()
                 .name(type.getSimpleName())
                 .rootElement(rootElement)
                 .build();
         return Optional.of(jsonSchema);
+    }
+
+    static JsonSchemaElement referenceIfRecursive(
+            JsonSchemaElement element, Class<?> baseType, Map<Class<?>, VisitedClassMetadata> visited) {
+        VisitedClassMetadata metadata = visited.get(baseType);
+        if (metadata != null && metadata.recursionDetected && element instanceof JsonAnyOfSchema) {
+            return JsonReferenceSchema.builder().reference(metadata.reference).build();
+        }
+        return element;
+    }
+
+    static JsonObjectSchema wrapPolymorphic(
+            String propertyName, JsonSchemaElement element, Map<Class<?>, VisitedClassMetadata> visited) {
+        JsonObjectSchema.Builder builder = JsonObjectSchema.builder()
+                .addProperty(propertyName, element)
+                .required(propertyName);
+        Map<String, JsonSchemaElement> definitions = new LinkedHashMap<>();
+        visited.forEach((clazz, meta) -> {
+            if (meta.recursionDetected) {
+                definitions.put(meta.reference, meta.jsonSchemaElement);
+            }
+        });
+        if (!definitions.isEmpty()) {
+            builder.definitions(definitions);
+        }
+        return builder.build();
     }
 
     @Override

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/PojoOutputParser.java
@@ -10,7 +10,6 @@ import static dev.langchain4j.service.IllegalConfigurationException.illegalConfi
 import static dev.langchain4j.service.output.ParsingUtils.outputParsingException;
 import static java.lang.String.format;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import dev.langchain4j.Internal;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.internal.Json;
@@ -48,50 +47,15 @@ class PojoOutputParser<T> implements OutputParser<T> {
 
         try {
             if (PolymorphicTypes.isPolymorphic(type)) {
-                return parsePolymorphic(text);
+                @SuppressWarnings("unchecked")
+                Map<String, Object> map = (Map<String, Object>) extractAndParseJson(text, Map.class).value();
+                Object payload = (map != null && map.size() == 1 && map.containsKey("value")) ? map.get("value") : map;
+                return type.cast(Json.fromJson(Json.toJson(payload), type));
             }
             return extractAndParseJson(text, type).value();
         } catch (Exception e) {
             throw outputParsingException(text, type.getTypeName(), e);
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private T parsePolymorphic(String text) throws Exception {
-        Map<String, Object> map = (Map<String, Object>) extractAndParseJson(text, Map.class).value();
-        Object payload = unwrapValueEnvelope(map);
-        if (!(payload instanceof Map)) {
-            throw outputParsingException(text, type);
-        }
-        return type.cast(deserializePolymorphic(type, (Map<String, Object>) payload));
-    }
-
-    static Object unwrapValueEnvelope(Map<String, Object> map) {
-        if (map != null && map.size() == 1 && map.containsKey("value")) {
-            return map.get("value");
-        }
-        return map;
-    }
-
-    static <T> T deserializePolymorphic(Class<T> baseType, Map<String, Object> payload) {
-        PolymorphicTypes.verifyJsonTypeInfoIsSupported(baseType);
-
-        // For @JsonTypeInfo with defaultImpl, pre-strip a missing or unknown discriminator so
-        // Jackson falls back to defaultImpl without tripping FAIL_ON_UNKNOWN_PROPERTIES on the
-        // unrecognized type id field. Sealed dispatch is handled by Jackson's BeanDeserializerModifier;
-        // Jackson-annotated dispatch is handled natively.
-        JsonTypeInfo info = baseType.getAnnotation(JsonTypeInfo.class);
-        if (info != null && info.defaultImpl() != JsonTypeInfo.None.class && info.defaultImpl() != Void.class) {
-            String discriminatorProperty = PolymorphicTypes.discriminatorPropertyName(baseType);
-            Object discriminatorValue = payload.get(discriminatorProperty);
-            if (discriminatorValue == null
-                    || PolymorphicTypes.findSubtypeByDiscriminator(baseType, discriminatorValue.toString()) == null) {
-                Map<String, Object> stripped = new LinkedHashMap<>(payload);
-                stripped.remove(discriminatorProperty);
-                payload = stripped;
-            }
-        }
-        return Json.fromJson(Json.toJson(payload), baseType);
     }
 
     @Override
@@ -103,25 +67,23 @@ class PojoOutputParser<T> implements OutputParser<T> {
             rootElement = wrapPolymorphic("value", referenceIfRecursive(anyOf, type, visited), visited);
         } else {
             rootElement = jsonObjectOrReferenceSchemaFrom(type, null, false, new LinkedHashMap<>(), true);
-            // Detect a useless empty-object schema: this happens when the user used an interface
-            // or abstract class as a return type without making it sealed or annotating it with
-            // @JsonSubTypes. Fail fast with a clear remediation message.
+            // A plain interface or abstract class without sealed-permits or @JsonSubTypes produces
+            // an empty schema that the LLM cannot meaningfully fill in. Fail fast with a clear
+            // remediation message.
             if (rootElement instanceof JsonObjectSchema obj
-                    && (obj.properties() == null || obj.properties().isEmpty())
+                    && obj.properties().isEmpty()
                     && java.lang.reflect.Modifier.isAbstract(type.getModifiers())) {
                 throw new UnsupportedFeatureException(String.format(
                         "Type %s is an interface or abstract class with no permitted subtypes discoverable "
                                 + "by langchain4j, which produced an empty JSON schema. To use it as a "
-                                + "polymorphic return type, either make it sealed or annotate it with "
-                                + "@JsonSubTypes.",
+                                + "polymorphic return type, either make it sealed or annotate it with @JsonSubTypes.",
                         type.getName()));
             }
         }
-        JsonSchema jsonSchema = JsonSchema.builder()
+        return Optional.of(JsonSchema.builder()
                 .name(type.getSimpleName())
                 .rootElement(rootElement)
-                .build();
-        return Optional.of(jsonSchema);
+                .build());
     }
 
     @Override

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -2017,5 +2019,123 @@ class AiServicesWithToolsIT {
                     && toolResult.text().contains("Camera is broken")
                     && Boolean.TRUE.equals(toolResult.isError());
         }));
+    }
+
+    sealed interface Animal permits Dog, Cat {}
+
+    record Dog(String name, String breed) implements Animal {}
+
+    record Cat(String name, boolean indoor) implements Animal {}
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Square.class, name = "square"),
+        @JsonSubTypes.Type(value = Circle.class, name = "circle")
+    })
+    interface Shape {}
+
+    static class Square implements Shape {
+        double side;
+
+        Square() {}
+    }
+
+    static class Circle implements Shape {
+        double radius;
+
+        Circle() {}
+    }
+
+    record Owner(String name, Animal pet) {}
+
+    static class AnimalRegistry {
+
+        @Tool("registers a single animal")
+        void registerAnimal(Animal animal) {}
+
+        @Tool("registers a batch of animals at once")
+        void registerAnimals(List<Animal> animals) {}
+
+        @Tool("registers an owner with their pet")
+        void registerOwner(Owner owner) {}
+
+        @Tool("registers a shape preference")
+        void registerShape(Shape shape) {}
+    }
+
+    interface RegistryAssistant {
+        Result<String> chat(String userMessage);
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    void should_call_tool_with_polymorphic_sealed_argument(ChatModel chatModel) {
+
+        AnimalRegistry registry = spy(new AnimalRegistry());
+
+        RegistryAssistant assistant = AiServices.builder(RegistryAssistant.class)
+                .chatModel(chatModel)
+                .tools(registry)
+                .build();
+
+        assistant.chat("Please register a Labrador dog named Rex.");
+
+        verify(registry).registerAnimal(argThat(animal -> animal instanceof Dog dog
+                && dog.name().equalsIgnoreCase("Rex")
+                && dog.breed().toLowerCase().contains("labrador")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    void should_call_tool_with_list_of_polymorphic_arguments(ChatModel chatModel) {
+
+        AnimalRegistry registry = spy(new AnimalRegistry());
+
+        RegistryAssistant assistant = AiServices.builder(RegistryAssistant.class)
+                .chatModel(chatModel)
+                .tools(registry)
+                .build();
+
+        assistant.chat("Register a batch of two animals in a single call using the registerAnimals tool "
+                + "(do NOT use registerAnimal): a Labrador dog named Rex, and an indoor cat named Whiskers.");
+
+        verify(registry).registerAnimals(argThat(animals -> animals.size() == 2
+                && animals.stream().anyMatch(Dog.class::isInstance)
+                && animals.stream().anyMatch(Cat.class::isInstance)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    void should_call_tool_with_pojo_containing_nested_polymorphic_field(ChatModel chatModel) {
+
+        AnimalRegistry registry = spy(new AnimalRegistry());
+
+        RegistryAssistant assistant = AiServices.builder(RegistryAssistant.class)
+                .chatModel(chatModel)
+                .tools(registry)
+                .build();
+
+        assistant.chat("Please register Alice as the owner of her Labrador dog named Rex.");
+
+        verify(registry).registerOwner(argThat(owner -> owner.name().equalsIgnoreCase("Alice")
+                && owner.pet() instanceof Dog dog
+                && dog.name().equalsIgnoreCase("Rex")
+                && dog.breed().toLowerCase().contains("labrador")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    void should_call_tool_with_jackson_annotated_polymorphic_argument(ChatModel chatModel) {
+
+        AnimalRegistry registry = spy(new AnimalRegistry());
+
+        RegistryAssistant assistant = AiServices.builder(RegistryAssistant.class)
+                .chatModel(chatModel)
+                .tools(registry)
+                .build();
+
+        assistant.chat("Please register a circle shape with radius 4.");
+
+        verify(registry).registerShape(argThat(shape -> shape instanceof Circle circle && circle.radius == 4.0));
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/common/openai/OpenAiAiServiceWithJsonSchemaIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/common/openai/OpenAiAiServiceWithJsonSchemaIT.java
@@ -393,4 +393,46 @@ class OpenAiAiServiceWithJsonSchemaIT extends AbstractAiServiceWithJsonSchemaIT 
                         .build());
         verify(model).supportedCapabilities();
     }
+
+    sealed interface ArithmeticExpression permits Constant, Addition {}
+
+    record Constant(int value) implements ArithmeticExpression {}
+
+    record Addition(ArithmeticExpression left, ArithmeticExpression right) implements ArithmeticExpression {}
+
+    interface ExpressionExtractor {
+        ArithmeticExpression extractFrom(String text);
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    void should_extract_recursive_polymorphic_type(ChatModel model) {
+
+        // given
+        ExpressionExtractor extractor = AiServices.create(ExpressionExtractor.class, model);
+
+        // when — the schema for ArithmeticExpression contains `$ref` back to itself; this verifies
+        // that the recursive schema is accepted by OpenAI and that the parser can handle a tree
+        // returned by the model.
+        ArithmeticExpression expression = extractor.extractFrom(
+                "Represent the literal expression 1+2+3 as a syntax tree. Do NOT simplify or evaluate. "
+                        + "Use a left-associative tree: Addition(Addition(Constant(1), Constant(2)), Constant(3)).");
+
+        // then — at minimum, dispatch worked and the result is a valid expression with leaves
+        // drawn from {1, 2, 3}. (Whether the LLM produces a deep or shallow tree depends on the
+        // model's strict-mode behavior.)
+        assertThat(expression).isInstanceOf(Addition.class);
+        List<Integer> leaves = new java.util.ArrayList<>();
+        collectLeaves(expression, leaves);
+        assertThat(leaves).isNotEmpty().allSatisfy(v -> assertThat(v).isIn(1, 2, 3));
+    }
+
+    private static void collectLeaves(ArithmeticExpression expr, List<Integer> leaves) {
+        if (expr instanceof Constant c) {
+            leaves.add(c.value());
+        } else if (expr instanceof Addition a) {
+            collectLeaves(a.left(), leaves);
+            collectLeaves(a.right(), leaves);
+        }
+    }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/common/openai/OpenAiAiServiceWithJsonSchemaIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/common/openai/OpenAiAiServiceWithJsonSchemaIT.java
@@ -1,13 +1,32 @@
 package dev.langchain4j.service.common.openai;
 
-import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
-import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
-
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.common.AbstractAiServiceWithJsonSchemaIT;
-import java.util.List;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+
+import static dev.langchain4j.data.message.UserMessage.userMessage;
+import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
+import static dev.langchain4j.model.chat.request.ResponseFormatType.JSON;
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 // TODO move to langchain4j-open-ai module once dependency cycle is resolved
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
@@ -74,5 +93,304 @@ class OpenAiAiServiceWithJsonSchemaIT extends AbstractAiServiceWithJsonSchemaIT 
     @Override
     protected boolean isStrictJsonSchemaEnabled(ChatModel model) {
         return model == modelWithStrictJsonSchema || model == modelWithStrictJsonSchemaLegacy;
+    }
+
+    sealed interface Animal permits Dog, Cat {
+    }
+
+    record Dog(String name, String breed) implements Animal {
+    }
+
+    record Cat(String name, boolean indoor) implements Animal {
+    }
+
+    interface AnimalExtractor {
+        Animal extractAnimalFrom(String text);
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    void should_extract_polymorphic_sealed_type(ChatModel model) {
+
+        // given
+        model = spy(model);
+
+        AnimalExtractor extractor = AiServices.create(AnimalExtractor.class, model);
+
+        String text = "Rex is a Labrador dog";
+
+        // when
+        Animal animal = extractor.extractAnimalFrom(text);
+
+        // then
+        assertThat(animal).isInstanceOf(Dog.class);
+        Dog dog = (Dog) animal;
+        assertThat(dog.name()).isEqualToIgnoringCase("Rex");
+        assertThat(dog.breed()).containsIgnoringCase("Labrador");
+
+        verify(model)
+                .chat(ChatRequest.builder()
+                        .messages(singletonList(userMessage(text)))
+                        .responseFormat(ResponseFormat.builder()
+                                .type(JSON)
+                                .jsonSchema(JsonSchema.builder()
+                                        .name("Animal")
+                                        .rootElement(JsonObjectSchema.builder()
+                                                .addProperty(
+                                                        "value",
+                                                        JsonAnyOfSchema.builder()
+                                                                .description("Animal")
+                                                                .anyOf(List.of(
+                                                                        JsonObjectSchema.builder()
+                                                                                .description("Dog")
+                                                                                .addProperty(
+                                                                                        "type",
+                                                                                        JsonEnumSchema.builder()
+                                                                                                .enumValues("Dog")
+                                                                                                .build())
+                                                                                .addStringProperty("name")
+                                                                                .addStringProperty("breed")
+                                                                                .required("type")
+                                                                                .build(),
+                                                                        JsonObjectSchema.builder()
+                                                                                .description("Cat")
+                                                                                .addProperty(
+                                                                                        "type",
+                                                                                        JsonEnumSchema.builder()
+                                                                                                .enumValues("Cat")
+                                                                                                .build())
+                                                                                .addStringProperty("name")
+                                                                                .addBooleanProperty("indoor")
+                                                                                .required("type")
+                                                                                .build()))
+                                                                .build())
+                                                .required("value")
+                                                .build())
+                                        .build())
+                                .build())
+                        .build());
+        verify(model).supportedCapabilities();
+    }
+
+    interface AnimalsExtractor {
+        List<Animal> extractAnimalsFrom(String text);
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    void should_extract_list_of_polymorphic_sealed_type(ChatModel model) {
+
+        // given
+        model = spy(model);
+
+        AnimalsExtractor extractor = AiServices.create(AnimalsExtractor.class, model);
+
+        String text = "Rex is a Labrador. Whiskers is an indoor cat.";
+
+        // when
+        List<Animal> animals = extractor.extractAnimalsFrom(text);
+
+        // then
+        assertThat(animals).hasSize(2);
+        assertThat(animals).hasAtLeastOneElementOfType(Dog.class);
+        assertThat(animals).hasAtLeastOneElementOfType(Cat.class);
+
+        verify(model)
+                .chat(ChatRequest.builder()
+                        .messages(singletonList(userMessage(text)))
+                        .responseFormat(ResponseFormat.builder()
+                                .type(JSON)
+                                .jsonSchema(JsonSchema.builder()
+                                        .name("List_of_Animal")
+                                        .rootElement(JsonObjectSchema.builder()
+                                                .addProperty(
+                                                        "values",
+                                                        JsonArraySchema.builder()
+                                                                .items(JsonAnyOfSchema.builder()
+                                                                        .description("Animal")
+                                                                        .anyOf(List.of(
+                                                                                JsonObjectSchema.builder()
+                                                                                        .description("Dog")
+                                                                                        .addProperty(
+                                                                                                "type",
+                                                                                                JsonEnumSchema.builder()
+                                                                                                        .enumValues(
+                                                                                                                "Dog")
+                                                                                                        .build())
+                                                                                        .addStringProperty("name")
+                                                                                        .addStringProperty("breed")
+                                                                                        .required("type")
+                                                                                        .build(),
+                                                                                JsonObjectSchema.builder()
+                                                                                        .description("Cat")
+                                                                                        .addProperty(
+                                                                                                "type",
+                                                                                                JsonEnumSchema.builder()
+                                                                                                        .enumValues(
+                                                                                                                "Cat")
+                                                                                                        .build())
+                                                                                        .addStringProperty("name")
+                                                                                        .addBooleanProperty("indoor")
+                                                                                        .required("type")
+                                                                                        .build()))
+                                                                        .build())
+                                                                .build())
+                                                .required("values")
+                                                .build())
+                                        .build())
+                                .build())
+                        .build());
+        verify(model).supportedCapabilities();
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = Square.class, name = "square"),
+            @JsonSubTypes.Type(value = Circle.class, name = "circle")
+    })
+    interface Shape {
+    }
+
+    static class Square implements Shape {
+        double side;
+    }
+
+    static class Circle implements Shape {
+        double radius;
+    }
+
+    interface ShapeExtractor {
+        Shape extractShapeFrom(String text);
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    void should_extract_polymorphic_jackson_annotated_type(ChatModel model) {
+
+        // given
+        model = spy(model);
+
+        ShapeExtractor extractor = AiServices.create(ShapeExtractor.class, model);
+
+        String text = "A circle with radius 2.5";
+
+        // when
+        Shape shape = extractor.extractShapeFrom(text);
+
+        // then
+        assertThat(shape).isInstanceOf(Circle.class);
+        assertThat(((Circle) shape).radius).isEqualTo(2.5);
+
+        verify(model)
+                .chat(ChatRequest.builder()
+                        .messages(singletonList(userMessage(text)))
+                        .responseFormat(ResponseFormat.builder()
+                                .type(JSON)
+                                .jsonSchema(JsonSchema.builder()
+                                        .name("Shape")
+                                        .rootElement(JsonObjectSchema.builder()
+                                                .addProperty(
+                                                        "value",
+                                                        JsonAnyOfSchema.builder()
+                                                                .description("Shape")
+                                                                .anyOf(List.of(
+                                                                        JsonObjectSchema.builder()
+                                                                                .description("Square")
+                                                                                .addProperty(
+                                                                                        "kind",
+                                                                                        JsonEnumSchema.builder()
+                                                                                                .enumValues("square")
+                                                                                                .build())
+                                                                                .addNumberProperty("side")
+                                                                                .required("kind")
+                                                                                .build(),
+                                                                        JsonObjectSchema.builder()
+                                                                                .description("Circle")
+                                                                                .addProperty(
+                                                                                        "kind",
+                                                                                        JsonEnumSchema.builder()
+                                                                                                .enumValues("circle")
+                                                                                                .build())
+                                                                                .addNumberProperty("radius")
+                                                                                .required("kind")
+                                                                                .build()))
+                                                                .build())
+                                                .required("value")
+                                                .build())
+                                        .build())
+                                .build())
+                        .build());
+        verify(model).supportedCapabilities();
+    }
+
+    record Owner(String name, Animal pet) {}
+
+    interface OwnerExtractor {
+        Owner extractOwnerFrom(String text);
+    }
+
+    @ParameterizedTest
+    @MethodSource("models")
+    void should_extract_pojo_with_nested_polymorphic_field(ChatModel model) {
+
+        // given
+        model = spy(model);
+
+        OwnerExtractor extractor = AiServices.create(OwnerExtractor.class, model);
+
+        String text = "Alice owns a Labrador dog named Rex.";
+
+        // when
+        Owner owner = extractor.extractOwnerFrom(text);
+
+        // then
+        assertThat(owner.name()).isEqualToIgnoringCase("Alice");
+        assertThat(owner.pet()).isInstanceOf(Dog.class);
+        Dog dog = (Dog) owner.pet();
+        assertThat(dog.name()).isEqualToIgnoringCase("Rex");
+        assertThat(dog.breed()).containsIgnoringCase("Labrador");
+
+        verify(model)
+                .chat(ChatRequest.builder()
+                        .messages(singletonList(userMessage(text)))
+                        .responseFormat(ResponseFormat.builder()
+                                .type(JSON)
+                                .jsonSchema(JsonSchema.builder()
+                                        .name("Owner")
+                                        .rootElement(JsonObjectSchema.builder()
+                                                .addStringProperty("name")
+                                                .addProperty(
+                                                        "pet",
+                                                        JsonAnyOfSchema.builder()
+                                                                .description("Animal")
+                                                                .anyOf(List.of(
+                                                                        JsonObjectSchema.builder()
+                                                                                .description("Dog")
+                                                                                .addProperty(
+                                                                                        "type",
+                                                                                        JsonEnumSchema.builder()
+                                                                                                .enumValues("Dog")
+                                                                                                .build())
+                                                                                .addStringProperty("name")
+                                                                                .addStringProperty("breed")
+                                                                                .required("type")
+                                                                                .build(),
+                                                                        JsonObjectSchema.builder()
+                                                                                .description("Cat")
+                                                                                .addProperty(
+                                                                                        "type",
+                                                                                        JsonEnumSchema.builder()
+                                                                                                .enumValues("Cat")
+                                                                                                .build())
+                                                                                .addStringProperty("name")
+                                                                                .addBooleanProperty("indoor")
+                                                                                .required("type")
+                                                                                .build()))
+                                                                .build())
+                                                .build())
+                                        .build())
+                                .build())
+                        .build());
+        verify(model).supportedCapabilities();
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/common/openai/OpenAiAiServiceWithJsonSchemaIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/common/openai/OpenAiAiServiceWithJsonSchemaIT.java
@@ -12,12 +12,20 @@ import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.service.AiServices;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder;
+import dev.langchain4j.http.client.log.LoggingHttpClient;
 import dev.langchain4j.service.common.AbstractAiServiceWithJsonSchemaIT;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.Optional;
 
 import static dev.langchain4j.data.message.UserMessage.userMessage;
 import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
@@ -25,6 +33,7 @@ import static dev.langchain4j.model.chat.request.ResponseFormatType.JSON;
 import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -434,5 +443,75 @@ class OpenAiAiServiceWithJsonSchemaIT extends AbstractAiServiceWithJsonSchemaIT 
             collectLeaves(a.left(), leaves);
             collectLeaves(a.right(), leaves);
         }
+    }
+
+    /**
+     * Tripwire test: documents — and proves — why the polymorphic schema generator wraps the
+     * LLM-facing {@code anyOf} under a {@code value} property. OpenAI's structured-outputs API
+     * currently rejects schemas whose root is not {@code type: "object"}, even though such a
+     * schema is itself a perfectly valid JSON Schema. We add the {@code value} envelope to
+     * satisfy that constraint.
+     *
+     * <p><strong>If this test starts failing</strong> (i.e., OpenAI returns 200 instead of 400
+     * for a schema with {@code anyOf} at the root), it means OpenAI has relaxed the restriction
+     * and the {@code value}/{@code values} envelope can be dropped from the polymorphic schema
+     * shape. At that point, simplify the schema and update {@code PojoOutputParser} /
+     * {@code PojoCollectionOutputParser} accordingly.</p>
+     *
+     * <p>Hits the raw HTTP endpoint via langchain4j's {@link HttpClient} to
+     * bypass {@code OpenAiChatModel}'s client-side validation.</p>
+     */
+    @Test
+    void openai_rejects_anyOf_at_schema_root() {
+
+        // given
+        String body =
+                """
+                {
+                  "model": "gpt-4o-mini",
+                  "messages": [{"role": "user", "content": "say hi"}],
+                  "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                      "name": "Animal",
+                      "strict": true,
+                      "schema": {
+                        "anyOf": [
+                          {"type": "object",
+                           "properties": {"kind": {"type": "string", "enum": ["Dog"]}},
+                           "required": ["kind"],
+                           "additionalProperties": false},
+                          {"type": "object",
+                           "properties": {"kind": {"type": "string", "enum": ["Cat"]}},
+                           "required": ["kind"],
+                           "additionalProperties": false}
+                        ]
+                      }
+                    }
+                  }
+                }
+                """;
+
+        String baseUrl = Optional.ofNullable(System.getenv("OPENAI_BASE_URL")).orElse("https://api.openai.com/v1");
+        HttpRequest request = HttpRequest.builder()
+                .method(HttpMethod.POST)
+                .url(baseUrl + "/chat/completions")
+                .addHeader("Authorization", "Bearer " + System.getenv("OPENAI_API_KEY"))
+                .addHeader("Content-Type", "application/json")
+                .body(body)
+                .build();
+
+        HttpClient httpClient = new LoggingHttpClient(new JdkHttpClientBuilder().build(), true, true);
+
+        // when
+        HttpException error = catchThrowableOfType(HttpException.class, () -> httpClient.execute(request));
+
+        // then
+        assertThat(error).isNotNull();
+        assertThat(error.statusCode()).isEqualTo(400);
+        assertThat(error.getMessage())
+                .containsIgnoringCase("invalid schema")
+                .containsIgnoringCase("type")
+                .containsIgnoringCase("object");
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/common/openai/OpenAiAiServiceWithJsonSchemaIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/common/openai/OpenAiAiServiceWithJsonSchemaIT.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -420,20 +421,16 @@ class OpenAiAiServiceWithJsonSchemaIT extends AbstractAiServiceWithJsonSchemaIT 
         // given
         ExpressionExtractor extractor = AiServices.create(ExpressionExtractor.class, model);
 
-        // when — the schema for ArithmeticExpression contains `$ref` back to itself; this verifies
-        // that the recursive schema is accepted by OpenAI and that the parser can handle a tree
-        // returned by the model.
+        // when
         ArithmeticExpression expression = extractor.extractFrom(
                 "Represent the literal expression 1+2+3 as a syntax tree. Do NOT simplify or evaluate. "
                         + "Use a left-associative tree: Addition(Addition(Constant(1), Constant(2)), Constant(3)).");
 
-        // then — at minimum, dispatch worked and the result is a valid expression with leaves
-        // drawn from {1, 2, 3}. (Whether the LLM produces a deep or shallow tree depends on the
-        // model's strict-mode behavior.)
+        // then
         assertThat(expression).isInstanceOf(Addition.class);
-        List<Integer> leaves = new java.util.ArrayList<>();
+        List<Integer> leaves = new ArrayList<>();
         collectLeaves(expression, leaves);
-        assertThat(leaves).isNotEmpty().allSatisfy(v -> assertThat(v).isIn(1, 2, 3));
+        assertThat(leaves).containsExactlyInAnyOrder(1, 2, 3);
     }
 
     private static void collectLeaves(ArithmeticExpression expr, List<Integer> leaves) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/PolymorphicOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/PolymorphicOutputParserTest.java
@@ -8,12 +8,14 @@ import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.output.structured.Description;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -22,23 +24,28 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PolymorphicOutputParserTest {
 
-    sealed interface Animal permits Dog, Cat {}
+    sealed interface Animal permits Dog, Cat {
+    }
 
-    record Dog(String name, String breed) implements Animal {}
+    record Dog(String name, String breed) implements Animal {
+    }
 
-    record Cat(String name, boolean indoor) implements Animal {}
+    record Cat(String name, boolean indoor) implements Animal {
+    }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
     @JsonSubTypes({
-        @JsonSubTypes.Type(value = Square.class, name = "square"),
-        @JsonSubTypes.Type(value = Circle.class, name = "circle")
+            @JsonSubTypes.Type(value = Square.class, name = "square"),
+            @JsonSubTypes.Type(value = Circle.class, name = "circle")
     })
-    interface Shape {}
+    interface Shape {
+    }
 
     static class Square implements Shape {
         double side;
 
-        Square() {}
+        Square() {
+        }
 
         Square(double side) {
             this.side = side;
@@ -48,7 +55,8 @@ class PolymorphicOutputParserTest {
     static class Circle implements Shape {
         double radius;
 
-        Circle() {}
+        Circle() {
+        }
 
         Circle(double radius) {
             this.radius = radius;
@@ -56,15 +64,19 @@ class PolymorphicOutputParserTest {
     }
 
     @Description("A pet that lives in your home")
-    sealed interface Pet permits Hamster, Parrot {}
+    sealed interface Pet permits Hamster, Parrot {
+    }
 
-    sealed interface Vehicle permits Truck {}
+    sealed interface Vehicle permits Truck {
+    }
 
-    record Truck(String type, int wheels) implements Vehicle {}
+    record Truck(String type, int wheels) implements Vehicle {
+    }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
     @JsonSubTypes(@JsonSubTypes.Type(Coffee.class))
-    interface Beverage {}
+    interface Beverage {
+    }
 
     static class Coffee implements Beverage {
         String origin;
@@ -72,7 +84,8 @@ class PolymorphicOutputParserTest {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
     @JsonSubTypes(@JsonSubTypes.Type(value = Apple.class, name = "apple"))
-    interface Fruit {}
+    interface Fruit {
+    }
 
     static class Apple implements Fruit {
         String variety;
@@ -80,7 +93,8 @@ class PolymorphicOutputParserTest {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.SIMPLE_NAME)
     @JsonSubTypes(@JsonSubTypes.Type(Pizza.class))
-    interface Food {}
+    interface Food {
+    }
 
     static class Pizza implements Food {
         String topping;
@@ -88,7 +102,8 @@ class PolymorphicOutputParserTest {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, defaultImpl = Wrench.class)
     @JsonSubTypes({@JsonSubTypes.Type(value = Hammer.class, name = "hammer")})
-    interface Tool {}
+    interface Tool {
+    }
 
     static class Hammer implements Tool {
         double weightKg;
@@ -100,43 +115,68 @@ class PolymorphicOutputParserTest {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
     @JsonSubTypes({@JsonSubTypes.Type(value = Sword.class, name = "sword")})
-    interface Weapon {}
+    interface Weapon {
+    }
 
     static class Sword implements Weapon {
         String kind; // intentionally collides; visible=true makes it OK
         int blade_length_cm;
     }
 
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.EXISTING_PROPERTY,
+            property = "category")
+    @JsonSubTypes({@JsonSubTypes.Type(value = HardCover.class, name = "hard")})
+    interface Book {
+    }
+
+    static class HardCover implements Book {
+        String category; // existing field used by Jackson as the type id
+        String title;
+    }
+
     @Description("A small caged rodent kept as a pet")
-    record Hamster(String name, double weightGrams) implements Pet {}
+    record Hamster(String name, double weightGrams) implements Pet {
+    }
 
     @Description("A talking bird that can mimic human speech")
-    record Parrot(String name, int vocabulary) implements Pet {}
+    record Parrot(String name, int vocabulary) implements Pet {
+    }
 
-    record Owner(String name, Animal pet) {}
+    record Owner(String name, Animal pet) {
+    }
 
-    sealed interface Bird permits Eagle, Sparrow {}
+    sealed interface Bird permits Eagle, Sparrow {
+    }
 
     @JsonTypeName("eagle")
-    record Eagle(double wingspanMeters) implements Bird {}
+    record Eagle(double wingspanMeters) implements Bird {
+    }
 
     @JsonTypeName("sparrow")
-    record Sparrow(boolean migratory) implements Bird {}
+    record Sparrow(boolean migratory) implements Bird {
+    }
 
-    sealed interface Tree permits Oak, Pine {}
+    sealed interface Tree permits Oak, Pine {
+    }
 
     // No annotation — should fall back to simpleName "Oak"
-    record Oak(int rings) implements Tree {}
+    record Oak(int rings) implements Tree {
+    }
 
     @JsonTypeName("pine")
-    record Pine(int needles) implements Tree {}
+    record Pine(int needles) implements Tree {
+    }
 
     @JsonSubTypes(@JsonSubTypes.Type(value = ElectricCar.class, name = "tesla"))
-    sealed interface Car permits ElectricCar {}
+    sealed interface Car permits ElectricCar {
+    }
 
     // @JsonSubTypes.Type(name="tesla") on the base should win over @JsonTypeName here.
     @JsonTypeName("losing-name")
-    record ElectricCar(int range) implements Car {}
+    record ElectricCar(int range) implements Car {
+    }
 
     sealed static class Plant permits Rose, Cactus {
     }
@@ -150,8 +190,8 @@ class PolymorphicOutputParserTest {
     }
 
     @JsonSubTypes({
-        @JsonSubTypes.Type(value = Email.class, name = "email"),
-        @JsonSubTypes.Type(value = SmsMessage.class, name = "sms")
+            @JsonSubTypes.Type(value = Email.class, name = "email"),
+            @JsonSubTypes.Type(value = SmsMessage.class, name = "sms")
     })
     abstract static class Notification {
     }
@@ -165,8 +205,8 @@ class PolymorphicOutputParserTest {
     }
 
     @JsonSubTypes({
-        @JsonSubTypes.Type(value = Pdf.class, name = "pdf"),
-        @JsonSubTypes.Type(value = Html.class, name = "html")
+            @JsonSubTypes.Type(value = Pdf.class, name = "pdf"),
+            @JsonSubTypes.Type(value = Html.class, name = "html")
     })
     interface Document {
     }
@@ -177,6 +217,185 @@ class PolymorphicOutputParserTest {
 
     static class Html implements Document {
         String url;
+    }
+
+    sealed interface ExpressionNode permits Literal, BinaryOp {
+    }
+
+    record Literal(int value) implements ExpressionNode {
+    }
+
+    record BinaryOp(String operator, ExpressionNode left, ExpressionNode right) implements ExpressionNode {
+    }
+
+    @Test
+    void recursive_polymorphic_schema_generation_does_not_loop() {
+
+        Optional<JsonSchema> schema = new PojoOutputParser<>(ExpressionNode.class).jsonSchema();
+        assertThat(schema).isPresent();
+    }
+
+    @Test
+    void recursive_polymorphic_schema_is_compact_and_uses_refs() {
+
+        JsonSchema actual = new PojoOutputParser<>(ExpressionNode.class).jsonSchema().get();
+
+        String reference = dev.langchain4j.internal.Utils.generateUUIDFrom(ExpressionNode.class.getName());
+        JsonReferenceSchema selfRef = JsonReferenceSchema.builder().reference(reference).build();
+
+        JsonSchema expected = JsonSchema.builder()
+                .name("ExpressionNode")
+                .rootElement(JsonObjectSchema.builder()
+                        .addProperty("value", selfRef)
+                        .required("value")
+                        .definitions(Map.of(
+                                reference,
+                                JsonAnyOfSchema.builder()
+                                        .description("ExpressionNode")
+                                        .anyOf(List.of(
+                                                JsonObjectSchema.builder()
+                                                        .description("Literal")
+                                                        .addProperty(
+                                                                "type",
+                                                                JsonEnumSchema.builder()
+                                                                        .enumValues("Literal")
+                                                                        .build())
+                                                        .addIntegerProperty("value")
+                                                        .required("type")
+                                                        .build(),
+                                                JsonObjectSchema.builder()
+                                                        .description("BinaryOp")
+                                                        .addProperty(
+                                                                "type",
+                                                                JsonEnumSchema.builder()
+                                                                        .enumValues("BinaryOp")
+                                                                        .build())
+                                                        .addStringProperty("operator")
+                                                        .addProperty("left", selfRef)
+                                                        .addProperty("right", selfRef)
+                                                        .required("type")
+                                                        .build()))
+                                        .build()))
+                        .build())
+                .build();
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void recursive_polymorphic_parses_correctly() {
+
+        // (1 + 2) * 3
+        ExpressionNode parsed = new PojoOutputParser<>(ExpressionNode.class).parse("""
+                {"value":{"type":"BinaryOp","operator":"*",
+                  "left": {"type":"BinaryOp","operator":"+",
+                            "left":{"type":"Literal","value":1},
+                            "right":{"type":"Literal","value":2}},
+                  "right":{"type":"Literal","value":3}}}""");
+
+        assertThat(parsed).isInstanceOf(BinaryOp.class);
+        BinaryOp outer = (BinaryOp) parsed;
+        assertThat(outer.operator()).isEqualTo("*");
+        assertThat(outer.right()).isEqualTo(new Literal(3));
+        assertThat(outer.left()).isInstanceOf(BinaryOp.class);
+        BinaryOp inner = (BinaryOp) outer.left();
+        assertThat(inner.left()).isEqualTo(new Literal(1));
+        assertThat(inner.right()).isEqualTo(new Literal(2));
+    }
+
+    record Container(Animal pet, Tree tree) {
+    }
+
+    @Test
+    void pojo_with_two_distinct_polymorphic_fields() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Container.class).jsonSchema().get().rootElement();
+
+        assertThat(root.properties().get("pet")).isInstanceOf(JsonAnyOfSchema.class);
+        assertThat(root.properties().get("tree")).isInstanceOf(JsonAnyOfSchema.class);
+
+        Container c = new PojoOutputParser<>(Container.class).parse("""
+                {"pet":{"type":"Cat","name":"Whiskers","indoor":true},
+                 "tree":{"type":"pine","needles":50000}}""");
+
+        assertThat(c.pet()).isInstanceOf(Cat.class);
+        assertThat(c.tree()).isInstanceOf(Pine.class);
+    }
+
+    sealed interface SingleVariant permits OnlyOne {
+    }
+
+    record OnlyOne(String value) implements SingleVariant {
+    }
+
+    @Test
+    void sealed_with_single_subtype_works() {
+
+        Optional<JsonSchema> schema = new PojoOutputParser<>(SingleVariant.class).jsonSchema();
+        assertThat(schema).isPresent();
+
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema)
+                ((JsonObjectSchema) schema.get().rootElement()).properties().get("value");
+        assertThat(anyOf.anyOf()).hasSize(1);
+
+        SingleVariant parsed = new PojoOutputParser<>(SingleVariant.class)
+                .parse("{\"value\":{\"type\":\"OnlyOne\",\"value\":\"hi\"}}");
+        assertThat(parsed).isInstanceOf(OnlyOne.class);
+        assertThat(((OnlyOne) parsed).value()).isEqualTo("hi");
+    }
+
+    sealed interface Action permits Ping, Print {
+    }
+
+    record Ping() implements Action {
+    }
+
+    record Print(String message) implements Action {
+    }
+
+    record OwnerWithDescribedPet(
+            String name,
+            @Description("The owner's pet, must be either a dog or a cat") Animal pet) {
+    }
+
+    @Test
+    void field_level_Description_on_polymorphic_field_flows_into_anyOf_description() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(OwnerWithDescribedPet.class).jsonSchema().get().rootElement();
+
+        JsonAnyOfSchema petAnyOf = (JsonAnyOfSchema) root.properties().get("pet");
+        assertThat(petAnyOf.description()).isEqualTo("The owner's pet, must be either a dog or a cat");
+    }
+
+    record OwnerWithDescribedPetAlsoOnBase(
+            String name,
+            @Description("Field-level description wins") Pet pet) {
+    }
+
+    @Test
+    void field_level_Description_wins_over_base_type_Description() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(OwnerWithDescribedPetAlsoOnBase.class)
+                        .jsonSchema()
+                        .get()
+                        .rootElement();
+
+        JsonAnyOfSchema petAnyOf = (JsonAnyOfSchema) root.properties().get("pet");
+        // Pet has @Description("A pet that lives in your home"), but the field's @Description wins
+        assertThat(petAnyOf.description()).isEqualTo("Field-level description wins");
+    }
+
+    @Test
+    void empty_subtype_works() {
+
+        Optional<JsonSchema> schema = new PojoOutputParser<>(Action.class).jsonSchema();
+        assertThat(schema).isPresent();
+
+        Action parsed = new PojoOutputParser<>(Action.class).parse("{\"value\":{\"type\":\"Ping\"}}");
+        assertThat(parsed).isInstanceOf(Ping.class);
     }
 
     @Test
@@ -209,6 +428,32 @@ class PolymorphicOutputParserTest {
                 .parse("{\"value\":{\"type\":\"email\",\"subject\":\"hello\"}}");
         assertThat(notification).isInstanceOf(Email.class);
         assertThat(((Email) notification).subject).isEqualTo("hello");
+    }
+
+    interface NotPolymorphicInterface {
+    }
+
+    abstract static class NotPolymorphicAbstractClass {
+    }
+
+    @Test
+    void plain_interface_without_subtypes_fails_with_clear_message() {
+
+        assertThatThrownBy(() -> new PojoOutputParser<>(NotPolymorphicInterface.class).jsonSchema())
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessageContaining("NotPolymorphicInterface")
+                .hasMessageContaining("sealed")
+                .hasMessageContaining("@JsonSubTypes");
+    }
+
+    @Test
+    void plain_abstract_class_without_subtypes_fails_with_clear_message() {
+
+        assertThatThrownBy(() -> new PojoOutputParser<>(NotPolymorphicAbstractClass.class).jsonSchema())
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessageContaining("NotPolymorphicAbstractClass")
+                .hasMessageContaining("sealed")
+                .hasMessageContaining("@JsonSubTypes");
     }
 
     @Test
@@ -286,7 +531,8 @@ class PolymorphicOutputParserTest {
         assertThat(discriminator.enumValues()).containsExactly("tesla");
     }
 
-    record Adoption(Owner owner, List<Animal> petsAdopted) {}
+    record Adoption(Owner owner, List<Animal> petsAdopted) {
+    }
 
     @Test
     void nested_sealed_field_produces_anyOf_in_outer_schema() {
@@ -324,11 +570,21 @@ class PolymorphicOutputParserTest {
         JsonObjectSchema root = (JsonObjectSchema)
                 new PojoOutputParser<>(Adoption.class).jsonSchema().get().rootElement();
 
+        // Polymorphic schema for Animal is generated once and reused via $ref everywhere else
+        // (compact schema). Either occurrence (owner.pet or petsAdopted items) carries the
+        // anyOf inline; the other points at the same schema via $ref.
         JsonArraySchema petsArray = (JsonArraySchema) root.properties().get("petsAdopted");
-        assertThat(petsArray.items()).isInstanceOf(JsonAnyOfSchema.class);
+        JsonSchemaElement petsItems = petsArray.items();
 
         JsonObjectSchema ownerObj = (JsonObjectSchema) root.properties().get("owner");
-        assertThat(ownerObj.properties().get("pet")).isInstanceOf(JsonAnyOfSchema.class);
+        JsonSchemaElement ownerPet = ownerObj.properties().get("pet");
+
+        assertThat(petsItems).isInstanceOfAny(JsonAnyOfSchema.class, JsonReferenceSchema.class);
+        assertThat(ownerPet).isInstanceOfAny(JsonAnyOfSchema.class, JsonReferenceSchema.class);
+
+        // Definitions must hold the actual anyOf used by the $ref(s).
+        assertThat(root.definitions()).isNotNull().isNotEmpty();
+        assertThat(root.definitions().values()).hasAtLeastOneElementOfType(JsonAnyOfSchema.class);
     }
 
     @Test
@@ -348,7 +604,8 @@ class PolymorphicOutputParserTest {
         assertThat(adoption.petsAdopted().get(1)).isInstanceOf(Cat.class);
     }
 
-    record Reservation(String customer, Shape preferredShape) {}
+    record Reservation(String customer, Shape preferredShape) {
+    }
 
     @Test
     void nested_jackson_annotated_field_produces_anyOf_with_jackson_discriminator() {
@@ -422,6 +679,21 @@ class PolymorphicOutputParserTest {
 
         assertThat(tool).isInstanceOf(Wrench.class);
         assertThat(((Wrench) tool).sizeMm).isEqualTo(17);
+    }
+
+    @Test
+    void existing_property_allows_subtype_to_have_discriminator_field() {
+
+        // schema generation succeeds despite the field collision because of As.EXISTING_PROPERTY
+        Optional<JsonSchema> schema = new PojoOutputParser<>(Book.class).jsonSchema();
+        assertThat(schema).isPresent();
+
+        // and parsing dispatches to the correct subtype
+        Book book = new PojoOutputParser<>(Book.class)
+                .parse("{\"value\":{\"category\":\"hard\",\"title\":\"Effective Java\"}}");
+
+        assertThat(book).isInstanceOf(HardCover.class);
+        assertThat(((HardCover) book).title).isEqualTo("Effective Java");
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/PolymorphicOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/PolymorphicOutputParserTest.java
@@ -228,6 +228,46 @@ class PolymorphicOutputParserTest {
     record BinaryOp(String operator, ExpressionNode left, ExpressionNode right) implements ExpressionNode {
     }
 
+    // Multi-level sealed hierarchy: Transport permits LandTransport, Plane;
+    // LandTransport itself is sealed and permits Bus, Train.
+    sealed interface Transport permits LandTransport, Plane {
+    }
+
+    sealed interface LandTransport extends Transport permits Bus, Train {
+    }
+
+    record Bus(int seats) implements LandTransport {}
+
+    record Train(int cars) implements LandTransport {}
+
+    record Plane(int wingspan) implements Transport {}
+
+    @Test
+    void multi_level_sealed_hierarchy_is_flattened_to_concrete_subtypes() {
+
+        // findConcreteSubtypes walks through the intermediate sealed `LandTransport` and returns
+        // only the leaf concrete classes.
+        List<Class<?>> concrete = dev.langchain4j.internal.PolymorphicTypes.findConcreteSubtypes(Transport.class);
+        assertThat(concrete).containsExactly(Bus.class, Train.class, Plane.class);
+
+        // The resulting anyOf is flat — one option per leaf, no nested anyOf.
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Transport.class).jsonSchema().get().rootElement();
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+        assertThat(anyOf.anyOf()).hasSize(3);
+        assertThat(anyOf.anyOf()).allMatch(JsonObjectSchema.class::isInstance);
+    }
+
+    @Test
+    void multi_level_sealed_hierarchy_parses_a_leaf_subtype() {
+
+        Transport transport = new PojoOutputParser<>(Transport.class)
+                .parse("{\"value\":{\"type\":\"Train\",\"cars\":12}}");
+
+        assertThat(transport).isInstanceOf(Train.class);
+        assertThat(((Train) transport).cars()).isEqualTo(12);
+    }
+
     @Test
     void recursive_polymorphic_schema_generation_does_not_loop() {
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/PolymorphicOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/PolymorphicOutputParserTest.java
@@ -138,6 +138,95 @@ class PolymorphicOutputParserTest {
     @JsonTypeName("losing-name")
     record ElectricCar(int range) implements Car {}
 
+    sealed static class Plant permits Rose, Cactus {
+    }
+
+    static final class Rose extends Plant {
+        String color;
+    }
+
+    static final class Cactus extends Plant {
+        int height;
+    }
+
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Email.class, name = "email"),
+        @JsonSubTypes.Type(value = SmsMessage.class, name = "sms")
+    })
+    abstract static class Notification {
+    }
+
+    static class Email extends Notification {
+        String subject;
+    }
+
+    static class SmsMessage extends Notification {
+        String phoneNumber;
+    }
+
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Pdf.class, name = "pdf"),
+        @JsonSubTypes.Type(value = Html.class, name = "html")
+    })
+    interface Document {
+    }
+
+    static class Pdf implements Document {
+        int pages;
+    }
+
+    static class Html implements Document {
+        String url;
+    }
+
+    @Test
+    void sealed_class_is_supported_without_annotations() {
+
+        Optional<JsonSchema> schemaOpt = new PojoOutputParser<>(Plant.class).jsonSchema();
+        assertThat(schemaOpt).isPresent();
+
+        JsonObjectSchema root = (JsonObjectSchema) schemaOpt.get().rootElement();
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+        assertThat(anyOf.anyOf()).hasSize(2);
+
+        Plant plant = new PojoOutputParser<>(Plant.class)
+                .parse("{\"value\":{\"type\":\"Rose\",\"color\":\"red\"}}");
+        assertThat(plant).isInstanceOf(Rose.class);
+        assertThat(((Rose) plant).color).isEqualTo("red");
+    }
+
+    @Test
+    void abstract_class_with_JsonSubTypes_is_supported() {
+
+        Optional<JsonSchema> schemaOpt = new PojoOutputParser<>(Notification.class).jsonSchema();
+        assertThat(schemaOpt).isPresent();
+
+        JsonObjectSchema root = (JsonObjectSchema) schemaOpt.get().rootElement();
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+        assertThat(anyOf.anyOf()).hasSize(2);
+
+        Notification notification = new PojoOutputParser<>(Notification.class)
+                .parse("{\"value\":{\"type\":\"email\",\"subject\":\"hello\"}}");
+        assertThat(notification).isInstanceOf(Email.class);
+        assertThat(((Email) notification).subject).isEqualTo("hello");
+    }
+
+    @Test
+    void plain_interface_with_JsonSubTypes_is_supported() {
+
+        Optional<JsonSchema> schemaOpt = new PojoOutputParser<>(Document.class).jsonSchema();
+        assertThat(schemaOpt).isPresent();
+
+        JsonObjectSchema root = (JsonObjectSchema) schemaOpt.get().rootElement();
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+        assertThat(anyOf.anyOf()).hasSize(2);
+
+        Document document = new PojoOutputParser<>(Document.class)
+                .parse("{\"value\":{\"type\":\"pdf\",\"pages\":42}}");
+        assertThat(document).isInstanceOf(Pdf.class);
+        assertThat(((Pdf) document).pages).isEqualTo(42);
+    }
+
     @Test
     void JsonTypeName_on_subtype_is_used_as_discriminator_value() {
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/PolymorphicOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/PolymorphicOutputParserTest.java
@@ -1,0 +1,558 @@
+package dev.langchain4j.service.output;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+import dev.langchain4j.model.output.structured.Description;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PolymorphicOutputParserTest {
+
+    sealed interface Animal permits Dog, Cat {}
+
+    record Dog(String name, String breed) implements Animal {}
+
+    record Cat(String name, boolean indoor) implements Animal {}
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Square.class, name = "square"),
+        @JsonSubTypes.Type(value = Circle.class, name = "circle")
+    })
+    interface Shape {}
+
+    static class Square implements Shape {
+        double side;
+
+        Square() {}
+
+        Square(double side) {
+            this.side = side;
+        }
+    }
+
+    static class Circle implements Shape {
+        double radius;
+
+        Circle() {}
+
+        Circle(double radius) {
+            this.radius = radius;
+        }
+    }
+
+    @Description("A pet that lives in your home")
+    sealed interface Pet permits Hamster, Parrot {}
+
+    sealed interface Vehicle permits Truck {}
+
+    record Truck(String type, int wheels) implements Vehicle {}
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
+    @JsonSubTypes(@JsonSubTypes.Type(Coffee.class))
+    interface Beverage {}
+
+    static class Coffee implements Beverage {
+        String origin;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+    @JsonSubTypes(@JsonSubTypes.Type(value = Apple.class, name = "apple"))
+    interface Fruit {}
+
+    static class Apple implements Fruit {
+        String variety;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.SIMPLE_NAME)
+    @JsonSubTypes(@JsonSubTypes.Type(Pizza.class))
+    interface Food {}
+
+    static class Pizza implements Food {
+        String topping;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, defaultImpl = Wrench.class)
+    @JsonSubTypes({@JsonSubTypes.Type(value = Hammer.class, name = "hammer")})
+    interface Tool {}
+
+    static class Hammer implements Tool {
+        double weightKg;
+    }
+
+    static class Wrench implements Tool {
+        int sizeMm;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+    @JsonSubTypes({@JsonSubTypes.Type(value = Sword.class, name = "sword")})
+    interface Weapon {}
+
+    static class Sword implements Weapon {
+        String kind; // intentionally collides; visible=true makes it OK
+        int blade_length_cm;
+    }
+
+    @Description("A small caged rodent kept as a pet")
+    record Hamster(String name, double weightGrams) implements Pet {}
+
+    @Description("A talking bird that can mimic human speech")
+    record Parrot(String name, int vocabulary) implements Pet {}
+
+    record Owner(String name, Animal pet) {}
+
+    sealed interface Bird permits Eagle, Sparrow {}
+
+    @JsonTypeName("eagle")
+    record Eagle(double wingspanMeters) implements Bird {}
+
+    @JsonTypeName("sparrow")
+    record Sparrow(boolean migratory) implements Bird {}
+
+    sealed interface Tree permits Oak, Pine {}
+
+    // No annotation — should fall back to simpleName "Oak"
+    record Oak(int rings) implements Tree {}
+
+    @JsonTypeName("pine")
+    record Pine(int needles) implements Tree {}
+
+    @JsonSubTypes(@JsonSubTypes.Type(value = ElectricCar.class, name = "tesla"))
+    sealed interface Car permits ElectricCar {}
+
+    // @JsonSubTypes.Type(name="tesla") on the base should win over @JsonTypeName here.
+    @JsonTypeName("losing-name")
+    record ElectricCar(int range) implements Car {}
+
+    @Test
+    void JsonTypeName_on_subtype_is_used_as_discriminator_value() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Bird.class).jsonSchema().get().rootElement();
+
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+
+        JsonObjectSchema eagleOption = (JsonObjectSchema) anyOf.anyOf().get(0);
+        JsonEnumSchema eagleDiscriminator = (JsonEnumSchema) eagleOption.properties().get("type");
+        assertThat(eagleDiscriminator.enumValues()).containsExactly("eagle");
+
+        JsonObjectSchema sparrowOption = (JsonObjectSchema) anyOf.anyOf().get(1);
+        JsonEnumSchema sparrowDiscriminator = (JsonEnumSchema) sparrowOption.properties().get("type");
+        assertThat(sparrowDiscriminator.enumValues()).containsExactly("sparrow");
+    }
+
+    @Test
+    void JsonTypeName_drives_dispatch_during_parsing() {
+
+        Bird bird = new PojoOutputParser<>(Bird.class)
+                .parse("{\"value\":{\"type\":\"eagle\",\"wingspanMeters\":2.5}}");
+
+        assertThat(bird).isInstanceOf(Eagle.class);
+        assertThat(((Eagle) bird).wingspanMeters()).isEqualTo(2.5);
+    }
+
+    @Test
+    void JsonTypeName_falls_back_to_simple_name_for_subtypes_without_the_annotation() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Tree.class).jsonSchema().get().rootElement();
+
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+
+        JsonObjectSchema oakOption = (JsonObjectSchema) anyOf.anyOf().get(0);
+        JsonEnumSchema oakDiscriminator = (JsonEnumSchema) oakOption.properties().get("type");
+        // Oak has no @JsonTypeName — falls back to simple name
+        assertThat(oakDiscriminator.enumValues()).containsExactly("Oak");
+
+        JsonObjectSchema pineOption = (JsonObjectSchema) anyOf.anyOf().get(1);
+        JsonEnumSchema pineDiscriminator = (JsonEnumSchema) pineOption.properties().get("type");
+        // Pine has @JsonTypeName("pine") — wins over simple name
+        assertThat(pineDiscriminator.enumValues()).containsExactly("pine");
+    }
+
+    @Test
+    void JsonSubTypes_name_wins_over_JsonTypeName_when_both_are_set() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Car.class).jsonSchema().get().rootElement();
+
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+        JsonObjectSchema option = (JsonObjectSchema) anyOf.anyOf().get(0);
+        JsonEnumSchema discriminator = (JsonEnumSchema) option.properties().get("type");
+        // @JsonSubTypes.Type(name = "tesla") wins over @JsonTypeName("losing-name")
+        assertThat(discriminator.enumValues()).containsExactly("tesla");
+    }
+
+    record Adoption(Owner owner, List<Animal> petsAdopted) {}
+
+    @Test
+    void nested_sealed_field_produces_anyOf_in_outer_schema() {
+
+        Optional<JsonSchema> schemaOpt = new PojoOutputParser<>(Owner.class).jsonSchema();
+
+        assertThat(schemaOpt).isPresent();
+        JsonObjectSchema root = (JsonObjectSchema) schemaOpt.get().rootElement();
+        // Outer object is non-polymorphic — no `value` envelope
+        assertThat(root.properties()).containsOnlyKeys("name", "pet");
+
+        JsonAnyOfSchema petAnyOf = (JsonAnyOfSchema) root.properties().get("pet");
+        assertThat(petAnyOf.anyOf()).hasSize(2);
+
+        JsonObjectSchema dogOption = (JsonObjectSchema) petAnyOf.anyOf().get(0);
+        JsonEnumSchema discriminator = (JsonEnumSchema) dogOption.properties().get("type");
+        assertThat(discriminator.enumValues()).containsExactly("Dog");
+    }
+
+    @Test
+    void nested_sealed_field_parses_correctly() {
+
+        Owner owner = new PojoOutputParser<>(Owner.class)
+                .parse("{\"name\":\"Alice\",\"pet\":{\"type\":\"Dog\",\"name\":\"Rex\",\"breed\":\"Labrador\"}}");
+
+        assertThat(owner.name()).isEqualTo("Alice");
+        assertThat(owner.pet()).isInstanceOf(Dog.class);
+        assertThat(((Dog) owner.pet()).name()).isEqualTo("Rex");
+        assertThat(((Dog) owner.pet()).breed()).isEqualTo("Labrador");
+    }
+
+    @Test
+    void deeply_nested_sealed_collection_produces_array_of_anyOf() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Adoption.class).jsonSchema().get().rootElement();
+
+        JsonArraySchema petsArray = (JsonArraySchema) root.properties().get("petsAdopted");
+        assertThat(petsArray.items()).isInstanceOf(JsonAnyOfSchema.class);
+
+        JsonObjectSchema ownerObj = (JsonObjectSchema) root.properties().get("owner");
+        assertThat(ownerObj.properties().get("pet")).isInstanceOf(JsonAnyOfSchema.class);
+    }
+
+    @Test
+    void deeply_nested_sealed_collection_parses_correctly() {
+
+        Adoption adoption = new PojoOutputParser<>(Adoption.class)
+                .parse("{\"owner\":{\"name\":\"Alice\",\"pet\":{\"type\":\"Cat\",\"name\":\"Whiskers\",\"indoor\":true}},"
+                        + "\"petsAdopted\":["
+                        + "{\"type\":\"Dog\",\"name\":\"Rex\",\"breed\":\"Lab\"},"
+                        + "{\"type\":\"Cat\",\"name\":\"Mittens\",\"indoor\":false}"
+                        + "]}");
+
+        assertThat(adoption.owner().name()).isEqualTo("Alice");
+        assertThat(adoption.owner().pet()).isInstanceOf(Cat.class);
+        assertThat(adoption.petsAdopted()).hasSize(2);
+        assertThat(adoption.petsAdopted().get(0)).isInstanceOf(Dog.class);
+        assertThat(adoption.petsAdopted().get(1)).isInstanceOf(Cat.class);
+    }
+
+    record Reservation(String customer, Shape preferredShape) {}
+
+    @Test
+    void nested_jackson_annotated_field_produces_anyOf_with_jackson_discriminator() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Reservation.class).jsonSchema().get().rootElement();
+
+        JsonAnyOfSchema shapeAnyOf = (JsonAnyOfSchema) root.properties().get("preferredShape");
+        JsonObjectSchema firstOption = (JsonObjectSchema) shapeAnyOf.anyOf().get(0);
+        // Jackson @JsonTypeInfo(property = "kind") is honored at field level too
+        assertThat(firstOption.properties()).containsKey("kind");
+    }
+
+    @Test
+    void nested_jackson_annotated_field_parses_correctly() {
+
+        Reservation reservation = new PojoOutputParser<>(Reservation.class)
+                .parse("{\"customer\":\"Bob\",\"preferredShape\":{\"kind\":\"circle\",\"radius\":3.14}}");
+
+        assertThat(reservation.customer()).isEqualTo("Bob");
+        assertThat(reservation.preferredShape()).isInstanceOf(Circle.class);
+        assertThat(((Circle) reservation.preferredShape()).radius).isEqualTo(3.14);
+    }
+
+    @Test
+    void schema_generation_fails_for_unsupported_JsonTypeInfo_use() {
+
+        assertThatThrownBy(() -> new PojoOutputParser<>(Beverage.class).jsonSchema())
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessageContaining("Id.MINIMAL_CLASS")
+                .hasMessageContaining("Id.NAME")
+                .hasMessageContaining("Beverage");
+    }
+
+    @Test
+    void Id_SIMPLE_NAME_falls_back_to_simple_class_name_when_no_explicit_name() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Food.class).jsonSchema().get().rootElement();
+
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+        JsonObjectSchema pizzaOption = (JsonObjectSchema) anyOf.anyOf().get(0);
+        // Jackson default property name for Id.SIMPLE_NAME is "@type"
+        JsonEnumSchema discriminator = (JsonEnumSchema) pizzaOption.properties().get("@type");
+        assertThat(discriminator.enumValues()).containsExactly("Pizza");
+    }
+
+    @Test
+    void Id_SIMPLE_NAME_parses_simple_name() {
+
+        Food food = new PojoOutputParser<>(Food.class).parse("{\"value\":{\"@type\":\"Pizza\",\"topping\":\"margherita\"}}");
+
+        assertThat(food).isInstanceOf(Pizza.class);
+        assertThat(((Pizza) food).topping).isEqualTo("margherita");
+    }
+
+    @Test
+    void defaultImpl_is_used_when_discriminator_is_missing() {
+
+        Tool tool = new PojoOutputParser<>(Tool.class).parse("{\"value\":{\"sizeMm\":17}}");
+
+        assertThat(tool).isInstanceOf(Wrench.class);
+        assertThat(((Wrench) tool).sizeMm).isEqualTo(17);
+    }
+
+    @Test
+    void defaultImpl_is_used_when_discriminator_is_unknown() {
+
+        // Jackson default property name for Id.NAME is "@type"
+        Tool tool = new PojoOutputParser<>(Tool.class).parse("{\"value\":{\"@type\":\"unknown\",\"sizeMm\":17}}");
+
+        assertThat(tool).isInstanceOf(Wrench.class);
+        assertThat(((Wrench) tool).sizeMm).isEqualTo(17);
+    }
+
+    @Test
+    void visible_true_allows_subtype_to_have_discriminator_field() {
+
+        // schema generation succeeds despite the field collision
+        Optional<JsonSchema> schema = new PojoOutputParser<>(Weapon.class).jsonSchema();
+        assertThat(schema).isPresent();
+
+        // and parsing populates the field
+        Weapon weapon = new PojoOutputParser<>(Weapon.class)
+                .parse("{\"value\":{\"kind\":\"sword\",\"blade_length_cm\":85}}");
+
+        assertThat(weapon).isInstanceOf(Sword.class);
+        assertThat(((Sword) weapon).kind).isEqualTo("sword");
+        assertThat(((Sword) weapon).blade_length_cm).isEqualTo(85);
+    }
+
+    @Test
+    void schema_generation_fails_for_unsupported_JsonTypeInfo_include() {
+
+        assertThatThrownBy(() -> new PojoOutputParser<>(Fruit.class).jsonSchema())
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessageContaining("As.WRAPPER_OBJECT")
+                .hasMessageContaining("As.PROPERTY")
+                .hasMessageContaining("Fruit");
+    }
+
+    @Test
+    void schema_generation_fails_when_subtype_field_collides_with_discriminator() {
+
+        assertThatThrownBy(() -> new PojoOutputParser<>(Vehicle.class).jsonSchema())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Truck")
+                .hasMessageContaining("'type'")
+                .hasMessageContaining("@JsonTypeInfo(property")
+                .hasMessageContaining("Vehicle");
+    }
+
+    @Test
+    void base_type_description_uses_Description_annotation_when_present() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Pet.class).jsonSchema().get().rootElement();
+
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+
+        assertThat(anyOf.description()).isEqualTo("A pet that lives in your home");
+    }
+
+    @Test
+    void base_type_description_falls_back_to_simple_name_when_no_annotation() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Animal.class).jsonSchema().get().rootElement();
+
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+
+        assertThat(anyOf.description()).isEqualTo("Animal");
+    }
+
+    @Test
+    void subtype_description_uses_Description_annotation_when_present() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Pet.class).jsonSchema().get().rootElement();
+
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+
+        JsonObjectSchema hamsterOption = (JsonObjectSchema) anyOf.anyOf().get(0);
+        assertThat(hamsterOption.description()).isEqualTo("A small caged rodent kept as a pet");
+
+        JsonObjectSchema parrotOption = (JsonObjectSchema) anyOf.anyOf().get(1);
+        assertThat(parrotOption.description()).isEqualTo("A talking bird that can mimic human speech");
+    }
+
+    @Test
+    void subtype_description_falls_back_to_simple_name_when_no_annotation() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Animal.class).jsonSchema().get().rootElement();
+
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+
+        assertThat(((JsonObjectSchema) anyOf.anyOf().get(0)).description()).isEqualTo("Dog");
+        assertThat(((JsonObjectSchema) anyOf.anyOf().get(1)).description()).isEqualTo("Cat");
+    }
+
+    @Test
+    void schema_for_sealed_interface_wraps_anyOf_under_value() {
+
+        Optional<JsonSchema> schemaOpt = new PojoOutputParser<>(Animal.class).jsonSchema();
+
+        assertThat(schemaOpt).isPresent();
+        JsonSchema schema = schemaOpt.get();
+        assertThat(schema.name()).isEqualTo("Animal");
+
+        JsonObjectSchema root = (JsonObjectSchema) schema.rootElement();
+        assertThat(root.required()).containsExactly("value");
+
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+        assertThat(anyOf.anyOf()).hasSize(2);
+
+        // Dog option includes synthesized type discriminator with simple-name enum value
+        JsonObjectSchema dogOption = (JsonObjectSchema) anyOf.anyOf().get(0);
+        assertThat(dogOption.required()).startsWith("type");
+        JsonEnumSchema dogDiscriminator = (JsonEnumSchema) dogOption.properties().get("type");
+        assertThat(dogDiscriminator.enumValues()).containsExactly("Dog");
+        assertThat(dogOption.properties()).containsKeys("name", "breed");
+
+        JsonObjectSchema catOption = (JsonObjectSchema) anyOf.anyOf().get(1);
+        JsonEnumSchema catDiscriminator = (JsonEnumSchema) catOption.properties().get("type");
+        assertThat(catDiscriminator.enumValues()).containsExactly("Cat");
+        assertThat(catOption.properties()).containsKeys("name", "indoor");
+    }
+
+    @Test
+    void schema_honors_jackson_discriminator_property_and_subtype_names() {
+
+        JsonObjectSchema root = (JsonObjectSchema)
+                new PojoOutputParser<>(Shape.class).jsonSchema().get().rootElement();
+
+        JsonAnyOfSchema anyOf = (JsonAnyOfSchema) root.properties().get("value");
+        JsonObjectSchema firstOption = (JsonObjectSchema) anyOf.anyOf().get(0);
+
+        // Discriminator property name comes from @JsonTypeInfo
+        assertThat(firstOption.properties()).containsKey("kind");
+        // Discriminator value comes from @JsonSubTypes.Type(name=...)
+        JsonEnumSchema kind = (JsonEnumSchema) firstOption.properties().get("kind");
+        assertThat(kind.enumValues()).containsExactly("square");
+    }
+
+    @Test
+    void schema_for_collection_of_polymorphic_uses_array_of_anyOf() {
+
+        Optional<JsonSchema> schemaOpt = new PojoListOutputParser<>(Animal.class).jsonSchema();
+
+        assertThat(schemaOpt).isPresent();
+        JsonObjectSchema root = (JsonObjectSchema) schemaOpt.get().rootElement();
+        assertThat(root.required()).containsExactly("values");
+
+        JsonArraySchema array = (JsonArraySchema) root.properties().get("values");
+        JsonSchemaElement items = array.items();
+        assertThat(items).isInstanceOf(JsonAnyOfSchema.class);
+        assertThat(((JsonAnyOfSchema) items).anyOf()).hasSize(2);
+    }
+
+    @Test
+    void parse_unwraps_value_envelope_for_single_polymorphic() {
+
+        Animal animal = new PojoOutputParser<>(Animal.class)
+                .parse("{\"value\":{\"type\":\"Dog\",\"name\":\"Rex\",\"breed\":\"Labrador\"}}");
+
+        assertThat(animal).isInstanceOf(Dog.class);
+        assertThat(((Dog) animal).name()).isEqualTo("Rex");
+        assertThat(((Dog) animal).breed()).isEqualTo("Labrador");
+    }
+
+    @Test
+    void parse_accepts_unwrapped_polymorphic_payload() {
+
+        Animal animal = new PojoOutputParser<>(Animal.class)
+                .parse("{\"type\":\"Cat\",\"name\":\"Whiskers\",\"indoor\":true}");
+
+        assertThat(animal).isInstanceOf(Cat.class);
+        assertThat(((Cat) animal).name()).isEqualTo("Whiskers");
+        assertThat(((Cat) animal).indoor()).isTrue();
+    }
+
+    @Test
+    void parse_collection_of_polymorphic() {
+
+        List<Animal> animals = new PojoListOutputParser<>(Animal.class)
+                .parse("{\"values\":["
+                        + "{\"type\":\"Dog\",\"name\":\"Rex\",\"breed\":\"Labrador\"},"
+                        + "{\"type\":\"Cat\",\"name\":\"Whiskers\",\"indoor\":true}"
+                        + "]}");
+
+        assertThat(animals).hasSize(2);
+        assertThat(animals.get(0)).isInstanceOf(Dog.class);
+        assertThat(animals.get(1)).isInstanceOf(Cat.class);
+    }
+
+    @Test
+    void parse_set_of_polymorphic() {
+
+        Set<Animal> animals = new PojoSetOutputParser<>(Animal.class)
+                .parse("{\"values\":["
+                        + "{\"type\":\"Dog\",\"name\":\"Rex\",\"breed\":\"Labrador\"}"
+                        + "]}");
+
+        assertThat(animals).hasSize(1);
+        assertThat(animals.iterator().next()).isInstanceOf(Dog.class);
+    }
+
+    @Test
+    void parse_polymorphic_with_jackson_discriminator() {
+
+        Shape shape = new PojoOutputParser<>(Shape.class)
+                .parse("{\"value\":{\"kind\":\"circle\",\"radius\":2.5}}");
+
+        assertThat(shape).isInstanceOf(Circle.class);
+        assertThat(((Circle) shape).radius).isEqualTo(2.5);
+    }
+
+    @Test
+    void parse_fails_for_unknown_discriminator_value() {
+
+        assertThatThrownBy(() -> new PojoOutputParser<>(Animal.class)
+                .parse("{\"type\":\"Hamster\",\"name\":\"Nibbles\"}"))
+                .isInstanceOf(OutputParsingException.class)
+                .hasMessageContaining("Failed to parse");
+    }
+
+    @Test
+    void parse_fails_when_discriminator_missing() {
+
+        assertThatThrownBy(() -> new PojoOutputParser<>(Animal.class)
+                .parse("{\"value\":{\"name\":\"Rex\",\"breed\":\"Labrador\"}}"))
+                .isInstanceOf(OutputParsingException.class)
+                .hasMessageContaining("Failed to parse");
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/PolymorphicOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/PolymorphicOutputParserTest.java
@@ -269,13 +269,6 @@ class PolymorphicOutputParserTest {
     }
 
     @Test
-    void recursive_polymorphic_schema_generation_does_not_loop() {
-
-        Optional<JsonSchema> schema = new PojoOutputParser<>(ExpressionNode.class).jsonSchema();
-        assertThat(schema).isPresent();
-    }
-
-    @Test
     void recursive_polymorphic_schema_is_compact_and_uses_refs() {
 
         JsonSchema actual = new PojoOutputParser<>(ExpressionNode.class).jsonSchema().get();


### PR DESCRIPTION
## Issue
Closes https://github.com/langchain4j/langchain4j/issues/2557

## Change
- Polymorphic types (sealed interfaces/classes, or types annotated with Jackson
    `@JsonSubTypes`/`@JsonTypeInfo`) can now be used as AI Service return types and as
    tool parameters. The schema sent to the LLM contains an `anyOf` over concrete
    subtypes with a discriminator property, and the LLM's response (or tool call) is
    dispatched to the correct subtype automatically.
- Works for the polymorphic type itself, for `List<T>`/`Set<T>` of polymorphic, and
    for polymorphic types nested inside other POJOs. Fixes the previously-empty schema
    generated for interface/abstract return types.
- Sealed types work with **zero annotations**; Jackson-annotated types are also
    supported and respect the user-configured `property`, `defaultImpl`, `visible`,
    `@JsonSubTypes.Type(name=...)`, and `@JsonTypeName`.
- Unsupported Jackson configurations (`Id.CLASS`, `Id.MINIMAL_CLASS`, `Id.CUSTOM`,
    `Id.DEDUCTION`, `As.WRAPPER_OBJECT`, `As.WRAPPER_ARRAY`, `As.EXTERNAL_PROPERTY`,
    `As.EXISTING_PROPERTY`) fail fast with a clear `UnsupportedFeatureException` at
    schema-generation time, instead of silently producing a payload Jackson can't parse.
- Discriminator field collisions on subtypes are detected and reported with three
    remediation options (rename, change `property=...`, or set `visible=true`).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)