### PR TITLE
feat: add customHeaders support to AnthropicChatModel and AnthropicStreamingChatModel

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
@@ -96,6 +97,7 @@ public class AnthropicChatModel implements ChatModel {
                 .logRequests(getOrDefault(builder.logRequests, false))
                 .logResponses(getOrDefault(builder.logResponses, false))
                 .logger(builder.logger)
+                .customHeaders(builder.customHeadersSupplier)
                 .build();
 
         this.cacheSystemMessages = getOrDefault(builder.cacheSystemMessages, false);
@@ -182,6 +184,7 @@ public class AnthropicChatModel implements ChatModel {
         private Map<String, Object> customParameters;
         private Boolean strictTools;
         private Set<Capability> supportedCapabilities;
+        private Supplier<Map<String, String>> customHeadersSupplier;
 
         public AnthropicChatModelBuilder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
             this.httpClientBuilder = httpClientBuilder;
@@ -474,6 +477,16 @@ public class AnthropicChatModel implements ChatModel {
 
         public AnthropicChatModelBuilder strictTools(Boolean strictTools) {
             this.strictTools = strictTools;
+            return this;
+        }
+
+        public AnthropicChatModelBuilder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        public AnthropicChatModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
@@ -95,6 +96,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 .logRequests(getOrDefault(builder.logRequests, false))
                 .logResponses(getOrDefault(builder.logResponses, false))
                 .logger(builder.logger)
+                .customHeaders(builder.customHeadersSupplier)
                 .build();
 
         ChatRequestParameters commonParameters = DefaultChatRequestParameters.EMPTY;
@@ -172,6 +174,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         private Map<String, Object> customParameters;
         private Boolean strictTools;
         private Set<Capability> supportedCapabilities;
+        private Supplier<Map<String, String>> customHeadersSupplier;
 
         public AnthropicStreamingChatModelBuilder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
             this.httpClientBuilder = httpClientBuilder;
@@ -465,6 +468,16 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
 
         public AnthropicStreamingChatModelBuilder supportedCapabilities(Set<Capability> supportedCapabilities) {
             this.supportedCapabilities = supportedCapabilities;
+            return this;
+        }
+
+        public AnthropicStreamingChatModelBuilder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        public AnthropicStreamingChatModelBuilder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/AnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/AnthropicClient.java
@@ -11,6 +11,8 @@ import dev.langchain4j.model.anthropic.internal.api.MessageTokenCountResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.spi.ServiceHelper;
 import java.time.Duration;
+import java.util.Map;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 @Internal
@@ -104,6 +106,7 @@ public abstract class AnthropicClient {
         public Logger logger;
         public Boolean logRequests;
         public Boolean logResponses;
+        public Supplier<Map<String, String>> customHeadersSupplier;
 
         /**
          * Builds and returns a new {@link AnthropicClient} instance.
@@ -272,6 +275,31 @@ public abstract class AnthropicClient {
          */
         public B logger(Logger logger) {
             this.logger = logger;
+            return self();
+        }
+
+        /**
+         * Sets custom HTTP headers to be sent with every request.
+         *
+         * @param customHeaders a map of header names to values
+         * @return this builder for method chaining
+         */
+        public B customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return self();
+        }
+
+        /**
+         * Sets a supplier that provides custom HTTP headers to be sent with every request.
+         *
+         * <p>The supplier is called for each request, allowing headers to be computed dynamically
+         * (e.g., short-lived auth tokens).</p>
+         *
+         * @param customHeadersSupplier a supplier that provides a map of header names to values
+         * @return this builder for method chaining
+         */
+        public B customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return self();
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
@@ -60,6 +60,7 @@ import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.output.FinishReason;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,6 +69,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 /**
  * Default implementation of {@link AnthropicClient} that provides methods to interact with the
@@ -130,6 +132,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
     private final String apiKey;
     private final String version;
     private final String beta;
+    private final Supplier<Map<String, String>> customHeadersSupplier;
 
     /**
      * Creates a new builder for constructing a {@link DefaultAnthropicClient} instance.
@@ -189,6 +192,8 @@ public class DefaultAnthropicClient extends AnthropicClient {
         this.apiKey = ensureNotBlank(builder.apiKey, "apiKey");
         this.version = ensureNotBlank(builder.version, "version");
         this.beta = builder.beta;
+        this.customHeadersSupplier =
+                builder.customHeadersSupplier != null ? builder.customHeadersSupplier : Collections::emptyMap;
     }
 
     /**
@@ -385,8 +390,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
                     if (isNotNullOrEmpty(signature)) {
                         thinkingSignatures.add(signature);
                     }
-                } else if (CONTENT_BLOCK_REDACTED_THINKING.equals(blockType)
-                        && options.returnThinking()) {
+                } else if (CONTENT_BLOCK_REDACTED_THINKING.equals(blockType) && options.returnThinking()) {
                     String redactedThinking = data.contentBlock.data;
                     if (isNotNullOrEmpty(redactedThinking)) {
                         redactedThinkings.add(redactedThinking);
@@ -433,8 +437,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
                     if (isNotNullOrEmpty(signature)) {
                         thinkingSignatures.add(signature);
                     }
-                } else if (CONTENT_BLOCK_REDACTED_THINKING.equals(blockType)
-                        && options.returnThinking()) {
+                } else if (CONTENT_BLOCK_REDACTED_THINKING.equals(blockType) && options.returnThinking()) {
                     String redactedThinking = data.delta.data;
                     if (isNotNullOrEmpty(redactedThinking)) {
                         redactedThinkings.add(redactedThinking);
@@ -664,6 +667,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
                 .addHeader("Content-Type", "application/json")
                 .addHeader("x-api-key", apiKey)
                 .addHeader("anthropic-version", version)
+                .addHeaders(customHeadersSupplier.get())
                 .body(jsonRequest);
 
         if (this.beta != null) {

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
@@ -626,6 +626,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
                 .url(baseUrl, "models")
                 .addHeader("x-api-key", apiKey)
                 .addHeader("anthropic-version", version)
+                .addHeaders(customHeadersSupplier.get())
                 .build();
         SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
         return fromJson(successfulHttpResponse.body(), AnthropicModelsListResponse.class);

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicCustomHeadersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicCustomHeadersTest.java
@@ -8,6 +8,7 @@ import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +45,7 @@ class AnthropicCustomHeadersTest {
             exchange.getRequestHeaders().forEach((name, values) -> headers.put(name.toLowerCase(), values.get(0)));
             capturedHeaders.set(headers);
 
-            byte[] body = SUCCESS_RESPONSE.getBytes();
+            byte[] body = SUCCESS_RESPONSE.getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", "application/json");
             exchange.sendResponseHeaders(200, body.length);
             exchange.getResponseBody().write(body);
@@ -146,7 +147,7 @@ class AnthropicCustomHeadersTest {
             exchange.getRequestHeaders().forEach((name, values) -> headers.put(name.toLowerCase(), values.get(0)));
             capturedHeaders.set(headers);
 
-            byte[] body = sseResponse.getBytes();
+            byte[] body = sseResponse.getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
             exchange.sendResponseHeaders(200, body.length);
             exchange.getResponseBody().write(body);

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicCustomHeadersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicCustomHeadersTest.java
@@ -1,0 +1,182 @@
+package dev.langchain4j.model.anthropic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnthropicCustomHeadersTest {
+
+    // language=json
+    private static final String SUCCESS_RESPONSE = """
+            {
+              "id": "msg_123",
+              "type": "message",
+              "role": "assistant",
+              "content": [{"type": "text", "text": "Hello"}],
+              "model": "claude-haiku-4-5-20251001",
+              "stop_reason": "end_turn",
+              "usage": {"input_tokens": 5, "output_tokens": 3}
+            }
+            """;
+
+    private HttpServer server;
+    private AtomicReference<Map<String, String>> capturedHeaders;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        capturedHeaders = new AtomicReference<>();
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/v1/messages", exchange -> {
+            Map<String, String> headers = new java.util.HashMap<>();
+            exchange.getRequestHeaders().forEach((name, values) -> headers.put(name.toLowerCase(), values.get(0)));
+            capturedHeaders.set(headers);
+
+            byte[] body = SUCCESS_RESPONSE.getBytes();
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.getResponseBody().close();
+        });
+        server.start();
+        baseUrl = "http://localhost:" + server.getAddress().getPort() + "/v1";
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void should_send_custom_headers_with_chat_model() {
+        ChatModel model = AnthropicChatModel.builder()
+                .apiKey("dummy-key")
+                .baseUrl(baseUrl)
+                .modelName(AnthropicChatModelName.CLAUDE_HAIKU_4_5_20251001)
+                .maxTokens(10)
+                .customHeaders(Map.of("x-custom-header", "my-value", "x-tenant-id", "tenant-42"))
+                .build();
+
+        model.chat(UserMessage.from("Hi"));
+
+        Map<String, String> headers = capturedHeaders.get();
+        assertThat(headers).containsEntry("x-custom-header", "my-value");
+        assertThat(headers).containsEntry("x-tenant-id", "tenant-42");
+    }
+
+    @Test
+    void should_send_custom_headers_via_supplier_with_chat_model() {
+        AtomicReference<String> dynamicValue = new AtomicReference<>("token-v1");
+
+        ChatModel model = AnthropicChatModel.builder()
+                .apiKey("dummy-key")
+                .baseUrl(baseUrl)
+                .modelName(AnthropicChatModelName.CLAUDE_HAIKU_4_5_20251001)
+                .maxTokens(10)
+                .customHeaders(() -> Map.of("x-auth-token", dynamicValue.get()))
+                .build();
+
+        model.chat(UserMessage.from("Hi"));
+        assertThat(capturedHeaders.get()).containsEntry("x-auth-token", "token-v1");
+
+        dynamicValue.set("token-v2");
+        model.chat(UserMessage.from("Hi again"));
+        assertThat(capturedHeaders.get()).containsEntry("x-auth-token", "token-v2");
+    }
+
+    @Test
+    void should_not_override_standard_headers() {
+        ChatModel model = AnthropicChatModel.builder()
+                .apiKey("my-real-key")
+                .baseUrl(baseUrl)
+                .modelName(AnthropicChatModelName.CLAUDE_HAIKU_4_5_20251001)
+                .maxTokens(10)
+                .customHeaders(Map.of("x-custom-header", "custom-value"))
+                .build();
+
+        model.chat(UserMessage.from("Hi"));
+
+        Map<String, String> headers = capturedHeaders.get();
+        assertThat(headers).containsEntry("x-custom-header", "custom-value");
+        assertThat(headers).containsEntry("x-api-key", "my-real-key");
+        assertThat(headers).containsKey("anthropic-version");
+    }
+
+    @Test
+    void should_send_custom_headers_with_streaming_chat_model() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // language=json
+        String sseResponse = """
+                event: message_start
+                data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-haiku-4-5-20251001","stop_reason":null,"usage":{"input_tokens":5,"output_tokens":0}}}
+
+                event: content_block_start
+                data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+                event: content_block_delta
+                data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}
+
+                event: content_block_stop
+                data: {"type":"content_block_stop","index":0}
+
+                event: message_delta
+                data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}
+
+                event: message_stop
+                data: {"type":"message_stop"}
+
+                """;
+
+        server.removeContext("/v1/messages");
+        server.createContext("/v1/messages", exchange -> {
+            Map<String, String> headers = new java.util.HashMap<>();
+            exchange.getRequestHeaders().forEach((name, values) -> headers.put(name.toLowerCase(), values.get(0)));
+            capturedHeaders.set(headers);
+
+            byte[] body = sseResponse.getBytes();
+            exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.getResponseBody().close();
+        });
+
+        StreamingChatModel model = AnthropicStreamingChatModel.builder()
+                .apiKey("dummy-key")
+                .baseUrl(baseUrl)
+                .modelName(AnthropicChatModelName.CLAUDE_HAIKU_4_5_20251001)
+                .maxTokens(10)
+                .customHeaders(Map.of("x-streaming-header", "streaming-value"))
+                .build();
+
+        model.chat(java.util.List.of(UserMessage.from("Hi")), new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {}
+
+            @Override
+            public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse response) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                latch.countDown();
+            }
+        });
+
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(capturedHeaders.get()).containsEntry("x-streaming-header", "streaming-value");
+    }
+}


### PR DESCRIPTION
## Problem

`AnthropicChatModel` and `AnthropicStreamingChatModel` had no way to attach custom HTTP headers to API requests. This is needed for use cases like:

- Routing/tracing headers required by API gateways or proxies
- Short-lived auth tokens (OAuth, STS) that must be rotated per-request
- Tenant or correlation IDs

The feature was already available for OpenAI, Mistral, Ollama, Voyage, and other integrations (see #4403), but was missing for Anthropic.

Closes #5100

## Solution

Added two `customHeaders` overloads to both model builders, matching the pattern established in #4403:

```java
// Static map — headers are fixed for the lifetime of the model
AnthropicChatModel.builder()
    .customHeaders(Map.of("X-Tenant-Id", "acme"))
    ...

// Dynamic supplier — evaluated on every request, allows credential rotation
AnthropicChatModel.builder()
    .customHeaders(() -> Map.of("Authorization", tokenService.currentToken()))
    ...
```

The same API is available on `AnthropicStreamingChatModel`.

## Changes

| File | Change |
|------|--------|
| `AnthropicClient.Builder` | Added `customHeadersSupplier` field + two `customHeaders()` builder methods |
| `DefaultAnthropicClient` | Stores the supplier; calls `customHeadersSupplier.get()` inside `toHttpRequest()` via `HttpRequest.Builder#addHeaders()` |
| `AnthropicChatModel.AnthropicChatModelBuilder` | Exposes `customHeaders(Map)` and `customHeaders(Supplier<Map>)` |
| `AnthropicStreamingChatModel.AnthropicStreamingChatModelBuilder` | Same as above |

## Tests

`AnthropicCustomHeadersTest` uses an embedded JDK `HttpServer` (no extra dependencies) to verify headers at the HTTP level:

- Custom headers from a static `Map` reach the server
- Supplier is evaluated per-request (dynamic rotation verified across two calls)
- Standard headers (`x-api-key`, `anthropic-version`) are not affected
- `AnthropicStreamingChatModel` sends custom headers correctly

A `null` return from the supplier is safe because `HttpRequest.Builder#addHeaders` delegates to `isNullOrEmpty` before iterating.