### PR TITLE
fix: guard against empty choices in AzureOpenAiChatModel

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiChatModel.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiChatModel.java
@@ -4,6 +4,7 @@ import static com.azure.ai.openai.models.CompletionsFinishReason.CONTENT_FILTERE
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.copyIfNotNull;
 import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.model.ModelProvider.AZURE_OPEN_AI;
 import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.aiMessageFrom;
@@ -214,7 +215,11 @@ public class AzureOpenAiChatModel implements ChatModel {
         ChatCompletions chatCompletions = AzureOpenAiExceptionMapper.INSTANCE.withExceptionMapper(
                 () -> client.getChatCompletions(parameters.modelName(), options));
 
-        ChatChoice chatChoice = chatCompletions.getChoices().get(0);
+        List<ChatChoice> choices = chatCompletions.getChoices();
+        if (isNullOrEmpty(choices)) {
+            throw new IllegalArgumentException("Azure OpenAI returned an empty choices list");
+        }
+        ChatChoice chatChoice = choices.get(0);
 
         if (chatChoice.getFinishReason() == CONTENT_FILTERED) {
             String details;


### PR DESCRIPTION
Fixes #4814.

AzureOpenAiChatModel.doChat() now checks if choices is null or empty before accessing index 0, throwing a clear IllegalArgumentException instead of a cryptic IndexOutOfBoundsException or NullPointerException when the Azure OpenAI API returns no choices.