### PR TITLE
fix(vertex-ai-gemini): preserve thought signatures

### DIFF
--- a/docs/docs/integrations/language-models/google-vertex-ai-gemini.md
+++ b/docs/docs/integrations/language-models/google-vertex-ai-gemini.md
@@ -296,6 +296,29 @@ The model will then be able to reply with a text response.
 
 Parallel function calling is also supported, when the model asks to make multiple tool execution requests in a single response.
 
+### Function call thought signatures
+
+Some Vertex AI Gemini models require
+[thought signatures](https://cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures)
+returned with function calls to be sent back in follow-up requests.
+
+To preserve and send these signatures, enable both `returnThinking(true)` and `sendThinking(true)`:
+
+```java
+ChatModel model = VertexAiGeminiChatModel.builder()
+        .project(PROJECT_ID)
+        .location(LOCATION)
+        .modelName(MODEL_NAME)
+        .returnThinking(true)
+        .sendThinking(true)
+        .build();
+```
+
+:::note
+For Vertex AI Gemini, these settings do not enable or return thinking text.
+They only preserve and send thought signatures returned with function calls.
+:::
+
 ### Tool support with AiServices
 
 You can use `AiServices` to create your own assistants powered by tools.

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/ContentsMapper.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/ContentsMapper.java
@@ -8,7 +8,6 @@ import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,14 +19,17 @@ class ContentsMapper {
 
         @Override
         public String toString() {
-            return "InstructionAndContent {\n" +
-                " systemInstruction = " + systemInstruction +
-                ",\n contents = " + contents +
-                "\n}";
+            return "InstructionAndContent {\n" + " systemInstruction = "
+                    + systemInstruction + ",\n contents = "
+                    + contents + "\n}";
         }
     }
 
     static InstructionAndContent splitInstructionAndContent(List<ChatMessage> messages) {
+        return splitInstructionAndContent(messages, false);
+    }
+
+    static InstructionAndContent splitInstructionAndContent(List<ChatMessage> messages, boolean sendThinking) {
         InstructionAndContent instructionAndContent = new InstructionAndContent();
         List<Part> sysInstructionParts = new ArrayList<>();
 
@@ -42,7 +44,7 @@ class ContentsMapper {
                 if (isLastMessage) {
                     // if there's no accumulated tool results, add it right away to the list of messages
                     if (executionResultMessages.isEmpty()) {
-                        instructionAndContent.contents.add(createContent(message));
+                        instructionAndContent.contents.add(createContent(message, sendThinking));
                     } else { // otherwise add to the list, and create the new user message with all the tool results
                         executionResultMessages.add(toolResult);
                         instructionAndContent.contents.add(createToolExecutionResultContent(executionResultMessages));
@@ -60,7 +62,7 @@ class ContentsMapper {
 
                 // directly add user and AI messages to the list
                 if (message instanceof UserMessage || message instanceof AiMessage) {
-                    instructionAndContent.contents.add(createContent(message));
+                    instructionAndContent.contents.add(createContent(message, sendThinking));
                 } else if (message instanceof SystemMessage) { // save system messages separately
                     sysInstructionParts.addAll(PartsMapper.map(message));
                 }
@@ -70,32 +72,31 @@ class ContentsMapper {
         // if there are system instructions, collect them together into one system instruction Content
         if (!sysInstructionParts.isEmpty()) {
             instructionAndContent.systemInstruction = Content.newBuilder()
-                .setRole("system")
-                .addAllParts(sysInstructionParts)
-                .build();
+                    .setRole("system")
+                    .addAllParts(sysInstructionParts)
+                    .build();
         }
 
         return instructionAndContent;
     }
 
     // transform a LangChain4j ChatMessage into a Gemini Content
-    private static Content createContent(ChatMessage message) {
+    private static Content createContent(ChatMessage message, boolean sendThinking) {
         return Content.newBuilder()
-            .setRole(RoleMapper.map(message.type()))
-            .addAllParts(PartsMapper.map(message))
-            .build();
+                .setRole(RoleMapper.map(message.type()))
+                .addAllParts(PartsMapper.map(message, sendThinking))
+                .build();
     }
 
     // transform a list of LangChain4j tool execution results
     // into a user message made of multiple Gemini Parts
     private static Content createToolExecutionResultContent(List<ToolExecutionResultMessage> executionResultMessages) {
         return Content.newBuilder()
-            .setRole(RoleMapper.map(ChatMessageType.TOOL_EXECUTION_RESULT))
-            .addAllParts(
-                executionResultMessages.stream()
-                    .map(PartsMapper::map)
-                    .flatMap(List::stream)
-                    .collect(Collectors.toList()))
-            .build();
+                .setRole(RoleMapper.map(ChatMessageType.TOOL_EXECUTION_RESULT))
+                .addAllParts(executionResultMessages.stream()
+                        .map(PartsMapper::map)
+                        .flatMap(List::stream)
+                        .collect(Collectors.toList()))
+                .build();
     }
 }

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/FunctionCallHelper.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/FunctionCallHelper.java
@@ -6,10 +6,14 @@ import com.google.cloud.vertexai.api.*;
 import com.google.gson.Gson;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Struct;
+import com.google.protobuf.UnknownFieldSet;
 import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +23,9 @@ import java.util.stream.IntStream;
 class FunctionCallHelper {
 
     private static final Gson GSON = new Gson();
+    private static final int THOUGHT_SIGNATURE_FIELD_NUMBER = 11;
+    private static final String FUNCTION_CALL_PART_THOUGHT_SIGNATURES_KEY =
+            "vertex_ai_gemini_function_call_part_thought_signatures";
 
     static FunctionCall fromToolExecutionRequest(ToolExecutionRequest toolExecutionRequest) {
         FunctionCall.Builder fnCallBuilder = FunctionCall.newBuilder().setName(toolExecutionRequest.name());
@@ -41,6 +48,41 @@ class FunctionCallHelper {
         return IntStream.range(0, functionCalls.size())
                 .mapToObj(index -> fromFunctionCall(index, functionCalls.get(index)))
                 .toList();
+    }
+
+    static AiMessage fromFunctionCallParts(List<Part> functionCallParts, boolean returnThinking) {
+        List<ToolExecutionRequest> toolExecutionRequests = IntStream.range(0, functionCallParts.size())
+                .mapToObj(index ->
+                        fromFunctionCall(index, functionCallParts.get(index).getFunctionCall()))
+                .toList();
+
+        Map<String, Object> attributes = returnThinking ? attributesFromFunctionCallParts(functionCallParts) : Map.of();
+
+        return AiMessage.builder()
+                .toolExecutionRequests(toolExecutionRequests)
+                .attributes(attributes)
+                .build();
+    }
+
+    static List<Part> toFunctionCallParts(AiMessage aiMessage, boolean sendThinking) {
+        List<String> encodedThoughtSignatures = sendThinking ? functionCallPartThoughtSignatures(aiMessage) : List.of();
+        List<Part> parts = new ArrayList<>(aiMessage.toolExecutionRequests().size());
+
+        for (int i = 0; i < aiMessage.toolExecutionRequests().size(); i++) {
+            ToolExecutionRequest toolExecutionRequest =
+                    aiMessage.toolExecutionRequests().get(i);
+            Part.Builder partBuilder =
+                    Part.newBuilder().setFunctionCall(fromToolExecutionRequest(toolExecutionRequest));
+
+            UnknownFieldSet thoughtSignature = decodeThoughtSignature(encodedThoughtSignatures, i);
+            if (!thoughtSignature.asMap().isEmpty()) {
+                partBuilder.mergeUnknownFields(thoughtSignature);
+            }
+
+            parts.add(partBuilder.build());
+        }
+
+        return parts;
     }
 
     /**
@@ -99,6 +141,60 @@ class FunctionCallHelper {
                 break;
         }
         return unwrappedValue;
+    }
+
+    private static Map<String, Object> attributesFromFunctionCallParts(List<Part> functionCallParts) {
+        List<String> encodedThoughtSignatures = functionCallParts.stream()
+                .map(FunctionCallHelper::thoughtSignatureUnknownField)
+                .map(UnknownFieldSet::toByteArray)
+                .map(bytes -> Base64.getEncoder().encodeToString(bytes))
+                .toList();
+
+        boolean hasThoughtSignatures = encodedThoughtSignatures.stream().anyMatch(encoded -> !encoded.isEmpty());
+        if (!hasThoughtSignatures) {
+            return Map.of();
+        }
+
+        return Map.of(FUNCTION_CALL_PART_THOUGHT_SIGNATURES_KEY, encodedThoughtSignatures);
+    }
+
+    private static UnknownFieldSet thoughtSignatureUnknownField(Part part) {
+        return thoughtSignatureUnknownField(part.getUnknownFields());
+    }
+
+    private static UnknownFieldSet thoughtSignatureUnknownField(UnknownFieldSet unknownFields) {
+        UnknownFieldSet.Field thoughtSignature = unknownFields.asMap().get(THOUGHT_SIGNATURE_FIELD_NUMBER);
+        if (thoughtSignature == null
+                || thoughtSignature.getLengthDelimitedList().isEmpty()) {
+            return UnknownFieldSet.getDefaultInstance();
+        }
+
+        return UnknownFieldSet.newBuilder()
+                .addField(THOUGHT_SIGNATURE_FIELD_NUMBER, thoughtSignature)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> functionCallPartThoughtSignatures(AiMessage aiMessage) {
+        Object encodedThoughtSignatures = aiMessage.attributes().get(FUNCTION_CALL_PART_THOUGHT_SIGNATURES_KEY);
+        if (encodedThoughtSignatures instanceof List
+                && ((List<?>) encodedThoughtSignatures).stream().allMatch(String.class::isInstance)) {
+            return (List<String>) encodedThoughtSignatures;
+        }
+        return List.of();
+    }
+
+    private static UnknownFieldSet decodeThoughtSignature(List<String> encodedThoughtSignatures, int index) {
+        if (index >= encodedThoughtSignatures.size() || isNullOrBlank(encodedThoughtSignatures.get(index))) {
+            return UnknownFieldSet.getDefaultInstance();
+        }
+
+        try {
+            return thoughtSignatureUnknownField(
+                    UnknownFieldSet.parseFrom(Base64.getDecoder().decode(encodedThoughtSignatures.get(index))));
+        } catch (InvalidProtocolBufferException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     static Tool convertToolSpecifications(List<ToolSpecification> toolSpecifications) {

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/PartsMapper.java
@@ -13,7 +13,6 @@ import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
 import dev.langchain4j.data.audio.Audio;
-import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.AudioContent;
@@ -28,6 +27,7 @@ import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.message.VideoContent;
 import dev.langchain4j.data.pdf.PdfFile;
 import dev.langchain4j.data.video.Video;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -84,6 +84,10 @@ class PartsMapper {
     }
 
     static List<Part> map(ChatMessage message) {
+        return map(message, false);
+    }
+
+    static List<Part> map(ChatMessage message, boolean sendThinking) {
         if (message instanceof AiMessage aiMessage) {
 
             List<Part> parts = new ArrayList<>();
@@ -93,12 +97,7 @@ class PartsMapper {
             }
 
             if (aiMessage.hasToolExecutionRequests()) {
-                List<Part> fnCallReqParts = aiMessage.toolExecutionRequests().stream()
-                        .map(FunctionCallHelper::fromToolExecutionRequest)
-                        .map(fnCall -> Part.newBuilder().setFunctionCall(fnCall).build())
-                        .toList();
-
-                parts.addAll(fnCallReqParts);
+                parts.addAll(FunctionCallHelper.toFunctionCallParts(aiMessage, sendThinking));
             }
 
             return parts;

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/StreamingChatResponseBuilder.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/StreamingChatResponseBuilder.java
@@ -6,7 +6,6 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,10 +14,20 @@ class StreamingChatResponseBuilder {
 
     private final StringBuffer contentBuilder = new StringBuffer();
 
-    private final List<FunctionCall> functionCalls = new ArrayList<>();
+    private final List<Part> functionCallParts = new ArrayList<>();
+
+    private final boolean returnThinking;
 
     private volatile TokenUsage tokenUsage;
     private volatile FinishReason finishReason;
+
+    StreamingChatResponseBuilder() {
+        this(false);
+    }
+
+    StreamingChatResponseBuilder(boolean returnThinking) {
+        this.returnThinking = returnThinking;
+    }
 
     record TextAndFunctions(String text, List<FunctionCall> functionCalls) {}
 
@@ -35,17 +44,19 @@ class StreamingChatResponseBuilder {
         String text = ResponseHandler.getText(partialResponse);
         contentBuilder.append(text);
 
-        List<FunctionCall> functionCalls = candidates.stream()
+        List<Part> functionCallParts = candidates.stream()
                 .map(Candidate::getContent)
                 .map(Content::getPartsList)
                 .flatMap(List::stream)
                 .filter(Part::hasFunctionCall)
-                .map(Part::getFunctionCall)
                 .collect(Collectors.toList());
 
-        if (!functionCalls.isEmpty()) {
-            this.functionCalls.addAll(functionCalls);
+        if (!functionCallParts.isEmpty()) {
+            this.functionCallParts.addAll(functionCallParts);
         }
+
+        List<FunctionCall> functionCalls =
+                functionCallParts.stream().map(Part::getFunctionCall).collect(Collectors.toList());
 
         if (partialResponse.hasUsageMetadata()) {
             tokenUsage = TokenUsageMapper.map(partialResponse.getUsageMetadata());
@@ -60,18 +71,13 @@ class StreamingChatResponseBuilder {
     }
 
     Response<AiMessage> build() {
-        if (!functionCalls.isEmpty()) {
+        if (!functionCallParts.isEmpty()) {
             return Response.from(
-                AiMessage.from(FunctionCallHelper.fromFunctionCalls(functionCalls)),
-                tokenUsage,
-                finishReason
-            );
+                    FunctionCallHelper.fromFunctionCallParts(functionCallParts, returnThinking),
+                    tokenUsage,
+                    finishReason);
         } else {
-            return Response.from(
-                AiMessage.from(contentBuilder.toString()),
-                tokenUsage,
-                finishReason
-            );
+            return Response.from(AiMessage.from(contentBuilder.toString()), tokenUsage, finishReason);
         }
     }
 }

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -14,7 +14,6 @@ import static java.util.Collections.emptyList;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.Content;
-import com.google.cloud.vertexai.api.FunctionCall;
 import com.google.cloud.vertexai.api.FunctionCallingConfig;
 import com.google.cloud.vertexai.api.GenerateContentRequest;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
@@ -26,7 +25,6 @@ import com.google.cloud.vertexai.api.ToolConfig;
 import com.google.cloud.vertexai.generativeai.GenerativeModel;
 import com.google.cloud.vertexai.generativeai.ResponseHandler;
 import com.google.common.annotations.VisibleForTesting;
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
@@ -101,6 +99,8 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
     private final Set<Capability> supportedCapabilities;
 
     private final Map<String, String> labels;
+    private final boolean returnThinking;
+    private final boolean sendThinking;
 
     public VertexAiGeminiChatModel(VertexAiGeminiChatModelBuilder builder) {
         ensureNotBlank(builder.modelName, "modelName");
@@ -217,6 +217,8 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
         this.labels = copy(builder.labels);
+        this.returnThinking = getOrDefault(builder.returnThinking, false);
+        this.sendThinking = getOrDefault(builder.sendThinking, false);
     }
 
     /**
@@ -345,6 +347,8 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         this.listeners = listeners == null ? emptyList() : new ArrayList<>(listeners);
         this.supportedCapabilities = copy(supportedCapabilities);
         this.labels = Collections.emptyMap();
+        this.returnThinking = false;
+        this.sendThinking = false;
     }
 
     public VertexAiGeminiChatModel(GenerativeModel generativeModel, GenerationConfig generationConfig) {
@@ -371,6 +375,8 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         this.listeners = Collections.emptyList();
         this.supportedCapabilities = Set.of();
         this.labels = Collections.emptyMap();
+        this.returnThinking = false;
+        this.sendThinking = false;
     }
 
     @Override
@@ -436,7 +442,7 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
                 .withToolConfig(this.toolConfig);
 
         ContentsMapper.InstructionAndContent instructionAndContent =
-                ContentsMapper.splitInstructionAndContent(messages);
+                ContentsMapper.splitInstructionAndContent(messages, sendThinking);
 
         if (instructionAndContent.systemInstruction != null) {
             model = model.withSystemInstruction(instructionAndContent.systemInstruction);
@@ -513,18 +519,14 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
 
         Content content = ResponseHandler.getContent(response);
 
-        List<FunctionCall> functionCalls = content.getPartsList().stream()
-                .filter(Part::hasFunctionCall)
-                .map(Part::getFunctionCall)
-                .toList();
+        List<Part> functionCallParts =
+                content.getPartsList().stream().filter(Part::hasFunctionCall).toList();
 
         final Response<AiMessage> finalResponse;
         final AiMessage aiMessage;
 
-        if (!functionCalls.isEmpty()) {
-            List<ToolExecutionRequest> toolExecutionRequests = FunctionCallHelper.fromFunctionCalls(functionCalls);
-
-            aiMessage = AiMessage.from(toolExecutionRequests);
+        if (!functionCallParts.isEmpty()) {
+            aiMessage = FunctionCallHelper.fromFunctionCallParts(functionCallParts, returnThinking);
         } else {
             aiMessage = AiMessage.from(ResponseHandler.getText(response));
         }
@@ -569,6 +571,14 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
     @VisibleForTesting
     Map<String, String> labels() {
         return this.labels;
+    }
+
+    public boolean returnThinking() {
+        return returnThinking;
+    }
+
+    public boolean sendThinking() {
+        return sendThinking;
     }
 
     // mirrors the SDK's private GenerativeModel.buildGenerateContentRequest envelope and
@@ -656,6 +666,8 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         private GoogleCredentials credentials;
         private String apiEndpoint;
         private Map<String, String> labels;
+        private Boolean returnThinking;
+        private Boolean sendThinking;
 
         public VertexAiGeminiChatModelBuilder() {
             // This is public so it can be extended
@@ -810,6 +822,16 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
          */
         public VertexAiGeminiChatModelBuilder labels(Map<String, String> labels) {
             this.labels = labels;
+            return this;
+        }
+
+        public VertexAiGeminiChatModelBuilder returnThinking(Boolean returnThinking) {
+            this.returnThinking = returnThinking;
+            return this;
+        }
+
+        public VertexAiGeminiChatModelBuilder sendThinking(Boolean sendThinking) {
+            this.sendThinking = sendThinking;
             return this;
         }
 

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModel.java
@@ -91,6 +91,8 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
     private final Executor executor;
 
     private final Map<String, String> labels;
+    private final Boolean returnThinking;
+    private final boolean sendThinking;
 
     public VertexAiGeminiStreamingChatModel(VertexAiGeminiStreamingChatModelBuilder builder) {
         ensureNotBlank(builder.modelName, "modelName");
@@ -199,6 +201,8 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         this.listeners = copy(builder.listeners);
         this.executor = getOrDefault(builder.executor, VertexAiGeminiStreamingChatModel::createDefaultExecutor);
         this.labels = copy(builder.labels);
+        this.returnThinking = getOrDefault(builder.returnThinking, false);
+        this.sendThinking = getOrDefault(builder.sendThinking, false);
     }
 
     /**
@@ -328,6 +332,8 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         this.listeners = listeners == null ? emptyList() : new ArrayList<>(listeners);
         this.executor = getOrDefault(executor, VertexAiGeminiStreamingChatModel::createDefaultExecutor);
         this.labels = Collections.emptyMap();
+        this.returnThinking = false;
+        this.sendThinking = false;
     }
 
     public VertexAiGeminiStreamingChatModel(GenerativeModel generativeModel, GenerationConfig generationConfig) {
@@ -348,6 +354,8 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         this.listeners = Collections.emptyList();
         this.executor = VertexAiGeminiStreamingChatModel.createDefaultExecutor();
         this.labels = Collections.emptyMap();
+        this.returnThinking = false;
+        this.sendThinking = false;
     }
 
     public VertexAiGeminiStreamingChatModel(
@@ -369,6 +377,8 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         this.listeners = Collections.emptyList();
         this.executor = getOrDefault(executor, VertexAiGeminiStreamingChatModel::createDefaultExecutor);
         this.labels = Collections.emptyMap();
+        this.returnThinking = false;
+        this.sendThinking = false;
     }
 
     private static ExecutorService createDefaultExecutor() {
@@ -416,7 +426,7 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         GenerativeModel model = this.generativeModel.withTools(tools).withToolConfig(this.toolConfig);
 
         ContentsMapper.InstructionAndContent instructionAndContent =
-                ContentsMapper.splitInstructionAndContent(messages);
+                ContentsMapper.splitInstructionAndContent(messages, sendThinking);
 
         if (instructionAndContent.systemInstruction != null) {
             model = model.withSystemInstruction(instructionAndContent.systemInstruction);
@@ -451,7 +461,7 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
             }
         });
 
-        StreamingChatResponseBuilder responseBuilder = new StreamingChatResponseBuilder();
+        StreamingChatResponseBuilder responseBuilder = new StreamingChatResponseBuilder(returnThinking);
         final GenerativeModel finalModel = model;
         AtomicInteger toolIndex = new AtomicInteger(0);
         StreamingHandle streamingHandle = new VertexAiGeminiStreamingHandle();
@@ -555,6 +565,14 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         return this.labels;
     }
 
+    public Boolean returnThinking() {
+        return returnThinking;
+    }
+
+    public boolean sendThinking() {
+        return sendThinking;
+    }
+
     @Override
     public void close() {
         if (this.vertexAI != null) {
@@ -607,6 +625,8 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         private GoogleCredentials credentials;
         private String apiEndpoint;
         private Map<String, String> labels;
+        private Boolean returnThinking;
+        private Boolean sendThinking;
 
         public VertexAiGeminiStreamingChatModelBuilder() {
             // This is public so it can be extended
@@ -755,6 +775,16 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
          */
         public VertexAiGeminiStreamingChatModelBuilder labels(Map<String, String> labels) {
             this.labels = labels;
+            return this;
+        }
+
+        public VertexAiGeminiStreamingChatModelBuilder returnThinking(Boolean returnThinking) {
+            this.returnThinking = returnThinking;
+            return this;
+        }
+
+        public VertexAiGeminiStreamingChatModelBuilder sendThinking(Boolean sendThinking) {
+            this.sendThinking = sendThinking;
             return this;
         }
 

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/ContentsMapperTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/ContentsMapperTest.java
@@ -4,7 +4,11 @@ import static dev.langchain4j.model.vertexai.gemini.ContentsMapper.splitInstruct
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.cloud.vertexai.api.Content;
+import com.google.cloud.vertexai.api.FunctionCall;
+import com.google.cloud.vertexai.api.Part;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Struct;
+import com.google.protobuf.UnknownFieldSet;
 import com.google.protobuf.Value;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
@@ -259,6 +263,27 @@ class ContentsMapperTest {
                         .getFunctionCall()
                         .getName())
                 .isEqualTo("Request");
+    }
+
+    @Test
+    void should_send_function_call_part_thought_signature_only_when_send_thinking_is_enabled() {
+        // given
+        Part functionCallPart = Part.newBuilder()
+                .setFunctionCall(FunctionCall.newBuilder().setName("getWeather").build())
+                .mergeUnknownFields(unknownFields("thought-signature"))
+                .build();
+        AiMessage aiMessage = FunctionCallHelper.fromFunctionCallParts(List.of(functionCallPart), true);
+
+        // when
+        Content contentWithoutThinking =
+                splitInstructionAndContent(List.of(aiMessage)).contents.get(0);
+        Content contentWithThinking =
+                splitInstructionAndContent(List.of(aiMessage), true).contents.get(0);
+
+        // then
+        assertThat(contentWithoutThinking.getParts(0).getUnknownFields().asMap())
+                .isEmpty();
+        assertThat(contentWithThinking.getParts(0).getUnknownFields()).isEqualTo(functionCallPart.getUnknownFields());
     }
 
     @Test
@@ -836,5 +861,15 @@ class ContentsMapperTest {
                 .getResponse();
         assertThat(response.getFieldsMap().get("url").getStringValue())
                 .isEqualTo("https://example.com/path?query=value&other=123");
+    }
+
+    private static UnknownFieldSet unknownFields(String thoughtSignature) {
+        return UnknownFieldSet.newBuilder()
+                .addField(
+                        11,
+                        UnknownFieldSet.Field.newBuilder()
+                                .addLengthDelimited(ByteString.copyFromUtf8(thoughtSignature))
+                                .build())
+                .build();
     }
 }

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/FunctionCallHelperTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/FunctionCallHelperTest.java
@@ -5,17 +5,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.cloud.vertexai.api.FunctionCall;
 import com.google.cloud.vertexai.api.FunctionDeclaration;
+import com.google.cloud.vertexai.api.Part;
 import com.google.cloud.vertexai.api.Schema;
 import com.google.cloud.vertexai.api.Tool;
 import com.google.cloud.vertexai.api.Type;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
 import com.google.protobuf.Struct;
+import com.google.protobuf.UnknownFieldSet;
 import com.google.protobuf.Value;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -174,5 +179,200 @@ class FunctionCallHelperTest {
 
         // then
         assertThat(newExecutionRequest).isEqualTo(sameExecutionRequest);
+    }
+
+    @Test
+    void should_round_trip_function_call_part_thought_signature() {
+        // given
+        Part functionCallPart = Part.newBuilder()
+                .setFunctionCall(FunctionCall.newBuilder()
+                        .setName("getWeatherForecast")
+                        .setArgs(Struct.newBuilder()
+                                .putFields(
+                                        "location",
+                                        Value.newBuilder()
+                                                .setStringValue("Paris")
+                                                .build())
+                                .build())
+                        .build())
+                .mergeUnknownFields(unknownFields("thought-signature"))
+                .build();
+
+        // when
+        AiMessage aiMessage =
+                FunctionCallHelper.fromFunctionCallParts(Collections.singletonList(functionCallPart), true);
+        Part sameFunctionCallPart =
+                FunctionCallHelper.toFunctionCallParts(aiMessage, true).get(0);
+
+        // then
+        assertThat(sameFunctionCallPart.getFunctionCall()).isEqualTo(functionCallPart.getFunctionCall());
+        assertThat(sameFunctionCallPart.getUnknownFields()).isEqualTo(functionCallPart.getUnknownFields());
+    }
+
+    @Test
+    void should_not_round_trip_non_thought_signature_unknown_fields() {
+        // given
+        Part functionCallPart = Part.newBuilder()
+                .setFunctionCall(FunctionCall.newBuilder()
+                        .setName("getWeatherForecast")
+                        .setArgs(Struct.newBuilder())
+                        .build())
+                .mergeUnknownFields(unknownFields("thought-signature"))
+                .mergeUnknownFields(unknownFields(99, "unrelated"))
+                .build();
+
+        // when
+        AiMessage aiMessage =
+                FunctionCallHelper.fromFunctionCallParts(Collections.singletonList(functionCallPart), true);
+        Part sameFunctionCallPart =
+                FunctionCallHelper.toFunctionCallParts(aiMessage, true).get(0);
+
+        // then
+        assertThat(sameFunctionCallPart.getFunctionCall()).isEqualTo(functionCallPart.getFunctionCall());
+        assertThat(sameFunctionCallPart.getUnknownFields().asMap()).containsOnlyKeys(11);
+        assertThat(sameFunctionCallPart.getUnknownFields().asMap().get(11))
+                .isEqualTo(functionCallPart.getUnknownFields().asMap().get(11));
+    }
+
+    @Test
+    void should_not_send_non_thought_signature_unknown_fields_from_attributes() {
+        // given
+        Part functionCallPart = Part.newBuilder()
+                .setFunctionCall(FunctionCall.newBuilder()
+                        .setName("getWeatherForecast")
+                        .setArgs(Struct.newBuilder())
+                        .build())
+                .mergeUnknownFields(unknownFields("thought-signature"))
+                .build();
+
+        AiMessage aiMessage =
+                FunctionCallHelper.fromFunctionCallParts(Collections.singletonList(functionCallPart), true);
+        String attributeKey = aiMessage.attributes().keySet().iterator().next();
+        String encodedUnknownFields = Base64.getEncoder()
+                .encodeToString(UnknownFieldSet.newBuilder()
+                        .mergeFrom(unknownFields("thought-signature"))
+                        .mergeFrom(unknownFields(99, "unrelated"))
+                        .build()
+                        .toByteArray());
+
+        HashMap<String, Object> attributes = new HashMap<>(aiMessage.attributes());
+        attributes.put(attributeKey, Collections.singletonList(encodedUnknownFields));
+        AiMessage aiMessageWithExtraUnknownField = AiMessage.builder()
+                .toolExecutionRequests(aiMessage.toolExecutionRequests())
+                .attributes(attributes)
+                .build();
+
+        // when
+        Part sameFunctionCallPart = FunctionCallHelper.toFunctionCallParts(aiMessageWithExtraUnknownField, true)
+                .get(0);
+
+        // then
+        assertThat(sameFunctionCallPart.getFunctionCall()).isEqualTo(functionCallPart.getFunctionCall());
+        assertThat(sameFunctionCallPart.getUnknownFields().asMap()).containsOnlyKeys(11);
+        assertThat(sameFunctionCallPart.getUnknownFields().asMap().get(11))
+                .isEqualTo(functionCallPart.getUnknownFields().asMap().get(11));
+    }
+
+    @Test
+    void should_not_add_attributes_when_return_thinking_is_disabled() {
+        // given
+        Part functionCallPart = Part.newBuilder()
+                .setFunctionCall(FunctionCall.newBuilder()
+                        .setName("getWeatherForecast")
+                        .setArgs(Struct.newBuilder())
+                        .build())
+                .mergeUnknownFields(unknownFields("thought-signature"))
+                .build();
+
+        // when
+        AiMessage aiMessage =
+                FunctionCallHelper.fromFunctionCallParts(Collections.singletonList(functionCallPart), false);
+        Part sameFunctionCallPart =
+                FunctionCallHelper.toFunctionCallParts(aiMessage, true).get(0);
+
+        // then
+        assertThat(aiMessage.attributes()).isEmpty();
+        assertThat(sameFunctionCallPart.getFunctionCall()).isEqualTo(functionCallPart.getFunctionCall());
+        assertThat(sameFunctionCallPart.getUnknownFields().asMap()).isEmpty();
+    }
+
+    @Test
+    void should_not_send_function_call_part_thought_signature_when_send_thinking_is_disabled() {
+        // given
+        Part functionCallPart = Part.newBuilder()
+                .setFunctionCall(FunctionCall.newBuilder()
+                        .setName("getWeatherForecast")
+                        .setArgs(Struct.newBuilder())
+                        .build())
+                .mergeUnknownFields(unknownFields("thought-signature"))
+                .build();
+
+        // when
+        AiMessage aiMessage =
+                FunctionCallHelper.fromFunctionCallParts(Collections.singletonList(functionCallPart), true);
+        Part sameFunctionCallPart =
+                FunctionCallHelper.toFunctionCallParts(aiMessage, false).get(0);
+
+        // then
+        assertThat(aiMessage.attributes()).isNotEmpty();
+        assertThat(sameFunctionCallPart.getFunctionCall()).isEqualTo(functionCallPart.getFunctionCall());
+        assertThat(sameFunctionCallPart.getUnknownFields().asMap()).isEmpty();
+    }
+
+    @Test
+    void should_not_add_attributes_when_function_call_part_has_no_thought_signature() {
+        // given
+        Part functionCallPart = Part.newBuilder()
+                .setFunctionCall(FunctionCall.newBuilder()
+                        .setName("getWeatherForecast")
+                        .setArgs(Struct.newBuilder())
+                        .build())
+                .build();
+
+        // when
+        AiMessage aiMessage =
+                FunctionCallHelper.fromFunctionCallParts(Collections.singletonList(functionCallPart), true);
+        Part sameFunctionCallPart =
+                FunctionCallHelper.toFunctionCallParts(aiMessage, true).get(0);
+
+        // then
+        assertThat(aiMessage.attributes()).isEmpty();
+        assertThat(sameFunctionCallPart.getFunctionCall()).isEqualTo(functionCallPart.getFunctionCall());
+        assertThat(sameFunctionCallPart.getUnknownFields().asMap()).isEmpty();
+    }
+
+    @Test
+    void should_preserve_function_call_part_thought_signature_by_position() {
+        // given
+        Part firstPart = Part.newBuilder()
+                .setFunctionCall(FunctionCall.newBuilder().setName("first").build())
+                .build();
+        Part secondPart = Part.newBuilder()
+                .setFunctionCall(FunctionCall.newBuilder().setName("second").build())
+                .mergeUnknownFields(unknownFields("second-thought-signature"))
+                .build();
+
+        // when
+        AiMessage aiMessage = FunctionCallHelper.fromFunctionCallParts(Arrays.asList(firstPart, secondPart), true);
+        List<Part> sameParts = FunctionCallHelper.toFunctionCallParts(aiMessage, true);
+
+        // then
+        assertThat(sameParts).hasSize(2);
+        assertThat(sameParts.get(0).getUnknownFields().asMap()).isEmpty();
+        assertThat(sameParts.get(1).getUnknownFields()).isEqualTo(secondPart.getUnknownFields());
+    }
+
+    private static UnknownFieldSet unknownFields(String thoughtSignature) {
+        return unknownFields(11, thoughtSignature);
+    }
+
+    private static UnknownFieldSet unknownFields(int fieldNumber, String value) {
+        return UnknownFieldSet.newBuilder()
+                .addField(
+                        fieldNumber,
+                        UnknownFieldSet.Field.newBuilder()
+                                .addLengthDelimited(ByteString.copyFromUtf8(value))
+                                .build())
+                .build();
     }
 }

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/StreamingChatResponseBuilderTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/StreamingChatResponseBuilderTest.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.model.vertexai.gemini;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.vertexai.api.Candidate;
+import com.google.cloud.vertexai.api.Content;
+import com.google.cloud.vertexai.api.FunctionCall;
+import com.google.cloud.vertexai.api.GenerateContentResponse;
+import com.google.cloud.vertexai.api.Part;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Struct;
+import com.google.protobuf.UnknownFieldSet;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.output.Response;
+import org.junit.jupiter.api.Test;
+
+class StreamingChatResponseBuilderTest {
+
+    @Test
+    void should_preserve_function_call_part_thought_signature_when_return_thinking_is_enabled() {
+        // given
+        Part functionCallPart = Part.newBuilder()
+                .setFunctionCall(FunctionCall.newBuilder().setName("getWeather").setArgs(Struct.newBuilder()))
+                .mergeUnknownFields(unknownFields("thought-signature"))
+                .build();
+        GenerateContentResponse partialResponse = GenerateContentResponse.newBuilder()
+                .addCandidates(
+                        Candidate.newBuilder().setContent(Content.newBuilder().addParts(functionCallPart)))
+                .build();
+
+        StreamingChatResponseBuilder builder = new StreamingChatResponseBuilder(true);
+
+        // when
+        builder.append(partialResponse);
+        Response<AiMessage> response = builder.build();
+        Part sameFunctionCallPart =
+                FunctionCallHelper.toFunctionCallParts(response.content(), true).get(0);
+
+        // then
+        assertThat(sameFunctionCallPart.getFunctionCall()).isEqualTo(functionCallPart.getFunctionCall());
+        assertThat(sameFunctionCallPart.getUnknownFields()).isEqualTo(functionCallPart.getUnknownFields());
+    }
+
+    private static UnknownFieldSet unknownFields(String thoughtSignature) {
+        return UnknownFieldSet.newBuilder()
+                .addField(
+                        11,
+                        UnknownFieldSet.Field.newBuilder()
+                                .addLengthDelimited(ByteString.copyFromUtf8(thoughtSignature))
+                                .build())
+                .build();
+    }
+}

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelDefaultsTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelDefaultsTest.java
@@ -1,0 +1,26 @@
+package dev.langchain4j.model.vertexai.gemini;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class VertexAiGeminiChatModelDefaultsTest {
+
+    @Test
+    void returnThinking_should_be_disabled_by_default() throws ReflectiveOperationException {
+        VertexAiGeminiChatModel model = VertexAiGeminiChatModel.builder()
+                .project("does-not-matter")
+                .location("does-not-matter")
+                .modelName("does-not-matter")
+                .build();
+
+        assertThat(fieldValue(model, "returnThinking")).isEqualTo(false);
+    }
+
+    private static Object fieldValue(Object target, String fieldName) throws ReflectiveOperationException {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelThinkingIT.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelThinkingIT.java
@@ -1,0 +1,234 @@
+package dev.langchain4j.model.vertexai.gemini;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "GCP_PROJECT_ID", matches = ".+")
+class VertexAiGeminiChatModelThinkingIT {
+
+    private static final String MODEL_NAME = envOrDefault("VERTEX_AI_GEMINI_THINKING_MODEL", "gemini-3.1-pro-preview");
+    private static final String LOCATION = envOrDefault("VERTEX_AI_GEMINI_THINKING_LOCATION", "global");
+    private static final String API_ENDPOINT =
+            envOrDefault("VERTEX_AI_GEMINI_THINKING_API_ENDPOINT", "aiplatform.googleapis.com");
+
+    @Test
+    void should_return_and_send_thought_signatures_with_tools() {
+        // given
+        boolean returnThinking = true;
+        boolean sendThinking = true;
+
+        ChatModel model = VertexAiGeminiChatModel.builder()
+                .project(System.getenv("GCP_PROJECT_ID"))
+                .location(LOCATION)
+                .apiEndpoint(API_ENDPOINT)
+                .modelName(MODEL_NAME)
+                .temperature(0.0f)
+                .topK(1)
+                .returnThinking(returnThinking)
+                .sendThinking(sendThinking)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        ToolSpecification toolSpecification = weatherTool();
+        UserMessage userMessage = UserMessage.from("What is the weather in Munich?");
+        ChatRequest toolCallRequest = ChatRequest.builder()
+                .messages(userMessage)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        // when
+        ChatResponse toolCallResponse = model.chat(toolCallRequest);
+
+        // then
+        AiMessage toolCallMessage = toolCallResponse.aiMessage();
+        assertThat(toolCallMessage.toolExecutionRequests()).hasSize(1);
+        assertThat(toolCallMessage.attributes()).isNotEmpty();
+
+        ToolExecutionRequest toolExecutionRequest =
+                toolCallMessage.toolExecutionRequests().get(0);
+        assertThat(toolExecutionRequest.name()).isEqualTo(toolSpecification.name());
+        assertThat(toolExecutionRequest.arguments()).contains("Munich");
+
+        // given
+        ToolExecutionResultMessage toolResultMessage = ToolExecutionResultMessage.from(toolExecutionRequest, "sunny");
+        ChatRequest finalRequest = ChatRequest.builder()
+                .messages(userMessage, toolCallMessage, toolResultMessage)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        // when
+        ChatResponse finalResponse = model.chat(finalRequest);
+
+        // then
+        assertThat(finalResponse.aiMessage().text()).containsIgnoringCase("sun");
+        assertThat(finalResponse.aiMessage().toolExecutionRequests()).isEmpty();
+    }
+
+    @Test
+    void should_return_and_send_thought_signatures_across_multiple_tool_rounds() {
+        // given
+        boolean returnThinking = true;
+        boolean sendThinking = true;
+
+        ChatModel model = VertexAiGeminiChatModel.builder()
+                .project(System.getenv("GCP_PROJECT_ID"))
+                .location(LOCATION)
+                .apiEndpoint(API_ENDPOINT)
+                .modelName(MODEL_NAME)
+                .temperature(0.0f)
+                .topK(1)
+                .returnThinking(returnThinking)
+                .sendThinking(sendThinking)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        ToolSpecification toolSpecification = weatherTool();
+
+        // --- Round 1: tool call for Munich ---
+        UserMessage userMessage1 = UserMessage.from("What is the weather in Munich?");
+        ChatRequest request1 = ChatRequest.builder()
+                .messages(userMessage1)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        ChatResponse response1 = model.chat(request1);
+        AiMessage aiMessage1 = response1.aiMessage();
+        assertThat(aiMessage1.toolExecutionRequests()).hasSize(1);
+        assertThat(aiMessage1.attributes()).isNotEmpty();
+
+        ToolExecutionRequest toolRequest1 = aiMessage1.toolExecutionRequests().get(0);
+        assertThat(toolRequest1.name()).isEqualTo(toolSpecification.name());
+        assertThat(toolRequest1.arguments()).contains("Munich");
+
+        // --- Round 2: tool result → final answer for Munich ---
+        ToolExecutionResultMessage toolResult1 = ToolExecutionResultMessage.from(toolRequest1, "sunny");
+        ChatRequest request2 = ChatRequest.builder()
+                .messages(userMessage1, aiMessage1, toolResult1)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        ChatResponse response2 = model.chat(request2);
+        AiMessage aiMessage2 = response2.aiMessage();
+        assertThat(aiMessage2.text()).containsIgnoringCase("sun");
+        assertThat(aiMessage2.toolExecutionRequests()).isEmpty();
+
+        // --- Round 3: new question → tool call for Paris ---
+        UserMessage userMessage2 = UserMessage.from("What is the weather in Paris?");
+        ChatRequest request3 = ChatRequest.builder()
+                .messages(userMessage1, aiMessage1, toolResult1, aiMessage2, userMessage2)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        ChatResponse response3 = model.chat(request3);
+        AiMessage aiMessage3 = response3.aiMessage();
+        assertThat(aiMessage3.toolExecutionRequests()).hasSize(1);
+        assertThat(aiMessage3.attributes()).isNotEmpty();
+
+        ToolExecutionRequest toolRequest2 = aiMessage3.toolExecutionRequests().get(0);
+        assertThat(toolRequest2.name()).isEqualTo(toolSpecification.name());
+        assertThat(toolRequest2.arguments()).contains("Paris");
+
+        // --- Round 4: tool result → final answer for Paris ---
+        ToolExecutionResultMessage toolResult2 = ToolExecutionResultMessage.from(toolRequest2, "rainy");
+        ChatRequest request4 = ChatRequest.builder()
+                .messages(userMessage1, aiMessage1, toolResult1, aiMessage2, userMessage2, aiMessage3, toolResult2)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        ChatResponse response4 = model.chat(request4);
+        AiMessage aiMessage4 = response4.aiMessage();
+        assertThat(aiMessage4.text()).containsIgnoringCase("rain");
+        assertThat(aiMessage4.toolExecutionRequests()).isEmpty();
+    }
+
+    @Test
+    void should_NOT_send_thought_signatures_when_sendThinking_is_false() {
+        // given
+        boolean returnThinking = true;
+        boolean sendThinking = false;
+
+        ChatModel model = VertexAiGeminiChatModel.builder()
+                .project(System.getenv("GCP_PROJECT_ID"))
+                .location(LOCATION)
+                .apiEndpoint(API_ENDPOINT)
+                .modelName(MODEL_NAME)
+                .temperature(0.0f)
+                .topK(1)
+                .returnThinking(returnThinking)
+                .sendThinking(sendThinking)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        ToolSpecification toolSpecification = weatherTool();
+        UserMessage userMessage = UserMessage.from("What is the weather in Munich?");
+        ChatRequest toolCallRequest = ChatRequest.builder()
+                .messages(userMessage)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        // when
+        ChatResponse toolCallResponse = model.chat(toolCallRequest);
+
+        // then — thought signatures are returned but will NOT be sent in follow-up
+        AiMessage toolCallMessage = toolCallResponse.aiMessage();
+        assertThat(toolCallMessage.toolExecutionRequests()).hasSize(1);
+        assertThat(toolCallMessage.attributes()).isNotEmpty();
+
+        ToolExecutionRequest toolExecutionRequest =
+                toolCallMessage.toolExecutionRequests().get(0);
+        assertThat(toolExecutionRequest.name()).isEqualTo(toolSpecification.name());
+        assertThat(toolExecutionRequest.arguments()).contains("Munich");
+
+        // given — follow-up without thought signatures
+        ToolExecutionResultMessage toolResultMessage = ToolExecutionResultMessage.from(toolExecutionRequest, "sunny");
+        ChatRequest finalRequest = ChatRequest.builder()
+                .messages(userMessage, toolCallMessage, toolResultMessage)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        // when/then — Gemini 3 requires thought signatures; follow-up is expected to fail
+        assertThatThrownBy(() -> model.chat(finalRequest))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("thought_signature");
+    }
+
+    private static ToolSpecification weatherTool() {
+        return ToolSpecification.builder()
+                .name("getWeather")
+                .description("Returns the current weather for a city.")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("city")
+                        .required("city")
+                        .build())
+                .build();
+    }
+
+    @AfterEach
+    void afterEach() throws InterruptedException {
+        String ciDelaySeconds = System.getenv("CI_DELAY_SECONDS_VERTEX_AI_GEMINI");
+        if (ciDelaySeconds != null) {
+            Thread.sleep(Integer.parseInt(ciDelaySeconds) * 1000L);
+        }
+    }
+
+    private static String envOrDefault(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+}

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModelBuilderTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModelBuilderTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.vertexai.gemini;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -79,5 +80,22 @@ class VertexAiGeminiStreamingChatModelBuilderTest {
                 .build();
 
         assertThat(model.labels()).isEmpty();
+    }
+
+    @Test
+    void returnThinking_should_be_disabled_by_default() throws ReflectiveOperationException {
+        VertexAiGeminiStreamingChatModel model = VertexAiGeminiStreamingChatModel.builder()
+                .project("does-not-matter")
+                .location("does-not-matter")
+                .modelName("does-not-matter")
+                .build();
+
+        assertThat(fieldValue(model, "returnThinking")).isEqualTo(false);
+    }
+
+    private static Object fieldValue(Object target, String fieldName) throws ReflectiveOperationException {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
     }
 }

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModelThinkingIT.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModelThinkingIT.java
@@ -1,0 +1,249 @@
+package dev.langchain4j.model.vertexai.gemini;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "GCP_PROJECT_ID", matches = ".+")
+class VertexAiGeminiStreamingChatModelThinkingIT {
+
+    private static final String MODEL_NAME = envOrDefault("VERTEX_AI_GEMINI_THINKING_MODEL", "gemini-3.1-pro-preview");
+    private static final String LOCATION = envOrDefault("VERTEX_AI_GEMINI_THINKING_LOCATION", "global");
+    private static final String API_ENDPOINT =
+            envOrDefault("VERTEX_AI_GEMINI_THINKING_API_ENDPOINT", "aiplatform.googleapis.com");
+
+    @Test
+    void should_return_and_send_thought_signatures_with_tools() {
+        // given
+        boolean returnThinking = true;
+        boolean sendThinking = true;
+
+        StreamingChatModel model = VertexAiGeminiStreamingChatModel.builder()
+                .project(System.getenv("GCP_PROJECT_ID"))
+                .location(LOCATION)
+                .apiEndpoint(API_ENDPOINT)
+                .modelName(MODEL_NAME)
+                .temperature(0.0f)
+                .topK(1)
+                .returnThinking(returnThinking)
+                .sendThinking(sendThinking)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        ToolSpecification toolSpecification = weatherTool();
+        UserMessage userMessage = UserMessage.from("What is the weather in Munich?");
+        ChatRequest toolCallRequest = ChatRequest.builder()
+                .messages(userMessage)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler toolCallHandler = new TestStreamingChatResponseHandler();
+        model.chat(toolCallRequest, toolCallHandler);
+        ChatResponse toolCallResponse = toolCallHandler.get();
+
+        // then
+        AiMessage toolCallMessage = toolCallResponse.aiMessage();
+        assertThat(toolCallMessage.toolExecutionRequests()).hasSize(1);
+        assertThat(toolCallMessage.attributes()).isNotEmpty();
+
+        ToolExecutionRequest toolExecutionRequest =
+                toolCallMessage.toolExecutionRequests().get(0);
+        assertThat(toolExecutionRequest.name()).isEqualTo(toolSpecification.name());
+        assertThat(toolExecutionRequest.arguments()).contains("Munich");
+
+        // given
+        ToolExecutionResultMessage toolResultMessage = ToolExecutionResultMessage.from(toolExecutionRequest, "sunny");
+        ChatRequest finalRequest = ChatRequest.builder()
+                .messages(userMessage, toolCallMessage, toolResultMessage)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler finalHandler = new TestStreamingChatResponseHandler();
+        model.chat(finalRequest, finalHandler);
+        ChatResponse finalResponse = finalHandler.get();
+
+        // then
+        assertThat(finalResponse.aiMessage().text()).containsIgnoringCase("sun");
+        assertThat(finalResponse.aiMessage().toolExecutionRequests()).isEmpty();
+    }
+
+    @Test
+    void should_return_and_send_thought_signatures_across_multiple_tool_rounds() {
+        // given
+        boolean returnThinking = true;
+        boolean sendThinking = true;
+
+        StreamingChatModel model = VertexAiGeminiStreamingChatModel.builder()
+                .project(System.getenv("GCP_PROJECT_ID"))
+                .location(LOCATION)
+                .apiEndpoint(API_ENDPOINT)
+                .modelName(MODEL_NAME)
+                .temperature(0.0f)
+                .topK(1)
+                .returnThinking(returnThinking)
+                .sendThinking(sendThinking)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        ToolSpecification toolSpecification = weatherTool();
+
+        // --- Round 1: tool call for Munich ---
+        UserMessage userMessage1 = UserMessage.from("What is the weather in Munich?");
+        ChatRequest request1 = ChatRequest.builder()
+                .messages(userMessage1)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        TestStreamingChatResponseHandler handler1 = new TestStreamingChatResponseHandler();
+        model.chat(request1, handler1);
+        AiMessage aiMessage1 = handler1.get().aiMessage();
+        assertThat(aiMessage1.toolExecutionRequests()).hasSize(1);
+        assertThat(aiMessage1.attributes()).isNotEmpty();
+
+        ToolExecutionRequest toolRequest1 = aiMessage1.toolExecutionRequests().get(0);
+        assertThat(toolRequest1.name()).isEqualTo(toolSpecification.name());
+        assertThat(toolRequest1.arguments()).contains("Munich");
+
+        // --- Round 2: tool result → final answer for Munich ---
+        ToolExecutionResultMessage toolResult1 = ToolExecutionResultMessage.from(toolRequest1, "sunny");
+        ChatRequest request2 = ChatRequest.builder()
+                .messages(userMessage1, aiMessage1, toolResult1)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        TestStreamingChatResponseHandler handler2 = new TestStreamingChatResponseHandler();
+        model.chat(request2, handler2);
+        AiMessage aiMessage2 = handler2.get().aiMessage();
+        assertThat(aiMessage2.text()).containsIgnoringCase("sun");
+        assertThat(aiMessage2.toolExecutionRequests()).isEmpty();
+
+        // --- Round 3: new question → tool call for Paris ---
+        UserMessage userMessage2 = UserMessage.from("What is the weather in Paris?");
+        ChatRequest request3 = ChatRequest.builder()
+                .messages(userMessage1, aiMessage1, toolResult1, aiMessage2, userMessage2)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        TestStreamingChatResponseHandler handler3 = new TestStreamingChatResponseHandler();
+        model.chat(request3, handler3);
+        AiMessage aiMessage3 = handler3.get().aiMessage();
+        assertThat(aiMessage3.toolExecutionRequests()).hasSize(1);
+        assertThat(aiMessage3.attributes()).isNotEmpty();
+
+        ToolExecutionRequest toolRequest2 = aiMessage3.toolExecutionRequests().get(0);
+        assertThat(toolRequest2.name()).isEqualTo(toolSpecification.name());
+        assertThat(toolRequest2.arguments()).contains("Paris");
+
+        // --- Round 4: tool result → final answer for Paris ---
+        ToolExecutionResultMessage toolResult2 = ToolExecutionResultMessage.from(toolRequest2, "rainy");
+        ChatRequest request4 = ChatRequest.builder()
+                .messages(userMessage1, aiMessage1, toolResult1, aiMessage2, userMessage2, aiMessage3, toolResult2)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        TestStreamingChatResponseHandler handler4 = new TestStreamingChatResponseHandler();
+        model.chat(request4, handler4);
+        AiMessage aiMessage4 = handler4.get().aiMessage();
+        assertThat(aiMessage4.text()).containsIgnoringCase("rain");
+        assertThat(aiMessage4.toolExecutionRequests()).isEmpty();
+    }
+
+    @Test
+    void should_NOT_send_thought_signatures_when_sendThinking_is_false() {
+        // given
+        boolean returnThinking = true;
+        boolean sendThinking = false;
+
+        StreamingChatModel model = VertexAiGeminiStreamingChatModel.builder()
+                .project(System.getenv("GCP_PROJECT_ID"))
+                .location(LOCATION)
+                .apiEndpoint(API_ENDPOINT)
+                .modelName(MODEL_NAME)
+                .temperature(0.0f)
+                .topK(1)
+                .returnThinking(returnThinking)
+                .sendThinking(sendThinking)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        ToolSpecification toolSpecification = weatherTool();
+        UserMessage userMessage = UserMessage.from("What is the weather in Munich?");
+        ChatRequest toolCallRequest = ChatRequest.builder()
+                .messages(userMessage)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler toolCallHandler = new TestStreamingChatResponseHandler();
+        model.chat(toolCallRequest, toolCallHandler);
+        ChatResponse toolCallResponse = toolCallHandler.get();
+
+        // then — thought signatures are returned but will NOT be sent in follow-up
+        AiMessage toolCallMessage = toolCallResponse.aiMessage();
+        assertThat(toolCallMessage.toolExecutionRequests()).hasSize(1);
+        assertThat(toolCallMessage.attributes()).isNotEmpty();
+
+        ToolExecutionRequest toolExecutionRequest =
+                toolCallMessage.toolExecutionRequests().get(0);
+        assertThat(toolExecutionRequest.name()).isEqualTo(toolSpecification.name());
+        assertThat(toolExecutionRequest.arguments()).contains("Munich");
+
+        // given — follow-up without thought signatures
+        ToolExecutionResultMessage toolResultMessage = ToolExecutionResultMessage.from(toolExecutionRequest, "sunny");
+        ChatRequest finalRequest = ChatRequest.builder()
+                .messages(userMessage, toolCallMessage, toolResultMessage)
+                .toolSpecifications(toolSpecification)
+                .build();
+
+        // when/then — Gemini 3 requires thought signatures; follow-up is expected to fail
+        TestStreamingChatResponseHandler finalHandler = new TestStreamingChatResponseHandler();
+        assertThatThrownBy(() -> {
+                    model.chat(finalRequest, finalHandler);
+                    finalHandler.get();
+                })
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("thought_signature");
+    }
+
+    private static ToolSpecification weatherTool() {
+        return ToolSpecification.builder()
+                .name("getWeather")
+                .description("Returns the current weather for a city.")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("city")
+                        .required("city")
+                        .build())
+                .build();
+    }
+
+    @AfterEach
+    void afterEach() throws InterruptedException {
+        String ciDelaySeconds = System.getenv("CI_DELAY_SECONDS_VERTEX_AI_GEMINI");
+        if (ciDelaySeconds != null) {
+            Thread.sleep(Integer.parseInt(ciDelaySeconds) * 1000L);
+        }
+    }
+
+    private static String envOrDefault(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5134

## Change
- Adds opt-in `returnThinking(Boolean)` and `sendThinking(Boolean)` support for Vertex AI Gemini chat and streaming chat models.
- Preserves thought signatures returned with function-call parts in `AiMessage.attributes()` only when `returnThinking(true)` is enabled.
- Sends preserved thought signatures back in follow-up function-call parts only when `sendThinking(true)` is enabled.
- Keeps the current Vertex AI SDK/BOM unchanged and only carries the `thoughtSignature` wire field used by the current API.

References checked:
- Vertex AI thought signatures: https://cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures
- Vertex AI Content Part: https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/Content#Part

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

## Tests run
- `mvn -pl langchain4j-vertex-ai-gemini -am -Dtest=FunctionCallHelperTest,ContentsMapperTest,StreamingChatResponseBuilderTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl langchain4j-vertex-ai-gemini -am test`
- `mvn -pl langchain4j-vertex-ai-gemini spotless:check`
- `git diff --check origin/main...HEAD`
