### PR TITLE
fix(ollama): add missing model card fields

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelCard.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelCard.java
@@ -20,8 +20,12 @@ public class OllamaModelCard {
     private String modelfile;
     private String parameters;
     private String template;
+    private String system;
     private OllamaModelDetails details;
+    private List<OllamaModelMessage> messages;
     private Map<String, Object> modelInfo;
+    private Map<String, Object> projectorInfo;
+    private List<OllamaModelTensor> tensors;
 
     @JsonDeserialize(using = OllamaDateDeserializer.class)
     private OffsetDateTime modifiedAt;
@@ -73,6 +77,14 @@ public class OllamaModelCard {
         this.template = template;
     }
 
+    public String getSystem() {
+        return system;
+    }
+
+    public void setSystem(String system) {
+        this.system = system;
+    }
+
     public OllamaModelDetails getDetails() {
         return details;
     }
@@ -81,12 +93,36 @@ public class OllamaModelCard {
         this.details = details;
     }
 
+    public List<OllamaModelMessage> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<OllamaModelMessage> messages) {
+        this.messages = messages;
+    }
+
     public Map<String, Object> getModelInfo() {
         return modelInfo;
     }
 
     public void setModelInfo(Map<String, Object> modelInfo) {
         this.modelInfo = modelInfo;
+    }
+
+    public Map<String, Object> getProjectorInfo() {
+        return projectorInfo;
+    }
+
+    public void setProjectorInfo(Map<String, Object> projectorInfo) {
+        this.projectorInfo = projectorInfo;
+    }
+
+    public List<OllamaModelTensor> getTensors() {
+        return tensors;
+    }
+
+    public void setTensors(List<OllamaModelTensor> tensors) {
+        this.tensors = tensors;
     }
 
     public OffsetDateTime getModifiedAt() {
@@ -111,8 +147,12 @@ public class OllamaModelCard {
         private String modelfile;
         private String parameters;
         private String template;
+        private String system;
         private OllamaModelDetails details;
+        private List<OllamaModelMessage> messages;
         private Map<String, Object> modelInfo;
+        private Map<String, Object> projectorInfo;
+        private List<OllamaModelTensor> tensors;
         private OffsetDateTime modifiedAt;
         private List<String> capabilities;
 
@@ -136,13 +176,33 @@ public class OllamaModelCard {
             return this;
         }
 
+        public Builder system(String system) {
+            this.system = system;
+            return this;
+        }
+
         public Builder details(OllamaModelDetails details) {
             this.details = details;
             return this;
         }
 
+        public Builder messages(List<OllamaModelMessage> messages) {
+            this.messages = messages;
+            return this;
+        }
+
         public Builder modelInfo(Map<String, Object> modelInfo) {
             this.modelInfo = modelInfo;
+            return this;
+        }
+
+        public Builder projectorInfo(Map<String, Object> projectorInfo) {
+            this.projectorInfo = projectorInfo;
+            return this;
+        }
+
+        public Builder tensors(List<OllamaModelTensor> tensors) {
+            this.tensors = tensors;
             return this;
         }
 
@@ -157,7 +217,16 @@ public class OllamaModelCard {
         }
 
         public OllamaModelCard build() {
-            return new OllamaModelCard(modelfile, parameters, template, details);
+            OllamaModelCard modelCard = new OllamaModelCard(modelfile, parameters, template, details);
+            modelCard.setLicense(license);
+            modelCard.setSystem(system);
+            modelCard.setMessages(messages);
+            modelCard.setModelInfo(modelInfo);
+            modelCard.setProjectorInfo(projectorInfo);
+            modelCard.setTensors(tensors);
+            modelCard.setCapabilities(capabilities);
+            modelCard.setModifiedAt(modifiedAt);
+            return modelCard;
         }
     }
 }

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelDetails.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelDetails.java
@@ -1,29 +1,29 @@
 package dev.langchain4j.model.ollama;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.util.List;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
 @JsonNaming(SnakeCaseStrategy.class)
 public class OllamaModelDetails {
 
+    private String parentModel;
     private String format;
     private String family;
     private List<String> families;
     private String parameterSize;
     private String quantizationLevel;
 
-    OllamaModelDetails() {
-    }
+    OllamaModelDetails() {}
 
-    public OllamaModelDetails(String format, String family, List<String> families, String parameterSize, String quantizationLevel) {
+    public OllamaModelDetails(
+            String format, String family, List<String> families, String parameterSize, String quantizationLevel) {
         this.format = format;
         this.family = family;
         this.families = families;
@@ -33,6 +33,14 @@ public class OllamaModelDetails {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    public String getParentModel() {
+        return parentModel;
+    }
+
+    public void setParentModel(String parentModel) {
+        this.parentModel = parentModel;
     }
 
     public String getFormat() {
@@ -77,11 +85,17 @@ public class OllamaModelDetails {
 
     public static class Builder {
 
+        private String parentModel;
         private String format;
         private String family;
         private List<String> families;
         private String parameterSize;
         private String quantizationLevel;
+
+        public Builder parentModel(String parentModel) {
+            this.parentModel = parentModel;
+            return this;
+        }
 
         public Builder format(String format) {
             this.format = format;
@@ -109,7 +123,10 @@ public class OllamaModelDetails {
         }
 
         public OllamaModelDetails build() {
-            return new OllamaModelDetails(format, family, families, parameterSize, quantizationLevel);
+            OllamaModelDetails details =
+                    new OllamaModelDetails(format, family, families, parameterSize, quantizationLevel);
+            details.setParentModel(parentModel);
+            return details;
         }
     }
 }

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelMessage.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelMessage.java
@@ -1,0 +1,140 @@
+package dev.langchain4j.model.ollama;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import java.util.Locale;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+@JsonNaming(SnakeCaseStrategy.class)
+public class OllamaModelMessage {
+
+    private String role;
+    private String content;
+    private String thinking;
+    private List<String> images;
+    private List<OllamaModelToolCall> toolCalls;
+    private String toolName;
+
+    OllamaModelMessage() {}
+
+    public OllamaModelMessage(
+            String role,
+            String content,
+            String thinking,
+            List<String> images,
+            List<OllamaModelToolCall> toolCalls,
+            String toolName) {
+        this.role = normalizeRole(role);
+        this.content = content;
+        this.thinking = thinking;
+        this.images = images;
+        this.toolCalls = toolCalls;
+        this.toolName = toolName;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = normalizeRole(role);
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public String getThinking() {
+        return thinking;
+    }
+
+    public void setThinking(String thinking) {
+        this.thinking = thinking;
+    }
+
+    public List<String> getImages() {
+        return images;
+    }
+
+    public void setImages(List<String> images) {
+        this.images = images;
+    }
+
+    public List<OllamaModelToolCall> getToolCalls() {
+        return toolCalls;
+    }
+
+    public void setToolCalls(List<OllamaModelToolCall> toolCalls) {
+        this.toolCalls = toolCalls;
+    }
+
+    public String getToolName() {
+        return toolName;
+    }
+
+    public void setToolName(String toolName) {
+        this.toolName = toolName;
+    }
+
+    public static class Builder {
+
+        private String role;
+        private String content;
+        private String thinking;
+        private List<String> images;
+        private List<OllamaModelToolCall> toolCalls;
+        private String toolName;
+
+        public Builder role(String role) {
+            this.role = normalizeRole(role);
+            return this;
+        }
+
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+
+        public Builder thinking(String thinking) {
+            this.thinking = thinking;
+            return this;
+        }
+
+        public Builder images(List<String> images) {
+            this.images = images;
+            return this;
+        }
+
+        public Builder toolCalls(List<OllamaModelToolCall> toolCalls) {
+            this.toolCalls = toolCalls;
+            return this;
+        }
+
+        public Builder toolName(String toolName) {
+            this.toolName = toolName;
+            return this;
+        }
+
+        public OllamaModelMessage build() {
+            return new OllamaModelMessage(role, content, thinking, images, toolCalls, toolName);
+        }
+    }
+
+    private static String normalizeRole(String role) {
+        return role == null ? null : role.toLowerCase(Locale.ROOT);
+    }
+}

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelTensor.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelTensor.java
@@ -1,0 +1,81 @@
+package dev.langchain4j.model.ollama;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+@JsonNaming(SnakeCaseStrategy.class)
+public class OllamaModelTensor {
+
+    private String name;
+    private String type;
+    private List<Long> shape;
+
+    OllamaModelTensor() {}
+
+    public OllamaModelTensor(String name, String type, List<Long> shape) {
+        this.name = name;
+        this.type = type;
+        this.shape = shape;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public List<Long> getShape() {
+        return shape;
+    }
+
+    public void setShape(List<Long> shape) {
+        this.shape = shape;
+    }
+
+    public static class Builder {
+
+        private String name;
+        private String type;
+        private List<Long> shape;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder type(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder shape(List<Long> shape) {
+            this.shape = shape;
+            return this;
+        }
+
+        public OllamaModelTensor build() {
+            return new OllamaModelTensor(name, type, shape);
+        }
+    }
+}

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelToolCall.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelToolCall.java
@@ -1,0 +1,48 @@
+package dev.langchain4j.model.ollama;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+@JsonNaming(SnakeCaseStrategy.class)
+public class OllamaModelToolCall {
+
+    private OllamaModelToolCallFunction function;
+
+    OllamaModelToolCall() {}
+
+    public OllamaModelToolCall(OllamaModelToolCallFunction function) {
+        this.function = function;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public OllamaModelToolCallFunction getFunction() {
+        return function;
+    }
+
+    public void setFunction(OllamaModelToolCallFunction function) {
+        this.function = function;
+    }
+
+    public static class Builder {
+
+        private OllamaModelToolCallFunction function;
+
+        public Builder function(OllamaModelToolCallFunction function) {
+            this.function = function;
+            return this;
+        }
+
+        public OllamaModelToolCall build() {
+            return new OllamaModelToolCall(function);
+        }
+    }
+}

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelToolCallFunction.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaModelToolCallFunction.java
@@ -1,0 +1,81 @@
+package dev.langchain4j.model.ollama;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+@JsonNaming(SnakeCaseStrategy.class)
+public class OllamaModelToolCallFunction {
+
+    private Integer index;
+    private String name;
+    private Map<String, Object> arguments;
+
+    OllamaModelToolCallFunction() {}
+
+    public OllamaModelToolCallFunction(Integer index, String name, Map<String, Object> arguments) {
+        this.index = index;
+        this.name = name;
+        this.arguments = arguments;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Integer getIndex() {
+        return index;
+    }
+
+    public void setIndex(Integer index) {
+        this.index = index;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, Object> getArguments() {
+        return arguments;
+    }
+
+    public void setArguments(Map<String, Object> arguments) {
+        this.arguments = arguments;
+    }
+
+    public static class Builder {
+
+        private Integer index;
+        private String name;
+        private Map<String, Object> arguments;
+
+        public Builder index(Integer index) {
+            this.index = index;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder arguments(Map<String, Object> arguments) {
+            this.arguments = arguments;
+            return this;
+        }
+
+        public OllamaModelToolCallFunction build() {
+            return new OllamaModelToolCallFunction(index, name, arguments);
+        }
+    }
+}

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaModelCardTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaModelCardTest.java
@@ -1,0 +1,214 @@
+package dev.langchain4j.model.ollama;
+
+import static dev.langchain4j.model.ollama.OllamaJsonUtils.fromJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OllamaModelCardTest {
+
+    @Test
+    void should_deserialize_show_model_information_response() {
+        String json = """
+                {
+                  "license": "Apache-2.0",
+                  "modelfile": "FROM llama3.2",
+                  "parameters": "temperature 0.8",
+                  "template": "{{ .Prompt }}",
+                  "system": "You are helpful",
+                  "details": {
+                    "parent_model": "llama3.2",
+                    "format": "gguf",
+                    "family": "llama",
+                    "families": [
+                      "llama"
+                    ],
+                    "parameter_size": "3.2B",
+                    "quantization_level": "Q4_K_M"
+                  },
+                  "messages": [
+                    {
+                      "role": "SYSTEM",
+                      "content": "Use short answers",
+                      "thinking": "Internal reasoning",
+                      "images": [
+                        "base64-image"
+                      ],
+                      "tool_calls": [
+                        {
+                          "function": {
+                            "index": 0,
+                            "name": "get_weather",
+                            "arguments": {
+                              "city": "Paris"
+                            }
+                          }
+                        },
+                        {
+                          "function": {
+                            "name": "get_time",
+                            "arguments": {
+                              "city": "Paris"
+                            }
+                          }
+                        }
+                      ],
+                      "tool_name": "get_weather"
+                    }
+                  ],
+                  "model_info": {
+                    "general.architecture": "llama"
+                  },
+                  "projector_info": {
+                    "clip.has_text_encoder": true
+                  },
+                  "tensors": [
+                    {
+                      "name": "token_embd.weight",
+                      "type": "F16",
+                      "shape": [
+                        32000,
+                        4096
+                      ]
+                    }
+                  ],
+                  "capabilities": [
+                    "completion",
+                    "tools"
+                  ],
+                  "modified_at": "2025-01-02T03:04:05Z"
+                }
+                """;
+
+        OllamaModelCard modelCard = fromJson(json, OllamaModelCard.class);
+
+        assertThat(modelCard.getLicense()).isEqualTo("Apache-2.0");
+        assertThat(modelCard.getModelfile()).isEqualTo("FROM llama3.2");
+        assertThat(modelCard.getParameters()).isEqualTo("temperature 0.8");
+        assertThat(modelCard.getTemplate()).isEqualTo("{{ .Prompt }}");
+        assertThat(modelCard.getSystem()).isEqualTo("You are helpful");
+        assertThat(modelCard.getDetails().getParentModel()).isEqualTo("llama3.2");
+        assertThat(modelCard.getModelInfo()).containsEntry("general.architecture", "llama");
+        assertThat(modelCard.getProjectorInfo()).containsEntry("clip.has_text_encoder", true);
+        assertThat(modelCard.getCapabilities()).containsExactly("completion", "tools");
+        assertThat(modelCard.getModifiedAt()).isEqualTo(OffsetDateTime.parse("2025-01-02T03:04:05Z"));
+
+        assertThat(modelCard.getMessages()).singleElement().satisfies(message -> {
+            assertThat(message.getRole()).isEqualTo("system");
+            assertThat(message.getContent()).isEqualTo("Use short answers");
+            assertThat(message.getThinking()).isEqualTo("Internal reasoning");
+            assertThat(message.getImages()).containsExactly("base64-image");
+            assertThat(message.getToolName()).isEqualTo("get_weather");
+            assertThat(message.getToolCalls())
+                    .hasSize(2)
+                    .satisfiesExactly(
+                            toolCall -> {
+                                assertThat(toolCall.getFunction().getIndex()).isEqualTo(0);
+                                assertThat(toolCall.getFunction().getName()).isEqualTo("get_weather");
+                                assertThat(toolCall.getFunction().getArguments())
+                                        .containsEntry("city", "Paris");
+                            },
+                            toolCall -> {
+                                assertThat(toolCall.getFunction().getIndex()).isNull();
+                                assertThat(toolCall.getFunction().getName()).isEqualTo("get_time");
+                                assertThat(toolCall.getFunction().getArguments())
+                                        .containsEntry("city", "Paris");
+                            });
+        });
+        assertThat(modelCard.getTensors()).singleElement().satisfies(tensor -> {
+            assertThat(tensor.getName()).isEqualTo("token_embd.weight");
+            assertThat(tensor.getType()).isEqualTo("F16");
+            assertThat(tensor.getShape()).containsExactly(32000L, 4096L);
+        });
+    }
+
+    @Test
+    void should_deserialize_show_model_information_response_without_optional_fields() {
+        String json = """
+                {
+                  "modelfile": "FROM llama3.2",
+                  "template": "{{ .Prompt }}",
+                  "details": {
+                    "format": "gguf"
+                  }
+                }
+                """;
+
+        OllamaModelCard modelCard = fromJson(json, OllamaModelCard.class);
+
+        assertThat(modelCard.getModelfile()).isEqualTo("FROM llama3.2");
+        assertThat(modelCard.getTemplate()).isEqualTo("{{ .Prompt }}");
+        assertThat(modelCard.getSystem()).isNull();
+        assertThat(modelCard.getMessages()).isNull();
+        assertThat(modelCard.getProjectorInfo()).isNull();
+        assertThat(modelCard.getTensors()).isNull();
+        assertThat(modelCard.getDetails().getParentModel()).isNull();
+    }
+
+    @Test
+    void should_build_with_all_model_card_fields() {
+        OffsetDateTime modifiedAt = OffsetDateTime.parse("2025-01-02T03:04:05Z");
+        OllamaModelDetails details = OllamaModelDetails.builder()
+                .parentModel("llama3.2")
+                .format("gguf")
+                .build();
+        List<OllamaModelMessage> messages = List.of(OllamaModelMessage.builder()
+                .role("SYSTEM")
+                .content("Use short answers")
+                .thinking("Internal reasoning")
+                .images(List.of("base64-image"))
+                .toolCalls(List.of(OllamaModelToolCall.builder()
+                        .function(OllamaModelToolCallFunction.builder()
+                                .index(0)
+                                .name("get_weather")
+                                .arguments(Map.of("city", "Paris"))
+                                .build())
+                        .build()))
+                .toolName("get_weather")
+                .build());
+        Map<String, Object> modelInfo = Map.of("general.architecture", "llama");
+        Map<String, Object> projectorInfo = Map.of("clip.has_text_encoder", true);
+        List<OllamaModelTensor> tensors = List.of(OllamaModelTensor.builder()
+                .name("token_embd.weight")
+                .type("F16")
+                .shape(List.of(32000L, 4096L))
+                .build());
+
+        OllamaModelCard modelCard = OllamaModelCard.builder()
+                .license("Apache-2.0")
+                .modelfile("FROM llama3.2")
+                .parameters("temperature 0.8")
+                .template("{{ .Prompt }}")
+                .system("You are helpful")
+                .details(details)
+                .messages(messages)
+                .modelInfo(modelInfo)
+                .projectorInfo(projectorInfo)
+                .tensors(tensors)
+                .capabilities(List.of("completion", "tools"))
+                .modifiedAt(modifiedAt)
+                .build();
+
+        assertThat(modelCard.getLicense()).isEqualTo("Apache-2.0");
+        assertThat(modelCard.getModelfile()).isEqualTo("FROM llama3.2");
+        assertThat(modelCard.getParameters()).isEqualTo("temperature 0.8");
+        assertThat(modelCard.getTemplate()).isEqualTo("{{ .Prompt }}");
+        assertThat(modelCard.getSystem()).isEqualTo("You are helpful");
+        assertThat(modelCard.getDetails()).isSameAs(details);
+        assertThat(modelCard.getMessages()).singleElement().satisfies(message -> {
+            assertThat(message.getRole()).isEqualTo("system");
+            assertThat(message.getToolCalls()).singleElement().satisfies(toolCall -> {
+                assertThat(toolCall.getFunction().getIndex()).isEqualTo(0);
+                assertThat(toolCall.getFunction().getName()).isEqualTo("get_weather");
+            });
+        });
+        assertThat(modelCard.getModelInfo()).isSameAs(modelInfo);
+        assertThat(modelCard.getProjectorInfo()).isSameAs(projectorInfo);
+        assertThat(modelCard.getTensors()).isSameAs(tensors);
+        assertThat(modelCard.getCapabilities()).containsExactly("completion", "tools");
+        assertThat(modelCard.getModifiedAt()).isEqualTo(modifiedAt);
+    }
+}


### PR DESCRIPTION
Closes #3333.

## Summary
- align the existing `OllamaModelCard` response DTO with the `ShowResponse` linked in #3333
- add missing response fields: `system`, `messages`, `projector_info`, `tensors`, and `details.parent_model`
- add typed nested DTOs for model-card messages, tool calls, and tensors
- cover full and partial JSON mapping plus builder behavior

## Scope
This PR is intentionally limited to the existing Ollama model info response path. It does not add request-side options, and it does not chase newer Ollama fields outside the `ShowResponse` linked in the issue.

## Test Plan
- `./mvnw -pl langchain4j-ollama -am -Dtest=OllamaModelCardTest,RunningOllamaModelTest -Dsurefire.failIfNoSpecifiedTests=false test`