### PR TITLE
fix: expose Bedrock Cohere embedding token usage

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModel.java
@@ -13,11 +13,13 @@ import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
 import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
@@ -36,6 +38,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 public class BedrockCohereEmbeddingModel extends DimensionAwareEmbeddingModel {
 
     private static final int DEFAULT_MAX_SEGMENTS_PER_BATCH = 96;
+    private static final String INPUT_TOKEN_COUNT_HEADER = "x-amzn-bedrock-input-token-count";
 
     private final BedrockRuntimeClient client;
     private final String model;
@@ -56,15 +59,16 @@ public class BedrockCohereEmbeddingModel extends DimensionAwareEmbeddingModel {
     private BedrockRuntimeClient initClient(Builder builder) {
         return BedrockRuntimeClient.builder()
                 .region(getOrDefault(builder.region, US_EAST_1))
-                .credentialsProvider(
-                        getOrDefault(builder.credentialsProvider, () -> DefaultCredentialsProvider.builder()
-                                .build()))
+                .credentialsProvider(getOrDefault(
+                        builder.credentialsProvider,
+                        () -> DefaultCredentialsProvider.builder().build()))
                 .build();
     }
 
     @Override
     public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
         List<Embedding> embeddings = new ArrayList<>();
+        Integer inputTokenCount = null;
 
         for (int i = 0; i < textSegments.size(); i += maxSegmentsPerBatch) {
             List<TextSegment> batch = textSegments.subList(i, Math.min(textSegments.size(), i + maxSegmentsPerBatch));
@@ -81,9 +85,32 @@ public class BedrockCohereEmbeddingModel extends DimensionAwareEmbeddingModel {
             embeddings.addAll(stream(embeddingResponse.getEmbeddings().getFloatEmbeddings())
                     .map(Embedding::from)
                     .toList());
+            inputTokenCount = sum(
+                    inputTokenCount,
+                    inputTokenCountFrom(invokeModelResponse).orElse(embeddingResponse.getInputTextTokenCount()));
         }
 
-        return Response.from(embeddings);
+        return Response.from(embeddings, tokenUsageFrom(inputTokenCount));
+    }
+
+    private Optional<Integer> inputTokenCountFrom(InvokeModelResponse response) {
+        return response.sdkHttpResponse()
+                .firstMatchingHeader(INPUT_TOKEN_COUNT_HEADER)
+                .map(Integer::parseInt);
+    }
+
+    private TokenUsage tokenUsageFrom(Integer inputTokenCount) {
+        return inputTokenCount == null ? null : new TokenUsage(inputTokenCount);
+    }
+
+    private Integer sum(Integer first, Integer second) {
+        if (first == null) {
+            return second;
+        }
+        if (second == null) {
+            return first;
+        }
+        return first + second;
     }
 
     private Map<String, Object> toRequestParameters(List<TextSegment> textSegments) {

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingResponse.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingResponse.java
@@ -21,11 +21,10 @@ class BedrockCohereEmbeddingResponse {
         public void setFloatEmbeddings(float[][] floatEmbeddings) {
             this.floatEmbeddings = floatEmbeddings;
         }
-
     }
 
     private Embeddings embeddings;
-    private int inputTextTokenCount;
+    private Integer inputTextTokenCount;
 
     public Embeddings getEmbeddings() {
         return embeddings;
@@ -35,11 +34,11 @@ class BedrockCohereEmbeddingResponse {
         this.embeddings = embeddings;
     }
 
-    public int getInputTextTokenCount() {
+    public Integer getInputTextTokenCount() {
         return inputTextTokenCount;
     }
 
-    public void setInputTextTokenCount(int inputTextTokenCount) {
+    public void setInputTextTokenCount(Integer inputTextTokenCount) {
         this.inputTextTokenCount = inputTextTokenCount;
     }
 }

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModelIT.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModelIT.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -36,7 +37,7 @@ class BedrockCohereEmbeddingModelIT {
 
         assertThat(embedding.vector()).hasSize(1024);
 
-        assertThat(response.tokenUsage()).isNull();
+        assertTokenUsage(response.tokenUsage());
         assertThat(response.finishReason()).isNull();
 
         assertThat(embeddingModel.dimension()).isEqualTo(1024);
@@ -64,7 +65,7 @@ class BedrockCohereEmbeddingModelIT {
         Embedding embedding = embeddings.get(0);
         assertThat(embedding.vector()).hasSize(1024);
 
-        assertThat(response.tokenUsage()).isNull();
+        assertTokenUsage(response.tokenUsage());
         assertThat(response.finishReason()).isNull();
 
         assertThat(embeddingModel.dimension()).isEqualTo(1024);
@@ -102,7 +103,7 @@ class BedrockCohereEmbeddingModelIT {
         // Verify embeddings are not null or empty
         assertThat(embeddings).allMatch(embedding -> embedding.vector() != null && embedding.vector().length > 0);
 
-        assertThat(response.tokenUsage()).isNull();
+        assertTokenUsage(response.tokenUsage());
         assertThat(response.finishReason()).isNull();
         assertThat(embeddingModel.dimension()).isEqualTo(1024);
     }
@@ -134,9 +135,16 @@ class BedrockCohereEmbeddingModelIT {
         // Verify embeddings exists for all textSegments
         assertThat(embeddings).allMatch(embedding -> embedding.vector() != null && embedding.vector().length > 0);
 
-        assertThat(response.tokenUsage()).isNull();
+        assertTokenUsage(response.tokenUsage());
         assertThat(response.finishReason()).isNull();
         assertThat(embeddingModel.dimension()).isEqualTo(1024);
+    }
+
+    private static void assertTokenUsage(TokenUsage tokenUsage) {
+        assertThat(tokenUsage).isNotNull();
+        assertThat(tokenUsage.inputTokenCount()).isPositive();
+        assertThat(tokenUsage.outputTokenCount()).isNull();
+        assertThat(tokenUsage.totalTokenCount()).isEqualTo(tokenUsage.inputTokenCount());
     }
 
     @AfterEach

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModelTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCohereEmbeddingModelTest.java
@@ -1,0 +1,131 @@
+package dev.langchain4j.model.bedrock;
+
+import static dev.langchain4j.model.bedrock.BedrockCohereEmbeddingModel.InputType.SEARCH_QUERY;
+import static dev.langchain4j.model.bedrock.BedrockCohereEmbeddingModel.Model.COHERE_EMBED_MULTILINGUAL_V3;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
+
+class BedrockCohereEmbeddingModelTest {
+
+    @Test
+    void should_return_token_usage_from_bedrock_input_token_count_header() {
+        Queue<InvokeModelResponse> responses =
+                new ArrayDeque<>(List.of(invokeModelResponse("[0.1,0.2]", "3"), invokeModelResponse("[0.3,0.4]", "4")));
+
+        BedrockCohereEmbeddingModel model = BedrockCohereEmbeddingModel.builder()
+                .client(clientReturning(responses))
+                .model(COHERE_EMBED_MULTILINGUAL_V3)
+                .inputType(SEARCH_QUERY)
+                .maxSegmentsPerBatch(1)
+                .build();
+
+        Response<List<Embedding>> response =
+                model.embedAll(List.of(TextSegment.from("first"), TextSegment.from("second")));
+
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.content())
+                .allSatisfy(embedding -> assertThat(embedding.vector()).hasSize(2));
+        assertThat(responses).isEmpty();
+
+        TokenUsage tokenUsage = response.tokenUsage();
+        assertThat(tokenUsage).isNotNull();
+        assertThat(tokenUsage.inputTokenCount()).isEqualTo(7);
+        assertThat(tokenUsage.outputTokenCount()).isNull();
+        assertThat(tokenUsage.totalTokenCount()).isEqualTo(7);
+    }
+
+    @Test
+    void should_not_return_token_usage_when_bedrock_does_not_provide_token_count() {
+        Queue<InvokeModelResponse> responses =
+                new ArrayDeque<>(List.of(invokeModelResponseWithoutTokenCount("[0.1,0.2]")));
+
+        BedrockCohereEmbeddingModel model = BedrockCohereEmbeddingModel.builder()
+                .client(clientReturning(responses))
+                .model(COHERE_EMBED_MULTILINGUAL_V3)
+                .inputType(SEARCH_QUERY)
+                .build();
+
+        Response<List<Embedding>> response = model.embedAll(List.of(TextSegment.from("first")));
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.tokenUsage()).isNull();
+    }
+
+    @Test
+    void should_fall_back_to_body_token_count_when_header_is_missing() {
+        Queue<InvokeModelResponse> responses =
+                new ArrayDeque<>(List.of(invokeModelResponseWithBodyTokenCount("[0.1,0.2]", 5)));
+
+        BedrockCohereEmbeddingModel model = BedrockCohereEmbeddingModel.builder()
+                .client(clientReturning(responses))
+                .model(COHERE_EMBED_MULTILINGUAL_V3)
+                .inputType(SEARCH_QUERY)
+                .build();
+
+        Response<List<Embedding>> response = model.embedAll(List.of(TextSegment.from("first")));
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.tokenUsage()).isNotNull();
+        assertThat(response.tokenUsage().inputTokenCount()).isEqualTo(5);
+        assertThat(response.tokenUsage().outputTokenCount()).isNull();
+        assertThat(response.tokenUsage().totalTokenCount()).isEqualTo(5);
+    }
+
+    private static BedrockRuntimeClient clientReturning(Queue<InvokeModelResponse> responses) {
+        return new BedrockRuntimeClient() {
+
+            @Override
+            public InvokeModelResponse invokeModel(InvokeModelRequest request) {
+                return responses.remove();
+            }
+
+            @Override
+            public String serviceName() {
+                return "bedrock-runtime";
+            }
+
+            @Override
+            public void close() {}
+        };
+    }
+
+    private static InvokeModelResponse invokeModelResponse(String vector, String inputTokenCount) {
+        InvokeModelResponse.Builder responseBuilder = InvokeModelResponse.builder()
+                .body(SdkBytes.fromUtf8String("{\"embeddings\":{\"float\":[" + vector + "]}}"));
+        responseBuilder.sdkHttpResponse(SdkHttpResponse.builder()
+                .statusCode(200)
+                .putHeader("x-amzn-bedrock-input-token-count", inputTokenCount)
+                .build());
+        return responseBuilder.build();
+    }
+
+    private static InvokeModelResponse invokeModelResponseWithoutTokenCount(String vector) {
+        InvokeModelResponse.Builder responseBuilder = InvokeModelResponse.builder()
+                .body(SdkBytes.fromUtf8String("{\"embeddings\":{\"float\":[" + vector + "]}}"));
+        responseBuilder.sdkHttpResponse(
+                SdkHttpResponse.builder().statusCode(200).build());
+        return responseBuilder.build();
+    }
+
+    private static InvokeModelResponse invokeModelResponseWithBodyTokenCount(String vector, int inputTokenCount) {
+        InvokeModelResponse.Builder responseBuilder = InvokeModelResponse.builder()
+                .body(SdkBytes.fromUtf8String("{\"embeddings\":{\"float\":[" + vector + "]},\"inputTextTokenCount\":"
+                        + inputTokenCount + "}"));
+        responseBuilder.sdkHttpResponse(
+                SdkHttpResponse.builder().statusCode(200).build());
+        return responseBuilder.build();
+    }
+}


### PR DESCRIPTION
Fixes #5057

## Summary
- Read Bedrock Cohere input token counts from `x-amzn-bedrock-input-token-count`
- Fall back to the response body token count when the header is not present
- Sum token usage across batched embedding requests and keep `tokenUsage()` null when no count is provided

## Testing
- `mvn -pl langchain4j-bedrock spotless:check`
- `mvn -pl langchain4j-bedrock -am -Dtest=BedrockCohereEmbeddingModelTest,BedrockCohereEmbeddingModelIT -Dsurefire.failIfNoSpecifiedTests=false test`