### PR TITLE
Add Sentence Window Retrieval support for RAG

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/segment/SentenceWindowTextSegmentTransformer.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/segment/SentenceWindowTextSegmentTransformer.java
@@ -1,0 +1,211 @@
+package dev.langchain4j.data.segment;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNegative;
+
+import dev.langchain4j.data.document.Metadata;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link TextSegmentTransformer} that enriches each {@link TextSegment} with the surrounding context
+ * from neighboring segments in the current {@link #transformAll(List)} input.
+ * <br>
+ * This implements the <b>Sentence Window Retrieval</b> pattern for advanced RAG:
+ * while embedding stores index individual (small) segments for precise retrieval,
+ * the LLM receives a wider context window around each retrieved segment,
+ * improving response quality.
+ * <br>
+ * <br>
+ * The surrounding context is stored in the segment's {@link Metadata} under the key
+ * {@value #SURROUNDING_CONTEXT_KEY}. It can later be extracted by
+ * {@link dev.langchain4j.rag.content.injector.SentenceWindowContentInjector}.
+ * <br>
+ * <br>
+ * <b>Note:</b> When segments contain numeric {@code index} metadata, such as segments produced by
+ * standard document splitters, this transformer avoids crossing document boundaries by detecting
+ * index resets. If segments do not contain usable {@code index} metadata, the input is processed as
+ * a flat list and the surrounding context window may span across document boundaries.
+ * <br>
+ * <br>
+ * Example usage:
+ * <pre>{@code
+ * TextSegmentTransformer transformer = SentenceWindowTextSegmentTransformer.builder()
+ *         .segmentsBefore(2)
+ *         .segmentsAfter(2)
+ *         .build();
+ *
+ * EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
+ *         .documentSplitter(new DocumentByParagraphSplitter(300, 0))
+ *         .textSegmentTransformer(transformer)
+ *         .embeddingModel(embeddingModel)
+ *         .embeddingStore(embeddingStore)
+ *         .build();
+ * }</pre>
+ *
+ * @see dev.langchain4j.rag.content.injector.SentenceWindowContentInjector
+ */
+public class SentenceWindowTextSegmentTransformer implements TextSegmentTransformer {
+
+    /**
+     * The metadata key under which the surrounding context is stored.
+     */
+    public static final String SURROUNDING_CONTEXT_KEY = "surrounding_context";
+
+    private static final String INDEX_METADATA_KEY = "index";
+
+    private final int segmentsBefore;
+    private final int segmentsAfter;
+
+    /**
+     * Creates a new {@code SentenceWindowTextSegmentTransformer}.
+     *
+     * @param segmentsBefore the number of preceding segments to include in the window context; must not be negative.
+     * @param segmentsAfter  the number of following segments to include in the window context; must not be negative.
+     */
+    public SentenceWindowTextSegmentTransformer(int segmentsBefore, int segmentsAfter) {
+        this.segmentsBefore = ensureNotNegative(segmentsBefore, "segmentsBefore");
+        this.segmentsAfter = ensureNotNegative(segmentsAfter, "segmentsAfter");
+    }
+
+    /**
+     * Transforms a single segment by enriching it with surrounding context.
+     * Since a single segment has no neighbors, the surrounding context will contain
+     * only the segment's own text.
+     *
+     * @param segment the segment to transform.
+     * @return a new segment with {@value #SURROUNDING_CONTEXT_KEY} in its metadata.
+     */
+    @Override
+    public TextSegment transform(TextSegment segment) {
+        return transformAll(Collections.singletonList(segment)).get(0);
+    }
+
+    /**
+     * Transforms all segments by enriching each segment's metadata
+     * with the surrounding context from neighboring segments in the list.
+     *
+     * @param segments the list of segments to transform.
+     * @return a new list of segments, each enriched with {@value #SURROUNDING_CONTEXT_KEY} in metadata.
+     */
+    @Override
+    public List<TextSegment> transformAll(List<TextSegment> segments) {
+        if (segments == null || segments.isEmpty()) {
+            return List.of();
+        }
+
+        List<TextSegment> result = new ArrayList<>(segments.size());
+        for (int i = 0; i < segments.size(); i++) {
+            TextSegment segment = segments.get(i);
+            String surroundingContext = buildSurroundingContext(segments, i);
+            Metadata newMetadata = segment.metadata().copy().put(SURROUNDING_CONTEXT_KEY, surroundingContext);
+            result.add(TextSegment.from(segment.text(), newMetadata));
+        }
+        return result;
+    }
+
+    private String buildSurroundingContext(List<TextSegment> segments, int currentIndex) {
+        int start = windowStart(segments, currentIndex);
+        int end = windowEnd(segments, currentIndex);
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = start; i <= end; i++) {
+            if (!sb.isEmpty()) {
+                sb.append("\n\n");
+            }
+            sb.append(segments.get(i).text());
+        }
+        return sb.toString();
+    }
+
+    private int windowStart(List<TextSegment> segments, int currentIndex) {
+        int start = Math.max(0, currentIndex - segmentsBefore);
+        for (int i = currentIndex; i > start; i--) {
+            if (isDocumentBoundary(segments.get(i - 1), segments.get(i))) {
+                return i;
+            }
+        }
+        return start;
+    }
+
+    private int windowEnd(List<TextSegment> segments, int currentIndex) {
+        int end = Math.min(segments.size() - 1, currentIndex + segmentsAfter);
+        for (int i = currentIndex; i < end; i++) {
+            if (isDocumentBoundary(segments.get(i), segments.get(i + 1))) {
+                return i;
+            }
+        }
+        return end;
+    }
+
+    private static boolean isDocumentBoundary(TextSegment previous, TextSegment next) {
+        Integer previousIndex = index(previous);
+        Integer nextIndex = index(next);
+        return previousIndex != null && nextIndex != null && nextIndex <= previousIndex;
+    }
+
+    private static Integer index(TextSegment segment) {
+        Object value = segment.metadata().toMap().get(INDEX_METADATA_KEY);
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String string) {
+            try {
+                return Integer.parseInt(string);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Creates a new {@link SentenceWindowTextSegmentTransformerBuilder}.
+     *
+     * @return a new builder instance.
+     */
+    public static SentenceWindowTextSegmentTransformerBuilder builder() {
+        return new SentenceWindowTextSegmentTransformerBuilder();
+    }
+
+    public static class SentenceWindowTextSegmentTransformerBuilder {
+
+        private int segmentsBefore = 1;
+        private int segmentsAfter = 1;
+
+        SentenceWindowTextSegmentTransformerBuilder() {}
+
+        /**
+         * Sets the number of preceding segments to include in the surrounding context.
+         * Default: 1.
+         *
+         * @param segmentsBefore the number of preceding segments; must not be negative.
+         * @return this builder.
+         */
+        public SentenceWindowTextSegmentTransformerBuilder segmentsBefore(int segmentsBefore) {
+            this.segmentsBefore = segmentsBefore;
+            return this;
+        }
+
+        /**
+         * Sets the number of following segments to include in the surrounding context.
+         * Default: 1.
+         *
+         * @param segmentsAfter the number of following segments; must not be negative.
+         * @return this builder.
+         */
+        public SentenceWindowTextSegmentTransformerBuilder segmentsAfter(int segmentsAfter) {
+            this.segmentsAfter = segmentsAfter;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link SentenceWindowTextSegmentTransformer}.
+         *
+         * @return a new transformer instance.
+         */
+        public SentenceWindowTextSegmentTransformer build() {
+            return new SentenceWindowTextSegmentTransformer(segmentsBefore, segmentsAfter);
+        }
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/segment/SentenceWindowTextSegmentTransformer.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/segment/SentenceWindowTextSegmentTransformer.java
@@ -1,0 +1,206 @@
+package dev.langchain4j.data.segment;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNegative;
+
+import dev.langchain4j.data.document.Metadata;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link TextSegmentTransformer} that enriches each {@link TextSegment} with the surrounding context
+ * from neighboring segments in the current {@link #transformAll(List)} input.
+ * <br>
+ * This implements the <b>Sentence Window Retrieval</b> pattern for advanced RAG:
+ * while embedding stores index individual (small) segments for precise retrieval,
+ * the LLM receives a wider context window around each retrieved segment,
+ * improving response quality.
+ * <br>
+ * <br>
+ * The surrounding context is stored in the segment's {@link Metadata} under the key
+ * {@value #SURROUNDING_CONTEXT_KEY}. It can later be extracted by
+ * {@link dev.langchain4j.rag.content.injector.SentenceWindowContentInjector}.
+ * <br>
+ * <br>
+ * <b>Note:</b> When segments contain numeric {@code index} metadata, such as segments produced by
+ * standard document splitters, this transformer avoids crossing document boundaries by detecting
+ * index resets. If segments do not contain usable {@code index} metadata, the input is processed as
+ * a flat list and the surrounding context window may span across document boundaries.
+ * <br>
+ * <br>
+ * Example usage:
+ * <pre>{@code
+ * TextSegmentTransformer transformer = SentenceWindowTextSegmentTransformer.builder()
+ *         .segmentsBefore(2)
+ *         .segmentsAfter(2)
+ *         .build();
+ *
+ * EmbeddingStoreIngestor ingestor = EmbeddingStoreIngestor.builder()
+ *         .documentSplitter(new DocumentByParagraphSplitter(300, 0))
+ *         .textSegmentTransformer(transformer)
+ *         .embeddingModel(embeddingModel)
+ *         .embeddingStore(embeddingStore)
+ *         .build();
+ * }</pre>
+ *
+ * @see dev.langchain4j.rag.content.injector.SentenceWindowContentInjector
+ */
+public class SentenceWindowTextSegmentTransformer implements TextSegmentTransformer {
+
+    /**
+     * The metadata key under which the surrounding context is stored.
+     */
+    public static final String SURROUNDING_CONTEXT_KEY = "surrounding_context";
+
+    private static final String INDEX_METADATA_KEY = "index";
+
+    private final int segmentsBefore;
+    private final int segmentsAfter;
+
+    /**
+     * Creates a new {@code SentenceWindowTextSegmentTransformer}.
+     *
+     * @param segmentsBefore the number of preceding segments to include in the window context; must not be negative.
+     * @param segmentsAfter  the number of following segments to include in the window context; must not be negative.
+     */
+    public SentenceWindowTextSegmentTransformer(int segmentsBefore, int segmentsAfter) {
+        this.segmentsBefore = ensureNotNegative(segmentsBefore, "segmentsBefore");
+        this.segmentsAfter = ensureNotNegative(segmentsAfter, "segmentsAfter");
+    }
+
+    /**
+     * Transforms a single segment by enriching it with surrounding context.
+     * Since a single segment has no neighbors, the surrounding context will contain
+     * only the segment's own text.
+     *
+     * @param segment the segment to transform.
+     * @return a new segment with {@value #SURROUNDING_CONTEXT_KEY} in its metadata.
+     */
+    @Override
+    public TextSegment transform(TextSegment segment) {
+        return transformAll(List.of(segment)).get(0);
+    }
+
+    /**
+     * Transforms all segments by enriching each segment's metadata
+     * with the surrounding context from neighboring segments in the list.
+     *
+     * @param segments the list of segments to transform.
+     * @return a new list of segments, each enriched with {@value #SURROUNDING_CONTEXT_KEY} in metadata.
+     */
+    @Override
+    public List<TextSegment> transformAll(List<TextSegment> segments) {
+        List<TextSegment> result = new ArrayList<>(segments.size());
+        for (int i = 0; i < segments.size(); i++) {
+            TextSegment segment = segments.get(i);
+            String surroundingContext = buildSurroundingContext(segments, i);
+            Metadata newMetadata = segment.metadata().copy().put(SURROUNDING_CONTEXT_KEY, surroundingContext);
+            result.add(TextSegment.from(segment.text(), newMetadata));
+        }
+        return result;
+    }
+
+    private String buildSurroundingContext(List<TextSegment> segments, int currentIndex) {
+        int start = windowStart(segments, currentIndex);
+        int end = windowEnd(segments, currentIndex);
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = start; i <= end; i++) {
+            if (!sb.isEmpty()) {
+                sb.append("\n\n");
+            }
+            sb.append(segments.get(i).text());
+        }
+        return sb.toString();
+    }
+
+    private int windowStart(List<TextSegment> segments, int currentIndex) {
+        int start = Math.max(0, currentIndex - segmentsBefore);
+        for (int i = currentIndex; i > start; i--) {
+            if (isDocumentBoundary(segments.get(i - 1), segments.get(i))) {
+                return i;
+            }
+        }
+        return start;
+    }
+
+    private int windowEnd(List<TextSegment> segments, int currentIndex) {
+        int end = Math.min(segments.size() - 1, currentIndex + segmentsAfter);
+        for (int i = currentIndex; i < end; i++) {
+            if (isDocumentBoundary(segments.get(i), segments.get(i + 1))) {
+                return i;
+            }
+        }
+        return end;
+    }
+
+    private static boolean isDocumentBoundary(TextSegment previous, TextSegment next) {
+        Integer previousIndex = index(previous);
+        Integer nextIndex = index(next);
+        return previousIndex != null && nextIndex != null && nextIndex <= previousIndex;
+    }
+
+    private static Integer index(TextSegment segment) {
+        Object value = segment.metadata().toMap().get(INDEX_METADATA_KEY);
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String string) {
+            try {
+                return Integer.parseInt(string);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Creates a new {@link SentenceWindowTextSegmentTransformerBuilder}.
+     *
+     * @return a new builder instance.
+     */
+    public static SentenceWindowTextSegmentTransformerBuilder builder() {
+        return new SentenceWindowTextSegmentTransformerBuilder();
+    }
+
+    public static class SentenceWindowTextSegmentTransformerBuilder {
+
+        private int segmentsBefore = 1;
+        private int segmentsAfter = 1;
+
+        SentenceWindowTextSegmentTransformerBuilder() {}
+
+        /**
+         * Sets the number of preceding segments to include in the surrounding context.
+         * Default: 1.
+         *
+         * @param segmentsBefore the number of preceding segments; must not be negative.
+         * @return this builder.
+         */
+        public SentenceWindowTextSegmentTransformerBuilder segmentsBefore(int segmentsBefore) {
+            this.segmentsBefore = segmentsBefore;
+            return this;
+        }
+
+        /**
+         * Sets the number of following segments to include in the surrounding context.
+         * Default: 1.
+         *
+         * @param segmentsAfter the number of following segments; must not be negative.
+         * @return this builder.
+         */
+        public SentenceWindowTextSegmentTransformerBuilder segmentsAfter(int segmentsAfter) {
+            this.segmentsAfter = segmentsAfter;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link SentenceWindowTextSegmentTransformer}.
+         *
+         * @return a new transformer instance.
+         */
+        public SentenceWindowTextSegmentTransformer build() {
+            return new SentenceWindowTextSegmentTransformer(segmentsBefore, segmentsAfter);
+        }
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/injector/SentenceWindowContentInjector.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/injector/SentenceWindowContentInjector.java
@@ -1,0 +1,146 @@
+package dev.langchain4j.rag.content.injector;
+
+import static dev.langchain4j.data.segment.SentenceWindowTextSegmentTransformer.SURROUNDING_CONTEXT_KEY;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.segment.SentenceWindowTextSegmentTransformer;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.input.PromptTemplate;
+import dev.langchain4j.rag.content.Content;
+import java.util.List;
+
+/**
+ * A {@link DefaultContentInjector} designed to work with {@link SentenceWindowTextSegmentTransformer}.
+ * <br>
+ * This implementation appends all given {@link Content}s to the end of the given {@link UserMessage}
+ * in their order of iteration, using the wider surrounding context stored in the segment's
+ * {@link Metadata} under the key
+ * {@value dev.langchain4j.data.segment.SentenceWindowTextSegmentTransformer#SURROUNDING_CONTEXT_KEY}
+ * when available, or the original segment text otherwise.
+ * <br>
+ * Refer to {@link #DEFAULT_PROMPT_TEMPLATE} and implementation for more details.
+ * <br>
+ * <br>
+ * Configurable parameters (optional):
+ * <br>
+ * - promptTemplate: The prompt template that defines how the original {@code userMessage}
+ * and {@code contents} are combined into the resulting {@link UserMessage}.
+ * The text of the template should contain the {@code {{userMessage}}} and {@code {{contents}}} variables.
+ * <br>
+ * - metadataKeysToInclude: A list of {@link Metadata} keys that should be included
+ * with each {@link Content#textSegment()}.
+ * <br>
+ * <br>
+ * Example usage:
+ * <pre>{@code
+ * ContentInjector injector = SentenceWindowContentInjector.builder()
+ *         .build();
+ *
+ * RetrievalAugmentor augmentor = DefaultRetrievalAugmentor.builder()
+ *         .contentInjector(injector)
+ *         .build();
+ * }</pre>
+ *
+ * @see SentenceWindowTextSegmentTransformer
+ * @see DefaultContentInjector
+ */
+public class SentenceWindowContentInjector extends DefaultContentInjector {
+
+    public SentenceWindowContentInjector() {
+        this(DEFAULT_PROMPT_TEMPLATE, null);
+    }
+
+    /**
+     * Creates a new {@code SentenceWindowContentInjector} with the given prompt template.
+     *
+     * @param promptTemplate the prompt template to use; if {@code null}, the {@link #DEFAULT_PROMPT_TEMPLATE} is used.
+     *                       The template should contain {@code {{userMessage}}} and {@code {{contents}}} variables.
+     */
+    public SentenceWindowContentInjector(PromptTemplate promptTemplate) {
+        this(promptTemplate, null);
+    }
+
+    /**
+     * Creates a new {@code SentenceWindowContentInjector} with the given prompt template and metadata keys.
+     *
+     * @param promptTemplate        the prompt template to use; if {@code null}, the {@link #DEFAULT_PROMPT_TEMPLATE}
+     *                              is used. The template should contain {@code {{userMessage}}} and
+     *                              {@code {{contents}}} variables.
+     * @param metadataKeysToInclude metadata keys to include with each {@link Content#textSegment()}.
+     */
+    public SentenceWindowContentInjector(PromptTemplate promptTemplate, List<String> metadataKeysToInclude) {
+        super(getOrDefault(promptTemplate, DEFAULT_PROMPT_TEMPLATE), withoutSurroundingContext(metadataKeysToInclude));
+    }
+
+    @Override
+    protected String format(Content content) {
+        TextSegment segment = content.textSegment();
+        String surroundingContext = segment.metadata().getString(SURROUNDING_CONTEXT_KEY);
+        String segmentContent = getOrDefault(surroundingContext, segment.text());
+        String segmentMetadata = format(segment.metadata());
+        return format(segmentContent, segmentMetadata);
+    }
+
+    private static List<String> withoutSurroundingContext(List<String> metadataKeysToInclude) {
+        if (metadataKeysToInclude == null) {
+            return null;
+        }
+        return metadataKeysToInclude.stream()
+                .filter(metadataKey -> !SURROUNDING_CONTEXT_KEY.equals(metadataKey))
+                .toList();
+    }
+
+    /**
+     * Creates a new {@link SentenceWindowContentInjectorBuilder}.
+     *
+     * @return a new builder instance.
+     */
+    public static SentenceWindowContentInjectorBuilder builder() {
+        return new SentenceWindowContentInjectorBuilder();
+    }
+
+    public static class SentenceWindowContentInjectorBuilder extends DefaultContentInjectorBuilder {
+
+        private PromptTemplate promptTemplate;
+        private List<String> metadataKeysToInclude;
+
+        SentenceWindowContentInjectorBuilder() {}
+
+        /**
+         * Sets the prompt template to use.
+         * Default: {@link #DEFAULT_PROMPT_TEMPLATE}.
+         *
+         * @param promptTemplate the prompt template; may be {@code null} to use the default.
+         * @return this builder.
+         */
+        @Override
+        public SentenceWindowContentInjectorBuilder promptTemplate(PromptTemplate promptTemplate) {
+            this.promptTemplate = promptTemplate;
+            return this;
+        }
+
+        /**
+         * Sets the metadata keys to include with each {@link Content#textSegment()}.
+         *
+         * @param metadataKeysToInclude metadata keys to include; may be {@code null}.
+         * @return this builder.
+         */
+        @Override
+        public SentenceWindowContentInjectorBuilder metadataKeysToInclude(List<String> metadataKeysToInclude) {
+            this.metadataKeysToInclude = metadataKeysToInclude;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link SentenceWindowContentInjector}.
+         *
+         * @return a new injector instance.
+         */
+        @Override
+        public SentenceWindowContentInjector build() {
+            return new SentenceWindowContentInjector(promptTemplate, metadataKeysToInclude);
+        }
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/segment/SentenceWindowTextSegmentTransformerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/segment/SentenceWindowTextSegmentTransformerTest.java
@@ -1,0 +1,271 @@
+package dev.langchain4j.data.segment;
+
+import static dev.langchain4j.data.segment.SentenceWindowTextSegmentTransformer.SURROUNDING_CONTEXT_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.document.Metadata;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SentenceWindowTextSegmentTransformerTest {
+
+    @Test
+    void should_enrich_segments_with_surrounding_context() {
+
+        // given
+        SentenceWindowTextSegmentTransformer transformer = SentenceWindowTextSegmentTransformer.builder()
+                .segmentsBefore(1)
+                .segmentsAfter(1)
+                .build();
+
+        Metadata docMeta = Metadata.from("file_name", "doc1.txt");
+        TextSegment s0 = TextSegment.from("Sentence 0.", docMeta.copy().put("index", "0"));
+        TextSegment s1 = TextSegment.from("Sentence 1.", docMeta.copy().put("index", "1"));
+        TextSegment s2 = TextSegment.from("Sentence 2.", docMeta.copy().put("index", "2"));
+
+        // when
+        List<TextSegment> result = transformer.transformAll(List.of(s0, s1, s2));
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("Sentence 0.\n\nSentence 1.");
+        assertThat(result.get(1).metadata().getString(SURROUNDING_CONTEXT_KEY))
+                .isEqualTo("Sentence 0.\n\nSentence 1.\n\nSentence 2.");
+        assertThat(result.get(2).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("Sentence 1.\n\nSentence 2.");
+    }
+
+    @Test
+    void should_handle_larger_window_size() {
+
+        // given
+        SentenceWindowTextSegmentTransformer transformer = SentenceWindowTextSegmentTransformer.builder()
+                .segmentsBefore(2)
+                .segmentsAfter(2)
+                .build();
+
+        Metadata docMeta = Metadata.from("file_name", "doc1.txt");
+        TextSegment s0 = TextSegment.from("S0.", docMeta.copy().put("index", "0"));
+        TextSegment s1 = TextSegment.from("S1.", docMeta.copy().put("index", "1"));
+        TextSegment s2 = TextSegment.from("S2.", docMeta.copy().put("index", "2"));
+        TextSegment s3 = TextSegment.from("S3.", docMeta.copy().put("index", "3"));
+        TextSegment s4 = TextSegment.from("S4.", docMeta.copy().put("index", "4"));
+
+        // when
+        List<TextSegment> result = transformer.transformAll(List.of(s0, s1, s2, s3, s4));
+
+        // then
+        assertThat(result).hasSize(5);
+        assertThat(result.get(0).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S0.\n\nS1.\n\nS2.");
+        assertThat(result.get(1).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S0.\n\nS1.\n\nS2.\n\nS3.");
+        assertThat(result.get(2).metadata().getString(SURROUNDING_CONTEXT_KEY))
+                .isEqualTo("S0.\n\nS1.\n\nS2.\n\nS3.\n\nS4.");
+        assertThat(result.get(3).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S1.\n\nS2.\n\nS3.\n\nS4.");
+        assertThat(result.get(4).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S2.\n\nS3.\n\nS4.");
+    }
+
+    @Test
+    void should_not_cross_document_boundary_when_index_resets() {
+
+        // given
+        SentenceWindowTextSegmentTransformer transformer = SentenceWindowTextSegmentTransformer.builder()
+                .segmentsBefore(1)
+                .segmentsAfter(1)
+                .build();
+
+        TextSegment doc1s0 = TextSegment.from("Doc 1 sentence 0.", Metadata.from("index", "0"));
+        TextSegment doc1s1 = TextSegment.from("Doc 1 sentence 1.", Metadata.from("index", "1"));
+        TextSegment doc2s0 = TextSegment.from("Doc 2 sentence 0.", Metadata.from("index", "0"));
+        TextSegment doc2s1 = TextSegment.from("Doc 2 sentence 1.", Metadata.from("index", "1"));
+
+        // when
+        List<TextSegment> result = transformer.transformAll(List.of(doc1s0, doc1s1, doc2s0, doc2s1));
+
+        // then
+        assertThat(result.get(0).metadata().getString(SURROUNDING_CONTEXT_KEY))
+                .isEqualTo("Doc 1 sentence 0.\n\nDoc 1 sentence 1.");
+        assertThat(result.get(1).metadata().getString(SURROUNDING_CONTEXT_KEY))
+                .isEqualTo("Doc 1 sentence 0.\n\nDoc 1 sentence 1.");
+        assertThat(result.get(2).metadata().getString(SURROUNDING_CONTEXT_KEY))
+                .isEqualTo("Doc 2 sentence 0.\n\nDoc 2 sentence 1.");
+        assertThat(result.get(3).metadata().getString(SURROUNDING_CONTEXT_KEY))
+                .isEqualTo("Doc 2 sentence 0.\n\nDoc 2 sentence 1.");
+    }
+
+    @Test
+    void should_preserve_original_metadata() {
+
+        // given
+        SentenceWindowTextSegmentTransformer transformer = SentenceWindowTextSegmentTransformer.builder()
+                .segmentsBefore(1)
+                .segmentsAfter(1)
+                .build();
+
+        Metadata meta = new Metadata()
+                .put("file_name", "doc.txt")
+                .put("author", "Alice")
+                .put("index", "0");
+        TextSegment segment = TextSegment.from("Hello.", meta);
+
+        // when
+        List<TextSegment> result = transformer.transformAll(List.of(segment));
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).metadata().getString("file_name")).isEqualTo("doc.txt");
+        assertThat(result.get(0).metadata().getString("author")).isEqualTo("Alice");
+        assertThat(result.get(0).metadata().getString("index")).isEqualTo("0");
+        assertThat(result.get(0).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("Hello.");
+    }
+
+    @Test
+    void should_return_empty_list_for_empty_input() {
+
+        // given
+        SentenceWindowTextSegmentTransformer transformer =
+                SentenceWindowTextSegmentTransformer.builder().build();
+
+        // when
+        List<TextSegment> result = transformer.transformAll(List.of());
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_list_for_null_input() {
+
+        // given
+        SentenceWindowTextSegmentTransformer transformer =
+                SentenceWindowTextSegmentTransformer.builder().build();
+
+        // when
+        List<TextSegment> result = transformer.transformAll((List<TextSegment>) null);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_enrich_single_segment_when_transforming() {
+
+        // given
+        SentenceWindowTextSegmentTransformer transformer =
+                SentenceWindowTextSegmentTransformer.builder().build();
+
+        TextSegment segment = TextSegment.from("Hello world.");
+
+        // when
+        TextSegment result = transformer.transform(segment);
+
+        // then
+        assertThat(result.text()).isEqualTo("Hello world.");
+        assertThat(result.metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("Hello world.");
+    }
+
+    @Test
+    void should_handle_segmentsBefore_zero() {
+
+        // given
+        SentenceWindowTextSegmentTransformer transformer = SentenceWindowTextSegmentTransformer.builder()
+                .segmentsBefore(0)
+                .segmentsAfter(1)
+                .build();
+
+        Metadata docMeta = Metadata.from("file_name", "doc.txt");
+        TextSegment s0 = TextSegment.from("S0.", docMeta.copy().put("index", "0"));
+        TextSegment s1 = TextSegment.from("S1.", docMeta.copy().put("index", "1"));
+        TextSegment s2 = TextSegment.from("S2.", docMeta.copy().put("index", "2"));
+
+        // when
+        List<TextSegment> result = transformer.transformAll(List.of(s0, s1, s2));
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S0.\n\nS1.");
+        assertThat(result.get(1).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S1.\n\nS2.");
+        assertThat(result.get(2).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S2.");
+    }
+
+    @Test
+    void should_handle_segmentsAfter_zero() {
+
+        // given
+        SentenceWindowTextSegmentTransformer transformer = SentenceWindowTextSegmentTransformer.builder()
+                .segmentsBefore(1)
+                .segmentsAfter(0)
+                .build();
+
+        Metadata docMeta = Metadata.from("file_name", "doc.txt");
+        TextSegment s0 = TextSegment.from("S0.", docMeta.copy().put("index", "0"));
+        TextSegment s1 = TextSegment.from("S1.", docMeta.copy().put("index", "1"));
+        TextSegment s2 = TextSegment.from("S2.", docMeta.copy().put("index", "2"));
+
+        // when
+        List<TextSegment> result = transformer.transformAll(List.of(s0, s1, s2));
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S0.");
+        assertThat(result.get(1).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S0.\n\nS1.");
+        assertThat(result.get(2).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S1.\n\nS2.");
+    }
+
+    @Test
+    void should_reject_negative_segmentsBefore() {
+        assertThatThrownBy(() -> SentenceWindowTextSegmentTransformer.builder()
+                        .segmentsBefore(-1)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_reject_negative_segmentsAfter() {
+        assertThatThrownBy(() -> SentenceWindowTextSegmentTransformer.builder()
+                        .segmentsAfter(-1)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_handle_segments_without_index_metadata() {
+
+        // given
+        SentenceWindowTextSegmentTransformer transformer = SentenceWindowTextSegmentTransformer.builder()
+                .segmentsBefore(1)
+                .segmentsAfter(1)
+                .build();
+
+        Metadata docMeta = Metadata.from("file_name", "doc.txt");
+        TextSegment s0 = TextSegment.from("S0.", docMeta.copy());
+        TextSegment s1 = TextSegment.from("S1.", docMeta.copy());
+
+        // when
+        List<TextSegment> result = transformer.transformAll(List.of(s0, s1));
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S0.\n\nS1.");
+        assertThat(result.get(1).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("S0.\n\nS1.");
+    }
+
+    @Test
+    void should_work_with_single_segment_in_transformAll() {
+
+        // given
+        SentenceWindowTextSegmentTransformer transformer = SentenceWindowTextSegmentTransformer.builder()
+                .segmentsBefore(1)
+                .segmentsAfter(1)
+                .build();
+
+        TextSegment segment = TextSegment.from("Only one.", Metadata.from("file_name", "doc.txt"));
+
+        // when
+        List<TextSegment> result = transformer.transformAll(List.of(segment));
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).text()).isEqualTo("Only one.");
+        assertThat(result.get(0).metadata().getString(SURROUNDING_CONTEXT_KEY)).isEqualTo("Only one.");
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/segment/SentenceWindowTextSegmentTransformerTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/segment/SentenceWindowTextSegmentTransformerTest.java
@@ -1,0 +1,61 @@
+package dev.langchain4j.data.segment;
+
+import static dev.langchain4j.data.segment.SentenceWindowTextSegmentTransformer.SURROUNDING_CONTEXT_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.document.Metadata;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SentenceWindowTextSegmentTransformerTest {
+
+    @Test
+    void should_add_surrounding_context_and_preserve_metadata() {
+        SentenceWindowTextSegmentTransformer transformer = new SentenceWindowTextSegmentTransformer(1, 1);
+        Metadata metadata = Metadata.from("source", "doc.txt");
+        TextSegment first = TextSegment.from("First", metadata.copy().put("index", "0"));
+        TextSegment second = TextSegment.from("Second", metadata.copy().put("index", "1"));
+        TextSegment third = TextSegment.from("Third", metadata.copy().put("index", "2"));
+
+        List<TextSegment> result = transformer.transformAll(List.of(first, second, third));
+
+        assertThat(result)
+                .extracting(it -> it.metadata().getString(SURROUNDING_CONTEXT_KEY))
+                .containsExactly("First\n\nSecond", "First\n\nSecond\n\nThird", "Second\n\nThird");
+        assertThat(result)
+                .allSatisfy(it -> assertThat(it.metadata().getString("source")).isEqualTo("doc.txt"));
+    }
+
+    @Test
+    void should_not_cross_index_reset() {
+        SentenceWindowTextSegmentTransformer transformer = new SentenceWindowTextSegmentTransformer(1, 1);
+        TextSegment first = TextSegment.from("Doc 1", Metadata.from("index", "0"));
+        TextSegment second = TextSegment.from("Doc 2", Metadata.from("index", "0"));
+
+        List<TextSegment> result = transformer.transformAll(List.of(first, second));
+
+        assertThat(result)
+                .extracting(it -> it.metadata().getString(SURROUNDING_CONTEXT_KEY))
+                .containsExactly("Doc 1", "Doc 2");
+    }
+
+    @Test
+    void should_handle_single_and_empty_inputs() {
+        SentenceWindowTextSegmentTransformer transformer =
+                SentenceWindowTextSegmentTransformer.builder().build();
+        TextSegment segment = TextSegment.from("Only");
+
+        assertThat(transformer.transform(segment).metadata().getString(SURROUNDING_CONTEXT_KEY))
+                .isEqualTo("Only");
+        assertThat(transformer.transformAll(List.of())).isEmpty();
+    }
+
+    @Test
+    void should_reject_negative_window_sizes() {
+        assertThatThrownBy(() -> new SentenceWindowTextSegmentTransformer(-1, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new SentenceWindowTextSegmentTransformer(0, -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/injector/SentenceWindowContentInjectorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/injector/SentenceWindowContentInjectorTest.java
@@ -1,0 +1,237 @@
+package dev.langchain4j.rag.content.injector;
+
+import static dev.langchain4j.data.segment.SentenceWindowTextSegmentTransformer.SURROUNDING_CONTEXT_KEY;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.input.PromptTemplate;
+import dev.langchain4j.rag.content.Content;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SentenceWindowContentInjectorTest {
+
+    @Test
+    void should_inject_surrounding_context_from_metadata() {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is this about?");
+
+        Metadata metadata = new Metadata().put(SURROUNDING_CONTEXT_KEY, "Before. Target. After.");
+        TextSegment segment = TextSegment.from("Target.", metadata);
+        List<Content> contents = singletonList(Content.from(segment));
+
+        ContentInjector injector = SentenceWindowContentInjector.builder().build();
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected.singleText()).isEqualTo("""
+            What is this about?
+
+            Answer using the following information:
+            Before. Target. After.\
+            """);
+    }
+
+    @Test
+    void should_inject_surrounding_context_with_userName() {
+
+        // given
+        UserMessage userMessage = UserMessage.from("ape", "What is this about?");
+
+        Metadata metadata = new Metadata().put(SURROUNDING_CONTEXT_KEY, "Before. Target. After.");
+        List<Content> contents = singletonList(Content.from(TextSegment.from("Target.", metadata)));
+
+        ContentInjector injector = SentenceWindowContentInjector.builder().build();
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected.singleText()).isEqualTo("""
+            What is this about?
+
+            Answer using the following information:
+            Before. Target. After.\
+            """);
+        assertThat(injected.name()).isEqualTo("ape");
+    }
+
+    @Test
+    void should_fallback_to_segment_text_when_no_surrounding_context() {
+
+        // given
+        UserMessage userMessage = UserMessage.from("Tell me more.");
+
+        List<Content> contents = singletonList(Content.from("Original text."));
+
+        ContentInjector injector = SentenceWindowContentInjector.builder().build();
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected.singleText()).isEqualTo("""
+            Tell me more.
+
+            Answer using the following information:
+            Original text.\
+            """);
+    }
+
+    @Test
+    void should_not_inject_when_no_content() {
+
+        // given
+        UserMessage userMessage = UserMessage.from("Hello.");
+
+        List<Content> contents = emptyList();
+
+        ContentInjector injector = SentenceWindowContentInjector.builder().build();
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected).isSameAs(userMessage);
+    }
+
+    @Test
+    void should_inject_multiple_contents() {
+
+        // given
+        UserMessage userMessage = UserMessage.from("Question?");
+
+        Metadata meta1 = new Metadata().put(SURROUNDING_CONTEXT_KEY, "Context A expanded.");
+        Metadata meta2 = new Metadata().put(SURROUNDING_CONTEXT_KEY, "Context B expanded.");
+        List<Content> contents =
+                asList(Content.from(TextSegment.from("A.", meta1)), Content.from(TextSegment.from("B.", meta2)));
+
+        ContentInjector injector = SentenceWindowContentInjector.builder().build();
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected.singleText()).isEqualTo("""
+            Question?
+
+            Answer using the following information:
+            Context A expanded.
+
+            Context B expanded.\
+            """);
+    }
+
+    @Test
+    void should_inject_with_custom_prompt_template() {
+
+        // given
+        PromptTemplate customTemplate = PromptTemplate.from("{{userMessage}}\n{{contents}}");
+
+        UserMessage userMessage = UserMessage.from("What?");
+
+        Metadata metadata = new Metadata().put(SURROUNDING_CONTEXT_KEY, "Expanded context here.");
+        List<Content> contents = singletonList(Content.from(TextSegment.from("Short.", metadata)));
+
+        ContentInjector injector = SentenceWindowContentInjector.builder()
+                .promptTemplate(customTemplate)
+                .build();
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected.singleText()).isEqualTo("What?\nExpanded context here.");
+    }
+
+    @Test
+    void should_mix_segments_with_and_without_surrounding_context() {
+
+        // given
+        UserMessage userMessage = UserMessage.from("Ask.");
+
+        Metadata metaWithContext = new Metadata().put(SURROUNDING_CONTEXT_KEY, "Wide context.");
+        List<Content> contents = asList(
+                Content.from(TextSegment.from("Narrow.", metaWithContext)),
+                Content.from(TextSegment.from("Plain text.")));
+
+        ContentInjector injector = SentenceWindowContentInjector.builder().build();
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected.singleText()).isEqualTo("""
+            Ask.
+
+            Answer using the following information:
+            Wide context.
+
+            Plain text.\
+            """);
+    }
+
+    @Test
+    void should_inject_surrounding_context_with_included_metadata() {
+
+        // given
+        UserMessage userMessage = UserMessage.from("Question?");
+
+        Metadata metadata = new Metadata()
+                .put(SURROUNDING_CONTEXT_KEY, "Before. Target. After.")
+                .put("source", "doc.txt");
+        List<Content> contents = singletonList(Content.from(TextSegment.from("Target.", metadata)));
+
+        ContentInjector injector = SentenceWindowContentInjector.builder()
+                .metadataKeysToInclude(singletonList("source"))
+                .build();
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected.singleText()).isEqualTo("""
+            Question?
+
+            Answer using the following information:
+            content: Before. Target. After.
+            source: doc.txt\
+            """);
+    }
+
+    @Test
+    void should_not_duplicate_surrounding_context_when_metadata_keys_include_it() {
+
+        // given
+        UserMessage userMessage = UserMessage.from("Question?");
+
+        Metadata metadata = new Metadata()
+                .put(SURROUNDING_CONTEXT_KEY, "Before. Target. After.")
+                .put("source", "doc.txt");
+        List<Content> contents = singletonList(Content.from(TextSegment.from("Target.", metadata)));
+
+        ContentInjector injector = SentenceWindowContentInjector.builder()
+                .metadataKeysToInclude(asList(SURROUNDING_CONTEXT_KEY, "source"))
+                .build();
+
+        // when
+        UserMessage injected = (UserMessage) injector.inject(contents, userMessage);
+
+        // then
+        assertThat(injected.singleText()).isEqualTo("""
+            Question?
+
+            Answer using the following information:
+            content: Before. Target. After.
+            source: doc.txt\
+            """);
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/content/injector/SentenceWindowContentInjectorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/content/injector/SentenceWindowContentInjectorTest.java
@@ -1,0 +1,49 @@
+package dev.langchain4j.rag.content.injector;
+
+import static dev.langchain4j.data.segment.SentenceWindowTextSegmentTransformer.SURROUNDING_CONTEXT_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.input.PromptTemplate;
+import dev.langchain4j.rag.content.Content;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SentenceWindowContentInjectorTest {
+
+    @Test
+    void should_inject_surrounding_context_and_fall_back_to_segment_text() {
+        Content context = Content.from(
+                TextSegment.from("Target", Metadata.from(SURROUNDING_CONTEXT_KEY, "Before. Target. After.")));
+        Content plain = Content.from("Plain text.");
+
+        UserMessage result = (UserMessage)
+                new SentenceWindowContentInjector().inject(List.of(context, plain), UserMessage.from("Question?"));
+
+        assertThat(result.singleText()).isEqualTo("""
+                Question?
+
+                Answer using the following information:
+                Before. Target. After.
+
+                Plain text.\
+                """);
+    }
+
+    @Test
+    void should_support_existing_content_injector_options() {
+        Metadata metadata =
+                new Metadata().put(SURROUNDING_CONTEXT_KEY, "Expanded").put("source", "doc.txt");
+        SentenceWindowContentInjector injector = SentenceWindowContentInjector.builder()
+                .promptTemplate(PromptTemplate.from("{{userMessage}}\n{{contents}}"))
+                .metadataKeysToInclude(List.of(SURROUNDING_CONTEXT_KEY, "source"))
+                .build();
+
+        UserMessage result = (UserMessage) injector.inject(
+                List.of(Content.from(TextSegment.from("Target", metadata))), UserMessage.from("Question?"));
+
+        assertThat(result.singleText()).isEqualTo("Question?\ncontent: Expanded\nsource: doc.txt");
+    }
+}


### PR DESCRIPTION
## Issue
Related to #3958

## Change
Adds Sentence Window Retrieval through two existing extension points:

- a TextSegmentTransformer that stores neighboring segment text in metadata during ingestion
- a ContentInjector that substitutes that stored window during retrieval and falls back to the matched segment text

Index resets from standard splitters prevent windows from crossing document boundaries. No EmbeddingStoreIngestor changes are included.

## Testing
- sentence-window transformer and injector: 6 tests passed
- existing DefaultContentInjectorTest: 11 tests passed
- git diff --check

This remains a draft for API-direction feedback.