### PR TITLE
Support setting default values for `@Tool` parameters

### DIFF
--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -409,41 +409,15 @@ instructing it to produce a value.
 A parameter can be made optional by annotating it with `@P(required = false)`:
 ```java
 @Tool
-void getTemperature(String location, @P("Unit of temperature", required = false) Unit unit) {
+String getTemperature(String location, @P(required = false) Unit unit) {
     ...
 }
 ```
 
-:::caution Required is advisory: the LLM can still omit arguments
-The `required` flag controls the JSON schema sent to the LLM (required parameters are listed
-in the schema's `required` array). The LLM is expected to honor this, but in practice it can
-disregard the schema and omit an argument anyway.
-
-In LangChain4j 1.x, this is detected only for **primitive** parameters (`int`, `long`, `boolean`, …) — a
-missing primitive triggers the `ToolArgumentsErrorHandler` (see [Error Handling](#handling-tool-arguments-errors)
-below). **Missing object parameters are not validated**: `null` is passed to the
-`@Tool`-annotated method even though the schema marked the parameter as required.
-
-We are planning to remove this asymmetry in LangChain4j 2.0 so that all required arguments are
-validated uniformly. If this planned change would affect your use case, please
-[open an issue](https://github.com/langchain4j/langchain4j/issues) so we can hear your feedback before it lands.
-
-If you want a real fallback instead of `null` (or instead of an error for primitive parameters), use
-[`@P(defaultValue = ...)`](#default-parameter-values).
-:::
-
-#### Alternative: Using `Optional<T>` for Optional Parameters
-
-Instead of annotating parameters with `@P(required = false)`, you simply declare the parameter as `Optional<T>`.
-Any parameter of type `Optional<T>` will be treated as optional automatically, even without specify `required = false` in the `@P` annotation.
-
-**Example:**
+Alternatively, you can declare the parameter as `Optional<T>`:
 ```java
 @Tool
-void getTemperature(
-    @P("Temperature value") double value,
-    @P("Unit of temperature") Optional<String> unit
-) {
+String getTemperature(String location, Optional<String> unit) {
     ...
 }
 ```
@@ -464,6 +438,24 @@ Please note that when used with [structured outputs](/tutorials/structured-outpu
 all fields and sub-fields are considered **_optional_** by default.
 :::
 
+:::caution Required is advisory: the LLM can still omit arguments
+The `required` flag controls the JSON schema sent to the LLM (required parameters are listed
+in the schema's `required` array). The LLM is expected to honor this, but in practice it can
+disregard the schema and omit an argument anyway.
+
+In LangChain4j 1.x, this is detected only for **primitive** parameters (`int`, `long`, `boolean`, …) — a
+missing primitive triggers the `ToolArgumentsErrorHandler` (see [Error Handling](#handling-tool-arguments-errors)
+below). **Missing object parameters are not validated**: `null` is passed to the
+`@Tool`-annotated method even though the schema marked the parameter as required.
+
+We are planning to remove this asymmetry in LangChain4j 2.0 so that all required arguments are
+validated uniformly. If this planned change would affect your use case, please
+[open an issue](https://github.com/langchain4j/langchain4j/issues) so we can hear your feedback before it lands.
+
+If you want a real fallback instead of `null` (or instead of an error for primitive parameters), use
+[`@P(defaultValue = ...)`](#default-parameter-values).
+:::
+
 Recursive parameters (e.g., a `Person` class having a `Set<Person> children` field)
 are currently supported only by OpenAI.
 
@@ -474,13 +466,19 @@ omits the argument. It's the simplest way to make a parameter optional and suppl
 sensible fallback that your tool method receives.
 
 ```java
+enum SortBy { RELEVANCE, DATE, RATING }
+
 @Tool
-List<Product> searchProducts(
+List<Article> searchArticles(
     String query,
     @P(defaultValue = "10") int limit,
-    @P(defaultValue = "0") int offset
+    @P(defaultValue = "[\"en\"]") List<String> languages,
+    @P(defaultValue = "RELEVANCE") SortBy sortBy
 ) {
-    // If the LLM omits 'limit', it is 10. If it omits 'offset', it is 0.
+    // When the LLM omits them:
+    //   'limit'     -> 10
+    //   'languages' -> ["en"]
+    //   'sortBy'    -> SortBy.RELEVANCE
 }
 ```
 

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -417,7 +417,7 @@ String getTemperature(String location, @P(required = false) Unit unit) {
 Alternatively, you can declare the parameter as `Optional<T>`:
 ```java
 @Tool
-String getTemperature(String location, Optional<String> unit) {
+String getTemperature(String location, Optional<Unit> unit) {
     ...
 }
 ```
@@ -455,9 +455,6 @@ validated uniformly. If this planned change would affect your use case, please
 If you want a real fallback instead of `null` (or instead of an error for primitive parameters), use
 [`@P(defaultValue = ...)`](#default-parameter-values).
 :::
-
-Recursive parameters (e.g., a `Person` class having a `Set<Person> children` field)
-are currently supported only by OpenAI.
 
 #### Default Parameter Values
 
@@ -586,6 +583,11 @@ The set of supported `@JsonTypeInfo` options, the discriminator-name resolution 
 `defaultImpl` behavior, the `visible` flag, and field-collision detection are described in
 detail in [Polymorphic Types](/tutorials/structured-outputs#polymorphic-types) under
 Structured Outputs — they apply identically to tool parameters.
+
+#### Recursive Parameters
+
+Recursive parameters (e.g., a `Person` class having a `Set<Person> children` field)
+are currently supported only by OpenAI.
 
 ### Tool Method Return Types
 Methods annotated with `@Tool` can return any type, including `void`.

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -429,7 +429,7 @@ validated uniformly. If this planned change would affect your use case, please
 [open an issue](https://github.com/langchain4j/langchain4j/issues) so we can hear your feedback before it lands.
 
 If you want a real fallback instead of `null` (or instead of an error for primitive parameters), use
-[`@P(defaultValue = ...)`](#default-values).
+[`@P(defaultValue = ...)`](#default-parameter-values).
 :::
 
 #### Alternative: Using `Optional<T>` for Optional Parameters
@@ -467,7 +467,7 @@ all fields and sub-fields are considered **_optional_** by default.
 Recursive parameters (e.g., a `Person` class having a `Set<Person> children` field)
 are currently supported only by OpenAI.
 
-#### Default Values
+#### Default Parameter Values
 
 `@P(defaultValue = "...")` declares a value that LangChain4j substitutes when the LLM
 omits the argument. It's the simplest way to make a parameter optional and supply a

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -424,7 +424,9 @@ missing primitive triggers the `ToolArgumentsErrorHandler` (see [Error Handling]
 below). **Missing object parameters are not validated**: `null` is passed to the
 `@Tool`-annotated method even though the schema marked the parameter as required.
 
-This asymmetry will be removed in LangChain4j 2.0, where all required arguments will be validated uniformly.
+We are planning to remove this asymmetry in LangChain4j 2.0 so that all required arguments are
+validated uniformly. If this planned change would affect your use case, please
+[open an issue](https://github.com/langchain4j/langchain4j/issues) so we can hear your feedback before it lands.
 
 If you want a real fallback instead of `null` (or instead of an error for primitive parameters), use
 [`@P(defaultValue = ...)`](#default-values).
@@ -446,20 +448,39 @@ void getTemperature(
 }
 ```
 
+Fields and sub-fields of complex parameters are also considered **_required_** by default.
+You can make a field optional by annotating it with `@JsonProperty(required = false)`:
+```java
+record User(String name, @JsonProperty(required = false) String email) {}
+
+@Tool
+void add(User user) {
+    ...
+}
+```
+
+:::note
+Please note that when used with [structured outputs](/tutorials/structured-outputs),
+all fields and sub-fields are considered **_optional_** by default.
+:::
+
+Recursive parameters (e.g., a `Person` class having a `Set<Person> children` field)
+are currently supported only by OpenAI.
+
 #### Default Values
 
 `@P(defaultValue = "...")` declares a value that LangChain4j substitutes when the LLM
-omits the argument. This is the most convenient way to make a parameter optional while
-keeping a non-`null`, non-default-JVM value in your tool method.
+omits the argument. It's the simplest way to make a parameter optional and supply a
+sensible fallback that your tool method receives.
 
 ```java
 @Tool
-void search(
+List<Product> searchProducts(
     String query,
     @P(defaultValue = "10") int limit,
-    @P(defaultValue = "USD") Currency currency
+    @P(defaultValue = "0") int offset
 ) {
-    // If the LLM omits 'limit', it is 10. If it omits 'currency', it is Currency.USD.
+    // If the LLM omits 'limit', it is 10. If it omits 'offset', it is 0.
 }
 ```
 
@@ -470,28 +491,21 @@ your method.
 
 **Supported types:**
 
-| Type | Format | Example |
-|---|---|---|
-| `String` | used verbatim | `defaultValue = "USD"` |
-| Primitive / boxed primitive | type-specific conversion | `"10"`, `"3.14"`, `"true"` |
-| `enum` | enum constant name | `defaultValue = "EUR"` |
-| `UUID` | `UUID.fromString` | `"550e8400-e29b-41d4-a716-446655440000"` |
-| `BigDecimal`, `BigInteger` | numeric literal | `"1.5"`, `"100"` |
-| `List<T>` / `Set<T>` / array | JSON array | `"[\"a\",\"b\"]"`, `"[1,2,3]"` |
-| `Map<K,V>` | JSON object | `"{\"a\":1,\"b\":2}"` |
-| POJOs (including nested) | JSON object | `"{\"name\":\"Klaus\",\"age\":42}"` |
+| Type                         | Format                   | Example                                  |
+|------------------------------|--------------------------|------------------------------------------|
+| `String`                     | used verbatim            | `defaultValue = "USD"`                   |
+| Primitive / boxed primitive  | type-specific conversion | `"10"`, `"3.14"`, `"true"`               |
+| `enum`                       | enum constant name       | `defaultValue = "EUR"`                   |
+| `UUID`                       | `UUID.fromString`        | `"550e8400-e29b-41d4-a716-446655440000"` |
+| `BigDecimal`, `BigInteger`   | numeric literal          | `"1.5"`, `"100"`                         |
+| `List<T>` / `Set<T>` / array | JSON array               | `"[\"a\",\"b\"]"`, `"[1,2,3]"`           |
+| `Map<K,V>`                   | JSON object              | `"{\"a\":1,\"b\":2}"`                    |
+| POJOs (including nested)     | JSON object              | `"{\"name\":\"Klaus\",\"age\":42}"`      |
 
 The default value string is parsed at AI Service registration time. If it cannot be
 converted into the parameter's type, AI Service construction fails immediately with
 `IllegalConfigurationException`, naming the offending parameter — typos are caught at
 startup rather than on the first LLM call.
-
-```java
-class BadTool {
-    @Tool
-    void search(@P(defaultValue = "ten") int limit) { ... } // <- caught at .build() time
-}
-```
 
 **Defaults only apply to absence, not to wrong values.** If the LLM provides an argument
 that fails type coercion (e.g. `"banana"` for an `int`), the coercion error propagates as
@@ -513,35 +527,6 @@ void process(@P(defaultValue = "[\"a\",\"b\"]") List<String> tags) {
   "absent"; pick one mechanism.
 - `defaultValue` cannot be set on LangChain4j-injected parameters (`@ToolMemoryId`,
   `InvocationContext`, etc.) — they don't come from the LLM.
-
-**Tip — making primitive parameters truly optional:** because Java primitives can't be
-`null`, LangChain4j rejects `@P(required = false) int x` at registration time
-(it would NPE when the LLM omits the argument). Use `defaultValue` instead to opt the
-primitive into optional-with-fallback behavior:
-
-```java
-@Tool
-void process(@P(required = false, defaultValue = "0") int startLine) { ... }
-```
-
-Fields and sub-fields of complex parameters are also considered **_required_** by default.
-You can make a field optional by annotating it with `@JsonProperty(required = false)`:
-```java
-record User(String name, @JsonProperty(required = false) String email) {}
-
-@Tool
-void add(User user) {
-    ...
-}
-```
-
-:::note
-Please note that when used with [structured outputs](/tutorials/structured-outputs),
-all fields and sub-fields are considered **_optional_** by default.
-:::
-
-Recursive parameters (e.g., a `Person` class having a `Set<Person> children` field)
-are currently supported only by OpenAI.
 
 #### Polymorphic Tool Parameters
 
@@ -1469,7 +1454,9 @@ Argument errors usually come from the LLM, and LLMs can typically self-correct w
 error message. Configure a `ToolArgumentsErrorHandler` that returns the error text so the LLM can
 retry with corrected arguments.
 
-The default will change to this behaviour in LangChain4j 2.0.
+We are planning to change the default to this behaviour in LangChain4j 2.0. If this planned change
+would affect your use case, please [open an issue](https://github.com/langchain4j/langchain4j/issues)
+so we can hear your feedback before it lands.
 :::
 
 You can customize this behaviour by configuring a `ToolArgumentsErrorHandler` on the AI Service:
@@ -1530,7 +1517,10 @@ and the LLM provider's logs.
 Configure a `ToolExecutionErrorHandler` that returns either a generic message or a curated/sanitized
 description of the failure, and rely on logs and observability events for the underlying detail.
 
-The default will change to "Throw an exception and abort AI Service invocation" in LangChain4j 2.0.
+We are planning to change the default to "Throw an exception and abort AI Service invocation" in
+LangChain4j 2.0. If this planned change would affect your use case, please
+[open an issue](https://github.com/langchain4j/langchain4j/issues) so we can hear your feedback
+before it lands.
 :::
 
 You can customize this behaviour by configuring a `ToolExecutionErrorHandler` on the AI Service:

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -416,7 +416,7 @@ void getTemperature(String location, @P("Unit of temperature", required = false)
 
 :::caution Required is advisory: the LLM can still omit arguments
 The `required` flag controls the JSON schema sent to the LLM (required parameters are listed
-in the schema's `required` array). The LLM is expected to honour this, but in practice it can
+in the schema's `required` array). The LLM is expected to honor this, but in practice it can
 disregard the schema and omit an argument anyway.
 
 In LangChain4j 1.x, this is detected only for **primitive** parameters (`int`, `long`, `boolean`, …) — a
@@ -425,6 +425,9 @@ below). **Missing object parameters are not validated**: `null` is passed to the
 `@Tool`-annotated method even though the schema marked the parameter as required.
 
 This asymmetry will be removed in LangChain4j 2.0, where all required arguments will be validated uniformly.
+
+If you want a real fallback instead of `null` (or instead of an error for primitive parameters), use
+[`@P(defaultValue = ...)`](#default-values).
 :::
 
 #### Alternative: Using `Optional<T>` for Optional Parameters
@@ -441,6 +444,84 @@ void getTemperature(
 ) {
     ...
 }
+```
+
+#### Default Values
+
+`@P(defaultValue = "...")` declares a value that LangChain4j substitutes when the LLM
+omits the argument. This is the most convenient way to make a parameter optional while
+keeping a non-`null`, non-default-JVM value in your tool method.
+
+```java
+@Tool
+void search(
+    String query,
+    @P(defaultValue = "10") int limit,
+    @P(defaultValue = "USD") Currency currency
+) {
+    // If the LLM omits 'limit', it is 10. If it omits 'currency', it is Currency.USD.
+}
+```
+
+**Setting `defaultValue` implies optional in the JSON schema** — the parameter is *not*
+listed in the schema's `required` array, regardless of `@P(required)`. The LLM is told
+it may omit the argument; if it does, LangChain4j fills in the default before invoking
+your method.
+
+**Supported types:**
+
+| Type | Format | Example |
+|---|---|---|
+| `String` | used verbatim | `defaultValue = "USD"` |
+| Primitive / boxed primitive | type-specific conversion | `"10"`, `"3.14"`, `"true"` |
+| `enum` | enum constant name | `defaultValue = "EUR"` |
+| `UUID` | `UUID.fromString` | `"550e8400-e29b-41d4-a716-446655440000"` |
+| `BigDecimal`, `BigInteger` | numeric literal | `"1.5"`, `"100"` |
+| `List<T>` / `Set<T>` / array | JSON array | `"[\"a\",\"b\"]"`, `"[1,2,3]"` |
+| `Map<K,V>` | JSON object | `"{\"a\":1,\"b\":2}"` |
+| POJOs (including nested) | JSON object | `"{\"name\":\"Klaus\",\"age\":42}"` |
+
+The default value string is parsed at AI Service registration time. If it cannot be
+converted into the parameter's type, AI Service construction fails immediately with
+`IllegalConfigurationException`, naming the offending parameter — typos are caught at
+startup rather than on the first LLM call.
+
+```java
+class BadTool {
+    @Tool
+    void search(@P(defaultValue = "ten") int limit) { ... } // <- caught at .build() time
+}
+```
+
+**Defaults only apply to absence, not to wrong values.** If the LLM provides an argument
+that fails type coercion (e.g. `"banana"` for an `int`), the coercion error propagates as
+usual — the default is *not* used as a fallback.
+
+**Defaults are re-parsed on every invocation,** so a tool that mutates a defaulted
+`List`/`Map`/POJO does not contaminate later calls:
+
+```java
+@Tool
+void process(@P(defaultValue = "[\"a\",\"b\"]") List<String> tags) {
+    tags.add("processed"); // safe — next invocation still receives ["a","b"]
+}
+```
+
+**Restrictions** (rejected with `IllegalConfigurationException` at registration time):
+
+- `defaultValue` cannot be combined with `Optional<T>` — `Optional` already encodes
+  "absent"; pick one mechanism.
+- `defaultValue` cannot be set on LangChain4j-injected parameters (`@ToolMemoryId`,
+  `InvocationContext`, etc.) — they don't come from the LLM.
+
+**Tip — making primitive parameters truly optional:** because Java primitives can't be
+`null`, LangChain4j rejects `@P(required = false) int x` at registration time
+(it would NPE when the LLM omits the argument). Use `defaultValue` instead to opt the
+primitive into optional-with-fallback behavior:
+
+```java
+@Tool
+void process(@P(required = false, defaultValue = "0") int startLine) { ... }
 ```
 
 Fields and sub-fields of complex parameters are also considered **_required_** by default.
@@ -470,7 +551,7 @@ plain abstract classes and interfaces must declare their subtypes with Jackson's
 `@JsonSubTypes`.
 The schema sent to the LLM contains an `anyOf` over the permitted subtypes, each with a
 discriminator property (defaulting to `"type"`) so the LLM can communicate which concrete
-type it produced; the framework deserializes the LLM's argument into the right subtype
+type it produced; LangChain4j deserializes the LLM's argument into the right subtype
 before invoking your tool method.
 
 This works for the polymorphic type as a parameter, for `List<T>` / `Set<T>` of polymorphic

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
@@ -44,13 +44,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface P {
 
     /**
-     * Sentinel value for {@link #defaultValue()} meaning "no default set".
-     * Lets the framework distinguish between "the developer did not specify a default"
-     * and "the default is an empty string".
-     */
-    String NO_DEFAULT = "\0__LANGCHAIN4J_NO_DEFAULT__\0";
-
-    /**
      * Name of the parameter as seen by the LLM.
      * <p>If not specified, the actual method parameter name is used (requires the {@code -parameters} javac option;
      * otherwise the name defaults to {@code arg0}, {@code arg1}, etc.).
@@ -108,10 +101,10 @@ public @interface P {
     /**
      * Default value to substitute when the LLM omits this argument.
      * <p>
-     * Setting a default value makes the parameter <b>optional in the JSON schema</b> sent to the LLM
-     * (the parameter is not added to the schema's {@code required} array). When the LLM omits the
-     * argument, the framework substitutes this default at runtime instead of passing {@code null}
-     * (or, for primitives, throwing).
+     * Setting a default value is equivalent to setting {@link #required()} to {@code false}: the parameter is
+     * marked as <b>optional in the JSON schema</b> sent to the LLM (it is not added to the schema's
+     * {@code required} array). When the LLM omits the argument, the framework substitutes this
+     * default at runtime instead of passing {@code null} (or, for primitives, throwing).
      * <p>
      * The string is parsed at AI Service registration time according to the parameter's type:
      * <ul>
@@ -121,8 +114,7 @@ public @interface P {
      *   <li>Collections, maps, POJOs: parsed as JSON
      *       (e.g. {@code "[]"}, {@code "{\"name\":\"foo\"}"}).</li>
      * </ul>
-     * If the value cannot be parsed into the parameter's type, AI Service construction fails with
-     * {@link dev.langchain4j.service.IllegalConfigurationException}.
+     * If the value cannot be parsed into the parameter's type, AI Service construction fails with exception.
      * <p>
      * <b>Restrictions:</b>
      * <ul>
@@ -135,4 +127,11 @@ public @interface P {
      * @return the default value as a string, or {@link #NO_DEFAULT} if not set
      */
     String defaultValue() default NO_DEFAULT;
+
+    /**
+     * Sentinel value for {@link #defaultValue()} meaning "no default set".
+     * Lets the framework distinguish between "the developer did not specify a default"
+     * and "the default is an empty string".
+     */
+    String NO_DEFAULT = "\0__LANGCHAIN4J_NO_DEFAULT__\0";
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
@@ -44,6 +44,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface P {
 
     /**
+     * Sentinel value for {@link #defaultValue()} meaning "no default set".
+     * Lets the framework distinguish between "the developer did not specify a default"
+     * and "the default is an empty string".
+     */
+    String NO_DEFAULT = "\0__LANGCHAIN4J_NO_DEFAULT__\0";
+
+    /**
      * Name of the parameter as seen by the LLM.
      * <p>If not specified, the actual method parameter name is used (requires the {@code -parameters} javac option;
      * otherwise the name defaults to {@code arg0}, {@code arg1}, etc.).
@@ -97,4 +104,35 @@ public @interface P {
      * @return {@code true} if the parameter is required, {@code false} otherwise
      */
     boolean required() default true;
+
+    /**
+     * Default value to substitute when the LLM omits this argument.
+     * <p>
+     * Setting a default value makes the parameter <b>optional in the JSON schema</b> sent to the LLM
+     * (the parameter is not added to the schema's {@code required} array). When the LLM omits the
+     * argument, the framework substitutes this default at runtime instead of passing {@code null}
+     * (or, for primitives, throwing).
+     * <p>
+     * The string is parsed at AI Service registration time according to the parameter's type:
+     * <ul>
+     *   <li>{@code String} parameters: used verbatim.</li>
+     *   <li>Primitives, boxed primitives, enums, {@code BigDecimal}, {@code BigInteger}, {@code UUID}:
+     *       parsed via type-specific conversion.</li>
+     *   <li>Collections, maps, POJOs: parsed as JSON
+     *       (e.g. {@code "[]"}, {@code "{\"name\":\"foo\"}"}).</li>
+     * </ul>
+     * If the value cannot be parsed into the parameter's type, AI Service construction fails with
+     * {@link dev.langchain4j.service.IllegalConfigurationException}.
+     * <p>
+     * <b>Restrictions:</b>
+     * <ul>
+     *   <li>Cannot be combined with {@code Optional<T>} parameters
+     *       (Optional already represents "absent"; pick one mechanism).</li>
+     *   <li>Cannot be set on framework-injected parameters
+     *       ({@link ToolMemoryId @ToolMemoryId} and similar).</li>
+     * </ul>
+     *
+     * @return the default value as a string, or {@link #NO_DEFAULT} if not set
+     */
+    String defaultValue() default NO_DEFAULT;
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/P.java
@@ -92,7 +92,10 @@ public @interface P {
      *   <li><b>Object parameters</b> — not validated; {@code null} is passed to the
      *       {@link Tool}-annotated method, even though the schema marked the parameter as required.</li>
      * </ul>
-     * This asymmetry will be removed in LangChain4j 2.0, where all required arguments will be validated uniformly.
+     * We are planning to remove this asymmetry in LangChain4j 2.0 so that all required arguments are
+     * validated uniformly. If this planned change would affect your use case, please open an issue at
+     * <a href="https://github.com/langchain4j/langchain4j/issues">github.com/langchain4j/langchain4j/issues</a>
+     * so we can hear your feedback before it lands.
      *
      * @return {@code true} if the parameter is required, {@code false} otherwise
      */

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
@@ -148,7 +148,10 @@ public class ToolSpecifications {
 
             boolean isOptional = Optional.class.equals(parameter.getType());
             P pAnnotation = parameter.getAnnotation(P.class);
+            boolean hasDefaultValue =
+                    pAnnotation != null && !P.NO_DEFAULT.equals(pAnnotation.defaultValue());
             boolean isRequired = !isOptional
+                    && !hasDefaultValue
                     && Optional.ofNullable(pAnnotation)
                             .map(P::required)
                             .orElse(true);

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
@@ -449,8 +449,7 @@ class ToolSpecificationsTest implements WithAssertions {
     }
 
     @Test
-    void parameter_with_default_value_is_not_required_even_when_required_is_true()
-            throws NoSuchMethodException {
+    void parameter_with_default_value_is_not_required_even_when_required_is_true() throws NoSuchMethodException {
         // defaultValue takes precedence over required = true for the schema's required array.
         class Tools {
             @Tool

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
@@ -437,7 +437,7 @@ class ToolSpecificationsTest implements WithAssertions {
     void parameter_with_default_value_is_not_required() throws NoSuchMethodException {
         class Tools {
             @Tool
-            public void tool(@P("foo") String foo, @P(value = "bar", defaultValue = "10") int bar) {}
+            public void tool(String foo, @P(defaultValue = "10") int bar) {}
         }
         Method method = Tools.class.getMethod("tool", String.class, int.class);
         ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);
@@ -454,9 +454,7 @@ class ToolSpecificationsTest implements WithAssertions {
         // defaultValue takes precedence over required = true for the schema's required array.
         class Tools {
             @Tool
-            public void tool(
-                    @P("foo") String foo,
-                    @P(value = "bar", required = true, defaultValue = "10") int bar) {}
+            public void tool(String foo, @P(required = true, defaultValue = "10") int bar) {}
         }
         Method method = Tools.class.getMethod("tool", String.class, int.class);
         ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
@@ -434,6 +434,40 @@ class ToolSpecificationsTest implements WithAssertions {
     }
 
     @Test
+    void parameter_with_default_value_is_not_required() throws NoSuchMethodException {
+        class Tools {
+            @Tool
+            public void tool(@P("foo") String foo, @P(value = "bar", defaultValue = "10") int bar) {}
+        }
+        Method method = Tools.class.getMethod("tool", String.class, int.class);
+        ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);
+
+        assertThat(ts.parameters()).isInstanceOf(JsonObjectSchema.class);
+        JsonObjectSchema schema = ts.parameters();
+        assertThat(schema.required()).containsExactly("arg0"); // 'bar' is optional because it has a default
+        assertThat(schema.properties().keySet()).containsExactly("arg0", "arg1");
+    }
+
+    @Test
+    void parameter_with_default_value_is_not_required_even_when_required_is_true()
+            throws NoSuchMethodException {
+        // defaultValue takes precedence over required = true for the schema's required array.
+        class Tools {
+            @Tool
+            public void tool(
+                    @P("foo") String foo,
+                    @P(value = "bar", required = true, defaultValue = "10") int bar) {}
+        }
+        Method method = Tools.class.getMethod("tool", String.class, int.class);
+        ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);
+
+        assertThat(ts.parameters()).isInstanceOf(JsonObjectSchema.class);
+        JsonObjectSchema schema = ts.parameters();
+        assertThat(schema.required()).containsExactly("arg0");
+        assertThat(schema.properties().keySet()).containsExactly("arg0", "arg1");
+    }
+
+    @Test
     void should_fail_when_both_value_and_description_are_set_in_P() throws NoSuchMethodException {
         class Tools {
             @Tool

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -40,7 +40,7 @@ public class DefaultToolExecutor implements ToolExecutor {
     private final Method methodToInvoke;
     private final boolean wrapToolArgumentsExceptions;
     private final boolean propagateToolExecutionExceptions;
-    private final Map<String, Object> defaultArguments; // TODO good place?
+    private final Map<String, Object> defaultArguments;
 
     public DefaultToolExecutor(Builder builder) {
         this.object = ensureNotNull(builder.object, "object");

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -26,6 +26,8 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -39,6 +41,7 @@ public class DefaultToolExecutor implements ToolExecutor {
     private final Method methodToInvoke;
     private final boolean wrapToolArgumentsExceptions;
     private final boolean propagateToolExecutionExceptions;
+    private final Map<String, Object> defaultArgumentValues;
 
     public DefaultToolExecutor(Builder builder) {
         this.object = ensureNotNull(builder.object, "object");
@@ -46,6 +49,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = ensureNotNull(builder.methodToInvoke, "methodToInvoke");
         this.wrapToolArgumentsExceptions = getOrDefault(builder.wrapToolArgumentsExceptions, false);
         this.propagateToolExecutionExceptions = getOrDefault(builder.propagateToolExecutionExceptions, false);
+        this.defaultArgumentValues = parseDefaultArgumentValues(this.originalMethod);
     }
 
     public DefaultToolExecutor(Object object, Method method) {
@@ -54,6 +58,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = this.originalMethod;
         this.wrapToolArgumentsExceptions = false;
         this.propagateToolExecutionExceptions = false;
+        this.defaultArgumentValues = parseDefaultArgumentValues(this.originalMethod);
     }
 
     public DefaultToolExecutor(Object object, ToolExecutionRequest toolExecutionRequest) {
@@ -63,6 +68,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = this.originalMethod;
         this.wrapToolArgumentsExceptions = false;
         this.propagateToolExecutionExceptions = false;
+        this.defaultArgumentValues = parseDefaultArgumentValues(this.originalMethod);
     }
 
     private Method findMethod(Object object, ToolExecutionRequest toolExecutionRequest) {
@@ -94,6 +100,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = ensureNotNull(methodToInvoke, "methodToInvoke");
         this.wrapToolArgumentsExceptions = false;
         this.propagateToolExecutionExceptions = false;
+        this.defaultArgumentValues = parseDefaultArgumentValues(this.originalMethod);
     }
 
     @Override
@@ -143,7 +150,8 @@ public class DefaultToolExecutor implements ToolExecutor {
     private Object[] prepareArguments(ToolExecutionRequest toolExecutionRequest, InvocationContext context) {
         try {
             Map<String, Object> argumentsMap = argumentsAsMap(toolExecutionRequest.arguments());
-            return prepareArguments(originalMethod, toolExecutionRequest.name(), argumentsMap, context);
+            return prepareArguments(
+                    originalMethod, toolExecutionRequest.name(), argumentsMap, defaultArgumentValues, context);
         } catch (Exception e) {
             if (wrapToolArgumentsExceptions) {
                 throw new ToolArgumentsException(unwrapRuntimeException(e));
@@ -198,6 +206,15 @@ public class DefaultToolExecutor implements ToolExecutor {
 
     static Object[] prepareArguments(
             Method method, String toolName, Map<String, Object> argumentsMap, InvocationContext context) {
+        return prepareArguments(method, toolName, argumentsMap, Collections.emptyMap(), context);
+    }
+
+    static Object[] prepareArguments(
+            Method method,
+            String toolName,
+            Map<String, Object> argumentsMap,
+            Map<String, Object> defaultArgumentValues,
+            InvocationContext context) {
         Parameter[] parameters = method.getParameters();
         Object[] arguments = new Object[parameters.length];
 
@@ -234,6 +251,8 @@ public class DefaultToolExecutor implements ToolExecutor {
                 arguments[i] = createOptional(argument, parameterName, parameterType);
             } else if (argument != null) {
                 arguments[i] = coerceArgument(argument, parameterName, parameterClass, parameterType);
+            } else if (defaultArgumentValues.containsKey(parameterName)) {
+                arguments[i] = defaultArgumentValues.get(parameterName);
             } else if (parameterClass.isPrimitive()) {
                 throw new IllegalArgumentException(String.format(
                         "Required parameter \"%s\" of tool \"%s\" is missing", parameterName, toolName));
@@ -275,6 +294,55 @@ public class DefaultToolExecutor implements ToolExecutor {
         Class<?> actualClass = extractActualClass(actualType);
         Object coercedValue = coerceArgument(argument, parameterName, actualClass, actualType);
         return Optional.of(coercedValue);
+    }
+
+    Map<String, Object> defaultArgumentValues() {
+        return defaultArgumentValues;
+    }
+
+    private static Map<String, Object> parseDefaultArgumentValues(Method method) {
+        Map<String, Object> defaults = new HashMap<>();
+        for (Parameter parameter : method.getParameters()) {
+            P p = parameter.getAnnotation(P.class);
+            if (p == null || P.NO_DEFAULT.equals(p.defaultValue())) {
+                continue;
+            }
+            String parameterName = getName(parameter);
+            defaults.put(
+                    parameterName,
+                    parseDefaultValue(
+                            p.defaultValue(),
+                            parameterName,
+                            parameter.getType(),
+                            parameter.getParameterizedType()));
+        }
+        return defaults;
+    }
+
+    static Object parseDefaultValue(
+            String defaultValue, String parameterName, Class<?> parameterClass, Type parameterType) {
+        if (parameterClass == String.class) {
+            return defaultValue;
+        }
+        if (parameterClass.isEnum()) {
+            return coerceArgument(defaultValue, parameterName, parameterClass, parameterType);
+        }
+        Object jsonParsed;
+        try {
+            jsonParsed = Json.fromJson(defaultValue, Object.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Cannot parse @P(defaultValue = \"%s\") for parameter \"%s\" of type %s: %s",
+                            defaultValue, parameterName, parameterClass.getName(), e.getMessage()),
+                    e);
+        }
+        if (jsonParsed == null) {
+            throw new IllegalArgumentException(String.format(
+                    "@P(defaultValue = \"%s\") parses to null for parameter \"%s\" of type %s",
+                    defaultValue, parameterName, parameterClass.getName()));
+        }
+        return coerceArgument(jsonParsed, parameterName, parameterClass, parameterType);
     }
 
     static Object coerceArgument(Object argument, String parameterName, Class<?> parameterClass, Type parameterType) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -40,7 +39,6 @@ public class DefaultToolExecutor implements ToolExecutor {
     private final Method methodToInvoke;
     private final boolean wrapToolArgumentsExceptions;
     private final boolean propagateToolExecutionExceptions;
-    private final Map<String, Object> defaultArguments;
 
     public DefaultToolExecutor(Builder builder) {
         this.object = ensureNotNull(builder.object, "object");
@@ -48,7 +46,6 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = ensureNotNull(builder.methodToInvoke, "methodToInvoke");
         this.wrapToolArgumentsExceptions = getOrDefault(builder.wrapToolArgumentsExceptions, false);
         this.propagateToolExecutionExceptions = getOrDefault(builder.propagateToolExecutionExceptions, false);
-        this.defaultArguments = parseDefaultArguments(this.originalMethod);
     }
 
     public DefaultToolExecutor(Object object, Method method) {
@@ -57,7 +54,6 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = this.originalMethod;
         this.wrapToolArgumentsExceptions = false;
         this.propagateToolExecutionExceptions = false;
-        this.defaultArguments = parseDefaultArguments(this.originalMethod);
     }
 
     public DefaultToolExecutor(Object object, ToolExecutionRequest toolExecutionRequest) {
@@ -67,7 +63,6 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = this.originalMethod;
         this.wrapToolArgumentsExceptions = false;
         this.propagateToolExecutionExceptions = false;
-        this.defaultArguments = parseDefaultArguments(this.originalMethod);
     }
 
     private Method findMethod(Object object, ToolExecutionRequest toolExecutionRequest) {
@@ -99,7 +94,6 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = ensureNotNull(methodToInvoke, "methodToInvoke");
         this.wrapToolArgumentsExceptions = false;
         this.propagateToolExecutionExceptions = false;
-        this.defaultArguments = parseDefaultArguments(this.originalMethod);
     }
 
     @Override
@@ -149,8 +143,7 @@ public class DefaultToolExecutor implements ToolExecutor {
     private Object[] prepareArguments(ToolExecutionRequest toolExecutionRequest, InvocationContext context) {
         try {
             Map<String, Object> argumentsMap = argumentsAsMap(toolExecutionRequest.arguments());
-            return prepareArguments(
-                    originalMethod, toolExecutionRequest.name(), argumentsMap, defaultArguments, context);
+            return prepareArguments(originalMethod, toolExecutionRequest.name(), argumentsMap, context);
         } catch (Exception e) {
             if (wrapToolArgumentsExceptions) {
                 throw new ToolArgumentsException(unwrapRuntimeException(e));
@@ -205,15 +198,6 @@ public class DefaultToolExecutor implements ToolExecutor {
 
     static Object[] prepareArguments(
             Method method, String toolName, Map<String, Object> argumentsMap, InvocationContext context) {
-        return prepareArguments(method, toolName, argumentsMap, Map.of(), context);
-    }
-
-    static Object[] prepareArguments(
-            Method method,
-            String toolName,
-            Map<String, Object> argumentsMap,
-            Map<String, Object> defaultArguments,
-            InvocationContext context) {
         Parameter[] parameters = method.getParameters();
         Object[] arguments = new Object[parameters.length];
 
@@ -250,11 +234,15 @@ public class DefaultToolExecutor implements ToolExecutor {
                 arguments[i] = createOptional(argument, parameterName, parameterType);
             } else if (argument != null) {
                 arguments[i] = coerceArgument(argument, parameterName, parameterClass, parameterType);
-            } else if (defaultArguments.containsKey(parameterName)) {
-                arguments[i] = defaultArguments.get(parameterName);
-            } else if (parameterClass.isPrimitive()) {
-                throw new IllegalArgumentException(String.format(
-                        "Required parameter \"%s\" of tool \"%s\" is missing", parameterName, toolName));
+            } else {
+                P pAnnotation = parameter.getAnnotation(P.class);
+                if (pAnnotation != null && !P.NO_DEFAULT.equals(pAnnotation.defaultValue())) {
+                    arguments[i] = parseDefaultValue(
+                            pAnnotation.defaultValue(), parameterName, parameterClass, parameterType);
+                } else if (parameterClass.isPrimitive()) {
+                    throw new IllegalArgumentException(String.format(
+                            "Required parameter \"%s\" of tool \"%s\" is missing", parameterName, toolName));
+                }
             }
         }
 
@@ -293,29 +281,6 @@ public class DefaultToolExecutor implements ToolExecutor {
         Class<?> actualClass = extractActualClass(actualType);
         Object coercedValue = coerceArgument(argument, parameterName, actualClass, actualType);
         return Optional.of(coercedValue);
-    }
-
-    Map<String, Object> defaultArguments() {
-        return defaultArguments;
-    }
-
-    private static Map<String, Object> parseDefaultArguments(Method method) {
-        Map<String, Object> defaults = new HashMap<>();
-        for (Parameter parameter : method.getParameters()) {
-            P p = parameter.getAnnotation(P.class);
-            if (p == null || P.NO_DEFAULT.equals(p.defaultValue())) {
-                continue;
-            }
-            String parameterName = getName(parameter);
-            defaults.put(
-                    parameterName,
-                    parseDefaultValue(
-                            p.defaultValue(),
-                            parameterName,
-                            parameter.getType(),
-                            parameter.getParameterizedType()));
-        }
-        return defaults;
     }
 
     static Object parseDefaultValue(

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -321,10 +320,7 @@ public class DefaultToolExecutor implements ToolExecutor {
 
     static Object parseDefaultValue(
             String defaultValue, String parameterName, Class<?> parameterClass, Type parameterType) {
-        if (parameterClass == String.class) {
-            return defaultValue;
-        }
-        if (parameterClass.isEnum()) {
+        if (parameterClass == String.class || parameterClass.isEnum() || parameterClass == UUID.class) {
             return coerceArgument(defaultValue, parameterName, parameterClass, parameterType);
         }
         Object jsonParsed;

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -41,7 +41,7 @@ public class DefaultToolExecutor implements ToolExecutor {
     private final Method methodToInvoke;
     private final boolean wrapToolArgumentsExceptions;
     private final boolean propagateToolExecutionExceptions;
-    private final Map<String, Object> defaultArgumentValues;
+    private final Map<String, Object> defaultArguments; // TODO good place?
 
     public DefaultToolExecutor(Builder builder) {
         this.object = ensureNotNull(builder.object, "object");
@@ -49,7 +49,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = ensureNotNull(builder.methodToInvoke, "methodToInvoke");
         this.wrapToolArgumentsExceptions = getOrDefault(builder.wrapToolArgumentsExceptions, false);
         this.propagateToolExecutionExceptions = getOrDefault(builder.propagateToolExecutionExceptions, false);
-        this.defaultArgumentValues = parseDefaultArgumentValues(this.originalMethod);
+        this.defaultArguments = parseDefaultArguments(this.originalMethod);
     }
 
     public DefaultToolExecutor(Object object, Method method) {
@@ -58,7 +58,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = this.originalMethod;
         this.wrapToolArgumentsExceptions = false;
         this.propagateToolExecutionExceptions = false;
-        this.defaultArgumentValues = parseDefaultArgumentValues(this.originalMethod);
+        this.defaultArguments = parseDefaultArguments(this.originalMethod);
     }
 
     public DefaultToolExecutor(Object object, ToolExecutionRequest toolExecutionRequest) {
@@ -68,7 +68,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = this.originalMethod;
         this.wrapToolArgumentsExceptions = false;
         this.propagateToolExecutionExceptions = false;
-        this.defaultArgumentValues = parseDefaultArgumentValues(this.originalMethod);
+        this.defaultArguments = parseDefaultArguments(this.originalMethod);
     }
 
     private Method findMethod(Object object, ToolExecutionRequest toolExecutionRequest) {
@@ -100,7 +100,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         this.methodToInvoke = ensureNotNull(methodToInvoke, "methodToInvoke");
         this.wrapToolArgumentsExceptions = false;
         this.propagateToolExecutionExceptions = false;
-        this.defaultArgumentValues = parseDefaultArgumentValues(this.originalMethod);
+        this.defaultArguments = parseDefaultArguments(this.originalMethod);
     }
 
     @Override
@@ -151,7 +151,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         try {
             Map<String, Object> argumentsMap = argumentsAsMap(toolExecutionRequest.arguments());
             return prepareArguments(
-                    originalMethod, toolExecutionRequest.name(), argumentsMap, defaultArgumentValues, context);
+                    originalMethod, toolExecutionRequest.name(), argumentsMap, defaultArguments, context);
         } catch (Exception e) {
             if (wrapToolArgumentsExceptions) {
                 throw new ToolArgumentsException(unwrapRuntimeException(e));
@@ -206,14 +206,14 @@ public class DefaultToolExecutor implements ToolExecutor {
 
     static Object[] prepareArguments(
             Method method, String toolName, Map<String, Object> argumentsMap, InvocationContext context) {
-        return prepareArguments(method, toolName, argumentsMap, Collections.emptyMap(), context);
+        return prepareArguments(method, toolName, argumentsMap, Map.of(), context);
     }
 
     static Object[] prepareArguments(
             Method method,
             String toolName,
             Map<String, Object> argumentsMap,
-            Map<String, Object> defaultArgumentValues,
+            Map<String, Object> defaultArguments,
             InvocationContext context) {
         Parameter[] parameters = method.getParameters();
         Object[] arguments = new Object[parameters.length];
@@ -251,8 +251,8 @@ public class DefaultToolExecutor implements ToolExecutor {
                 arguments[i] = createOptional(argument, parameterName, parameterType);
             } else if (argument != null) {
                 arguments[i] = coerceArgument(argument, parameterName, parameterClass, parameterType);
-            } else if (defaultArgumentValues.containsKey(parameterName)) {
-                arguments[i] = defaultArgumentValues.get(parameterName);
+            } else if (defaultArguments.containsKey(parameterName)) {
+                arguments[i] = defaultArguments.get(parameterName);
             } else if (parameterClass.isPrimitive()) {
                 throw new IllegalArgumentException(String.format(
                         "Required parameter \"%s\" of tool \"%s\" is missing", parameterName, toolName));
@@ -296,11 +296,11 @@ public class DefaultToolExecutor implements ToolExecutor {
         return Optional.of(coercedValue);
     }
 
-    Map<String, Object> defaultArgumentValues() {
-        return defaultArgumentValues;
+    Map<String, Object> defaultArguments() {
+        return defaultArguments;
     }
 
-    private static Map<String, Object> parseDefaultArgumentValues(Method method) {
+    private static Map<String, Object> parseDefaultArguments(Method method) {
         Map<String, Object> defaults = new HashMap<>();
         for (Parameter parameter : method.getParameters()) {
             P p = parameter.getAnnotation(P.class);

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -20,9 +20,12 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.agent.tool.ToolMemoryId;
 import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.invocation.InvocationParameters;
+import dev.langchain4j.invocation.LangChain4jManaged;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -135,18 +138,60 @@ public class ToolService {
 
     private static void validateToolParameters(Method toolMethod) {
         for (Parameter parameter : toolMethod.getParameters()) {
-            if (!parameter.getType().isPrimitive()) {
+            P pAnnotation = parameter.getAnnotation(P.class);
+            if (pAnnotation == null) {
                 continue;
             }
-            P pAnnotation = parameter.getAnnotation(P.class);
-            if (pAnnotation != null && !pAnnotation.required()) {
+            Class<?> type = parameter.getType();
+            boolean hasDefault = !P.NO_DEFAULT.equals(pAnnotation.defaultValue());
+
+            if (type.isPrimitive() && !pAnnotation.required() && !hasDefault) {
                 throw illegalConfiguration(
                         "Parameter '%s' of tool '%s.%s' is a primitive (%s) and cannot be marked as @P(required = false). "
-                                + "Use a boxed type (e.g. Integer instead of int) or Optional<T> to allow optional values.",
+                                + "Use a boxed type (e.g. Integer instead of int), Optional<T>, or set a @P(defaultValue = ...) to allow optional values.",
                         parameter.getName(),
                         toolMethod.getDeclaringClass().getName(),
                         toolMethod.getName(),
-                        parameter.getType().getName());
+                        type.getName());
+            }
+
+            if (!hasDefault) {
+                continue;
+            }
+
+            if (type == Optional.class) {
+                throw illegalConfiguration(
+                        "Parameter '%s' of tool '%s.%s' has @P(defaultValue = ...) and is Optional<T>. "
+                                + "Optional<T> already represents \"absent\"; use one mechanism or the other.",
+                        parameter.getName(),
+                        toolMethod.getDeclaringClass().getName(),
+                        toolMethod.getName());
+            }
+
+            if (parameter.isAnnotationPresent(ToolMemoryId.class)
+                    || InvocationParameters.class.isAssignableFrom(type)
+                    || type == InvocationContext.class
+                    || LangChain4jManaged.class.isAssignableFrom(type)) {
+                throw illegalConfiguration(
+                        "Parameter '%s' of tool '%s.%s' has @P(defaultValue = ...) but is a framework-injected parameter; "
+                                + "default values are not supported on framework-injected parameters.",
+                        parameter.getName(),
+                        toolMethod.getDeclaringClass().getName(),
+                        toolMethod.getName());
+            }
+
+            try {
+                DefaultToolExecutor.parseDefaultValue(
+                        pAnnotation.defaultValue(), parameter.getName(), type, parameter.getParameterizedType());
+            } catch (Exception e) {
+                throw illegalConfiguration(
+                        "Cannot parse @P(defaultValue = \"%s\") for parameter '%s' of tool '%s.%s' (type %s): %s",
+                        pAnnotation.defaultValue(),
+                        parameter.getName(),
+                        toolMethod.getDeclaringClass().getName(),
+                        toolMethod.getName(),
+                        type.getName(),
+                        e.getMessage());
             }
         }
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -147,7 +147,7 @@ public class ToolService {
             if (type.isPrimitive() && !pAnnotation.required() && !hasDefault) {
                 throw illegalConfiguration(
                         "Parameter '%s' of tool '%s.%s' is a primitive (%s) and cannot be marked as @P(required = false). "
-                                + "Use a boxed type (e.g. Integer instead of int), Optional<T>, or set a @P(defaultValue = ...) to allow optional values.",
+                                + "Use a boxed type (e.g. Integer instead of int), Optional<T>, or @P(defaultValue = ...).",
                         parameter.getName(),
                         toolMethod.getDeclaringClass().getName(),
                         toolMethod.getName(),

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesBuilderTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesBuilderTest.java
@@ -230,4 +230,78 @@ class AiServicesBuilderTest {
                         .build())
                 .withMessageContaining("Optional<T>");
     }
+
+    @Test
+    void should_raise_an_error_when_default_value_overflows_target_type() {
+        // 999999999999999 fits in long but not int → bounds check at registration time.
+        class ToolWithOverflowingDefault {
+            @Tool
+            void tool(@P(defaultValue = "999999999999999") int x) {}
+        }
+
+        ChatModel chatModel = ChatModelMock.thatAlwaysResponds("Hello there!");
+
+        assertThatExceptionOfType(IllegalConfigurationException.class)
+                .isThrownBy(() -> AiServices.builder(TestService.class)
+                        .chatModel(chatModel)
+                        .tools(new ToolWithOverflowingDefault())
+                        .build())
+                .withMessageContaining("Cannot parse @P(defaultValue = \"999999999999999\")");
+    }
+
+    @Test
+    void should_raise_an_error_when_default_value_is_not_a_valid_boolean() {
+        class ToolWithBadBooleanDefault {
+            @Tool
+            void tool(@P(defaultValue = "yes") boolean x) {}
+        }
+
+        ChatModel chatModel = ChatModelMock.thatAlwaysResponds("Hello there!");
+
+        assertThatExceptionOfType(IllegalConfigurationException.class)
+                .isThrownBy(() -> AiServices.builder(TestService.class)
+                        .chatModel(chatModel)
+                        .tools(new ToolWithBadBooleanDefault())
+                        .build())
+                .withMessageContaining("Cannot parse @P(defaultValue = \"yes\")");
+    }
+
+    enum Currency {
+        USD,
+        EUR
+    }
+
+    @Test
+    void should_raise_an_error_when_default_value_is_not_a_valid_enum_constant() {
+        class ToolWithBadEnumDefault {
+            @Tool
+            void tool(@P(defaultValue = "ZZZ") Currency c) {}
+        }
+
+        ChatModel chatModel = ChatModelMock.thatAlwaysResponds("Hello there!");
+
+        assertThatExceptionOfType(IllegalConfigurationException.class)
+                .isThrownBy(() -> AiServices.builder(TestService.class)
+                        .chatModel(chatModel)
+                        .tools(new ToolWithBadEnumDefault())
+                        .build())
+                .withMessageContaining("Cannot parse @P(defaultValue = \"ZZZ\")");
+    }
+
+    @Test
+    void should_raise_an_error_when_default_value_is_not_a_valid_UUID() {
+        class ToolWithBadUuidDefault {
+            @Tool
+            void tool(@P(defaultValue = "not-a-uuid") java.util.UUID id) {}
+        }
+
+        ChatModel chatModel = ChatModelMock.thatAlwaysResponds("Hello there!");
+
+        assertThatExceptionOfType(IllegalConfigurationException.class)
+                .isThrownBy(() -> AiServices.builder(TestService.class)
+                        .chatModel(chatModel)
+                        .tools(new ToolWithBadUuidDefault())
+                        .build())
+                .withMessageContaining("Cannot parse @P(defaultValue = \"not-a-uuid\")");
+    }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesBuilderTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesBuilderTest.java
@@ -179,4 +179,55 @@ class AiServicesBuilderTest {
                 .withMessageContaining("is a primitive")
                 .withMessageContaining("@P(required = false)");
     }
+
+    @Test
+    void should_allow_optional_primitive_when_default_value_is_set() {
+        class ToolWithDefaultPrimitive {
+            @Tool("Read part of a file")
+            void readFile(String filePath, @P(required = false, defaultValue = "0") int startLine) {}
+        }
+
+        ChatModel chatModel = ChatModelMock.thatAlwaysResponds("Hello there!");
+
+        TestService service = AiServices.builder(TestService.class)
+                .chatModel(chatModel)
+                .tools(new ToolWithDefaultPrimitive())
+                .build();
+
+        assertThat(service).isNotNull();
+    }
+
+    @Test
+    void should_raise_an_error_when_default_value_cannot_be_parsed() {
+        class ToolWithBadDefault {
+            @Tool
+            void tool(@P(defaultValue = "not-an-int") int x) {}
+        }
+
+        ChatModel chatModel = ChatModelMock.thatAlwaysResponds("Hello there!");
+
+        assertThatExceptionOfType(IllegalConfigurationException.class)
+                .isThrownBy(() -> AiServices.builder(TestService.class)
+                        .chatModel(chatModel)
+                        .tools(new ToolWithBadDefault())
+                        .build())
+                .withMessageContaining("Cannot parse @P(defaultValue = \"not-an-int\")");
+    }
+
+    @Test
+    void should_raise_an_error_when_default_value_is_combined_with_Optional() {
+        class ToolWithDefaultAndOptional {
+            @Tool
+            void tool(@P(defaultValue = "10") java.util.Optional<Integer> x) {}
+        }
+
+        ChatModel chatModel = ChatModelMock.thatAlwaysResponds("Hello there!");
+
+        assertThatExceptionOfType(IllegalConfigurationException.class)
+                .isThrownBy(() -> AiServices.builder(TestService.class)
+                        .chatModel(chatModel)
+                        .tools(new ToolWithDefaultAndOptional())
+                        .build())
+                .withMessageContaining("Optional<T>");
+    }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithDefaultValuesTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithDefaultValuesTest.java
@@ -527,8 +527,312 @@ class AiServicesWithToolsWithDefaultValuesTest {
     }
 
     // ---------------------------------------------------------------------
+    // Arrays
+    // ---------------------------------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_int_array_when_LLM_omits_it(String missingArguments) {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "[1,2,3]") int[] values) {
+            }
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(new int[] {1, 2, 3});
+        verifyNoMoreInteractions(tool);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_String_array_when_LLM_omits_it(String missingArguments) {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "[\"a\",\"b\"]") String[] values) {
+            }
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(new String[] {"a", "b"});
+        verifyNoMoreInteractions(tool);
+    }
+
+    // ---------------------------------------------------------------------
+    // Empty collection / map defaults
+    // ---------------------------------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_empty_List_when_LLM_omits_it(String missingArguments) {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "[]") List<String> tags) {
+            }
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(List.of());
+        verifyNoMoreInteractions(tool);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_empty_Map_when_LLM_omits_it(String missingArguments) {
+        class Tools {
+            @Tool
+            void process(@P(value = "string keys to string values", defaultValue = "{}")
+                    Map<String, String> entries) {
+            }
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(Map.of());
+        verifyNoMoreInteractions(tool);
+    }
+
+    // ---------------------------------------------------------------------
+    // Enum collection
+    // ---------------------------------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_List_of_enums_when_LLM_omits_it(String missingArguments) {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "[\"USD\",\"EUR\"]") List<Currency> currencies) {
+            }
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(List.of(Currency.USD, Currency.EUR));
+        verifyNoMoreInteractions(tool);
+    }
+
+    // ---------------------------------------------------------------------
+    // Mutation safety — verify defaults are re-parsed per invocation so
+    // tool-side mutation does not contaminate later calls.
+    // ---------------------------------------------------------------------
+
+    /** Helper: two consecutive tool calls, both omitting the argument. */
+    private static ChatModel mockReturningTwoToolCalls(String toolName) {
+        return ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("1")
+                        .name(toolName)
+                        .arguments("{}")
+                        .build()),
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("2")
+                        .name(toolName)
+                        .arguments("{}")
+                        .build()),
+                AiMessage.from("Done"));
+    }
+
+    @Test
+    void mutation_of_List_default_does_not_leak_between_invocations() {
+        java.util.List<Integer> sizesAtEntry = new java.util.ArrayList<>();
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "[\"a\",\"b\"]") List<String> tags) {
+                sizesAtEntry.add(tags.size());
+                tags.add("mutated"); // would contaminate later calls if shared
+            }
+        }
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningTwoToolCalls("process"))
+                .tools(new Tools())
+                .build();
+        assistant.chat("call the tool twice");
+
+        assertThat(sizesAtEntry).containsExactly(2, 2);
+    }
+
+    @Test
+    void mutation_of_Set_default_does_not_leak_between_invocations() {
+        java.util.List<Integer> sizesAtEntry = new java.util.ArrayList<>();
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "[1,2]") Set<Integer> ids) {
+                sizesAtEntry.add(ids.size());
+                ids.add(99);
+            }
+        }
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningTwoToolCalls("process"))
+                .tools(new Tools())
+                .build();
+        assistant.chat("call the tool twice");
+
+        assertThat(sizesAtEntry).containsExactly(2, 2);
+    }
+
+    @Test
+    void mutation_of_Map_default_does_not_leak_between_invocations() {
+        java.util.List<Integer> sizesAtEntry = new java.util.ArrayList<>();
+        class Tools {
+            @Tool
+            void process(@P(value = "string keys to integer values", defaultValue = "{\"a\":1}")
+                    Map<String, Integer> counts) {
+                sizesAtEntry.add(counts.size());
+                counts.put("b", 2);
+            }
+        }
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningTwoToolCalls("process"))
+                .tools(new Tools())
+                .build();
+        assistant.chat("call the tool twice");
+
+        assertThat(sizesAtEntry).containsExactly(1, 1);
+    }
+
+    /** POJO whose internal collection is mutable — mutation through the field must not leak either. */
+    public static final class MutableContainer {
+        public java.util.List<String> items = new java.util.ArrayList<>();
+    }
+
+    @Test
+    void mutation_of_POJO_default_does_not_leak_between_invocations() {
+        java.util.List<Integer> sizesAtEntry = new java.util.ArrayList<>();
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "{\"items\":[\"a\",\"b\"]}") MutableContainer container) {
+                sizesAtEntry.add(container.items.size());
+                container.items.add("mutated");
+            }
+        }
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningTwoToolCalls("process"))
+                .tools(new Tools())
+                .build();
+        assistant.chat("call the tool twice");
+
+        assertThat(sizesAtEntry).containsExactly(2, 2);
+    }
+
+    /**
+     * Records are immutable at the top level, but their inner collections aren't.
+     * A naive cache that stores the parsed record would share the same inner list
+     * across invocations — this test ensures fresh inner state on each call.
+     */
+    public record RecordWithList(java.util.List<String> items) {}
+
+    @Test
+    void mutation_of_record_inner_collection_does_not_leak_between_invocations() {
+        java.util.List<Integer> sizesAtEntry = new java.util.ArrayList<>();
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "{\"items\":[\"a\",\"b\"]}") RecordWithList container) {
+                sizesAtEntry.add(container.items().size());
+                container.items().add("mutated");
+            }
+        }
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningTwoToolCalls("process"))
+                .tools(new Tools())
+                .build();
+        assistant.chat("call the tool twice");
+
+        assertThat(sizesAtEntry).containsExactly(2, 2);
+    }
+
+    // ---------------------------------------------------------------------
+    // Non-defaulted object parameter: explicit null and absent both produce null
+    // (1.x asymmetry — flagged in docs as changing in 2.x)
+    // ---------------------------------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_pass_null_for_non_defaulted_object_when_LLM_omits_it(String missingArguments) {
+        // No @P(defaultValue) → object param is missing → framework passes null.
+        class Tools {
+            @Tool
+            void process(Person person) {
+            }
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process((Person) null);
+        verifyNoMoreInteractions(tool);
+    }
+
+    // ---------------------------------------------------------------------
     // Corner cases
     // ---------------------------------------------------------------------
+
+    @Test
+    void should_propagate_coercion_error_for_LLM_provided_value_instead_of_falling_back_to_default() {
+        // Default value is a fallback for absence, not for wrong-type values:
+        // if the LLM provides "banana" for an int parameter, that's a coercion error,
+        // not a trigger to use the default. With the framework's default
+        // toolArgumentsErrorHandler (which rethrows the cause), the
+        // IllegalArgumentException from coerceArgument propagates out of assistant.chat().
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "10") int limit) {
+            }
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{\"arg0\":\"banana\"}"))
+                .tools(tool)
+                .build();
+
+        org.assertj.core.api.Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> assistant.chat("call the tool"))
+                .withMessageContaining("not convertable to int");
+        org.mockito.Mockito.verifyNoInteractions(tool);
+    }
 
     @Test
     void should_use_LLM_provided_value_over_default() {

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithDefaultValuesTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithDefaultValuesTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -51,8 +53,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
     // Primitives
     // ---------------------------------------------------------------------
 
-    @Test
-    void should_substitute_default_for_primitive_int_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_primitive_int_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
             void process(@P(defaultValue = "10") int limit) {}
@@ -60,7 +63,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -70,8 +73,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
         verifyNoMoreInteractions(tool);
     }
 
-    @Test
-    void should_substitute_default_for_primitive_double_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_primitive_double_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
             void process(@P(defaultValue = "3.14") double pi) {}
@@ -79,7 +83,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -89,8 +93,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
         verifyNoMoreInteractions(tool);
     }
 
-    @Test
-    void should_substitute_default_for_primitive_boolean_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_primitive_boolean_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
             void process(@P(defaultValue = "true") boolean verbose) {}
@@ -98,7 +103,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -108,8 +113,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
         verifyNoMoreInteractions(tool);
     }
 
-    @Test
-    void should_substitute_default_for_primitive_long_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_primitive_long_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
             void process(@P(defaultValue = "9999999999") long bigNumber) {}
@@ -117,7 +123,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -131,8 +137,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
     // Boxed / object scalar types
     // ---------------------------------------------------------------------
 
-    @Test
-    void should_substitute_default_for_boxed_Integer_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_boxed_Integer_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
             void process(@P(defaultValue = "42") Integer limit) {}
@@ -140,7 +147,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -150,8 +157,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
         verifyNoMoreInteractions(tool);
     }
 
-    @Test
-    void should_substitute_default_for_String_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_String_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
             void process(@P(defaultValue = "USD") String currency) {}
@@ -159,7 +167,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -169,8 +177,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
         verifyNoMoreInteractions(tool);
     }
 
-    @Test
-    void should_substitute_default_for_BigDecimal_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_BigDecimal_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
             void process(@P(defaultValue = "1.5") BigDecimal value) {}
@@ -178,7 +187,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -198,8 +207,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
         GBP
     }
 
-    @Test
-    void should_substitute_default_for_enum_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_enum_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
             void process(@P(defaultValue = "EUR") Currency currency) {}
@@ -207,7 +217,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -225,11 +235,13 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
     public record Person(String name, int age, Address address) {}
 
-    @Test
-    void should_substitute_default_for_POJO_with_nested_POJO_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_POJO_with_nested_POJO_when_LLM_omits_it(String missingArguments) {
         class Tools {
 
-            public static final String DEFAULT_PERSON = """
+            public static final String DEFAULT_PERSON =
+                    """
                     {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}}""";
 
             @Tool
@@ -238,7 +250,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -263,8 +275,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
     public record Dog(String breed) implements Animal {}
 
-    @Test
-    void should_substitute_default_for_polymorphic_sealed_type_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_polymorphic_sealed_type_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
             void process(@P(defaultValue = "{\"type\":\"cat\",\"name\":\"Whiskers\"}") Animal animal) {}
@@ -272,7 +285,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -286,8 +299,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
     // Collections and maps
     // ---------------------------------------------------------------------
 
-    @Test
-    void should_substitute_default_for_List_of_strings_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_List_of_strings_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
             void process(@P(defaultValue = "[\"red\",\"green\",\"blue\"]") List<String> colors) {}
@@ -295,7 +309,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -305,8 +319,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
         verifyNoMoreInteractions(tool);
     }
 
-    @Test
-    void should_substitute_default_for_Set_of_integers_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_Set_of_integers_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
             void process(@P(defaultValue = "[1,2,3]") Set<Integer> ids) {}
@@ -314,7 +329,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -324,17 +339,19 @@ class AiServicesWithToolsWithDefaultValuesTest {
         verifyNoMoreInteractions(tool);
     }
 
-    @Test
-    void should_substitute_default_for_Map_when_LLM_omits_it() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_Map_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(value = "string keys to integer values", defaultValue = "{\"a\":1,\"b\":2}")
-                    Map<String, Integer> counts) {}
+            void process(
+                    @P(value = "string keys to integer values", defaultValue = "{\"a\":1,\"b\":2}")
+                            Map<String, Integer> counts) {}
         }
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
                 .tools(tool)
                 .build();
 
@@ -343,6 +360,101 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Map<String, Integer> expected = new LinkedHashMap<>();
         expected.put("a", 1);
         expected.put("b", 2);
+        verify(tool).process(expected);
+        verifyNoMoreInteractions(tool);
+    }
+
+    // ---------------------------------------------------------------------
+    // Collections of POJOs
+    // ---------------------------------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_List_of_POJOs_when_LLM_omits_it(String missingArguments) {
+        class Tools {
+            public static final String DEFAULT_PEOPLE =
+                    """
+                    [
+                      {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}},
+                      {"name":"Peter","age":43,"address":{"city":"Munich","country":"DE"}}
+                    ]""";
+
+            @Tool
+            void process(@P(defaultValue = DEFAULT_PEOPLE) List<Person> people) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool)
+                .process(List.of(
+                        new Person("Klaus", 42, new Address("Berlin", "DE")),
+                        new Person("Peter", 43, new Address("Munich", "DE"))));
+        verifyNoMoreInteractions(tool);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_Set_of_POJOs_when_LLM_omits_it(String missingArguments) {
+        class Tools {
+            public static final String DEFAULT_PEOPLE =
+                    """
+                    [
+                      {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}},
+                      {"name":"Peter","age":43,"address":{"city":"Munich","country":"DE"}}
+                    ]""";
+
+            @Tool
+            void process(@P(defaultValue = DEFAULT_PEOPLE) Set<Person> people) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        Set<Person> expected = new LinkedHashSet<>();
+        expected.add(new Person("Klaus", 42, new Address("Berlin", "DE")));
+        expected.add(new Person("Peter", 43, new Address("Munich", "DE")));
+        verify(tool).process(expected);
+        verifyNoMoreInteractions(tool);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_Map_of_String_to_POJO_when_LLM_omits_it(String missingArguments) {
+        class Tools {
+            public static final String DEFAULT_MAP =
+                    """
+                    {
+                      "p1": {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}},
+                      "p2": {"name":"Peter","age":43,"address":{"city":"Munich","country":"DE"}}
+                    }""";
+
+            @Tool
+            void process(
+                    @P(value = "string id to person", defaultValue = DEFAULT_MAP) Map<String, Person> people) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        Map<String, Person> expected = new LinkedHashMap<>();
+        expected.put("p1", new Person("Klaus", 42, new Address("Berlin", "DE")));
+        expected.put("p2", new Person("Peter", 43, new Address("Munich", "DE")));
         verify(tool).process(expected);
         verifyNoMoreInteractions(tool);
     }
@@ -370,8 +482,13 @@ class AiServicesWithToolsWithDefaultValuesTest {
         verifyNoMoreInteractions(tool);
     }
 
-    @Test
-    void should_mix_defaulted_and_LLM_provided_parameters() {
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "{\"arg0\":\"hello\"}",
+                "{\"arg0\":\"hello\",\"arg1\":null,\"arg2\":null}"
+            })
+    void should_mix_defaulted_and_LLM_provided_parameters(String arguments) {
         class Tools {
             @Tool
             void search(String query, @P(defaultValue = "10") int limit, @P(defaultValue = "0") int offset) {}
@@ -379,7 +496,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         Tools tool = spy(new Tools());
 
         Assistant assistant = AiServices.builder(Assistant.class)
-                .chatModel(mockReturningToolCallWithArgs("search", "{\"arg0\":\"hello\"}"))
+                .chatModel(mockReturningToolCallWithArgs("search", arguments))
                 .tools(tool)
                 .build();
 
@@ -389,8 +506,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
         verifyNoMoreInteractions(tool);
     }
 
-    @Test
-    void should_apply_default_even_when_required_is_explicitly_true() {
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_apply_default_even_when_required_is_explicitly_true(String missingArguments) {
         // defaultValue forces the schema to mark the param as optional
         // (so the LLM is told it can omit it), and supplies the runtime fallback.
         class Tools {
@@ -399,7 +517,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         }
         Tools tool = spy(new Tools());
 
-        ChatModel chatModelMock = mockReturningToolCallWithArgs("process", "{}");
+        ChatModel chatModelMock = mockReturningToolCallWithArgs("process", missingArguments);
         Assistant assistant = AiServices.builder(Assistant.class)
                 .chatModel(chatModelMock)
                 .tools(tool)

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithDefaultValuesTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithDefaultValuesTest.java
@@ -1,10 +1,5 @@
 package dev.langchain4j.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import dev.langchain4j.agent.tool.P;
@@ -15,12 +10,6 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.mock.ChatModelMock;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import java.math.BigDecimal;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +17,19 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class AiServicesWithToolsWithDefaultValuesTest {
@@ -58,7 +60,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_substitute_default_for_primitive_int_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "10") int limit) {}
+            void process(@P(defaultValue = "10") int limit) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -78,7 +81,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_substitute_default_for_primitive_double_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "3.14") double pi) {}
+            void process(@P(defaultValue = "3.14") double pi) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -98,7 +102,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_substitute_default_for_primitive_boolean_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "true") boolean verbose) {}
+            void process(@P(defaultValue = "true") boolean verbose) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -118,7 +123,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_substitute_default_for_primitive_long_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "9999999999") long bigNumber) {}
+            void process(@P(defaultValue = "9999999999") long bigNumber) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -142,7 +148,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_substitute_default_for_boxed_Integer_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "42") Integer limit) {}
+            void process(@P(defaultValue = "42") Integer limit) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -162,7 +169,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_substitute_default_for_String_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "USD") String currency) {}
+            void process(@P(defaultValue = "USD") String currency) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -179,10 +187,55 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_empty_string_default_when_LLM_omits_it(String missingArguments) {
+        // Verifies the NO_DEFAULT sentinel actually distinguishes "no default set"
+        // from "default is the empty string". An empty-string default must be applied.
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "") String filter) {
+            }
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process("");
+        verifyNoMoreInteractions(tool);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
+    void should_substitute_default_for_UUID_when_LLM_omits_it(String missingArguments) {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "550e8400-e29b-41d4-a716-446655440000") UUID id) {
+            }
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", missingArguments))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"));
+        verifyNoMoreInteractions(tool);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"arg0\":null}"})
     void should_substitute_default_for_BigDecimal_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "1.5") BigDecimal value) {}
+            void process(@P(defaultValue = "1.5") BigDecimal value) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -212,7 +265,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_substitute_default_for_enum_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "EUR") Currency currency) {}
+            void process(@P(defaultValue = "EUR") Currency currency) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -231,9 +285,11 @@ class AiServicesWithToolsWithDefaultValuesTest {
     // POJOs (including nested)
     // ---------------------------------------------------------------------
 
-    public record Address(String city, String country) {}
+    public record Address(String city, String country) {
+    }
 
-    public record Person(String name, int age, Address address) {}
+    public record Person(String name, int age, Address address) {
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {"{}", "{\"arg0\":null}"})
@@ -242,10 +298,11 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
             public static final String DEFAULT_PERSON =
                     """
-                    {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}}""";
+                            {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}}""";
 
             @Tool
-            void process(@P(defaultValue = DEFAULT_PERSON) Person person) {}
+            void process(@P(defaultValue = DEFAULT_PERSON) Person person) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -266,21 +323,25 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
     @JsonSubTypes({
-        @JsonSubTypes.Type(value = Cat.class, name = "cat"),
-        @JsonSubTypes.Type(value = Dog.class, name = "dog")
+            @JsonSubTypes.Type(value = Cat.class, name = "cat"),
+            @JsonSubTypes.Type(value = Dog.class, name = "dog")
     })
-    public sealed interface Animal permits Cat, Dog {}
+    public sealed interface Animal permits Cat, Dog {
+    }
 
-    public record Cat(String name) implements Animal {}
+    public record Cat(String name) implements Animal {
+    }
 
-    public record Dog(String breed) implements Animal {}
+    public record Dog(String breed) implements Animal {
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {"{}", "{\"arg0\":null}"})
     void should_substitute_default_for_polymorphic_sealed_type_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "{\"type\":\"cat\",\"name\":\"Whiskers\"}") Animal animal) {}
+            void process(@P(defaultValue = "{\"type\":\"cat\",\"name\":\"Whiskers\"}") Animal animal) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -304,7 +365,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_substitute_default_for_List_of_strings_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "[\"red\",\"green\",\"blue\"]") List<String> colors) {}
+            void process(@P(defaultValue = "[\"red\",\"green\",\"blue\"]") List<String> colors) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -324,7 +386,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_substitute_default_for_Set_of_integers_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "[1,2,3]") Set<Integer> ids) {}
+            void process(@P(defaultValue = "[1,2,3]") Set<Integer> ids) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -346,7 +409,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
             @Tool
             void process(
                     @P(value = "string keys to integer values", defaultValue = "{\"a\":1,\"b\":2}")
-                            Map<String, Integer> counts) {}
+                    Map<String, Integer> counts) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -374,13 +438,14 @@ class AiServicesWithToolsWithDefaultValuesTest {
         class Tools {
             public static final String DEFAULT_PEOPLE =
                     """
-                    [
-                      {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}},
-                      {"name":"Peter","age":43,"address":{"city":"Munich","country":"DE"}}
-                    ]""";
+                            [
+                              {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}},
+                              {"name":"Peter","age":43,"address":{"city":"Munich","country":"DE"}}
+                            ]""";
 
             @Tool
-            void process(@P(defaultValue = DEFAULT_PEOPLE) List<Person> people) {}
+            void process(@P(defaultValue = DEFAULT_PEOPLE) List<Person> people) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -404,13 +469,14 @@ class AiServicesWithToolsWithDefaultValuesTest {
         class Tools {
             public static final String DEFAULT_PEOPLE =
                     """
-                    [
-                      {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}},
-                      {"name":"Peter","age":43,"address":{"city":"Munich","country":"DE"}}
-                    ]""";
+                            [
+                              {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}},
+                              {"name":"Peter","age":43,"address":{"city":"Munich","country":"DE"}}
+                            ]""";
 
             @Tool
-            void process(@P(defaultValue = DEFAULT_PEOPLE) Set<Person> people) {}
+            void process(@P(defaultValue = DEFAULT_PEOPLE) Set<Person> people) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -434,14 +500,15 @@ class AiServicesWithToolsWithDefaultValuesTest {
         class Tools {
             public static final String DEFAULT_MAP =
                     """
-                    {
-                      "p1": {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}},
-                      "p2": {"name":"Peter","age":43,"address":{"city":"Munich","country":"DE"}}
-                    }""";
+                            {
+                              "p1": {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}},
+                              "p2": {"name":"Peter","age":43,"address":{"city":"Munich","country":"DE"}}
+                            }""";
 
             @Tool
             void process(
-                    @P(value = "string id to person", defaultValue = DEFAULT_MAP) Map<String, Person> people) {}
+                    @P(value = "string id to person", defaultValue = DEFAULT_MAP) Map<String, Person> people) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -467,7 +534,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_use_LLM_provided_value_over_default() {
         class Tools {
             @Tool
-            void process(@P(defaultValue = "10") int limit) {}
+            void process(@P(defaultValue = "10") int limit) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -485,13 +553,14 @@ class AiServicesWithToolsWithDefaultValuesTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
-                "{\"arg0\":\"hello\"}",
-                "{\"arg0\":\"hello\",\"arg1\":null,\"arg2\":null}"
+                    "{\"arg0\":\"hello\"}",
+                    "{\"arg0\":\"hello\",\"arg1\":null,\"arg2\":null}"
             })
     void should_mix_defaulted_and_LLM_provided_parameters(String arguments) {
         class Tools {
             @Tool
-            void search(String query, @P(defaultValue = "10") int limit, @P(defaultValue = "0") int offset) {}
+            void search(String query, @P(defaultValue = "10") int limit, @P(defaultValue = "0") int offset) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -513,7 +582,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
         // (so the LLM is told it can omit it), and supplies the runtime fallback.
         class Tools {
             @Tool
-            void process(@P(required = true, defaultValue = "10") int limit) {}
+            void process(@P(required = true, defaultValue = "10") int limit) {
+            }
         }
         Tools tool = spy(new Tools());
 
@@ -535,7 +605,8 @@ class AiServicesWithToolsWithDefaultValuesTest {
         // is not in the "required" array.
         class Tools {
             @Tool
-            void process(String mandatory, @P(defaultValue = "10") int withDefault) {}
+            void process(String mandatory, @P(defaultValue = "10") int withDefault) {
+            }
         }
         Tools tool = spy(new Tools());
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithDefaultValuesTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithDefaultValuesTest.java
@@ -19,6 +19,7 @@ import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -27,8 +28,11 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
@@ -407,9 +411,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_substitute_default_for_Map_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(
-                    @P(value = "string keys to integer values", defaultValue = "{\"a\":1,\"b\":2}")
-                    Map<String, Integer> counts) {
+            void process(@P(defaultValue = "{\"a\":1,\"b\":2}") Map<String, Integer> counts) {
             }
         }
         Tools tool = spy(new Tools());
@@ -506,8 +508,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
                             }""";
 
             @Tool
-            void process(
-                    @P(value = "string id to person", defaultValue = DEFAULT_MAP) Map<String, Person> people) {
+            void process(@P(defaultValue = DEFAULT_MAP) Map<String, Person> people) {
             }
         }
         Tools tool = spy(new Tools());
@@ -547,7 +548,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
         assistant.chat("call the tool");
 
-        verify(tool).process(new int[] {1, 2, 3});
+        verify(tool).process(new int[]{1, 2, 3});
         verifyNoMoreInteractions(tool);
     }
 
@@ -568,7 +569,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
         assistant.chat("call the tool");
 
-        verify(tool).process(new String[] {"a", "b"});
+        verify(tool).process(new String[]{"a", "b"});
         verifyNoMoreInteractions(tool);
     }
 
@@ -602,8 +603,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
     void should_substitute_default_for_empty_Map_when_LLM_omits_it(String missingArguments) {
         class Tools {
             @Tool
-            void process(@P(value = "string keys to string values", defaultValue = "{}")
-                    Map<String, String> entries) {
+            void process(@P(defaultValue = "{}") Map<String, String> entries) {
             }
         }
         Tools tool = spy(new Tools());
@@ -649,7 +649,9 @@ class AiServicesWithToolsWithDefaultValuesTest {
     // tool-side mutation does not contaminate later calls.
     // ---------------------------------------------------------------------
 
-    /** Helper: two consecutive tool calls, both omitting the argument. */
+    /**
+     * Helper: two consecutive tool calls, both omitting the argument.
+     */
     private static ChatModel mockReturningTwoToolCalls(String toolName) {
         return ChatModelMock.thatAlwaysResponds(
                 AiMessage.from(ToolExecutionRequest.builder()
@@ -667,7 +669,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
     @Test
     void mutation_of_List_default_does_not_leak_between_invocations() {
-        java.util.List<Integer> sizesAtEntry = new java.util.ArrayList<>();
+        List<Integer> sizesAtEntry = new ArrayList<>();
         class Tools {
             @Tool
             void process(@P(defaultValue = "[\"a\",\"b\"]") List<String> tags) {
@@ -687,7 +689,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
     @Test
     void mutation_of_Set_default_does_not_leak_between_invocations() {
-        java.util.List<Integer> sizesAtEntry = new java.util.ArrayList<>();
+        List<Integer> sizesAtEntry = new ArrayList<>();
         class Tools {
             @Tool
             void process(@P(defaultValue = "[1,2]") Set<Integer> ids) {
@@ -707,11 +709,10 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
     @Test
     void mutation_of_Map_default_does_not_leak_between_invocations() {
-        java.util.List<Integer> sizesAtEntry = new java.util.ArrayList<>();
+        List<Integer> sizesAtEntry = new ArrayList<>();
         class Tools {
             @Tool
-            void process(@P(value = "string keys to integer values", defaultValue = "{\"a\":1}")
-                    Map<String, Integer> counts) {
+            void process(@P(defaultValue = "{\"a\":1}") Map<String, Integer> counts) {
                 sizesAtEntry.add(counts.size());
                 counts.put("b", 2);
             }
@@ -726,14 +727,16 @@ class AiServicesWithToolsWithDefaultValuesTest {
         assertThat(sizesAtEntry).containsExactly(1, 1);
     }
 
-    /** POJO whose internal collection is mutable — mutation through the field must not leak either. */
+    /**
+     * POJO whose internal collection is mutable — mutation through the field must not leak either.
+     */
     public static final class MutableContainer {
-        public java.util.List<String> items = new java.util.ArrayList<>();
+        public List<String> items = new ArrayList<>();
     }
 
     @Test
     void mutation_of_POJO_default_does_not_leak_between_invocations() {
-        java.util.List<Integer> sizesAtEntry = new java.util.ArrayList<>();
+        List<Integer> sizesAtEntry = new ArrayList<>();
         class Tools {
             @Tool
             void process(@P(defaultValue = "{\"items\":[\"a\",\"b\"]}") MutableContainer container) {
@@ -756,11 +759,12 @@ class AiServicesWithToolsWithDefaultValuesTest {
      * A naive cache that stores the parsed record would share the same inner list
      * across invocations — this test ensures fresh inner state on each call.
      */
-    public record RecordWithList(java.util.List<String> items) {}
+    public record RecordWithList(List<String> items) {
+    }
 
     @Test
     void mutation_of_record_inner_collection_does_not_leak_between_invocations() {
-        java.util.List<Integer> sizesAtEntry = new java.util.ArrayList<>();
+        List<Integer> sizesAtEntry = new ArrayList<>();
         class Tools {
             @Tool
             void process(@P(defaultValue = "{\"items\":[\"a\",\"b\"]}") RecordWithList container) {
@@ -801,7 +805,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
         assistant.chat("call the tool");
 
-        verify(tool).process((Person) null);
+        verify(tool).process(null);
         verifyNoMoreInteractions(tool);
     }
 
@@ -828,10 +832,10 @@ class AiServicesWithToolsWithDefaultValuesTest {
                 .tools(tool)
                 .build();
 
-        org.assertj.core.api.Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+        assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> assistant.chat("call the tool"))
                 .withMessageContaining("not convertable to int");
-        org.mockito.Mockito.verifyNoInteractions(tool);
+        verifyNoInteractions(tool);
     }
 
     @Test
@@ -914,8 +918,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
         }
         Tools tool = spy(new Tools());
 
-        ChatModel chatModelMock = org.mockito.Mockito.spy(
-                mockReturningToolCallWithArgs("process", "{\"arg0\":\"hi\"}"));
+        ChatModel chatModelMock = spy(mockReturningToolCallWithArgs("process", "{\"arg0\":\"hi\"}"));
         Assistant assistant = AiServices.builder(Assistant.class)
                 .chatModel(chatModelMock)
                 .tools(tool)
@@ -923,7 +926,7 @@ class AiServicesWithToolsWithDefaultValuesTest {
 
         assistant.chat("call the tool");
 
-        verify(chatModelMock, org.mockito.Mockito.atLeastOnce()).chat(chatRequestCaptor.capture());
+        verify(chatModelMock, atLeastOnce()).chat(chatRequestCaptor.capture());
         ToolSpecification spec = chatRequestCaptor.getValue().parameters().toolSpecifications().get(0);
         assertThat(spec.parameters().required()).containsExactly("arg0");
         assertThat(spec.parameters().properties().keySet()).containsExactly("arg0", "arg1");

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithDefaultValuesTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsWithDefaultValuesTest.java
@@ -1,0 +1,438 @@
+package dev.langchain4j.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AiServicesWithToolsWithDefaultValuesTest {
+
+    @Captor
+    ArgumentCaptor<ChatRequest> chatRequestCaptor;
+
+    interface Assistant {
+        String chat(String userMessage);
+    }
+
+    private static ChatModel mockReturningToolCallWithArgs(String toolName, String arguments) {
+        return ChatModelMock.thatAlwaysResponds(
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("1")
+                        .name(toolName)
+                        .arguments(arguments)
+                        .build()),
+                AiMessage.from("Done"));
+    }
+
+    // ---------------------------------------------------------------------
+    // Primitives
+    // ---------------------------------------------------------------------
+
+    @Test
+    void should_substitute_default_for_primitive_int_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "10") int limit) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(10);
+        verifyNoMoreInteractions(tool);
+    }
+
+    @Test
+    void should_substitute_default_for_primitive_double_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "3.14") double pi) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(3.14);
+        verifyNoMoreInteractions(tool);
+    }
+
+    @Test
+    void should_substitute_default_for_primitive_boolean_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "true") boolean verbose) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(true);
+        verifyNoMoreInteractions(tool);
+    }
+
+    @Test
+    void should_substitute_default_for_primitive_long_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "9999999999") long bigNumber) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(9999999999L);
+        verifyNoMoreInteractions(tool);
+    }
+
+    // ---------------------------------------------------------------------
+    // Boxed / object scalar types
+    // ---------------------------------------------------------------------
+
+    @Test
+    void should_substitute_default_for_boxed_Integer_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "42") Integer limit) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(42);
+        verifyNoMoreInteractions(tool);
+    }
+
+    @Test
+    void should_substitute_default_for_String_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "USD") String currency) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process("USD");
+        verifyNoMoreInteractions(tool);
+    }
+
+    @Test
+    void should_substitute_default_for_BigDecimal_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "1.5") BigDecimal value) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(BigDecimal.valueOf(1.5));
+        verifyNoMoreInteractions(tool);
+    }
+
+    // ---------------------------------------------------------------------
+    // Enums
+    // ---------------------------------------------------------------------
+
+    enum Currency {
+        USD,
+        EUR,
+        GBP
+    }
+
+    @Test
+    void should_substitute_default_for_enum_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "EUR") Currency currency) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(Currency.EUR);
+        verifyNoMoreInteractions(tool);
+    }
+
+    // ---------------------------------------------------------------------
+    // POJOs (including nested)
+    // ---------------------------------------------------------------------
+
+    public record Address(String city, String country) {}
+
+    public record Person(String name, int age, Address address) {}
+
+    @Test
+    void should_substitute_default_for_POJO_with_nested_POJO_when_LLM_omits_it() {
+        class Tools {
+
+            public static final String DEFAULT_PERSON = """
+                    {"name":"Klaus","age":42,"address":{"city":"Berlin","country":"DE"}}""";
+
+            @Tool
+            void process(@P(defaultValue = DEFAULT_PERSON) Person person) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(new Person("Klaus", 42, new Address("Berlin", "DE")));
+        verifyNoMoreInteractions(tool);
+    }
+
+    // ---------------------------------------------------------------------
+    // Polymorphic types
+    // ---------------------------------------------------------------------
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = Cat.class, name = "cat"),
+        @JsonSubTypes.Type(value = Dog.class, name = "dog")
+    })
+    public sealed interface Animal permits Cat, Dog {}
+
+    public record Cat(String name) implements Animal {}
+
+    public record Dog(String breed) implements Animal {}
+
+    @Test
+    void should_substitute_default_for_polymorphic_sealed_type_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "{\"type\":\"cat\",\"name\":\"Whiskers\"}") Animal animal) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(new Cat("Whiskers"));
+        verifyNoMoreInteractions(tool);
+    }
+
+    // ---------------------------------------------------------------------
+    // Collections and maps
+    // ---------------------------------------------------------------------
+
+    @Test
+    void should_substitute_default_for_List_of_strings_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "[\"red\",\"green\",\"blue\"]") List<String> colors) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(List.of("red", "green", "blue"));
+        verifyNoMoreInteractions(tool);
+    }
+
+    @Test
+    void should_substitute_default_for_Set_of_integers_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "[1,2,3]") Set<Integer> ids) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(new LinkedHashSet<>(List.of(1, 2, 3)));
+        verifyNoMoreInteractions(tool);
+    }
+
+    @Test
+    void should_substitute_default_for_Map_when_LLM_omits_it() {
+        class Tools {
+            @Tool
+            void process(@P(value = "string keys to integer values", defaultValue = "{\"a\":1,\"b\":2}")
+                    Map<String, Integer> counts) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        Map<String, Integer> expected = new LinkedHashMap<>();
+        expected.put("a", 1);
+        expected.put("b", 2);
+        verify(tool).process(expected);
+        verifyNoMoreInteractions(tool);
+    }
+
+    // ---------------------------------------------------------------------
+    // Corner cases
+    // ---------------------------------------------------------------------
+
+    @Test
+    void should_use_LLM_provided_value_over_default() {
+        class Tools {
+            @Tool
+            void process(@P(defaultValue = "10") int limit) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("process", "{\"arg0\":42}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(42);
+        verifyNoMoreInteractions(tool);
+    }
+
+    @Test
+    void should_mix_defaulted_and_LLM_provided_parameters() {
+        class Tools {
+            @Tool
+            void search(String query, @P(defaultValue = "10") int limit, @P(defaultValue = "0") int offset) {}
+        }
+        Tools tool = spy(new Tools());
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockReturningToolCallWithArgs("search", "{\"arg0\":\"hello\"}"))
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).search("hello", 10, 0);
+        verifyNoMoreInteractions(tool);
+    }
+
+    @Test
+    void should_apply_default_even_when_required_is_explicitly_true() {
+        // defaultValue forces the schema to mark the param as optional
+        // (so the LLM is told it can omit it), and supplies the runtime fallback.
+        class Tools {
+            @Tool
+            void process(@P(required = true, defaultValue = "10") int limit) {}
+        }
+        Tools tool = spy(new Tools());
+
+        ChatModel chatModelMock = mockReturningToolCallWithArgs("process", "{}");
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModelMock)
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(tool).process(10);
+        verifyNoMoreInteractions(tool);
+    }
+
+    @Test
+    void should_advertise_defaulted_parameter_as_optional_in_JSON_schema() {
+        // Capture the schema actually sent to the LLM and verify the defaulted param
+        // is not in the "required" array.
+        class Tools {
+            @Tool
+            void process(String mandatory, @P(defaultValue = "10") int withDefault) {}
+        }
+        Tools tool = spy(new Tools());
+
+        ChatModel chatModelMock = org.mockito.Mockito.spy(
+                mockReturningToolCallWithArgs("process", "{\"arg0\":\"hi\"}"));
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(chatModelMock)
+                .tools(tool)
+                .build();
+
+        assistant.chat("call the tool");
+
+        verify(chatModelMock, org.mockito.Mockito.atLeastOnce()).chat(chatRequestCaptor.capture());
+        ToolSpecification spec = chatRequestCaptor.getValue().parameters().toolSpecifications().get(0);
+        assertThat(spec.parameters().required()).containsExactly("arg0");
+        assertThat(spec.parameters().properties().keySet()).containsExactly("arg0", "arg1");
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -6,7 +6,6 @@ import static java.util.Collections.singletonMap;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolMemoryId;
@@ -709,120 +708,5 @@ class DefaultToolExecutorTest implements WithAssertions {
         assertThatExceptionOfType(ToolArgumentsException.class)
                 .isThrownBy(() -> executor.execute(request, "DEFAULT"))
                 .withCauseInstanceOf(IllegalArgumentException.class);
-    }
-
-    @SuppressWarnings("unused")
-    public void primitiveToolWithDefault(String filePath, @P(defaultValue = "10") int startLine) {}
-
-    @Test
-    void should_substitute_default_when_primitive_is_missing() throws Exception {
-        Method method = getClass().getMethod("primitiveToolWithDefault", String.class, int.class);
-        DefaultToolExecutor executor = DefaultToolExecutor.builder()
-                .object(this)
-                .originalMethod(method)
-                .methodToInvoke(method)
-                .build();
-
-        Map<String, Object> arguments = new HashMap<>();
-        arguments.put("arg0", "/tmp/foo.txt");
-
-        InvocationContext context = InvocationContext.builder().build();
-
-        Object[] args = DefaultToolExecutor.prepareArguments(
-                method,
-                "primitiveToolWithDefault",
-                arguments,
-                executor.defaultArguments(),
-                context);
-
-        assertThat(args).containsExactly("/tmp/foo.txt", 10);
-    }
-
-    @SuppressWarnings("unused")
-    public void toolWithStringDefault(@P(defaultValue = "USD") String currency) {}
-
-    @Test
-    void should_substitute_default_for_string_parameter() throws Exception {
-        Method method = getClass().getMethod("toolWithStringDefault", String.class);
-        DefaultToolExecutor executor = DefaultToolExecutor.builder()
-                .object(this)
-                .originalMethod(method)
-                .methodToInvoke(method)
-                .build();
-
-        InvocationContext context = InvocationContext.builder().build();
-
-        Object[] args = DefaultToolExecutor.prepareArguments(
-                method,
-                "toolWithStringDefault",
-                new HashMap<>(),
-                executor.defaultArguments(),
-                context);
-
-        assertThat(args).containsExactly("USD");
-    }
-
-    @SuppressWarnings("unused")
-    public void toolWithListDefault(
-            @P(defaultValue = "[\"a\",\"b\"]") List<String> tags) {}
-
-    @Test
-    void should_substitute_default_for_list_parameter() throws Exception {
-        Method method = getClass().getMethod("toolWithListDefault", List.class);
-        DefaultToolExecutor executor = DefaultToolExecutor.builder()
-                .object(this)
-                .originalMethod(method)
-                .methodToInvoke(method)
-                .build();
-
-        InvocationContext context = InvocationContext.builder().build();
-
-        Object[] args = DefaultToolExecutor.prepareArguments(
-                method,
-                "toolWithListDefault",
-                new HashMap<>(),
-                executor.defaultArguments(),
-                context);
-
-        assertThat(args).hasSize(1);
-        assertThat(args[0]).isEqualTo(asList("a", "b"));
-    }
-
-    @Test
-    void should_use_llm_provided_value_over_default() throws Exception {
-        Method method = getClass().getMethod("primitiveToolWithDefault", String.class, int.class);
-        DefaultToolExecutor executor = DefaultToolExecutor.builder()
-                .object(this)
-                .originalMethod(method)
-                .methodToInvoke(method)
-                .build();
-
-        Map<String, Object> arguments = new HashMap<>();
-        arguments.put("arg0", "/tmp/foo.txt");
-        arguments.put("arg1", 5.0);
-
-        InvocationContext context = InvocationContext.builder().build();
-
-        Object[] args = DefaultToolExecutor.prepareArguments(
-                method,
-                "primitiveToolWithDefault",
-                arguments,
-                executor.defaultArguments(),
-                context);
-
-        assertThat(args).containsExactly("/tmp/foo.txt", 5);
-    }
-
-    @Test
-    void should_throw_when_default_value_cannot_be_parsed() throws Exception {
-        @SuppressWarnings("unused")
-        class BadDefault {
-            public void tool(@P(defaultValue = "ten") int x) {}
-        }
-        Method method = BadDefault.class.getMethod("tool", int.class);
-
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> new DefaultToolExecutor(new BadDefault(), method))
-                .withMessageContaining("Cannot parse @P(defaultValue = \"ten\")");
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -6,6 +6,7 @@ import static java.util.Collections.singletonMap;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolMemoryId;
@@ -711,15 +712,11 @@ class DefaultToolExecutorTest implements WithAssertions {
     }
 
     @SuppressWarnings("unused")
-    public void primitiveToolWithDefault(
-            String filePath,
-            @dev.langchain4j.agent.tool.P(defaultValue = "10") int startLine,
-            @dev.langchain4j.agent.tool.P(defaultValue = "20") int endLine) {}
+    public void primitiveToolWithDefault(String filePath, @P(defaultValue = "10") int startLine) {}
 
     @Test
     void should_substitute_default_when_primitive_is_missing() throws Exception {
-        Method method = getClass()
-                .getMethod("primitiveToolWithDefault", String.class, int.class, int.class);
+        Method method = getClass().getMethod("primitiveToolWithDefault", String.class, int.class);
         DefaultToolExecutor executor = DefaultToolExecutor.builder()
                 .object(this)
                 .originalMethod(method)
@@ -735,15 +732,14 @@ class DefaultToolExecutorTest implements WithAssertions {
                 method,
                 "primitiveToolWithDefault",
                 arguments,
-                executor.defaultArgumentValues(),
+                executor.defaultArguments(),
                 context);
 
-        assertThat(args).containsExactly("/tmp/foo.txt", 10, 20);
+        assertThat(args).containsExactly("/tmp/foo.txt", 10);
     }
 
     @SuppressWarnings("unused")
-    public void toolWithStringDefault(
-            @dev.langchain4j.agent.tool.P(defaultValue = "USD") String currency) {}
+    public void toolWithStringDefault(@P(defaultValue = "USD") String currency) {}
 
     @Test
     void should_substitute_default_for_string_parameter() throws Exception {
@@ -760,7 +756,7 @@ class DefaultToolExecutorTest implements WithAssertions {
                 method,
                 "toolWithStringDefault",
                 new HashMap<>(),
-                executor.defaultArgumentValues(),
+                executor.defaultArguments(),
                 context);
 
         assertThat(args).containsExactly("USD");
@@ -768,7 +764,7 @@ class DefaultToolExecutorTest implements WithAssertions {
 
     @SuppressWarnings("unused")
     public void toolWithListDefault(
-            @dev.langchain4j.agent.tool.P(defaultValue = "[\"a\",\"b\"]") List<String> tags) {}
+            @P(defaultValue = "[\"a\",\"b\"]") List<String> tags) {}
 
     @Test
     void should_substitute_default_for_list_parameter() throws Exception {
@@ -785,7 +781,7 @@ class DefaultToolExecutorTest implements WithAssertions {
                 method,
                 "toolWithListDefault",
                 new HashMap<>(),
-                executor.defaultArgumentValues(),
+                executor.defaultArguments(),
                 context);
 
         assertThat(args).hasSize(1);
@@ -794,8 +790,7 @@ class DefaultToolExecutorTest implements WithAssertions {
 
     @Test
     void should_use_llm_provided_value_over_default() throws Exception {
-        Method method = getClass()
-                .getMethod("primitiveToolWithDefault", String.class, int.class, int.class);
+        Method method = getClass().getMethod("primitiveToolWithDefault", String.class, int.class);
         DefaultToolExecutor executor = DefaultToolExecutor.builder()
                 .object(this)
                 .originalMethod(method)
@@ -805,7 +800,6 @@ class DefaultToolExecutorTest implements WithAssertions {
         Map<String, Object> arguments = new HashMap<>();
         arguments.put("arg0", "/tmp/foo.txt");
         arguments.put("arg1", 5.0);
-        arguments.put("arg2", 30.0);
 
         InvocationContext context = InvocationContext.builder().build();
 
@@ -813,17 +807,17 @@ class DefaultToolExecutorTest implements WithAssertions {
                 method,
                 "primitiveToolWithDefault",
                 arguments,
-                executor.defaultArgumentValues(),
+                executor.defaultArguments(),
                 context);
 
-        assertThat(args).containsExactly("/tmp/foo.txt", 5, 30);
+        assertThat(args).containsExactly("/tmp/foo.txt", 5);
     }
 
     @Test
     void should_throw_when_default_value_cannot_be_parsed() throws Exception {
         @SuppressWarnings("unused")
         class BadDefault {
-            public void tool(@dev.langchain4j.agent.tool.P(defaultValue = "ten") int x) {}
+            public void tool(@P(defaultValue = "ten") int x) {}
         }
         Method method = BadDefault.class.getMethod("tool", int.class);
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -709,4 +709,126 @@ class DefaultToolExecutorTest implements WithAssertions {
                 .isThrownBy(() -> executor.execute(request, "DEFAULT"))
                 .withCauseInstanceOf(IllegalArgumentException.class);
     }
+
+    @SuppressWarnings("unused")
+    public void primitiveToolWithDefault(
+            String filePath,
+            @dev.langchain4j.agent.tool.P(defaultValue = "10") int startLine,
+            @dev.langchain4j.agent.tool.P(defaultValue = "20") int endLine) {}
+
+    @Test
+    void should_substitute_default_when_primitive_is_missing() throws Exception {
+        Method method = getClass()
+                .getMethod("primitiveToolWithDefault", String.class, int.class, int.class);
+        DefaultToolExecutor executor = DefaultToolExecutor.builder()
+                .object(this)
+                .originalMethod(method)
+                .methodToInvoke(method)
+                .build();
+
+        Map<String, Object> arguments = new HashMap<>();
+        arguments.put("arg0", "/tmp/foo.txt");
+
+        InvocationContext context = InvocationContext.builder().build();
+
+        Object[] args = DefaultToolExecutor.prepareArguments(
+                method,
+                "primitiveToolWithDefault",
+                arguments,
+                executor.defaultArgumentValues(),
+                context);
+
+        assertThat(args).containsExactly("/tmp/foo.txt", 10, 20);
+    }
+
+    @SuppressWarnings("unused")
+    public void toolWithStringDefault(
+            @dev.langchain4j.agent.tool.P(defaultValue = "USD") String currency) {}
+
+    @Test
+    void should_substitute_default_for_string_parameter() throws Exception {
+        Method method = getClass().getMethod("toolWithStringDefault", String.class);
+        DefaultToolExecutor executor = DefaultToolExecutor.builder()
+                .object(this)
+                .originalMethod(method)
+                .methodToInvoke(method)
+                .build();
+
+        InvocationContext context = InvocationContext.builder().build();
+
+        Object[] args = DefaultToolExecutor.prepareArguments(
+                method,
+                "toolWithStringDefault",
+                new HashMap<>(),
+                executor.defaultArgumentValues(),
+                context);
+
+        assertThat(args).containsExactly("USD");
+    }
+
+    @SuppressWarnings("unused")
+    public void toolWithListDefault(
+            @dev.langchain4j.agent.tool.P(defaultValue = "[\"a\",\"b\"]") List<String> tags) {}
+
+    @Test
+    void should_substitute_default_for_list_parameter() throws Exception {
+        Method method = getClass().getMethod("toolWithListDefault", List.class);
+        DefaultToolExecutor executor = DefaultToolExecutor.builder()
+                .object(this)
+                .originalMethod(method)
+                .methodToInvoke(method)
+                .build();
+
+        InvocationContext context = InvocationContext.builder().build();
+
+        Object[] args = DefaultToolExecutor.prepareArguments(
+                method,
+                "toolWithListDefault",
+                new HashMap<>(),
+                executor.defaultArgumentValues(),
+                context);
+
+        assertThat(args).hasSize(1);
+        assertThat(args[0]).isEqualTo(asList("a", "b"));
+    }
+
+    @Test
+    void should_use_llm_provided_value_over_default() throws Exception {
+        Method method = getClass()
+                .getMethod("primitiveToolWithDefault", String.class, int.class, int.class);
+        DefaultToolExecutor executor = DefaultToolExecutor.builder()
+                .object(this)
+                .originalMethod(method)
+                .methodToInvoke(method)
+                .build();
+
+        Map<String, Object> arguments = new HashMap<>();
+        arguments.put("arg0", "/tmp/foo.txt");
+        arguments.put("arg1", 5.0);
+        arguments.put("arg2", 30.0);
+
+        InvocationContext context = InvocationContext.builder().build();
+
+        Object[] args = DefaultToolExecutor.prepareArguments(
+                method,
+                "primitiveToolWithDefault",
+                arguments,
+                executor.defaultArgumentValues(),
+                context);
+
+        assertThat(args).containsExactly("/tmp/foo.txt", 5, 30);
+    }
+
+    @Test
+    void should_throw_when_default_value_cannot_be_parsed() throws Exception {
+        @SuppressWarnings("unused")
+        class BadDefault {
+            public void tool(@dev.langchain4j.agent.tool.P(defaultValue = "ten") int x) {}
+        }
+        Method method = BadDefault.class.getMethod("tool", int.class);
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new DefaultToolExecutor(new BadDefault(), method))
+                .withMessageContaining("Cannot parse @P(defaultValue = \"ten\")");
+    }
 }


### PR DESCRIPTION
## Issue
Closes #5085

## Change
 - New `@P(defaultValue = "...")` attribute lets tool authors declare a runtime fallback that LangChain4j substitutes when the LLM omits an argument.
  - Works for primitives, boxed types, `String`, `enum`, `UUID`, `BigDecimal`/`BigInteger`, `List<T>`/`Set<T>`/arrays, `Map<K,V>`, and POJOs (including nested and polymorphic
  types).
  - Eager validation at AI Service registration time: misconfigured defaults fail with `IllegalConfigurationException` at `AiServices.builder(...).tools(...).build()` rather than
  on the first LLM call.

  ## Usage

  ```java
  enum SortBy { RELEVANCE, DATE, RATING }

  @Tool
  List<Article> searchArticles(
      String query,
      @P(defaultValue = "10") int limit,
      @P(defaultValue = "[\"en\"]") List<String> languages,
      @P(defaultValue = "RELEVANCE") SortBy sortBy
  ) {
      // limit -> 10, languages -> ["en"], sortBy -> SortBy.RELEVANCE when omitted by the LLM
  }
  ```

  ## Semantics

  - **Setting `defaultValue` makes the parameter optional in the JSON schema** — the parameter is *not* added to the schema's `required` array, regardless of `@P(required)`. The
  LLM is told it may omit the argument; if it does, LangChain4j fills in the default before invoking the method.
  - **Defaults are re-parsed on every invocation**, so a tool that mutates a defaulted `List`/`Map`/POJO does not contaminate later calls.
  - **Defaults only apply to absence, not to wrong-typed values**: if the LLM sends `"banana"` for an `int`, the coercion error propagates normally — the default is not used as a
  fallback.
  - **Empty-string default `@P(defaultValue = "") String filter` is distinct from "no default set"** — implemented via a `NO_DEFAULT` sentinel constant on `P`.

  ## Supported types

  | Type                         | Format                   | Example                                  |
  |------------------------------|--------------------------|------------------------------------------|
  | `String`                     | used verbatim            | `defaultValue = "USD"`                   |
  | Primitive / boxed primitive  | type-specific conversion | `"10"`, `"3.14"`, `"true"`               |
  | `enum`                       | enum constant name       | `defaultValue = "EUR"`                   |
  | `UUID`                       | `UUID.fromString`        | `"550e8400-e29b-41d4-a716-446655440000"` |
  | `BigDecimal`, `BigInteger`   | numeric literal          | `"1.5"`, `"100"`                         |
  | `List<T>` / `Set<T>` / array | JSON array               | `"[\"a\",\"b\"]"`, `"[1,2,3]"`           |
  | `Map<K,V>`                   | JSON object              | `"{\"a\":1,\"b\":2}"`                    |
  | POJOs (including nested)     | JSON object              | `"{\"name\":\"Klaus\",\"age\":42}"`      |

  ## Registration-time validation

  The default value string is parsed at AI Service registration time. The following all throw `IllegalConfigurationException` from `AiServices.builder(...).tools(...).build()`,
  naming the offending `ClassName.methodName.parameterName`:

  - Unparseable defaults — typos (`@P(defaultValue = "ten") int x`), numeric overflow (`"999999999999999"` on an `int`), invalid enum constants, invalid `UUID`, invalid booleans.
  - `defaultValue` combined with `Optional<T>` — `Optional` already encodes absence; pick one mechanism.
  - `defaultValue` on framework-injected parameters (`@ToolMemoryId`, `InvocationContext`, etc.) — they never come from the LLM.

  Existing rule **relaxed**: `@P(required = false)` on a primitive without `defaultValue` still throws (a primitive can't represent absence), but is now legal *with* a
  `defaultValue`:

  ```java
  @Tool
  void process(@P(required = false, defaultValue = "0") int startLine) { ... }
  ```

  The validation error message has been updated to point users to this option.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)