### PR TITLE
feat: add customHeaders support to BedrockChatModel and BedrockStreamingChatModel

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AbstractBedrockChatModel.java
@@ -61,6 +61,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,6 +144,7 @@ abstract class AbstractBedrockChatModel {
     protected final BedrockChatRequestParameters defaultRequestParameters;
     protected final List<ChatModelListener> listeners;
     protected final Set<Capability> supportedCapabilities;
+    protected final Supplier<Map<String, String>> customHeadersSupplier;
 
     protected AbstractBedrockChatModel(AbstractBuilder<?> builder) {
         this.region = getOrDefault(builder.region, Region.US_EAST_1);
@@ -151,6 +153,7 @@ abstract class AbstractBedrockChatModel {
         this.sendThinking = getOrDefault(builder.sendThinking, true);
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
+        this.customHeadersSupplier = builder.customHeadersSupplier;
 
         ChatRequestParameters commonParameters;
         if (builder.defaultRequestParameters != null) {
@@ -1096,6 +1099,7 @@ abstract class AbstractBedrockChatModel {
         protected Logger logger;
         protected List<ChatModelListener> listeners;
         protected Set<Capability> supportedCapabilities;
+        protected Supplier<Map<String, String>> customHeadersSupplier;
 
         @SuppressWarnings("unchecked")
         public T self() {
@@ -1209,6 +1213,16 @@ abstract class AbstractBedrockChatModel {
 
         public T supportedCapabilities(Capability... supportedCapabilities) {
             this.supportedCapabilities = Arrays.stream(supportedCapabilities).collect(Collectors.toSet());
+            return self();
+        }
+
+        public T customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return self();
+        }
+
+        public T customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return self();
         }
     }

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatModel.java
@@ -124,6 +124,8 @@ public class BedrockChatModel extends AbstractBedrockChatModel implements ChatMo
                     config.apiCallTimeout(this.timeout);
                     if (logRequests || logResponses)
                         config.addExecutionInterceptor(new AwsLoggingInterceptor(logRequests, logResponses, logger));
+                    if (customHeadersSupplier != null)
+                        config.addExecutionInterceptor(new BedrockCustomHeadersInterceptor(customHeadersSupplier));
                 })
                 .build();
     }

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCustomHeadersInterceptor.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockCustomHeadersInterceptor.java
@@ -1,0 +1,30 @@
+package dev.langchain4j.model.bedrock;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+@dev.langchain4j.Internal
+class BedrockCustomHeadersInterceptor implements ExecutionInterceptor {
+
+    private final Supplier<Map<String, String>> customHeadersSupplier;
+
+    BedrockCustomHeadersInterceptor(Supplier<Map<String, String>> customHeadersSupplier) {
+        this.customHeadersSupplier = customHeadersSupplier;
+    }
+
+    @Override
+    public SdkHttpRequest modifyHttpRequest(
+            Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+        Map<String, String> headers = customHeadersSupplier.get();
+        if (headers == null || headers.isEmpty()) {
+            return context.httpRequest();
+        }
+        SdkHttpRequest.Builder builder = context.httpRequest().toBuilder();
+        headers.forEach(builder::appendHeader);
+        return builder.build();
+    }
+}

--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockStreamingChatModel.java
@@ -250,6 +250,8 @@ public class BedrockStreamingChatModel extends AbstractBedrockChatModel implemen
                     config.apiCallTimeout(this.timeout);
                     if (logRequests || logResponses)
                         config.addExecutionInterceptor(new AwsLoggingInterceptor(logRequests, logResponses, logger));
+                    if (customHeadersSupplier != null)
+                        config.addExecutionInterceptor(new BedrockCustomHeadersInterceptor(customHeadersSupplier));
                 })
                 .build();
     }

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCustomHeadersInterceptorTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockCustomHeadersInterceptorTest.java
@@ -1,0 +1,111 @@
+package dev.langchain4j.model.bedrock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+class BedrockCustomHeadersInterceptorTest {
+
+    private static final SdkHttpFullRequest BASE_REQUEST = SdkHttpFullRequest.builder()
+            .method(SdkHttpMethod.POST)
+            .uri(URI.create("https://bedrock-runtime.us-east-1.amazonaws.com/test"))
+            .build();
+
+    private static final ExecutionAttributes EMPTY_ATTRS = new ExecutionAttributes();
+
+    private SdkHttpRequest invoke(BedrockCustomHeadersInterceptor interceptor, SdkHttpFullRequest request) {
+        return interceptor.modifyHttpRequest(contextFor(request), EMPTY_ATTRS);
+    }
+
+    private Context.ModifyHttpRequest contextFor(SdkHttpFullRequest req) {
+        return new Context.ModifyHttpRequest() {
+            @Override
+            public SdkRequest request() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public SdkHttpRequest httpRequest() {
+                return req;
+            }
+
+            @Override
+            public Optional<RequestBody> requestBody() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<AsyncRequestBody> asyncRequestBody() {
+                return Optional.empty();
+            }
+        };
+    }
+
+    @Test
+    void should_add_custom_headers() {
+        BedrockCustomHeadersInterceptor interceptor =
+                new BedrockCustomHeadersInterceptor(() -> Map.of("X-Custom-Header", "my-value"));
+
+        SdkHttpRequest result = invoke(interceptor, BASE_REQUEST);
+
+        assertThat(result.headers()).containsKey("X-Custom-Header");
+        assertThat(result.headers().get("X-Custom-Header")).containsExactly("my-value");
+    }
+
+    @Test
+    void should_call_supplier_per_request() {
+        AtomicInteger counter = new AtomicInteger(0);
+        Supplier<Map<String, String>> supplier = () -> Map.of("X-Count", String.valueOf(counter.incrementAndGet()));
+        BedrockCustomHeadersInterceptor interceptor = new BedrockCustomHeadersInterceptor(supplier);
+
+        SdkHttpRequest first = invoke(interceptor, BASE_REQUEST);
+        SdkHttpRequest second = invoke(interceptor, BASE_REQUEST);
+
+        assertThat(first.headers().get("X-Count")).containsExactly("1");
+        assertThat(second.headers().get("X-Count")).containsExactly("2");
+    }
+
+    @Test
+    void should_handle_null_from_supplier() {
+        BedrockCustomHeadersInterceptor interceptor = new BedrockCustomHeadersInterceptor(() -> null);
+
+        SdkHttpRequest result = invoke(interceptor, BASE_REQUEST);
+
+        assertThat(result).isSameAs(BASE_REQUEST);
+    }
+
+    @Test
+    void should_handle_empty_map() {
+        BedrockCustomHeadersInterceptor interceptor = new BedrockCustomHeadersInterceptor(Map::of);
+
+        SdkHttpRequest result = invoke(interceptor, BASE_REQUEST);
+
+        assertThat(result).isSameAs(BASE_REQUEST);
+    }
+
+    @Test
+    void should_add_multiple_custom_headers() {
+        BedrockCustomHeadersInterceptor interceptor =
+                new BedrockCustomHeadersInterceptor(() -> Map.of("X-Header-A", "value-a", "X-Header-B", "value-b"));
+
+        SdkHttpRequest result = invoke(interceptor, BASE_REQUEST);
+
+        assertThat(result.headers()).containsKey("X-Header-A");
+        assertThat(result.headers()).containsKey("X-Header-B");
+        assertThat(result.headers().get("X-Header-A")).containsExactly("value-a");
+        assertThat(result.headers().get("X-Header-B")).containsExactly("value-b");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5108

## Change
Added `customHeaders(Map<String, String>)` and `customHeaders(Supplier<Map<String, String>>)` builder methods to `BedrockChatModel` and `BedrockStreamingChatModel`.

Since Bedrock uses the AWS SDK rather than langchain4j's HTTP client abstraction, header injection goes through a new `BedrockCustomHeadersInterceptor` — an `ExecutionInterceptor` that calls `modifyHttpRequest()` before each HTTP request, following the same pattern as the existing `AwsLoggingInterceptor`.

The `Supplier` overload allows dynamic headers per request (e.g. rotating tokens).

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green