### PR TITLE
fix: prevent NPE in AgentInvocationHandler when managedParameters is null

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentInvocationHandler.java
@@ -1,5 +1,13 @@
 package dev.langchain4j.agentic.agent;
 
+import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
+import static dev.langchain4j.agentic.observability.ComposedAgentListener.listenerOfType;
+import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.afterAgentInvocation;
+import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.agentError;
+import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.beforeAgentInvocation;
+import static dev.langchain4j.agentic.scope.DefaultAgenticScope.ephemeralAgenticScope;
+
+import dev.langchain4j.agentic.internal.AgenticScopeOwner;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.observability.AfterAgentToolExecution;
 import dev.langchain4j.agentic.observability.AgentListener;
@@ -9,7 +17,6 @@ import dev.langchain4j.agentic.observability.ComposedAgentListener;
 import dev.langchain4j.agentic.observability.MonitoredAgent;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
-import dev.langchain4j.agentic.internal.AgenticScopeOwner;
 import dev.langchain4j.agentic.planner.AgenticSystemConfigurationException;
 import dev.langchain4j.agentic.planner.AgenticSystemTopology;
 import dev.langchain4j.agentic.planner.Planner;
@@ -25,8 +32,6 @@ import dev.langchain4j.service.AiServiceContext;
 import dev.langchain4j.service.ParameterNameResolver;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
 import dev.langchain4j.service.memory.ChatMemoryService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -37,13 +42,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-
