### PR TITLE
Support multi-value metadata

### DIFF
--- a/docs/docs/tutorials/rag.md
+++ b/docs/docs/tutorials/rag.md
@@ -233,7 +233,9 @@ It stores meta information about the `Document`, such as its name, source, last 
 or any other relevant details.
 
 The `Metadata` is stored as a key-value map, where the key is of the `String` type,
-and the value can be one of the following types: `String`, `Integer`, `Long`, `Float`, `Double`, `UUID`.
+and the value can be one of the following types: `String`, `Integer`, `Long`, `Float`, `Double`, `UUID`,
+or a `Collection` containing either `String` or `UUID` values.
+Support for storing and filtering by collection values depends on the `EmbeddingStore` implementation.
 
 `Metadata` is useful for several reasons:
 - When including the content of the `Document` in a prompt to the LLM,
@@ -252,8 +254,9 @@ and update it in the `EmbeddingStore` as well to keep it in sync.
 
 - `Metadata.from(Map)` creates `Metadata` from a `Map`
 - `Metadata.put(String key, String value)` / `put(String, int)` / etc., adds an entry to the `Metadata`
+- `Metadata.put(String key, Collection<?> values)` adds a collection entry containing only `String`s or only `UUID`s to the `Metadata`
 - `Metadata.putAll(Map)` adds multiple entries to the `Metadata`
-- `Metadata.getString(String key)` / `getInteger(String key)` / etc., returns a value of the `Metadata` entry, casting it to the required type
+- `Metadata.getString(String key)` / `getInteger(String key)` / `getStrings(String key)` / `getUUIDs(String key)` / etc., returns a value of the `Metadata` entry, casting it to the required type
 - `Metadata.containsKey(String key)` checks whether `Metadata` contains an entry with the specified key
 - `Metadata.remove(String key)` removes an entry from the `Metadata` by key
 - `Metadata.copy()` returns a copy of the `Metadata`

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
@@ -7,9 +7,13 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -26,7 +30,9 @@ import org.jspecify.annotations.Nullable;
  * segment-specific information, such as the page number, the position of the segment within the document, chapter, etc.
  * <br>
  * The metadata is stored as a key-value map, where the key is a {@link String} and the value can be one of:
- * {@link String}, {@link UUID}, {@link Integer}, {@link Long}, {@link Float}, {@link Double}.
+ * {@link String}, {@link UUID}, {@link Integer}, {@link Long}, {@link Float}, {@link Double},
+ * or a {@link Collection} containing either {@link String} or {@link UUID} values.
+ * Support for storing and filtering by collection values depends on the {@link EmbeddingStore} implementation.
  * If you require additional types, please <a href="https://github.com/langchain4j/langchain4j/issues/new/choose">open an issue</a>.
  * <br>
  * {@code null} values are not permitted.
