### PR TITLE
fix: read ReturnBehavior from ToolServiceContext in streaming handler

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -5,9 +5,6 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.service.AiServiceParamsUtil.chatRequestParameters;
 import static dev.langchain4j.service.tool.ToolService.refreshDynamicProviders;
 
-import dev.langchain4j.service.tool.ToolService;
-import dev.langchain4j.service.tool.search.ToolSearchService;
-
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ReturnBehavior;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -43,7 +40,9 @@ import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolService;
 import dev.langchain4j.service.tool.ToolServiceContext;
+import dev.langchain4j.service.tool.search.ToolSearchService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -310,7 +309,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                                 toResultMessage(toolRequest, toolResult);
                         addToMemory(toolExecutionResultMessage);
                         anyToolErrored = anyToolErrored || toolResult.isError();
-                        returnBehaviors.add(context.toolService.returnBehavior(toolRequest.name()));
+                        returnBehaviors.add(toolServiceContext.returnBehavior(toolRequest.name()));
                     } catch (ExecutionException e) {
                         if (e.getCause() instanceof RuntimeException re) {
                             throw re;
@@ -328,11 +327,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     toolResults.add(toolResult);
                     ToolRequestResult toolRequestResult = new ToolRequestResult(toolRequest, toolResult);
                     fireToolExecutedEvent(toolRequestResult);
-                    ToolExecutionResultMessage toolExecutionResultMessage =
-                            toResultMessage(toolRequest, toolResult);
+                    ToolExecutionResultMessage toolExecutionResultMessage = toResultMessage(toolRequest, toolResult);
                     addToMemory(toolExecutionResultMessage);
                     anyToolErrored = anyToolErrored || toolResult.isError();
-                    returnBehaviors.add(context.toolService.returnBehavior(toolRequest.name()));
+                    returnBehaviors.add(toolServiceContext.returnBehavior(toolRequest.name()));
                 }
             }
 
@@ -348,11 +346,12 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
             List<ChatMessage> messages = messagesToSend(invocationContext.chatMemoryId());
 
-            ToolServiceContext updatedToolContext = refreshDynamicProviders(toolServiceContext, messages, invocationContext);
+            ToolServiceContext updatedToolContext =
+                    refreshDynamicProviders(toolServiceContext, messages, invocationContext);
             updatedToolContext = ToolSearchService.addFoundTools(updatedToolContext, toolResults);
 
