### PR TITLE
fix: fall back to exception class name when tool error has no message

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -114,7 +114,7 @@ public class DefaultToolExecutor implements ToolExecutor {
                 } else {
                     return ToolExecutionResult.builder()
                             .isError(true)
-                            .resultText(e2.getCause().getMessage())
+                            .resultText(errorMessage(e2.getCause()))
                             .build();
                 }
             }
@@ -124,7 +124,7 @@ public class DefaultToolExecutor implements ToolExecutor {
             } else {
                 return ToolExecutionResult.builder()
                         .isError(true)
-                        .resultText(e.getCause().getMessage())
+                        .resultText(errorMessage(e.getCause()))
                         .build();
             }
         }
@@ -175,7 +175,8 @@ public class DefaultToolExecutor implements ToolExecutor {
             return List.of(ImageContent.from(image));
         } else if (result instanceof Content content) {
             return List.of(content);
-        } else if (result instanceof Collection<?> collection && !collection.isEmpty()
+        } else if (result instanceof Collection<?> collection
+                && !collection.isEmpty()
                 && collection.iterator().next() instanceof Content) {
             return collection.stream().map(Content.class::cast).toList();
         } else if (result instanceof Content[] array) {
@@ -236,6 +237,11 @@ public class DefaultToolExecutor implements ToolExecutor {
         }
 
         return arguments;
+    }
+
+    private static String errorMessage(Throwable cause) {
+        String message = cause.getMessage();
+        return message != null ? message : cause.getClass().getName();
     }
 
     private static String getName(Parameter parameter) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -291,6 +291,49 @@ class DefaultToolExecutorTest implements WithAssertions {
         }
     }
 
+    private static class ThrowingTool {
+
+        @Tool
+        public String throwsWithMessage() {
+            throw new IllegalStateException("something went wrong");
+        }
+
+        @Tool
+        public String throwsWithoutMessage() {
+            throw new NullPointerException();
+        }
+    }
+
+    @Test
+    void tool_exception_with_message_is_returned_as_error() throws NoSuchMethodException {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("1")
+                .name("throwsWithMessage")
+                .arguments("{}")
+                .build();
+
+        DefaultToolExecutor executor =
+                new DefaultToolExecutor(new ThrowingTool(), ThrowingTool.class.getDeclaredMethod("throwsWithMessage"));
+
+        String result = executor.execute(request, "DEFAULT");
+        assertThat(result).isEqualTo("something went wrong");
+    }
+
+    @Test
+    void tool_exception_without_message_falls_back_to_class_name() throws NoSuchMethodException {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("1")
+                .name("throwsWithoutMessage")
+                .arguments("{}")
+                .build();
+
+        DefaultToolExecutor executor = new DefaultToolExecutor(
+                new ThrowingTool(), ThrowingTool.class.getDeclaredMethod("throwsWithoutMessage"));
+
+        String result = executor.execute(request, "DEFAULT");
+        assertThat(result).isEqualTo(NullPointerException.class.getName());
+    }
+
     @Test
     void should_execute_tool_by_method_name() throws NoSuchMethodException {
         ToolExecutionRequest request = ToolExecutionRequest.builder()
@@ -448,9 +491,7 @@ class DefaultToolExecutorTest implements WithAssertions {
                 .build();
         DefaultToolExecutor toolExecutor2 = new DefaultToolExecutor(new PersonTool(), request2);
         String result2 = toolExecutor2.execute(request2, "DEFAULT");
-        assertThat(result2)
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(result2).isEqualToIgnoringWhitespace("""
                 [
                   {
                     "name": "Klaus",
@@ -469,9 +510,7 @@ class DefaultToolExecutorTest implements WithAssertions {
                 .build();
         DefaultToolExecutor toolExecutor3 = new DefaultToolExecutor(new PersonTool(), request3);
         String result3 = toolExecutor3.execute(request3, "DEFAULT");
-        assertThat(result3)
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(result3).isEqualToIgnoringWhitespace("""
                 [
                   {
                     "name": "Peter",
@@ -491,9 +530,7 @@ class DefaultToolExecutorTest implements WithAssertions {
                 .build();
         DefaultToolExecutor toolExecutor4 = new DefaultToolExecutor(new PersonTool(), request4);
         String result4 = toolExecutor4.execute(request4, "DEFAULT");
-        assertThat(result4)
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(result4).isEqualToIgnoringWhitespace("""
                 {
                   "p1": {
                     "name": "Klaus",
@@ -512,9 +549,7 @@ class DefaultToolExecutorTest implements WithAssertions {
                 .build();
         DefaultToolExecutor toolExecutor5 = new DefaultToolExecutor(new PersonTool(), request5);
         String result5 = toolExecutor5.execute(request5, "DEFAULT");
-        assertThat(result5)
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(result5).isEqualToIgnoringWhitespace("""
                 [
                   {
                     "name": "Klaus",


### PR DESCRIPTION
## Issue
Closes #5087

## Change
When a tool method throws an exception with a \`null\` message (e.g. \`throw new NullPointerException()\`), \`DefaultToolExecutor.executeWithContext\` passed \`null\` to \`ToolExecutionResult.builder().resultText()\`. The builder treated \`null\` as "not set" and threw:

\`\`\`
IllegalStateException: One of resultText, resultTextSupplier, or resultContents must be provided
\`\`\`

This secondary exception masked the original tool failure entirely.

Fix: extract error message resolution into a small \`errorMessage(Throwable)\` helper that falls back to \`cause.getClass().getName()\` when \`getMessage()\` returns \`null\`.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)