-import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
-import static dev.langchain4j.agentic.observability.ComposedAgentListener.listenerOfType;
-import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.afterAgentInvocation;
-import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.agentError;
-import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.beforeAgentInvocation;
-import static dev.langchain4j.agentic.scope.DefaultAgenticScope.ephemeralAgenticScope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AgentInvocationHandler implements InvocationHandler, InternalAgent {
 
@@ -60,10 +60,7 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
     private final Map<Object, AiServiceResponseReceivedEvent> lastResponseEvents = new ConcurrentHashMap<>();
 
     AgentInvocationHandler(
-            AiServiceContext context,
-            Object agent,
-            AgentBuilder<?, ?> builder,
-            boolean agenticScopeDependent) {
+            AiServiceContext context, Object agent, AgentBuilder<?, ?> builder, boolean agenticScopeDependent) {
         this.context = context;
         this.agent = agent;
         this.builder = builder;
@@ -74,18 +71,22 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Exception {
-        if (method.getDeclaringClass() == AiServiceListener.class || method.getDeclaringClass() == AiServiceResponseReceivedListener.class) {
+        if (method.getDeclaringClass() == AiServiceListener.class
+                || method.getDeclaringClass() == AiServiceResponseReceivedListener.class) {
             return switch (method.getName()) {
                 case "getEventClass" -> AiServiceResponseReceivedEvent.class;
                 case "onEvent" -> {
                     AiServiceResponseReceivedEvent event = (AiServiceResponseReceivedEvent) args[0];
-                    AgenticScope agenticScope = (AgenticScope) event.invocationContext().managedParameters().get(AgenticScope.class);
-                    lastResponseEvents.put(agenticScope.memoryId(), event);
+                    AgenticScope agenticScope = (AgenticScope)
+                            event.invocationContext().managedParameters().get(AgenticScope.class);
+                    if (agenticScope != null) {
+                        lastResponseEvents.put(agenticScope.memoryId(), event);
+                    }
                     yield null;
                 }
                 default ->
-                        throw new UnsupportedOperationException(
-                                "Unknown method on AiServiceResponseReceivedListener class : " + method.getName());
+                    throw new UnsupportedOperationException(
+                            "Unknown method on AiServiceResponseReceivedListener class : " + method.getName());
             };
         }
 
@@ -99,7 +100,8 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
                 return null;
             }
             return switch (method.getName()) {
-                case "lastUserMessage" -> lastUserMessage(lastResponseEvent.request().messages()).orElse(null);
+                case "lastUserMessage" ->
+                    lastUserMessage(lastResponseEvent.request().messages()).orElse(null);
                 case "lastChatRequest" -> lastResponseEvent.request();
                 case "lastChatResponse" -> lastResponseEvent.response();
                 default ->
@@ -132,9 +134,10 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
         if (method.getDeclaringClass() == ChatMemoryAccess.class) {
             return switch (method.getName()) {
                 case "getChatMemory" ->
-                    context.hasChatMemory() && (ChatMemoryService.DEFAULT.equals(args[0]) || builder.hasNonDefaultChatMemory()) ?
-                            context.chatMemoryService.getChatMemory(args[0]) :
-                            null;
+                    context.hasChatMemory()
+                                    && (ChatMemoryService.DEFAULT.equals(args[0]) || builder.hasNonDefaultChatMemory())
+                            ? context.chatMemoryService.getChatMemory(args[0])
+                            : null;
                 case "evictChatMemory" ->
                     context.hasChatMemory() && context.chatMemoryService.evictChatMemory(args[0]) != null;
                 default ->
@@ -156,8 +159,7 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
                 case "toString" -> "Agent<" + builder.agentServiceClass.getSimpleName() + ">";
                 case "hashCode" -> System.identityHashCode(agent);
                 default ->
-                        throw new UnsupportedOperationException(
-                                "Unknown method on Object class : " + method.getName());
+                    throw new UnsupportedOperationException("Unknown method on Object class : " + method.getName());
             };
         }
 
@@ -166,7 +168,8 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
     }
 
     private Object invokeStandaloneAgent(Method method, Object[] args) {
-        LOGGER.warn("Improper invocation of a standalone agent outside of an agentic system, consider using AiServices instead.");
+        LOGGER.warn(
+                "Improper invocation of a standalone agent outside of an agentic system, consider using AiServices instead.");
 
         AgenticScope standaloneAgenticScope = ephemeralAgenticScope();
         LangChain4jManaged.setCurrent(Map.of(AgenticScope.class, standaloneAgenticScope));
@@ -178,7 +181,8 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
         try {
             result = method.invoke(agent, args);
         } catch (Exception e) {
-            AgentInvocationException invocationException = new AgentInvocationException("Failed to invoke agent method: " + method, e);
+            AgentInvocationException invocationException =
+                    new AgentInvocationException("Failed to invoke agent method: " + method, e);
             agentError(agentListener, standaloneAgenticScope, this, namedArgs, invocationException);
             throw invocationException;
         } finally {
@@ -220,7 +224,8 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
     @Override
     public void setParent(InternalAgent parent) {
         if (builder.hasChatMemory() && parent != null && !parent.allowChatMemory()) {
-            throw new AgenticSystemConfigurationException("Agents with chat memory can't be a subagent of " + parent.type());
+            throw new AgenticSystemConfigurationException(
+                    "Agents with chat memory can't be a subagent of " + parent.type());
         }
         this.parent = parent;
         registerInheritedParentListener(parent.listener());
@@ -228,7 +233,9 @@ public class AgentInvocationHandler implements InvocationHandler, InternalAgent 
 
     @Override
     public void registerInheritedParentListener(AgentListener parentListener) {
-        if (parentListener != null && parentListener.inheritedBySubagents() && isNewListener(agentListener, parentListener)) {
+        if (parentListener != null
+                && parentListener.inheritedBySubagents()
+                && isNewListener(agentListener, parentListener)) {
             agentListener = composeWithInherited(agentListener, parentListener);
             context.toolService.beforeToolExecution(beforeToolExecution ->
                     agentListener.beforeAgentToolExecution(new BeforeAgentToolExecution(this, beforeToolExecution)));

--- a/langchain4j-core/src/main/java/dev/langchain4j/invocation/InvocationContext.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/invocation/InvocationContext.java
@@ -195,7 +195,8 @@ public interface InvocationContext {
         /**
          * Sets the LC4j managed parameters for the builder.
          */
-        public Builder managedParameters(Map<Class<? extends LangChain4jManaged>, LangChain4jManaged> managedParameters) {
+        public Builder managedParameters(
+                Map<Class<? extends LangChain4jManaged>, LangChain4jManaged> managedParameters) {
             this.managedParameters = managedParameters;
             return this;
         }
@@ -253,7 +254,7 @@ public interface InvocationContext {
         }
 
         public Map<Class<? extends LangChain4jManaged>, LangChain4jManaged> managedParameters() {
-            return managedParameters;
+            return managedParameters != null ? managedParameters : Map.of();
         }
 
         public Instant timestamp() {

--- a/langchain4j-core/src/test/java/dev/langchain4j/invocation/InvocationContextTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/invocation/InvocationContextTest.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.invocation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class InvocationContextTest {
+
+    @Test
+    void managedParameters_returns_empty_map_when_not_set() {
+        // When LangChain4jManaged.current() returns null, managedParameters is built with null.
+        // managedParameters() must return an empty map (not null) to honour the interface contract
+        // and prevent NPE in callers such as AgentInvocationHandler.
+        InvocationContext ctx = InvocationContext.builder()
+                .chatMemoryId("test")
+                .managedParameters(null)
+                .build();
+
+        assertThat(ctx.managedParameters()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void managedParameters_returns_supplied_map_when_set() {
+        var params = new java.util.HashMap<Class<? extends LangChain4jManaged>, LangChain4jManaged>();
+        InvocationContext ctx = InvocationContext.builder()
+                .chatMemoryId("test")
+                .managedParameters(params)
+                .build();
+
+        assertThat(ctx.managedParameters()).isSameAs(params);
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/query/MetadataTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/query/MetadataTest.java
@@ -97,10 +97,8 @@ class MetadataTest {
         String toString = metadata.toString();
 
         // then
-        assertThat(toString)
-                .isEqualToIgnoringWhitespace(
-                        """
-                        Metadata { chatMessage = UserMessage { name = null, contents = [TextContent { text = "user message" }], attributes = {} }, systemMessage = SystemMessage { text = "Be polite" }, chatMemory = [UserMessage { name = null, contents = [TextContent { text = "Hello" }], attributes = {} }, AiMessage { text = "Hi, how can I help you today?", thinking = null, toolExecutionRequests = [], attributes = {} }], invocationContext = DefaultInvocationContext{invocationId=null, interfaceName='null', methodName='null', methodArguments=[], userMessage=null, chatMemoryId=42, invocationParameters=null, managedParameters=null, timestamp=null} }
+        assertThat(toString).isEqualToIgnoringWhitespace("""
+                        Metadata { chatMessage = UserMessage { name = null, contents = [TextContent { text = "user message" }], attributes = {} }, systemMessage = SystemMessage { text = "Be polite" }, chatMemory = [UserMessage { name = null, contents = [TextContent { text = "Hello" }], attributes = {} }, AiMessage { text = "Hi, how can I help you today?", thinking = null, toolExecutionRequests = [], attributes = {} }], invocationContext = DefaultInvocationContext{invocationId=null, interfaceName='null', methodName='null', methodArguments=[], userMessage=null, chatMemoryId=42, invocationParameters=null, managedParameters={}, timestamp=null} }
                         """);
     }
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/rag/query/QueryTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/rag/query/QueryTest.java
@@ -91,10 +91,8 @@ class QueryTest {
         String toString = query.toString();
 
         // then
-        assertThat(toString)
-                .isEqualToIgnoringWhitespace(
-                        """
-                        Query { text = "query", metadata = Metadata { chatMessage = UserMessage { name = null, contents = [TextContent { text = "user message" }], attributes = {} }, systemMessage = SystemMessage { text = "Be polite" }, chatMemory = [UserMessage { name = null, contents = [TextContent { text = "Hello" }], attributes = {} }, AiMessage { text = "Hi, how can I help you today?", thinking = null, toolExecutionRequests = [], attributes = {} }], invocationContext = DefaultInvocationContext{invocationId=null, interfaceName='null', methodName='null', methodArguments=[], userMessage=null, chatMemoryId=42, invocationParameters=null, managedParameters=null, timestamp=null} } }
+        assertThat(toString).isEqualToIgnoringWhitespace("""
+                        Query { text = "query", metadata = Metadata { chatMessage = UserMessage { name = null, contents = [TextContent { text = "user message" }], attributes = {} }, systemMessage = SystemMessage { text = "Be polite" }, chatMemory = [UserMessage { name = null, contents = [TextContent { text = "Hello" }], attributes = {} }, AiMessage { text = "Hi, how can I help you today?", thinking = null, toolExecutionRequests = [], attributes = {} }], invocationContext = DefaultInvocationContext{invocationId=null, interfaceName='null', methodName='null', methodArguments=[], userMessage=null, chatMemoryId=42, invocationParameters=null, managedParameters={}, timestamp=null} } }
                         """);
     }
 


### PR DESCRIPTION
## Issue

Closes #5103

## Change

In agentic mode, the first sub-agent invoked by the planner triggers an `AiServiceResponseReceivedEvent`. Because `LangChain4jManaged.current()` is null at that point (the ThreadLocal has not been populated yet), the `InvocationContext` is built with `managedParameters = null`. `AgentInvocationHandler.onEvent()` then calls `managedParameters().get(AgenticScope.class)` and NPEs.

Two fixes:

**1. `DefaultInvocationContext.managedParameters()` — align with the interface contract**

The `InvocationContext` interface already defines a default of `Map.of()`. The concrete implementation was returning the raw (potentially null) field instead. Fixed to return an empty map when null:

```java
public Map<Class<? extends LangChain4jManaged>, LangChain4jManaged> managedParameters() {
    return managedParameters != null ? managedParameters : Map.of();
}
```

**2. `AgentInvocationHandler.onEvent()` — guard against absent `AgenticScope`**

Even with a non-null map, the `AgenticScope` key may be absent when the event originates outside an agentic execution context. Added a null-guard so the event is silently ignored in that case instead of crashing:

```java
AgenticScope agenticScope = (AgenticScope) event.invocationContext().managedParameters().get(AgenticScope.class);
if (agenticScope != null) {
    lastResponseEvents.put(agenticScope.memoryId(), event);
}
```

Updated `MetadataTest` and `QueryTest` `toString` assertions to reflect the new `managedParameters={}` output.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)