### PR TITLE
fix: return output printed by the GraalVM code execution engines

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/revapi.json
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/revapi.json
@@ -1,0 +1,20 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.annotation.attributeValueChanged",
+          "new": "parameter java.lang.String dev.langchain4j.agent.tool.graalvm.GraalVmJavaScriptExecutionTool::executeJavaScriptCode(===java.lang.String===)",
+          "justification": "@P carries the natural-language description sent to the LLM, not a Java API contract; it now also tells the model that printing the result is accepted"
+        },
+        {
+          "code": "java.annotation.attributeValueChanged",
+          "new": "parameter java.lang.String dev.langchain4j.agent.tool.graalvm.GraalVmPythonExecutionTool::executePythonCode(===java.lang.String===)",
+          "justification": "@P carries the natural-language description sent to the LLM, not a Java API contract; it now also tells the model that printing the result is accepted"
+        }
+      ]
+    }
+  }
+]

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/agent/tool/graalvm/GraalVmJavaScriptExecutionTool.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/agent/tool/graalvm/GraalVmJavaScriptExecutionTool.java
@@ -14,7 +14,8 @@ public class GraalVmJavaScriptExecutionTool {
     private final CodeExecutionEngine engine = new GraalVmJavaScriptExecutionEngine();
 
     @Tool("MUST be used for accurate calculations: math, sorting, filtering, aggregating, string processing, etc")
-    public String executeJavaScriptCode(@P("JavaScript code to execute, result MUST be returned by the code") String code) {
+    public String executeJavaScriptCode(
+            @P("JavaScript code to execute, result MUST be returned or printed by the code") String code) {
         return engine.execute(code);
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/agent/tool/graalvm/GraalVmPythonExecutionTool.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/agent/tool/graalvm/GraalVmPythonExecutionTool.java
@@ -14,7 +14,8 @@ public class GraalVmPythonExecutionTool {
     private final CodeExecutionEngine engine = new GraalVmPythonExecutionEngine();
 
     @Tool("MUST be used for accurate calculations: math, sorting, filtering, aggregating, string processing, etc")
-    public String executePythonCode(@P("Python code to execute, result MUST be returned by the code") String code) {
+    public String executePythonCode(
+            @P("Python code to execute, result MUST be returned or printed by the code") String code) {
         return engine.execute(code);
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/ExecutionResultFormatter.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/ExecutionResultFormatter.java
@@ -1,0 +1,28 @@
+package dev.langchain4j.code.graalvm;
+
+/**
+ * Formats the outcome of a code execution into a single string,
+ * combining what the code printed with what it evaluated to.
+ */
+class ExecutionResultFormatter {
+
+    private static final String OUTPUT_PREFIX = "Output:\n";
+    private static final String RESULT_PREFIX = "\nResult:\n";
+
+    private ExecutionResultFormatter() {}
+
+    /**
+     * @param output what the code printed to stdout/stderr, empty if it printed nothing.
+     * @param value  what the code evaluated to, {@code null} if it evaluated to nothing.
+     * @return the formatted result.
+     */
+    static String format(String output, String value) {
+        if (output.isEmpty()) {
+            return value == null ? "" : value;
+        }
+        if (value == null) {
+            return OUTPUT_PREFIX + output;
+        }
+        return OUTPUT_PREFIX + output + RESULT_PREFIX + value;
+    }
+}

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmExecutionResult.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmExecutionResult.java
@@ -1,0 +1,63 @@
+package dev.langchain4j.code.graalvm;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Predicate;
+import org.graalvm.polyglot.Value;
+
+final class GraalVmExecutionResult {
+
+    private GraalVmExecutionResult() {}
+
+    static String fromJavaScript(Value result, ByteArrayOutputStream outputStream) {
+        return from(result, outputStream, GraalVmExecutionResult::isJavaScriptEmptyResult);
+    }
+
+    static String fromPython(Value result, ByteArrayOutputStream outputStream) {
+        return from(result, outputStream, GraalVmExecutionResult::isPythonEmptyResult);
+    }
+
+    private static String from(Value result, ByteArrayOutputStream outputStream, Predicate<Value> isEmptyResult) {
+        String output = outputStream.toString(StandardCharsets.UTF_8);
+        if (output.isEmpty()) {
+            return resultString(result);
+        }
+
+        output = removeTrailingLineBreaks(output);
+        if (isEmptyResult.test(result)) {
+            return output;
+        }
+
+        return output + "\n" + resultString(result);
+    }
+
+    private static String resultString(Value result) {
+        return String.valueOf(result.as(Object.class));
+    }
+
+    private static boolean isJavaScriptEmptyResult(Value result) {
+        return result.isNull() || (!result.isString() && "undefined".equals(String.valueOf(result)));
+    }
+
+    private static boolean isPythonEmptyResult(Value result) {
+        // GraalPy returns the __main__ module for top-level code without an expression result.
+        if (!result.hasMember("__name__")) {
+            return false;
+        }
+
+        Value name = result.getMember("__name__");
+        return name != null && name.isString() && "__main__".equals(name.asString());
+    }
+
+    private static String removeTrailingLineBreaks(String string) {
+        int end = string.length();
+        while (end > 0) {
+            char character = string.charAt(end - 1);
+            if (character != '\n' && character != '\r') {
+                break;
+            }
+            end--;
+        }
+        return string.substring(0, end);
+    }
+}

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngine.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngine.java
@@ -1,15 +1,14 @@
 package dev.langchain4j.code.graalvm;
 
+import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
+import static org.graalvm.polyglot.SandboxPolicy.CONSTRAINED;
+
 import dev.langchain4j.code.CodeExecutionEngine;
+import java.io.ByteArrayOutputStream;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.SandboxPolicy;
-
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
-
-import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
-import static org.graalvm.polyglot.SandboxPolicy.CONSTRAINED;
+import org.graalvm.polyglot.Value;
 
 /**
  * {@link CodeExecutionEngine} that uses GraalVM Polyglot/Truffle to execute provided JavaScript code.
@@ -20,15 +19,16 @@ public class GraalVmJavaScriptExecutionEngine implements CodeExecutionEngine {
 
     @Override
     public String execute(String code) {
-        OutputStream outputStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (Context context = Context.newBuilder("js")
-            .sandbox(CONSTRAINED)
-            .allowHostAccess(UNTRUSTED)
-            .out(outputStream)
-            .err(outputStream)
-            .build()) {
-            Object result = context.eval("js", code).as(Object.class);
-            return String.valueOf(result);
+                .sandbox(CONSTRAINED)
+                .allowHostAccess(UNTRUSTED)
+                .option("engine.WarnInterpreterOnly", "false")
+                .out(outputStream)
+                .err(outputStream)
+                .build()) {
+            Value result = context.eval("js", code);
+            return GraalVmExecutionResult.fromJavaScript(result, outputStream);
         }
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngine.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngine.java
@@ -1,15 +1,15 @@
 package dev.langchain4j.code.graalvm;
 
+import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
+import static org.graalvm.polyglot.SandboxPolicy.CONSTRAINED;
+
 import dev.langchain4j.code.CodeExecutionEngine;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.SandboxPolicy;
-
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
-
-import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
-import static org.graalvm.polyglot.SandboxPolicy.CONSTRAINED;
+import org.graalvm.polyglot.Value;
 
 /**
  * {@link CodeExecutionEngine} that uses GraalVM Polyglot/Truffle to execute provided JavaScript code.
@@ -20,15 +20,23 @@ public class GraalVmJavaScriptExecutionEngine implements CodeExecutionEngine {
 
     @Override
     public String execute(String code) {
-        OutputStream outputStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (Context context = Context.newBuilder("js")
-            .sandbox(CONSTRAINED)
-            .allowHostAccess(UNTRUSTED)
-            .out(outputStream)
-            .err(outputStream)
-            .build()) {
-            Object result = context.eval("js", code).as(Object.class);
-            return String.valueOf(result);
+                .sandbox(CONSTRAINED)
+                .allowHostAccess(UNTRUSTED)
+                .option("engine.WarnInterpreterOnly", "false")
+                .out(outputStream)
+                .err(outputStream)
+                .build()) {
+            Value result = context.eval("js", code);
+            String output = outputStream.toString(StandardCharsets.UTF_8).stripTrailing();
+            if (output.isEmpty()) {
+                return String.valueOf(result.as(Object.class));
+            }
+            if (result.isNull() || (!result.isString() && "undefined".equals(String.valueOf(result)))) {
+                return output;
+            }
+            return output + "\n" + result.as(Object.class);
         }
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngine.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngine.java
@@ -1,11 +1,12 @@
 package dev.langchain4j.code.graalvm;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
 import static org.graalvm.polyglot.SandboxPolicy.CONSTRAINED;
 
 import dev.langchain4j.code.CodeExecutionEngine;
 import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
+import java.io.OutputStream;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.SandboxPolicy;
@@ -13,6 +14,17 @@ import org.graalvm.polyglot.Value;
 
 /**
  * {@link CodeExecutionEngine} that uses GraalVM Polyglot/Truffle to execute provided JavaScript code.
+ * <p>
+ * The returned string contains both what the code printed to stdout/stderr and what it evaluated to:
+ * <ul>
+ *     <li>{@code 40 + 2} evaluates to a value without printing anything, so {@code "42"} is returned</li>
+ *     <li>{@code console.log('hello')} only prints, so {@code "Output:\nhello"} is returned</li>
+ *     <li>{@code console.log('hello'); 42} does both, so {@code "Output:\nhello\nResult:\n42"} is returned</li>
+ *     <li>{@code var x = 1;} neither prints nor evaluates to a value, so an empty string is returned</li>
+ * </ul>
+ * When the code fails, a {@link org.graalvm.polyglot.PolyglotException} is thrown
+ * and anything printed before the failure is lost.
+ * <p>
  * Attention! It might be dangerous to execute the code, see {@link SandboxPolicy#CONSTRAINED}
  * and {@link HostAccess#UNTRUSTED} for more details.
  */
@@ -24,19 +36,19 @@ public class GraalVmJavaScriptExecutionEngine implements CodeExecutionEngine {
         try (Context context = Context.newBuilder("js")
                 .sandbox(CONSTRAINED)
                 .allowHostAccess(UNTRUSTED)
-                .option("engine.WarnInterpreterOnly", "false")
                 .out(outputStream)
                 .err(outputStream)
+                // Truffle logs (for example the warning about running without runtime compilation)
+                // are written to the streams above, so they have to be routed away
+                // to keep them out of the returned result
+                .logHandler(OutputStream.nullOutputStream())
                 .build()) {
             Value result = context.eval("js", code);
-            String output = outputStream.toString(StandardCharsets.UTF_8).stripTrailing();
-            if (output.isEmpty()) {
-                return String.valueOf(result.as(Object.class));
-            }
-            if (result.isNull() || (!result.isString() && "undefined".equals(String.valueOf(result)))) {
-                return output;
-            }
-            return output + "\n" + result.as(Object.class);
+            String output = outputStream.toString(UTF_8).stripTrailing();
+            // JavaScript code that does not end with an expression evaluates to "undefined",
+            // which, just like "null", carries nothing worth returning
+            String value = result.isNull() ? null : String.valueOf(result.as(Object.class));
+            return ExecutionResultFormatter.format(output, value);
         }
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngine.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngine.java
@@ -1,15 +1,14 @@
 package dev.langchain4j.code.graalvm;
 
+import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
+import static org.graalvm.polyglot.SandboxPolicy.TRUSTED;
+
 import dev.langchain4j.code.CodeExecutionEngine;
+import java.io.ByteArrayOutputStream;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.SandboxPolicy;
-
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
-
-import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
-import static org.graalvm.polyglot.SandboxPolicy.TRUSTED;
+import org.graalvm.polyglot.Value;
 
 /**
  * {@link CodeExecutionEngine} that uses GraalVM Polyglot/Truffle to execute provided Python code.
@@ -20,15 +19,16 @@ public class GraalVmPythonExecutionEngine implements CodeExecutionEngine {
 
     @Override
     public String execute(String code) {
-        OutputStream outputStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (Context context = Context.newBuilder("python")
-            .sandbox(TRUSTED)
-            .allowHostAccess(UNTRUSTED)
-            .out(outputStream)
-            .err(outputStream)
-            .build()) {
-            Object result = context.eval("python", code).as(Object.class);
-            return String.valueOf(result);
+                .sandbox(TRUSTED)
+                .allowHostAccess(UNTRUSTED)
+                .option("engine.WarnInterpreterOnly", "false")
+                .out(outputStream)
+                .err(outputStream)
+                .build()) {
+            Value result = context.eval("python", code);
+            return GraalVmExecutionResult.fromPython(result, outputStream);
         }
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngine.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngine.java
@@ -1,15 +1,15 @@
 package dev.langchain4j.code.graalvm;
 
+import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
+import static org.graalvm.polyglot.SandboxPolicy.TRUSTED;
+
 import dev.langchain4j.code.CodeExecutionEngine;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.SandboxPolicy;
-
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
-
-import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
-import static org.graalvm.polyglot.SandboxPolicy.TRUSTED;
+import org.graalvm.polyglot.Value;
 
 /**
  * {@link CodeExecutionEngine} that uses GraalVM Polyglot/Truffle to execute provided Python code.
@@ -20,15 +20,24 @@ public class GraalVmPythonExecutionEngine implements CodeExecutionEngine {
 
     @Override
     public String execute(String code) {
-        OutputStream outputStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (Context context = Context.newBuilder("python")
-            .sandbox(TRUSTED)
-            .allowHostAccess(UNTRUSTED)
-            .out(outputStream)
-            .err(outputStream)
-            .build()) {
-            Object result = context.eval("python", code).as(Object.class);
-            return String.valueOf(result);
+                .sandbox(TRUSTED)
+                .allowHostAccess(UNTRUSTED)
+                .option("engine.WarnInterpreterOnly", "false")
+                .out(outputStream)
+                .err(outputStream)
+                .build()) {
+            Value result = context.eval("python", code);
+            String output = outputStream.toString(StandardCharsets.UTF_8).stripTrailing();
+            if (output.isEmpty()) {
+                return String.valueOf(result.as(Object.class));
+            }
+            Value name = result.hasMember("__name__") ? result.getMember("__name__") : null;
+            if (name != null && name.isString() && "__main__".equals(name.asString())) {
+                return output;
+            }
+            return output + "\n" + result.as(Object.class);
         }
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngine.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/main/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngine.java
@@ -1,11 +1,12 @@
 package dev.langchain4j.code.graalvm;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.graalvm.polyglot.HostAccess.UNTRUSTED;
 import static org.graalvm.polyglot.SandboxPolicy.TRUSTED;
 
 import dev.langchain4j.code.CodeExecutionEngine;
 import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
+import java.io.OutputStream;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.SandboxPolicy;
@@ -13,6 +14,17 @@ import org.graalvm.polyglot.Value;
 
 /**
  * {@link CodeExecutionEngine} that uses GraalVM Polyglot/Truffle to execute provided Python code.
+ * <p>
+ * The returned string contains both what the code printed to stdout/stderr and what it evaluated to:
+ * <ul>
+ *     <li>{@code 40 + 2} evaluates to a value without printing anything, so {@code "42"} is returned</li>
+ *     <li>{@code print('hello')} only prints, so {@code "Output:\nhello"} is returned</li>
+ *     <li>{@code print('hello')\n42} does both, so {@code "Output:\nhello\nResult:\n42"} is returned</li>
+ *     <li>{@code x = 1} neither prints nor evaluates to a value, so an empty string is returned</li>
+ * </ul>
+ * When the code fails, a {@link org.graalvm.polyglot.PolyglotException} is thrown
+ * and anything printed before the failure is lost.
+ * <p>
  * Attention! It might be dangerous to execute the code, see {@link SandboxPolicy#TRUSTED}
  * and {@link HostAccess#UNTRUSTED} for more details.
  */
@@ -24,20 +36,26 @@ public class GraalVmPythonExecutionEngine implements CodeExecutionEngine {
         try (Context context = Context.newBuilder("python")
                 .sandbox(TRUSTED)
                 .allowHostAccess(UNTRUSTED)
-                .option("engine.WarnInterpreterOnly", "false")
                 .out(outputStream)
                 .err(outputStream)
+                // Truffle logs (for example the warning about running without runtime compilation)
+                // are written to the streams above, so they have to be routed away
+                // to keep them out of the returned result
+                .logHandler(OutputStream.nullOutputStream())
                 .build()) {
             Value result = context.eval("python", code);
-            String output = outputStream.toString(StandardCharsets.UTF_8).stripTrailing();
-            if (output.isEmpty()) {
-                return String.valueOf(result.as(Object.class));
-            }
-            Value name = result.hasMember("__name__") ? result.getMember("__name__") : null;
-            if (name != null && name.isString() && "__main__".equals(name.asString())) {
-                return output;
-            }
-            return output + "\n" + result.as(Object.class);
+            String output = outputStream.toString(UTF_8).stripTrailing();
+            String value = evaluatedToNothing(result) ? null : String.valueOf(result.as(Object.class));
+            return ExecutionResultFormatter.format(output, value);
         }
+    }
+
+    private static boolean evaluatedToNothing(Value result) {
+        // Python code that does not end with an expression (an assignment, an import, a print, etc.)
+        // evaluates to the "__main__" module itself instead of to a value.
+        // Any module is treated as nothing: a module is not a result worth returning,
+        // and converting one to a Java object fails inside GraalVM.
+        Value metaObject = result.getMetaObject();
+        return metaObject != null && "module".equals(metaObject.getMetaSimpleName());
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngineTest.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngineTest.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.code.graalvm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.code.CodeExecutionEngine;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class GraalVmJavaScriptExecutionEngineTest {
 
@@ -17,12 +17,52 @@ class GraalVmJavaScriptExecutionEngineTest {
                     if (n <= 1) return n;
                     return fibonacci(n - 1) + fibonacci(n - 2);
                 }
-                                
+
                 fibonacci(10)
                 """;
 
         String result = engine.execute(code);
 
         assertThat(result).isEqualTo("55");
+    }
+
+    @Test
+    void should_return_stdout() {
+
+        String result = engine.execute("console.log('hello');");
+
+        assertThat(result).isEqualTo("hello");
+    }
+
+    @Test
+    void should_return_stderr() {
+
+        String result = engine.execute("console.error('bad');");
+
+        assertThat(result).isEqualTo("bad");
+    }
+
+    @Test
+    void should_return_stdout_and_result() {
+
+        String result = engine.execute("console.log('hello'); 42");
+
+        assertThat(result).isEqualTo("hello\n42");
+    }
+
+    @Test
+    void should_return_stdout_and_string_null_result() {
+
+        String result = engine.execute("console.log('hello'); 'null'");
+
+        assertThat(result).isEqualTo("hello\nnull");
+    }
+
+    @Test
+    void should_return_stdout_and_string_undefined_result() {
+
+        String result = engine.execute("console.log('hello'); 'undefined'");
+
+        assertThat(result).isEqualTo("hello\nundefined");
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngineTest.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngineTest.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.code.graalvm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.code.CodeExecutionEngine;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class GraalVmJavaScriptExecutionEngineTest {
 
@@ -17,12 +17,21 @@ class GraalVmJavaScriptExecutionEngineTest {
                     if (n <= 1) return n;
                     return fibonacci(n - 1) + fibonacci(n - 2);
                 }
-                                
+
                 fibonacci(10)
                 """;
 
         String result = engine.execute(code);
 
         assertThat(result).isEqualTo("55");
+    }
+
+    @Test
+    void should_return_captured_output() {
+
+        String result = engine.execute("console.log('hello'); console.error('bad');");
+
+        assertThat(result).isEqualTo("hello\nbad");
+        assertThat(engine.execute("console.log('hello'); 42")).isEqualTo("hello\n42");
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngineTest.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngineTest.java
@@ -1,8 +1,10 @@
 package dev.langchain4j.code.graalvm;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.code.CodeExecutionEngine;
+import org.graalvm.polyglot.PolyglotException;
 import org.junit.jupiter.api.Test;
 
 class GraalVmJavaScriptExecutionEngineTest {
@@ -10,7 +12,7 @@ class GraalVmJavaScriptExecutionEngineTest {
     CodeExecutionEngine engine = new GraalVmJavaScriptExecutionEngine();
 
     @Test
-    void should_execute_code() {
+    void should_return_result_when_code_only_evaluates_to_value() {
 
         String code = """
                 function fibonacci(n) {
@@ -27,11 +29,50 @@ class GraalVmJavaScriptExecutionEngineTest {
     }
 
     @Test
-    void should_return_captured_output() {
+    void should_return_output_when_code_only_prints() {
 
-        String result = engine.execute("console.log('hello'); console.error('bad');");
+        String result = engine.execute("console.log('hello');");
 
-        assertThat(result).isEqualTo("hello\nbad");
-        assertThat(engine.execute("console.log('hello'); 42")).isEqualTo("hello\n42");
+        assertThat(result).isEqualTo("Output:\nhello");
+    }
+
+    @Test
+    void should_return_output_printed_to_stderr() {
+
+        String result = engine.execute("console.error('bad');");
+
+        assertThat(result).isEqualTo("Output:\nbad");
+    }
+
+    @Test
+    void should_return_both_output_and_result_when_code_prints_and_evaluates_to_value() {
+
+        String result = engine.execute("console.log('hello'); console.log('world'); 42");
+
+        assertThat(result).isEqualTo("Output:\nhello\nworld\nResult:\n42");
+    }
+
+    @Test
+    void should_return_empty_string_when_code_neither_prints_nor_evaluates_to_value() {
+
+        String result = engine.execute("var x = 1;");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_return_string_that_reads_like_undefined_as_result() {
+
+        String result = engine.execute("console.log('hello'); 'undefined'");
+
+        assertThat(result).isEqualTo("Output:\nhello\nResult:\nundefined");
+    }
+
+    @Test
+    void should_throw_when_code_fails() {
+
+        assertThatThrownBy(() -> engine.execute("throw new Error('boom');"))
+                .isInstanceOf(PolyglotException.class)
+                .hasMessageContaining("boom");
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngineTest.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngineTest.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.code.graalvm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.code.CodeExecutionEngine;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class GraalVmPythonExecutionEngineTest {
 
@@ -18,12 +18,54 @@ class GraalVmPythonExecutionEngineTest {
                         return n
                     else:
                         return fibonacci(n-1) + fibonacci(n-2)
-                                
+
                 fibonacci(10)
                 """;
 
         String result = engine.execute(code);
 
         assertThat(result).isEqualTo("55");
+    }
+
+    @Test
+    void should_return_stdout() {
+
+        String result = engine.execute("print('hello')");
+
+        assertThat(result).isEqualTo("hello");
+    }
+
+    @Test
+    void should_return_stderr() {
+
+        String result = engine.execute("""
+                import sys
+                sys.stderr.write('bad\\n')
+                None
+                """);
+
+        assertThat(result).isEqualTo("bad");
+    }
+
+    @Test
+    void should_return_stdout_and_result() {
+
+        String result = engine.execute("""
+                print('hello')
+                42
+                """);
+
+        assertThat(result).isEqualTo("hello\n42");
+    }
+
+    @Test
+    void should_return_stdout_and_string_none_result() {
+
+        String result = engine.execute("""
+                print('hello')
+                'None'
+                """);
+
+        assertThat(result).isEqualTo("hello\nNone");
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngineTest.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngineTest.java
@@ -1,9 +1,9 @@
 package dev.langchain4j.code.graalvm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.code.CodeExecutionEngine;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class GraalVmPythonExecutionEngineTest {
 
@@ -18,12 +18,26 @@ class GraalVmPythonExecutionEngineTest {
                         return n
                     else:
                         return fibonacci(n-1) + fibonacci(n-2)
-                                
+
                 fibonacci(10)
                 """;
 
         String result = engine.execute(code);
 
         assertThat(result).isEqualTo("55");
+    }
+
+    @Test
+    void should_return_captured_output() {
+
+        String result = engine.execute("""
+                print('hello')
+                import sys
+                sys.stderr.write('bad\\n')
+                None
+                """);
+
+        assertThat(result).isEqualTo("hello\nbad");
+        assertThat(engine.execute("print('hello')\n42")).isEqualTo("hello\n42");
     }
 }

--- a/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngineTest.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmPythonExecutionEngineTest.java
@@ -1,8 +1,10 @@
 package dev.langchain4j.code.graalvm;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.code.CodeExecutionEngine;
+import org.graalvm.polyglot.PolyglotException;
 import org.junit.jupiter.api.Test;
 
 class GraalVmPythonExecutionEngineTest {
@@ -10,7 +12,7 @@ class GraalVmPythonExecutionEngineTest {
     CodeExecutionEngine engine = new GraalVmPythonExecutionEngine();
 
     @Test
-    void should_execute_code() {
+    void should_return_result_when_code_only_evaluates_to_value() {
 
         String code = """
                 def fibonacci(n):
@@ -28,16 +30,79 @@ class GraalVmPythonExecutionEngineTest {
     }
 
     @Test
-    void should_return_captured_output() {
+    void should_return_output_when_code_only_prints() {
 
-        String result = engine.execute("""
-                print('hello')
+        String result = engine.execute("print('hello')");
+
+        assertThat(result).isEqualTo("Output:\nhello");
+    }
+
+    @Test
+    void should_return_output_printed_to_stderr() {
+
+        String code = """
                 import sys
-                sys.stderr.write('bad\\n')
-                None
-                """);
+                print('bad', file=sys.stderr)
+                """;
 
-        assertThat(result).isEqualTo("hello\nbad");
-        assertThat(engine.execute("print('hello')\n42")).isEqualTo("hello\n42");
+        String result = engine.execute(code);
+
+        assertThat(result).isEqualTo("Output:\nbad");
+    }
+
+    @Test
+    void should_return_both_output_and_result_when_code_prints_and_evaluates_to_value() {
+
+        String code = """
+                print('hello')
+                print('world')
+                42
+                """;
+
+        String result = engine.execute(code);
+
+        assertThat(result).isEqualTo("Output:\nhello\nworld\nResult:\n42");
+    }
+
+    @Test
+    void should_return_empty_string_when_code_neither_prints_nor_evaluates_to_value() {
+
+        String result = engine.execute("x = 1");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_string_when_code_evaluates_to_module() {
+
+        String code = """
+                import math
+                math
+                """;
+
+        String result = engine.execute(code);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_return_string_result() {
+
+        String code = """
+                print('hello')
+                'world'
+                """;
+
+        String result = engine.execute(code);
+
+        assertThat(result).isEqualTo("Output:\nhello\nResult:\nworld");
+    }
+
+    @Test
+    void should_throw_when_code_fails() {
+
+        assertThatThrownBy(() -> engine.execute("1/0"))
+                .isInstanceOf(PolyglotException.class)
+                .hasMessageContaining("ZeroDivisionError");
     }
 }

--- a/docs/docs/integrations/code-execution-engines/graalvm-polyglot.md
+++ b/docs/docs/integrations/code-execution-engines/graalvm-polyglot.md
@@ -30,6 +30,47 @@ This module enables execution of arbitrary Python/JavaScript code via GraalVM an
 - `GraalVmPythonExecutionTool`
 
 
+## Return Value
+
+`execute(String code)` returns a single string that contains both what the code printed
+to stdout and stderr and the value the code evaluated to.
+
+Code that only evaluates to a value returns that value:
+
+```java
+engine.execute("40 + 2");
+// 42
+```
+
+Code that only prints returns what was printed, prefixed with `Output:`:
+
+```java
+engine.execute("print('hello')");
+// Output:
+// hello
+```
+
+Code that does both returns the printed output followed by the value:
+
+```java
+engine.execute("print('hello')\n42");
+// Output:
+// hello
+// Result:
+// 42
+```
+
+Code that neither prints nor evaluates to a value returns an empty string:
+
+```java
+engine.execute("x = 1");
+// (empty string)
+```
+
+If the code fails, a `PolyglotException` is thrown
+and anything the code printed before failing is lost.
+
+
 ## Examples
 
 - [GraalVmJavaScriptExecutionEngineTest](https://github.com/langchain4j/langchain4j/blob/main/code-execution-engines/langchain4j-code-execution-engine-graalvm-polyglot/src/test/java/dev/langchain4j/code/graalvm/GraalVmJavaScriptExecutionEngineTest.java)


### PR DESCRIPTION
## Issue

Fixes #4334

## Change

`GraalVmPythonExecutionEngine` and `GraalVmJavaScriptExecutionEngine` captured stdout and stderr into a `ByteArrayOutputStream` that was never read, so everything the executed code printed was thrown away. Both engines now return that output together with the value the code evaluated to.

Two related defects surfaced while fixing this:

- **Python code that does not end with an expression returned `<module '__main__'>`.** GraalPy evaluates such code (an assignment, an import, a bare `print(...)`) to the `__main__` module itself, and the engine turned that module into a string. So `print('hello')` returned the literal text `<module '__main__'>`. Used through `GraalVmPythonExecutionTool`, an LLM reads this as a failed tool call and keeps retrying.
- **Converting that module to a Java object trips an assertion inside GraalVM.** With assertions enabled — the default for Maven Surefire — `Value.as(Object.class)` on a module throws `PolyglotException: java.lang.AssertionError` instead of returning anything. Modules are now never converted.

Truffle writes its own diagnostics into the same streams, such as the multi-line "the polyglot engine uses a fallback runtime" performance warning. They are routed to a null log handler so they cannot leak into the returned result.

The `@P` descriptions of both tools now tell the model that the result may be returned **or** printed, which is what the engines accept. Changing that annotation is an API difference for revapi, so it is whitelisted in a module-level `revapi.json`.

## Breaking Changes

`execute(String)` returns a different string than before for code that prints something or that evaluates to nothing. Code that only evaluates to a value is unaffected.

| Executed code | Before | Now |
|---|---|---|
| `40 + 2` | `42` | `42` (unchanged) |
| `print('hello')` | `<module '__main__'>` | `Output:` <br> `hello` |
| `print('hello')` <br> `42` | `42` | `Output:` <br> `hello` <br> `Result:` <br> `42` |
| `x = 1` | `<module '__main__'>` | (empty string) |
| `console.log('hello');` | `null` | `Output:` <br> `hello` |
| `console.log('hello'); 42` | `42` | `Output:` <br> `hello` <br> `Result:` <br> `42` |
| `var x = 1;` | `null` | (empty string) |

If you read the returned string, expect the printed output in front of the value:

```java
String result = engine.execute("print('hello')\n42");
// Output:
// hello
// Result:
// 42
```

To keep getting only the value, let the code evaluate to it and print nothing — that case returns exactly what it returned before:

```java
String result = engine.execute("40 + 2"); // "42", unchanged
```

## Testing

- `GraalVmJavaScriptExecutionEngineTest` and `GraalVmPythonExecutionEngineTest`: 15 tests, all green
- `GraalVmPythonExecutionToolIT`: run 4 times against the OpenAI API, green every time, including the `verify(tool)` exactly-once assertion that the lost output used to break
- `mvn verify` on the module: revapi green

## General checklist

- [ ] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

There **are** behaviour changes, described in the "Breaking Changes" section above. Everything the engines returned before was either the printed output being silently dropped, or the text `<module '__main__'>` / `null` in place of a result.