@@ -34,6 +40,7 @@ import org.jspecify.annotations.Nullable;
 public class Metadata {
 
     private static final Set<Class<?>> SUPPORTED_VALUE_TYPES = new LinkedHashSet<>();
+    private static final Set<Class<?>> SUPPORTED_COLLECTION_VALUE_TYPES = new LinkedHashSet<>();
 
     static {
         SUPPORTED_VALUE_TYPES.add(String.class);
@@ -51,6 +58,9 @@ public class Metadata {
 
         SUPPORTED_VALUE_TYPES.add(double.class);
         SUPPORTED_VALUE_TYPES.add(Double.class);
+
+        SUPPORTED_COLLECTION_VALUE_TYPES.add(String.class);
+        SUPPORTED_COLLECTION_VALUE_TYPES.add(UUID.class);
     }
 
     private final Map<String, Object> metadata;
@@ -66,28 +76,66 @@ public class Metadata {
      * Constructs a Metadata object from a map of key-value pairs.
      *
      * @param metadata the map of key-value pairs; must not be {@code null}. {@code null} values are not permitted.
-     *                 Supported value types: {@link String}, {@link Integer}, {@link Long}, {@link Float}, {@link Double}, {@link UUID}
+     *                 Supported value types: {@link String}, {@link Integer}, {@link Long}, {@link Float}, {@link Double}, {@link UUID},
+     *                 and {@link Collection}s containing either {@link String} or {@link UUID} values.
      */
     public Metadata(Map<String, ?> metadata) {
-        validate(metadata);
-        this.metadata = new HashMap<>(metadata);
+        this.metadata = copyAndValidate(metadata);
     }
 
-    private static void validate(Map<String, ?> metadata) {
+    private static Map<String, Object> copyAndValidate(Map<String, ?> metadata) {
+        Map<String, Object> copy = new HashMap<>();
         ensureNotNull(metadata, "metadata").forEach((key, value) -> {
-            validate(key, value);
-            if (!SUPPORTED_VALUE_TYPES.contains(value.getClass())) {
-                throw illegalArgument(
-                        "The metadata key '%s' has the value '%s', which is of the unsupported type '%s'. "
-                                + "Currently, the supported types are: %s",
-                        key, value, value.getClass().getName(), SUPPORTED_VALUE_TYPES);
-            }
+            copy.put(key, copyAndValidate(key, value));
         });
+        return copy;
+    }
+
+    private static Object copyAndValidate(String key, Object value) {
+        validate(key, value);
+        if (value instanceof Collection<?> collection) {
+            return copyAndValidateCollection(key, collection);
+        }
+        validateValue(key, value);
+        return value;
     }
 
     private static void validate(String key, Object value) {
         ensureNotBlank(key, "The metadata key with the value '" + value + "'");
         ensureNotNull(value, "The metadata value for the key '" + key + "'");
+    }
+
+    private static void validateValue(String key, Object value) {
+        if (!SUPPORTED_VALUE_TYPES.contains(value.getClass())) {
+            throw illegalArgument(
+                    "The metadata key '%s' has the value '%s', which is of the unsupported type '%s'. "
+                            + "Currently, the supported types are: %s and collections containing values of these types: %s",
+                    key, value, value.getClass().getName(), SUPPORTED_VALUE_TYPES, SUPPORTED_COLLECTION_VALUE_TYPES);
+        }
+    }
+
+    private static List<?> copyAndValidateCollection(String key, Collection<?> values) {
+        List<Object> copy = new ArrayList<>(values.size());
+        Class<?> collectionValueType = null;
+        for (Object value : values) {
+            ensureNotNull(value, "The metadata collection value for the key '" + key + "'");
+            if (!SUPPORTED_COLLECTION_VALUE_TYPES.contains(value.getClass())) {
+                throw illegalArgument(
+                        "The metadata key '%s' has collection value '%s', which is of the unsupported collection value type '%s'. "
+                                + "Currently, the supported collection value types are: %s",
+                        key, value, value.getClass().getName(), SUPPORTED_COLLECTION_VALUE_TYPES);
+            }
+            if (collectionValueType == null) {
+                collectionValueType = value.getClass();
+            } else if (collectionValueType != value.getClass()) {
+                throw illegalArgument(
+                        "The metadata key '%s' has a collection with mixed value types: '%s' and '%s'. "
+                                + "Metadata collections must contain values of the same type.",
+                        key, collectionValueType.getName(), value.getClass().getName());
+            }
+            copy.add(value);
+        }
+        return Collections.unmodifiableList(copy);
     }
 
     /**
@@ -115,6 +163,40 @@ public class Metadata {
     }
 
     /**
+     * Returns the {@code String} values associated with the given key.
+     *
+     * @param key the key
+     * @return the {@code String} values associated with the given key, or an empty collection if the key is not present.
+     * @throws RuntimeException if the value is not a {@link Collection} of {@link String}s
+     */
+    public Collection<String> getStrings(String key) {
+        Object values = metadata.get(key);
+        if (values == null) {
+            return Collections.emptyList();
+        }
+
+        if (values instanceof Collection<?> collection) {
+            List<String> strings = new ArrayList<>(collection.size());
+            for (Object value : collection) {
+                if (value instanceof String string) {
+                    strings.add(string);
+                } else {
+                    throw runtime(
+                            "Metadata entry with the key '%s' has a collection value of '%s' and type '%s'. "
+                                    + "It cannot be returned as a Collection<String>.",
+                            key, value, value.getClass().getName());
+                }
+            }
+            return Collections.unmodifiableList(strings);
+        }
+
+        throw runtime(
+                "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
+                        + "It cannot be returned as a Collection<String>.",
+                key, values, values.getClass().getName());
+    }
+
+    /**
      * Returns the {@code UUID} value associated with the given key.
      *
      * @param key the key
@@ -139,6 +221,45 @@ public class Metadata {
                 "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
                         + "It cannot be returned as a UUID.",
                 key, value, value.getClass().getName());
+    }
+
+    /**
+     * Returns the {@code UUID} values associated with the given key.
+     * <br>
+     * Some {@link EmbeddingStore} implementations store {@code UUID}s as {@code String}s.
+     * In this case, the {@code String} values will be parsed into {@code UUID}s when this method is called.
+     *
+     * @param key the key
+     * @return the {@code UUID} values associated with the given key, or an empty collection if the key is not present.
+     * @throws RuntimeException if the value is not a {@link Collection} of {@link UUID}s or {@link String}s
+     */
+    public Collection<UUID> getUUIDs(String key) {
+        Object values = metadata.get(key);
+        if (values == null) {
+            return Collections.emptyList();
+        }
+
+        if (values instanceof Collection<?> collection) {
+            List<UUID> uuids = new ArrayList<>(collection.size());
+            for (Object value : collection) {
+                if (value instanceof UUID uuid) {
+                    uuids.add(uuid);
+                } else if (value instanceof String string) {
+                    uuids.add(UUID.fromString(string));
+                } else {
+                    throw runtime(
+                            "Metadata entry with the key '%s' has a collection value of '%s' and type '%s'. "
+                                    + "It cannot be returned as a Collection<UUID>.",
+                            key, value, value.getClass().getName());
+                }
+            }
+            return Collections.unmodifiableList(uuids);
+        }
+
+        throw runtime(
+                "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
+                        + "It cannot be returned as a Collection<UUID>.",
+                key, values, values.getClass().getName());
     }
 
     /**
@@ -369,9 +490,20 @@ public class Metadata {
         return this;
     }
 
+    /**
+     * Adds a key-value pair to the metadata.
+     *
+     * @param key    the key
+     * @param values the values; must contain only {@link String}s or only {@link UUID}s
+     * @return {@code this}
+     */
+    public Metadata put(String key, Collection<?> values) {
+        this.metadata.put(key, copyAndValidate(key, values));
+        return this;
+    }
+
     public Metadata putAll(Map<String, Object> metadata) {
-        validate(metadata);
-        this.metadata.putAll(metadata);
+        this.metadata.putAll(copyAndValidate(metadata));
         return this;
     }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/document/Metadata.java
@@ -8,9 +8,13 @@ import static java.util.stream.Collectors.joining;
 
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -27,7 +31,9 @@ import org.jspecify.annotations.Nullable;
  * segment-specific information, such as the page number, the position of the segment within the document, chapter, etc.
  * <br>
  * The metadata is stored as a key-value map, where the key is a {@link String} and the value can be one of:
- * {@link String}, {@link UUID}, {@link Integer}, {@link Long}, {@link Float}, {@link Double}.
+ * {@link String}, {@link UUID}, {@link Integer}, {@link Long}, {@link Float}, {@link Double},
+ * or a {@link Collection} containing either {@link String} or {@link UUID} values.
+ * Support for storing and filtering by collection values depends on the {@link EmbeddingStore} implementation.
  * If you require additional types, please <a href="https://github.com/langchain4j/langchain4j/issues/new/choose">open an issue</a>.
  * <br>
  * {@code null} values are not permitted.
@@ -35,6 +41,7 @@ import org.jspecify.annotations.Nullable;
 public class Metadata {
 
     private static final Set<Class<?>> SUPPORTED_VALUE_TYPES = new LinkedHashSet<>();
+    private static final Set<Class<?>> SUPPORTED_COLLECTION_VALUE_TYPES = new LinkedHashSet<>();
 
     static {
         SUPPORTED_VALUE_TYPES.add(String.class);
@@ -52,6 +59,9 @@ public class Metadata {
 
         SUPPORTED_VALUE_TYPES.add(double.class);
         SUPPORTED_VALUE_TYPES.add(Double.class);
+
+        SUPPORTED_COLLECTION_VALUE_TYPES.add(String.class);
+        SUPPORTED_COLLECTION_VALUE_TYPES.add(UUID.class);
     }
 
     private final Map<String, Object> metadata;
@@ -67,28 +77,66 @@ public class Metadata {
      * Constructs a Metadata object from a map of key-value pairs.
      *
      * @param metadata the map of key-value pairs; must not be {@code null}. {@code null} values are not permitted.
-     *                 Supported value types: {@link String}, {@link Integer}, {@link Long}, {@link Float}, {@link Double}, {@link UUID}
+     *                 Supported value types: {@link String}, {@link Integer}, {@link Long}, {@link Float}, {@link Double}, {@link UUID},
+     *                 and {@link Collection}s containing either {@link String} or {@link UUID} values.
      */
     public Metadata(Map<String, ?> metadata) {
-        validate(metadata);
-        this.metadata = new HashMap<>(metadata);
+        this.metadata = copyAndValidate(metadata);
     }
 
-    private static void validate(Map<String, ?> metadata) {
+    private static Map<String, Object> copyAndValidate(Map<String, ?> metadata) {
+        Map<String, Object> copy = new HashMap<>();
         ensureNotNull(metadata, "metadata").forEach((key, value) -> {
-            validate(key, value);
-            if (!SUPPORTED_VALUE_TYPES.contains(value.getClass())) {
-                throw illegalArgument(
-                        "The metadata key '%s' has the value '%s', which is of the unsupported type '%s'. "
-                                + "Currently, the supported types are: %s",
-                        key, value, value.getClass().getName(), SUPPORTED_VALUE_TYPES);
-            }
+            copy.put(key, copyAndValidate(key, value));
         });
+        return copy;
+    }
+
+    private static Object copyAndValidate(String key, Object value) {
+        validate(key, value);
+        if (value instanceof Collection<?> collection) {
+            return copyAndValidateCollection(key, collection);
+        }
+        validateValue(key, value);
+        return value;
     }
 
     private static void validate(String key, Object value) {
         ensureNotBlank(key, "The metadata key with the value '" + value + "'");
         ensureNotNull(value, "The metadata value for the key '" + key + "'");
+    }
+
+    private static void validateValue(String key, Object value) {
+        if (!SUPPORTED_VALUE_TYPES.contains(value.getClass())) {
+            throw illegalArgument(
+                    "The metadata key '%s' has the value '%s', which is of the unsupported type '%s'. "
+                            + "Currently, the supported types are: %s and collections containing values of these types: %s",
+                    key, value, value.getClass().getName(), SUPPORTED_VALUE_TYPES, SUPPORTED_COLLECTION_VALUE_TYPES);
+        }
+    }
+
+    private static List<?> copyAndValidateCollection(String key, Collection<?> values) {
+        List<Object> copy = new ArrayList<>(values.size());
+        Class<?> collectionValueType = null;
+        for (Object value : values) {
+            ensureNotNull(value, "The metadata collection value for the key '" + key + "'");
+            if (!SUPPORTED_COLLECTION_VALUE_TYPES.contains(value.getClass())) {
+                throw illegalArgument(
+                        "The metadata key '%s' has collection value '%s', which is of the unsupported collection value type '%s'. "
+                                + "Currently, the supported collection value types are: %s",
+                        key, value, value.getClass().getName(), SUPPORTED_COLLECTION_VALUE_TYPES);
+            }
+            if (collectionValueType == null) {
+                collectionValueType = value.getClass();
+            } else if (collectionValueType != value.getClass()) {
+                throw illegalArgument(
+                        "The metadata key '%s' has a collection with mixed value types: '%s' and '%s'. "
+                                + "Metadata collections must contain values of the same type.",
+                        key, collectionValueType.getName(), value.getClass().getName());
+            }
+            copy.add(value);
+        }
+        return Collections.unmodifiableList(copy);
     }
 
     /**
@@ -116,6 +164,40 @@ public class Metadata {
     }
 
     /**
+     * Returns the {@code String} values associated with the given key.
+     *
+     * @param key the key
+     * @return the {@code String} values associated with the given key, or an empty collection if the key is not present.
+     * @throws RuntimeException if the value is not a {@link Collection} of {@link String}s
+     */
+    public Collection<String> getStrings(String key) {
+        Object values = metadata.get(key);
+        if (values == null) {
+            return Collections.emptyList();
+        }
+
+        if (values instanceof Collection<?> collection) {
+            List<String> strings = new ArrayList<>(collection.size());
+            for (Object value : collection) {
+                if (value instanceof String string) {
+                    strings.add(string);
+                } else {
+                    throw runtime(
+                            "Metadata entry with the key '%s' has a collection value of '%s' and type '%s'. "
+                                    + "It cannot be returned as a Collection<String>.",
+                            key, value, value.getClass().getName());
+                }
+            }
+            return Collections.unmodifiableList(strings);
+        }
+
+        throw runtime(
+                "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
+                        + "It cannot be returned as a Collection<String>.",
+                key, values, values.getClass().getName());
+    }
+
+    /**
      * Returns the {@code UUID} value associated with the given key.
      *
      * @param key the key
@@ -140,6 +222,45 @@ public class Metadata {
                 "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
                         + "It cannot be returned as a UUID.",
                 key, value, value.getClass().getName());
+    }
+
+    /**
+     * Returns the {@code UUID} values associated with the given key.
+     * <br>
+     * Some {@link EmbeddingStore} implementations store {@code UUID}s as {@code String}s.
+     * In this case, the {@code String} values will be parsed into {@code UUID}s when this method is called.
+     *
+     * @param key the key
+     * @return the {@code UUID} values associated with the given key, or an empty collection if the key is not present.
+     * @throws RuntimeException if the value is not a {@link Collection} of {@link UUID}s or {@link String}s
+     */
+    public Collection<UUID> getUUIDs(String key) {
+        Object values = metadata.get(key);
+        if (values == null) {
+            return Collections.emptyList();
+        }
+
+        if (values instanceof Collection<?> collection) {
+            List<UUID> uuids = new ArrayList<>(collection.size());
+            for (Object value : collection) {
+                if (value instanceof UUID uuid) {
+                    uuids.add(uuid);
+                } else if (value instanceof String string) {
+                    uuids.add(UUID.fromString(string));
+                } else {
+                    throw runtime(
+                            "Metadata entry with the key '%s' has a collection value of '%s' and type '%s'. "
+                                    + "It cannot be returned as a Collection<UUID>.",
+                            key, value, value.getClass().getName());
+                }
+            }
+            return Collections.unmodifiableList(uuids);
+        }
+
+        throw runtime(
+                "Metadata entry with the key '%s' has a value of '%s' and type '%s'. "
+                        + "It cannot be returned as a Collection<UUID>.",
+                key, values, values.getClass().getName());
     }
 
     /**
@@ -370,9 +491,20 @@ public class Metadata {
         return this;
     }
 
+    /**
+     * Adds a key-value pair to the metadata.
+     *
+     * @param key    the key
+     * @param values the values; must contain only {@link String}s or only {@link UUID}s
+     * @return {@code this}
+     */
+    public Metadata put(String key, Collection<?> values) {
+        this.metadata.put(key, copyAndValidate(key, values));
+        return this;
+    }
+
     public Metadata putAll(Map<String, Object> metadata) {
-        validate(metadata);
-        this.metadata.putAll(metadata);
+        this.metadata.putAll(copyAndValidate(metadata));
         return this;
     }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/ComparisonUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/ComparisonUtils.java
@@ -1,0 +1,44 @@
+package dev.langchain4j.store.embedding.filter.comparison;
+
+import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.compareAsBigDecimals;
+import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.containsAsBigDecimals;
+import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
+import static dev.langchain4j.store.embedding.filter.comparison.UUIDComparator.containsAsUUID;
+
+import dev.langchain4j.Internal;
+import java.util.Collection;
+import java.util.UUID;
+
+@Internal
+class ComparisonUtils {
+
+    static boolean isEqualTo(Object actualValue, Object comparisonValue, String key) {
+        ensureTypesAreCompatible(actualValue, comparisonValue, key);
+
+        if (actualValue instanceof Number) {
+            return compareAsBigDecimals(actualValue, comparisonValue) == 0;
+        }
+
+        if (comparisonValue instanceof UUID && actualValue instanceof String) {
+            return actualValue.equals(comparisonValue.toString());
+        }
+
+        return actualValue.equals(comparisonValue);
+    }
+
+    static boolean isIn(Object actualValue, Collection<?> comparisonValues, String key) {
+        Object comparisonValue = comparisonValues.iterator().next();
+        ensureTypesAreCompatible(actualValue, comparisonValue, key);
+
+        if (comparisonValue instanceof Number) {
+            return containsAsBigDecimals(actualValue, comparisonValues);
+        }
+        if (comparisonValue instanceof UUID) {
+            return containsAsUUID(actualValue, comparisonValues);
+        }
+
+        return comparisonValues.contains(actualValue);
+    }
+
+    private ComparisonUtils() {}
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/ComparisonUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/ComparisonUtils.java
@@ -1,0 +1,42 @@
+package dev.langchain4j.store.embedding.filter.comparison;
+
+import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
+import static dev.langchain4j.store.embedding.filter.comparison.UUIDComparator.containsAsUUID;
+
+import dev.langchain4j.Internal;
+import java.util.Collection;
+import java.util.UUID;
+
+@Internal
+class ComparisonUtils {
+
+    static boolean isEqualTo(Object actualValue, Object comparisonValue, String key) {
+        ensureTypesAreCompatible(actualValue, comparisonValue, key);
+
+        if (actualValue instanceof Number) {
+            return NumberComparator.isEqualTo(actualValue, comparisonValue);
+        }
+
+        if (comparisonValue instanceof UUID && actualValue instanceof String) {
+            return actualValue.equals(comparisonValue.toString());
+        }
+
+        return actualValue.equals(comparisonValue);
+    }
+
+    static boolean isIn(Object actualValue, Collection<?> comparisonValues, String key) {
+        Object comparisonValue = comparisonValues.iterator().next();
+        ensureTypesAreCompatible(actualValue, comparisonValue, key);
+
+        if (comparisonValue instanceof Number) {
+            return NumberComparator.isIn(actualValue, comparisonValues);
+        }
+        if (comparisonValue instanceof UUID) {
+            return containsAsUUID(actualValue, comparisonValues);
+        }
+
+        return comparisonValues.contains(actualValue);
+    }
+
+    private ComparisonUtils() {}
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualTo.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualTo.java
@@ -1,15 +1,13 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.store.embedding.filter.Filter;
-
-import java.util.Objects;
-import java.util.UUID;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.compareAsBigDecimals;
-import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
+import static dev.langchain4j.store.embedding.filter.comparison.ComparisonUtils.isEqualTo;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.Collection;
+import java.util.Objects;
 
 public class IsEqualTo implements Filter {
 
@@ -40,25 +38,18 @@ public class IsEqualTo implements Filter {
         }
 
         Object actualValue = metadata.toMap().get(key);
-        ensureTypesAreCompatible(actualValue, comparisonValue, key);
-
-        if (actualValue instanceof Number) {
-            return compareAsBigDecimals(actualValue, comparisonValue) == 0;
+        if (actualValue instanceof Collection<?> actualValues) {
+            return actualValues.stream().anyMatch(it -> isEqualTo(it, comparisonValue, key));
         }
 
-        if (comparisonValue instanceof UUID && actualValue instanceof String) {
-            return actualValue.equals(comparisonValue.toString());
-        }
-
-        return actualValue.equals(comparisonValue);
+        return isEqualTo(actualValue, comparisonValue, key);
     }
 
     public boolean equals(final Object o) {
         if (o == this) return true;
         if (!(o instanceof IsEqualTo other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValue, other.comparisonValue);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValue, other.comparisonValue);
     }
 
     public int hashCode() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualTo.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualTo.java
@@ -1,15 +1,13 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.store.embedding.filter.Filter;
-
-import java.util.Objects;
-import java.util.UUID;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.isEqualTo;
-import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
+import static dev.langchain4j.store.embedding.filter.comparison.ComparisonUtils.isEqualTo;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.Collection;
+import java.util.Objects;
 
 public class IsEqualTo implements Filter {
 
@@ -40,25 +38,18 @@ public class IsEqualTo implements Filter {
         }
 
         Object actualValue = metadata.toMap().get(key);
-        ensureTypesAreCompatible(actualValue, comparisonValue, key);
-
-        if (actualValue instanceof Number) {
-            return isEqualTo(actualValue, comparisonValue);
+        if (actualValue instanceof Collection<?> actualValues) {
+            return actualValues.stream().anyMatch(it -> isEqualTo(it, comparisonValue, key));
         }
 
-        if (comparisonValue instanceof UUID && actualValue instanceof String) {
-            return actualValue.equals(comparisonValue.toString());
-        }
-
-        return actualValue.equals(comparisonValue);
+        return isEqualTo(actualValue, comparisonValue, key);
     }
 
     public boolean equals(final Object o) {
         if (o == this) return true;
         if (!(o instanceof IsEqualTo other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValue, other.comparisonValue);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValue, other.comparisonValue);
     }
 
     public int hashCode() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsIn.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsIn.java
@@ -1,21 +1,17 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.store.embedding.filter.comparison.ComparisonUtils.isIn;
+import static java.util.Collections.unmodifiableSet;
+
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.store.embedding.filter.Filter;
-
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.containsAsBigDecimals;
-import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
-import static dev.langchain4j.store.embedding.filter.comparison.UUIDComparator.containsAsUUID;
-import static java.util.Collections.unmodifiableSet;
 
 public class IsIn implements Filter {
 
@@ -48,30 +44,23 @@ public class IsIn implements Filter {
         }
 
         Object actualValue = metadata.toMap().get(key);
-        ensureTypesAreCompatible(actualValue, comparisonValues.iterator().next(), key);
-
-        if (comparisonValues.iterator().next() instanceof Number) {
-            return containsAsBigDecimals(actualValue, comparisonValues);
-        }
-        if (comparisonValues.iterator().next() instanceof UUID) {
-            return containsAsUUID(actualValue, comparisonValues);
+        if (actualValue instanceof Collection<?> actualValues) {
+            return actualValues.stream().anyMatch(it -> isIn(it, comparisonValues, key));
         }
 
-        return comparisonValues.contains(actualValue);
+        return isIn(actualValue, comparisonValues, key);
     }
 
     public boolean equals(final Object o) {
         if (o == this) return true;
         if (!(o instanceof IsIn other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValues, other.comparisonValues);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValues, other.comparisonValues);
     }
 
     public int hashCode() {
         return Objects.hash(key, comparisonValues);
     }
-
 
     public String toString() {
         return "IsIn(key=" + this.key + ", comparisonValues=" + this.comparisonValues + ")";

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsIn.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsIn.java
@@ -1,21 +1,17 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.store.embedding.filter.comparison.ComparisonUtils.isIn;
+import static java.util.Collections.unmodifiableSet;
+
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.store.embedding.filter.Filter;
-
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.isIn;
-import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
-import static dev.langchain4j.store.embedding.filter.comparison.UUIDComparator.containsAsUUID;
-import static java.util.Collections.unmodifiableSet;
 
 public class IsIn implements Filter {
 
@@ -48,30 +44,23 @@ public class IsIn implements Filter {
         }
 
         Object actualValue = metadata.toMap().get(key);
-        ensureTypesAreCompatible(actualValue, comparisonValues.iterator().next(), key);
-
-        if (comparisonValues.iterator().next() instanceof Number) {
-            return isIn(actualValue, comparisonValues);
-        }
-        if (comparisonValues.iterator().next() instanceof UUID) {
-            return containsAsUUID(actualValue, comparisonValues);
+        if (actualValue instanceof Collection<?> actualValues) {
+            return actualValues.stream().anyMatch(it -> isIn(it, comparisonValues, key));
         }
 
-        return comparisonValues.contains(actualValue);
+        return isIn(actualValue, comparisonValues, key);
     }
 
     public boolean equals(final Object o) {
         if (o == this) return true;
         if (!(o instanceof IsIn other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValues, other.comparisonValues);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValues, other.comparisonValues);
     }
 
     public int hashCode() {
         return Objects.hash(key, comparisonValues);
     }
-
 
     public String toString() {
         return "IsIn(key=" + this.key + ", comparisonValues=" + this.comparisonValues + ")";

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsNotEqualTo.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsNotEqualTo.java
@@ -1,15 +1,13 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.store.embedding.filter.Filter;
-
-import java.util.Objects;
-import java.util.UUID;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.compareAsBigDecimals;
-import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
+import static dev.langchain4j.store.embedding.filter.comparison.ComparisonUtils.isEqualTo;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.Collection;
+import java.util.Objects;
 
 public class IsNotEqualTo implements Filter {
 
@@ -40,25 +38,18 @@ public class IsNotEqualTo implements Filter {
         }
 
         Object actualValue = metadata.toMap().get(key);
-        ensureTypesAreCompatible(actualValue, comparisonValue, key);
-
-        if (actualValue instanceof Number) {
-            return compareAsBigDecimals(actualValue, comparisonValue) != 0;
+        if (actualValue instanceof Collection<?> actualValues) {
+            return actualValues.stream().noneMatch(it -> isEqualTo(it, comparisonValue, key));
         }
 
-        if (comparisonValue instanceof UUID && actualValue instanceof String) {
-            return !actualValue.equals(comparisonValue.toString());
-        }
-
-        return !actualValue.equals(comparisonValue);
+        return !isEqualTo(actualValue, comparisonValue, key);
     }
 
     public boolean equals(final Object o) {
         if (o == this) return true;
         if (!(o instanceof IsNotEqualTo other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValue, other.comparisonValue);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValue, other.comparisonValue);
     }
 
     public int hashCode() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsNotEqualTo.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsNotEqualTo.java
@@ -1,15 +1,13 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
-import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.store.embedding.filter.Filter;
-
-import java.util.Objects;
-import java.util.UUID;
-
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.isEqualTo;
-import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
+import static dev.langchain4j.store.embedding.filter.comparison.ComparisonUtils.isEqualTo;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.store.embedding.filter.Filter;
+import java.util.Collection;
+import java.util.Objects;
 
 public class IsNotEqualTo implements Filter {
 
@@ -40,25 +38,18 @@ public class IsNotEqualTo implements Filter {
         }
 
         Object actualValue = metadata.toMap().get(key);
-        ensureTypesAreCompatible(actualValue, comparisonValue, key);
-
-        if (actualValue instanceof Number) {
-            return !isEqualTo(actualValue, comparisonValue);
+        if (actualValue instanceof Collection<?> actualValues) {
+            return actualValues.stream().noneMatch(it -> isEqualTo(it, comparisonValue, key));
         }
 
-        if (comparisonValue instanceof UUID && actualValue instanceof String) {
-            return !actualValue.equals(comparisonValue.toString());
-        }
-
-        return !actualValue.equals(comparisonValue);
+        return !isEqualTo(actualValue, comparisonValue, key);
     }
 
     public boolean equals(final Object o) {
         if (o == this) return true;
         if (!(o instanceof IsNotEqualTo other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValue, other.comparisonValue);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValue, other.comparisonValue);
     }
 
     public int hashCode() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsNotIn.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsNotIn.java
@@ -1,21 +1,17 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.store.embedding.filter.comparison.ComparisonUtils.isIn;
+import static java.util.Collections.unmodifiableSet;
+
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.store.embedding.filter.Filter;
-
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.containsAsBigDecimals;
-import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
-import static dev.langchain4j.store.embedding.filter.comparison.UUIDComparator.containsAsUUID;
-import static java.util.Collections.unmodifiableSet;
 
 public class IsNotIn implements Filter {
 
@@ -48,24 +44,18 @@ public class IsNotIn implements Filter {
         }
 
         Object actualValue = metadata.toMap().get(key);
-        ensureTypesAreCompatible(actualValue, comparisonValues.iterator().next(), key);
-
-        if (comparisonValues.iterator().next() instanceof Number) {
-            return !containsAsBigDecimals(actualValue, comparisonValues);
-        }
-        if (comparisonValues.iterator().next() instanceof UUID) {
-            return !containsAsUUID(actualValue, comparisonValues);
+        if (actualValue instanceof Collection<?> actualValues) {
+            return actualValues.stream().noneMatch(it -> isIn(it, comparisonValues, key));
         }
 
-        return !comparisonValues.contains(actualValue);
+        return !isIn(actualValue, comparisonValues, key);
     }
 
     public boolean equals(final Object o) {
         if (o == this) return true;
         if (!(o instanceof IsNotIn other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValues, other.comparisonValues);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValues, other.comparisonValues);
     }
 
     public int hashCode() {

--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsNotIn.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/IsNotIn.java
@@ -1,21 +1,17 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.store.embedding.filter.comparison.ComparisonUtils.isIn;
+import static java.util.Collections.unmodifiableSet;
+
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.store.embedding.filter.Filter;
-
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.store.embedding.filter.comparison.NumberComparator.isIn;
-import static dev.langchain4j.store.embedding.filter.comparison.TypeChecker.ensureTypesAreCompatible;
-import static dev.langchain4j.store.embedding.filter.comparison.UUIDComparator.containsAsUUID;
-import static java.util.Collections.unmodifiableSet;
 
 public class IsNotIn implements Filter {
 
@@ -48,24 +44,18 @@ public class IsNotIn implements Filter {
         }
 
         Object actualValue = metadata.toMap().get(key);
-        ensureTypesAreCompatible(actualValue, comparisonValues.iterator().next(), key);
-
-        if (comparisonValues.iterator().next() instanceof Number) {
-            return !isIn(actualValue, comparisonValues);
-        }
-        if (comparisonValues.iterator().next() instanceof UUID) {
-            return !containsAsUUID(actualValue, comparisonValues);
+        if (actualValue instanceof Collection<?> actualValues) {
+            return actualValues.stream().noneMatch(it -> isIn(it, comparisonValues, key));
         }
 
-        return !comparisonValues.contains(actualValue);
+        return !isIn(actualValue, comparisonValues, key);
     }
 
     public boolean equals(final Object o) {
         if (o == this) return true;
         if (!(o instanceof IsNotIn other)) return false;
 
-        return Objects.equals(this.key, other.key)
-                && Objects.equals(this.comparisonValues, other.comparisonValues);
+        return Objects.equals(this.key, other.key) && Objects.equals(this.comparisonValues, other.comparisonValues);
     }
 
     public int hashCode() {

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/document/MetadataTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/document/MetadataTest.java
@@ -2,8 +2,12 @@ package dev.langchain4j.data.document;
 
 import static java.util.Collections.singletonMap;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
@@ -121,6 +125,19 @@ class MetadataTest implements WithAssertions {
         Metadata metadata = Metadata.from(map);
 
         assertThat(metadata.getString("key")).isEqualTo("value");
+    }
+
+    @Test
+    void should_create_from_map_with_collection_values() {
+        UUID uuid1 = UUID.randomUUID();
+        UUID uuid2 = UUID.randomUUID();
+
+        Metadata metadata = Metadata.from(Map.of(
+                "tags", List.of("public", "internal"),
+                "roles", List.of(uuid1, uuid2)));
+
+        assertThat(metadata.getStrings("tags")).containsExactly("public", "internal");
+        assertThat(metadata.getUUIDs("roles")).containsExactly(uuid1, uuid2);
     }
 
     @Test
@@ -252,16 +269,37 @@ class MetadataTest implements WithAssertions {
         assertThatThrownBy(() -> new Metadata(map))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("The metadata key 'key' has the value")
-                .hasMessageEndingWith("which is of the unsupported type 'java.lang.Object'. "
-                        + "Currently, the supported types are: [class java.lang.String, class java.util.UUID, int, class java.lang.Integer, "
-                        + "long, class java.lang.Long, float, class java.lang.Float, double, class java.lang.Double]");
+                .hasMessageEndingWith(
+                        "which is of the unsupported type 'java.lang.Object'. "
+                                + "Currently, the supported types are: [class java.lang.String, class java.util.UUID, int, class java.lang.Integer, "
+                                + "long, class java.lang.Long, float, class java.lang.Float, double, class java.lang.Double] "
+                                + "and collections containing values of these types: [class java.lang.String, class java.util.UUID]");
 
         assertThatThrownBy(() -> Metadata.from(map))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("The metadata key 'key' has the value")
-                .hasMessageEndingWith("which is of the unsupported type 'java.lang.Object'. "
-                        + "Currently, the supported types are: [class java.lang.String, class java.util.UUID, int, class java.lang.Integer, "
-                        + "long, class java.lang.Long, float, class java.lang.Float, double, class java.lang.Double]");
+                .hasMessageEndingWith(
+                        "which is of the unsupported type 'java.lang.Object'. "
+                                + "Currently, the supported types are: [class java.lang.String, class java.util.UUID, int, class java.lang.Integer, "
+                                + "long, class java.lang.Long, float, class java.lang.Float, double, class java.lang.Double] "
+                                + "and collections containing values of these types: [class java.lang.String, class java.util.UUID]");
+    }
+
+    @Test
+    void should_fail_to_create_from_map_when_collection_value_is_not_supported() {
+        assertThatThrownBy(() -> Metadata.from(Map.of("key", List.of(1))))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unsupported collection value type");
+
+        assertThatThrownBy(() -> Metadata.from(Map.of("key", List.of("value", UUID.randomUUID()))))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mixed value types");
+
+        List<Object> values = new ArrayList<>();
+        values.add(null);
+        assertThatThrownBy(() -> Metadata.from(Map.of("key", values)))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The metadata collection value for the key 'key' cannot be null");
     }
 
     @Test
@@ -291,6 +329,49 @@ class MetadataTest implements WithAssertions {
 
         assertThat(metadata.getDouble("double")).isEqualTo(1d);
         assertThat(metadata.getDouble("banana")).isNull();
+    }
+
+    @Test
+    void should_get_collection_values() {
+        UUID uuid1 = UUID.randomUUID();
+        UUID uuid2 = UUID.randomUUID();
+        Metadata metadata = new Metadata()
+                .put("tags", List.of("public", "internal"))
+                .put("roles", List.of(uuid1, uuid2))
+                .put("serialized_roles", List.of(uuid1.toString(), uuid2.toString()));
+
+        assertThat(metadata.getStrings("tags")).containsExactly("public", "internal");
+        assertThat(metadata.getUUIDs("roles")).containsExactly(uuid1, uuid2);
+        assertThat(metadata.getUUIDs("serialized_roles")).containsExactly(uuid1, uuid2);
+        assertThat(metadata.getStrings("banana")).isEmpty();
+        assertThat(metadata.getUUIDs("banana")).isEmpty();
+    }
+
+    @Test
+    void should_accept_collection_values() {
+        Metadata metadata = new Metadata().put("tags", Set.of("public", "internal"));
+
+        assertThat(metadata.getStrings("tags")).containsExactlyInAnyOrder("public", "internal");
+    }
+
+    @Test
+    void should_copy_collection_values() {
+        List<String> tags = new ArrayList<>();
+        tags.add("public");
+
+        Metadata metadataFromPut = new Metadata().put("tags", tags);
+        Metadata metadataFromMap = Metadata.from(Map.of("tags", tags));
+        Map<String, Object> map = new HashMap<>();
+        map.put("tags", tags);
+        Metadata metadataFromPutAll = new Metadata().putAll(map);
+
+        tags.add("internal");
+
+        assertThat(metadataFromPut.getStrings("tags")).containsExactly("public");
+        assertThat(metadataFromMap.getStrings("tags")).containsExactly("public");
+        assertThat(metadataFromPutAll.getStrings("tags")).containsExactly("public");
+        assertThatThrownBy(() -> metadataFromPut.getStrings("tags").add("internal"))
+                .isExactlyInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
@@ -340,6 +421,10 @@ class MetadataTest implements WithAssertions {
         assertThatThrownBy(() -> metadata.put("key", (UUID) null))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The metadata value for the key 'key' cannot be null");
+
+        assertThatThrownBy(() -> metadata.put("key", (Collection<?>) null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The metadata value for the key 'key' cannot be null");
     }
 
     @Test
@@ -373,10 +458,18 @@ class MetadataTest implements WithAssertions {
         assertThat(new Metadata().putAll(Map.of("k1", "v1", "k2", "v2")).toMap())
                 .isEqualTo(Map.of("k1", "v1", "k2", "v2"));
 
+        Map<String, Object> map = new HashMap<>();
+        map.put("tags", List.of("public", "internal"));
+        assertThat(new Metadata().putAll(map).getStrings("tags")).containsExactly("public", "internal");
+
         assertThat(new Metadata().put("k1", "v1").putAll(Map.of("k1", "v2")).toMap())
                 .isEqualTo(Map.of("k1", "v2"));
 
-        assertThatThrownBy(() -> new Metadata().putAll(new HashMap<>() {{ put("k", null); }}))
+        assertThatThrownBy(() -> new Metadata().putAll(new HashMap<>() {
+                    {
+                        put("k", null);
+                    }
+                }))
                 .isExactlyInstanceOf(IllegalArgumentException.class);
 
         assertThatThrownBy(() -> new Metadata().putAll(Map.of("k", new Object())))

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/FilterTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/FilterTest.java
@@ -8,6 +8,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.data.document.Metadata;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class FilterTest {
@@ -288,5 +290,86 @@ class FilterTest {
         assertThatThrownBy(() -> metadataKey("id").isNotIn(asList(1, null)).test(metadata))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("comparisonValue with key 'id' cannot be null");
+    }
+
+    @Test
+    void collection_metadata_string() {
+
+        // given
+        Metadata metadata = new Metadata().put("roles", List.of("admin", "editor"));
+
+        // when-then
+        assertThat(metadataKey("roles").isEqualTo("admin").test(metadata)).isTrue();
+        assertThat(metadataKey("roles").isEqualTo("viewer").test(metadata)).isFalse();
+
+        assertThat(metadataKey("roles").isIn("viewer", "editor").test(metadata)).isTrue();
+        assertThat(metadataKey("roles").isIn("viewer").test(metadata)).isFalse();
+
+        assertThat(metadataKey("roles").isNotEqualTo("viewer").test(metadata)).isTrue();
+        assertThat(metadataKey("roles").isNotEqualTo("admin").test(metadata)).isFalse();
+
+        assertThat(metadataKey("roles").isNotIn("viewer").test(metadata)).isTrue();
+        assertThat(metadataKey("roles").isNotIn("viewer", "admin").test(metadata))
+                .isFalse();
+    }
+
+    @Test
+    void collection_metadata_uuid() {
+
+        // given
+        UUID role = UUID.randomUUID();
+        UUID anotherRole = UUID.randomUUID();
+        Metadata metadata = new Metadata().put("roles", List.of(role));
+        Metadata serializedMetadata = new Metadata().put("roles", List.of(role.toString()));
+
+        // when-then
+        assertThat(metadataKey("roles").isEqualTo(role).test(metadata)).isTrue();
+        assertThat(metadataKey("roles").isEqualTo(role).test(serializedMetadata))
+                .isTrue();
+        assertThat(metadataKey("roles").isEqualTo(anotherRole).test(metadata)).isFalse();
+
+        assertThat(metadataKey("roles").isIn(anotherRole, role).test(metadata)).isTrue();
+        assertThat(metadataKey("roles").isIn(anotherRole, role).test(serializedMetadata))
+                .isTrue();
+        assertThat(metadataKey("roles").isIn(anotherRole).test(metadata)).isFalse();
+
+        assertThat(metadataKey("roles").isNotEqualTo(anotherRole).test(metadata))
+                .isTrue();
+        assertThat(metadataKey("roles").isNotEqualTo(role).test(metadata)).isFalse();
+
+        assertThat(metadataKey("roles").isNotIn(anotherRole).test(metadata)).isTrue();
+        assertThat(metadataKey("roles").isNotIn(anotherRole, role).test(metadata))
+                .isFalse();
+    }
+
+    @Test
+    void collection_metadata_type_mismatch() {
+
+        // given
+        Metadata metadata = new Metadata().put("roles", List.of("admin"));
+
+        // when-then
+        assertThatThrownBy(() -> metadataKey("roles").isEqualTo(1).test(metadata))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Type mismatch: actual value of metadata key \"roles\" (admin) "
+                        + "has type java.lang.String, while comparison value (1) has type java.lang.Integer");
+
+        assertThatThrownBy(() -> metadataKey("roles").isIn(1).test(metadata))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Type mismatch: actual value of metadata key \"roles\" (admin) "
+                        + "has type java.lang.String, while comparison value (1) has type java.lang.Integer");
+    }
+
+    @Test
+    void collection_metadata_empty() {
+
+        // given
+        Metadata metadata = new Metadata().put("roles", List.of());
+
+        // when-then
+        assertThat(metadataKey("roles").isEqualTo("admin").test(metadata)).isFalse();
+        assertThat(metadataKey("roles").isIn("admin").test(metadata)).isFalse();
+        assertThat(metadataKey("roles").isNotEqualTo("admin").test(metadata)).isTrue();
+        assertThat(metadataKey("roles").isNotIn("admin").test(metadata)).isTrue();
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualToTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsEqualToTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import dev.langchain4j.data.document.Metadata;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,22 @@ class IsEqualToTest {
             }
         });
         assertThat(isEqualTo.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenActualCollectionContainsComparisonValue() {
+        Metadata metadata = new Metadata().put("key", List.of("a", "b"));
+
+        assertThat(new IsEqualTo("key", "a").test(metadata)).isTrue();
+        assertThat(new IsEqualTo("key", "c").test(metadata)).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenActualCollectionContainsUUIDAsString() {
+        UUID uuid = UUID.randomUUID();
+        Metadata metadata = new Metadata().put("key", List.of(uuid.toString()));
+
+        assertThat(new IsEqualTo("key", uuid).test(metadata)).isTrue();
     }
 
     @Test

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreKnnIT.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreKnnIT.java
@@ -2,10 +2,20 @@ package dev.langchain4j.store.embedding.elasticsearch;
 
 import static dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfiguration.TEXT_FIELD;
 import static dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfiguration.VECTOR_FIELD;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import co.elastic.clients.elasticsearch._types.mapping.DenseVectorIndexOptionsType;
 import co.elastic.clients.transport.endpoints.BooleanResponse;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
 
 class ElasticsearchEmbeddingStoreKnnIT extends AbstractElasticsearchEmbeddingStoreIT {
 
@@ -36,5 +46,60 @@ class ElasticsearchEmbeddingStoreKnnIT extends AbstractElasticsearchEmbeddingSto
                                                     // as the tests are failing otherwise due to the approximation
                                                     .type(DenseVectorIndexOptionsType.Hnsw))))));
         }
+    }
+
+    @Test
+    void should_filter_by_multi_value_metadata() throws IOException {
+        UUID role1 = UUID.randomUUID();
+        UUID role2 = UUID.randomUUID();
+        UUID role3 = UUID.randomUUID();
+
+        TextSegment matchingSegment = TextSegment.from(
+                "matching",
+                new Metadata().put("roles", List.of(role1, role2)).put("labels", List.of("finance", "internal")));
+        TextSegment notMatchingSegment = TextSegment.from(
+                "matching", new Metadata().put("roles", List.of(role3)).put("labels", List.of("public")));
+        List<TextSegment> segments = List.of(matchingSegment, notMatchingSegment);
+        List<Embedding> embeddings = embeddingModel().embedAll(segments).content();
+        embeddingStore().addAll(embeddings, segments);
+        elasticsearchClientHelper.refreshIndex(indexName);
+
+        Embedding queryEmbedding = embeddingModel().embed("matching").content();
+        EmbeddingSearchRequest inSearchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(queryEmbedding)
+                .filter(metadataKey("roles").isIn(role1, UUID.randomUUID()))
+                .maxResults(10)
+                .build();
+
+        List<EmbeddingMatch<TextSegment>> matches =
+                embeddingStore().search(inSearchRequest).matches();
+
+        assertThat(matches).hasSize(1);
+        assertThat(matches.get(0).embedded().metadata().getUUIDs("roles")).containsExactlyInAnyOrder(role1, role2);
+        assertThat(matches.get(0).embedded().metadata().getStrings("labels"))
+                .containsExactlyInAnyOrder("finance", "internal");
+
+        EmbeddingSearchRequest equalToSearchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(queryEmbedding)
+                .filter(metadataKey("roles").isEqualTo(role1))
+                .maxResults(10)
+                .build();
+
+        matches = embeddingStore().search(equalToSearchRequest).matches();
+
+        assertThat(matches).hasSize(1);
+        assertThat(matches.get(0).embedded().metadata().getUUIDs("roles")).containsExactlyInAnyOrder(role1, role2);
+
+        EmbeddingSearchRequest labelSearchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(queryEmbedding)
+                .filter(metadataKey("labels").isEqualTo("finance"))
+                .maxResults(10)
+                .build();
+
+        matches = embeddingStore().search(labelSearchRequest).matches();
+
+        assertThat(matches).hasSize(1);
+        assertThat(matches.get(0).embedded().metadata().getStrings("labels"))
+                .containsExactlyInAnyOrder("finance", "internal");
     }
 }

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreKnnIT.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchEmbeddingStoreKnnIT.java
@@ -2,10 +2,20 @@ package dev.langchain4j.store.embedding.elasticsearch;
 
 import static dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfiguration.TEXT_FIELD;
 import static dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfiguration.VECTOR_FIELD;
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import co.elastic.clients.elasticsearch._types.mapping.DenseVectorIndexOptionsType;
 import co.elastic.clients.transport.endpoints.BooleanResponse;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
 
 class ElasticsearchEmbeddingStoreKnnIT extends AbstractElasticsearchEmbeddingStoreIT {
 
@@ -36,5 +46,32 @@ class ElasticsearchEmbeddingStoreKnnIT extends AbstractElasticsearchEmbeddingSto
                                                     // as the tests are failing otherwise due to the approximation
                                                     .type(DenseVectorIndexOptionsType.Hnsw))))));
         }
+    }
+
+    @Test
+    void should_filter_by_multi_value_metadata() throws IOException {
+        UUID role1 = UUID.randomUUID();
+        UUID role2 = UUID.randomUUID();
+        UUID role3 = UUID.randomUUID();
+
+        TextSegment matchingSegment = TextSegment.from("matching", new Metadata().put("roles", List.of(role1, role2)));
+        TextSegment notMatchingSegment = TextSegment.from("matching", new Metadata().put("roles", List.of(role3)));
+        List<TextSegment> segments = List.of(matchingSegment, notMatchingSegment);
+        List<Embedding> embeddings = embeddingModel().embedAll(segments).content();
+        embeddingStore().addAll(embeddings, segments);
+        elasticsearchClientHelper.refreshIndex(indexName);
+
+        Embedding queryEmbedding = embeddingModel().embed("matching").content();
+        EmbeddingSearchRequest inSearchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(queryEmbedding)
+                .filter(metadataKey("roles").isIn(role1, UUID.randomUUID()))
+                .maxResults(10)
+                .build();
+
+        List<EmbeddingMatch<TextSegment>> matches =
+                embeddingStore().search(inSearchRequest).matches();
+
+        assertThat(matches).hasSize(1);
+        assertThat(matches.get(0).embedded().metadata().getUUIDs("roles")).containsExactlyInAnyOrder(role1, role2);
     }
 }


### PR DESCRIPTION
## Issue
Addresses #1905

## Change
Adds homogeneous Collection<String> and Collection<UUID> values to Metadata, including defensive copies and typed accessors. Local equality and inclusion filters compare collection elements while preserving the current scalar, numeric, and UUID semantics.

Elasticsearch coverage verifies that multi-value UUID metadata can be stored, filtered, and read back. Collection support remains dependent on the EmbeddingStore implementation.

## Testing
- Metadata and filter suites: 90 tests passed
- Elasticsearch multi-value integration test
- git diff --check