### PR TITLE
fix(anthropic): map JsonObjectSchema definitions to $defs

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -479,6 +479,11 @@ public class AnthropicMapper {
             // All Anthropic object schemas require setting additionalProperties=false
             // https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-schema-limitations
             map.put("additionalProperties", false);
+
+            if (!objectSchema.definitions().isEmpty()) {
+                map.put("$defs", mapDefs(objectSchema.definitions()));
+            }
+
             return map;
         }
         if (schemaElement instanceof JsonArraySchema arraySchema) {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -41,6 +41,7 @@ import dev.langchain4j.model.anthropic.internal.api.AnthropicToolResultContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicToolSchema;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import java.net.URI;
 import java.util.AbstractMap;
@@ -273,9 +274,7 @@ class AnthropicMapperTest {
         Map<String, Object> map = toAnthropicSchema(jsonSchemaElement);
 
         // then
-        assertThat(new ObjectMapper().writeValueAsString(map))
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(new ObjectMapper().writeValueAsString(map)).isEqualToIgnoringWhitespace("""
                         {
                           "type": "object",
                           "properties": {
@@ -286,6 +285,47 @@ class AnthropicMapperTest {
                           },
                           "required": ["name", "email", "plan_interest", "demo_requested"],
                           "additionalProperties": false
+                        }
+                       """);
+    }
+
+    @Test
+    void test_toAnthropicSchema_with_definitions() throws JsonProcessingException {
+
+        // given
+        String reference = "Person";
+        JsonSchemaElement personSchema = JsonObjectSchema.builder()
+                .addStringProperty("name")
+                .required("name")
+                .build();
+        JsonSchemaElement rootSchema = JsonObjectSchema.builder()
+                .addProperty(
+                        "person",
+                        JsonReferenceSchema.builder().reference(reference).build())
+                .required("person")
+                .definitions(Map.of(reference, personSchema))
+                .build();
+
+        // when
+        Map<String, Object> map = toAnthropicSchema(rootSchema);
+
+        // then
+        assertThat(new ObjectMapper().writeValueAsString(map)).isEqualToIgnoringWhitespace("""
+                        {
+                          "type": "object",
+                          "properties": {
+                              "person": { "$ref": "#/$defs/Person" }
+                          },
+                          "required": ["person"],
+                          "additionalProperties": false,
+                          "$defs": {
+                              "Person": {
+                                  "type": "object",
+                                  "properties": { "name": { "type": "string" } },
+                                  "required": ["name"],
+                                  "additionalProperties": false
+                              }
+                          }
                         }
                        """);
     }
@@ -306,9 +346,7 @@ class AnthropicMapperTest {
         Map<String, Object> map = toAnthropicSchema(bookRecord);
 
         // then
-        assertThat(new ObjectMapper().writeValueAsString(map))
-                .isEqualToIgnoringWhitespace(
-                        """
+        assertThat(new ObjectMapper().writeValueAsString(map)).isEqualToIgnoringWhitespace("""
                         {
                           "type": "object",
                           "properties": {


### PR DESCRIPTION
## Issue
Closes #5133

## Change

`AnthropicMapper.toAnthropicSchema(...)` no longer mapped `JsonObjectSchema.definitions()` to a `$defs` entry on the produced Anthropic schema. As a result, any tool or response-format schema containing a `JsonReferenceSchema` (e.g. recursive types, or polymorphic AI Service return types lowered to `anyOf` of `$ref`) was serialized with `$ref: "#/$defs/<id>"` entries and no matching `$defs` block, and Anthropic rejected the request:

```
400 Bad Request: invalid_request_error
output_config.format.schema: Invalid schema:
Reference to non-existent definition: #/$defs/15d2a4f5-f977-330a-9c2b-b4d343c805c7
```

This is a regression introduced by #5060 (commit [`205cb5ada`](https://github.com/langchain4j/langchain4j/commit/205cb5adae7e2f9d46419673313b06d8a2934cfc), "AI Services: support polymorphic return types and tool parameters") — that refactor added a `JsonAnyOfSchema` branch but accidentally removed:

```java
if (!objectSchema.definitions().isEmpty()) {
    map.put("$defs", mapDefs(objectSchema.definitions()));
}
```

The pre-existing `mapDefs(...)` helper has remained in the file but became unused.

This PR:
- Re-inserts the `definitions() -> $defs` mapping inside the `JsonObjectSchema` branch of `toAnthropicSchema`. The existing `mapDefs` helper is reused as-is.
- Adds `test_toAnthropicSchema_with_definitions` in `AnthropicMapperTest`, which builds a root `JsonObjectSchema` with a `definitions()` entry referenced via `JsonReferenceSchema` and asserts the produced map contains a matching `$defs` block. Verified failing on `main` and passing with the fix.

Verification:
```
mvn -pl langchain4j-anthropic -Dtest=AnthropicMapperTest test
```
All 24 tests pass.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)