### PR TITLE
fix: stack overflow when using offsetdatetime

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
@@ -8,6 +8,9 @@ import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
+import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -32,11 +35,23 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import dev.langchain4j.Internal;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * A JSON codec implementation using Jackson for serialization and deserialization.
@@ -135,6 +150,22 @@ class JacksonJsonCodec implements Json.JsonCodec {
             }
         });
 
+        // String-only handlers for the remaining java.time types declared as ISO-8601 strings in
+        // dev.langchain4j.internal.JsonSchemaElementUtils#DEFAULT_TIME_DESCRIPTIONS. Without
+        // these, deserializing a tool argument or structured output containing one of these types
+        // fails because jackson-datatype-jsr310 is not a declared dependency.
+        addIsoStringHandlers(module, Instant.class, Instant::parse);
+        addIsoStringHandlers(module, OffsetDateTime.class, s -> OffsetDateTime.parse(s, ISO_OFFSET_DATE_TIME));
+        addIsoStringHandlers(module, OffsetTime.class, s -> OffsetTime.parse(s, ISO_OFFSET_TIME));
+        addIsoStringHandlers(module, ZonedDateTime.class, s -> ZonedDateTime.parse(s, ISO_ZONED_DATE_TIME));
+        addIsoStringHandlers(module, Duration.class, Duration::parse);
+        addIsoStringHandlers(module, Period.class, Period::parse);
+        addIsoStringHandlers(module, Year.class, Year::parse);
+        addIsoStringHandlers(module, YearMonth.class, YearMonth::parse);
+        addIsoStringHandlers(module, MonthDay.class, MonthDay::parse);
+        addIsoStringHandlers(module, ZoneId.class, ZoneId::of);
+        addIsoStringHandlers(module, ZoneOffset.class, ZoneOffset::of);
+
         ObjectMapper mapper = JsonMapper.builder()
                 .visibility(FIELD, ANY)
                 .disable(INDENT_OUTPUT) // disabled on purpose to save tokens when sending tool results to LLM
