### PR TITLE
Allow ClassPathSkillLoader to load skills packaged in JAR files

### DIFF
--- a/langchain4j-skills/revapi.json
+++ b/langchain4j-skills/revapi.json
@@ -1,0 +1,34 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.langchain4j.skills.FileSystemSkill dev.langchain4j.skills.ClassPathSkillLoader::loadSkill(java.lang.String)",
+          "new": "method dev.langchain4j.skills.Skill dev.langchain4j.skills.ClassPathSkillLoader::loadSkill(java.lang.String)",
+          "justification": "ClassPathSkillLoader no longer exposes FileSystemSkill because skills loaded from JARs do not have a meaningful filesystem base path"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.langchain4j.skills.FileSystemSkill dev.langchain4j.skills.ClassPathSkillLoader::loadSkill(java.lang.String, java.lang.ClassLoader)",
+          "new": "method dev.langchain4j.skills.Skill dev.langchain4j.skills.ClassPathSkillLoader::loadSkill(java.lang.String, java.lang.ClassLoader)",
+          "justification": "ClassPathSkillLoader no longer exposes FileSystemSkill because skills loaded from JARs do not have a meaningful filesystem base path"
+        },
+        {
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method java.util.List<dev.langchain4j.skills.FileSystemSkill> dev.langchain4j.skills.ClassPathSkillLoader::loadSkills(java.lang.String)",
+          "new": "method java.util.List<dev.langchain4j.skills.Skill> dev.langchain4j.skills.ClassPathSkillLoader::loadSkills(java.lang.String)",
+          "justification": "ClassPathSkillLoader no longer exposes FileSystemSkill because skills loaded from JARs do not have a meaningful filesystem base path"
+        },
+        {
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method java.util.List<dev.langchain4j.skills.FileSystemSkill> dev.langchain4j.skills.ClassPathSkillLoader::loadSkills(java.lang.String, java.lang.ClassLoader)",
+          "new": "method java.util.List<dev.langchain4j.skills.Skill> dev.langchain4j.skills.ClassPathSkillLoader::loadSkills(java.lang.String, java.lang.ClassLoader)",
+          "justification": "ClassPathSkillLoader no longer exposes FileSystemSkill because skills loaded from JARs do not have a meaningful filesystem base path"
+        }
+      ]
+    }
+  }
+]

--- a/langchain4j-skills/src/main/java/dev/langchain4j/skills/ClassPathSkillLoader.java
+++ b/langchain4j-skills/src/main/java/dev/langchain4j/skills/ClassPathSkillLoader.java
@@ -10,6 +10,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.MalformedInputException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -20,7 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Loads skills from the classpath.
+ * Loads skills from the classpath (including cases when they are packaged inside
+ * a JAR file that is on the classpath).
  * <p>
  * Each skill must reside in its own directory containing a {@code SKILL.md} file.
  * The file must have a YAML front matter block that declares the skill's {@code name}
