### PR TITLE
fix: add ONNX encoder abstraction,  support non-BERT ONNX embedding encoders

### DIFF
--- a/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/AbstractInProcessEmbeddingModel.java
+++ b/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/AbstractInProcessEmbeddingModel.java
@@ -10,7 +10,6 @@ import static java.util.stream.Collectors.toList;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
-import dev.langchain4j.model.embedding.onnx.OnnxBertBiEncoder.EmbeddingAndTokenCount;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import java.io.InputStream;
@@ -48,6 +47,56 @@ public abstract class AbstractInProcessEmbeddingModel extends DimensionAwareEmbe
 
     protected abstract OnnxBertBiEncoder model();
 
+    protected Encoder encoder() {
+        return asEncoder(model());
+    }
+
+    static Encoder asEncoder(OnnxBertBiEncoder model) {
+        return new OnnxBertBiEncoderAdapter(model);
+    }
+
+    static Encoder asEncoder(OnnxBpeBiEncoder model) {
+        return new OnnxBpeBiEncoderAdapter(model);
+    }
+
+    private static final class OnnxBertBiEncoderAdapter implements Encoder {
+
+        private final OnnxBertBiEncoder model;
+
+        private OnnxBertBiEncoderAdapter(OnnxBertBiEncoder model) {
+            this.model = model;
+        }
+
+        @Override
+        public EmbeddingAndTokenCount embed(String text) {
+            return model.embed(text);
+        }
+
+        @Override
+        public int countTokens(String text) {
+            return model.countTokens(text);
+        }
+    }
+
+    private static final class OnnxBpeBiEncoderAdapter implements Encoder {
+
+        private final OnnxBpeBiEncoder model;
+
+        private OnnxBpeBiEncoderAdapter(OnnxBpeBiEncoder model) {
+            this.model = model;
+        }
+
+        @Override
+        public EmbeddingAndTokenCount embed(String text) {
+            return model.embed(text);
+        }
+
+        @Override
+        public int countTokens(String text) {
+            return model.countTokens(text);
+        }
+    }
+
     @Override
     public Response<List<Embedding>> embedAll(List<TextSegment> segments) {
         ensureNotEmpty(segments, "segments");
@@ -59,16 +108,15 @@ public abstract class AbstractInProcessEmbeddingModel extends DimensionAwareEmbe
     }
 
     private Response<List<Embedding>> embedInTheSameThread(TextSegment segment) {
-        EmbeddingAndTokenCount embeddingAndTokenCount = model().embed(segment.text());
+        EmbeddingAndTokenCount embeddingAndTokenCount = encoder().embed(segment.text());
         return Response.from(
                 singletonList(Embedding.from(embeddingAndTokenCount.embedding)),
-                new TokenUsage(embeddingAndTokenCount.tokenCount - 2) // do not count special tokens [CLS] and [SEP])
-                );
+                new TokenUsage(embeddingAndTokenCount.tokenCount));
     }
 
     private Response<List<Embedding>> parallelizeEmbedding(List<TextSegment> segments) {
         List<CompletableFuture<EmbeddingAndTokenCount>> futures = segments.stream()
-                .map(segment -> supplyAsync(() -> model().embed(segment.text()), executor))
+                .map(segment -> supplyAsync(() -> encoder().embed(segment.text()), executor))
                 .collect(toList());
 
         int inputTokenCount = 0;
@@ -78,9 +126,9 @@ public abstract class AbstractInProcessEmbeddingModel extends DimensionAwareEmbe
             try {
                 EmbeddingAndTokenCount embeddingAndTokenCount = future.get();
                 embeddings.add(Embedding.from(embeddingAndTokenCount.embedding));
-                inputTokenCount += embeddingAndTokenCount.tokenCount - 2; // do not count special tokens [CLS] and [SEP]
+                inputTokenCount += embeddingAndTokenCount.tokenCount;
             } catch (InterruptedException e) {
-                Thread.currentThread().interrupt(); 
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             } catch (ExecutionException e) {
                 throw new RuntimeException(e);

--- a/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/EmbeddingAndTokenCount.java
+++ b/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/EmbeddingAndTokenCount.java
@@ -1,0 +1,28 @@
+package dev.langchain4j.model.embedding.onnx;
+
+/**
+ * Embedding vector together with the token count reported by an encoder.
+ */
+public final class EmbeddingAndTokenCount {
+
+    /**
+     * The embedding vector.
+     */
+    public final float[] embedding;
+
+    /**
+     * The token count reported by the encoder.
+     */
+    public final int tokenCount;
+
+    /**
+     * Creates an embedding result with token usage.
+     *
+     * @param embedding The embedding vector.
+     * @param tokenCount The token count reported by the encoder.
+     */
+    public EmbeddingAndTokenCount(float[] embedding, int tokenCount) {
+        this.embedding = embedding;
+        this.tokenCount = tokenCount;
+    }
+}

--- a/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/Encoder.java
+++ b/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/Encoder.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.model.embedding.onnx;
+
+/**
+ * Encodes text into embeddings and reports the token count used by the encoder.
+ */
+public interface Encoder {
+
+    /**
+     * Embeds the provided text.
+     *
+     * @param text The text to embed.
+     * @return The embedding and token count.
+     */
+    EmbeddingAndTokenCount embed(String text);
+
+    /**
+     * Counts the tokens produced for the provided text.
+     *
+     * @param text The text to tokenize.
+     * @return The token count.
+     */
+    int countTokens(String text);
+}

--- a/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoder.java
+++ b/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoder.java
@@ -67,17 +67,6 @@ public class OnnxBertBiEncoder {
         }
     }
 
-    static class EmbeddingAndTokenCount {
-
-        float[] embedding;
-        int tokenCount;
-
-        EmbeddingAndTokenCount(float[] embedding, int tokenCount) {
-            this.embedding = embedding;
-            this.tokenCount = tokenCount;
-        }
-    }
-
     EmbeddingAndTokenCount embed(String text) {
 
         List<String> tokens = tokenizer.tokenize(text);
@@ -101,7 +90,9 @@ public class OnnxBertBiEncoder {
 
         float[] embedding = normalize(weightedAverage(embeddings, weights));
 
-        return new EmbeddingAndTokenCount(embedding, tokens.size());
+        // Subtract 2 to exclude [CLS] and [SEP] special tokens from the reported count.
+        // Each Encoder is responsible for reporting its own "content-only" token count.
+        return new EmbeddingAndTokenCount(embedding, Math.max(0, tokens.size() - 2));
     }
 
     static List<List<String>> partition(List<String> tokens, int partitionSize) {
@@ -257,12 +248,10 @@ public class OnnxBertBiEncoder {
 
     private byte[] loadModel(InputStream modelInputStream) {
         if (modelInputStream == null) {
-            throw new IllegalStateException(
-                    "Embedding model file is not available. " +
-                            "This usually happens when running LangChain4j tests from sources. " +
-                            "If you are developing LangChain4j locally, run 'mvn generate-resources' " +
-                            "from the project root to download the required model files."
-            );
+            throw new IllegalStateException("Embedding model file is not available. "
+                    + "This usually happens when running LangChain4j tests from sources. "
+                    + "If you are developing LangChain4j locally, run 'mvn generate-resources' "
+                    + "from the project root to download the required model files.");
         }
         try (InputStream inputStream = modelInputStream;
                 ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {

--- a/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxBpeBiEncoder.java
+++ b/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxBpeBiEncoder.java
@@ -1,0 +1,290 @@
+package dev.langchain4j.model.embedding.onnx;
+
+import static ai.onnxruntime.OnnxTensor.createTensor;
+import static dev.langchain4j.internal.Exceptions.illegalArgument;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.nio.LongBuffer.wrap;
+import static java.util.Collections.singletonMap;
+
+import ai.djl.huggingface.tokenizers.Encoding;
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtSession;
+import ai.onnxruntime.OrtSession.Result;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * ONNX-based encoder for BPE-tokenized / decoder-family embedding models
+ * (e.g., Qwen3-Embedding, E5-Mistral, gte-Qwen).
+ *
+ * <h2>Design differences from {@link OnnxBertBiEncoder}</h2>
+ * <ul>
+ *   <li>No dependency on {@code [CLS]} / {@code [SEP]} special tokens</li>
+ *   <li>No WordPiece {@code ##} subword boundary logic</li>
+ *   <li>Uses {@code attention_mask} for pooling (respects padding)</li>
+ *   <li>Supports {@link PoolingMode#LAST_TOKEN} and {@link PoolingMode#MEAN_MASKED}</li>
+ *   <li>Does not send {@code token_type_ids} to the model</li>
+ *   <li>Long inputs are truncated, not partitioned (Qwen3 supports 32k context,
+ *       partitioning makes less sense for decoder models)</li>
+ * </ul>
+ *
+ * <p><b>Reference implementations:</b>
+ * <ul>
+ *   <li>Qwen3-Embedding official inference code
+ *       (<a href="https://huggingface.co/Qwen/Qwen3-Embedding-0.6B">HuggingFace model card</a>)</li>
+ *   <li>sentence-transformers {@code Pooling} module
+ *       (<a href="https://github.com/UKPLab/sentence-transformers">UKPLab/sentence-transformers</a>)</li>
+ * </ul>
+ */
+public class OnnxBpeBiEncoder {
+
+    /** Default maximum tokens per input. Qwen3 supports up to 32k, but most use cases use fewer than 2048 tokens. */
+    public static final int DEFAULT_MAX_LENGTH = 2048;
+
+    private final OrtEnvironment environment;
+    private final OrtSession session;
+    private final Set<String> expectedInputs;
+    private final HuggingFaceTokenizer tokenizer;
+    private final PoolingMode poolingMode;
+    private final int maxLength;
+
+    public OnnxBpeBiEncoder(Path pathToModel, Path pathToTokenizer, PoolingMode poolingMode) {
+        this(pathToModel, pathToTokenizer, poolingMode, DEFAULT_MAX_LENGTH);
+    }
+
+    public OnnxBpeBiEncoder(Path pathToModel, Path pathToTokenizer, PoolingMode poolingMode, int maxLength) {
+        try {
+            this.environment = OrtEnvironment.getEnvironment();
+            this.session = environment.createSession(pathToModel.toString());
+            this.expectedInputs = session.getInputNames();
+            this.tokenizer = HuggingFaceTokenizer.newInstance(pathToTokenizer, singletonMap("padding", "false"));
+            this.poolingMode = validatePoolingMode(poolingMode);
+            this.maxLength = validateMaxLength(maxLength);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public OnnxBpeBiEncoder(InputStream model, InputStream tokenizer, PoolingMode poolingMode, int maxLength) {
+        try {
+            this.environment = OrtEnvironment.getEnvironment();
+            this.session = environment.createSession(loadModel(model));
+            this.expectedInputs = session.getInputNames();
+            this.tokenizer = HuggingFaceTokenizer.newInstance(tokenizer, singletonMap("padding", "false"));
+            this.poolingMode = validatePoolingMode(poolingMode);
+            this.maxLength = validateMaxLength(maxLength);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static PoolingMode validatePoolingMode(PoolingMode mode) {
+        ensureNotNull(mode, "poolingMode");
+        if (mode == PoolingMode.CLS) {
+            throw illegalArgument("PoolingMode.CLS is not meaningful for BPE/decoder models. "
+                    + "Use LAST_TOKEN or MEAN_MASKED instead.");
+        }
+        return mode;
+    }
+
+    private static int validateMaxLength(int maxLength) {
+        if (maxLength < 1) {
+            throw illegalArgument("maxLength must be >= 1, got " + maxLength);
+        }
+        return maxLength;
+    }
+
+    EmbeddingAndTokenCount embed(String text) {
+
+        Encoding encoding = tokenizer.encode(text, true, false);
+
+        long[] inputIds = encoding.getIds();
+        long[] attentionMask = encoding.getAttentionMask();
+
+        // Decoder-based embedding models work best with the whole sequence
+        // contextualized at once. Truncate if it exceeds maxLength.
+        if (inputIds.length > maxLength) {
+            inputIds = Arrays.copyOf(inputIds, maxLength);
+            attentionMask = Arrays.copyOf(attentionMask, maxLength);
+        }
+
+        if (inputIds.length == 0) {
+            throw illegalArgument("Cannot embed empty or whitespace-only text");
+        }
+
+        float[][] hiddenStates;
+        try (Result result = runInference(inputIds, attentionMask)) {
+            hiddenStates = extractHiddenStates(result);
+        } catch (OrtException e) {
+            throw new RuntimeException(e);
+        }
+
+        float[] pooled = pool(hiddenStates, attentionMask);
+        float[] normalized = normalize(pooled);
+
+        return new EmbeddingAndTokenCount(normalized, inputIds.length);
+    }
+
+    int countTokens(String text) {
+        return tokenizer.tokenize(text).size();
+    }
+
+    private Result runInference(long[] inputIds, long[] attentionMask) throws OrtException {
+        long[] shape = {1, inputIds.length};
+
+        try (OnnxTensor inputIdsTensor = createTensor(environment, wrap(inputIds), shape);
+                OnnxTensor attentionMaskTensor = createTensor(environment, wrap(attentionMask), shape)) {
+
+            Map<String, OnnxTensor> inputs = new HashMap<>();
+            inputs.put("input_ids", inputIdsTensor);
+            inputs.put("attention_mask", attentionMaskTensor);
+            // Decoder models do not use token_type_ids.
+
+            return session.run(inputs);
+        }
+    }
+
+    private static float[][] extractHiddenStates(Result result) throws OrtException {
+        // Shape: [batch=1, seqLen, hiddenDim]; use batch 0.
+        return ((float[][][]) result.get(0).getValue())[0];
+    }
+
+    private float[] pool(float[][] hiddenStates, long[] attentionMask) {
+        switch (poolingMode) {
+            case LAST_TOKEN:
+                return lastTokenPool(hiddenStates, attentionMask);
+            case MEAN_MASKED:
+                return meanMaskedPool(hiddenStates, attentionMask);
+            case MEAN:
+                return meanPool(hiddenStates); // legacy, unmasked
+            default:
+                throw illegalArgument("PoolingMode " + poolingMode + " is not supported by OnnxBpeBiEncoder");
+        }
+    }
+
+    /**
+     * Last-token pooling per Qwen3-Embedding official implementation.
+     *
+     * <p>Handles both padding conventions:
+     * <pre>
+     *   Left-padded:   [PAD, PAD, ..., token_N]      -> return position N-1
+     *   Right-padded:  [token_1, ..., token_N, PAD]  -> return position N-1 (find last mask=1)
+     * </pre>
+     *
+     * <p>For single-input encoding (current langchain4j use case), there is no padding
+     * and all {@code attention_mask} values are 1, so this reduces to {@code hiddenStates[last]}.
+     * The full logic is kept for correctness with future batch-style callers.
+     */
+    static float[] lastTokenPool(float[][] hiddenStates, long[] attentionMask) {
+        int seqLen = attentionMask.length;
+
+        // Common fast path: last position is a real token (no right-padding)
+        if (attentionMask[seqLen - 1] == 1L) {
+            return hiddenStates[seqLen - 1];
+        }
+
+        // Right-padded: walk backward to the last non-padded position
+        for (int i = seqLen - 1; i >= 0; i--) {
+            if (attentionMask[i] == 1L) {
+                return hiddenStates[i];
+            }
+        }
+
+        throw new IllegalStateException("No non-padded tokens in attention_mask");
+    }
+
+    /**
+     * Mean pooling respecting {@code attention_mask} - equivalent to
+     * sentence-transformers' {@code pooling_mode_mean_tokens}.
+     *
+     * <p>Unlike legacy {@link #meanPool(float[][])}, this skips padding positions,
+     * giving correct results even when inputs are padded.
+     */
+    static float[] meanMaskedPool(float[][] hiddenStates, long[] attentionMask) {
+        int seqLen = hiddenStates.length;
+        int dim = hiddenStates[0].length;
+
+        float[] sum = new float[dim];
+        int count = 0;
+
+        for (int i = 0; i < seqLen; i++) {
+            if (attentionMask[i] == 1L) {
+                float[] vec = hiddenStates[i];
+                for (int j = 0; j < dim; j++) {
+                    sum[j] += vec[j];
+                }
+                count++;
+            }
+        }
+
+        if (count == 0) {
+            throw new IllegalStateException("No non-padded tokens to average");
+        }
+
+        for (int j = 0; j < dim; j++) {
+            sum[j] /= count;
+        }
+        return sum;
+    }
+
+    /** Legacy mean pooling (doesn't consider attention_mask). Keeps BERT-encoder parity. */
+    static float[] meanPool(float[][] hiddenStates) {
+        int numVectors = hiddenStates.length;
+        int dim = hiddenStates[0].length;
+
+        float[] avg = new float[dim];
+        for (float[] vec : hiddenStates) {
+            for (int j = 0; j < dim; j++) {
+                avg[j] += vec[j];
+            }
+        }
+        for (int j = 0; j < dim; j++) {
+            avg[j] /= numVectors;
+        }
+        return avg;
+    }
+
+    private static float[] normalize(float[] vector) {
+        float sumSquare = 0;
+        for (float v : vector) {
+            sumSquare += v * v;
+        }
+        float norm = (float) Math.sqrt(sumSquare);
+
+        float[] result = new float[vector.length];
+        for (int i = 0; i < vector.length; i++) {
+            result[i] = vector[i] / norm;
+        }
+        return result;
+    }
+
+    private byte[] loadModel(InputStream modelInputStream) {
+        if (modelInputStream == null) {
+            throw new IllegalStateException("Embedding model file is not available. "
+                    + "This usually happens when running LangChain4j tests from sources. "
+                    + "If you are developing LangChain4j locally, run 'mvn generate-resources' "
+                    + "from the project root to download the required model files.");
+        }
+        try (InputStream inputStream = modelInputStream;
+                ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+            byte[] data = new byte[1024];
+            int nRead;
+            while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+                buffer.write(data, 0, nRead);
+            }
+            buffer.flush();
+            return buffer.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxEmbeddingModel.java
+++ b/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxEmbeddingModel.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Executor;
 public class OnnxEmbeddingModel extends AbstractInProcessEmbeddingModel {
 
     private final OnnxBertBiEncoder onnxBertBiEncoder;
+    private final Encoder encoder;
 
     /**
      * @param pathToModel     The path to the modelPath file (e.g., "/path/to/model.onnx")
@@ -31,7 +32,35 @@ public class OnnxEmbeddingModel extends AbstractInProcessEmbeddingModel {
      */
     public OnnxEmbeddingModel(Path pathToModel, Path pathToTokenizer, PoolingMode poolingMode) {
         super(null);
-        this.onnxBertBiEncoder = loadFromFileSystem(pathToModel, pathToTokenizer, poolingMode);
+        this.onnxBertBiEncoder = new OnnxBertBiEncoder(pathToModel, pathToTokenizer, poolingMode);
+        this.encoder = asEncoder(onnxBertBiEncoder);
+    }
+
+    /**
+     * Creates an ONNX embedding model with the selected encoder implementation.
+     *
+     * @param pathToModel     The path to the model file.
+     * @param pathToTokenizer The path to the tokenizer file.
+     * @param poolingMode     The pooling mode to use.
+     * @param encoderType     The encoder implementation to use.
+     */
+    public OnnxEmbeddingModel(
+            Path pathToModel, Path pathToTokenizer, PoolingMode poolingMode, EncoderType encoderType) {
+        super(null);
+        OnnxBertBiEncoder onnxBertBiEncoder = null;
+        Encoder encoder = null;
+        switch (ensureNotNull(encoderType, "encoderType")) {
+            case BERT -> {
+                onnxBertBiEncoder = new OnnxBertBiEncoder(pathToModel, pathToTokenizer, poolingMode);
+                encoder = asEncoder(onnxBertBiEncoder);
+            }
+            case BPE -> {
+                onnxBertBiEncoder = null;
+                encoder = asEncoder(new OnnxBpeBiEncoder(pathToModel, pathToTokenizer, poolingMode));
+            }
+        }
+        this.onnxBertBiEncoder = onnxBertBiEncoder;
+        this.encoder = encoder;
     }
 
     /**
@@ -45,6 +74,7 @@ public class OnnxEmbeddingModel extends AbstractInProcessEmbeddingModel {
     public OnnxEmbeddingModel(Path pathToModel, Path pathToTokenizer, PoolingMode poolingMode, Executor executor) {
         super(ensureNotNull(executor, "executor"));
         this.onnxBertBiEncoder = loadFromFileSystem(pathToModel, pathToTokenizer, poolingMode);
+        this.encoder = asEncoder(onnxBertBiEncoder);
     }
 
     /**
@@ -72,6 +102,30 @@ public class OnnxEmbeddingModel extends AbstractInProcessEmbeddingModel {
 
     @Override
     protected OnnxBertBiEncoder model() {
-        return onnxBertBiEncoder;
+        if (onnxBertBiEncoder != null) {
+            return onnxBertBiEncoder;
+        }
+        throw new UnsupportedOperationException(
+                "model() only returns OnnxBertBiEncoder. Use encoder() for generic access.");
+    }
+
+    @Override
+    protected Encoder encoder() {
+        return encoder;
+    }
+
+    /**
+     * Encoder implementation used by the ONNX embedding model.
+     */
+    public enum EncoderType {
+        /**
+         * BERT-style encoder using WordPiece tokenization and token type IDs.
+         */
+        BERT,
+
+        /**
+         * BPE or decoder-style encoder that does not use token type IDs.
+         */
+        BPE
     }
 }

--- a/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/PoolingMode.java
+++ b/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/PoolingMode.java
@@ -1,6 +1,19 @@
 package dev.langchain4j.model.embedding.onnx;
 
+/**
+ * Pooling strategies for ONNX embedding models.
+ */
 public enum PoolingMode {
     CLS,
-    MEAN
+    MEAN,
+
+    /**
+     * Mean pooling over tokens selected by the attention mask.
+     */
+    MEAN_MASKED,
+
+    /**
+     * Pooling that uses the final non-padding token hidden state.
+     */
+    LAST_TOKEN
 }

--- a/embeddings/langchain4j-embeddings/src/test/java/dev/langchain4j/model/embedding/onnx/OnnxBpeBiEncoderManualIT.java
+++ b/embeddings/langchain4j-embeddings/src/test/java/dev/langchain4j/model/embedding/onnx/OnnxBpeBiEncoderManualIT.java
@@ -1,0 +1,122 @@
+package dev.langchain4j.model.embedding.onnx;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Manual end-to-end test for OnnxBpeBiEncoder with the real Qwen3-Embedding model.
+ *
+ * <p>To run locally:
+ * <pre>
+ *   # Windows PowerShell:
+ *   $env:QWEN3_MODEL_PATH     = "D:\qwen3-models\model.onnx"
+ *   $env:QWEN3_TOKENIZER_PATH = "D:\qwen3-models\tokenizer.json"
+ *
+ *   # Linux / Mac:
+ *   export QWEN3_MODEL_PATH=/path/to/qwen3/model.onnx
+ *   export QWEN3_TOKENIZER_PATH=/path/to/qwen3/tokenizer.json
+ *
+ *   ./mvnw -pl embeddings/langchain4j-embeddings test -Dtest=OnnxBpeBiEncoderManualIT
+ * </pre>
+ *
+ * <p>Expected similarities (from Python reference run with the same 3 texts):
+ * <pre>
+ *   [0] vs [1]  ~0.77   (semantically related - same topic)
+ *   [0] vs [2]  ~0.14   (semantically unrelated)
+ *   [1] vs [2]  ~0.14   (semantically unrelated)
+ * </pre>
+ *
+ * <p>This test is intentionally NOT part of the regular test suite - it requires a
+ * ~600MB-1.2GB model file that we don't want in CI. When the env vars are not set,
+ * JUnit silently skips the class.
+ */
+@EnabledIfEnvironmentVariable(named = "QWEN3_MODEL_PATH", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "QWEN3_TOKENIZER_PATH", matches = ".+")
+class OnnxBpeBiEncoderManualIT {
+
+    private static final List<String> TEXTS =
+            List.of("What is the capital of China?", "The capital of China is Beijing.", "Explain gravity");
+
+    @Test
+    void embed_three_texts_and_print_similarities() throws Exception {
+
+        Path modelPath = Paths.get(System.getenv("QWEN3_MODEL_PATH"));
+        Path tokenizerPath = Paths.get(System.getenv("QWEN3_TOKENIZER_PATH"));
+
+        // Fail fast with a clear message if files are missing
+        if (!Files.exists(modelPath)) {
+            throw new IllegalStateException("Model file not found: " + modelPath);
+        }
+        if (!Files.exists(tokenizerPath)) {
+            throw new IllegalStateException("Tokenizer file not found: " + tokenizerPath);
+        }
+
+        System.out.println("Loading OnnxBpeBiEncoder...");
+        System.out.println("  Model:     " + modelPath);
+        System.out.println("  Tokenizer: " + tokenizerPath);
+        long t0 = System.currentTimeMillis();
+
+        OnnxBpeBiEncoder encoder = new OnnxBpeBiEncoder(modelPath, tokenizerPath, PoolingMode.LAST_TOKEN);
+        System.out.printf("Model loaded in %d ms%n", System.currentTimeMillis() - t0);
+
+        // Embed each text individually.
+        float[][] vectors = new float[TEXTS.size()][];
+        int[] tokenCounts = new int[TEXTS.size()];
+
+        for (int i = 0; i < TEXTS.size(); i++) {
+            String text = TEXTS.get(i);
+            long tStart = System.currentTimeMillis();
+            EmbeddingAndTokenCount result = encoder.embed(text);
+            long tEnd = System.currentTimeMillis();
+
+            vectors[i] = result.embedding;
+            tokenCounts[i] = result.tokenCount;
+
+            System.out.println();
+            System.out.printf("[%d] %s%n", i, text);
+            System.out.printf("    tokenCount: %d%n", result.tokenCount);
+            System.out.printf("    dimension : %d%n", result.embedding.length);
+            System.out.printf("    L2 norm   : %.6f%n", l2Norm(result.embedding));
+            System.out.printf("    latency   : %d ms%n", tEnd - tStart);
+            System.out.printf(
+                    "    first 5   : [%.4f, %.4f, %.4f, %.4f, %.4f]%n",
+                    result.embedding[0],
+                    result.embedding[1],
+                    result.embedding[2],
+                    result.embedding[3],
+                    result.embedding[4]);
+        }
+
+        // Pairwise cosine similarities.
+        System.out.println();
+        System.out.println("----------------------------------------------------------");
+        System.out.println("  COSINE SIMILARITIES (Java)");
+        System.out.println("----------------------------------------------------------");
+        System.out.printf("  [0] vs [1]  = %.4f   (expected ~0.77)%n", cosine(vectors[0], vectors[1]));
+        System.out.printf("  [0] vs [2]  = %.4f   (expected ~0.14)%n", cosine(vectors[0], vectors[2]));
+        System.out.printf("  [1] vs [2]  = %.4f   (expected ~0.14)%n", cosine(vectors[1], vectors[2]));
+        System.out.println();
+    }
+
+    // Helpers.
+
+    private static double cosine(float[] a, float[] b) {
+        double dot = 0.0;
+        for (int i = 0; i < a.length; i++) {
+            dot += a[i] * b[i];
+        }
+        return dot; // already L2-normalized by the encoder, so dot == cosine
+    }
+
+    private static double l2Norm(float[] v) {
+        double sum = 0.0;
+        for (float x : v) {
+            sum += x * x;
+        }
+        return Math.sqrt(sum);
+    }
+}


### PR DESCRIPTION
## Issue

Closes #4407

## Change

This PR adds an encoder abstraction for ONNX embedding models so `AbstractInProcessEmbeddingModel` is no longer tied only to `OnnxBertBiEncoder`.

Changes included:

- Introduced an `Encoder` interface for ONNX embedding implementations.
- Moved `EmbeddingAndTokenCount` into a shared class so multiple encoders can return embedding vectors with token usage.
- Updated `AbstractInProcessEmbeddingModel` to use the generic encoder path.
- Updated `OnnxBertBiEncoder` to implement `Encoder` while keeping the existing BERT/WordPiece behavior.
- Added `OnnxBpeBiEncoder` for BPE / decoder-family embedding models such as Qwen3-style ONNX embeddings.
- Added `PoolingMode.MEAN_MASKED` and `PoolingMode.LAST_TOKEN`.
- Added a manual Qwen3 ONNX integration test guarded by `QWEN3_MODEL_PATH` and `QWEN3_TOKENIZER_PATH`.

The new BPE encoder does not send `token_type_ids`, uses `attention_mask` for masked mean pooling, and supports last-token pooling for decoder-family embedding models.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module

- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration

- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration

- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
