### PR TITLE
fix(tools): throw clear error when LLM omits a required primitive parameter

### DIFF
--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -404,7 +404,8 @@ void getTemperature(
 #### Required and Optional
 
 By default, all tool method parameters are considered **_required_**.
-This means that the LLM will have to produce a value for such a parameter.
+This means the parameter is listed in the JSON schema's `required` array sent to the LLM,
+instructing it to produce a value.
 A parameter can be made optional by annotating it with `@P(required = false)`:
 ```java
 @Tool
@@ -412,6 +413,19 @@ void getTemperature(String location, @P("Unit of temperature", required = false)
     ...
 }
 ```
+
+:::caution Required is advisory: the LLM can still omit arguments
+The `required` flag controls the JSON schema sent to the LLM (required parameters are listed
+in the schema's `required` array). The LLM is expected to honour this, but in practice it can
+disregard the schema and omit an argument anyway.
+
+In LangChain4j 1.x, this is detected only for **primitive** parameters (`int`, `long`, `boolean`, …) — a
+missing primitive triggers the `ToolArgumentsErrorHandler` (see [Error Handling](#handling-tool-arguments-errors)
+below). **Missing object parameters are not validated**: `null` is passed to the
+`@Tool`-annotated method even though the schema marked the parameter as required.
+
+This asymmetry will be removed in LangChain4j 2.0, where all required arguments will be validated uniformly.
+:::
 
 #### Alternative: Using `Optional<T>` for Optional Parameters
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.agent.tool;
 
+import dev.langchain4j.exception.ToolArgumentsException;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -78,6 +80,19 @@ public @interface P {
     /**
      * Whether the parameter is required.
      * Default is {@code true}.
+     * <p>
+     * The {@code required} flag controls the JSON schema sent to the LLM: required parameters are
+     * listed in the schema's {@code required} array. The LLM is expected to honour this, but in
+     * practice it can disregard the schema and omit an argument anyway.
+     * <p>
+     * <b>1.x behaviour when a required argument is missing:</b>
+     * <ul>
+     *   <li><b>Primitive parameters</b> ({@code int}, {@code long}, {@code boolean}, …) — detected
+     *       and surfaced as a {@link ToolArgumentsException}.</li>
+     *   <li><b>Object parameters</b> — not validated; {@code null} is passed to the
+     *       {@link Tool}-annotated method, even though the schema marked the parameter as required.</li>
+     * </ul>
+     * This asymmetry will be removed in LangChain4j 2.0, where all required arguments will be validated uniformly.
      *
      * @return {@code true} if the parameter is required, {@code false} otherwise
      */

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -143,7 +143,7 @@ public class DefaultToolExecutor implements ToolExecutor {
     private Object[] prepareArguments(ToolExecutionRequest toolExecutionRequest, InvocationContext context) {
         try {
             Map<String, Object> argumentsMap = argumentsAsMap(toolExecutionRequest.arguments());
-            return prepareArguments(originalMethod, argumentsMap, context);
+            return prepareArguments(originalMethod, toolExecutionRequest.name(), argumentsMap, context);
         } catch (Exception e) {
             if (wrapToolArgumentsExceptions) {
                 throw new ToolArgumentsException(unwrapRuntimeException(e));
@@ -196,7 +196,8 @@ public class DefaultToolExecutor implements ToolExecutor {
         }
     }
 
-    static Object[] prepareArguments(Method method, Map<String, Object> argumentsMap, InvocationContext context) {
+    static Object[] prepareArguments(
+            Method method, String toolName, Map<String, Object> argumentsMap, InvocationContext context) {
         Parameter[] parameters = method.getParameters();
         Object[] arguments = new Object[parameters.length];
 
@@ -233,6 +234,9 @@ public class DefaultToolExecutor implements ToolExecutor {
                 arguments[i] = createOptional(argument, parameterName, parameterType);
             } else if (argument != null) {
                 arguments[i] = coerceArgument(argument, parameterName, parameterClass, parameterType);
+            } else if (parameterClass.isPrimitive()) {
+                throw new IllegalArgumentException(String.format(
+                        "Required parameter \"%s\" of tool \"%s\" is missing", parameterName, toolName));
             }
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -11,6 +11,7 @@ import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.ReturnBehavior;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -37,6 +38,7 @@ import dev.langchain4j.service.Result;
 import dev.langchain4j.service.tool.search.ToolSearchService;
 import dev.langchain4j.service.tool.search.ToolSearchStrategy;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -131,6 +133,24 @@ public class ToolService {
         addTools(tools, this.toolExecutors, this.toolSpecifications, this.returnBehaviors);
     }
 
+    private static void validateToolParameters(Method toolMethod) {
+        for (Parameter parameter : toolMethod.getParameters()) {
+            if (!parameter.getType().isPrimitive()) {
+                continue;
+            }
+            P pAnnotation = parameter.getAnnotation(P.class);
+            if (pAnnotation != null && !pAnnotation.required()) {
+                throw illegalConfiguration(
+                        "Parameter '%s' of tool '%s.%s' is a primitive (%s) and cannot be marked as @P(required = false). "
+                                + "Use a boxed type (e.g. Integer instead of int) or Optional<T> to allow optional values.",
+                        parameter.getName(),
+                        toolMethod.getDeclaringClass().getName(),
+                        toolMethod.getName(),
+                        parameter.getType().getName());
+            }
+        }
+    }
+
     private static ToolExecutor createToolExecutor(Object object, Method method) {
         return DefaultToolExecutor.builder()
                 .object(object)
@@ -166,6 +186,7 @@ public class ToolService {
             Optional<Method> annotatedMethod = getAnnotatedMethod(method, Tool.class);
             if (annotatedMethod.isPresent()) {
                 Method toolMethod = annotatedMethod.get();
+                validateToolParameters(toolMethod);
                 result.add(AiServiceTool.builder()
                         .toolSpecification(toolSpecificationFrom(toolMethod))
                         .toolExecutor(createToolExecutor(objectWithTools, toolMethod))

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesBuilderTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesBuilderTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 
+import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.mock.ChatModelMock;
@@ -159,5 +160,23 @@ class AiServicesBuilderTest {
                         .tools((Object) listOfTools) // passing a List as a single tool object
                         .build())
                 .withMessageContaining("is an Iterable");
+    }
+
+    @Test
+    void should_raise_an_error_when_primitive_tool_parameter_is_marked_as_optional() {
+        class ToolWithOptionalPrimitive {
+            @Tool("Read part of a file")
+            void readFile(String filePath, @P(required = false) int startLine) {}
+        }
+
+        ChatModel chatModel = ChatModelMock.thatAlwaysResponds("Hello there!");
+
+        assertThatExceptionOfType(IllegalConfigurationException.class)
+                .isThrownBy(() -> AiServices.builder(TestService.class)
+                        .chatModel(chatModel)
+                        .tools(new ToolWithOptionalPrimitive())
+                        .build())
+                .withMessageContaining("is a primitive")
+                .withMessageContaining("@P(required = false)");
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithRequiredIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithRequiredIT.java
@@ -4,16 +4,21 @@ import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
 import static dev.langchain4j.service.AiServicesIT.verifyNoMoreInteractionsFor;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
@@ -242,5 +247,38 @@ class AiServicesWithToolsWithRequiredIT {
         ToolSpecification toolSpecification = toolSpecifications.get(0);
         assertThat(toolSpecification.name()).isEqualTo("process");
         assertThat(toolSpecification.parameters()).isEqualTo(ToolWithOptionalComplexType.EXPECTED_SCHEMA);
+    }
+
+    @Test
+    void should_fail_when_LLM_omits_required_primitive_parameter() {
+
+        // given
+        class ToolWithPrimitiveParameter {
+
+            @Tool
+            void process(@P("name") String name, @P("age") int age) {
+                // this method is empty
+            }
+        }
+
+        ToolWithPrimitiveParameter tool = spy(new ToolWithPrimitiveParameter());
+
+        ChatModel chatModelMock = spy(ChatModelMock.thatAlwaysResponds(AiMessage.from(ToolExecutionRequest.builder()
+                .id("1")
+                .name("process")
+                .arguments("{\"arg0\":\"Klaus\"}")
+                .build())));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModelMock)
+                .tools(tool)
+                .build();
+
+        // when - then
+        assertThatThrownBy(() -> assistant.chat("does not matter"))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContainingAll("Required parameter", "arg1");
+
+        verifyNoInteractions(tool);
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolMemoryId;
+import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.invocation.InvocationContext;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
@@ -119,7 +120,7 @@ class DefaultToolExecutorTest implements WithAssertions {
         InvocationContext invocationContext =
                 InvocationContext.builder().chatMemoryId(memoryId).build();
 
-        Object[] args = DefaultToolExecutor.prepareArguments(method, arguments, invocationContext);
+        Object[] args = DefaultToolExecutor.prepareArguments(method, "example", arguments, invocationContext);
 
         assertThat(args)
                 .containsExactly(
@@ -150,7 +151,7 @@ class DefaultToolExecutorTest implements WithAssertions {
             as.put("arg1", "abc");
 
             assertThatExceptionOfType(IllegalArgumentException.class)
-                    .isThrownBy(() -> DefaultToolExecutor.prepareArguments(method, as, invocationContext))
+                    .isThrownBy(() -> DefaultToolExecutor.prepareArguments(method, "example", as, invocationContext))
                     .withMessage("Argument \"arg1\" is not convertable to int, got java.lang.String: <abc>")
                     .withNoCause();
         }
@@ -637,7 +638,7 @@ class DefaultToolExecutorTest implements WithAssertions {
         InvocationContext context = InvocationContext.builder().build();
 
         // when
-        Object[] args = DefaultToolExecutor.prepareArguments(method, arguments, context);
+        Object[] args = DefaultToolExecutor.prepareArguments(method, "tool", arguments, context);
 
         // then
         assertThat(args).hasSize(2);
@@ -661,12 +662,51 @@ class DefaultToolExecutorTest implements WithAssertions {
         InvocationContext context = InvocationContext.builder().build();
 
         // when
-        Object[] args = DefaultToolExecutor.prepareArguments(method, arguments, context);
+        Object[] args = DefaultToolExecutor.prepareArguments(method, "tool", arguments, context);
 
         // then
         assertThat(args).hasSize(2);
         assertThat(args[0]).isEqualTo("Klaus");
         assertThat(args[1]).isInstanceOf(Optional.class);
         assertThat((Optional<?>) args[1]).isEmpty();
+    }
+
+    @SuppressWarnings("unused")
+    public void primitiveTool(String filePath, int startLine, int endLine) {}
+
+    @Test
+    void should_throw_when_required_primitive_is_missing() throws Exception {
+        Method method = getClass().getMethod("primitiveTool", String.class, int.class, int.class);
+        Map<String, Object> arguments = new HashMap<>();
+        arguments.put("arg0", "/tmp/foo.txt");
+
+        InvocationContext context = InvocationContext.builder().build();
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> DefaultToolExecutor.prepareArguments(method, "primitiveTool", arguments, context))
+                .withMessageContaining("Required parameter")
+                .withMessageContaining("arg1")
+                .withMessageContaining("primitiveTool");
+    }
+
+    @Test
+    void should_wrap_missing_required_primitive_into_ToolArgumentsException_when_configured() throws Exception {
+        Method method = getClass().getMethod("primitiveTool", String.class, int.class, int.class);
+        DefaultToolExecutor executor = DefaultToolExecutor.builder()
+                .object(this)
+                .originalMethod(method)
+                .methodToInvoke(method)
+                .wrapToolArgumentsExceptions(true)
+                .build();
+
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("1")
+                .name("primitiveTool")
+                .arguments("{ \"arg0\": \"/tmp/foo.txt\" }")
+                .build();
+
+        assertThatExceptionOfType(ToolArgumentsException.class)
+                .isThrownBy(() -> executor.execute(request, "DEFAULT"))
+                .withCauseInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
## Issue
Fixes #5085

## Change
- When the LLM omitted a required primitive parameter (e.g. `int`, `boolean`), Java reflection threw a generic NPE during unboxing (`Cannot invoke
  "java.lang.Number.intValue()" because the return value of "sun.invoke.util.ValueConversions.primitiveConversion(...)" is null`). The error leaked JVM-internal `MethodHandle`
  plumbing and gave the LLM nothing actionable to retry with.
- Now `DefaultToolExecutor.prepareArguments` detects the missing primitive up front and throws `IllegalArgumentException("Required parameter \"argN\" of tool \"toolName\" is
  missing")`. The exception flows through the existing `wrapToolArgumentsExceptions` path, so AI Service users see a `ToolArgumentsException` (with the original
  `IllegalArgumentException` as cause) and can route it through `toolArgumentsErrorHandler` as usual.
- Adds eager validation at AI Service build time: `@P(required = false)` on a primitive parameter is contradictory (primitives cannot represent absence) and now fails with
  `IllegalConfigurationException` from `ToolService.findTools`, alongside the other tool-misconfig checks. This catches the developer error before any LLM call.

## Breaking changes

1. **Default behavior: AI Service now throws when the LLM omits a required primitive parameter, instead of letting the LLM receive an obscure error message.**

Before this PR, when the LLM called a tool without a required primitive, Java reflection NPE'd during unboxing. That NPE bubbled up through the *tool execution* error path (`InvocationTargetException` → `ToolExecutionException`) and the default `toolExecutionErrorHandler` returned the (ugly, JVM-internal) message to the LLM as a tool result with `isError=true`. The agent loop continued and the LLM had a chance to retry with corrected arguments.

After this PR, the missing primitive is detected before the method is invoked and surfaced as an *arguments* error (`IllegalArgumentException` → wrapped as `ToolArgumentsException`). It is now routed through `toolArgumentsErrorHandler`, whose default is to **throw** — so `assistant.chat(...)` propagates the exception out and the AI Service flow stops.

**Net effect:** what used to be a (clumsy) recoverable agent step is now a fatal error by default. Users who relied on the LLM-driven recovery for missing primitives must configure a `toolArgumentsErrorHandler` that returns the error to the LLM:
```java
AiServices.builder(...)
    ...
    .toolArgumentsErrorHandler((error, ctx) -> ToolErrorHandlerResult.text(error.getMessage()))
    .build();
```
The exception text itself is also cleaner: `IllegalArgumentException("Required parameter \"argN\" of tool \"...\" is missing") ` instead of the previous `NullPointerException("Cannot invoke \"java.lang.Number.intValue()\" ...")`. Anyone catching the NPE by type or matching its text will need to update.

2. `@P(required = false)` on a primitive parameter now fails at AI Service build time.

Previously this misconfiguration silently passed validation and produced the runtime NPE described above whenever the LLM happened to omit the parameter.
Now `AiServices.builder(...).tools(yourToolObject).build()` throws `IllegalConfigurationException` immediately, naming the offending ClassName.methodName.

Migration: if you really want parameter to be optional, change the parameter to a boxed type (`Integer`, `Long`, `Boolean`, …) or `Optional<T>`.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)