### PR TITLE
Add audio transcription timestamp support

### DIFF
--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
@@ -186,13 +186,13 @@ public class ApacheHttpClient implements HttpClient {
                     case POST -> new HttpPost(request.url());
                 };
 
-        if (request.formDataFields().isEmpty() && request.formDataFiles().isEmpty()) {
+        if (request.formDataFieldEntries().isEmpty() && request.formDataFiles().isEmpty()) {
             if (request.body() != null) {
                 apacheRequest.setEntity(new StringEntity(request.body(), ContentType.APPLICATION_JSON));
             }
         } else {
-            HttpEntity entity =
-                    MultipartBodyPublisher.buildMultipartEntity(request.formDataFields(), request.formDataFiles());
+            HttpEntity entity = MultipartBodyPublisher.buildMultipartEntity(
+                    request.formDataFieldEntries(), request.formDataFiles());
             apacheRequest.setEntity(entity);
         }
 
@@ -211,7 +211,7 @@ public class ApacheHttpClient implements HttpClient {
         SimpleRequestBuilder builder;
         String uri = request.url();
 
-        if (request.formDataFields().isEmpty() && request.formDataFiles().isEmpty()) {
+        if (request.formDataFieldEntries().isEmpty() && request.formDataFiles().isEmpty()) {
             builder = switch (request.method()) {
                 case GET -> SimpleRequestBuilder.get(uri);
                 case DELETE -> SimpleRequestBuilder.delete(uri);
@@ -223,8 +223,8 @@ public class ApacheHttpClient implements HttpClient {
             }
         } else {
             builder = SimpleRequestBuilder.post(uri);
-            HttpEntity entity =
-                    MultipartBodyPublisher.buildMultipartEntity(request.formDataFields(), request.formDataFiles());
+            HttpEntity entity = MultipartBodyPublisher.buildMultipartEntity(
+                    request.formDataFieldEntries(), request.formDataFiles());
             try {
                 byte[] bytes = EntityUtils.toByteArray(entity);
                 String contentTypeStr = entity.getContentType();

--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/ApacheHttpClient.java
@@ -205,13 +205,13 @@ public class ApacheHttpClient implements HttpClient {
                     case POST -> new HttpPost(request.url());
                 };
 
-        if (request.formDataFields().isEmpty() && request.formDataFiles().isEmpty()) {
+        if (request.formDataFieldEntries().isEmpty() && request.formDataFiles().isEmpty()) {
             if (request.body() != null) {
                 apacheRequest.setEntity(new StringEntity(request.body(), ContentType.APPLICATION_JSON));
             }
         } else {
-            HttpEntity entity =
-                    MultipartBodyPublisher.buildMultipartEntity(request.formDataFields(), request.formDataFiles());
+            HttpEntity entity = MultipartBodyPublisher.buildMultipartEntity(
+                    request.formDataFieldEntries(), request.formDataFiles());
             apacheRequest.setEntity(entity);
         }
 
@@ -230,7 +230,7 @@ public class ApacheHttpClient implements HttpClient {
         SimpleRequestBuilder builder;
         String uri = request.url();
 
-        if (request.formDataFields().isEmpty() && request.formDataFiles().isEmpty()) {
+        if (request.formDataFieldEntries().isEmpty() && request.formDataFiles().isEmpty()) {
             builder = switch (request.method()) {
                 case GET -> SimpleRequestBuilder.get(uri);
                 case DELETE -> SimpleRequestBuilder.delete(uri);
@@ -242,8 +242,8 @@ public class ApacheHttpClient implements HttpClient {
             }
         } else {
             builder = SimpleRequestBuilder.post(uri);
-            HttpEntity entity =
-                    MultipartBodyPublisher.buildMultipartEntity(request.formDataFields(), request.formDataFiles());
+            HttpEntity entity = MultipartBodyPublisher.buildMultipartEntity(
+                    request.formDataFieldEntries(), request.formDataFiles());
             try {
                 byte[] bytes = EntityUtils.toByteArray(entity);
                 String contentTypeStr = entity.getContentType();

--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/MultipartBodyPublisher.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/MultipartBodyPublisher.java
@@ -53,11 +53,11 @@ class MultipartBodyPublisher {
     }
 
     static HttpEntity buildMultipartEntity(
-            Map<String, String> formDataFields, Map<String, FormDataFile> formDataFiles) {
+            List<Map.Entry<String, String>> formDataFields, Map<String, FormDataFile> formDataFiles) {
         MultipartBodyPublisher publisher = new MultipartBodyPublisher();
 
-        for (Map.Entry<String, String> entry : formDataFields.entrySet()) {
-            publisher.addField(entry.getKey(), entry.getValue());
+        for (Map.Entry<String, String> field : formDataFields) {
+            publisher.addField(field.getKey(), field.getValue());
         }
 
         for (Map.Entry<String, FormDataFile> entry : formDataFiles.entrySet()) {

--- a/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/MultipartBodyPublisherTest.java
+++ b/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/MultipartBodyPublisherTest.java
@@ -156,6 +156,31 @@ class MultipartBodyPublisherTest {
         assertEquals(normalize(expected), body);
     }
 
+    @Test
+    void should_build_body_with_repeated_form_fields() {
+        MultipartBodyPublisher publisher = new MultipartBodyPublisher();
+
+        publisher.addField("timestamp_granularities[]", "word");
+        publisher.addField("timestamp_granularities[]", "segment");
+        publisher.build();
+
+        String body = bodyAsString(publisher.parts());
+
+        String expected = """
+                        ------LangChain4j
+                        Content-Disposition: form-data; name="timestamp_granularities[]"
+
+                        word
+                        ------LangChain4j
+                        Content-Disposition: form-data; name="timestamp_granularities[]"
+
+                        segment
+                        ------LangChain4j--
+                        """;
+
+        assertEquals(normalize(expected), body);
+    }
+
     private static String bodyAsString(List<byte[]> parts) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         for (byte[] part : parts) {

--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
@@ -23,6 +23,7 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
 public class JdkHttpClient implements HttpClient {
@@ -110,14 +111,14 @@ public class JdkHttpClient implements HttpClient {
         });
 
         BodyPublisher bodyPublisher;
-        if (request.formDataFields().isEmpty() && request.formDataFiles().isEmpty()) {
+        if (request.formDataFieldEntries().isEmpty() && request.formDataFiles().isEmpty()) {
             if (request.body() != null) {
                 bodyPublisher = BodyPublishers.ofString(request.body());
             } else {
                 bodyPublisher = BodyPublishers.noBody();
             }
         } else {
-            bodyPublisher = ofMultipartData(request.formDataFields(), request.formDataFiles());
+            bodyPublisher = ofMultipartData(request.formDataFieldEntries(), request.formDataFiles());
             builder.setHeader("Content-Type", MultipartBodyPublisher.contentType());
         }
         builder.method(request.method().name(), bodyPublisher);
@@ -129,10 +130,11 @@ public class JdkHttpClient implements HttpClient {
         return builder.build();
     }
 
-    private static BodyPublisher ofMultipartData(Map<String, String> fields, Map<String, FormDataFile> files) {
+    private static BodyPublisher ofMultipartData(
+            List<Map.Entry<String, String>> fields, Map<String, FormDataFile> files) {
         MultipartBodyPublisher publisher = new MultipartBodyPublisher();
-        for (Map.Entry<String, String> entry : fields.entrySet()) {
-            publisher.addField(entry.getKey(), entry.getValue());
+        for (Map.Entry<String, String> field : fields) {
+            publisher.addField(field.getKey(), field.getValue());
         }
         for (Map.Entry<String, FormDataFile> entry : files.entrySet()) {
             publisher.addFile(entry.getKey(), entry.getValue());

--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
@@ -20,6 +20,7 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
 public class JdkHttpClient implements HttpClient {
@@ -107,14 +108,14 @@ public class JdkHttpClient implements HttpClient {
         });
 
         BodyPublisher bodyPublisher;
-        if (request.formDataFields().isEmpty() && request.formDataFiles().isEmpty()) {
+        if (request.formDataFieldEntries().isEmpty() && request.formDataFiles().isEmpty()) {
             if (request.body() != null) {
                 bodyPublisher = BodyPublishers.ofString(request.body());
             } else {
                 bodyPublisher = BodyPublishers.noBody();
             }
         } else {
-            bodyPublisher = ofMultipartData(request.formDataFields(), request.formDataFiles());
+            bodyPublisher = ofMultipartData(request.formDataFieldEntries(), request.formDataFiles());
             builder.setHeader("Content-Type", MultipartBodyPublisher.contentType());
         }
         builder.method(request.method().name(), bodyPublisher);
@@ -126,10 +127,11 @@ public class JdkHttpClient implements HttpClient {
         return builder.build();
     }
 
-    private static BodyPublisher ofMultipartData(Map<String, String> fields, Map<String, FormDataFile> files) {
+    private static BodyPublisher ofMultipartData(
+            List<Map.Entry<String, String>> fields, Map<String, FormDataFile> files) {
         MultipartBodyPublisher publisher = new MultipartBodyPublisher();
-        for (Map.Entry<String, String> entry : fields.entrySet()) {
-            publisher.addField(entry.getKey(), entry.getValue());
+        for (Map.Entry<String, String> field : fields) {
+            publisher.addField(field.getKey(), field.getValue());
         }
         for (Map.Entry<String, FormDataFile> entry : files.entrySet()) {
             publisher.addFile(entry.getKey(), entry.getValue());

--- a/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/MultipartBodyPublisherTest.java
+++ b/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/MultipartBodyPublisherTest.java
@@ -138,6 +138,31 @@ class MultipartBodyPublisherTest {
                 bodyAsString(publisher.parts()).contains("------LangChain4j"));
     }
 
+    @Test
+    void should_build_body_with_repeated_form_fields() {
+        MultipartBodyPublisher publisher = new MultipartBodyPublisher();
+
+        publisher.addField("timestamp_granularities[]", "word");
+        publisher.addField("timestamp_granularities[]", "segment");
+        publisher.build();
+
+        String body = bodyAsString(publisher.parts());
+
+        String expected = """
+                        ------LangChain4j
+                        Content-Disposition: form-data; name="timestamp_granularities[]"
+
+                        word
+                        ------LangChain4j
+                        Content-Disposition: form-data; name="timestamp_granularities[]"
+
+                        segment
+                        ------LangChain4j--
+                        """;
+
+        assertEquals(normalize(expected), body);
+    }
+
     private static String bodyAsString(List<byte[]> parts) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         for (byte[] part : parts) {

--- a/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.http.client.okhttp;
 
+import static dev.langchain4j.http.client.sse.ServerSentEventListenerUtils.ignoringExceptions;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.TimeoutException;
 import dev.langchain4j.http.client.FormDataFile;
@@ -8,14 +11,6 @@ import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.MediaType;
-import okhttp3.MultipartBody;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.SocketTimeoutException;
@@ -23,9 +18,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import static dev.langchain4j.http.client.sse.ServerSentEventListenerUtils.ignoringExceptions;
-import static dev.langchain4j.internal.Utils.getOrDefault;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 public class OkHttpClient implements HttpClient {
 
@@ -164,18 +163,17 @@ public class OkHttpClient implements HttpClient {
     }
 
     private RequestBody buildRequestBody(HttpRequest request) {
-        if (!request.formDataFields().isEmpty() || !request.formDataFiles().isEmpty()) {
-            MultipartBody.Builder multipartBuilder =
-                    new MultipartBody.Builder().setType(MultipartBody.FORM);
+        if (!request.formDataFieldEntries().isEmpty()
+                || !request.formDataFiles().isEmpty()) {
+            MultipartBody.Builder multipartBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
 
-            for (Map.Entry<String, String> entry : request.formDataFields().entrySet()) {
-                multipartBuilder.addFormDataPart(entry.getKey(), entry.getValue());
+            for (Map.Entry<String, String> field : request.formDataFieldEntries()) {
+                multipartBuilder.addFormDataPart(field.getKey(), field.getValue());
             }
 
             for (Map.Entry<String, FormDataFile> entry : request.formDataFiles().entrySet()) {
                 FormDataFile file = entry.getValue();
-                RequestBody fileBody = RequestBody.create(
-                        file.content(), MediaType.parse(file.contentType()));
+                RequestBody fileBody = RequestBody.create(file.content(), MediaType.parse(file.contentType()));
                 multipartBuilder.addFormDataPart(entry.getKey(), file.fileName(), fileBody);
             }
 

--- a/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/main/java/dev/langchain4j/http/client/okhttp/OkHttpClient.java
@@ -171,11 +171,12 @@ public class OkHttpClient implements HttpClient {
     }
 
     private RequestBody buildRequestBody(HttpRequest request) {
-        if (!request.formDataFields().isEmpty() || !request.formDataFiles().isEmpty()) {
+        if (!request.formDataFieldEntries().isEmpty()
+                || !request.formDataFiles().isEmpty()) {
             MultipartBody.Builder multipartBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
 
-            for (Map.Entry<String, String> entry : request.formDataFields().entrySet()) {
-                multipartBuilder.addFormDataPart(entry.getKey(), entry.getValue());
+            for (Map.Entry<String, String> field : request.formDataFieldEntries()) {
+                multipartBuilder.addFormDataPart(field.getKey(), field.getValue());
             }
 
             for (Map.Entry<String, FormDataFile> entry : request.formDataFiles().entrySet()) {

--- a/http-clients/langchain4j-http-client-okhttp/src/test/java/dev/langchain4j/http/client/okhttp/OkHttpClientTest.java
+++ b/http-clients/langchain4j-http-client-okhttp/src/test/java/dev/langchain4j/http/client/okhttp/OkHttpClientTest.java
@@ -1,0 +1,58 @@
+package dev.langchain4j.http.client.okhttp;
+
+import static dev.langchain4j.http.client.HttpMethod.POST;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class OkHttpClientTest {
+
+    @Test
+    void should_send_repeated_form_data_fields() throws Exception {
+        AtomicReference<String> requestBody = new AtomicReference<>();
+
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/upload", exchange -> {
+            requestBody.set(new String(exchange.getRequestBody().readAllBytes(), UTF_8));
+            byte[] response = "ok".getBytes(UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+
+        try {
+            HttpRequest request = HttpRequest.builder()
+                    .method(POST)
+                    .url("http://localhost:" + server.getAddress().getPort() + "/upload")
+                    .addFormDataField("timestamp_granularities[]", "word")
+                    .addFormDataField("timestamp_granularities[]", "segment")
+                    .build();
+
+            SuccessfulHttpResponse response = OkHttpClient.builder().build().execute(request);
+
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(requestBody.get()).contains("word").contains("segment");
+            assertThat(numberOfOccurrences(requestBody.get(), "name=\"timestamp_granularities[]\""))
+                    .isEqualTo(2);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static int numberOfOccurrences(String value, String substring) {
+        int count = 0;
+        int fromIndex = 0;
+        while ((fromIndex = value.indexOf(substring, fromIndex)) >= 0) {
+            count++;
+            fromIndex += substring.length();
+        }
+        return count;
+    }
+}

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiAudioTranscriptionModel.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiAudioTranscriptionModel.java
@@ -8,6 +8,7 @@ import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.AudioTranscription;
 import com.azure.ai.openai.models.AudioTranscriptionFormat;
 import com.azure.ai.openai.models.AudioTranscriptionOptions;
+import com.azure.ai.openai.models.AudioTranscriptionTimestampGranularity;
 import com.azure.core.credential.KeyCredential;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.HttpClientProvider;
@@ -19,8 +20,11 @@ import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.audio.AudioTranscriptionModel;
 import dev.langchain4j.model.audio.AudioTranscriptionRequest;
 import dev.langchain4j.model.audio.AudioTranscriptionResponse;
+import dev.langchain4j.model.audio.AudioTranscriptionSegment;
+import dev.langchain4j.model.audio.AudioTranscriptionWord;
 import dev.langchain4j.model.azure.spi.AzureOpenAiAudioTranscriptionModelBuilderFactory;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -123,10 +127,40 @@ public class AzureOpenAiAudioTranscriptionModel implements AudioTranscriptionMod
             options.setTemperature(request.temperature());
         }
 
+        if (!request.timestampGranularities().isEmpty()) {
+            options.setResponseFormat(AudioTranscriptionFormat.VERBOSE_JSON);
+            options.setTimestampGranularities(request.timestampGranularities().stream()
+                    .map(AudioTranscriptionTimestampGranularity::fromString)
+                    .toList());
+        }
+
         AudioTranscription audioTranscription =
                 client.getAudioTranscription(deploymentName, options.getFilename(), options);
 
-        return AudioTranscriptionResponse.from(audioTranscription.getText());
+        return new AudioTranscriptionResponse(
+                audioTranscription.getText(),
+                toAudioTranscriptionSegments(audioTranscription.getSegments()),
+                toAudioTranscriptionWords(audioTranscription.getWords()));
+    }
+
+    private static List<AudioTranscriptionSegment> toAudioTranscriptionSegments(
+            List<com.azure.ai.openai.models.AudioTranscriptionSegment> segments) {
+        if (segments == null || segments.isEmpty()) {
+            return List.of();
+        }
+        return segments.stream()
+                .map(segment -> new AudioTranscriptionSegment(segment.getText(), segment.getStart(), segment.getEnd()))
+                .toList();
+    }
+
+    private static List<AudioTranscriptionWord> toAudioTranscriptionWords(
+            List<com.azure.ai.openai.models.AudioTranscriptionWord> words) {
+        if (words == null || words.isEmpty()) {
+            return List.of();
+        }
+        return words.stream()
+                .map(word -> new AudioTranscriptionWord(word.getWord(), word.getStart(), word.getEnd()))
+                .toList();
     }
 
     /**

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiAudioTranscriptionModelTest.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiAudioTranscriptionModelTest.java
@@ -12,12 +12,15 @@ import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.AudioTranscription;
 import com.azure.ai.openai.models.AudioTranscriptionFormat;
 import com.azure.ai.openai.models.AudioTranscriptionOptions;
+import com.azure.ai.openai.models.AudioTranscriptionTimestampGranularity;
 import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpClientProvider;
 import dev.langchain4j.data.audio.Audio;
 import dev.langchain4j.model.audio.AudioTranscriptionRequest;
 import dev.langchain4j.model.audio.AudioTranscriptionResponse;
+import java.time.Duration;
 import java.util.Base64;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -322,5 +325,100 @@ class AzureOpenAiAudioTranscriptionModelTest {
         // then - should use default filename "audio.mp3"
         verify(client)
                 .getAudioTranscription(eq("test-deployment"), eq("audio.mp3"), any(AudioTranscriptionOptions.class));
+    }
+
+    @Test
+    void should_not_request_verbose_response_when_timestamp_granularities_are_empty() {
+        // given
+        OpenAIClient client = mock(OpenAIClient.class);
+        AudioTranscription mockTranscription = mock(AudioTranscription.class);
+        when(mockTranscription.getText()).thenReturn("Transcribed text");
+        when(client.getAudioTranscription(any(), any(), any(AudioTranscriptionOptions.class)))
+                .thenReturn(mockTranscription);
+
+        AzureOpenAiAudioTranscriptionModel model =
+                new AzureOpenAiAudioTranscriptionModel(client, "test-deployment", AudioTranscriptionFormat.JSON);
+
+        Audio audio = Audio.builder()
+                .binaryData("test audio".getBytes())
+                .mimeType("audio/wav")
+                .build();
+
+        AudioTranscriptionRequest request = AudioTranscriptionRequest.builder()
+                .audio(audio)
+                .timestampGranularities(List.of())
+                .build();
+
+        // when
+        AudioTranscriptionResponse response = model.transcribe(request);
+
+        // then
+        ArgumentCaptor<AudioTranscriptionOptions> optionsCaptor =
+                ArgumentCaptor.forClass(AudioTranscriptionOptions.class);
+        verify(client).getAudioTranscription(eq("test-deployment"), eq("audio.mp3"), optionsCaptor.capture());
+
+        assertThat(optionsCaptor.getValue().getResponseFormat()).isEqualTo(AudioTranscriptionFormat.JSON);
+        assertThat(response.text()).isEqualTo("Transcribed text");
+        assertThat(response.segments()).isEmpty();
+        assertThat(response.words()).isEmpty();
+    }
+
+    @Test
+    void should_transcribe_with_timestamp_granularities() {
+        // given
+        OpenAIClient client = mock(OpenAIClient.class);
+        AudioTranscription mockTranscription = mock(AudioTranscription.class);
+        com.azure.ai.openai.models.AudioTranscriptionSegment mockSegment =
+                mock(com.azure.ai.openai.models.AudioTranscriptionSegment.class);
+        com.azure.ai.openai.models.AudioTranscriptionWord mockWord =
+                mock(com.azure.ai.openai.models.AudioTranscriptionWord.class);
+
+        when(mockTranscription.getText()).thenReturn("Hello world");
+        when(mockTranscription.getSegments()).thenReturn(List.of(mockSegment));
+        when(mockTranscription.getWords()).thenReturn(List.of(mockWord));
+        when(mockSegment.getText()).thenReturn("Hello world");
+        when(mockSegment.getStart()).thenReturn(Duration.ZERO);
+        when(mockSegment.getEnd()).thenReturn(Duration.ofMillis(1200));
+        when(mockWord.getWord()).thenReturn("Hello");
+        when(mockWord.getStart()).thenReturn(Duration.ZERO);
+        when(mockWord.getEnd()).thenReturn(Duration.ofMillis(500));
+        when(client.getAudioTranscription(any(), any(), any(AudioTranscriptionOptions.class)))
+                .thenReturn(mockTranscription);
+
+        AzureOpenAiAudioTranscriptionModel model =
+                new AzureOpenAiAudioTranscriptionModel(client, "test-deployment", AudioTranscriptionFormat.JSON);
+
+        Audio audio = Audio.builder()
+                .binaryData("test audio".getBytes())
+                .mimeType("audio/wav")
+                .build();
+
+        AudioTranscriptionRequest request = AudioTranscriptionRequest.builder()
+                .audio(audio)
+                .timestampGranularities("word", "segment")
+                .build();
+
+        // when
+        AudioTranscriptionResponse response = model.transcribe(request);
+
+        // then
+        ArgumentCaptor<AudioTranscriptionOptions> optionsCaptor =
+                ArgumentCaptor.forClass(AudioTranscriptionOptions.class);
+        verify(client).getAudioTranscription(eq("test-deployment"), eq("audio.mp3"), optionsCaptor.capture());
+
+        assertThat(optionsCaptor.getValue().getResponseFormat()).isEqualTo(AudioTranscriptionFormat.VERBOSE_JSON);
+        assertThat(optionsCaptor.getValue().getTimestampGranularities())
+                .containsExactly(
+                        AudioTranscriptionTimestampGranularity.WORD, AudioTranscriptionTimestampGranularity.SEGMENT);
+
+        assertThat(response.text()).isEqualTo("Hello world");
+        assertThat(response.segments()).hasSize(1);
+        assertThat(response.segments().get(0).text()).isEqualTo("Hello world");
+        assertThat(response.segments().get(0).startTime()).isEqualTo(Duration.ZERO);
+        assertThat(response.segments().get(0).endTime()).isEqualTo(Duration.ofMillis(1200));
+        assertThat(response.words()).hasSize(1);
+        assertThat(response.words().get(0).word()).isEqualTo("Hello");
+        assertThat(response.words().get(0).startTime()).isEqualTo(Duration.ZERO);
+        assertThat(response.words().get(0).endTime()).isEqualTo(Duration.ofMillis(500));
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/audio/AudioTranscriptionRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/audio/AudioTranscriptionRequest.java
@@ -1,7 +1,11 @@
 package dev.langchain4j.model.audio;
 
+import static dev.langchain4j.internal.Utils.copy;
+import static java.util.Arrays.asList;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.data.audio.Audio;
+import java.util.List;
 
 /**
  * Request to transcribe audio.
@@ -13,12 +17,14 @@ public class AudioTranscriptionRequest {
     private final String prompt;
     private final String language;
     private final Double temperature;
+    private final List<String> timestampGranularities;
 
     private AudioTranscriptionRequest(Builder builder) {
         this.audio = builder.audio;
         this.prompt = builder.prompt;
         this.language = builder.language;
         this.temperature = builder.temperature;
+        this.timestampGranularities = copy(builder.timestampGranularities);
     }
 
     /**
@@ -49,6 +55,19 @@ public class AudioTranscriptionRequest {
         return temperature;
     }
 
+    /**
+     * @return Optional timestamp granularities to include in the transcription response.
+     * <p>
+     * This feature is disabled by default. When configured, integrations may request
+     * a provider-specific verbose response format to return timestamps.
+     * Supported values and model or deployment support are provider-specific.
+     * If the selected model or deployment does not support the requested timestamp
+     * granularity, the provider will return an error.
+     */
+    public List<String> timestampGranularities() {
+        return timestampGranularities;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -62,6 +81,7 @@ public class AudioTranscriptionRequest {
         private String prompt;
         private String language;
         private Double temperature;
+        private List<String> timestampGranularities;
 
         /**
          * Sets the audio data to transcribe.
@@ -105,6 +125,35 @@ public class AudioTranscriptionRequest {
         public Builder temperature(Double temperature) {
             this.temperature = temperature;
             return this;
+        }
+
+        /**
+         * Sets optional timestamp granularities to include in the transcription response.
+         * <p>
+         * This feature is disabled by default. When configured, integrations may request
+         * a provider-specific verbose response format to return timestamps.
+         * Supported values and model or deployment support are provider-specific.
+         * If the selected model or deployment does not support the requested timestamp
+         * granularity, the provider will return an error.
+         *
+         * @param timestampGranularities The timestamp granularities, for example "word" or "segment"
+         * @return builder
+         */
+        public Builder timestampGranularities(List<String> timestampGranularities) {
+            this.timestampGranularities = timestampGranularities;
+            return this;
+        }
+
+        /**
+         * Sets optional timestamp granularities to include in the transcription response.
+         *
+         * @see #timestampGranularities(List)
+         *
+         * @param timestampGranularities The timestamp granularities, for example "word" or "segment"
+         * @return builder
+         */
+        public Builder timestampGranularities(String... timestampGranularities) {
+            return timestampGranularities(asList(timestampGranularities));
         }
 
         public AudioTranscriptionRequest build() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/audio/AudioTranscriptionResponse.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/audio/AudioTranscriptionResponse.java
@@ -1,6 +1,9 @@
 package dev.langchain4j.model.audio;
 
+import static dev.langchain4j.internal.Utils.copy;
+
 import dev.langchain4j.Experimental;
+import java.util.List;
 
 /**
  * Response containing the transcription of an audio file.
@@ -9,6 +12,8 @@ import dev.langchain4j.Experimental;
 public class AudioTranscriptionResponse {
 
     private final String text;
+    private final List<AudioTranscriptionSegment> segments;
+    private final List<AudioTranscriptionWord> words;
 
     /**
      * Creates a new response with the given text.
@@ -16,7 +21,21 @@ public class AudioTranscriptionResponse {
      * @param text The transcribed text
      */
     public AudioTranscriptionResponse(String text) {
+        this(text, null, null);
+    }
+
+    /**
+     * Creates a new response with the given text and timestamps.
+     *
+     * @param text The transcribed text
+     * @param segments The transcribed segments with timestamps
+     * @param words The transcribed words with timestamps
+     */
+    public AudioTranscriptionResponse(
+            String text, List<AudioTranscriptionSegment> segments, List<AudioTranscriptionWord> words) {
         this.text = text;
+        this.segments = copy(segments);
+        this.words = copy(words);
     }
 
     /**
@@ -24,6 +43,22 @@ public class AudioTranscriptionResponse {
      */
     public String text() {
         return text;
+    }
+
+    /**
+     * @return The transcribed segments with timestamps
+     * or an empty list when segment timestamps were not requested or not returned.
+     */
+    public List<AudioTranscriptionSegment> segments() {
+        return segments;
+    }
+
+    /**
+     * @return The transcribed words with timestamps
+     * or an empty list when word timestamps were not requested or not returned.
+     */
+    public List<AudioTranscriptionWord> words() {
+        return words;
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/audio/AudioTranscriptionSegment.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/audio/AudioTranscriptionSegment.java
@@ -1,0 +1,61 @@
+package dev.langchain4j.model.audio;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * A transcribed audio segment with timestamps.
+ */
+@Experimental
+public class AudioTranscriptionSegment {
+
+    private final String text;
+    private final Duration startTime;
+    private final Duration endTime;
+
+    public AudioTranscriptionSegment(String text, Duration startTime, Duration endTime) {
+        this.text = text;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public String text() {
+        return text;
+    }
+
+    public Duration startTime() {
+        return startTime;
+    }
+
+    public Duration endTime() {
+        return endTime;
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AudioTranscriptionSegment that = (AudioTranscriptionSegment) o;
+        return Objects.equals(text, that.text)
+                && Objects.equals(startTime, that.startTime)
+                && Objects.equals(endTime, that.endTime);
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public int hashCode() {
+        return Objects.hash(text, startTime, endTime);
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public String toString() {
+        return "AudioTranscriptionSegment {" + " text = "
+                + text + ", startTime = "
+                + startTime + ", endTime = "
+                + endTime + " }";
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/audio/AudioTranscriptionWord.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/audio/AudioTranscriptionWord.java
@@ -1,0 +1,61 @@
+package dev.langchain4j.model.audio;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * A transcribed audio word with timestamps.
+ */
+@Experimental
+public class AudioTranscriptionWord {
+
+    private final String word;
+    private final Duration startTime;
+    private final Duration endTime;
+
+    public AudioTranscriptionWord(String word, Duration startTime, Duration endTime) {
+        this.word = word;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public String word() {
+        return word;
+    }
+
+    public Duration startTime() {
+        return startTime;
+    }
+
+    public Duration endTime() {
+        return endTime;
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AudioTranscriptionWord that = (AudioTranscriptionWord) o;
+        return Objects.equals(word, that.word)
+                && Objects.equals(startTime, that.startTime)
+                && Objects.equals(endTime, that.endTime);
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public int hashCode() {
+        return Objects.hash(word, startTime, endTime);
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public String toString() {
+        return "AudioTranscriptionWord {" + " word = "
+                + word + ", startTime = "
+                + startTime + ", endTime = "
+                + endTime + " }";
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/audio/AudioTranscriptionRequestTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/audio/AudioTranscriptionRequestTest.java
@@ -25,6 +25,7 @@ class AudioTranscriptionRequestTest {
         assertThat(request.prompt()).isNull();
         assertThat(request.language()).isNull();
         assertThat(request.temperature()).isNull();
+        assertThat(request.timestampGranularities()).isEmpty();
     }
 
     @Test
@@ -51,6 +52,7 @@ class AudioTranscriptionRequestTest {
         assertThat(request.prompt()).isEqualTo(prompt);
         assertThat(request.language()).isEqualTo(language);
         assertThat(request.temperature()).isEqualTo(temperature);
+        assertThat(request.timestampGranularities()).isEmpty();
     }
 
     @Test
@@ -179,5 +181,23 @@ class AudioTranscriptionRequestTest {
 
         // then
         assertThat(request.prompt()).isEqualTo(longPrompt);
+    }
+
+    @Test
+    void should_create_request_with_timestamp_granularities() {
+        // given
+        Audio audio = Audio.builder()
+                .binaryData("test audio".getBytes())
+                .mimeType("audio/wav")
+                .build();
+
+        // when
+        AudioTranscriptionRequest request = AudioTranscriptionRequest.builder()
+                .audio(audio)
+                .timestampGranularities("word", "segment")
+                .build();
+
+        // then
+        assertThat(request.timestampGranularities()).containsExactly("word", "segment");
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/audio/AudioTranscriptionResponseTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/audio/AudioTranscriptionResponseTest.java
@@ -2,6 +2,8 @@ package dev.langchain4j.model.audio;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class AudioTranscriptionResponseTest {
@@ -127,6 +129,33 @@ class AudioTranscriptionResponseTest {
 
         // then
         assertThat(response1.text()).isEqualTo(response2.text());
+    }
+
+    @Test
+    void should_create_text_response_with_empty_timestamp_lists() {
+        // when
+        AudioTranscriptionResponse response = AudioTranscriptionResponse.from("Text only");
+
+        // then
+        assertThat(response.segments()).isEmpty();
+        assertThat(response.words()).isEmpty();
+    }
+
+    @Test
+    void should_create_response_with_segments_and_words() {
+        // given
+        AudioTranscriptionSegment segment =
+                new AudioTranscriptionSegment("Hello world", Duration.ZERO, Duration.ofMillis(1200));
+        AudioTranscriptionWord word = new AudioTranscriptionWord("Hello", Duration.ZERO, Duration.ofMillis(500));
+
+        // when
+        AudioTranscriptionResponse response =
+                new AudioTranscriptionResponse("Hello world", List.of(segment), List.of(word));
+
+        // then
+        assertThat(response.text()).isEqualTo("Hello world");
+        assertThat(response.segments()).containsExactly(segment);
+        assertThat(response.words()).containsExactly(word);
     }
 
     @Test

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
@@ -12,6 +12,8 @@ import static java.util.stream.Collectors.joining;
 import dev.langchain4j.Experimental;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -23,6 +25,7 @@ public class HttpRequest {
     private final String url;
     private final Map<String, List<String>> headers;
     private final Map<String, String> formDataFields;
+    private final List<Map.Entry<String, String>> formDataFieldEntries;
     private final Map<String, FormDataFile> formDataFiles;
     private final String body;
 
@@ -32,13 +35,14 @@ public class HttpRequest {
         this.url = buildUrl(builder);
         this.headers = copy(builder.headers);
         this.formDataFields = copy(builder.formDataFields);
+        this.formDataFieldEntries = copy(builder.formDataFieldEntries);
         this.formDataFiles = copy(builder.formDataFiles);
         this.body = builder.body;
     }
 
     private static void validate(Builder builder) {
         boolean hasBody = builder.body != null;
-        boolean hasFormDataFields = builder.formDataFields != null && !builder.formDataFields.isEmpty();
+        boolean hasFormDataFields = builder.formDataFieldEntries != null && !builder.formDataFieldEntries.isEmpty();
         boolean hasFormDataFiles = builder.formDataFiles != null && !builder.formDataFiles.isEmpty();
         if (hasBody && hasFormDataFields) {
             throw illegalArgument("Cannot specify both body and formDataFields");
@@ -90,6 +94,14 @@ public class HttpRequest {
     }
 
     /**
+     * @since 1.15.0
+     */
+    @Experimental
+    public List<Map.Entry<String, String>> formDataFieldEntries() {
+        return formDataFieldEntries;
+    }
+
+    /**
      * @since 1.10.0
      */
     @Experimental
@@ -112,6 +124,7 @@ public class HttpRequest {
         private Map<String, List<String>> headers;
         private Map<String, String> queryParams;
         private Map<String, String> formDataFields;
+        private List<Map.Entry<String, String>> formDataFieldEntries;
         private Map<String, FormDataFile> formDataFiles;
         private String body;
 
@@ -211,6 +224,12 @@ public class HttpRequest {
                 this.formDataFields = new LinkedHashMap<>();
             }
             this.formDataFields.put(name, value);
+
+            if (this.formDataFieldEntries == null) {
+                this.formDataFieldEntries = new ArrayList<>();
+            }
+            this.formDataFieldEntries.add(new SimpleImmutableEntry<>(name, value));
+
             return this;
         }
 
@@ -221,8 +240,12 @@ public class HttpRequest {
         public Builder formDataFields(Map<String, String> formDataFields) {
             if (formDataFields == null) {
                 this.formDataFields = null;
+                this.formDataFieldEntries = null;
             } else {
                 this.formDataFields = new LinkedHashMap<>(formDataFields);
+                this.formDataFieldEntries = new ArrayList<>();
+                formDataFields.forEach(
+                        (name, value) -> this.formDataFieldEntries.add(new SimpleImmutableEntry<>(name, value)));
             }
             return this;
         }

--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/HttpRequest.java
@@ -12,6 +12,8 @@ import static java.util.stream.Collectors.joining;
 import dev.langchain4j.Experimental;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -23,6 +25,7 @@ public class HttpRequest {
     private final String url;
     private final Map<String, List<String>> headers;
     private final Map<String, String> formDataFields;
+    private final List<Map.Entry<String, String>> formDataFieldEntries;
     private final Map<String, FormDataFile> formDataFiles;
     private final String body;
 
@@ -32,13 +35,14 @@ public class HttpRequest {
         this.url = buildUrl(builder);
         this.headers = HttpHeaders.copyCaseInsensitive(builder.headers);
         this.formDataFields = copy(builder.formDataFields);
+        this.formDataFieldEntries = copy(builder.formDataFieldEntries);
         this.formDataFiles = copy(builder.formDataFiles);
         this.body = builder.body;
     }
 
     private static void validate(Builder builder) {
         boolean hasBody = builder.body != null;
-        boolean hasFormDataFields = builder.formDataFields != null && !builder.formDataFields.isEmpty();
+        boolean hasFormDataFields = builder.formDataFieldEntries != null && !builder.formDataFieldEntries.isEmpty();
         boolean hasFormDataFiles = builder.formDataFiles != null && !builder.formDataFiles.isEmpty();
         if (hasBody && hasFormDataFields) {
             throw illegalArgument("Cannot specify both body and formDataFields");
@@ -90,6 +94,14 @@ public class HttpRequest {
     }
 
     /**
+     * @since 1.15.0
+     */
+    @Experimental
+    public List<Map.Entry<String, String>> formDataFieldEntries() {
+        return formDataFieldEntries;
+    }
+
+    /**
      * @since 1.10.0
      */
     @Experimental
@@ -112,6 +124,7 @@ public class HttpRequest {
         private Map<String, List<String>> headers;
         private Map<String, String> queryParams;
         private Map<String, String> formDataFields;
+        private List<Map.Entry<String, String>> formDataFieldEntries;
         private Map<String, FormDataFile> formDataFiles;
         private String body;
 
@@ -211,6 +224,12 @@ public class HttpRequest {
                 this.formDataFields = new LinkedHashMap<>();
             }
             this.formDataFields.put(name, value);
+
+            if (this.formDataFieldEntries == null) {
+                this.formDataFieldEntries = new ArrayList<>();
+            }
+            this.formDataFieldEntries.add(new SimpleImmutableEntry<>(name, value));
+
             return this;
         }
 
@@ -221,8 +240,12 @@ public class HttpRequest {
         public Builder formDataFields(Map<String, String> formDataFields) {
             if (formDataFields == null) {
                 this.formDataFields = null;
+                this.formDataFieldEntries = null;
             } else {
                 this.formDataFields = new LinkedHashMap<>(formDataFields);
+                this.formDataFieldEntries = new ArrayList<>();
+                formDataFields.forEach(
+                        (name, value) -> this.formDataFieldEntries.add(new SimpleImmutableEntry<>(name, value)));
             }
             return this;
         }

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpRequestTest.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpRequestTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.http.client;
 
 import static dev.langchain4j.http.client.HttpMethod.GET;
 import static dev.langchain4j.http.client.HttpMethod.POST;
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -492,5 +493,22 @@ class HttpRequestTest {
         // then
         assertThat(builder.build().url()).isEqualTo("http://example.com/api");
         assertThat(builder.build().formDataFields()).isEmpty();
+    }
+
+    @Test
+    void should_preserve_repeated_form_data_fields() {
+        // when
+        HttpRequest request = HttpRequest.builder()
+                .method(POST)
+                .url("http://example.com/api")
+                .addFormDataField("timestamp_granularities[]", "word")
+                .addFormDataField("timestamp_granularities[]", "segment")
+                .build();
+
+        // then
+        assertThat(request.formDataFields()).containsEntry("timestamp_granularities[]", "segment");
+        assertThat(request.formDataFieldEntries())
+                .containsExactly(
+                        entry("timestamp_granularities[]", "word"), entry("timestamp_granularities[]", "segment"));
     }
 }

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpRequestTest.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/HttpRequestTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.http.client;
 
 import static dev.langchain4j.http.client.HttpMethod.GET;
 import static dev.langchain4j.http.client.HttpMethod.POST;
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -555,5 +556,22 @@ class HttpRequestTest {
         assertThatThrownBy(builder::build)
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Header name cannot be null");
+    }
+
+    @Test
+    void should_preserve_repeated_form_data_fields() {
+        // when
+        HttpRequest request = HttpRequest.builder()
+                .method(POST)
+                .url("http://example.com/api")
+                .addFormDataField("timestamp_granularities[]", "word")
+                .addFormDataField("timestamp_granularities[]", "segment")
+                .build();
+
+        // then
+        assertThat(request.formDataFields()).containsEntry("timestamp_granularities[]", "segment");
+        assertThat(request.formDataFieldEntries())
+                .containsExactly(
+                        entry("timestamp_granularities[]", "word"), entry("timestamp_granularities[]", "segment"));
     }
 }

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiAudioTranscriptionModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiAudioTranscriptionModel.java
@@ -1,28 +1,33 @@
 package dev.langchain4j.model.openai;
 
+import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.model.ModelProvider.OPEN_AI;
+import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_OPENAI_URL;
+import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_USER_AGENT;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+import static java.time.Duration.ofSeconds;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.audio.AudioTranscriptionModel;
 import dev.langchain4j.model.audio.AudioTranscriptionRequest;
 import dev.langchain4j.model.audio.AudioTranscriptionResponse;
+import dev.langchain4j.model.audio.AudioTranscriptionSegment;
+import dev.langchain4j.model.audio.AudioTranscriptionWord;
 import dev.langchain4j.model.openai.internal.OpenAiClient;
 import dev.langchain4j.model.openai.internal.ParsedAndRawResponse;
+import dev.langchain4j.model.openai.internal.audio.transcription.AudioFile;
 import dev.langchain4j.model.openai.internal.audio.transcription.OpenAiAudioTranscriptionRequest;
 import dev.langchain4j.model.openai.internal.audio.transcription.OpenAiAudioTranscriptionResponse;
-import dev.langchain4j.model.openai.internal.audio.transcription.AudioFile;
+import dev.langchain4j.model.openai.internal.audio.transcription.OpenAiAudioTranscriptionSegment;
+import dev.langchain4j.model.openai.internal.audio.transcription.OpenAiAudioTranscriptionWord;
 import dev.langchain4j.model.openai.spi.OpenAiAudioTranscriptionModelBuilderFactory;
-import org.slf4j.Logger;
-
 import java.time.Duration;
-
-import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.model.ModelProvider.OPEN_AI;
-import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_OPENAI_URL;
-import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_USER_AGENT;
-import static dev.langchain4j.spi.ServiceHelper.loadFactories;
-import static java.time.Duration.ofSeconds;
+import java.util.List;
+import org.slf4j.Logger;
 
 /**
  * Represents an OpenAI audio model with a transcription interface, only gpt-4o-transcribe,
@@ -64,23 +69,58 @@ public class OpenAiAudioTranscriptionModel implements AudioTranscriptionModel {
             throw new IllegalArgumentException("Request and audio are required");
         }
 
-        OpenAiAudioTranscriptionRequest openAiRequest = requestBuilder(audioRequest).build();
+        OpenAiAudioTranscriptionRequest openAiRequest =
+                requestBuilder(audioRequest).build();
 
         ParsedAndRawResponse<OpenAiAudioTranscriptionResponse> parsedAndRawResponse = withRetryMappingExceptions(
                 () -> client.audioTranscription(openAiRequest).executeRaw(), maxRetries);
 
         OpenAiAudioTranscriptionResponse openAiResponse = parsedAndRawResponse.parsedResponse();
 
-        return AudioTranscriptionResponse.from(openAiResponse.text());
+        return new AudioTranscriptionResponse(
+                openAiResponse.text(),
+                toAudioTranscriptionSegments(openAiResponse.segments()),
+                toAudioTranscriptionWords(openAiResponse.words()));
     }
 
     private OpenAiAudioTranscriptionRequest.Builder requestBuilder(AudioTranscriptionRequest request) {
-        return OpenAiAudioTranscriptionRequest.builder()
+        OpenAiAudioTranscriptionRequest.Builder builder = OpenAiAudioTranscriptionRequest.builder()
                 .model(modelName)
                 .file(AudioFile.from(request.audio()))
                 .language(request.language())
                 .prompt(request.prompt())
-                .temperature(request.temperature());
+                .temperature(request.temperature())
+                .timestampGranularities(request.timestampGranularities());
+
+        if (!isNullOrEmpty(request.timestampGranularities())) {
+            builder.responseFormat("verbose_json");
+        }
+
+        return builder;
+    }
+
+    private static List<AudioTranscriptionSegment> toAudioTranscriptionSegments(
+            List<OpenAiAudioTranscriptionSegment> segments) {
+        if (isNullOrEmpty(segments)) {
+            return List.of();
+        }
+        return segments.stream()
+                .map(segment -> new AudioTranscriptionSegment(
+                        segment.text(), toDuration(segment.start()), toDuration(segment.end())))
+                .toList();
+    }
+
+    private static List<AudioTranscriptionWord> toAudioTranscriptionWords(List<OpenAiAudioTranscriptionWord> words) {
+        if (isNullOrEmpty(words)) {
+            return List.of();
+        }
+        return words.stream()
+                .map(word -> new AudioTranscriptionWord(word.word(), toDuration(word.start()), toDuration(word.end())))
+                .toList();
+    }
+
+    private static Duration toDuration(Double seconds) {
+        return seconds == null ? null : Duration.ofNanos(Math.round(seconds * 1_000_000_000));
     }
 
     @Override
@@ -89,7 +129,8 @@ public class OpenAiAudioTranscriptionModel implements AudioTranscriptionModel {
     }
 
     public static Builder builder() {
-        for (OpenAiAudioTranscriptionModelBuilderFactory factory : loadFactories(OpenAiAudioTranscriptionModelBuilderFactory.class)) {
+        for (OpenAiAudioTranscriptionModelBuilderFactory factory :
+                loadFactories(OpenAiAudioTranscriptionModelBuilderFactory.class)) {
             return factory.get();
         }
         return new Builder();

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/DefaultOpenAiClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/DefaultOpenAiClient.java
@@ -276,6 +276,16 @@ public class DefaultOpenAiClient extends OpenAiClient {
             httpRequestBuilder.addFormDataField("temperature", Double.toString(request.temperature()));
         }
 
+        if (request.responseFormat() != null) {
+            httpRequestBuilder.addFormDataField("response_format", request.responseFormat());
+        }
+
+        if (!isNullOrEmpty(request.timestampGranularities())) {
+            request.timestampGranularities()
+                    .forEach(granularity ->
+                            httpRequestBuilder.addFormDataField("timestamp_granularities[]", granularity));
+        }
+
         return new RequestExecutor<>(httpClient, httpRequestBuilder.build(), OpenAiAudioTranscriptionResponse.class);
     }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/audio/transcription/OpenAiAudioTranscriptionRequest.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/audio/transcription/OpenAiAudioTranscriptionRequest.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.model.openai.internal.audio.transcription;
 
+import java.util.List;
+
 /**
  * Represents the audio request.
  * Find description of parameters
@@ -23,6 +25,8 @@ public class OpenAiAudioTranscriptionRequest {
     private final String language;
     private final String prompt;
     private final Double temperature;
+    private final String responseFormat;
+    private final List<String> timestampGranularities;
 
     public OpenAiAudioTranscriptionRequest(Builder builder) {
         this.file = builder.file;
@@ -30,6 +34,8 @@ public class OpenAiAudioTranscriptionRequest {
         this.language = builder.language;
         this.prompt = builder.prompt;
         this.temperature = builder.temperature;
+        this.responseFormat = builder.responseFormat;
+        this.timestampGranularities = builder.timestampGranularities;
     }
 
     public AudioFile file() {
@@ -52,6 +58,14 @@ public class OpenAiAudioTranscriptionRequest {
         return temperature;
     }
 
+    public String responseFormat() {
+        return responseFormat;
+    }
+
+    public List<String> timestampGranularities() {
+        return timestampGranularities;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -63,6 +77,8 @@ public class OpenAiAudioTranscriptionRequest {
         private String language;
         private String prompt;
         private Double temperature;
+        private String responseFormat;
+        private List<String> timestampGranularities;
 
         public Builder file(AudioFile file) {
             this.file = file;
@@ -86,6 +102,16 @@ public class OpenAiAudioTranscriptionRequest {
 
         public Builder temperature(Double temperature) {
             this.temperature = temperature;
+            return this;
+        }
+
+        public Builder responseFormat(String responseFormat) {
+            this.responseFormat = responseFormat;
+            return this;
+        }
+
+        public Builder timestampGranularities(List<String> timestampGranularities) {
+            this.timestampGranularities = timestampGranularities;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/audio/transcription/OpenAiAudioTranscriptionResponse.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/audio/transcription/OpenAiAudioTranscriptionResponse.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
-
+import java.util.List;
 import java.util.Objects;
 
 @JsonDeserialize(builder = OpenAiAudioTranscriptionResponse.Builder.class)
@@ -22,9 +22,17 @@ public final class OpenAiAudioTranscriptionResponse {
     @JsonProperty
     private final AudioTokenUsage usage;
 
+    @JsonProperty
+    private final List<OpenAiAudioTranscriptionSegment> segments;
+
+    @JsonProperty
+    private final List<OpenAiAudioTranscriptionWord> words;
+
     public OpenAiAudioTranscriptionResponse(Builder builder) {
         this.text = builder.text;
         this.usage = builder.usage;
+        this.segments = builder.segments;
+        this.words = builder.words;
     }
 
     public String text() {
@@ -33,6 +41,14 @@ public final class OpenAiAudioTranscriptionResponse {
 
     public AudioTokenUsage usage() {
         return usage;
+    }
+
+    public List<OpenAiAudioTranscriptionSegment> segments() {
+        return segments;
+    }
+
+    public List<OpenAiAudioTranscriptionWord> words() {
+        return words;
     }
 
     @Override
@@ -45,7 +61,10 @@ public final class OpenAiAudioTranscriptionResponse {
 
     @JacocoIgnoreCoverageGenerated
     private boolean equalTo(OpenAiAudioTranscriptionResponse another) {
-        return Objects.equals(text, another.text) && Objects.equals(usage, another.usage);
+        return Objects.equals(text, another.text)
+                && Objects.equals(usage, another.usage)
+                && Objects.equals(segments, another.segments)
+                && Objects.equals(words, another.words);
     }
 
     @Override
@@ -54,13 +73,16 @@ public final class OpenAiAudioTranscriptionResponse {
         int h = 5381;
         h += (h << 5) + Objects.hashCode(text);
         h += (h << 5) + Objects.hashCode(usage);
+        h += (h << 5) + Objects.hashCode(segments);
+        h += (h << 5) + Objects.hashCode(words);
         return h;
     }
 
     @Override
     @JacocoIgnoreCoverageGenerated
     public String toString() {
-        return "OpenAiAudioTranscriptionResponse{" + "text=" + text + ", usage=" + usage + "}";
+        return "OpenAiAudioTranscriptionResponse{" + "text=" + text + ", usage=" + usage + ", segments=" + segments
+                + ", words=" + words + "}";
     }
 
     public static Builder builder() {
@@ -74,6 +96,8 @@ public final class OpenAiAudioTranscriptionResponse {
 
         private String text;
         private AudioTokenUsage usage;
+        private List<OpenAiAudioTranscriptionSegment> segments;
+        private List<OpenAiAudioTranscriptionWord> words;
 
         public Builder text(String text) {
             this.text = text;
@@ -82,6 +106,16 @@ public final class OpenAiAudioTranscriptionResponse {
 
         public Builder usage(AudioTokenUsage usage) {
             this.usage = usage;
+            return this;
+        }
+
+        public Builder segments(List<OpenAiAudioTranscriptionSegment> segments) {
+            this.segments = segments;
+            return this;
+        }
+
+        public Builder words(List<OpenAiAudioTranscriptionWord> words) {
+            this.words = words;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/audio/transcription/OpenAiAudioTranscriptionSegment.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/audio/transcription/OpenAiAudioTranscriptionSegment.java
@@ -1,0 +1,104 @@
+package dev.langchain4j.model.openai.internal.audio.transcription;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
+import java.util.Objects;
+
+@JsonDeserialize(builder = OpenAiAudioTranscriptionSegment.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class OpenAiAudioTranscriptionSegment {
+
+    @JsonProperty
+    private final String text;
+
+    @JsonProperty
+    private final Double start;
+
+    @JsonProperty
+    private final Double end;
+
+    public OpenAiAudioTranscriptionSegment(Builder builder) {
+        this.text = builder.text;
+        this.start = builder.start;
+        this.end = builder.end;
+    }
+
+    public String text() {
+        return text;
+    }
+
+    public Double start() {
+        return start;
+    }
+
+    public Double end() {
+        return end;
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public boolean equals(Object another) {
+        if (this == another) return true;
+        return another instanceof OpenAiAudioTranscriptionSegment openAiAudioTranscriptionSegment
+                && equalTo(openAiAudioTranscriptionSegment);
+    }
+
+    @JacocoIgnoreCoverageGenerated
+    private boolean equalTo(OpenAiAudioTranscriptionSegment another) {
+        return Objects.equals(text, another.text)
+                && Objects.equals(start, another.start)
+                && Objects.equals(end, another.end);
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public int hashCode() {
+        int h = 5381;
+        h += (h << 5) + Objects.hashCode(text);
+        h += (h << 5) + Objects.hashCode(start);
+        h += (h << 5) + Objects.hashCode(end);
+        return h;
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public String toString() {
+        return "OpenAiAudioTranscriptionSegment{" + "text=" + text + ", start=" + start + ", end=" + end + "}";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+
+        private String text;
+        private Double start;
+        private Double end;
+
+        public Builder text(String text) {
+            this.text = text;
+            return this;
+        }
+
+        public Builder start(Double start) {
+            this.start = start;
+            return this;
+        }
+
+        public Builder end(Double end) {
+            this.end = end;
+            return this;
+        }
+
+        public OpenAiAudioTranscriptionSegment build() {
+            return new OpenAiAudioTranscriptionSegment(this);
+        }
+    }
+}

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/audio/transcription/OpenAiAudioTranscriptionWord.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/audio/transcription/OpenAiAudioTranscriptionWord.java
@@ -1,0 +1,104 @@
+package dev.langchain4j.model.openai.internal.audio.transcription;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
+import java.util.Objects;
+
+@JsonDeserialize(builder = OpenAiAudioTranscriptionWord.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class OpenAiAudioTranscriptionWord {
+
+    @JsonProperty
+    private final String word;
+
+    @JsonProperty
+    private final Double start;
+
+    @JsonProperty
+    private final Double end;
+
+    public OpenAiAudioTranscriptionWord(Builder builder) {
+        this.word = builder.word;
+        this.start = builder.start;
+        this.end = builder.end;
+    }
+
+    public String word() {
+        return word;
+    }
+
+    public Double start() {
+        return start;
+    }
+
+    public Double end() {
+        return end;
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public boolean equals(Object another) {
+        if (this == another) return true;
+        return another instanceof OpenAiAudioTranscriptionWord openAiAudioTranscriptionWord
+                && equalTo(openAiAudioTranscriptionWord);
+    }
+
+    @JacocoIgnoreCoverageGenerated
+    private boolean equalTo(OpenAiAudioTranscriptionWord another) {
+        return Objects.equals(word, another.word)
+                && Objects.equals(start, another.start)
+                && Objects.equals(end, another.end);
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public int hashCode() {
+        int h = 5381;
+        h += (h << 5) + Objects.hashCode(word);
+        h += (h << 5) + Objects.hashCode(start);
+        h += (h << 5) + Objects.hashCode(end);
+        return h;
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public String toString() {
+        return "OpenAiAudioTranscriptionWord{" + "word=" + word + ", start=" + start + ", end=" + end + "}";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class Builder {
+
+        private String word;
+        private Double start;
+        private Double end;
+
+        public Builder word(String word) {
+            this.word = word;
+            return this;
+        }
+
+        public Builder start(Double start) {
+            this.start = start;
+            return this;
+        }
+
+        public Builder end(Double end) {
+            this.end = end;
+            return this;
+        }
+
+        public OpenAiAudioTranscriptionWord build() {
+            return new OpenAiAudioTranscriptionWord(this);
+        }
+    }
+}

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiAudioTranscriptionModelTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiAudioTranscriptionModelTest.java
@@ -1,0 +1,124 @@
+package dev.langchain4j.model.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import dev.langchain4j.data.audio.Audio;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.model.audio.AudioTranscriptionRequest;
+import dev.langchain4j.model.audio.AudioTranscriptionResponse;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OpenAiAudioTranscriptionModelTest {
+
+    @Test
+    void should_not_request_verbose_response_when_timestamp_granularities_are_not_set() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body("""
+                        {
+                          "text": "Hello world"
+                        }
+                        """).build());
+
+        OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+                .apiKey("test-key")
+                .modelName("whisper-1")
+                .httpClientProvider(new MockHttpClientBuilder(mockHttpClient))
+                .build();
+
+        Audio audio = Audio.builder()
+                .binaryData("test audio".getBytes())
+                .mimeType("audio/wav")
+                .build();
+
+        AudioTranscriptionRequest request =
+                AudioTranscriptionRequest.builder().audio(audio).build();
+
+        // when
+        AudioTranscriptionResponse response = model.transcribe(request);
+
+        // then
+        assertThat(mockHttpClient.request().formDataFieldEntries())
+                .extracting(Map.Entry::getKey, Map.Entry::getValue)
+                .containsExactly(tuple("model", "whisper-1"));
+
+        assertThat(response.text()).isEqualTo("Hello world");
+        assertThat(response.segments()).isEmpty();
+        assertThat(response.words()).isEmpty();
+    }
+
+    @Test
+    void should_send_timestamp_granularities_and_map_verbose_response() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                SuccessfulHttpResponse.builder().statusCode(200).body("""
+                        {
+                          "text": "Hello world",
+                          "segments": [
+                            {
+                              "id": 0,
+                              "seek": 0,
+                              "start": 0.0,
+                              "end": 1.2,
+                              "text": "Hello world",
+                              "tokens": [1, 2],
+                              "temperature": 0.0,
+                              "avg_logprob": -0.1,
+                              "compression_ratio": 1.0,
+                              "no_speech_prob": 0.0
+                            }
+                          ],
+                          "words": [
+                            {
+                              "word": "Hello",
+                              "start": 0.0,
+                              "end": 0.5
+                            }
+                          ]
+                        }
+                        """).build());
+
+        OpenAiAudioTranscriptionModel model = OpenAiAudioTranscriptionModel.builder()
+                .apiKey("test-key")
+                .modelName("whisper-1")
+                .httpClientProvider(new MockHttpClientBuilder(mockHttpClient))
+                .build();
+
+        Audio audio = Audio.builder()
+                .binaryData("test audio".getBytes())
+                .mimeType("audio/wav")
+                .build();
+
+        AudioTranscriptionRequest request = AudioTranscriptionRequest.builder()
+                .audio(audio)
+                .timestampGranularities("word", "segment")
+                .build();
+
+        // when
+        AudioTranscriptionResponse response = model.transcribe(request);
+
+        // then
+        assertThat(mockHttpClient.request().formDataFieldEntries())
+                .extracting(Map.Entry::getKey, Map.Entry::getValue)
+                .containsExactly(
+                        tuple("model", "whisper-1"),
+                        tuple("response_format", "verbose_json"),
+                        tuple("timestamp_granularities[]", "word"),
+                        tuple("timestamp_granularities[]", "segment"));
+
+        assertThat(response.text()).isEqualTo("Hello world");
+        assertThat(response.segments()).hasSize(1);
+        assertThat(response.segments().get(0).text()).isEqualTo("Hello world");
+        assertThat(response.segments().get(0).startTime()).isEqualTo(Duration.ZERO);
+        assertThat(response.segments().get(0).endTime()).isEqualTo(Duration.ofMillis(1200));
+        assertThat(response.words()).hasSize(1);
+        assertThat(response.words().get(0).word()).isEqualTo("Hello");
+        assertThat(response.words().get(0).startTime()).isEqualTo(Duration.ZERO);
+        assertThat(response.words().get(0).endTime()).isEqualTo(Duration.ofMillis(500));
+    }
+}


### PR DESCRIPTION
## Issue
Refs #5046

## Change
Adds timestamp support to the existing OpenAI and Azure OpenAI audio transcription integrations:

- optional word and segment timestamp granularities on AudioTranscriptionRequest
- word and segment timestamps on AudioTranscriptionResponse
- verbose JSON mapping for both providers
- repeated multipart fields across the existing HTTP clients

The default text-only path is unchanged. This PR does not add providers, diarization, speaker identification, or long-audio handling.

## Testing
- Focused timestamp and multipart suites passed across 12 reactor modules
- git diff --check