### PR TITLE
feat: add customHeaders support to GoogleAiGeminiChatModel and GoogleAiGeminiStreamingChatModel

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 class BaseGeminiChatModel {
@@ -112,7 +113,8 @@ class BaseGeminiChatModel {
                 getOrDefault(builder.logRequests, false),
                 getOrDefault(builder.logResponses, false),
                 builder.logger,
-                builder.timeout);
+                builder.timeout,
+                builder.customHeadersSupplier);
     }
 
     protected GeminiGenerateContentRequest createGenerateContentRequest(ChatRequest chatRequest) {
@@ -345,6 +347,7 @@ class BaseGeminiChatModel {
         protected Boolean mediaResolutionPerPartEnabled;
         protected String aspectRatio;
         protected String imageSize;
+        protected Supplier<Map<String, String>> customHeadersSupplier;
 
         @SuppressWarnings("unchecked")
         protected B builder() {
@@ -741,6 +744,16 @@ class BaseGeminiChatModel {
          */
         public B imageSize(String imageSize) {
             this.imageSize = imageSize;
+            return builder();
+        }
+
+        public B customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return builder();
+        }
+
+        public B customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return builder();
         }
     }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiService.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiService.java
@@ -38,7 +38,9 @@ import dev.langchain4j.model.googleai.GeminiEmbeddingRequestResponse.GeminiEmbed
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
@@ -54,6 +56,7 @@ class GeminiService {
     private final HttpClient httpClient;
     private final String baseUrl;
     private final String apiKey;
+    private final Supplier<Map<String, String>> customHeadersSupplier;
 
     enum BatchOperationType {
         BATCH_GENERATE_CONTENT("batchGenerateContent"),
@@ -78,9 +81,11 @@ class GeminiService {
             final boolean logRequests,
             final boolean logResponses,
             final Logger logger,
-            final Duration timeout) {
+            final Duration timeout,
+            final @Nullable Supplier<Map<String, String>> customHeadersSupplier) {
         this.apiKey = apiKey;
         this.baseUrl = getOrDefault(baseUrl, GeminiService.GEMINI_AI_ENDPOINT);
+        this.customHeadersSupplier = customHeadersSupplier;
         final var builder = getOrDefault(httpClientBuilder, HttpClientBuilderLoader::loadHttpClientBuilder);
         HttpClient httpClient = builder.connectTimeout(
                         firstNotNull("connectTimeout", timeout, builder.connectTimeout(), DEFAULT_CONNECT_TIMEOUT))
@@ -265,6 +270,12 @@ class GeminiService {
                 .addHeader("User-Agent", "LangChain4j");
         if (apiKey != null) {
             builder.addHeader(API_KEY_HEADER_NAME, apiKey);
+        }
+        if (customHeadersSupplier != null) {
+            Map<String, String> customHeaders = customHeadersSupplier.get();
+            if (customHeaders != null) {
+                customHeaders.forEach(builder::addHeader);
+            }
         }
         if (body != null) {
             builder.body(Json.toJson(body));

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiEmbeddingModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiEmbeddingModel.java
@@ -40,7 +40,8 @@ public class GoogleAiEmbeddingModel extends DimensionAwareEmbeddingModel {
                 getOrDefault(builder.logRequests, false),
                 getOrDefault(builder.logResponses, false),
                 builder.logger,
-                builder.timeout);
+                builder.timeout,
+                null);
         this.modelName = ensureNotBlank(builder.modelName, "modelName");
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
         this.taskType = builder.taskType;

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiBatchEmbeddingModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiBatchEmbeddingModel.java
@@ -49,7 +49,8 @@ public final class GoogleAiGeminiBatchEmbeddingModel {
                         getOrDefault(builder.logRequests, false),
                         getOrDefault(builder.logResponses, false),
                         builder.logger,
-                        builder.timeout));
+                        builder.timeout,
+                        null));
     }
 
     GoogleAiGeminiBatchEmbeddingModel(Builder builder, final GeminiService geminiService) {

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiBatchImageModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiBatchImageModel.java
@@ -139,7 +139,8 @@ public final class GoogleAiGeminiBatchImageModel {
                 getOrDefault(builder.logRequests, false),
                 getOrDefault(builder.logResponses, false),
                 builder.logger,
-                builder.timeout);
+                builder.timeout,
+                null);
     }
 
     /**

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiImageModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiImageModel.java
@@ -105,7 +105,8 @@ public class GoogleAiGeminiImageModel implements ImageModel {
                 getOrDefault(builder.logRequests, false),
                 getOrDefault(builder.logResponses, false),
                 builder.logger,
-                builder.timeout);
+                builder.timeout,
+                null);
 
         this.modelName = ensureNotNull(builder.modelName, "modelName");
         this.maxRetries = getOrDefault(builder.maxRetries, 2);

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiModelCatalog.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiModelCatalog.java
@@ -40,7 +40,8 @@ public class GoogleAiGeminiModelCatalog implements ModelCatalog {
                 builder.logRequests,
                 builder.logResponses,
                 builder.logger,
-                builder.timeout);
+                builder.timeout,
+                null);
     }
 
     public static Builder builder() {

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiTokenCountEstimator.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiTokenCountEstimator.java
@@ -33,7 +33,8 @@ public class GoogleAiGeminiTokenCountEstimator implements TokenCountEstimator {
                 getOrDefault(builder.logRequests, false),
                 getOrDefault(builder.logResponses, false),
                 builder.logger,
-                builder.timeout);
+                builder.timeout,
+                null);
         this.modelName = ensureNotBlank(builder.modelName, "modelName");
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
     }

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiServiceTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiServiceTest.java
@@ -602,7 +602,15 @@ class GeminiServiceTest {
 
     private static GeminiService createService(MockHttpClient mockHttpClient, String baseUrl, Duration timeout) {
         return new GeminiService(
-                new MockHttpClientBuilder(mockHttpClient), TEST_API_KEY, baseUrl, false, false, false, null, timeout);
+                new MockHttpClientBuilder(mockHttpClient),
+                TEST_API_KEY,
+                baseUrl,
+                false,
+                false,
+                false,
+                null,
+                timeout,
+                null);
     }
 
     private static GeminiGenerateContentResponse createGenerateContentResponse(String text) {

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiCustomHeadersSupplierTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiCustomHeadersSupplierTest.java
@@ -1,0 +1,134 @@
+package dev.langchain4j.model.googleai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class GoogleAiGeminiCustomHeadersSupplierTest {
+
+    @Test
+    void should_invoke_supplier_and_propagate_headers() {
+        // given
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        Supplier<Map<String, String>> headerSupplier = () -> {
+            callCount.incrementAndGet();
+            return Map.of("X-Custom-Token", "token-" + callCount.get());
+        };
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        GoogleAiGeminiChatModel model = GoogleAiGeminiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost")
+                .apiKey("dummy")
+                .modelName("gemini-pro")
+                .maxRetries(0)
+                .customHeaders(headerSupplier)
+                .build();
+
+        // when
+        try {
+            model.chat("test");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.request().headers()).containsEntry("X-Custom-Token", List.of("token-1"));
+    }
+
+    @Test
+    void should_call_supplier_for_each_request() {
+        // given
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        Supplier<Map<String, String>> headerSupplier = () -> {
+            callCount.incrementAndGet();
+            return Map.of("X-Custom-Token", "token-" + callCount.get());
+        };
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        GoogleAiGeminiChatModel model = GoogleAiGeminiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost")
+                .apiKey("dummy")
+                .modelName("gemini-pro")
+                .maxRetries(0)
+                .customHeaders(headerSupplier)
+                .build();
+
+        // when
+        try {
+            model.chat("first");
+        } catch (Exception ignored) {
+        }
+
+        try {
+            model.chat("second");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.requests().get(0).headers()).containsEntry("X-Custom-Token", List.of("token-1"));
+        assertThat(mockHttpClient.requests().get(1).headers()).containsEntry("X-Custom-Token", List.of("token-2"));
+    }
+
+    @Test
+    void should_handle_null_from_supplier() {
+        // given
+        Supplier<Map<String, String>> nullSupplier = () -> null;
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        GoogleAiGeminiChatModel model = GoogleAiGeminiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost")
+                .apiKey("dummy")
+                .modelName("gemini-pro")
+                .maxRetries(0)
+                .customHeaders(nullSupplier)
+                .build();
+
+        // when
+        try {
+            model.chat("test");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.requests()).hasSize(1);
+    }
+
+    @Test
+    void should_support_static_map_for_backward_compatibility() {
+        // given
+        Map<String, String> staticHeaders = Map.of("X-Static", "value");
+
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        GoogleAiGeminiChatModel model = GoogleAiGeminiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost")
+                .apiKey("dummy")
+                .modelName("gemini-pro")
+                .maxRetries(0)
+                .customHeaders(staticHeaders)
+                .build();
+
+        // when
+        try {
+            model.chat("test");
+        } catch (Exception ignored) {
+        }
+
+        // then
+        assertThat(mockHttpClient.request().headers()).containsEntry("X-Static", List.of("value"));
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5110

## Change
Added `customHeaders(Map<String, String>)` and `customHeaders(Supplier<Map<String, String>>)` builder methods to `GoogleAiGeminiChatModel` and `GoogleAiGeminiStreamingChatModel` (via `GoogleAiGeminiChatModelBaseBuilder` in `BaseGeminiChatModel`).

Header injection is handled in `GeminiService.buildHttpRequest()`, which already builds each HTTP request — the supplier is called per request, consistent with the Ollama and Mistral implementations.

The `GeminiService` constructor signature was extended with a nullable `Supplier` parameter; all non-chat call sites (embedding, image, token count, etc.) pass `null`.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green