### PR TITLE
feat: add per-tool strict schema enforcement on ToolSpecification

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -410,8 +410,7 @@ public class AnthropicMapper {
         JsonObjectSchema parameters = toolSpecification.parameters();
 
         // Per-tool strict overrides model-level default
-        Boolean effectiveStrict =
-                toolSpecification.strict() != null ? toolSpecification.strict() : strictTools;
+        Boolean effectiveStrict = toolSpecification.strict() != null ? toolSpecification.strict() : strictTools;
         boolean strict = Boolean.TRUE.equals(effectiveStrict);
 
         AnthropicTool.Builder toolBuilder = AnthropicTool.builder()

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -409,8 +409,11 @@ public class AnthropicMapper {
             Boolean strictTools) {
         JsonObjectSchema parameters = toolSpecification.parameters();
 
-        // prevent NPE during unboxing
-        boolean strict = Boolean.TRUE.equals(strictTools);
+        // Per-tool strict overrides model-level default
+        Boolean effectiveStrict = toolSpecification.strict() != null
+                ? toolSpecification.strict()
+                : strictTools;
+        boolean strict = Boolean.TRUE.equals(effectiveStrict);
 
         AnthropicTool.Builder toolBuilder = AnthropicTool.builder()
                 .name(toolSpecification.name())

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -410,9 +410,8 @@ public class AnthropicMapper {
         JsonObjectSchema parameters = toolSpecification.parameters();
 
         // Per-tool strict overrides model-level default
-        Boolean effectiveStrict = toolSpecification.strict() != null
-                ? toolSpecification.strict()
-                : strictTools;
+        Boolean effectiveStrict =
+                toolSpecification.strict() != null ? toolSpecification.strict() : strictTools;
         boolean strict = Boolean.TRUE.equals(effectiveStrict);
 
         AnthropicTool.Builder toolBuilder = AnthropicTool.builder()

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.anthropic.internal.mapper;
 
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
+import static dev.langchain4j.internal.ToolSpecificationUtils.isEffectivelyStrict;
 import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
@@ -409,7 +410,7 @@ public class AnthropicMapper {
             Boolean strictTools) {
         JsonObjectSchema parameters = toolSpecification.parameters();
 
-        boolean strict = toolSpecification.isEffectivelyStrict(Boolean.TRUE.equals(strictTools));
+        boolean strict = isEffectivelyStrict(toolSpecification, Boolean.TRUE.equals(strictTools));
 
         AnthropicTool.Builder toolBuilder = AnthropicTool.builder()
                 .name(toolSpecification.name())

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -409,9 +409,7 @@ public class AnthropicMapper {
             Boolean strictTools) {
         JsonObjectSchema parameters = toolSpecification.parameters();
 
-        // Per-tool strict overrides model-level default
-        Boolean effectiveStrict = toolSpecification.strict() != null ? toolSpecification.strict() : strictTools;
-        boolean strict = Boolean.TRUE.equals(effectiveStrict);
+        boolean strict = toolSpecification.isEffectivelyStrict(Boolean.TRUE.equals(strictTools));
 
         AnthropicTool.Builder toolBuilder = AnthropicTool.builder()
                 .name(toolSpecification.name())

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -273,9 +273,7 @@ class AnthropicMapperTest {
         Map<String, Object> map = toAnthropicSchema(jsonSchemaElement);
 
         // then
-        assertThat(new ObjectMapper().writeValueAsString(map))
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(new ObjectMapper().writeValueAsString(map)).isEqualToIgnoringWhitespace("""
                         {
                           "type": "object",
                           "properties": {
@@ -306,9 +304,7 @@ class AnthropicMapperTest {
         Map<String, Object> map = toAnthropicSchema(bookRecord);
 
         // then
-        assertThat(new ObjectMapper().writeValueAsString(map))
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(new ObjectMapper().writeValueAsString(map)).isEqualToIgnoringWhitespace("""
                         {
                           "type": "object",
                           "properties": {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -357,6 +357,68 @@ class AnthropicMapperTest {
     }
 
     @Test
+    void per_tool_strict_true_should_override_model_level_null() {
+        // given
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("strict_tool")
+                .description("description")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("param")
+                        .required("param")
+                        .build())
+                .strict(true)
+                .build();
+
+        // when - model-level strictTools is null
+        AnthropicTool tool = toAnthropicTool(toolSpec, AnthropicCacheType.NO_CACHE, Set.of(), null);
+
+        // then
+        assertThat(tool.strict).isTrue();
+        assertThat(tool.inputSchema.additionalProperties).isFalse();
+    }
+
+    @Test
+    void per_tool_strict_false_should_override_model_level_true() {
+        // given
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("non_strict_tool")
+                .description("description")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("param")
+                        .required("param")
+                        .build())
+                .strict(false)
+                .build();
+
+        // when - model-level strictTools is true
+        AnthropicTool tool = toAnthropicTool(toolSpec, AnthropicCacheType.NO_CACHE, Set.of(), true);
+
+        // then
+        assertThat(tool.strict).isNull();
+        assertThat(tool.inputSchema.additionalProperties).isNull();
+    }
+
+    @Test
+    void per_tool_strict_null_should_fall_back_to_model_level() {
+        // given
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("default_tool")
+                .description("description")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("param")
+                        .required("param")
+                        .build())
+                .build();
+
+        // when - model-level strictTools is true
+        AnthropicTool tool = toAnthropicTool(toolSpec, AnthropicCacheType.NO_CACHE, Set.of(), true);
+
+        // then - falls back to model-level
+        assertThat(tool.strict).isTrue();
+        assertThat(tool.inputSchema.additionalProperties).isFalse();
+    }
+
+    @Test
     void should_retain_keys() {
         assertThat(retainKeys(Map.of(), Set.of())).isEqualTo(Map.of());
         assertThat(retainKeys(Map.of("one", "one"), Set.of("one"))).isEqualTo(Map.of("one", "one"));

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecification.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecification.java
@@ -24,6 +24,7 @@ public class ToolSpecification {
     private final String description;
     private final JsonObjectSchema parameters;
     private final Map<String, Object> metadata;
+    private final Boolean strict;
 
     /**
      * Creates a {@link ToolSpecification} from a {@link Builder}.
@@ -35,6 +36,7 @@ public class ToolSpecification {
         this.description = builder.description;
         this.parameters = builder.parameters;
         this.metadata = copy(builder.metadata);
+        this.strict = builder.strict;
     }
 
     /**
@@ -74,6 +76,22 @@ public class ToolSpecification {
         return metadata;
     }
 
+    /**
+     * Returns whether this tool should use strict schema enforcement.
+     * <p>
+     * When {@code true}, the LLM provider will validate tool calls against this tool's schema server-side.
+     * When {@code false}, strict enforcement is explicitly disabled for this tool.
+     * When {@code null} (default), the model-level strict setting is used.
+     * <p>
+     * NOTE: Currently, per-tool strict is supported by the {@code langchain4j-anthropic}
+     * and {@code langchain4j-open-ai} modules.
+     *
+     * @return {@code true} to enable strict enforcement, {@code false} to disable, or {@code null} to use the model default.
+     */
+    public Boolean strict() {
+        return strict;
+    }
+
     @Override
     public boolean equals(Object another) {
         if (this == another) return true;
@@ -84,7 +102,8 @@ public class ToolSpecification {
         return Objects.equals(name, another.name)
                 && Objects.equals(description, another.description)
                 && Objects.equals(parameters, another.parameters)
-                && Objects.equals(metadata, another.metadata);
+                && Objects.equals(metadata, another.metadata)
+                && Objects.equals(strict, another.strict);
     }
 
     @Override
@@ -94,6 +113,7 @@ public class ToolSpecification {
         h += (h << 5) + Objects.hashCode(description);
         h += (h << 5) + Objects.hashCode(parameters);
         h += (h << 5) + Objects.hashCode(metadata);
+        h += (h << 5) + Objects.hashCode(strict);
         return h;
     }
 
@@ -104,6 +124,7 @@ public class ToolSpecification {
                 + ", description = " + quoted(description)
                 + ", parameters = " + parameters
                 + ", metadata = " + metadata
+                + ", strict = " + strict
                 + " }";
     }
 
@@ -133,7 +154,8 @@ public class ToolSpecification {
                 .name(name)
                 .description(description)
                 .parameters(parameters)
-                .metadata(mutableCopy(metadata));
+                .metadata(mutableCopy(metadata))
+                .strict(strict);
     }
 
     /**
@@ -154,6 +176,7 @@ public class ToolSpecification {
         private String description;
         private JsonObjectSchema parameters;
         private Map<String, Object> metadata;
+        private Boolean strict;
 
         /**
          * Creates a {@link Builder}.
@@ -211,6 +234,21 @@ public class ToolSpecification {
          */
         public Builder addMetadata(String key, Object value) {
             this.metadata.put(key, value);
+            return this;
+        }
+
+        /**
+         * Sets whether this tool should use strict schema enforcement.
+         * <p>
+         * When {@code true}, the LLM provider will validate tool calls against this tool's schema server-side.
+         * When {@code false}, strict enforcement is explicitly disabled for this tool.
+         * When {@code null} (default), the model-level strict setting is used.
+         *
+         * @param strict whether to enable strict enforcement for this tool
+         * @return {@code this}
+         */
+        public Builder strict(Boolean strict) {
+            this.strict = strict;
             return this;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecification.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecification.java
@@ -92,6 +92,17 @@ public class ToolSpecification {
         return strict;
     }
 
+    /**
+     * Resolves whether this tool should use strict schema enforcement,
+     * falling back to the model-level default when no per-tool value is set.
+     *
+     * @param modelLevelStrict the model-level strict setting to use as fallback
+     * @return {@code true} if strict enforcement should be used, {@code false} otherwise
+     */
+    public boolean isEffectivelyStrict(boolean modelLevelStrict) {
+        return strict != null ? strict : modelLevelStrict;
+    }
+
     @Override
     public boolean equals(Object another) {
         if (this == another) return true;

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecification.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecification.java
@@ -92,17 +92,6 @@ public class ToolSpecification {
         return strict;
     }
 
-    /**
-     * Resolves whether this tool should use strict schema enforcement,
-     * falling back to the model-level default when no per-tool value is set.
-     *
-     * @param modelLevelStrict the model-level strict setting to use as fallback
-     * @return {@code true} if strict enforcement should be used, {@code false} otherwise
-     */
-    public boolean isEffectivelyStrict(boolean modelLevelStrict) {
-        return strict != null ? strict : modelLevelStrict;
-    }
-
     @Override
     public boolean equals(Object another) {
         if (this == another) return true;

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/ToolSpecificationJsonUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/ToolSpecificationJsonUtils.java
@@ -49,6 +49,9 @@ public class ToolSpecificationJsonUtils {
                 && !toolSpecification.metadata().isEmpty()) {
             map.put("metadata", toolSpecification.metadata());
         }
+        if (toolSpecification.strict() != null) {
+            map.put("strict", toolSpecification.strict());
+        }
         return CODEC.toJson(map);
     }
 
@@ -86,6 +89,14 @@ public class ToolSpecificationJsonUtils {
         } else if (metadataObj != null) {
             throw new IllegalArgumentException("\"metadata\" must be a JSON object, but was: "
                     + metadataObj.getClass().getSimpleName());
+        }
+
+        Object strictObj = map.get("strict");
+        if (strictObj instanceof Boolean) {
+            builder.strict((Boolean) strictObj);
+        } else if (strictObj != null) {
+            throw new IllegalArgumentException("\"strict\" must be a boolean, but was: "
+                    + strictObj.getClass().getSimpleName());
         }
 
         return builder.build();

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/ToolSpecificationUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/ToolSpecificationUtils.java
@@ -1,0 +1,18 @@
+package dev.langchain4j.internal;
+
+import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ToolSpecification;
+
+@Internal
+public class ToolSpecificationUtils {
+
+    private ToolSpecificationUtils() {}
+
+    /**
+     * Resolves whether a tool should use strict schema enforcement,
+     * falling back to the model-level default when no per-tool value is set.
+     */
+    public static boolean isEffectivelyStrict(ToolSpecification toolSpecification, boolean modelLevelStrict) {
+        return toolSpecification.strict() != null ? toolSpecification.strict() : modelLevelStrict;
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationJsonTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationJsonTest.java
@@ -98,9 +98,8 @@ class ToolSpecificationJsonTest {
 
     @Test
     void should_round_trip_with_strict_null() {
-        ToolSpecification original = ToolSpecification.builder()
-                .name("default_tool")
-                .build();
+        ToolSpecification original =
+                ToolSpecification.builder().name("default_tool").build();
 
         String json = original.toJson();
         assertThat(json).doesNotContain("strict");
@@ -166,48 +165,72 @@ class ToolSpecificationJsonTest {
                 .description("A tool exercising every schema element type")
                 .parameters(JsonObjectSchema.builder()
                         .description("root params")
-                        .addProperty("stringProp", JsonStringSchema.builder()
-                                .description("a string")
-                                .build())
-                        .addProperty("intProp", JsonIntegerSchema.builder()
-                                .description("an integer")
-                                .build())
-                        .addProperty("numProp", JsonNumberSchema.builder()
-                                .description("a number")
-                                .build())
-                        .addProperty("boolProp", JsonBooleanSchema.builder()
-                                .description("a boolean")
-                                .build())
+                        .addProperty(
+                                "stringProp",
+                                JsonStringSchema.builder()
+                                        .description("a string")
+                                        .build())
+                        .addProperty(
+                                "intProp",
+                                JsonIntegerSchema.builder()
+                                        .description("an integer")
+                                        .build())
+                        .addProperty(
+                                "numProp",
+                                JsonNumberSchema.builder()
+                                        .description("a number")
+                                        .build())
+                        .addProperty(
+                                "boolProp",
+                                JsonBooleanSchema.builder()
+                                        .description("a boolean")
+                                        .build())
                         .addProperty("nullProp", new JsonNullSchema())
-                        .addProperty("enumProp", JsonEnumSchema.builder()
-                                .description("a color")
-                                .enumValues("RED", "GREEN", "BLUE")
-                                .build())
-                        .addProperty("arrayProp", JsonArraySchema.builder()
-                                .description("a list of integers")
-                                .items(new JsonIntegerSchema())
-                                .build())
-                        .addProperty("objectProp", JsonObjectSchema.builder()
-                                .description("nested object")
-                                .addProperty("inner", JsonStringSchema.builder()
-                                        .description("inner field")
+                        .addProperty(
+                                "enumProp",
+                                JsonEnumSchema.builder()
+                                        .description("a color")
+                                        .enumValues("RED", "GREEN", "BLUE")
                                         .build())
-                                .required("inner")
-                                .additionalProperties(false)
-                                .build())
-                        .addProperty("anyOfProp", JsonAnyOfSchema.builder()
-                                .description("string or number")
-                                .anyOf(new JsonStringSchema(), new JsonNumberSchema())
-                                .build())
-                        .addProperty("refProp", JsonReferenceSchema.builder()
-                                .reference("SharedDef")
-                                .build())
-                        .definitions(Map.of("SharedDef", JsonObjectSchema.builder()
-                                .addProperty("id", JsonIntegerSchema.builder()
-                                        .description("identifier")
+                        .addProperty(
+                                "arrayProp",
+                                JsonArraySchema.builder()
+                                        .description("a list of integers")
+                                        .items(new JsonIntegerSchema())
                                         .build())
-                                .required("id")
-                                .build()))
+                        .addProperty(
+                                "objectProp",
+                                JsonObjectSchema.builder()
+                                        .description("nested object")
+                                        .addProperty(
+                                                "inner",
+                                                JsonStringSchema.builder()
+                                                        .description("inner field")
+                                                        .build())
+                                        .required("inner")
+                                        .additionalProperties(false)
+                                        .build())
+                        .addProperty(
+                                "anyOfProp",
+                                JsonAnyOfSchema.builder()
+                                        .description("string or number")
+                                        .anyOf(new JsonStringSchema(), new JsonNumberSchema())
+                                        .build())
+                        .addProperty(
+                                "refProp",
+                                JsonReferenceSchema.builder()
+                                        .reference("SharedDef")
+                                        .build())
+                        .definitions(Map.of(
+                                "SharedDef",
+                                JsonObjectSchema.builder()
+                                        .addProperty(
+                                                "id",
+                                                JsonIntegerSchema.builder()
+                                                        .description("identifier")
+                                                        .build())
+                                        .required("id")
+                                        .build()))
                         .required("stringProp", "enumProp")
                         .build())
                 .addMetadata("cache", true)

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationJsonTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationJsonTest.java
@@ -98,8 +98,7 @@ class ToolSpecificationJsonTest {
 
     @Test
     void should_round_trip_with_strict_null() {
-        ToolSpecification original =
-                ToolSpecification.builder().name("default_tool").build();
+        ToolSpecification original = ToolSpecification.builder().name("default_tool").build();
 
         String json = original.toJson();
         assertThat(json).doesNotContain("strict");
@@ -165,72 +164,48 @@ class ToolSpecificationJsonTest {
                 .description("A tool exercising every schema element type")
                 .parameters(JsonObjectSchema.builder()
                         .description("root params")
-                        .addProperty(
-                                "stringProp",
-                                JsonStringSchema.builder()
-                                        .description("a string")
-                                        .build())
-                        .addProperty(
-                                "intProp",
-                                JsonIntegerSchema.builder()
-                                        .description("an integer")
-                                        .build())
-                        .addProperty(
-                                "numProp",
-                                JsonNumberSchema.builder()
-                                        .description("a number")
-                                        .build())
-                        .addProperty(
-                                "boolProp",
-                                JsonBooleanSchema.builder()
-                                        .description("a boolean")
-                                        .build())
+                        .addProperty("stringProp", JsonStringSchema.builder()
+                                .description("a string")
+                                .build())
+                        .addProperty("intProp", JsonIntegerSchema.builder()
+                                .description("an integer")
+                                .build())
+                        .addProperty("numProp", JsonNumberSchema.builder()
+                                .description("a number")
+                                .build())
+                        .addProperty("boolProp", JsonBooleanSchema.builder()
+                                .description("a boolean")
+                                .build())
                         .addProperty("nullProp", new JsonNullSchema())
-                        .addProperty(
-                                "enumProp",
-                                JsonEnumSchema.builder()
-                                        .description("a color")
-                                        .enumValues("RED", "GREEN", "BLUE")
+                        .addProperty("enumProp", JsonEnumSchema.builder()
+                                .description("a color")
+                                .enumValues("RED", "GREEN", "BLUE")
+                                .build())
+                        .addProperty("arrayProp", JsonArraySchema.builder()
+                                .description("a list of integers")
+                                .items(new JsonIntegerSchema())
+                                .build())
+                        .addProperty("objectProp", JsonObjectSchema.builder()
+                                .description("nested object")
+                                .addProperty("inner", JsonStringSchema.builder()
+                                        .description("inner field")
                                         .build())
-                        .addProperty(
-                                "arrayProp",
-                                JsonArraySchema.builder()
-                                        .description("a list of integers")
-                                        .items(new JsonIntegerSchema())
+                                .required("inner")
+                                .additionalProperties(false)
+                                .build())
+                        .addProperty("anyOfProp", JsonAnyOfSchema.builder()
+                                .description("string or number")
+                                .anyOf(new JsonStringSchema(), new JsonNumberSchema())
+                                .build())
+                        .addProperty("refProp", JsonReferenceSchema.builder()
+                                .reference("SharedDef")
+                                .build())
+                        .definitions(Map.of("SharedDef", JsonObjectSchema.builder()
+                                .addProperty("id", JsonIntegerSchema.builder()
+                                        .description("identifier")
                                         .build())
-                        .addProperty(
-                                "objectProp",
-                                JsonObjectSchema.builder()
-                                        .description("nested object")
-                                        .addProperty(
-                                                "inner",
-                                                JsonStringSchema.builder()
-                                                        .description("inner field")
-                                                        .build())
-                                        .required("inner")
-                                        .additionalProperties(false)
-                                        .build())
-                        .addProperty(
-                                "anyOfProp",
-                                JsonAnyOfSchema.builder()
-                                        .description("string or number")
-                                        .anyOf(new JsonStringSchema(), new JsonNumberSchema())
-                                        .build())
-                        .addProperty(
-                                "refProp",
-                                JsonReferenceSchema.builder()
-                                        .reference("SharedDef")
-                                        .build())
-                        .definitions(Map.of(
-                                "SharedDef",
-                                JsonObjectSchema.builder()
-                                        .addProperty(
-                                                "id",
-                                                JsonIntegerSchema.builder()
-                                                        .description("identifier")
-                                                        .build())
-                                        .required("id")
-                                        .build()))
+                                .required("id")
+                                .build()))
                         .required("stringProp", "enumProp")
                         .build())
                 .addMetadata("cache", true)

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationJsonTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationJsonTest.java
@@ -98,7 +98,8 @@ class ToolSpecificationJsonTest {
 
     @Test
     void should_round_trip_with_strict_null() {
-        ToolSpecification original = ToolSpecification.builder().name("default_tool").build();
+        ToolSpecification original =
+                ToolSpecification.builder().name("default_tool").build();
 
         String json = original.toJson();
         assertThat(json).doesNotContain("strict");

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationJsonTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationJsonTest.java
@@ -66,6 +66,59 @@ class ToolSpecificationJsonTest {
     }
 
     @Test
+    void should_round_trip_with_strict_true() {
+        ToolSpecification original = ToolSpecification.builder()
+                .name("strict_tool")
+                .description("A tool with strict enforcement")
+                .strict(true)
+                .build();
+
+        String json = original.toJson();
+        assertThat(json).contains("\"strict\":true");
+
+        ToolSpecification restored = ToolSpecification.fromJson(json);
+        assertThat(restored).isEqualTo(original);
+        assertThat(restored.strict()).isTrue();
+    }
+
+    @Test
+    void should_round_trip_with_strict_false() {
+        ToolSpecification original = ToolSpecification.builder()
+                .name("non_strict_tool")
+                .strict(false)
+                .build();
+
+        String json = original.toJson();
+        assertThat(json).contains("\"strict\":false");
+
+        ToolSpecification restored = ToolSpecification.fromJson(json);
+        assertThat(restored).isEqualTo(original);
+        assertThat(restored.strict()).isFalse();
+    }
+
+    @Test
+    void should_round_trip_with_strict_null() {
+        ToolSpecification original = ToolSpecification.builder()
+                .name("default_tool")
+                .build();
+
+        String json = original.toJson();
+        assertThat(json).doesNotContain("strict");
+
+        ToolSpecification restored = ToolSpecification.fromJson(json);
+        assertThat(restored).isEqualTo(original);
+        assertThat(restored.strict()).isNull();
+    }
+
+    @Test
+    void should_reject_non_boolean_strict() {
+        String json = "{\"name\":\"test\",\"strict\":\"yes\"}";
+        assertThatThrownBy(() -> ToolSpecification.fromJson(json))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("strict");
+    }
+
+    @Test
     void should_reject_non_object_parameters() {
         String json = "{\"name\":\"test\",\"parameters\":{\"type\":\"string\"}}";
         assertThatThrownBy(() -> ToolSpecification.fromJson(json))

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationJsonTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationJsonTest.java
@@ -165,48 +165,72 @@ class ToolSpecificationJsonTest {
                 .description("A tool exercising every schema element type")
                 .parameters(JsonObjectSchema.builder()
                         .description("root params")
-                        .addProperty("stringProp", JsonStringSchema.builder()
-                                .description("a string")
-                                .build())
-                        .addProperty("intProp", JsonIntegerSchema.builder()
-                                .description("an integer")
-                                .build())
-                        .addProperty("numProp", JsonNumberSchema.builder()
-                                .description("a number")
-                                .build())
-                        .addProperty("boolProp", JsonBooleanSchema.builder()
-                                .description("a boolean")
-                                .build())
+                        .addProperty(
+                                "stringProp",
+                                JsonStringSchema.builder()
+                                        .description("a string")
+                                        .build())
+                        .addProperty(
+                                "intProp",
+                                JsonIntegerSchema.builder()
+                                        .description("an integer")
+                                        .build())
+                        .addProperty(
+                                "numProp",
+                                JsonNumberSchema.builder()
+                                        .description("a number")
+                                        .build())
+                        .addProperty(
+                                "boolProp",
+                                JsonBooleanSchema.builder()
+                                        .description("a boolean")
+                                        .build())
                         .addProperty("nullProp", new JsonNullSchema())
-                        .addProperty("enumProp", JsonEnumSchema.builder()
-                                .description("a color")
-                                .enumValues("RED", "GREEN", "BLUE")
-                                .build())
-                        .addProperty("arrayProp", JsonArraySchema.builder()
-                                .description("a list of integers")
-                                .items(new JsonIntegerSchema())
-                                .build())
-                        .addProperty("objectProp", JsonObjectSchema.builder()
-                                .description("nested object")
-                                .addProperty("inner", JsonStringSchema.builder()
-                                        .description("inner field")
+                        .addProperty(
+                                "enumProp",
+                                JsonEnumSchema.builder()
+                                        .description("a color")
+                                        .enumValues("RED", "GREEN", "BLUE")
                                         .build())
-                                .required("inner")
-                                .additionalProperties(false)
-                                .build())
-                        .addProperty("anyOfProp", JsonAnyOfSchema.builder()
-                                .description("string or number")
-                                .anyOf(new JsonStringSchema(), new JsonNumberSchema())
-                                .build())
-                        .addProperty("refProp", JsonReferenceSchema.builder()
-                                .reference("SharedDef")
-                                .build())
-                        .definitions(Map.of("SharedDef", JsonObjectSchema.builder()
-                                .addProperty("id", JsonIntegerSchema.builder()
-                                        .description("identifier")
+                        .addProperty(
+                                "arrayProp",
+                                JsonArraySchema.builder()
+                                        .description("a list of integers")
+                                        .items(new JsonIntegerSchema())
                                         .build())
-                                .required("id")
-                                .build()))
+                        .addProperty(
+                                "objectProp",
+                                JsonObjectSchema.builder()
+                                        .description("nested object")
+                                        .addProperty(
+                                                "inner",
+                                                JsonStringSchema.builder()
+                                                        .description("inner field")
+                                                        .build())
+                                        .required("inner")
+                                        .additionalProperties(false)
+                                        .build())
+                        .addProperty(
+                                "anyOfProp",
+                                JsonAnyOfSchema.builder()
+                                        .description("string or number")
+                                        .anyOf(new JsonStringSchema(), new JsonNumberSchema())
+                                        .build())
+                        .addProperty(
+                                "refProp",
+                                JsonReferenceSchema.builder()
+                                        .reference("SharedDef")
+                                        .build())
+                        .definitions(Map.of(
+                                "SharedDef",
+                                JsonObjectSchema.builder()
+                                        .addProperty(
+                                                "id",
+                                                JsonIntegerSchema.builder()
+                                                        .description("identifier")
+                                                        .build())
+                                        .required("id")
+                                        .build()))
                         .required("stringProp", "enumProp")
                         .build())
                 .addMetadata("cache", true)

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/ToolSpecificationUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/ToolSpecificationUtilsTest.java
@@ -1,0 +1,34 @@
+package dev.langchain4j.internal;
+
+import static dev.langchain4j.internal.ToolSpecificationUtils.isEffectivelyStrict;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import org.junit.jupiter.api.Test;
+
+class ToolSpecificationUtilsTest {
+
+    @Test
+    void per_tool_true_overrides_model_false() {
+        ToolSpecification tool = ToolSpecification.builder().name("t").strict(true).build();
+        assertThat(isEffectivelyStrict(tool, false)).isTrue();
+    }
+
+    @Test
+    void per_tool_false_overrides_model_true() {
+        ToolSpecification tool = ToolSpecification.builder().name("t").strict(false).build();
+        assertThat(isEffectivelyStrict(tool, true)).isFalse();
+    }
+
+    @Test
+    void per_tool_null_falls_back_to_model_true() {
+        ToolSpecification tool = ToolSpecification.builder().name("t").build();
+        assertThat(isEffectivelyStrict(tool, true)).isTrue();
+    }
+
+    @Test
+    void per_tool_null_falls_back_to_model_false() {
+        ToolSpecification tool = ToolSpecification.builder().name("t").build();
+        assertThat(isEffectivelyStrict(tool, false)).isFalse();
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/ToolSpecificationUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/ToolSpecificationUtilsTest.java
@@ -10,13 +10,15 @@ class ToolSpecificationUtilsTest {
 
     @Test
     void per_tool_true_overrides_model_false() {
-        ToolSpecification tool = ToolSpecification.builder().name("t").strict(true).build();
+        ToolSpecification tool =
+                ToolSpecification.builder().name("t").strict(true).build();
         assertThat(isEffectivelyStrict(tool, false)).isTrue();
     }
 
     @Test
     void per_tool_false_overrides_model_true() {
-        ToolSpecification tool = ToolSpecification.builder().name("t").strict(false).build();
+        ToolSpecification tool =
+                ToolSpecification.builder().name("t").strict(false).build();
         assertThat(isEffectivelyStrict(tool, true)).isFalse();
     }
 

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.openaiofficial;
 
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
+import static dev.langchain4j.internal.ToolSpecificationUtils.isEffectivelyStrict;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.chat.request.ResponseFormat.JSON;
 import static dev.langchain4j.model.chat.request.ResponseFormatType.TEXT;
@@ -196,7 +197,7 @@ class InternalOpenAiOfficialHelper {
     }
 
     private static ChatCompletionTool toTool(ToolSpecification toolSpecification, boolean strict) {
-        boolean effectiveStrict = toolSpecification.isEffectivelyStrict(strict);
+        boolean effectiveStrict = isEffectivelyStrict(toolSpecification, strict);
 
         FunctionDefinition.Builder functionDefinitionBuilder = FunctionDefinition.builder()
                 .name(toolSpecification.name())

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -196,9 +196,7 @@ class InternalOpenAiOfficialHelper {
     }
 
     private static ChatCompletionTool toTool(ToolSpecification toolSpecification, boolean strict) {
-        // Per-tool strict overrides model-level default
-        boolean effectiveStrict =
-                toolSpecification.strict() != null ? Boolean.TRUE.equals(toolSpecification.strict()) : strict;
+        boolean effectiveStrict = toolSpecification.isEffectivelyStrict(strict);
 
         FunctionDefinition.Builder functionDefinitionBuilder = FunctionDefinition.builder()
                 .name(toolSpecification.name())

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -196,13 +196,16 @@ class InternalOpenAiOfficialHelper {
     }
 
     private static ChatCompletionTool toTool(ToolSpecification toolSpecification, boolean strict) {
+        // Per-tool strict overrides model-level default
+        boolean effectiveStrict =
+                toolSpecification.strict() != null ? Boolean.TRUE.equals(toolSpecification.strict()) : strict;
 
         FunctionDefinition.Builder functionDefinitionBuilder = FunctionDefinition.builder()
                 .name(toolSpecification.name())
                 .description(toolSpecification.description() != null ? toolSpecification.description() : "")
-                .parameters(toOpenAiParameters(toolSpecification, strict));
+                .parameters(toOpenAiParameters(toolSpecification, effectiveStrict));
 
-        if (strict) {
+        if (effectiveStrict) {
             functionDefinitionBuilder.strict(true);
         }
 

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
@@ -1,5 +1,16 @@
 package dev.langchain4j.model.openaiofficial;
 
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialResponse;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialThinking;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialToolCall;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.setupSyncClient;
+import static java.util.Arrays.asList;
+
 import com.openai.azure.AzureOpenAIServiceVersion;
 import com.openai.client.OpenAIClient;
 import com.openai.core.JsonField;
@@ -25,7 +36,6 @@ import com.openai.models.responses.ResponseFunctionCallArgumentsDeltaEvent;
 import com.openai.models.responses.ResponseFunctionCallArgumentsDoneEvent;
 import com.openai.models.responses.ResponseFunctionCallOutputItem;
 import com.openai.models.responses.ResponseFunctionToolCall;
-import com.openai.models.responses.ResponseInProgressEvent;
 import com.openai.models.responses.ResponseIncludable;
 import com.openai.models.responses.ResponseIncompleteEvent;
 import com.openai.models.responses.ResponseInputContent;
@@ -82,9 +92,6 @@ import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.output.FinishReason;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -98,17 +105,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialResponse;
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialThinking;
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialToolCall;
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
-import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
-import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.setupSyncClient;
-import static java.util.Arrays.asList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * StreamingChatModel implementation using the official OpenAI Java client for the Responses API.
@@ -130,19 +128,19 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         this.client = builder.client != null
                 ? builder.client
                 : setupSyncClient(
-                builder.baseUrl,
-                builder.apiKey,
-                builder.credential,
-                builder.microsoftFoundryDeploymentName,
-                builder.azureOpenAIServiceVersion,
-                builder.organizationId,
-                builder.isMicrosoftFoundry,
-                builder.isGitHubModels,
-                builder.modelName,
-                builder.timeout,
-                builder.maxRetries,
-                builder.proxy,
-                builder.customHeaders);
+                        builder.baseUrl,
+                        builder.apiKey,
+                        builder.credential,
+                        builder.microsoftFoundryDeploymentName,
+                        builder.azureOpenAIServiceVersion,
+                        builder.organizationId,
+                        builder.isMicrosoftFoundry,
+                        builder.isGitHubModels,
+                        builder.modelName,
+                        builder.timeout,
+                        builder.maxRetries,
+                        builder.proxy,
+                        builder.customHeaders);
         this.executorService =
                 getOrDefault(builder.executorService, DefaultExecutorProvider::getDefaultExecutorService);
 
@@ -160,7 +158,6 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                         : OpenAiOfficialResponsesChatRequestParameters.EMPTY;
 
         this.defaultRequestParameters = OpenAiOfficialResponsesChatRequestParameters.builder()
-
                 .modelName(ensureNotNull(getOrDefault(builder.modelName, commonParameters.modelName()), "modelName"))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -168,7 +165,6 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 .toolSpecifications(getOrDefault(builder.toolSpecifications, commonParameters.toolSpecifications()))
                 .toolChoice(getOrDefault(builder.toolChoice, commonParameters.toolChoice()))
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
-
                 .previousResponseId(getOrDefault(builder.previousResponseId, responsesParameters.previousResponseId()))
                 .maxToolCalls(getOrDefault(builder.maxToolCalls, responsesParameters.maxToolCalls()))
                 .parallelToolCalls(getOrDefault(builder.parallelToolCalls, responsesParameters.parallelToolCalls()))
@@ -178,11 +174,13 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 .serviceTier(getOrDefault(builder.serviceTier, responsesParameters.serviceTier()))
                 .safetyIdentifier(getOrDefault(builder.safetyIdentifier, responsesParameters.safetyIdentifier()))
                 .promptCacheKey(getOrDefault(builder.promptCacheKey, responsesParameters.promptCacheKey()))
-                .promptCacheRetention(getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
+                .promptCacheRetention(
+                        getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
                 .reasoningEffort(getOrDefault(builder.reasoningEffort, responsesParameters.reasoningEffort()))
                 .reasoningSummary(getOrDefault(builder.reasoningSummary, responsesParameters.reasoningSummary()))
                 .textVerbosity(getOrDefault(builder.textVerbosity, responsesParameters.textVerbosity()))
-                .streamIncludeObfuscation(getOrDefault(builder.streamIncludeObfuscation, responsesParameters.streamIncludeObfuscation()))
+                .streamIncludeObfuscation(
+                        getOrDefault(builder.streamIncludeObfuscation, responsesParameters.streamIncludeObfuscation()))
                 .store(getOrDefault(builder.store, getOrDefault(responsesParameters.store(), false)))
                 .strictTools(getOrDefault(builder.strictTools, responsesParameters.strictTools()))
                 .strictJsonSchema(getOrDefault(builder.strictJsonSchema, responsesParameters.strictJsonSchema()))
@@ -217,8 +215,8 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 }
             });
 
-            var eventHandler = new ResponsesEventHandler(
-                    handler, responseIdRef, parameters.modelName(), streamingHandle);
+            var eventHandler =
+                    new ResponsesEventHandler(handler, responseIdRef, parameters.modelName(), streamingHandle);
 
             // The forEach call blocks, so it is submitted to the executor service to run asynchronously.
             // We keep this on our executor (instead of OpenAIClientAsync callbacks) to ensure that user
@@ -319,14 +317,9 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
     }
 
     static AiMessage buildAiMessage(
-            String text,
-            String thinking,
-            List<ToolExecutionRequest> toolExecutionRequests,
-            String encryptedReasoning) {
-        AiMessage.Builder builder = AiMessage.builder()
-                .text(text)
-                .thinking(thinking)
-                .toolExecutionRequests(toolExecutionRequests);
+            String text, String thinking, List<ToolExecutionRequest> toolExecutionRequests, String encryptedReasoning) {
+        AiMessage.Builder builder =
+                AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(toolExecutionRequests);
         if (encryptedReasoning != null) {
             builder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedReasoning));
         }
@@ -468,8 +461,8 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         }
 
         boolean strictJsonSchema = Boolean.TRUE.equals(parameters.strictJsonSchema());
-        ResponseTextConfig textConfig = toResponseTextConfig(
-                parameters.responseFormat(), strictJsonSchema, parameters.textVerbosity());
+        ResponseTextConfig textConfig =
+                toResponseTextConfig(parameters.responseFormat(), strictJsonSchema, parameters.textVerbosity());
         if (textConfig != null) {
             paramsBuilder.text(textConfig);
         }
@@ -482,10 +475,12 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             throw new UnsupportedFeatureException("'topK' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.frequencyPenalty() != null) {
-            throw new UnsupportedFeatureException("'frequencyPenalty' parameter is not supported by OpenAI Responses API");
+            throw new UnsupportedFeatureException(
+                    "'frequencyPenalty' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.presencePenalty() != null) {
-            throw new UnsupportedFeatureException("'presencePenalty' parameter is not supported by OpenAI Responses API");
+            throw new UnsupportedFeatureException(
+                    "'presencePenalty' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.stopSequences() != null && !parameters.stopSequences().isEmpty()) {
             throw new UnsupportedFeatureException("'stopSequences' parameter is not supported by OpenAI Responses API");
@@ -530,8 +525,7 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
 
             return items;
         } else if (msg instanceof ToolExecutionResultMessage toolResultMessage) {
-            var outputBuilder = ResponseInputItem.FunctionCallOutput.builder()
-                    .callId(toolResultMessage.id());
+            var outputBuilder = ResponseInputItem.FunctionCallOutput.builder().callId(toolResultMessage.id());
 
             if (toolResultMessage.hasSingleText()) {
                 outputBuilder.output(toolResultMessage.text());
@@ -539,24 +533,22 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 var outputItems = new ArrayList<ResponseFunctionCallOutputItem>();
                 for (Content content : toolResultMessage.contents()) {
                     if (content instanceof TextContent textContent) {
-                        outputItems.add(ResponseFunctionCallOutputItem.ofInputText(
-                                ResponseInputTextContent.builder()
-                                        .text(textContent.text())
-                                        .build()));
+                        outputItems.add(ResponseFunctionCallOutputItem.ofInputText(ResponseInputTextContent.builder()
+                                .text(textContent.text())
+                                .build()));
                     } else if (content instanceof ImageContent imageContent) {
-                        outputItems.add(ResponseFunctionCallOutputItem.ofInputImage(
-                                ResponseInputImageContent.builder()
-                                        .imageUrl(buildImageUrl(imageContent.image()))
-                                        .detail(toResponsesImageDetail(imageContent.detailLevel()))
-                                        .build()));
+                        outputItems.add(ResponseFunctionCallOutputItem.ofInputImage(ResponseInputImageContent.builder()
+                                .imageUrl(buildImageUrl(imageContent.image()))
+                                .detail(toResponsesImageDetail(imageContent.detailLevel()))
+                                .build()));
                     } else {
                         throw new UnsupportedFeatureException("Unsupported content type in tool result: "
                                 + content.getClass().getName()
                                 + ". Only TextContent and ImageContent are supported.");
                     }
                 }
-                outputBuilder.output(ResponseInputItem.FunctionCallOutput.Output
-                        .ofResponseFunctionCallOutputItemList(outputItems));
+                outputBuilder.output(
+                        ResponseInputItem.FunctionCallOutput.Output.ofResponseFunctionCallOutputItemList(outputItems));
             }
 
             return List.of(ResponseInputItem.ofFunctionCallOutput(outputBuilder.build()));
@@ -638,8 +630,9 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             case LOW -> ResponseInputImage.Detail.LOW;
             case HIGH -> ResponseInputImage.Detail.HIGH;
             case AUTO -> ResponseInputImage.Detail.AUTO;
-            default -> throw new UnsupportedFeatureException(
-                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default ->
+                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
+                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
@@ -648,8 +641,9 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             case LOW -> ResponseInputImageContent.Detail.LOW;
             case HIGH -> ResponseInputImageContent.Detail.HIGH;
             case AUTO -> ResponseInputImageContent.Detail.AUTO;
-            default -> throw new UnsupportedFeatureException(
-                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default ->
+                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
+                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
@@ -1261,10 +1255,7 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         private void extractTokenUsageAndComplete(com.openai.models.responses.Response response) {
             var text = !textBuilder.isEmpty() ? textBuilder.toString() : null;
             var aiMessage = buildAiMessage(
-                    text,
-                    extractReasoningSummary(response),
-                    completedToolCalls,
-                    extractEncryptedReasoning(response));
+                    text, extractReasoningSummary(response), completedToolCalls, extractEncryptedReasoning(response));
 
             tokenUsage = extractTokenUsage(response);
             var metadata = buildResponseMetadata(responseId, modelName, response, finishReason, tokenUsage);

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
@@ -1,5 +1,16 @@
 package dev.langchain4j.model.openaiofficial;
 
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialResponse;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialThinking;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialToolCall;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.setupSyncClient;
+import static java.util.Arrays.asList;
+
 import com.openai.azure.AzureOpenAIServiceVersion;
 import com.openai.client.OpenAIClient;
 import com.openai.core.JsonField;
@@ -25,7 +36,6 @@ import com.openai.models.responses.ResponseFunctionCallArgumentsDeltaEvent;
 import com.openai.models.responses.ResponseFunctionCallArgumentsDoneEvent;
 import com.openai.models.responses.ResponseFunctionCallOutputItem;
 import com.openai.models.responses.ResponseFunctionToolCall;
-import com.openai.models.responses.ResponseInProgressEvent;
 import com.openai.models.responses.ResponseIncludable;
 import com.openai.models.responses.ResponseIncompleteEvent;
 import com.openai.models.responses.ResponseInputContent;
@@ -81,9 +91,6 @@ import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.output.FinishReason;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -97,17 +104,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialResponse;
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialThinking;
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialToolCall;
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
-import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
-import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.setupSyncClient;
-import static java.util.Arrays.asList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * StreamingChatModel implementation using the official OpenAI Java client for the Responses API.
@@ -129,19 +127,19 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         this.client = builder.client != null
                 ? builder.client
                 : setupSyncClient(
-                builder.baseUrl,
-                builder.apiKey,
-                builder.credential,
-                builder.microsoftFoundryDeploymentName,
-                builder.azureOpenAIServiceVersion,
-                builder.organizationId,
-                builder.isMicrosoftFoundry,
-                builder.isGitHubModels,
-                builder.modelName,
-                builder.timeout,
-                builder.maxRetries,
-                builder.proxy,
-                builder.customHeaders);
+                        builder.baseUrl,
+                        builder.apiKey,
+                        builder.credential,
+                        builder.microsoftFoundryDeploymentName,
+                        builder.azureOpenAIServiceVersion,
+                        builder.organizationId,
+                        builder.isMicrosoftFoundry,
+                        builder.isGitHubModels,
+                        builder.modelName,
+                        builder.timeout,
+                        builder.maxRetries,
+                        builder.proxy,
+                        builder.customHeaders);
         this.executorService =
                 getOrDefault(builder.executorService, DefaultExecutorProvider::getDefaultExecutorService);
 
@@ -159,7 +157,6 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                         : OpenAiOfficialResponsesChatRequestParameters.EMPTY;
 
         this.defaultRequestParameters = OpenAiOfficialResponsesChatRequestParameters.builder()
-
                 .modelName(ensureNotNull(getOrDefault(builder.modelName, commonParameters.modelName()), "modelName"))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -167,7 +164,6 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 .toolSpecifications(getOrDefault(builder.toolSpecifications, commonParameters.toolSpecifications()))
                 .toolChoice(getOrDefault(builder.toolChoice, commonParameters.toolChoice()))
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
-
                 .previousResponseId(getOrDefault(builder.previousResponseId, responsesParameters.previousResponseId()))
                 .maxToolCalls(getOrDefault(builder.maxToolCalls, responsesParameters.maxToolCalls()))
                 .parallelToolCalls(getOrDefault(builder.parallelToolCalls, responsesParameters.parallelToolCalls()))
@@ -177,11 +173,13 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 .serviceTier(getOrDefault(builder.serviceTier, responsesParameters.serviceTier()))
                 .safetyIdentifier(getOrDefault(builder.safetyIdentifier, responsesParameters.safetyIdentifier()))
                 .promptCacheKey(getOrDefault(builder.promptCacheKey, responsesParameters.promptCacheKey()))
-                .promptCacheRetention(getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
+                .promptCacheRetention(
+                        getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
                 .reasoningEffort(getOrDefault(builder.reasoningEffort, responsesParameters.reasoningEffort()))
                 .reasoningSummary(getOrDefault(builder.reasoningSummary, responsesParameters.reasoningSummary()))
                 .textVerbosity(getOrDefault(builder.textVerbosity, responsesParameters.textVerbosity()))
-                .streamIncludeObfuscation(getOrDefault(builder.streamIncludeObfuscation, responsesParameters.streamIncludeObfuscation()))
+                .streamIncludeObfuscation(
+                        getOrDefault(builder.streamIncludeObfuscation, responsesParameters.streamIncludeObfuscation()))
                 .store(getOrDefault(builder.store, getOrDefault(responsesParameters.store(), false)))
                 .strictTools(getOrDefault(builder.strictTools, responsesParameters.strictTools()))
                 .strictJsonSchema(getOrDefault(builder.strictJsonSchema, responsesParameters.strictJsonSchema()))
@@ -216,8 +214,8 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 }
             });
 
-            var eventHandler = new ResponsesEventHandler(
-                    handler, responseIdRef, parameters.modelName(), streamingHandle);
+            var eventHandler =
+                    new ResponsesEventHandler(handler, responseIdRef, parameters.modelName(), streamingHandle);
 
             // The forEach call blocks, so it is submitted to the executor service to run asynchronously.
             // We keep this on our executor (instead of OpenAIClientAsync callbacks) to ensure that user
@@ -318,14 +316,9 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
     }
 
     static AiMessage buildAiMessage(
-            String text,
-            String thinking,
-            List<ToolExecutionRequest> toolExecutionRequests,
-            String encryptedReasoning) {
-        AiMessage.Builder builder = AiMessage.builder()
-                .text(text)
-                .thinking(thinking)
-                .toolExecutionRequests(toolExecutionRequests);
+            String text, String thinking, List<ToolExecutionRequest> toolExecutionRequests, String encryptedReasoning) {
+        AiMessage.Builder builder =
+                AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(toolExecutionRequests);
         if (encryptedReasoning != null) {
             builder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedReasoning));
         }
@@ -467,8 +460,8 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         }
 
         boolean strictJsonSchema = Boolean.TRUE.equals(parameters.strictJsonSchema());
-        ResponseTextConfig textConfig = toResponseTextConfig(
-                parameters.responseFormat(), strictJsonSchema, parameters.textVerbosity());
+        ResponseTextConfig textConfig =
+                toResponseTextConfig(parameters.responseFormat(), strictJsonSchema, parameters.textVerbosity());
         if (textConfig != null) {
             paramsBuilder.text(textConfig);
         }
@@ -481,10 +474,12 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             throw new UnsupportedFeatureException("'topK' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.frequencyPenalty() != null) {
-            throw new UnsupportedFeatureException("'frequencyPenalty' parameter is not supported by OpenAI Responses API");
+            throw new UnsupportedFeatureException(
+                    "'frequencyPenalty' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.presencePenalty() != null) {
-            throw new UnsupportedFeatureException("'presencePenalty' parameter is not supported by OpenAI Responses API");
+            throw new UnsupportedFeatureException(
+                    "'presencePenalty' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.stopSequences() != null && !parameters.stopSequences().isEmpty()) {
             throw new UnsupportedFeatureException("'stopSequences' parameter is not supported by OpenAI Responses API");
@@ -529,8 +524,7 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
 
             return items;
         } else if (msg instanceof ToolExecutionResultMessage toolResultMessage) {
-            var outputBuilder = ResponseInputItem.FunctionCallOutput.builder()
-                    .callId(toolResultMessage.id());
+            var outputBuilder = ResponseInputItem.FunctionCallOutput.builder().callId(toolResultMessage.id());
 
             if (toolResultMessage.hasSingleText()) {
                 outputBuilder.output(toolResultMessage.text());
@@ -538,24 +532,22 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 var outputItems = new ArrayList<ResponseFunctionCallOutputItem>();
                 for (Content content : toolResultMessage.contents()) {
                     if (content instanceof TextContent textContent) {
-                        outputItems.add(ResponseFunctionCallOutputItem.ofInputText(
-                                ResponseInputTextContent.builder()
-                                        .text(textContent.text())
-                                        .build()));
+                        outputItems.add(ResponseFunctionCallOutputItem.ofInputText(ResponseInputTextContent.builder()
+                                .text(textContent.text())
+                                .build()));
                     } else if (content instanceof ImageContent imageContent) {
-                        outputItems.add(ResponseFunctionCallOutputItem.ofInputImage(
-                                ResponseInputImageContent.builder()
-                                        .imageUrl(buildImageUrl(imageContent.image()))
-                                        .detail(toResponsesImageDetail(imageContent.detailLevel()))
-                                        .build()));
+                        outputItems.add(ResponseFunctionCallOutputItem.ofInputImage(ResponseInputImageContent.builder()
+                                .imageUrl(buildImageUrl(imageContent.image()))
+                                .detail(toResponsesImageDetail(imageContent.detailLevel()))
+                                .build()));
                     } else {
                         throw new UnsupportedFeatureException("Unsupported content type in tool result: "
                                 + content.getClass().getName()
                                 + ". Only TextContent and ImageContent are supported.");
                     }
                 }
-                outputBuilder.output(ResponseInputItem.FunctionCallOutput.Output
-                        .ofResponseFunctionCallOutputItemList(outputItems));
+                outputBuilder.output(
+                        ResponseInputItem.FunctionCallOutput.Output.ofResponseFunctionCallOutputItemList(outputItems));
             }
 
             return List.of(ResponseInputItem.ofFunctionCallOutput(outputBuilder.build()));
@@ -637,8 +629,9 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             case LOW -> ResponseInputImage.Detail.LOW;
             case HIGH -> ResponseInputImage.Detail.HIGH;
             case AUTO -> ResponseInputImage.Detail.AUTO;
-            default -> throw new UnsupportedFeatureException(
-                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default ->
+                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
+                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
@@ -647,18 +640,21 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             case LOW -> ResponseInputImageContent.Detail.LOW;
             case HIGH -> ResponseInputImageContent.Detail.HIGH;
             case AUTO -> ResponseInputImageContent.Detail.AUTO;
-            default -> throw new UnsupportedFeatureException(
-                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default ->
+                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
+                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
     private static FunctionTool toResponsesTool(ToolSpecification toolSpec, boolean strict) {
+        // Per-tool strict overrides model-level default
+        boolean effectiveStrict = toolSpec.strict() != null ? Boolean.TRUE.equals(toolSpec.strict()) : strict;
         try {
             var parametersBuilder = FunctionTool.Parameters.builder();
             if (toolSpec.parameters() != null) {
-                toMap(toolSpec.parameters(), strict)
+                toMap(toolSpec.parameters(), effectiveStrict)
                         .forEach((key, value) -> parametersBuilder.putAdditionalProperty(key, JsonValue.from(value)));
-            } else if (strict) {
+            } else if (effectiveStrict) {
                 parametersBuilder
                         .putAdditionalProperty("type", JsonValue.from("object"))
                         .putAdditionalProperty("properties", JsonValue.from(Collections.emptyMap()))
@@ -668,7 +664,7 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                     .name(toolSpec.name())
                     .description(toolSpec.description())
                     .parameters(parametersBuilder.build())
-                    .strict(strict)
+                    .strict(effectiveStrict)
                     .build();
         } catch (Exception e) {
             throw new RuntimeException("Failed to convert tool specification for tool: " + toolSpec.name(), e);
@@ -1259,10 +1255,7 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         private void extractTokenUsageAndComplete(com.openai.models.responses.Response response) {
             var text = !textBuilder.isEmpty() ? textBuilder.toString() : null;
             var aiMessage = buildAiMessage(
-                    text,
-                    extractReasoningSummary(response),
-                    completedToolCalls,
-                    extractEncryptedReasoning(response));
+                    text, extractReasoningSummary(response), completedToolCalls, extractEncryptedReasoning(response));
 
             tokenUsage = extractTokenUsage(response);
             var metadata = buildResponseMetadata(responseId, modelName, response, finishReason, tokenUsage);

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
@@ -1,16 +1,5 @@
 package dev.langchain4j.model.openaiofficial;
 
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialResponse;
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialThinking;
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialToolCall;
-import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
-import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
-import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.setupSyncClient;
-import static java.util.Arrays.asList;
-
 import com.openai.azure.AzureOpenAIServiceVersion;
 import com.openai.client.OpenAIClient;
 import com.openai.core.JsonField;
@@ -36,6 +25,7 @@ import com.openai.models.responses.ResponseFunctionCallArgumentsDeltaEvent;
 import com.openai.models.responses.ResponseFunctionCallArgumentsDoneEvent;
 import com.openai.models.responses.ResponseFunctionCallOutputItem;
 import com.openai.models.responses.ResponseFunctionToolCall;
+import com.openai.models.responses.ResponseInProgressEvent;
 import com.openai.models.responses.ResponseIncludable;
 import com.openai.models.responses.ResponseIncompleteEvent;
 import com.openai.models.responses.ResponseInputContent;
@@ -91,6 +81,9 @@ import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.output.FinishReason;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -104,8 +97,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialResponse;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialThinking;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onPartialToolCall;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
+import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static dev.langchain4j.model.openaiofficial.setup.OpenAiOfficialSetup.setupSyncClient;
+import static java.util.Arrays.asList;
 
 /**
  * StreamingChatModel implementation using the official OpenAI Java client for the Responses API.
@@ -127,19 +129,19 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         this.client = builder.client != null
                 ? builder.client
                 : setupSyncClient(
-                        builder.baseUrl,
-                        builder.apiKey,
-                        builder.credential,
-                        builder.microsoftFoundryDeploymentName,
-                        builder.azureOpenAIServiceVersion,
-                        builder.organizationId,
-                        builder.isMicrosoftFoundry,
-                        builder.isGitHubModels,
-                        builder.modelName,
-                        builder.timeout,
-                        builder.maxRetries,
-                        builder.proxy,
-                        builder.customHeaders);
+                builder.baseUrl,
+                builder.apiKey,
+                builder.credential,
+                builder.microsoftFoundryDeploymentName,
+                builder.azureOpenAIServiceVersion,
+                builder.organizationId,
+                builder.isMicrosoftFoundry,
+                builder.isGitHubModels,
+                builder.modelName,
+                builder.timeout,
+                builder.maxRetries,
+                builder.proxy,
+                builder.customHeaders);
         this.executorService =
                 getOrDefault(builder.executorService, DefaultExecutorProvider::getDefaultExecutorService);
 
@@ -157,6 +159,7 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                         : OpenAiOfficialResponsesChatRequestParameters.EMPTY;
 
         this.defaultRequestParameters = OpenAiOfficialResponsesChatRequestParameters.builder()
+
                 .modelName(ensureNotNull(getOrDefault(builder.modelName, commonParameters.modelName()), "modelName"))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -164,6 +167,7 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 .toolSpecifications(getOrDefault(builder.toolSpecifications, commonParameters.toolSpecifications()))
                 .toolChoice(getOrDefault(builder.toolChoice, commonParameters.toolChoice()))
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
+
                 .previousResponseId(getOrDefault(builder.previousResponseId, responsesParameters.previousResponseId()))
                 .maxToolCalls(getOrDefault(builder.maxToolCalls, responsesParameters.maxToolCalls()))
                 .parallelToolCalls(getOrDefault(builder.parallelToolCalls, responsesParameters.parallelToolCalls()))
@@ -173,13 +177,11 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 .serviceTier(getOrDefault(builder.serviceTier, responsesParameters.serviceTier()))
                 .safetyIdentifier(getOrDefault(builder.safetyIdentifier, responsesParameters.safetyIdentifier()))
                 .promptCacheKey(getOrDefault(builder.promptCacheKey, responsesParameters.promptCacheKey()))
-                .promptCacheRetention(
-                        getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
+                .promptCacheRetention(getOrDefault(builder.promptCacheRetention, responsesParameters.promptCacheRetention()))
                 .reasoningEffort(getOrDefault(builder.reasoningEffort, responsesParameters.reasoningEffort()))
                 .reasoningSummary(getOrDefault(builder.reasoningSummary, responsesParameters.reasoningSummary()))
                 .textVerbosity(getOrDefault(builder.textVerbosity, responsesParameters.textVerbosity()))
-                .streamIncludeObfuscation(
-                        getOrDefault(builder.streamIncludeObfuscation, responsesParameters.streamIncludeObfuscation()))
+                .streamIncludeObfuscation(getOrDefault(builder.streamIncludeObfuscation, responsesParameters.streamIncludeObfuscation()))
                 .store(getOrDefault(builder.store, getOrDefault(responsesParameters.store(), false)))
                 .strictTools(getOrDefault(builder.strictTools, responsesParameters.strictTools()))
                 .strictJsonSchema(getOrDefault(builder.strictJsonSchema, responsesParameters.strictJsonSchema()))
@@ -214,8 +216,8 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 }
             });
 
-            var eventHandler =
-                    new ResponsesEventHandler(handler, responseIdRef, parameters.modelName(), streamingHandle);
+            var eventHandler = new ResponsesEventHandler(
+                    handler, responseIdRef, parameters.modelName(), streamingHandle);
 
             // The forEach call blocks, so it is submitted to the executor service to run asynchronously.
             // We keep this on our executor (instead of OpenAIClientAsync callbacks) to ensure that user
@@ -316,9 +318,14 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
     }
 
     static AiMessage buildAiMessage(
-            String text, String thinking, List<ToolExecutionRequest> toolExecutionRequests, String encryptedReasoning) {
-        AiMessage.Builder builder =
-                AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(toolExecutionRequests);
+            String text,
+            String thinking,
+            List<ToolExecutionRequest> toolExecutionRequests,
+            String encryptedReasoning) {
+        AiMessage.Builder builder = AiMessage.builder()
+                .text(text)
+                .thinking(thinking)
+                .toolExecutionRequests(toolExecutionRequests);
         if (encryptedReasoning != null) {
             builder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedReasoning));
         }
@@ -460,8 +467,8 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         }
 
         boolean strictJsonSchema = Boolean.TRUE.equals(parameters.strictJsonSchema());
-        ResponseTextConfig textConfig =
-                toResponseTextConfig(parameters.responseFormat(), strictJsonSchema, parameters.textVerbosity());
+        ResponseTextConfig textConfig = toResponseTextConfig(
+                parameters.responseFormat(), strictJsonSchema, parameters.textVerbosity());
         if (textConfig != null) {
             paramsBuilder.text(textConfig);
         }
@@ -474,12 +481,10 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             throw new UnsupportedFeatureException("'topK' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.frequencyPenalty() != null) {
-            throw new UnsupportedFeatureException(
-                    "'frequencyPenalty' parameter is not supported by OpenAI Responses API");
+            throw new UnsupportedFeatureException("'frequencyPenalty' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.presencePenalty() != null) {
-            throw new UnsupportedFeatureException(
-                    "'presencePenalty' parameter is not supported by OpenAI Responses API");
+            throw new UnsupportedFeatureException("'presencePenalty' parameter is not supported by OpenAI Responses API");
         }
         if (parameters.stopSequences() != null && !parameters.stopSequences().isEmpty()) {
             throw new UnsupportedFeatureException("'stopSequences' parameter is not supported by OpenAI Responses API");
@@ -524,7 +529,8 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
 
             return items;
         } else if (msg instanceof ToolExecutionResultMessage toolResultMessage) {
-            var outputBuilder = ResponseInputItem.FunctionCallOutput.builder().callId(toolResultMessage.id());
+            var outputBuilder = ResponseInputItem.FunctionCallOutput.builder()
+                    .callId(toolResultMessage.id());
 
             if (toolResultMessage.hasSingleText()) {
                 outputBuilder.output(toolResultMessage.text());
@@ -532,22 +538,24 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
                 var outputItems = new ArrayList<ResponseFunctionCallOutputItem>();
                 for (Content content : toolResultMessage.contents()) {
                     if (content instanceof TextContent textContent) {
-                        outputItems.add(ResponseFunctionCallOutputItem.ofInputText(ResponseInputTextContent.builder()
-                                .text(textContent.text())
-                                .build()));
+                        outputItems.add(ResponseFunctionCallOutputItem.ofInputText(
+                                ResponseInputTextContent.builder()
+                                        .text(textContent.text())
+                                        .build()));
                     } else if (content instanceof ImageContent imageContent) {
-                        outputItems.add(ResponseFunctionCallOutputItem.ofInputImage(ResponseInputImageContent.builder()
-                                .imageUrl(buildImageUrl(imageContent.image()))
-                                .detail(toResponsesImageDetail(imageContent.detailLevel()))
-                                .build()));
+                        outputItems.add(ResponseFunctionCallOutputItem.ofInputImage(
+                                ResponseInputImageContent.builder()
+                                        .imageUrl(buildImageUrl(imageContent.image()))
+                                        .detail(toResponsesImageDetail(imageContent.detailLevel()))
+                                        .build()));
                     } else {
                         throw new UnsupportedFeatureException("Unsupported content type in tool result: "
                                 + content.getClass().getName()
                                 + ". Only TextContent and ImageContent are supported.");
                     }
                 }
-                outputBuilder.output(
-                        ResponseInputItem.FunctionCallOutput.Output.ofResponseFunctionCallOutputItemList(outputItems));
+                outputBuilder.output(ResponseInputItem.FunctionCallOutput.Output
+                        .ofResponseFunctionCallOutputItemList(outputItems));
             }
 
             return List.of(ResponseInputItem.ofFunctionCallOutput(outputBuilder.build()));
@@ -629,9 +637,8 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             case LOW -> ResponseInputImage.Detail.LOW;
             case HIGH -> ResponseInputImage.Detail.HIGH;
             case AUTO -> ResponseInputImage.Detail.AUTO;
-            default ->
-                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
-                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default -> throw new UnsupportedFeatureException(
+                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
@@ -640,15 +647,13 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
             case LOW -> ResponseInputImageContent.Detail.LOW;
             case HIGH -> ResponseInputImageContent.Detail.HIGH;
             case AUTO -> ResponseInputImageContent.Detail.AUTO;
-            default ->
-                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
-                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default -> throw new UnsupportedFeatureException(
+                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
     private static FunctionTool toResponsesTool(ToolSpecification toolSpec, boolean strict) {
-        // Per-tool strict overrides model-level default
-        boolean effectiveStrict = toolSpec.strict() != null ? Boolean.TRUE.equals(toolSpec.strict()) : strict;
+        boolean effectiveStrict = toolSpec.isEffectivelyStrict(strict);
         try {
             var parametersBuilder = FunctionTool.Parameters.builder();
             if (toolSpec.parameters() != null) {
@@ -1255,7 +1260,10 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
         private void extractTokenUsageAndComplete(com.openai.models.responses.Response response) {
             var text = !textBuilder.isEmpty() ? textBuilder.toString() : null;
             var aiMessage = buildAiMessage(
-                    text, extractReasoningSummary(response), completedToolCalls, extractEncryptedReasoning(response));
+                    text,
+                    extractReasoningSummary(response),
+                    completedToolCalls,
+                    extractEncryptedReasoning(response));
 
             tokenUsage = extractTokenUsage(response);
             var metadata = buildResponseMetadata(responseId, modelName, response, finishReason, tokenUsage);

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialResponsesStreamingChatModel.java
@@ -62,6 +62,7 @@ import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.internal.ExceptionMapper;
+import dev.langchain4j.internal.ToolSpecificationUtils;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -653,7 +654,7 @@ public class OpenAiOfficialResponsesStreamingChatModel implements StreamingChatM
     }
 
     private static FunctionTool toResponsesTool(ToolSpecification toolSpec, boolean strict) {
-        boolean effectiveStrict = toolSpec.isEffectivelyStrict(strict);
+        boolean effectiveStrict = ToolSpecificationUtils.isEffectivelyStrict(toolSpec, strict);
         try {
             var parametersBuilder = FunctionTool.Parameters.builder();
             if (toolSpec.parameters() != null) {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -58,8 +58,7 @@ import java.util.Set;
 
 class OpenAiResponsesClient {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .enable(INDENT_OUTPUT);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().enable(INDENT_OUTPUT);
 
     private static final String DEFAULT_BASE_URL = "https://api.openai.com/v1";
     private static final String OPENAI_ORGANIZATION_HEADER = "OpenAI-Organization";
@@ -150,7 +149,8 @@ class OpenAiResponsesClient {
     private static final String ROLE_USER = "user";
     private static final String ROLE_ASSISTANT = "assistant";
 
-    static final String ENCRYPTED_REASONING_KEY = "encrypted_reasoning"; // do not change, will break backward compatibility!
+    static final String ENCRYPTED_REASONING_KEY =
+            "encrypted_reasoning"; // do not change, will break backward compatibility!
 
     private static final String TYPE_FUNCTION = "function";
     private static final String TYPE_FUNCTION_CALL = "function_call";
@@ -199,9 +199,10 @@ class OpenAiResponsesClient {
         }
     }
 
-    void streamingChat(ChatRequest chatRequest,
-                       OpenAiResponsesChatRequestParameters parameters,
-                       StreamingChatResponseHandler handler) {
+    void streamingChat(
+            ChatRequest chatRequest,
+            OpenAiResponsesChatRequestParameters parameters,
+            StreamingChatResponseHandler handler) {
         try {
             Map<String, Object> payload = buildRequestPayload(chatRequest, parameters, true);
             HttpRequest request = buildHttpRequest(payload, true);
@@ -213,9 +214,8 @@ class OpenAiResponsesClient {
         }
     }
 
-    private Map<String, Object> buildRequestPayload(ChatRequest chatRequest,
-                                                    OpenAiResponsesChatRequestParameters parameters,
-                                                    boolean stream) {
+    private Map<String, Object> buildRequestPayload(
+            ChatRequest chatRequest, OpenAiResponsesChatRequestParameters parameters, boolean stream) {
         List<Map<String, Object>> input = new ArrayList<>();
         for (ChatMessage message : chatRequest.messages()) {
             input.addAll(toResponsesMessages(message));
@@ -404,7 +404,8 @@ class OpenAiResponsesClient {
                 JsonNode summaryArray = item.path(FIELD_SUMMARY);
                 if (summaryArray.isArray()) {
                     for (JsonNode summaryItem : summaryArray) {
-                        if (FIELD_SUMMARY_TEXT.equals(summaryItem.path(FIELD_TYPE).asText())) {
+                        if (FIELD_SUMMARY_TEXT.equals(
+                                summaryItem.path(FIELD_TYPE).asText())) {
                             summaryBuilder.append(summaryItem.path(FIELD_TEXT).asText());
                         }
                     }
@@ -476,7 +477,8 @@ class OpenAiResponsesClient {
         JsonNode outputDetailsNode = usageNode.path(FIELD_OUTPUT_TOKENS_DETAILS);
         if (!outputDetailsNode.isMissingNode()) {
             usageBuilder.outputTokensDetails(OpenAiTokenUsage.OutputTokensDetails.builder()
-                    .reasoningTokens(outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
+                    .reasoningTokens(
+                            outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
                     .build());
         }
 
@@ -502,18 +504,14 @@ class OpenAiResponsesClient {
         String text = extractText(outputNode);
         String thinking = extractReasoningSummary(outputNode);
         String encryptedContent = extractReasoningEncryptedContent(outputNode);
-        List<ToolExecutionRequest> toolExecutionRequests =
-                extractToolExecutionRequests(outputNode);
+        List<ToolExecutionRequest> toolExecutionRequests = extractToolExecutionRequests(outputNode);
 
-        AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                .text(text)
-                .thinking(thinking)
-                .toolExecutionRequests(toolExecutionRequests);
+        AiMessage.Builder aiMessageBuilder =
+                AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(toolExecutionRequests);
         if (encryptedContent != null) {
             aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
         }
         AiMessage aiMessage = aiMessageBuilder.build();
-
 
         OpenAiResponsesChatResponseMetadata.Builder metadataBuilder = OpenAiResponsesChatResponseMetadata.builder()
                 .id(responseNode.path(FIELD_ID).asText(null))
@@ -688,8 +686,9 @@ class OpenAiResponsesClient {
             case LOW -> "low";
             case HIGH -> "high";
             case AUTO -> "auto";
-            default -> throw new UnsupportedFeatureException(
-                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default ->
+                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
+                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
@@ -977,10 +976,8 @@ class OpenAiResponsesClient {
             String thinking = extractReasoningSummary(outputNode);
             String encryptedContent = extractReasoningEncryptedContent(outputNode);
 
-            AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                    .text(text)
-                    .thinking(thinking)
-                    .toolExecutionRequests(completedToolCalls);
+            AiMessage.Builder aiMessageBuilder =
+                    AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(completedToolCalls);
             if (encryptedContent != null) {
                 aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
             }
@@ -995,8 +992,8 @@ class OpenAiResponsesClient {
                 metadataBuilder.tokenUsage(tokenUsage);
             }
 
-            FinishReason finishReason = finishReasonFromStatus(
-                    responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
+            FinishReason finishReason =
+                    finishReasonFromStatus(responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
             if (finishReason != null) {
                 metadataBuilder.finishReason(finishReason);
             }
@@ -1005,10 +1002,12 @@ class OpenAiResponsesClient {
                 metadataBuilder.createdAt(responseNode.path(FIELD_CREATED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_COMPLETED_AT)) {
-                metadataBuilder.completedAt(responseNode.path(FIELD_COMPLETED_AT).asLong());
+                metadataBuilder.completedAt(
+                        responseNode.path(FIELD_COMPLETED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_SERVICE_TIER)) {
-                metadataBuilder.serviceTier(responseNode.path(FIELD_SERVICE_TIER).asText());
+                metadataBuilder.serviceTier(
+                        responseNode.path(FIELD_SERVICE_TIER).asText());
             }
             if (rawHttpResponse != null) {
                 metadataBuilder.rawHttpResponse(rawHttpResponse);
@@ -1017,9 +1016,7 @@ class OpenAiResponsesClient {
                 metadataBuilder.rawServerSentEvents(new ArrayList<>(rawServerSentEvents));
             }
 
-            var responseBuilder = ChatResponse.builder()
-                    .aiMessage(aiMessage)
-                    .metadata(metadataBuilder.build());
+            var responseBuilder = ChatResponse.builder().aiMessage(aiMessage).metadata(metadataBuilder.build());
 
             if (!isCancelled()) {
                 try {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -57,8 +57,7 @@ import java.util.Set;
 
 class OpenAiResponsesClient {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .enable(INDENT_OUTPUT);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().enable(INDENT_OUTPUT);
 
     private static final String DEFAULT_BASE_URL = "https://api.openai.com/v1";
     private static final String OPENAI_ORGANIZATION_HEADER = "OpenAI-Organization";
@@ -149,7 +148,8 @@ class OpenAiResponsesClient {
     private static final String ROLE_USER = "user";
     private static final String ROLE_ASSISTANT = "assistant";
 
-    static final String ENCRYPTED_REASONING_KEY = "encrypted_reasoning"; // do not change, will break backward compatibility!
+    static final String ENCRYPTED_REASONING_KEY =
+            "encrypted_reasoning"; // do not change, will break backward compatibility!
 
     private static final String TYPE_FUNCTION = "function";
     private static final String TYPE_FUNCTION_CALL = "function_call";
@@ -198,9 +198,10 @@ class OpenAiResponsesClient {
         }
     }
 
-    void streamingChat(ChatRequest chatRequest,
-                       OpenAiResponsesChatRequestParameters parameters,
-                       StreamingChatResponseHandler handler) {
+    void streamingChat(
+            ChatRequest chatRequest,
+            OpenAiResponsesChatRequestParameters parameters,
+            StreamingChatResponseHandler handler) {
         try {
             Map<String, Object> payload = buildRequestPayload(chatRequest, parameters, true);
             HttpRequest request = buildHttpRequest(payload, true);
@@ -212,9 +213,8 @@ class OpenAiResponsesClient {
         }
     }
 
-    private Map<String, Object> buildRequestPayload(ChatRequest chatRequest,
-                                                    OpenAiResponsesChatRequestParameters parameters,
-                                                    boolean stream) {
+    private Map<String, Object> buildRequestPayload(
+            ChatRequest chatRequest, OpenAiResponsesChatRequestParameters parameters, boolean stream) {
         List<Map<String, Object>> input = new ArrayList<>();
         for (ChatMessage message : chatRequest.messages()) {
             input.addAll(toResponsesMessages(message));
@@ -300,6 +300,10 @@ class OpenAiResponsesClient {
         if (toolSpecifications != null && !toolSpecifications.isEmpty()) {
             List<Map<String, Object>> tools = new ArrayList<>();
             for (ToolSpecification toolSpec : toolSpecifications) {
+                // Per-tool strict overrides model-level default
+                boolean effectiveStrict =
+                        toolSpec.strict() != null ? Boolean.TRUE.equals(toolSpec.strict()) : strictTools;
+
                 Map<String, Object> tool = new LinkedHashMap<>();
                 tool.put(FIELD_TYPE, TYPE_FUNCTION);
                 tool.put(FIELD_NAME, toolSpec.name());
@@ -309,8 +313,8 @@ class OpenAiResponsesClient {
 
                 Map<String, Object> functionParameters = null;
                 if (toolSpec.parameters() != null) {
-                    functionParameters = toMap(toolSpec.parameters(), strictTools);
-                } else if (strictTools) {
+                    functionParameters = toMap(toolSpec.parameters(), effectiveStrict);
+                } else if (effectiveStrict) {
                     functionParameters = new LinkedHashMap<>();
                     functionParameters.put(FIELD_TYPE, TYPE_OBJECT);
                     functionParameters.put(FIELD_PROPERTIES, Map.of());
@@ -321,7 +325,7 @@ class OpenAiResponsesClient {
                     tool.put(FIELD_PARAMETERS, functionParameters);
                 }
 
-                if (strictTools) {
+                if (effectiveStrict) {
                     tool.put(FIELD_STRICT, true);
                 }
 
@@ -401,7 +405,8 @@ class OpenAiResponsesClient {
                 JsonNode summaryArray = item.path(FIELD_SUMMARY);
                 if (summaryArray.isArray()) {
                     for (JsonNode summaryItem : summaryArray) {
-                        if (FIELD_SUMMARY_TEXT.equals(summaryItem.path(FIELD_TYPE).asText())) {
+                        if (FIELD_SUMMARY_TEXT.equals(
+                                summaryItem.path(FIELD_TYPE).asText())) {
                             summaryBuilder.append(summaryItem.path(FIELD_TEXT).asText());
                         }
                     }
@@ -473,7 +478,8 @@ class OpenAiResponsesClient {
         JsonNode outputDetailsNode = usageNode.path(FIELD_OUTPUT_TOKENS_DETAILS);
         if (!outputDetailsNode.isMissingNode()) {
             usageBuilder.outputTokensDetails(OpenAiTokenUsage.OutputTokensDetails.builder()
-                    .reasoningTokens(outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
+                    .reasoningTokens(
+                            outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
                     .build());
         }
 
@@ -499,18 +505,14 @@ class OpenAiResponsesClient {
         String text = extractText(outputNode);
         String thinking = extractReasoningSummary(outputNode);
         String encryptedContent = extractReasoningEncryptedContent(outputNode);
-        List<ToolExecutionRequest> toolExecutionRequests =
-                extractToolExecutionRequests(outputNode);
+        List<ToolExecutionRequest> toolExecutionRequests = extractToolExecutionRequests(outputNode);
 
-        AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                .text(text)
-                .thinking(thinking)
-                .toolExecutionRequests(toolExecutionRequests);
+        AiMessage.Builder aiMessageBuilder =
+                AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(toolExecutionRequests);
         if (encryptedContent != null) {
             aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
         }
         AiMessage aiMessage = aiMessageBuilder.build();
-
 
         OpenAiResponsesChatResponseMetadata.Builder metadataBuilder = OpenAiResponsesChatResponseMetadata.builder()
                 .id(responseNode.path(FIELD_ID).asText(null))
@@ -685,8 +687,9 @@ class OpenAiResponsesClient {
             case LOW -> "low";
             case HIGH -> "high";
             case AUTO -> "auto";
-            default -> throw new UnsupportedFeatureException(
-                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default ->
+                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
+                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
@@ -974,10 +977,8 @@ class OpenAiResponsesClient {
             String thinking = extractReasoningSummary(outputNode);
             String encryptedContent = extractReasoningEncryptedContent(outputNode);
 
-            AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                    .text(text)
-                    .thinking(thinking)
-                    .toolExecutionRequests(completedToolCalls);
+            AiMessage.Builder aiMessageBuilder =
+                    AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(completedToolCalls);
             if (encryptedContent != null) {
                 aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
             }
@@ -992,8 +993,8 @@ class OpenAiResponsesClient {
                 metadataBuilder.tokenUsage(tokenUsage);
             }
 
-            FinishReason finishReason = finishReasonFromStatus(
-                    responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
+            FinishReason finishReason =
+                    finishReasonFromStatus(responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
             if (finishReason != null) {
                 metadataBuilder.finishReason(finishReason);
             }
@@ -1002,10 +1003,12 @@ class OpenAiResponsesClient {
                 metadataBuilder.createdAt(responseNode.path(FIELD_CREATED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_COMPLETED_AT)) {
-                metadataBuilder.completedAt(responseNode.path(FIELD_COMPLETED_AT).asLong());
+                metadataBuilder.completedAt(
+                        responseNode.path(FIELD_COMPLETED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_SERVICE_TIER)) {
-                metadataBuilder.serviceTier(responseNode.path(FIELD_SERVICE_TIER).asText());
+                metadataBuilder.serviceTier(
+                        responseNode.path(FIELD_SERVICE_TIER).asText());
             }
             if (rawHttpResponse != null) {
                 metadataBuilder.rawHttpResponse(rawHttpResponse);
@@ -1014,9 +1017,7 @@ class OpenAiResponsesClient {
                 metadataBuilder.rawServerSentEvents(new ArrayList<>(rawServerSentEvents));
             }
 
-            var responseBuilder = ChatResponse.builder()
-                    .aiMessage(aiMessage)
-                    .metadata(metadataBuilder.build());
+            var responseBuilder = ChatResponse.builder().aiMessage(aiMessage).metadata(metadataBuilder.build());
 
             if (!isCancelled()) {
                 try {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -4,6 +4,7 @@ import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
 import static dev.langchain4j.http.client.sse.ServerSentEventParsingHandleUtils.toStreamingHandle;
 import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.withLoggingExceptions;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
+import static dev.langchain4j.internal.ToolSpecificationUtils.isEffectivelyStrict;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -300,7 +301,7 @@ class OpenAiResponsesClient {
         if (toolSpecifications != null && !toolSpecifications.isEmpty()) {
             List<Map<String, Object>> tools = new ArrayList<>();
             for (ToolSpecification toolSpec : toolSpecifications) {
-                boolean effectiveStrict = toolSpec.isEffectivelyStrict(strictTools);
+                boolean effectiveStrict = isEffectivelyStrict(toolSpec, strictTools);
 
                 Map<String, Object> tool = new LinkedHashMap<>();
                 tool.put(FIELD_TYPE, TYPE_FUNCTION);

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiResponsesClient.java
@@ -57,7 +57,8 @@ import java.util.Set;
 
 class OpenAiResponsesClient {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().enable(INDENT_OUTPUT);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .enable(INDENT_OUTPUT);
 
     private static final String DEFAULT_BASE_URL = "https://api.openai.com/v1";
     private static final String OPENAI_ORGANIZATION_HEADER = "OpenAI-Organization";
@@ -148,8 +149,7 @@ class OpenAiResponsesClient {
     private static final String ROLE_USER = "user";
     private static final String ROLE_ASSISTANT = "assistant";
 
-    static final String ENCRYPTED_REASONING_KEY =
-            "encrypted_reasoning"; // do not change, will break backward compatibility!
+    static final String ENCRYPTED_REASONING_KEY = "encrypted_reasoning"; // do not change, will break backward compatibility!
 
     private static final String TYPE_FUNCTION = "function";
     private static final String TYPE_FUNCTION_CALL = "function_call";
@@ -198,10 +198,9 @@ class OpenAiResponsesClient {
         }
     }
 
-    void streamingChat(
-            ChatRequest chatRequest,
-            OpenAiResponsesChatRequestParameters parameters,
-            StreamingChatResponseHandler handler) {
+    void streamingChat(ChatRequest chatRequest,
+                       OpenAiResponsesChatRequestParameters parameters,
+                       StreamingChatResponseHandler handler) {
         try {
             Map<String, Object> payload = buildRequestPayload(chatRequest, parameters, true);
             HttpRequest request = buildHttpRequest(payload, true);
@@ -213,8 +212,9 @@ class OpenAiResponsesClient {
         }
     }
 
-    private Map<String, Object> buildRequestPayload(
-            ChatRequest chatRequest, OpenAiResponsesChatRequestParameters parameters, boolean stream) {
+    private Map<String, Object> buildRequestPayload(ChatRequest chatRequest,
+                                                    OpenAiResponsesChatRequestParameters parameters,
+                                                    boolean stream) {
         List<Map<String, Object>> input = new ArrayList<>();
         for (ChatMessage message : chatRequest.messages()) {
             input.addAll(toResponsesMessages(message));
@@ -300,9 +300,7 @@ class OpenAiResponsesClient {
         if (toolSpecifications != null && !toolSpecifications.isEmpty()) {
             List<Map<String, Object>> tools = new ArrayList<>();
             for (ToolSpecification toolSpec : toolSpecifications) {
-                // Per-tool strict overrides model-level default
-                boolean effectiveStrict =
-                        toolSpec.strict() != null ? Boolean.TRUE.equals(toolSpec.strict()) : strictTools;
+                boolean effectiveStrict = toolSpec.isEffectivelyStrict(strictTools);
 
                 Map<String, Object> tool = new LinkedHashMap<>();
                 tool.put(FIELD_TYPE, TYPE_FUNCTION);
@@ -405,8 +403,7 @@ class OpenAiResponsesClient {
                 JsonNode summaryArray = item.path(FIELD_SUMMARY);
                 if (summaryArray.isArray()) {
                     for (JsonNode summaryItem : summaryArray) {
-                        if (FIELD_SUMMARY_TEXT.equals(
-                                summaryItem.path(FIELD_TYPE).asText())) {
+                        if (FIELD_SUMMARY_TEXT.equals(summaryItem.path(FIELD_TYPE).asText())) {
                             summaryBuilder.append(summaryItem.path(FIELD_TEXT).asText());
                         }
                     }
@@ -478,8 +475,7 @@ class OpenAiResponsesClient {
         JsonNode outputDetailsNode = usageNode.path(FIELD_OUTPUT_TOKENS_DETAILS);
         if (!outputDetailsNode.isMissingNode()) {
             usageBuilder.outputTokensDetails(OpenAiTokenUsage.OutputTokensDetails.builder()
-                    .reasoningTokens(
-                            outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
+                    .reasoningTokens(outputDetailsNode.path(FIELD_REASONING_TOKENS).asInt())
                     .build());
         }
 
@@ -505,14 +501,18 @@ class OpenAiResponsesClient {
         String text = extractText(outputNode);
         String thinking = extractReasoningSummary(outputNode);
         String encryptedContent = extractReasoningEncryptedContent(outputNode);
-        List<ToolExecutionRequest> toolExecutionRequests = extractToolExecutionRequests(outputNode);
+        List<ToolExecutionRequest> toolExecutionRequests =
+                extractToolExecutionRequests(outputNode);
 
-        AiMessage.Builder aiMessageBuilder =
-                AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(toolExecutionRequests);
+        AiMessage.Builder aiMessageBuilder = AiMessage.builder()
+                .text(text)
+                .thinking(thinking)
+                .toolExecutionRequests(toolExecutionRequests);
         if (encryptedContent != null) {
             aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
         }
         AiMessage aiMessage = aiMessageBuilder.build();
+
 
         OpenAiResponsesChatResponseMetadata.Builder metadataBuilder = OpenAiResponsesChatResponseMetadata.builder()
                 .id(responseNode.path(FIELD_ID).asText(null))
@@ -687,9 +687,8 @@ class OpenAiResponsesClient {
             case LOW -> "low";
             case HIGH -> "high";
             case AUTO -> "auto";
-            default ->
-                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
-                        + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
+            default -> throw new UnsupportedFeatureException(
+                    "DetailLevel " + detailLevel + " is not supported by OpenAI Responses API. Supported values: LOW, HIGH, AUTO");
         };
     }
 
@@ -977,8 +976,10 @@ class OpenAiResponsesClient {
             String thinking = extractReasoningSummary(outputNode);
             String encryptedContent = extractReasoningEncryptedContent(outputNode);
 
-            AiMessage.Builder aiMessageBuilder =
-                    AiMessage.builder().text(text).thinking(thinking).toolExecutionRequests(completedToolCalls);
+            AiMessage.Builder aiMessageBuilder = AiMessage.builder()
+                    .text(text)
+                    .thinking(thinking)
+                    .toolExecutionRequests(completedToolCalls);
             if (encryptedContent != null) {
                 aiMessageBuilder.attributes(Map.of(ENCRYPTED_REASONING_KEY, encryptedContent));
             }
@@ -993,8 +994,8 @@ class OpenAiResponsesClient {
                 metadataBuilder.tokenUsage(tokenUsage);
             }
 
-            FinishReason finishReason =
-                    finishReasonFromStatus(responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
+            FinishReason finishReason = finishReasonFromStatus(
+                    responseNode.path(FIELD_STATUS).asText(null), !completedToolCalls.isEmpty());
             if (finishReason != null) {
                 metadataBuilder.finishReason(finishReason);
             }
@@ -1003,12 +1004,10 @@ class OpenAiResponsesClient {
                 metadataBuilder.createdAt(responseNode.path(FIELD_CREATED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_COMPLETED_AT)) {
-                metadataBuilder.completedAt(
-                        responseNode.path(FIELD_COMPLETED_AT).asLong());
+                metadataBuilder.completedAt(responseNode.path(FIELD_COMPLETED_AT).asLong());
             }
             if (responseNode.hasNonNull(FIELD_SERVICE_TIER)) {
-                metadataBuilder.serviceTier(
-                        responseNode.path(FIELD_SERVICE_TIER).asText());
+                metadataBuilder.serviceTier(responseNode.path(FIELD_SERVICE_TIER).asText());
             }
             if (rawHttpResponse != null) {
                 metadataBuilder.rawHttpResponse(rawHttpResponse);
@@ -1017,7 +1016,9 @@ class OpenAiResponsesClient {
                 metadataBuilder.rawServerSentEvents(new ArrayList<>(rawServerSentEvents));
             }
 
-            var responseBuilder = ChatResponse.builder().aiMessage(aiMessage).metadata(metadataBuilder.build());
+            var responseBuilder = ChatResponse.builder()
+                    .aiMessage(aiMessage)
+                    .metadata(metadataBuilder.build());
 
             if (!isCancelled()) {
                 try {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
@@ -295,9 +295,7 @@ public class OpenAiUtils {
     }
 
     private static Tool toTool(ToolSpecification toolSpecification, boolean strict) {
-        // Per-tool strict overrides model-level default
-        boolean effectiveStrict =
-                toolSpecification.strict() != null ? Boolean.TRUE.equals(toolSpecification.strict()) : strict;
+        boolean effectiveStrict = toolSpecification.isEffectivelyStrict(strict);
         Function.Builder functionBuilder = Function.builder()
                 .name(toolSpecification.name())
                 .description(toolSpecification.description())

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
@@ -296,9 +296,8 @@ public class OpenAiUtils {
 
     private static Tool toTool(ToolSpecification toolSpecification, boolean strict) {
         // Per-tool strict overrides model-level default
-        boolean effectiveStrict = toolSpecification.strict() != null
-                ? Boolean.TRUE.equals(toolSpecification.strict())
-                : strict;
+        boolean effectiveStrict =
+                toolSpecification.strict() != null ? Boolean.TRUE.equals(toolSpecification.strict()) : strict;
         Function.Builder functionBuilder = Function.builder()
                 .name(toolSpecification.name())
                 .description(toolSpecification.description())

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.openai.internal;
 
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.JsonSchemaElementUtils.toMap;
+import static dev.langchain4j.internal.ToolSpecificationUtils.isEffectivelyStrict;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
@@ -295,7 +296,7 @@ public class OpenAiUtils {
     }
 
     private static Tool toTool(ToolSpecification toolSpecification, boolean strict) {
-        boolean effectiveStrict = toolSpecification.isEffectivelyStrict(strict);
+        boolean effectiveStrict = isEffectivelyStrict(toolSpecification, strict);
         Function.Builder functionBuilder = Function.builder()
                 .name(toolSpecification.name())
                 .description(toolSpecification.description())

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
@@ -295,11 +295,15 @@ public class OpenAiUtils {
     }
 
     private static Tool toTool(ToolSpecification toolSpecification, boolean strict) {
+        // Per-tool strict overrides model-level default
+        boolean effectiveStrict = toolSpecification.strict() != null
+                ? Boolean.TRUE.equals(toolSpecification.strict())
+                : strict;
         Function.Builder functionBuilder = Function.builder()
                 .name(toolSpecification.name())
                 .description(toolSpecification.description())
-                .parameters(toOpenAiParameters(toolSpecification.parameters(), strict));
-        if (strict) {
+                .parameters(toOpenAiParameters(toolSpecification.parameters(), effectiveStrict));
+        if (effectiveStrict) {
             functionBuilder.strict(true);
         }
         Function function = functionBuilder.build();

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/OpenAiUtilsTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/OpenAiUtilsTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.openai.internal;
 
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.aiMessageFrom;
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.toOpenAiToolChoice;
+import static dev.langchain4j.model.openai.internal.OpenAiUtils.toTools;
 import static dev.langchain4j.model.openai.internal.chat.ToolType.FUNCTION;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -9,15 +10,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.exception.InternalServerException;
 import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.openai.internal.chat.AssistantMessage;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
 import dev.langchain4j.model.openai.internal.chat.FunctionCall;
+import dev.langchain4j.model.openai.internal.chat.Tool;
 import dev.langchain4j.model.openai.internal.chat.ToolCall;
 import dev.langchain4j.model.openai.internal.chat.ToolChoiceMode;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -272,5 +277,67 @@ class OpenAiUtilsTest {
         assertThatThrownBy(() -> aiMessageFrom(response))
                 .isInstanceOf(InternalServerException.class)
                 .hasMessageContaining("no choices returned");
+    }
+
+    @Test
+    void per_tool_strict_true_should_override_model_level_false() {
+        // given
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("strict_tool")
+                .description("description")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("param")
+                        .required("param")
+                        .build())
+                .strict(true)
+                .build();
+
+        // when - model-level strict is false
+        List<Tool> tools = toTools(List.of(toolSpec), false);
+
+        // then
+        assertThat(tools).hasSize(1);
+        assertThat(tools.get(0).function().strict()).isTrue();
+    }
+
+    @Test
+    void per_tool_strict_false_should_override_model_level_true() {
+        // given
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("non_strict_tool")
+                .description("description")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("param")
+                        .required("param")
+                        .build())
+                .strict(false)
+                .build();
+
+        // when - model-level strict is true
+        List<Tool> tools = toTools(List.of(toolSpec), true);
+
+        // then
+        assertThat(tools).hasSize(1);
+        assertThat(tools.get(0).function().strict()).isNull();
+    }
+
+    @Test
+    void per_tool_strict_null_should_fall_back_to_model_level() {
+        // given
+        ToolSpecification toolSpec = ToolSpecification.builder()
+                .name("default_tool")
+                .description("description")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("param")
+                        .required("param")
+                        .build())
+                .build();
+
+        // when - model-level strict is true
+        List<Tool> tools = toTools(List.of(toolSpec), true);
+
+        // then - falls back to model-level
+        assertThat(tools).hasSize(1);
+        assertThat(tools.get(0).function().strict()).isTrue();
     }
 }


### PR DESCRIPTION
Closes #5128

## Summary

- Adds a `Boolean strict` field to `ToolSpecification` enabling per-tool strict schema enforcement
- When `null` (default), defers to the model-level `strictTools` setting — fully backward compatible
- When `true`/`false`, overrides the model-level default for that specific tool
- Updates `AnthropicMapper` and `OpenAiUtils` to resolve per-tool strict before falling back to the model default
- Includes JSON serialization/deserialization support and tests for all three modules

## Motivation

Anthropic limits strict tools to **20 per request**. Agentic architectures that send 20+ tools in a single request cannot use `strictTools(true)` on the model without hitting this limit. Per-tool strict allows selectively enforcing strict on high-value tools while leaving others non-strict.

## Usage

```java
ToolSpecification.builder()
    .name("runSql")
    .description("Execute a SQL query")
    .parameters(schema)
    .strict(true)   // enforce strict for this tool
    .build();
```

## Test plan

- [x] `ToolSpecificationJsonTest` — round-trip for `strict` true, false, null; rejection of non-boolean
- [x] `AnthropicMapperTest` — per-tool true overrides model null, per-tool false overrides model true, per-tool null falls back to model
- [x] `OpenAiUtilsTest` — same three override/fallback scenarios