-            ChatRequestParameters parameters = chatRequestParameters(invocationContext.methodArguments(),
-                    updatedToolContext.effectiveTools());
+            ChatRequestParameters parameters =
+                    chatRequestParameters(invocationContext.methodArguments(), updatedToolContext.effectiveTools());
 
             ChatRequest nextChatRequest = context.chatRequestTransformer.apply(
                     ChatRequest.builder()

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingProgrammaticCreatedImmediateReturnToolTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingProgrammaticCreatedImmediateReturnToolTest.java
@@ -1,0 +1,101 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ReturnBehavior;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.TokenStream;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for the streaming counterpart of
+ * {@link ProgrammaticCreatedImmediateReturnToolTest}: a tool supplied via
+ * {@link ToolProvider} with {@link ReturnBehavior#IMMEDIATE} must short-circuit the
+ * tool-execution loop in the streaming path as well.
+ */
+class StreamingProgrammaticCreatedImmediateReturnToolTest {
+
+    interface Assistant {
+        TokenStream chat(String userMessage);
+    }
+
+    @Test
+    void should_execute_dynamic_tool_with_immediate_return_in_streaming() throws InterruptedException {
+        AtomicBoolean toolExecuted = new AtomicBoolean(false);
+
+        ToolSpecification tool = ToolSpecification.builder()
+                .name("calculate")
+                .description("Performs calculation")
+                .build();
+
+        ToolExecutor executor = (toolExecutionRequest, memoryId) -> {
+            toolExecuted.set(true);
+            return "4";
+        };
+
+        // The mock has only ONE message queued: a tool call. If IMMEDIATE is honored,
+        // the streaming handler stops after the tool is executed and never asks the
+        // model again. If IMMEDIATE is ignored (the bug we are guarding against), the
+        // handler calls the model a second time, the queue is empty, and the mock
+        // throws — surfacing as onError.
+        AiMessage toolCallMessage = AiMessage.from(ToolExecutionRequest.builder()
+                .id("calc-1")
+                .name("calculate")
+                .arguments("{\"expression\": \"2+2\"}")
+                .build());
+        StreamingChatModelMock mockModel = StreamingChatModelMock.thatAlwaysStreams(toolCallMessage);
+
+        ToolProvider provider = request -> ToolProviderResult.builder()
+                .add(tool, executor, ReturnBehavior.IMMEDIATE)
+                .build();
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .streamingChatModel(mockModel)
+                .toolProvider(provider)
+                .build();
+
+        AtomicReference<ChatResponse> completeResponse = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+
+        assistant
+                .chat("What is 2+2?")
+                .onPartialResponse(token -> {})
+                .onToolExecuted(execution -> {})
+                .onCompleteResponse(response -> {
+                    completeResponse.set(response);
+                    done.countDown();
+                })
+                .onError(t -> {
+                    error.set(t);
+                    done.countDown();
+                })
+                .start();
+
+        assertThat(done.await(10, TimeUnit.SECONDS))
+                .as(
+                        "streaming should complete within 10s — if IMMEDIATE is ignored a second LLM call is attempted and the mock throws")
+                .isTrue();
+        assertThat(error.get()).isNull();
+        assertThat(toolExecuted.get()).isTrue();
+        assertThat(mockModel.requests()).hasSize(1);
+
+        ChatResponse response = completeResponse.get();
+        assertThat(response).isNotNull();
+        AiMessage finalAiMessage = response.aiMessage();
+        assertThat(finalAiMessage.hasToolExecutionRequests()).isTrue();
+        List<ToolExecutionRequest> requests = finalAiMessage.toolExecutionRequests();
+        assertThat(requests).hasSize(1);
+        assertThat(requests.get(0).name()).isEqualTo("calculate");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5079

`AiServiceStreamingResponseHandler` was reading `ReturnBehavior` from `ToolService` instance fields, which only contain statically registered tools. Tools supplied via `ToolProvider` are recorded in the per-invocation `ToolServiceContext`, so their configured `ReturnBehavior.IMMEDIATE` / `IMMEDIATE_IF_LAST` was silently downgraded to `TO_LLM` in the streaming path. The non-streaming path (`ToolService.executeInferenceAndToolsLoop`, line 393) already reads from `toolServiceContext` correctly — this PR aligns the streaming path with that.

## Change

**`AiServiceStreamingResponseHandler.java` — two-line fix at the call sites where the per-tool `ReturnBehavior` is collected:**

```diff
-returnBehaviors.add(context.toolService.returnBehavior(toolRequest.name()));
+returnBehaviors.add(toolServiceContext.returnBehavior(toolRequest.name()));
```

Applied to both the concurrent (`toolExecutor != null`) and sequential branches. The handler already holds the right `ToolServiceContext` as an instance field (`this.toolServiceContext`).

**Regression test:** `StreamingProgrammaticCreatedImmediateReturnToolTest` — streaming counterpart of the existing `ProgrammaticCreatedImmediateReturnToolTest`. Mocks the streaming model with a single tool-call message; if `IMMEDIATE` is honored, the handler completes after executing the tool. If `IMMEDIATE` is dropped (the bug), the handler attempts a second LLM call, the mock queue is empty, and `StreamingChatModelMock` throws `aiMessage cannot be null`, surfacing through `onError`.

Verified: test fails on `main` with `IllegalArgumentException: aiMessage cannot be null` and passes with the fix applied.

## General checklist
- [x] There are no breaking changes (API, behaviour) — restores intended behavior of an existing API
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases — verified the test fails without the fix and passes with it
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green (`./mvnw -pl langchain4j -am test -DskipITs` → 1307 tests, 0 failures)
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) — N/A (bug fix, no doc-visible API change)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) — N/A
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) — N/A