### PR TITLE
feat(#5141): Adds vector as Double Array conversion in Embeddings

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/data/embedding/Embedding.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/data/embedding/Embedding.java
@@ -46,6 +46,20 @@ public class Embedding {
     }
 
     /**
+     * Returns a copy of the vector as double array.
+     * @return the vector as double array.
+     */
+    public double[] vectorAsDoubleArray() {
+        double[] doubles = new double[vector.length];
+
+        for(int i = 0; i < vector.length; i++) {
+            doubles[i] = vector[i];
+        }
+
+        return doubles;
+    }
+
+    /**
      * Normalize vector
      */
     public void normalize() {

--- a/langchain4j-core/src/test/java/dev/langchain4j/data/embedding/EmbeddingTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/data/embedding/EmbeddingTest.java
@@ -28,6 +28,7 @@ class EmbeddingTest implements WithAssertions {
         assertThat(e1.dimension()).isEqualTo(3);
         assertThat(e1.vector()).containsExactly(1.0f, 2.0f, 3.0f);
         assertThat(e1.vectorAsList()).containsExactly(1.0f, 2.0f, 3.0f);
+        assertThat(e1.vectorAsDoubleArray()).containsExactly(1.0d, 2.0d, 3.0d);
 
         assertThat(e1).hasToString("Embedding { vector = [1.0, 2.0, 3.0] }");
     }


### PR DESCRIPTION
## Issue

Closes #5141

## Change

Added the new method that converts the float[] to double[] an `Embedding`


## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)