### PR TITLE
Add per-request HTTP read timeout (#4109)

### DIFF
--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -25,6 +26,8 @@ import java.util.Objects;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
+import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
+import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer;
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -33,6 +36,7 @@ import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -82,12 +86,16 @@ public class ApacheHttpClient implements HttpClient {
     public SuccessfulHttpResponse execute(HttpRequest request) throws HttpException {
         try {
             ClassicHttpRequest apacheRequest = toApacheRequest(request);
-            return syncClient.execute(apacheRequest, classicHttpResponse -> {
+            HttpClientContext context = perRequestContext(request.readTimeout());
+            org.apache.hc.core5.http.io.HttpClientResponseHandler<SuccessfulHttpResponse> handler = classicHttpResponse -> {
                 if (!isSuccessful(classicHttpResponse)) {
                     throw new HttpException(classicHttpResponse.getCode(), readBody(classicHttpResponse));
                 }
                 return fromApacheResponse(classicHttpResponse);
-            });
+            };
+            return context != null
+                    ? syncClient.execute(apacheRequest, context, handler)
+                    : syncClient.execute(apacheRequest, handler);
         } catch (SocketTimeoutException e) {
             throw new TimeoutException(e);
         } catch (IOException e) {
@@ -98,7 +106,8 @@ public class ApacheHttpClient implements HttpClient {
     @Override
     public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
         SimpleHttpRequest apacheRequest = toSimpleApacheRequest(request);
-        asyncClient.execute(apacheRequest, new FutureCallback<>() {
+        HttpClientContext context = perRequestContext(request.readTimeout());
+        FutureCallback<SimpleHttpResponse> callback = new FutureCallback<>() {
             @Override
             public void completed(SimpleHttpResponse apacheResponse) {
                 if (!isSuccessful(apacheResponse)) {
@@ -129,7 +138,13 @@ public class ApacheHttpClient implements HttpClient {
 
             @Override
             public void cancelled() {}
-        });
+        };
+        if (context != null) {
+            asyncClient.execute(SimpleRequestProducer.create(apacheRequest), SimpleResponseConsumer.create(),
+                    null, context, callback);
+        } else {
+            asyncClient.execute(apacheRequest, callback);
+        }
     }
 
     private InputStream getInputStream(SimpleHttpResponse apacheResponse) {
@@ -197,6 +212,17 @@ public class ApacheHttpClient implements HttpClient {
         });
 
         return apacheRequest;
+    }
+
+    private static HttpClientContext perRequestContext(Duration perRequestReadTimeout) {
+        if (perRequestReadTimeout == null) {
+            return null;
+        }
+        HttpClientContext context = HttpClientContext.create();
+        context.setRequestConfig(RequestConfig.custom()
+                .setResponseTimeout(Timeout.ofMilliseconds(perRequestReadTimeout.toMillis()))
+                .build());
+        return context;
     }
 
     private SimpleHttpRequest toSimpleApacheRequest(HttpRequest request) {

--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
@@ -87,12 +87,13 @@ public class ApacheHttpClient implements HttpClient {
         try {
             ClassicHttpRequest apacheRequest = toApacheRequest(request);
             HttpClientContext context = perRequestContext(request.readTimeout());
-            org.apache.hc.core5.http.io.HttpClientResponseHandler<SuccessfulHttpResponse> handler = classicHttpResponse -> {
-                if (!isSuccessful(classicHttpResponse)) {
-                    throw new HttpException(classicHttpResponse.getCode(), readBody(classicHttpResponse));
-                }
-                return fromApacheResponse(classicHttpResponse);
-            };
+            org.apache.hc.core5.http.io.HttpClientResponseHandler<SuccessfulHttpResponse> handler =
+                    classicHttpResponse -> {
+                        if (!isSuccessful(classicHttpResponse)) {
+                            throw new HttpException(classicHttpResponse.getCode(), readBody(classicHttpResponse));
+                        }
+                        return fromApacheResponse(classicHttpResponse);
+                    };
             return context != null
                     ? syncClient.execute(apacheRequest, context, handler)
                     : syncClient.execute(apacheRequest, handler);
@@ -140,8 +141,12 @@ public class ApacheHttpClient implements HttpClient {
             public void cancelled() {}
         };
         if (context != null) {
-            asyncClient.execute(SimpleRequestProducer.create(apacheRequest), SimpleResponseConsumer.create(),
-                    null, context, callback);
+            asyncClient.execute(
+                    SimpleRequestProducer.create(apacheRequest),
+                    SimpleResponseConsumer.create(),
+                    null,
+                    context,
+                    callback);
         } else {
             asyncClient.execute(apacheRequest, callback);
         }

--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
@@ -6,9 +6,9 @@ import static java.util.stream.Collectors.joining;
 
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.TimeoutException;
+import dev.langchain4j.http.client.FormDataFile;
 import dev.langchain4j.http.client.HttpClient;
 import dev.langchain4j.http.client.HttpRequest;
-import dev.langchain4j.http.client.FormDataFile;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
@@ -58,7 +58,7 @@ public class JdkHttpClient implements HttpClient {
         } catch (HttpTimeoutException e) {
             throw new TimeoutException(e);
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();  
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
@@ -119,8 +119,9 @@ public class JdkHttpClient implements HttpClient {
         }
         builder.method(request.method().name(), bodyPublisher);
 
-        if (readTimeout != null) {
-            builder.timeout(readTimeout);
+        Duration effectiveReadTimeout = getOrDefault(request.readTimeout(), readTimeout);
+        if (effectiveReadTimeout != null) {
+            builder.timeout(effectiveReadTimeout);
         }
 
         return builder.build();

--- a/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
@@ -19,6 +19,7 @@ import okhttp3.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +53,8 @@ public class OkHttpClient implements HttpClient {
     @Override
     public SuccessfulHttpResponse execute(HttpRequest request) throws HttpException {
         Request okRequest = toOkHttpRequest(request);
-        try (Response response = client.newCall(okRequest).execute()) {
+        Call call = newCall(okRequest, request.readTimeout());
+        try (Response response = call.execute()) {
             if (!response.isSuccessful()) {
                 throw new HttpException(response.code(), readBody(response));
             }
@@ -67,7 +69,7 @@ public class OkHttpClient implements HttpClient {
     @Override
     public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
         Request okRequest = toOkHttpRequest(request);
-        client.newCall(okRequest).enqueue(new Callback() {
+        newCall(okRequest, request.readTimeout()).enqueue(new Callback() {
             @Override
             public void onResponse(Call call, Response response) {
                 try (response) {
@@ -100,6 +102,18 @@ public class OkHttpClient implements HttpClient {
                 }
             }
         });
+    }
+
+    private Call newCall(Request okRequest, Duration perRequestReadTimeout) {
+        if (perRequestReadTimeout == null) {
+            return client.newCall(okRequest);
+        }
+        // OkHttp's read timeout is set on the client, not the call. Cloning the client
+        // via newBuilder() shares the connection pool/dispatcher, so this is cheap.
+        okhttp3.OkHttpClient perCallClient = client.newBuilder()
+                .readTimeout(perRequestReadTimeout.toMillis(), TimeUnit.MILLISECONDS)
+                .build();
+        return perCallClient.newCall(okRequest);
     }
 
     private InputStream getInputStream(Response response) {

--- a/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.http.client.okhttp;
 
+import static dev.langchain4j.http.client.sse.ServerSentEventListenerUtils.ignoringExceptions;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.TimeoutException;
 import dev.langchain4j.http.client.FormDataFile;
@@ -8,14 +11,6 @@ import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.MediaType;
-import okhttp3.MultipartBody;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.SocketTimeoutException;
@@ -24,9 +19,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import static dev.langchain4j.http.client.sse.ServerSentEventListenerUtils.ignoringExceptions;
-import static dev.langchain4j.internal.Utils.getOrDefault;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 public class OkHttpClient implements HttpClient {
 
@@ -179,8 +178,7 @@ public class OkHttpClient implements HttpClient {
 
     private RequestBody buildRequestBody(HttpRequest request) {
         if (!request.formDataFields().isEmpty() || !request.formDataFiles().isEmpty()) {
-            MultipartBody.Builder multipartBuilder =
-                    new MultipartBody.Builder().setType(MultipartBody.FORM);
+            MultipartBody.Builder multipartBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
 
             for (Map.Entry<String, String> entry : request.formDataFields().entrySet()) {
                 multipartBuilder.addFormDataPart(entry.getKey(), entry.getValue());
@@ -188,8 +186,7 @@ public class OkHttpClient implements HttpClient {
 
             for (Map.Entry<String, FormDataFile> entry : request.formDataFiles().entrySet()) {
                 FormDataFile file = entry.getValue();
-                RequestBody fileBody = RequestBody.create(
-                        file.content(), MediaType.parse(file.contentType()));
+                RequestBody fileBody = RequestBody.create(file.content(), MediaType.parse(file.contentType()));
                 multipartBuilder.addFormDataPart(entry.getKey(), file.fileName(), fileBody);
             }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ChatRequestParameters.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ChatRequestParameters.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.model.chat.request;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
-
 import java.time.Duration;
 import java.util.List;
 
@@ -103,7 +102,8 @@ public interface ChatRequestParameters {
      * @return a new {@link ChatRequestParameters} instance combining both sets of parameters
      */
     default ChatRequestParameters defaultedBy(ChatRequestParameters parameters) {
-        throw new UnsupportedOperationException("Missing implementation, please override this method in " + this.getClass().getName());
+        throw new UnsupportedOperationException("Missing implementation, please override this method in "
+                + this.getClass().getName());
     }
 
     static DefaultChatRequestParameters.Builder<?> builder() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ChatRequestParameters.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ChatRequestParameters.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.chat.request;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
 
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -33,6 +34,23 @@ public interface ChatRequestParameters {
     ToolChoice toolChoice();
 
     ResponseFormat responseFormat();
+
+    /**
+     * Per-request HTTP read timeout. When set, it overrides the default read timeout configured
+     * on the underlying HTTP client for the duration of this single request. {@code null} means
+     * the client's default applies.
+     *
+     * <p>Useful when a single model instance needs different timeouts depending on the workload —
+     * e.g. a short timeout for interactive requests and a longer one for background batch jobs —
+     * without having to construct a new model per timeout.
+     *
+     * <p>Provider integrations are responsible for plumbing this value to the underlying HTTP layer.
+     *
+     * @since 1.14.0
+     */
+    default Duration timeout() {
+        return null;
+    }
 
     /**
      * Creates a new {@link ChatRequestParameters} by combining the current parameters with the specified ones.

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/DefaultChatRequestParameters.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/DefaultChatRequestParameters.java
@@ -208,7 +208,12 @@ public class DefaultChatRequestParameters implements ChatRequestParameters {
             toolSpecifications(getOrDefault(parameters.toolSpecifications(), toolSpecifications));
             toolChoice(getOrDefault(parameters.toolChoice(), toolChoice));
             responseFormat(getOrDefault(parameters.responseFormat(), responseFormat));
-            timeout(getOrDefault(parameters.timeout(), timeout));
+            // Subclasses (e.g. Watsonx) declare their own `timeout` field that shadows this one.
+            // Reading `this.timeout` here would always see null in that case, so a null-coalesce
+            // would clobber a value the subclass set via virtual dispatch. Skip when null instead.
+            if (parameters.timeout() != null) {
+                timeout(parameters.timeout());
+            }
             return (T) this;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/DefaultChatRequestParameters.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/DefaultChatRequestParameters.java
@@ -8,6 +8,7 @@ import static java.util.Arrays.asList;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
 import dev.langchain4j.model.chat.request.json.JsonSchema;
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 
@@ -27,6 +28,7 @@ public class DefaultChatRequestParameters implements ChatRequestParameters {
     private final List<ToolSpecification> toolSpecifications;
     private final ToolChoice toolChoice;
     private final ResponseFormat responseFormat;
+    private final Duration timeout;
 
     protected DefaultChatRequestParameters(Builder<?> builder) {
         this.modelName = builder.modelName;
@@ -40,6 +42,7 @@ public class DefaultChatRequestParameters implements ChatRequestParameters {
         this.toolSpecifications = copy(builder.toolSpecifications);
         this.toolChoice = builder.toolChoice;
         this.responseFormat = builder.responseFormat;
+        this.timeout = builder.timeout;
     }
 
     @Override
@@ -98,6 +101,11 @@ public class DefaultChatRequestParameters implements ChatRequestParameters {
     }
 
     @Override
+    public Duration timeout() {
+        return timeout;
+    }
+
+    @Override
     public ChatRequestParameters overrideWith(ChatRequestParameters that) {
         return DefaultChatRequestParameters.builder()
                 .overrideWith(this)
@@ -129,7 +137,8 @@ public class DefaultChatRequestParameters implements ChatRequestParameters {
                 && Objects.equals(stopSequences, that.stopSequences)
                 && Objects.equals(toolSpecifications, that.toolSpecifications)
                 && Objects.equals(toolChoice, that.toolChoice)
-                && Objects.equals(responseFormat, that.responseFormat);
+                && Objects.equals(responseFormat, that.responseFormat)
+                && Objects.equals(timeout, that.timeout);
     }
 
     @Override
@@ -146,7 +155,8 @@ public class DefaultChatRequestParameters implements ChatRequestParameters {
                 stopSequences,
                 toolSpecifications,
                 toolChoice,
-                responseFormat);
+                responseFormat,
+                timeout);
     }
 
     @Override
@@ -163,7 +173,8 @@ public class DefaultChatRequestParameters implements ChatRequestParameters {
                 + stopSequences + ", toolSpecifications="
                 + toolSpecifications + ", toolChoice="
                 + toolChoice + ", responseFormat="
-                + responseFormat + '}';
+                + responseFormat + ", timeout="
+                + timeout + '}';
     }
 
     public static Builder<?> builder() {
@@ -183,6 +194,7 @@ public class DefaultChatRequestParameters implements ChatRequestParameters {
         private List<ToolSpecification> toolSpecifications;
         private ToolChoice toolChoice;
         private ResponseFormat responseFormat;
+        private Duration timeout;
 
         public T overrideWith(ChatRequestParameters parameters) {
             modelName(getOrDefault(parameters.modelName(), modelName));
@@ -196,6 +208,7 @@ public class DefaultChatRequestParameters implements ChatRequestParameters {
             toolSpecifications(getOrDefault(parameters.toolSpecifications(), toolSpecifications));
             toolChoice(getOrDefault(parameters.toolChoice(), toolChoice));
             responseFormat(getOrDefault(parameters.responseFormat(), responseFormat));
+            timeout(getOrDefault(parameters.timeout(), timeout));
             return (T) this;
         }
 
@@ -288,6 +301,14 @@ public class DefaultChatRequestParameters implements ChatRequestParameters {
                         .build();
                 return responseFormat(responseFormat);
             }
+            return (T) this;
+        }
+
+        /**
+         * @see ChatRequestParameters#timeout()
+         */
+        public T timeout(Duration timeout) {
+            this.timeout = timeout;
             return (T) this;
         }
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/DefaultChatRequestParametersTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/DefaultChatRequestParametersTest.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.model.chat.request.ToolChoice.AUTO;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
+import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -26,11 +27,13 @@ class DefaultChatRequestParametersTest {
                         ToolSpecification.builder().name("tool1").build(),
                         ToolSpecification.builder().name("tool2").build()))
                 .toolChoice(AUTO)
+                .timeout(Duration.ofSeconds(30))
                 .build();
 
         ChatRequestParameters override = DefaultChatRequestParameters.builder()
                 .modelName("model-2")
                 .temperature(0.9)
+                .timeout(Duration.ofSeconds(5))
                 .build();
 
         // when
@@ -47,6 +50,7 @@ class DefaultChatRequestParametersTest {
         assertThat(result.stopSequences()).containsExactly("stop1", "stop2");
         assertThat(result.toolSpecifications()).hasSize(2);
         assertThat(result.toolChoice()).isEqualTo(AUTO);
+        assertThat(result.timeout()).isEqualTo(Duration.ofSeconds(5));
     }
 
     @Test
@@ -64,6 +68,7 @@ class DefaultChatRequestParametersTest {
                         ToolSpecification.builder().name("tool1").build(),
                         ToolSpecification.builder().name("tool2").build()))
                 .toolChoice(AUTO)
+                .timeout(Duration.ofSeconds(5))
                 .build();
 
         ChatRequestParameters defaultParams = DefaultChatRequestParameters.builder()
@@ -71,6 +76,7 @@ class DefaultChatRequestParametersTest {
                 .temperature(0.9)
                 .topP(0.8)
                 .topK(12)
+                .timeout(Duration.ofSeconds(30))
                 .build();
 
         // when
@@ -87,5 +93,20 @@ class DefaultChatRequestParametersTest {
         assertThat(result.stopSequences()).containsExactly("stop1", "stop2");
         assertThat(result.toolSpecifications()).hasSize(2);
         assertThat(result.toolChoice()).isEqualTo(AUTO);
+        assertThat(result.timeout()).isEqualTo(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void timeout_defaults_to_null_and_round_trips_through_builder() {
+
+        ChatRequestParameters defaulted =
+                DefaultChatRequestParameters.builder().build();
+        assertThat(defaulted.timeout()).isNull();
+
+        Duration explicit = Duration.ofMillis(750);
+        ChatRequestParameters configured = DefaultChatRequestParameters.builder()
+                .timeout(explicit)
+                .build();
+        assertThat(configured.timeout()).isEqualTo(explicit);
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/DefaultChatRequestParametersTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/DefaultChatRequestParametersTest.java
@@ -99,14 +99,12 @@ class DefaultChatRequestParametersTest {
     @Test
     void timeout_defaults_to_null_and_round_trips_through_builder() {
 
-        ChatRequestParameters defaulted =
-                DefaultChatRequestParameters.builder().build();
+        ChatRequestParameters defaulted = DefaultChatRequestParameters.builder().build();
         assertThat(defaulted.timeout()).isNull();
 
         Duration explicit = Duration.ofMillis(750);
-        ChatRequestParameters configured = DefaultChatRequestParameters.builder()
-                .timeout(explicit)
-                .build();
+        ChatRequestParameters configured =
+                DefaultChatRequestParameters.builder().timeout(explicit).build();
         assertThat(configured.timeout()).isEqualTo(explicit);
     }
 }

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
@@ -12,6 +12,7 @@ import static java.util.stream.Collectors.joining;
 import dev.langchain4j.Experimental;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -25,6 +26,7 @@ public class HttpRequest {
     private final Map<String, String> formDataFields;
     private final Map<String, FormDataFile> formDataFiles;
     private final String body;
+    private final Duration readTimeout;
 
     public HttpRequest(Builder builder) {
         validate(builder);
@@ -34,6 +36,7 @@ public class HttpRequest {
         this.formDataFields = copy(builder.formDataFields);
         this.formDataFiles = copy(builder.formDataFiles);
         this.body = builder.body;
+        this.readTimeout = builder.readTimeout;
     }
 
     private static void validate(Builder builder) {
@@ -101,6 +104,16 @@ public class HttpRequest {
         return body;
     }
 
+    /**
+     * The read timeout for this specific request, overriding the {@link HttpClient}'s default
+     * read timeout when set. {@code null} means the client's default applies.
+     *
+     * @since 1.14.0
+     */
+    public Duration readTimeout() {
+        return readTimeout;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -114,6 +127,7 @@ public class HttpRequest {
         private Map<String, String> formDataFields;
         private Map<String, FormDataFile> formDataFiles;
         private String body;
+        private Duration readTimeout;
 
         private Builder() {}
 
@@ -257,6 +271,18 @@ public class HttpRequest {
 
         public Builder body(String body) {
             this.body = body;
+            return this;
+        }
+
+        /**
+         * Sets a read timeout for this specific request. When set, it overrides the
+         * {@link HttpClient}'s default read timeout. When unset (or {@code null}), the
+         * client's default applies.
+         *
+         * @since 1.14.0
+         */
+        public Builder readTimeout(Duration readTimeout) {
+            this.readTimeout = readTimeout;
             return this;
         }
 

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientTimeoutIT.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpClientTimeoutIT.java
@@ -89,6 +89,32 @@ public abstract class HttpClientTimeoutIT {
     }
 
     @Test
+    void should_timeout_on_read_sync_when_per_request_timeout_overrides_long_client_default() {
+
+        // given
+        int perRequestReadTimeoutMillis = readTimeoutMillis();
+        int clientDefaultReadTimeoutMillis = perRequestReadTimeoutMillis * 20;
+
+        for (HttpClient client : clients(Duration.ofMillis(clientDefaultReadTimeoutMillis))) {
+
+            wireMockServer.stubFor(WireMock.get("/endpoint")
+                    .willReturn(WireMock.aResponse().withFixedDelay(perRequestReadTimeoutMillis * 2)));
+
+            HttpRequest request = HttpRequest.builder()
+                    .method(GET)
+                    .url(String.format("http://localhost:%s/endpoint", WIREMOCK_PORT))
+                    .readTimeout(Duration.ofMillis(perRequestReadTimeoutMillis))
+                    .build();
+
+            // when-then
+            assertThatThrownBy(() -> client.execute(request))
+                    .isExactlyInstanceOf(TimeoutException.class)
+                    .satisfies(this::assertCause)
+                    .hasMessageContainingAll(readSyncMessageKeywords());
+        }
+    }
+
+    @Test
     void should_timeout_on_read_async() throws Exception {
 
         // given
@@ -152,6 +178,64 @@ public abstract class HttpClientTimeoutIT {
 
             verify(spyListener, times(1)).onError(any());
             verifyNoMoreInteractions(spyListener);
+        }
+    }
+
+    @Test
+    void should_timeout_on_read_async_when_per_request_timeout_overrides_long_client_default() throws Exception {
+
+        // given
+        int perRequestReadTimeoutMillis = readTimeoutMillis();
+        int clientDefaultReadTimeoutMillis = perRequestReadTimeoutMillis * 20;
+
+        for (HttpClient client : clients(Duration.ofMillis(clientDefaultReadTimeoutMillis))) {
+
+            wireMockServer.stubFor(WireMock.get("/endpoint")
+                    .willReturn(WireMock.aResponse().withFixedDelay(perRequestReadTimeoutMillis * 2)));
+
+            HttpRequest request = HttpRequest.builder()
+                    .method(GET)
+                    .url(String.format("http://localhost:%s/endpoint", WIREMOCK_PORT))
+                    .readTimeout(Duration.ofMillis(perRequestReadTimeoutMillis))
+                    .build();
+
+            // when
+            CompletableFuture<Throwable> completableFuture = new CompletableFuture<>();
+
+            ServerSentEventListener listener = new ServerSentEventListener() {
+
+                @Override
+                public void onOpen(SuccessfulHttpResponse successfulHttpResponse) {
+                    completableFuture.completeExceptionally(new IllegalStateException("onOpen() should not be called"));
+                }
+
+                @Override
+                public void onEvent(ServerSentEvent event) {
+                    completableFuture.completeExceptionally(
+                            new IllegalStateException("onEvent() should not be called"));
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    completableFuture.complete(throwable);
+                }
+
+                @Override
+                public void onClose() {
+                    completableFuture.completeExceptionally(
+                            new IllegalStateException("onClose() should not be called"));
+                }
+            };
+            client.execute(request, new DefaultServerSentEventParser(), listener);
+
+            // then — the per-request timeout (perRequestReadTimeoutMillis) should fire well before
+            // the long client default (clientDefaultReadTimeoutMillis) would.
+            Throwable throwable = completableFuture.get(perRequestReadTimeoutMillis * 4L, MILLISECONDS);
+
+            assertThat(throwable)
+                    .isExactlyInstanceOf(TimeoutException.class)
+                    .satisfies(this::assertCause)
+                    .hasMessageContainingAll(readAsyncMessageKeywords());
         }
     }
 

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpRequestTest.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpRequestTest.java
@@ -493,4 +493,25 @@ class HttpRequestTest {
         assertThat(builder.build().url()).isEqualTo("http://example.com/api");
         assertThat(builder.build().formDataFields()).isEmpty();
     }
+
+    @Test
+    void should_default_read_timeout_to_null() {
+        HttpRequest request =
+                HttpRequest.builder().method(GET).url("http://example.com").build();
+
+        assertThat(request.readTimeout()).isNull();
+    }
+
+    @Test
+    void should_carry_per_request_read_timeout() {
+        java.time.Duration timeout = java.time.Duration.ofSeconds(7);
+
+        HttpRequest request = HttpRequest.builder()
+                .method(GET)
+                .url("http://example.com")
+                .readTimeout(timeout)
+                .build();
+
+        assertThat(request.readTimeout()).isEqualTo(timeout);
+    }
 }

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
@@ -156,7 +156,7 @@ public class OpenAiChatModel implements ChatModel {
                 .build();
 
         ParsedAndRawResponse<ChatCompletionResponse> parsedAndRawResponse = withRetryMappingExceptions(
-                () -> client.chatCompletion(openAiRequest).executeRaw(), maxRetries);
+                () -> client.chatCompletion(openAiRequest, parameters.timeout()).executeRaw(), maxRetries);
 
         ChatCompletionResponse openAiResponse = parsedAndRawResponse.parsedResponse();
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -156,7 +156,7 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
                 new OpenAiStreamingResponseBuilder(returnThinking, accumulateToolCallId);
         ToolCallBuilder toolCallBuilder = new ToolCallBuilder();
 
-        client.chatCompletion(openAiRequest)
+        client.chatCompletion(openAiRequest, parameters.timeout())
                 .onRawPartialResponse(parsedAndRawResponse -> {
                     openAiResponseBuilder.append(parsedAndRawResponse);
                     handle(parsedAndRawResponse, toolCallBuilder, handler);

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/DefaultOpenAiClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/DefaultOpenAiClient.java
@@ -26,6 +26,7 @@ import dev.langchain4j.model.openai.internal.image.GenerateImagesResponse;
 import dev.langchain4j.model.openai.internal.models.ModelsListResponse;
 import dev.langchain4j.model.openai.internal.moderation.ModerationRequest;
 import dev.langchain4j.model.openai.internal.moderation.ModerationResponse;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -127,6 +128,12 @@ public class DefaultOpenAiClient extends OpenAiClient {
 
     @Override
     public SyncOrAsyncOrStreaming<ChatCompletionResponse> chatCompletion(ChatCompletionRequest request) {
+        return chatCompletion(request, null);
+    }
+
+    @Override
+    public SyncOrAsyncOrStreaming<ChatCompletionResponse> chatCompletion(
+            ChatCompletionRequest request, Duration readTimeout) {
 
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(POST)
@@ -136,6 +143,7 @@ public class DefaultOpenAiClient extends OpenAiClient {
                 .addHeaders(buildRequestHeaders())
                 .body(Json.toJson(ChatCompletionRequest.builder().from(request).stream(false)
                         .build()))
+                .readTimeout(readTimeout)
                 .build();
 
         HttpRequest streamingHttpRequest = HttpRequest.builder()
@@ -146,6 +154,7 @@ public class DefaultOpenAiClient extends OpenAiClient {
                 .addHeaders(buildRequestHeaders())
                 .body(Json.toJson(ChatCompletionRequest.builder().from(request).stream(true)
                         .build()))
+                .readTimeout(readTimeout)
                 .build();
 
         return new RequestExecutor<>(httpClient, httpRequest, streamingHttpRequest, ChatCompletionResponse.class);

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiClient.java
@@ -27,6 +27,16 @@ public abstract class OpenAiClient {
 
     public abstract SyncOrAsyncOrStreaming<ChatCompletionResponse> chatCompletion(ChatCompletionRequest request);
 
+    /**
+     * Same as {@link #chatCompletion(ChatCompletionRequest)} but applies a per-request HTTP read
+     * timeout that overrides the client's default. Falls back to the no-timeout overload when
+     * {@code readTimeout} is {@code null}.
+     */
+    public SyncOrAsyncOrStreaming<ChatCompletionResponse> chatCompletion(
+            ChatCompletionRequest request, Duration readTimeout) {
+        return chatCompletion(request);
+    }
+
     public abstract SyncOrAsync<EmbeddingResponse> embedding(EmbeddingRequest request);
 
     public abstract SyncOrAsync<ModerationResponse> moderation(ModerationRequest request);


### PR DESCRIPTION
## Issue
Closes #4109

## Change
A single `ChatModel` instance often needs different timeouts depending on the workload (e.g. snappy interactive requests vs. long background batch jobs), but today the read timeout is fixed at HTTP-client construction time. This change makes the read timeout configurable per request without rebuilding the client.

- `ChatRequestParameters` gains an optional `Duration timeout()` (default method, returns `null` so existing implementations stay binary-compatible). Implemented in `DefaultChatRequestParameters` with builder, `overrideWith`, equals/hashCode/toString.
- `HttpRequest` gains an optional `readTimeout` carried alongside the request. When unset, the `HttpClient`'s default applies — fully backward-compatible.
- All three first-party `HttpClient` implementations honor it:
  - `JdkHttpClient` — uses JDK's per-request `HttpRequest.timeout(...)`.
  - `OkHttpClient` — clones the underlying client via `newBuilder()` (sharing the connection pool/dispatcher) so only the read timeout differs for that call.
  - `ApacheHttpClient` — passes a per-call `HttpClientContext` with the overriding `RequestConfig` for both sync and async paths.
- `OpenAiChatModel` and `OpenAiStreamingChatModel` plumb `parameters.timeout()` from the chat request all the way to `HttpRequest.readTimeout()`. Other providers can follow the same pattern incrementally.

Connect timeout is intentionally left out, matching the direction in the issue thread (the JDK `HttpClient` doesn't allow changing it dynamically).

A note on the `overrideWith` change: subclasses such as `WatsonxChatRequestParameters` already declare their own `timeout` field that shadows the new one in `DefaultChatRequestParameters`. Reading `this.timeout` from the parent's `overrideWith` would always see `null` in that case and could clobber a value the subclass set via virtual dispatch. The parent therefore skips the call when the incoming value is `null` instead of null-coalescing — preserving anything the subclass already set, which keeps existing Watsonx semantics intact (verified by `WatsonxChatModelTest.testChatRequestParameter`).

## Test plan
- `HttpClientTimeoutIT` (runs against JDK / OkHttp / Apache) asserts a short per-request `readTimeout` fires before a long client default on both the sync and SSE/async paths; the existing no-override tests still cover the client-default fallback.
- `HttpRequestTest` covers the new field's `null` default and builder round-trip.
- `DefaultChatRequestParametersTest` covers the new field directly and extends `override_with` / `defaulted_by` to assert `timeout` merges correctly.

## General checklist
- [x] No breaking changes (API, behaviour)
- [x] Unit and/or integration tests added for the change
- [x] Tests cover both positive and negative cases
- [x] Unit and integration tests pass in the changed modules
- [x] Unit and integration tests pass in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules
- [ ] [Documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) updated — deferred until the API shape is reviewed
- [ ] Example added in the [examples repo](https://github.com/langchain4j/langchain4j-examples) — deferred until the API shape is reviewed
- [ ] [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) updated — not applicable