### PR TITLE
feat: add customHeaders support to VertexAiGeminiChatModel

### DIFF
--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -181,10 +181,18 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
                     .build();
         }
 
+        final Map<String, String> headers;
+        if (builder.customHeaders != null) {
+            headers = new HashMap<>(builder.customHeaders);
+            headers.putIfAbsent("user-agent", "LangChain4j");
+        } else {
+            headers = Map.of("user-agent", "LangChain4j");
+        }
+
         VertexAI.Builder vertexAiBuilder = new VertexAI.Builder()
                 .setProjectId(ensureNotBlank(builder.project, "project"))
                 .setLocation(ensureNotBlank(builder.location, "location"))
-                .setCustomHeaders(Collections.singletonMap("user-agent", "LangChain4j"));
+                .setCustomHeaders(headers);
 
         if (builder.credentials != null) {
             GoogleCredentials scopedCredentials =
@@ -586,6 +594,7 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         private Boolean logResponses;
         private List<ChatModelListener> listeners;
         private Set<Capability> supportedCapabilities;
+        private Map<String, String> customHeaders;
         private GoogleCredentials credentials;
         private String apiEndpoint;
 
@@ -704,6 +713,22 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
 
         public VertexAiGeminiChatModelBuilder apiEndpoint(String apiEndpoint) {
             this.apiEndpoint = apiEndpoint;
+            return this;
+        }
+
+        /**
+         * Sets custom headers to be included in the LLM requests.
+         * Main use-case is to support provision throughput quota.
+         * E.g: "X-Vertex-AI-LLM-Request-Type: dedicated" will exhaust the provisioned throughput quota first, and will
+         * return HTTP_429 if the quota is exhausted.
+         * "X-Vertex-AI-LLM-Request-Type: shared" will bypass the provisioned throughput quota completely.
+         *  For more information please refer to the <a href="https://cloud.google.com/vertex-ai/generative-ai/docs/use-provisioned-throughput">official documentation</a>
+         *
+         * @param customHeaders a map of custom header keys and their corresponding values
+         * @return the updated instance of {@code VertexAiGeminiChatModelBuilder}
+         */
+        public VertexAiGeminiChatModelBuilder customHeaders(Map<String, String> customHeaders) {
+            this.customHeaders = customHeaders;
             return this;
         }
 

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelBuilderTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelBuilderTest.java
@@ -2,9 +2,36 @@ package dev.langchain4j.model.vertexai.gemini;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class VertexAiGeminiChatModelBuilderTest {
+
+    @Test
+    void setCustomHeader() {
+        VertexAiGeminiChatModel model = VertexAiGeminiChatModel.builder()
+                .project("does-not-matter")
+                .location("does-not-matter")
+                .modelName("does-not-matter")
+                .customHeaders(Map.of("X-Test", "value"))
+                .build();
+
+        assertThat(model.vertexAI().getHeaders().get("X-Test")).isEqualTo("value");
+        assertThat(model.vertexAI().getHeaders().getOrDefault("user-agent", "error"))
+                .contains("LangChain4j");
+    }
+
+    @Test
+    void overwriteDefaultUserAgent() {
+        VertexAiGeminiChatModel model = VertexAiGeminiChatModel.builder()
+                .project("does-not-matter")
+                .location("does-not-matter")
+                .modelName("does-not-matter")
+                .customHeaders(Map.of("user-agent", "my-custom-user-agent"))
+                .build();
+
+        assertThat(model.vertexAI().getHeaders().get("user-agent")).contains("my-custom-user-agent");
+    }
 
     @Test
     void setDefaultUserAgent() {


### PR DESCRIPTION
## Issue
Closes #5109

## Change
Added `customHeaders(Map<String, String>)` builder method to `VertexAiGeminiChatModel`, mirroring the existing support already present on `VertexAiGeminiStreamingChatModel`.

The merge logic is identical to the streaming counterpart: user-supplied headers are merged with the default `user-agent: LangChain4j` header using `putIfAbsent`, so a custom `user-agent` takes precedence.

Note: only a `Map` overload is provided (no `Supplier`) because the VertexAI SDK sets headers at client construction time, not per-request — dynamic per-request headers are not applicable here.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green