@@ -170,10 +174,30 @@ public class ClassPathSkillLoader {
 
         try {
             URI uri = url.toURI();
+            if ("jar".equals(uri.getScheme())) {
+                return resolveJarPath(uri);
+            }
             return Path.of(uri);
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException | IOException e) {
             throw new RuntimeException("Failed to resolve classpath resource: " + pathOnClasspath, e);
         }
+    }
+
+    private static Path resolveJarPath(URI jarUri) throws IOException {
+        String schemeSpecific = jarUri.getSchemeSpecificPart();
+        int separator = schemeSpecific.indexOf("!/");
+        if (separator == -1) {
+            throw new IllegalArgumentException("Invalid JAR URI: " + jarUri);
+        }
+        String pathInJar = schemeSpecific.substring(separator + 1);
+
+        FileSystem fs;
+        try {
+            fs = FileSystems.newFileSystem(jarUri, Map.of());
+        } catch (FileSystemAlreadyExistsException e) {
+            fs = FileSystems.getFileSystem(jarUri);
+        }
+        return fs.getPath(pathInJar);
     }
 
     private static ClassLoader getDefaultClassLoader() {

--- a/langchain4j-skills/src/main/java/dev/langchain4j/skills/ClassPathSkillLoader.java
+++ b/langchain4j-skills/src/main/java/dev/langchain4j/skills/ClassPathSkillLoader.java
@@ -49,7 +49,7 @@ public class ClassPathSkillLoader {
      * @param directoryOnClasspath the classpath directory whose immediate subdirectories are scanned for skills
      * @return the list of loaded skills
      */
-    public static List<FileSystemSkill> loadSkills(String directoryOnClasspath) {
+    public static List<Skill> loadSkills(String directoryOnClasspath) {
         return loadSkills(directoryOnClasspath, getDefaultClassLoader());
     }
 
@@ -60,16 +60,19 @@ public class ClassPathSkillLoader {
      * @param classLoader          the class loader to use
      * @return the list of loaded skills
      */
-    public static List<FileSystemSkill> loadSkills(String directoryOnClasspath, ClassLoader classLoader) {
-        Path dirPath = resolveClasspathDirectory(directoryOnClasspath, classLoader);
+    public static List<Skill> loadSkills(String directoryOnClasspath, ClassLoader classLoader) {
+        ResolvedDirectory resolved = resolveClasspathDirectory(directoryOnClasspath, classLoader);
 
-        try (Stream<Path> entries = Files.list(dirPath)) {
+        try (Stream<Path> entries = Files.list(resolved.path)) {
             return entries.filter(Files::isDirectory)
                     .filter(dir -> Files.exists(dir.resolve("SKILL.md")))
-                    .map(dir -> loadSkillFromPath(dir, directoryOnClasspath, classLoader))
+                    .map((Path skillDirectory) ->
+                            loadSkillFromPath(new ResolvedDirectory(skillDirectory, resolved.jarFileSystem, false)))
                     .toList();
         } catch (IOException e) {
             throw new RuntimeException("Failed to load skills from classpath directory: " + directoryOnClasspath, e);
+        } finally {
+            closeJarFileSystem(resolved);
         }
     }
 
@@ -80,7 +83,7 @@ public class ClassPathSkillLoader {
      * @param skillDirectoryOnClasspath the classpath path to the skill directory
      * @return the loaded skill
      */
-    public static FileSystemSkill loadSkill(String skillDirectoryOnClasspath) {
+    public static Skill loadSkill(String skillDirectoryOnClasspath) {
         return loadSkill(skillDirectoryOnClasspath, getDefaultClassLoader());
     }
 
@@ -91,14 +94,17 @@ public class ClassPathSkillLoader {
      * @param classLoader               the class loader to use
      * @return the loaded skill
      */
-    public static FileSystemSkill loadSkill(String skillDirectoryOnClasspath, ClassLoader classLoader) {
-        Path dirPath = resolveClasspathDirectory(skillDirectoryOnClasspath, classLoader);
-        return loadSkillFromPath(dirPath, skillDirectoryOnClasspath, classLoader);
+    public static Skill loadSkill(String skillDirectoryOnClasspath, ClassLoader classLoader) {
+        ResolvedDirectory resolved = resolveClasspathDirectory(skillDirectoryOnClasspath, classLoader);
+        try {
+            return loadSkillFromPath(resolved);
+        } finally {
+            closeJarFileSystem(resolved);
+        }
     }
 
-    private static FileSystemSkill loadSkillFromPath(
-            Path skillDirectory, String classpathRoot, ClassLoader classLoader) {
-        Path skillFile = skillDirectory.resolve("SKILL.md");
+    private static Skill loadSkillFromPath(ResolvedDirectory skillDirectory) {
+        Path skillFile = skillDirectory.path.resolve("SKILL.md");
 
         if (!Files.exists(skillFile)) {
             throw new IllegalArgumentException("SKILL.md not found in " + skillDirectory);
@@ -113,15 +119,27 @@ public class ClassPathSkillLoader {
             String name = SkillLoaderCommon.getSingle(frontMatter, "name");
             String description = SkillLoaderCommon.getSingle(frontMatter, "description");
 
-            List<DefaultSkillResource> resources = loadResources(skillDirectory);
+            List<DefaultSkillResource> resources = loadResources(skillDirectory.path);
 
-            return DefaultFileSystemSkill.builder()
-                    .name(name)
-                    .basePath(skillDirectory)
-                    .description(description)
-                    .content(content)
-                    .resources(resources)
-                    .build();
+            if (skillDirectory.jarFileSystem != null) {
+                // skill loaded from a JAR
+                return DefaultSkill.builder()
+                        .name(name)
+                        .description(description)
+                        .content(content)
+                        .resources(resources)
+                        .build();
+            } else {
+                // skill loaded from the regular filesystem
+                return DefaultFileSystemSkill.builder()
+                        .name(name)
+                        .description(description)
+                        .content(content)
+                        .resources(resources)
+                        .basePath(skillDirectory.path)
+                        .build();
+            }
+
         } catch (IOException e) {
             throw new RuntimeException("Failed to load skill from " + skillDirectory, e);
         }
@@ -166,7 +184,9 @@ public class ClassPathSkillLoader {
         }
     }
 
-    private static Path resolveClasspathDirectory(String pathOnClasspath, ClassLoader classLoader) {
+    private record ResolvedDirectory(Path path, FileSystem jarFileSystem, boolean shouldCloseFileSystemAfterLoading) {}
+
+    private static ResolvedDirectory resolveClasspathDirectory(String pathOnClasspath, ClassLoader classLoader) {
         URL url = classLoader.getResource(pathOnClasspath);
         if (url == null) {
             throw new IllegalArgumentException("Classpath resource not found: " + pathOnClasspath);
@@ -177,13 +197,13 @@ public class ClassPathSkillLoader {
             if ("jar".equals(uri.getScheme())) {
                 return resolveJarPath(uri);
             }
-            return Path.of(uri);
+            return new ResolvedDirectory(Path.of(uri), null, false);
         } catch (URISyntaxException | IOException e) {
             throw new RuntimeException("Failed to resolve classpath resource: " + pathOnClasspath, e);
         }
     }
 
-    private static Path resolveJarPath(URI jarUri) throws IOException {
+    private static ResolvedDirectory resolveJarPath(URI jarUri) throws IOException {
         String schemeSpecific = jarUri.getSchemeSpecificPart();
         int separator = schemeSpecific.indexOf("!/");
         if (separator == -1) {
@@ -192,12 +212,25 @@ public class ClassPathSkillLoader {
         String pathInJar = schemeSpecific.substring(separator + 1);
 
         FileSystem fs;
+        boolean created;
         try {
             fs = FileSystems.newFileSystem(jarUri, Map.of());
+            created = true;
         } catch (FileSystemAlreadyExistsException e) {
             fs = FileSystems.getFileSystem(jarUri);
+            created = false;
         }
-        return fs.getPath(pathInJar);
+        return new ResolvedDirectory(fs.getPath(pathInJar), fs, created);
+    }
+
+    private static void closeJarFileSystem(ResolvedDirectory resolvedDirectory) {
+        if (resolvedDirectory.shouldCloseFileSystemAfterLoading() && resolvedDirectory.jarFileSystem() != null) {
+            try {
+                resolvedDirectory.jarFileSystem().close();
+            } catch (IOException e) {
+                log.warn("Failed to close JAR filesystem", e);
+            }
+        }
     }
 
     private static ClassLoader getDefaultClassLoader() {

--- a/langchain4j-skills/src/test/java/dev/langchain4j/skills/ClassPathSkillLoaderTest.java
+++ b/langchain4j-skills/src/test/java/dev/langchain4j/skills/ClassPathSkillLoaderTest.java
@@ -2,8 +2,19 @@ package dev.langchain4j.skills;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class ClassPathSkillLoaderTest {
 
@@ -79,5 +90,79 @@ class ClassPathSkillLoaderTest {
                 "skills/using-process-tool", Thread.currentThread().getContextClassLoader());
 
         assertThat(skill.name()).isEqualTo("using-process-tool");
+    }
+
+    @Test
+    void should_load_skill_from_jar(@TempDir Path tempDir) throws IOException {
+        Path jarFile = createSkillsJar(tempDir);
+        try (URLClassLoader classLoader =
+                new URLClassLoader(new URL[] {jarFile.toUri().toURL()}, null)) {
+
+            Skill skill = ClassPathSkillLoader.loadSkill("skills/using-process-tool", classLoader);
+
+            assertThat(skill.name()).isEqualTo("using-process-tool");
+            assertThat(skill.description()).isEqualTo("Describes how to correctly use 'process' tool");
+            assertThat(skill.content()).contains("call the 'process' tool with 3 arguments");
+            assertThat(skill.resources()).hasSize(2);
+            assertThat(skill.resources())
+                    .anySatisfy(file -> {
+                        assertThat(file.relativePath()).isEqualTo("references/17.md");
+                        assertThat(file.content()).contains("code 17");
+                    })
+                    .anySatisfy(file -> {
+                        assertThat(file.relativePath()).isEqualTo("references/25.md");
+                        assertThat(file.content()).contains("code 25");
+                    });
+        }
+    }
+
+    @Test
+    void should_load_all_skills_from_jar(@TempDir Path tempDir) throws IOException {
+        Path jarFile = createSkillsJar(tempDir);
+        try (URLClassLoader classLoader =
+                new URLClassLoader(new URL[] {jarFile.toUri().toURL()}, null)) {
+
+            List<FileSystemSkill> skills = ClassPathSkillLoader.loadSkills("skills", classLoader);
+
+            assertThat(skills)
+                    .extracting(Skill::name)
+                    .containsExactlyInAnyOrder("greeting-user", "test-skill", "using-process-tool");
+        }
+    }
+
+    /**
+     * Packages the contents of src/test/resources/skills into a JAR file and stores it in the given
+     * temporary directory. The goal is to be able to test that the ClassPathSkillLoader
+     * works properly when skills are packaged inside a JAR.
+     */
+    private static Path createSkillsJar(Path directory) throws IOException {
+        Path sourceDir = Path.of("src/test/resources/skills");
+        Path jarFile = directory.resolve("skills.jar");
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarFile))) {
+            Files.walkFileTree(sourceDir, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    String entryName = "skills/" + sourceDir.relativize(dir) + "/";
+                    if (!entryName.equals("skills//")) {
+                        jos.putNextEntry(new JarEntry(entryName));
+                        jos.closeEntry();
+                    } else {
+                        jos.putNextEntry(new JarEntry("skills/"));
+                        jos.closeEntry();
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    String entryName = "skills/" + sourceDir.relativize(file);
+                    jos.putNextEntry(new JarEntry(entryName));
+                    Files.copy(file, jos);
+                    jos.closeEntry();
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        return jarFile;
     }
 }

--- a/langchain4j-skills/src/test/java/dev/langchain4j/skills/ClassPathSkillLoaderTest.java
+++ b/langchain4j-skills/src/test/java/dev/langchain4j/skills/ClassPathSkillLoaderTest.java
@@ -20,7 +20,7 @@ class ClassPathSkillLoaderTest {
 
     @Test
     void should_load_all_skills_from_directory() {
-        List<FileSystemSkill> skills = ClassPathSkillLoader.loadSkills("skills");
+        List<Skill> skills = ClassPathSkillLoader.loadSkills("skills");
 
         assertThat(skills)
                 .extracting(Skill::name)
@@ -29,7 +29,7 @@ class ClassPathSkillLoaderTest {
 
     @Test
     void should_skip_directories_without_skill_md() {
-        List<FileSystemSkill> skills = ClassPathSkillLoader.loadSkills("skills/using-process-tool");
+        List<Skill> skills = ClassPathSkillLoader.loadSkills("skills/using-process-tool");
 
         assertThat(skills).isEmpty();
     }
@@ -122,7 +122,7 @@ class ClassPathSkillLoaderTest {
         try (URLClassLoader classLoader =
                 new URLClassLoader(new URL[] {jarFile.toUri().toURL()}, null)) {
 
-            List<FileSystemSkill> skills = ClassPathSkillLoader.loadSkills("skills", classLoader);
+            List<Skill> skills = ClassPathSkillLoader.loadSkills("skills", classLoader);
 
             assertThat(skills)
                     .extracting(Skill::name)


### PR DESCRIPTION
- Fixes: https://github.com/langchain4j/langchain4j/issues/5058

The second commit (about closing) is kinda up for debate but I think this is the best way to prevent leaking open `FileSystem` instances. If we think it's not a big issue, I could remove that commit.