### PR TITLE
fix(mistralai): null-guard MistralAiChatMessage.getContent() in aiMes…

### DIFF
--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/mapper/MistralAiMapper.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/mapper/MistralAiMapper.java
@@ -110,9 +110,8 @@ public class MistralAiMapper {
 
         if (message instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
             if (!toolExecutionResultMessage.hasSingleText()) {
-                throw new UnsupportedFeatureException(
-                        "Mistral AI does not support non-text content in tool results. "
-                                + "Only text content is supported.");
+                throw new UnsupportedFeatureException("Mistral AI does not support non-text content in tool results. "
+                        + "Only text content is supported.");
             }
             return MistralAiChatMessage.builder()
                     .role(MistralAiRole.TOOL)
@@ -168,7 +167,14 @@ public class MistralAiMapper {
             toolExecutionRequests = toToolExecutionRequests(toolCalls);
         }
 
-        String text = aiMistralMessage.getContent().stream()
+        // OpenAI-compatible servers (e.g. vLLM) return content=null when the assistant
+        // emits only tool calls. Treat null content as empty to avoid an NPE.
+        List<MistralAiMessageContent> contents = aiMistralMessage.getContent();
+        if (contents == null) {
+            contents = List.of();
+        }
+
+        String text = contents.stream()
                 .filter(content -> "text".equals(content.getType()))
                 .map(MistralAiTextContent.class::cast)
                 .map(MistralAiTextContent::getText)
@@ -176,7 +182,7 @@ public class MistralAiMapper {
 
         String thinking = null;
         if (returnThinking) {
-            List<String> thinkingTexts = aiMistralMessage.getContent().stream()
+            List<String> thinkingTexts = contents.stream()
                     .filter(content -> "thinking".equals(content.getType()))
                     .map(MistralAiThinkingContent.class::cast)
                     .map(MistralAiThinkingContent::getThinking)

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/mapper/MistralAiMapper.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/mapper/MistralAiMapper.java
@@ -167,8 +167,6 @@ public class MistralAiMapper {
             toolExecutionRequests = toToolExecutionRequests(toolCalls);
         }
 
-        // OpenAI-compatible servers (e.g. vLLM) return content=null when the assistant
-        // emits only tool calls. Treat null content as empty to avoid an NPE.
         List<MistralAiMessageContent> contents = aiMistralMessage.getContent();
         if (contents == null) {
             contents = List.of();

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelToolCallsTest.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiChatModelToolCallsTest.java
@@ -1,0 +1,194 @@
+package dev.langchain4j.model.mistralai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.Test;
+
+class MistralAiChatModelToolCallsTest {
+
+    /**
+     * OpenAI-compatible servers (vLLM, llama.cpp, …) often return {@code message.content = null}
+     * when the assistant emits only tool calls. This test pins that response shape so the mapper
+     * never reintroduces an NPE on null content.
+     */
+    @Test
+    void should_handle_response_with_only_tool_calls_and_null_content() {
+        // given - vLLM-style response: assistant emits only tool_calls, content is null
+        String jsonResponse = """
+                {
+                    "id": "chatcmpl-9ccb8be3370654bc",
+                    "object": "chat.completion",
+                    "created": 1778075620,
+                    "model": "mistralai/Ministral-3-8B-Instruct-2512",
+                    "choices": [{
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": null,
+                            "tool_calls": [{
+                                "id": "chatcmpl-tool-b51c242ff1eacb66",
+                                "type": "function",
+                                "function": {
+                                    "name": "verifier_date_incident",
+                                    "arguments": "{\\"date\\": \\"2026-05-06\\"}"
+                                }
+                            }]
+                        },
+                        "finish_reason": "tool_calls"
+                    }],
+                    "usage": {"prompt_tokens": 4175, "completion_tokens": 23, "total_tokens": 4198}
+                }
+                """;
+
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(jsonResponse)
+                .build());
+
+        ChatModel model = MistralAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("test-api-key")
+                .modelName("mistralai/Ministral-3-8B-Instruct-2512")
+                .build();
+
+        ToolSpecification verifierDateIncident = ToolSpecification.builder()
+                .name("verifier_date_incident")
+                .description("Vérifie la date d'un incident")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("date")
+                        .required("date")
+                        .build())
+                .build();
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("Vérifie la date d'incident pour aujourd'hui."))
+                .toolSpecifications(verifierDateIncident)
+                .build();
+
+        // when
+        ChatResponse response = model.chat(chatRequest);
+
+        // then - no NPE; tool call is parsed; text is empty (no text content was returned)
+        assertThat(response.aiMessage().hasToolExecutionRequests()).isTrue();
+        assertThat(response.aiMessage().toolExecutionRequests()).hasSize(1);
+        assertThat(response.aiMessage().toolExecutionRequests().get(0).name()).isEqualTo("verifier_date_incident");
+        assertThat(response.aiMessage().toolExecutionRequests().get(0).arguments())
+                .contains("2026-05-06");
+        assertThat(response.aiMessage().text()).isEmpty();
+    }
+
+    /**
+     * Sanity: when {@code content} carries text alongside {@code tool_calls}, both must be
+     * exposed on the {@link dev.langchain4j.data.message.AiMessage}.
+     */
+    @Test
+    void should_handle_response_with_both_text_content_and_tool_calls() {
+        // given
+        String jsonResponse = """
+                {
+                    "id": "chatcmpl-mixed",
+                    "created": 1778075620,
+                    "model": "mistralai/Ministral-3-8B-Instruct-2512",
+                    "choices": [{
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Je vérifie cela tout de suite."}],
+                            "tool_calls": [{
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "verifier_date_incident",
+                                    "arguments": "{\\"date\\": \\"2026-05-06\\"}"
+                                }
+                            }]
+                        },
+                        "finish_reason": "tool_calls"
+                    }],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+                }
+                """;
+
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(jsonResponse)
+                .build());
+
+        ChatModel model = MistralAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("test-api-key")
+                .modelName("mistralai/Ministral-3-8B-Instruct-2512")
+                .build();
+
+        // when
+        ChatResponse response = model.chat(ChatRequest.builder()
+                .messages(UserMessage.from("Vérifie la date."))
+                .toolSpecifications(ToolSpecification.builder()
+                        .name("verifier_date_incident")
+                        .parameters(JsonObjectSchema.builder()
+                                .addStringProperty("date")
+                                .required("date")
+                                .build())
+                        .build())
+                .build());
+
+        // then
+        assertThat(response.aiMessage().text()).isEqualTo("Je vérifie cela tout de suite.");
+        assertThat(response.aiMessage().hasToolExecutionRequests()).isTrue();
+        assertThat(response.aiMessage().toolExecutionRequests()).hasSize(1);
+        assertThat(response.aiMessage().toolExecutionRequests().get(0).name()).isEqualTo("verifier_date_incident");
+    }
+
+    /**
+     * Regression guard: text-only response (no tool calls) must continue to work — confirms
+     * the null-guard added for tool-call-only responses doesn't disturb the regular path.
+     */
+    @Test
+    void should_handle_response_with_text_only_and_no_tool_calls() {
+        // given
+        String jsonResponse = """
+                {
+                    "id": "chatcmpl-textonly",
+                    "created": 1778075620,
+                    "model": "mistralai/Ministral-3-8B-Instruct-2512",
+                    "choices": [{
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Bonjour, comment puis-je vous aider ?"}],
+                            "tool_calls": null
+                        },
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15}
+                }
+                """;
+
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(jsonResponse)
+                .build());
+
+        ChatModel model = MistralAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("test-api-key")
+                .modelName("mistralai/Ministral-3-8B-Instruct-2512")
+                .build();
+
+        // when
+        ChatResponse response = model.chat(UserMessage.from("Bonjour"));
+
+        // then
+        assertThat(response.aiMessage().text()).isEqualTo("Bonjour, comment puis-je vous aider ?");
+        assertThat(response.aiMessage().hasToolExecutionRequests()).isFalse();
+    }
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #5121.

## Change
<!-- Please describe the changes you made. -->
Minimal, behavior-preserving null-guard in `MistralAiMapper.aiMessageFrom`. OpenAI-compatible servers (vLLM, llama.cpp, …) return `content: null` on assistant messages that carry only `tool_calls`. The current mapper unconditionally calls `.stream()` on `aiMistralMessage.getContent()`, which NPEs on this spec-compliant payload.

The fix treats null content as an empty list — both the `text` and `thinking` extraction streams now operate on the local reference:

```java
List<MistralAiMessageContent> contents = aiMistralMessage.getContent();
if (contents == null) {
    contents = List.of();
}
```

No public API or behaviour change for callers: `text` is still `""` when there is no text content, `thinking` stays `null` when no thinking content. No new dependencies. Spotless applied.

Adds `MistralAiChatModelToolCallsTest` mirroring `MistralAiChatModelReturnThinkingTest` (uses `MockHttpClient`), with three scenarios:
1. `should_handle_response_with_only_tool_calls_and_null_content` — the regression case (vLLM-style payload, captured byte-for-byte from a real production response).
2. `should_handle_response_with_both_text_content_and_tool_calls` — sanity, both fields present.
3. `should_handle_response_with_text_only_and_no_tool_calls` — ensures the null-guard doesn't disturb the existing text-only path.


## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Doc/example checkboxes left unchecked: a 3-line internal-mapper null-guard does not require docs or example updates. Happy to add either if a maintainer disagrees. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

 ### Note on the test runs

Ran `mvn -fae clean test` from the repo root and a follow-up `mvn -fae clean test -pl '!embeddings/langchain4j-embeddings'`. Combined: **59 modules pass cleanly, 2 modules fail, 46 modules auto-skip** as transitive dependents of the failures.

**Both failures share a single root cause unrelated to this change**: `ai.djl.engine.EngineException: Failed to load Huggingface native library` (`Unexpected flavor:
  cpu` — DJL HuggingFace native binaries do not load on aarch64 / Apple Silicon). Affects:
  - `langchain4j-embeddings` directly
  - `langchain4j` main module (15 test classes touching `AllMiniLmL6V2QuantizedEmbeddingModel` static init)
  - `langchain4j-azure-ai-search` (`AzureAiSearchContentRetrieverTest` setup uses the same embedding model)

The module touched by this PR — `langchain4j-mistral-ai` — was tested independently: **21/21 unit tests green** (3 new + 18 pre-existing). CI will validate the rest.


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