@@ -150,6 +181,21 @@ class JacksonJsonCodec implements Json.JsonCodec {
         mapper.setAnnotationIntrospector(AnnotationIntrospectorPair.pair(
                 new SealedTypePolymorphicIntrospector(), mapper.getDeserializationConfig().getAnnotationIntrospector()));
         return mapper;
+    }
+
+    private static <T> void addIsoStringHandlers(SimpleModule module, Class<T> type, Function<String, T> parser) {
+        module.addSerializer(type, new StdSerializer<T>(type) {
+            @Override
+            public void serialize(T value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+                gen.writeString(value.toString());
+            }
+        });
+        module.addDeserializer(type, new JsonDeserializer<T>() {
+            @Override
+            public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+                return parser.apply(p.getValueAsString());
+            }
+        });
     }
 
     /**
@@ -246,7 +292,24 @@ class JacksonJsonCodec implements Json.JsonCodec {
             // Step in for any polymorphic base that doesn't already declare its own type-info
             // strategy via @JsonTypeInfo. This covers both sealed types (no annotations) and
             // types that only use @JsonSubTypes for subtype enumeration.
-            return raw.getAnnotation(JsonTypeInfo.class) == null && PolymorphicTypes.isPolymorphic(raw);
+            // Skip JDK types: some are sealed in JDK 17+ (e.g. java.time.ZoneId permits
+            // ZoneOffset/ZoneRegion) but we register custom (de)serializers for them and
+            // don't want polymorphic dispatch.
+            return raw.getAnnotation(JsonTypeInfo.class) == null
+                    && !isJdkType(raw)
+                    && PolymorphicTypes.isPolymorphic(raw);
+        }
+
+        private static boolean isJdkType(Class<?> raw) {
+            if (raw.getPackage() == null) {
+                return false;
+            }
+            String name = raw.getPackage().getName();
+            return name.startsWith("java.")
+                    || name.startsWith("javax.")
+                    || name.startsWith("jdk.")
+                    || name.startsWith("sun.")
+                    || name.startsWith("com.sun.");
         }
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JacksonJsonCodec.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -26,10 +25,10 @@ import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import dev.langchain4j.Internal;
@@ -179,7 +178,8 @@ class JacksonJsonCodec implements Json.JsonCodec {
         // having to add @JsonTypeInfo+@JsonSubTypes. We synthesize equivalent metadata via a
         // custom AnnotationIntrospector consulted ahead of Jackson's default one.
         mapper.setAnnotationIntrospector(AnnotationIntrospectorPair.pair(
-                new SealedTypePolymorphicIntrospector(), mapper.getDeserializationConfig().getAnnotationIntrospector()));
+                new SealedTypePolymorphicIntrospector(),
+                mapper.getDeserializationConfig().getAnnotationIntrospector()));
         return mapper;
     }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -30,6 +30,20 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -37,6 +51,31 @@ import java.util.stream.Collectors;
 public class JsonSchemaElementUtils {
 
     private static final String DEFAULT_UUID_DESCRIPTION = "String in a UUID format";
+
+    /**
+     * Default descriptions for {@link java.time} types that are mapped to {@link JsonStringSchema}.
+     * <p>
+     * Reflecting these types is unsafe: the JDK contains real reference cycles between these types (e.g.
+     * {@code ZoneOffset -> ZoneRules -> ZoneOffset[]}) that would otherwise blow the stack when a
+     * tool/structured-output schema transitively reaches them.
+     */
+    private static final Map<Class<?>, String> DEFAULT_TIME_DESCRIPTIONS = Map.ofEntries(
+            Map.entry(Instant.class, "String in ISO-8601 instant format, e.g. '2007-12-03T10:15:30.00Z'"),
+            Map.entry(LocalDate.class, "String in ISO-8601 date format, e.g. '2007-12-03'"),
+            Map.entry(LocalTime.class, "String in ISO-8601 time format, e.g. '10:15:30'"),
+            Map.entry(LocalDateTime.class, "String in ISO-8601 local date-time format, e.g. '2007-12-03T10:15:30'"),
+            Map.entry(OffsetTime.class, "String in ISO-8601 offset time format, e.g. '10:15:30+01:00'"),
+            Map.entry(OffsetDateTime.class,
+                    "String in ISO-8601 offset date-time format, e.g. '2007-12-03T10:15:30+01:00'"),
+            Map.entry(ZonedDateTime.class,
+                    "String in ISO-8601 zoned date-time format, e.g. '2007-12-03T10:15:30+01:00[Europe/Paris]'"),
+            Map.entry(Duration.class, "String in ISO-8601 duration format, e.g. 'PT15M'"),
+            Map.entry(Period.class, "String in ISO-8601 period format, e.g. 'P1Y2M3D'"),
+            Map.entry(Year.class, "String representing a year, e.g. '2007'"),
+            Map.entry(YearMonth.class, "String in ISO-8601 year-month format, e.g. '2007-12'"),
+            Map.entry(MonthDay.class, "String in ISO-8601 month-day format, e.g. '--12-03'"),
+            Map.entry(ZoneId.class, "String representing a time-zone ID, e.g. 'Europe/Paris'"),
+            Map.entry(ZoneOffset.class, "String representing a zone offset, e.g. '+01:00'"));
 
     public static JsonSchemaElement jsonSchemaElementFrom(Class<?> clazz) {
         return jsonSchemaElementFrom(clazz, clazz, null, false, new LinkedHashMap<>());
@@ -234,7 +273,7 @@ public class JsonSchemaElementUtils {
             boolean areSubFieldsRequiredByDefault,
             Map<Class<?>, VisitedClassMetadata> visited,
             boolean setDefinitions) {
-        if (visited.containsKey(type) && isCustomClass(type)) {
+        if (visited.containsKey(type)) {
             VisitedClassMetadata visitedClassMetadata = visited.get(type);
             JsonSchemaElement jsonSchemaElement = visitedClassMetadata.jsonSchemaElement;
             if (jsonSchemaElement instanceof JsonReferenceSchema) {
@@ -309,6 +348,10 @@ public class JsonSchemaElementUtils {
     private static String descriptionFrom(Class<?> type) {
         if (type == UUID.class) {
             return DEFAULT_UUID_DESCRIPTION;
+        }
+        String timeDescription = DEFAULT_TIME_DESCRIPTIONS.get(type);
+        if (timeDescription != null) {
+            return timeDescription;
         }
         return descriptionFrom(type.getAnnotation(Description.class));
     }
@@ -492,7 +535,7 @@ public class JsonSchemaElementUtils {
             // Emulating an optional parameter by using a union type with null.
             // See
             // https://platform.openai.com/docs/guides/structured-outputs/supported-schemas?api-mode=chat#all-fields-must-be-required
-            return new String[] {type, "null"};
+            return new String[]{type, "null"};
         } else {
             return type;
         }
@@ -527,7 +570,8 @@ public class JsonSchemaElementUtils {
                 || type == char.class
                 || type == Character.class
                 || CharSequence.class.isAssignableFrom(type)
-                || type == UUID.class;
+                || type == UUID.class
+                || DEFAULT_TIME_DESCRIPTIONS.containsKey(type);
     }
 
     static boolean isJsonArray(Class<?> type) {

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -65,9 +65,11 @@ public class JsonSchemaElementUtils {
             Map.entry(LocalTime.class, "String in ISO-8601 time format, e.g. '10:15:30'"),
             Map.entry(LocalDateTime.class, "String in ISO-8601 local date-time format, e.g. '2007-12-03T10:15:30'"),
             Map.entry(OffsetTime.class, "String in ISO-8601 offset time format, e.g. '10:15:30+01:00'"),
-            Map.entry(OffsetDateTime.class,
+            Map.entry(
+                    OffsetDateTime.class,
                     "String in ISO-8601 offset date-time format, e.g. '2007-12-03T10:15:30+01:00'"),
-            Map.entry(ZonedDateTime.class,
+            Map.entry(
+                    ZonedDateTime.class,
                     "String in ISO-8601 zoned date-time format, e.g. '2007-12-03T10:15:30+01:00[Europe/Paris]'"),
             Map.entry(Duration.class, "String in ISO-8601 duration format, e.g. 'PT15M'"),
             Map.entry(Period.class, "String in ISO-8601 period format, e.g. 'P1Y2M3D'"),
@@ -151,15 +153,15 @@ public class JsonSchemaElementUtils {
         }
 
         String reference = generateUUIDFrom(baseType.getName());
-        VisitedClassMetadata metadata =
-                new VisitedClassMetadata(JsonReferenceSchema.builder().reference(reference).build(), reference, false);
+        VisitedClassMetadata metadata = new VisitedClassMetadata(
+                JsonReferenceSchema.builder().reference(reference).build(), reference, false);
         visited.put(baseType, metadata);
 
         String discriminatorProperty = discriminatorPropertyName(baseType);
         List<JsonSchemaElement> options = new ArrayList<>();
         for (Class<?> subtype : findConcreteSubtypes(baseType)) {
-            JsonSchemaElement subtypeSchema = jsonObjectOrReferenceSchemaFrom(
-                    subtype, null, areSubFieldsRequiredByDefault, visited, false);
+            JsonSchemaElement subtypeSchema =
+                    jsonObjectOrReferenceSchemaFrom(subtype, null, areSubFieldsRequiredByDefault, visited, false);
             JsonSchemaElement withDiscriminator =
                     addDiscriminator(subtypeSchema, baseType, subtype, discriminatorProperty);
             options.add(withDiscriminator);
@@ -169,9 +171,11 @@ public class JsonSchemaElementUtils {
                 subtypeMetadata.jsonSchemaElement = withDiscriminator;
             }
         }
-        String desc = description != null ? description : Optional.ofNullable(descriptionFrom(baseType))
-                .orElse(baseType.getSimpleName());
-        JsonAnyOfSchema anyOf = JsonAnyOfSchema.builder().description(desc).anyOf(options).build();
+        String desc = description != null
+                ? description
+                : Optional.ofNullable(descriptionFrom(baseType)).orElse(baseType.getSimpleName());
+        JsonAnyOfSchema anyOf =
+                JsonAnyOfSchema.builder().description(desc).anyOf(options).build();
         metadata.jsonSchemaElement = anyOf;
         return anyOf;
     }
@@ -196,8 +200,7 @@ public class JsonSchemaElementUtils {
             JsonTypeInfo info = baseType.getAnnotation(JsonTypeInfo.class);
             // The discriminator field is allowed to coexist with a same-named bean field only when
             // @JsonTypeInfo(visible=true) or @JsonTypeInfo(include=As.EXISTING_PROPERTY).
-            boolean allowed = info != null
-                    && (info.visible() || info.include() == JsonTypeInfo.As.EXISTING_PROPERTY);
+            boolean allowed = info != null && (info.visible() || info.include() == JsonTypeInfo.As.EXISTING_PROPERTY);
             if (!allowed) {
                 throw new IllegalArgumentException(String.format(
                         "Polymorphic subtype %s declares a field named '%s', which collides with the discriminator "
@@ -205,16 +208,14 @@ public class JsonSchemaElementUtils {
                                 + "name with @JsonTypeInfo(property = \"...\") on %s, set @JsonTypeInfo(visible = true), "
                                 + "or use @JsonTypeInfo(include = As.EXISTING_PROPERTY) if the field is intentionally "
                                 + "part of the subtype.",
-                        subtype.getName(),
-                        discriminatorProperty,
-                        baseType.getName(),
-                        baseType.getName()));
+                        subtype.getName(), discriminatorProperty, baseType.getName(), baseType.getName()));
             }
         }
 
         Map<String, JsonSchemaElement> properties = new LinkedHashMap<>();
         properties.put(
-                discriminatorProperty, JsonEnumSchema.builder().enumValues(discriminatorValue).build());
+                discriminatorProperty,
+                JsonEnumSchema.builder().enumValues(discriminatorValue).build());
         obj.properties().forEach(properties::putIfAbsent);
 
         List<String> required = new ArrayList<>();
@@ -535,7 +536,7 @@ public class JsonSchemaElementUtils {
             // Emulating an optional parameter by using a union type with null.
             // See
             // https://platform.openai.com/docs/guides/structured-outputs/supported-schemas?api-mode=chat#all-fields-must-be-required
-            return new String[]{type, "null"};
+            return new String[] {type, "null"};
         } else {
             return type;
         }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonCodecTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonCodecTest.java
@@ -6,12 +6,27 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -408,5 +423,152 @@ class JsonCodecTest {
         // then
         assertThat(pojo.name).isEqualTo("Klaus");
         assertThat(pojo.age).isEqualTo(42);
+    }
+
+
+    @Nested
+    class JavaTime {
+
+        record JavaTimeRecord(
+                Instant instant,
+                LocalDate localDate,
+                LocalDate localDate2,
+                LocalTime localTime,
+                LocalTime localTime2,
+                LocalDateTime localDateTime,
+                LocalDateTime localDateTime2,
+                OffsetTime offsetTime,
+                OffsetDateTime offsetDateTime,
+                ZonedDateTime zonedDateTime,
+                Duration duration,
+                Period period,
+                Year year,
+                YearMonth yearMonth,
+                MonthDay monthDay,
+                ZoneId zoneId,
+                ZoneOffset zoneOffset) {
+        }
+
+        @ParameterizedTest
+        @MethodSource("dev.langchain4j.internal.JsonCodecTest#codecs")
+        void record_with_java_time_fields(Json.JsonCodec codec) {
+
+            // given - regression test: without explicit (de)serializers in JacksonJsonCodec,
+            // none of these except LocalDate/LocalTime/LocalDateTime would parse.
+            var jsonSrc = """
+            {
+                "instant": "2007-12-03T10:15:30Z",
+                "localDate": "2007-12-03",
+                "localDate2": {
+                    "year": "2007",
+                    "month": "12",
+                    "day": "04"
+                },
+                "localTime": "10:15:30",
+                "localTime2": {
+                    "hour": "10",
+                    "minute": "15",
+                    "second": "31"
+                },
+                "localDateTime": "2007-12-03T10:15:30",
+                "localDateTime2": {
+                    "date": {
+                        "year": "2007",
+                        "month": "12",
+                        "day": "03"
+                    },
+                    "time": {
+                        "hour": "10",
+                        "minute": "15",
+                        "second": "31"
+                    }
+                },
+                "offsetTime": "10:15:30+01:00",
+                "offsetDateTime": "2007-12-03T10:15:30+01:00",
+                "zonedDateTime": "2007-12-03T10:15:30+01:00[Europe/Paris]",
+                "duration": "PT15M",
+                "period": "P1Y2M3D",
+                "year": "2007",
+                "yearMonth": "2007-12",
+                "monthDay": "--12-03",
+                "zoneId": "Europe/Paris",
+                "zoneOffset": "+01:00"
+            }
+            """;
+
+            // when
+            JavaTimeRecord pojo = codec.fromJson(jsonSrc, JavaTimeRecord.class);
+
+            // then
+            assertThat(pojo.instant()).isEqualTo(Instant.parse("2007-12-03T10:15:30.00Z"));
+            assertThat(pojo.localDate()).isEqualTo(LocalDate.of(2007, 12, 3));
+            assertThat(pojo.localDate2()).isEqualTo(LocalDate.of(2007, 12, 4));
+            assertThat(pojo.localTime()).isEqualTo(LocalTime.of(10, 15, 30));
+            assertThat(pojo.localTime2()).isEqualTo(LocalTime.of(10, 15, 31));
+            assertThat(pojo.localDateTime()).isEqualTo(LocalDateTime.of(2007, 12, 3, 10, 15, 30));
+            assertThat(pojo.localDateTime2()).isEqualTo(LocalDateTime.of(2007, 12, 3, 10, 15, 31));
+            assertThat(pojo.offsetTime()).isEqualTo(OffsetTime.parse("10:15:30+01:00"));
+            assertThat(pojo.offsetDateTime()).isEqualTo(OffsetDateTime.parse("2007-12-03T10:15:30+01:00"));
+            assertThat(pojo.zonedDateTime()).isEqualTo(ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"));
+            assertThat(pojo.duration()).isEqualTo(Duration.ofMinutes(15));
+            assertThat(pojo.period()).isEqualTo(Period.of(1, 2, 3));
+            assertThat(pojo.year()).isEqualTo(Year.of(2007));
+            assertThat(pojo.yearMonth()).isEqualTo(YearMonth.of(2007, 12));
+            assertThat(pojo.monthDay()).isEqualTo(MonthDay.of(12, 3));
+            assertThat(pojo.zoneId()).isEqualTo(ZoneId.of("Europe/Paris"));
+            assertThat(pojo.zoneOffset()).isEqualTo(ZoneOffset.of("+01:00"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("dev.langchain4j.internal.JsonCodecTest#codecs")
+        void java_time_round_trip(Json.JsonCodec codec) {
+
+            // given
+            JavaTimeRecord javaObject = new JavaTimeRecord(
+                    Instant.parse("2007-12-03T10:15:30.00Z"),
+                    LocalDate.of(2007, 12, 3),
+                    LocalDate.of(2007, 12, 4),
+                    LocalTime.of(10, 15, 30),
+                    LocalTime.of(10, 15, 31),
+                    LocalDateTime.of(2007, 12, 3, 10, 15, 30),
+                    LocalDateTime.of(2007, 12, 3, 10, 15, 31),
+                    OffsetTime.parse("10:15:30+01:00"),
+                    OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
+                    ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"),
+                    Duration.ofMinutes(15),
+                    Period.of(1, 2, 3),
+                    Year.of(2007),
+                    YearMonth.of(2007, 12),
+                    MonthDay.of(12, 3),
+                    ZoneId.of("Europe/Paris"),
+                    ZoneOffset.of("+01:00"));
+            var jsonTarget = """
+            {
+                "instant": "2007-12-03T10:15:30Z",
+                "localDate": "2007-12-03",
+                "localDate2": "2007-12-04",
+                "localTime": "10:15:30",
+                "localTime2": "10:15:31",
+                "localDateTime": "2007-12-03T10:15:30",
+                "localDateTime2": "2007-12-03T10:15:31",
+                "offsetTime": "10:15:30+01:00",
+                "offsetDateTime": "2007-12-03T10:15:30+01:00",
+                "zonedDateTime": "2007-12-03T10:15:30+01:00[Europe/Paris]",
+                "duration": "PT15M",
+                "period": "P1Y2M3D",
+                "year": "2007",
+                "yearMonth": "2007-12",
+                "monthDay": "--12-03",
+                "zoneId": "Europe/Paris",
+                "zoneOffset": "+01:00"
+            }
+            """;
+
+            // when
+            String json = codec.toJson(javaObject);
+
+            // then
+            assertThat(json).isEqualTo(jsonTarget.replaceAll("\\s", ""));
+        }
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonCodecTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonCodecTest.java
@@ -34,8 +34,7 @@ class JsonCodecTest {
 
     record Person(String name, int age) {}
 
-    private static final String PERSON_JSON =
-            """
+    private static final String PERSON_JSON = """
             {
                 "name": "Klaus",
                 "age": 42
@@ -78,8 +77,7 @@ class JsonCodecTest {
     void record_different_field_order(Json.JsonCodec codec) {
 
         // given
-        String json =
-                """
+        String json = """
                 {
                     "age": 42,
                     "name": "Klaus"
@@ -105,8 +103,7 @@ class JsonCodecTest {
     void should_fail_on_unknown_fields_by_default(Json.JsonCodec codec) {
 
         // given
-        String json =
-                """
+        String json = """
                 {
                     "name": "Klaus",
                     "age": 42,
@@ -133,8 +130,7 @@ class JsonCodecTest {
     void record_null_value(Json.JsonCodec codec) {
 
         // given
-        String json =
-                """
+        String json = """
                 {
                     "name": "Klaus",
                     "age": null
@@ -154,8 +150,7 @@ class JsonCodecTest {
     void record_wrong_type(Json.JsonCodec codec) {
 
         // given
-        String json =
-                """
+        String json = """
                 {
                     "name": "Klaus",
                     "age": "42"
@@ -175,8 +170,7 @@ class JsonCodecTest {
     void record_wrong_type_2(Json.JsonCodec codec) {
 
         // given
-        String json =
-                """
+        String json = """
                 {
                     "name": "Klaus",
                     "age": 42.0
@@ -200,8 +194,7 @@ class JsonCodecTest {
     void record_with_nested_record(Json.JsonCodec codec) {
 
         // given
-        String json =
-                """
+        String json = """
                 {
                     "name": "Klaus",
                     "address": {
@@ -254,8 +247,7 @@ class JsonCodecTest {
     void record_with_empty_collections(Json.JsonCodec codec) {
 
         // given
-        String json =
-                """
+        String json = """
                 {
                     "name": "Klaus",
                     "collection": [],
@@ -319,8 +311,7 @@ class JsonCodecTest {
     void record_with_optional_null(Json.JsonCodec codec) {
 
         // given
-        String json =
-                """
+        String json = """
                 {
                     "name": "Klaus",
                     "age": null
@@ -364,8 +355,7 @@ class JsonCodecTest {
     void record_with_validation(Json.JsonCodec codec) {
 
         // given
-        String json =
-                """
+        String json = """
                 {
                     "name": "Klaus",
                     "age": -1
@@ -392,13 +382,11 @@ class JsonCodecTest {
     void record_with_custom_ctor(Json.JsonCodec codec) {
 
         // when
-        PersonRecordCustomCtor pojo = codec.fromJson(
-                """
+        PersonRecordCustomCtor pojo = codec.fromJson("""
                 {
                     "name": "Klaus"
                 }
-                """,
-                PersonRecordCustomCtor.class);
+                """, PersonRecordCustomCtor.class);
 
         // then
         assertThat(pojo.name()).isEqualTo("Klaus");
@@ -425,7 +413,6 @@ class JsonCodecTest {
         assertThat(pojo.age).isEqualTo(42);
     }
 
-
     @Nested
     class JavaTime {
 
@@ -446,8 +433,7 @@ class JsonCodecTest {
                 YearMonth yearMonth,
                 MonthDay monthDay,
                 ZoneId zoneId,
-                ZoneOffset zoneOffset) {
-        }
+                ZoneOffset zoneOffset) {}
 
         @ParameterizedTest
         @MethodSource("dev.langchain4j.internal.JsonCodecTest#codecs")

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
@@ -18,7 +18,12 @@ import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.model.output.structured.Description;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
@@ -139,6 +144,110 @@ class JsonSchemaElementUtilsTest {
                 .isEqualTo(JsonObjectSchema.builder()
                         .addStringProperty("uuid", "My UUID")
                         .required("uuid")
+                        .build());
+    }
+
+    @Test
+    void should_set_default_description_for_offset_date_time() {
+
+        // when
+        JsonSchemaElement jsonSchemaElement =
+                jsonSchemaElementFrom(OffsetDateTime.class, null, null, true, new LinkedHashMap<>());
+
+        // then
+        assertThat(jsonSchemaElement)
+                .isEqualTo(JsonStringSchema.builder()
+                        .description("String in ISO-8601 offset date-time format, e.g. '2007-12-03T10:15:30+01:00'")
+                        .build());
+    }
+
+    @Test
+    void should_set_default_description_for_zone_offset() {
+
+        // when - regression test: this used to throw StackOverflowError because
+        // ZoneOffset -> ZoneRules -> ZoneOffset[] is a real cycle in the JDK and
+        // java.* types bypassed the cycle guard
+        JsonSchemaElement jsonSchemaElement =
+                jsonSchemaElementFrom(ZoneOffset.class, null, null, true, new LinkedHashMap<>());
+
+        // then
+        assertThat(jsonSchemaElement)
+                .isEqualTo(JsonStringSchema.builder()
+                        .description("String representing a zone offset, e.g. '+01:00'")
+                        .build());
+    }
+
+    @Test
+    void should_set_default_description_for_zoned_date_time() {
+
+        // when
+        JsonSchemaElement jsonSchemaElement =
+                jsonSchemaElementFrom(ZonedDateTime.class, null, null, true, new LinkedHashMap<>());
+
+        // then
+        assertThat(jsonSchemaElement)
+                .isEqualTo(JsonStringSchema.builder()
+                        .description(
+                                "String in ISO-8601 zoned date-time format, e.g. '2007-12-03T10:15:30+01:00[Europe/Paris]'")
+                        .build());
+    }
+
+    static class MyClassWithJavaTimeFields {
+
+        Instant createdAt;
+        LocalDate birthDate;
+        LocalDateTime localTimestamp;
+        OffsetDateTime updatedAt;
+        ZonedDateTime scheduledAt;
+        ZoneOffset offset;
+    }
+
+    @Test
+    void should_set_default_descriptions_for_java_time_fields_in_class() {
+
+        // when - regression test: an OffsetDateTime / ZonedDateTime / ZoneOffset
+        // field used to trigger StackOverflowError when building the schema
+        JsonSchemaElement jsonSchemaElement = jsonSchemaElementFrom(
+                MyClassWithJavaTimeFields.class, null, null, true, new LinkedHashMap<>());
+
+        // then
+        assertThat(jsonSchemaElement)
+                .isEqualTo(JsonObjectSchema.builder()
+                        .addStringProperty(
+                                "createdAt", "String in ISO-8601 instant format, e.g. '2007-12-03T10:15:30.00Z'")
+                        .addStringProperty("birthDate", "String in ISO-8601 date format, e.g. '2007-12-03'")
+                        .addStringProperty(
+                                "localTimestamp",
+                                "String in ISO-8601 local date-time format, e.g. '2007-12-03T10:15:30'")
+                        .addStringProperty(
+                                "updatedAt",
+                                "String in ISO-8601 offset date-time format, e.g. '2007-12-03T10:15:30+01:00'")
+                        .addStringProperty(
+                                "scheduledAt",
+                                "String in ISO-8601 zoned date-time format, e.g. '2007-12-03T10:15:30+01:00[Europe/Paris]'")
+                        .addStringProperty("offset", "String representing a zone offset, e.g. '+01:00'")
+                        .required("createdAt", "birthDate", "localTimestamp", "updatedAt", "scheduledAt", "offset")
+                        .build());
+    }
+
+    static class MyClassWithDescribedOffsetDateTime {
+
+        @Description("When the record was last updated")
+        OffsetDateTime updatedAt;
+    }
+
+    @Test
+    void should_use_non_null_description_for_java_time() {
+
+        // when
+        JsonSchemaElement jsonSchemaElement =
+                jsonSchemaElementFrom(MyClassWithDescribedOffsetDateTime.class, null, null, true, new LinkedHashMap<>());
+
+        // then
+        assertThat(jsonSchemaElement)
+                .isEqualTo(JsonObjectSchema.builder()
+                        .addStringProperty("updatedAt", "When the record was last updated")
+                        .required("updatedAt")
                         .build());
     }
 
@@ -277,6 +386,13 @@ class JsonSchemaElementUtilsTest {
         assertThat(isJsonString(StringBuilder.class)).isTrue();
         assertThat(isJsonString(CharSequence.class)).isTrue();
         assertThat(isJsonString(UUID.class)).isTrue();
+
+        assertThat(isJsonString(Instant.class)).isTrue();
+        assertThat(isJsonString(LocalDate.class)).isTrue();
+        assertThat(isJsonString(LocalDateTime.class)).isTrue();
+        assertThat(isJsonString(OffsetDateTime.class)).isTrue();
+        assertThat(isJsonString(ZonedDateTime.class)).isTrue();
+        assertThat(isJsonString(ZoneOffset.class)).isTrue();
     }
 
     @Test

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonSchemaElementUtilsTest.java
@@ -207,8 +207,8 @@ class JsonSchemaElementUtilsTest {
 
         // when - regression test: an OffsetDateTime / ZonedDateTime / ZoneOffset
         // field used to trigger StackOverflowError when building the schema
-        JsonSchemaElement jsonSchemaElement = jsonSchemaElementFrom(
-                MyClassWithJavaTimeFields.class, null, null, true, new LinkedHashMap<>());
+        JsonSchemaElement jsonSchemaElement =
+                jsonSchemaElementFrom(MyClassWithJavaTimeFields.class, null, null, true, new LinkedHashMap<>());
 
         // then
         assertThat(jsonSchemaElement)
@@ -240,8 +240,8 @@ class JsonSchemaElementUtilsTest {
     void should_use_non_null_description_for_java_time() {
 
         // when
-        JsonSchemaElement jsonSchemaElement =
-                jsonSchemaElementFrom(MyClassWithDescribedOffsetDateTime.class, null, null, true, new LinkedHashMap<>());
+        JsonSchemaElement jsonSchemaElement = jsonSchemaElementFrom(
+                MyClassWithDescribedOffsetDateTime.class, null, null, true, new LinkedHashMap<>());
 
         // then
         assertThat(jsonSchemaElement)
@@ -296,9 +296,7 @@ class JsonSchemaElementUtilsTest {
         Map<String, Object> map = toMap(person, false);
 
         // then
-        assertThat(new ObjectMapper().writeValueAsString(map))
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(new ObjectMapper().writeValueAsString(map)).isEqualToIgnoringWhitespace("""
                 {
                    "type":"object",
                    "properties":{
@@ -330,9 +328,7 @@ class JsonSchemaElementUtilsTest {
         Map<String, Object> map = toMap(person, true);
 
         // then
-        assertThat(new ObjectMapper().writeValueAsString(map))
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(new ObjectMapper().writeValueAsString(map)).isEqualToIgnoringWhitespace("""
                 {
                    "type":"object",
                    "properties":{
@@ -354,8 +350,7 @@ class JsonSchemaElementUtilsTest {
     @Test
     void nativeSchemaToMap() throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
-        String rawJsonSchema =
-                """
+        String rawJsonSchema = """
         {
             "additionalProperties": false,
             "type" : "object",
@@ -413,16 +408,17 @@ class JsonSchemaElementUtilsTest {
 
         // given
         enum MyEnum {
-            A, B, C;
+            A,
+            B,
+            C;
         }
 
         // when
         JsonSchemaElement schema = jsonSchemaElementFrom(MyEnum.class);
 
         // then
-        assertThat(schema).isEqualTo(JsonEnumSchema.builder()
-                .enumValues("A", "B", "C")
-                .build());
+        assertThat(schema)
+                .isEqualTo(JsonEnumSchema.builder().enumValues("A", "B", "C").build());
     }
 
     @Test
@@ -430,7 +426,9 @@ class JsonSchemaElementUtilsTest {
 
         // given
         enum MyEnumWithToString {
-            A, B, C;
+            A,
+            B,
+            C;
 
             @Override
             public String toString() {
@@ -444,61 +442,48 @@ class JsonSchemaElementUtilsTest {
         JsonSchemaElement schema = jsonSchemaElementFrom(MyEnumWithToString.class);
 
         // then
-        assertThat(schema).isEqualTo(JsonEnumSchema.builder()
-                .enumValues("A", "B", "C")
-                .build());
+        assertThat(schema)
+                .isEqualTo(JsonEnumSchema.builder().enumValues("A", "B", "C").build());
     }
 
     @Test
     void shouldConvertJsonStringSchemaToMap() {
-        JsonStringSchema schema = JsonStringSchema.builder()
-                .description("string description")
-                .build();
+        JsonStringSchema schema =
+                JsonStringSchema.builder().description("string description").build();
 
         Map<String, Object> map = JsonSchemaElementUtils.toMap(schema);
 
-        assertThat(map)
-                .containsEntry("type", "string")
-                .containsEntry("description", "string description");
+        assertThat(map).containsEntry("type", "string").containsEntry("description", "string description");
     }
 
     @Test
     void shouldConvertJsonIntegerSchemaToMap() {
-        JsonIntegerSchema schema = JsonIntegerSchema.builder()
-                .description("integer description")
-                .build();
+        JsonIntegerSchema schema =
+                JsonIntegerSchema.builder().description("integer description").build();
 
         Map<String, Object> map = JsonSchemaElementUtils.toMap(schema);
 
-        assertThat(map)
-                .containsEntry("type", "integer")
-                .containsEntry("description", "integer description");
+        assertThat(map).containsEntry("type", "integer").containsEntry("description", "integer description");
     }
 
     @Test
     void shouldConvertJsonNumberSchemaToMap() {
-        JsonNumberSchema schema = JsonNumberSchema.builder()
-                .description("number description")
-                .build();
+        JsonNumberSchema schema =
+                JsonNumberSchema.builder().description("number description").build();
 
         Map<String, Object> map = JsonSchemaElementUtils.toMap(schema);
 
-        assertThat(map)
-                .containsEntry("type", "number")
-                .containsEntry("description", "number description");
+        assertThat(map).containsEntry("type", "number").containsEntry("description", "number description");
     }
 
     @Test
     void shouldConvertJsonBooleanSchemaToMap() {
-        JsonBooleanSchema schema = JsonBooleanSchema.builder()
-                .description("boolean description")
-                .build();
+        JsonBooleanSchema schema =
+                JsonBooleanSchema.builder().description("boolean description").build();
 
         Map<String, Object> map = JsonSchemaElementUtils.toMap(schema);
 
-        assertThat(map)
-                .containsEntry("type", "boolean")
-                .containsEntry("description", "boolean description");
+        assertThat(map).containsEntry("type", "boolean").containsEntry("description", "boolean description");
     }
 
     @Test
@@ -555,9 +540,8 @@ class JsonSchemaElementUtilsTest {
 
     @Test
     void shouldConvertJsonReferenceSchemaToMap() {
-        JsonReferenceSchema schema = JsonReferenceSchema.builder()
-                .reference("my-ref")
-                .build();
+        JsonReferenceSchema schema =
+                JsonReferenceSchema.builder().reference("my-ref").build();
 
         Map<String, Object> map = JsonSchemaElementUtils.toMap(schema);
 
@@ -569,8 +553,7 @@ class JsonSchemaElementUtilsTest {
         JsonAnyOfSchema schema = JsonAnyOfSchema.builder()
                 .anyOf(Arrays.asList(
                         JsonSchemaElementUtils.jsonSchemaElementFrom(String.class),
-                        JsonSchemaElementUtils.jsonSchemaElementFrom(Integer.class)
-                ))
+                        JsonSchemaElementUtils.jsonSchemaElementFrom(Integer.class)))
                 .description("anyOf description")
                 .build();
 
@@ -597,7 +580,8 @@ class JsonSchemaElementUtilsTest {
     @Test
     void shouldConvertJsonRawSchemaToMap() {
         Map<String, Object> rawMap = Map.of("foo", "bar");
-        JsonRawSchema schema = JsonRawSchema.builder().schema(Json.toJson(rawMap)).build();
+        JsonRawSchema schema =
+                JsonRawSchema.builder().schema(Json.toJson(rawMap)).build();
 
         Map<String, Object> map = JsonSchemaElementUtils.toMap(schema);
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -211,7 +211,8 @@ public class DefaultToolExecutor implements ToolExecutor {
             return List.of(ImageContent.from(image));
         } else if (result instanceof Content content) {
             return List.of(content);
-        } else if (result instanceof Collection<?> collection && !collection.isEmpty()
+        } else if (result instanceof Collection<?> collection
+                && !collection.isEmpty()
                 && collection.iterator().next() instanceof Content) {
             return collection.stream().map(Content.class::cast).toList();
         } else if (result instanceof Content[] array) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -25,14 +25,50 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 
 public class DefaultToolExecutor implements ToolExecutor {
+
+    /**
+     * Top-level scalar parsers for java.time parameters. The LLM passes these as raw ISO-8601
+     * strings (not JSON-quoted), so {@code Json.fromJson} would fail; we parse them directly.
+     * Mirrors the explicit {@link UUID} branch below.
+     */
+    private static final Map<Class<?>, Function<String, ?>> JAVA_TIME_PARSERS = Map.ofEntries(
+            Map.entry(Instant.class, Instant::parse),
+            Map.entry(LocalDate.class, LocalDate::parse),
+            Map.entry(LocalTime.class, LocalTime::parse),
+            Map.entry(LocalDateTime.class, LocalDateTime::parse),
+            Map.entry(OffsetTime.class, OffsetTime::parse),
+            Map.entry(OffsetDateTime.class, OffsetDateTime::parse),
+            Map.entry(ZonedDateTime.class, ZonedDateTime::parse),
+            Map.entry(Duration.class, Duration::parse),
+            Map.entry(Period.class, Period::parse),
+            Map.entry(Year.class, Year::parse),
+            Map.entry(YearMonth.class, YearMonth::parse),
+            Map.entry(MonthDay.class, MonthDay::parse),
+            Map.entry(ZoneId.class, ZoneId::of),
+            Map.entry(ZoneOffset.class, (Function<String, ?>) ZoneOffset::of));
 
     private final Object object;
     private final Method originalMethod;
@@ -347,6 +383,11 @@ public class DefaultToolExecutor implements ToolExecutor {
 
         if (parameterClass == UUID.class) {
             return UUID.fromString(argument.toString());
+        }
+
+        Function<String, ?> javaTimeParser = JAVA_TIME_PARSERS.get(parameterClass);
+        if (javaTimeParser != null) {
+            return javaTimeParser.apply(argument.toString());
         }
 
         if (argument instanceof String) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -13,6 +13,20 @@ import dev.langchain4j.invocation.InvocationContext;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -281,6 +295,50 @@ class DefaultToolExecutorTest implements WithAssertions {
                         List.class,
                         new TypeReference<Map<String, Integer>>() {}.getType()))
                 .isEqualTo(singletonMap("A", 1));
+    }
+
+    @Test
+    void coerce_argument_java_time() {
+
+        // ISO-8601 strings produced by an LLM coerced to the matching java.time type.
+        assertThat(coerceArgument("2007-12-03T10:15:30.00Z", "arg", Instant.class, null))
+                .isEqualTo(Instant.parse("2007-12-03T10:15:30.00Z"));
+
+        assertThat(coerceArgument("2007-12-03", "arg", LocalDate.class, null))
+                .isEqualTo(LocalDate.of(2007, 12, 3));
+
+        assertThat(coerceArgument("10:15:30", "arg", LocalTime.class, null))
+                .isEqualTo(LocalTime.of(10, 15, 30));
+
+        assertThat(coerceArgument("2007-12-03T10:15:30", "arg", LocalDateTime.class, null))
+                .isEqualTo(LocalDateTime.of(2007, 12, 3, 10, 15, 30));
+
+        assertThat(coerceArgument("10:15:30+01:00", "arg", OffsetTime.class, null))
+                .isEqualTo(OffsetTime.parse("10:15:30+01:00"));
+
+        assertThat(coerceArgument("2007-12-03T10:15:30+01:00", "arg", OffsetDateTime.class, null))
+                .isEqualTo(OffsetDateTime.parse("2007-12-03T10:15:30+01:00"));
+
+        assertThat(coerceArgument("2007-12-03T10:15:30+01:00[Europe/Paris]", "arg", ZonedDateTime.class, null))
+                .isEqualTo(ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]"));
+
+        assertThat(coerceArgument("PT15M", "arg", Duration.class, null)).isEqualTo(Duration.ofMinutes(15));
+
+        assertThat(coerceArgument("P1Y2M3D", "arg", Period.class, null)).isEqualTo(Period.of(1, 2, 3));
+
+        assertThat(coerceArgument("2007", "arg", Year.class, null)).isEqualTo(Year.of(2007));
+
+        assertThat(coerceArgument("2007-12", "arg", YearMonth.class, null))
+                .isEqualTo(YearMonth.of(2007, 12));
+
+        assertThat(coerceArgument("--12-03", "arg", MonthDay.class, null))
+                .isEqualTo(MonthDay.of(12, 3));
+
+        assertThat(coerceArgument("Europe/Paris", "arg", ZoneId.class, null))
+                .isEqualTo(ZoneId.of("Europe/Paris"));
+
+        assertThat(coerceArgument("+01:00", "arg", ZoneOffset.class, null))
+                .isEqualTo(ZoneOffset.of("+01:00"));
     }
 
     private static class TestTool {

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -304,11 +304,9 @@ class DefaultToolExecutorTest implements WithAssertions {
         assertThat(coerceArgument("2007-12-03T10:15:30.00Z", "arg", Instant.class, null))
                 .isEqualTo(Instant.parse("2007-12-03T10:15:30.00Z"));
 
-        assertThat(coerceArgument("2007-12-03", "arg", LocalDate.class, null))
-                .isEqualTo(LocalDate.of(2007, 12, 3));
+        assertThat(coerceArgument("2007-12-03", "arg", LocalDate.class, null)).isEqualTo(LocalDate.of(2007, 12, 3));
 
-        assertThat(coerceArgument("10:15:30", "arg", LocalTime.class, null))
-                .isEqualTo(LocalTime.of(10, 15, 30));
+        assertThat(coerceArgument("10:15:30", "arg", LocalTime.class, null)).isEqualTo(LocalTime.of(10, 15, 30));
 
         assertThat(coerceArgument("2007-12-03T10:15:30", "arg", LocalDateTime.class, null))
                 .isEqualTo(LocalDateTime.of(2007, 12, 3, 10, 15, 30));
@@ -328,17 +326,13 @@ class DefaultToolExecutorTest implements WithAssertions {
 
         assertThat(coerceArgument("2007", "arg", Year.class, null)).isEqualTo(Year.of(2007));
 
-        assertThat(coerceArgument("2007-12", "arg", YearMonth.class, null))
-                .isEqualTo(YearMonth.of(2007, 12));
+        assertThat(coerceArgument("2007-12", "arg", YearMonth.class, null)).isEqualTo(YearMonth.of(2007, 12));
 
-        assertThat(coerceArgument("--12-03", "arg", MonthDay.class, null))
-                .isEqualTo(MonthDay.of(12, 3));
+        assertThat(coerceArgument("--12-03", "arg", MonthDay.class, null)).isEqualTo(MonthDay.of(12, 3));
 
-        assertThat(coerceArgument("Europe/Paris", "arg", ZoneId.class, null))
-                .isEqualTo(ZoneId.of("Europe/Paris"));
+        assertThat(coerceArgument("Europe/Paris", "arg", ZoneId.class, null)).isEqualTo(ZoneId.of("Europe/Paris"));
 
-        assertThat(coerceArgument("+01:00", "arg", ZoneOffset.class, null))
-                .isEqualTo(ZoneOffset.of("+01:00"));
+        assertThat(coerceArgument("+01:00", "arg", ZoneOffset.class, null)).isEqualTo(ZoneOffset.of("+01:00"));
     }
 
     private static class TestTool {
@@ -506,9 +500,7 @@ class DefaultToolExecutorTest implements WithAssertions {
                 .build();
         DefaultToolExecutor toolExecutor2 = new DefaultToolExecutor(new PersonTool(), request2);
         String result2 = toolExecutor2.execute(request2, "DEFAULT");
-        assertThat(result2)
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(result2).isEqualToIgnoringWhitespace("""
                 [
                   {
                     "name": "Klaus",
@@ -527,9 +519,7 @@ class DefaultToolExecutorTest implements WithAssertions {
                 .build();
         DefaultToolExecutor toolExecutor3 = new DefaultToolExecutor(new PersonTool(), request3);
         String result3 = toolExecutor3.execute(request3, "DEFAULT");
-        assertThat(result3)
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(result3).isEqualToIgnoringWhitespace("""
                 [
                   {
                     "name": "Peter",
@@ -549,9 +539,7 @@ class DefaultToolExecutorTest implements WithAssertions {
                 .build();
         DefaultToolExecutor toolExecutor4 = new DefaultToolExecutor(new PersonTool(), request4);
         String result4 = toolExecutor4.execute(request4, "DEFAULT");
-        assertThat(result4)
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(result4).isEqualToIgnoringWhitespace("""
                 {
                   "p1": {
                     "name": "Klaus",
@@ -570,9 +558,7 @@ class DefaultToolExecutorTest implements WithAssertions {
                 .build();
         DefaultToolExecutor toolExecutor5 = new DefaultToolExecutor(new PersonTool(), request5);
         String result5 = toolExecutor5.execute(request5, "DEFAULT");
-        assertThat(result5)
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(result5).isEqualToIgnoringWhitespace("""
                 [
                   {
                     "name": "Klaus",


### PR DESCRIPTION
## Issue
Closes #2440 

## Change
Add support of JsonSchema for java.time classes.
There was a bug that create a stackoverflow when using any time type that refer to ZoneOffSet:
The cycle is in the JDK itself:                                                                                                                                                                                                                                                                                                                                                                                                                                         
  - java.time.ZoneOffset has field rules: ZoneRules                                                                                                                                                                                       
  - java.time.zone.ZoneRules has fields standardOffsets: ZoneOffset[] and wallOffsets: ZoneOffset[]                                                                                                                                     

ZoneOffset → ZoneRules → ZoneOffset[] → ZoneOffset → ... is an infinite cycle. LangChain4j's cycle detector at JsonSchemaElementUtils.java:97 only fires when isCustomClass(type) is true — and isCustomClass returns false for any java.* package. 

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
