### PR TITLE
refactor: rename maxSequentialToolsInvocations to maxToolCallingRound…

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentBuilder.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentBuilder.java
@@ -350,7 +350,7 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
     }
 
     /** @deprecated Use {@link #maxToolCallingRoundTrips(int)} instead. */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "1.15.0")
     public B maxSequentialToolsInvocations(int maxSequentialToolsInvocations) {
         return maxToolCallingRoundTrips(maxSequentialToolsInvocations);
     }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentBuilder.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentBuilder.java
@@ -12,6 +12,9 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.declarative.TypedKey;
+import dev.langchain4j.agentic.internal.AgentUtil;
+import dev.langchain4j.agentic.internal.AgenticScopeOwner;
+import dev.langchain4j.agentic.internal.Context;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.observability.AfterAgentToolExecution;
 import dev.langchain4j.agentic.observability.AgentListener;
@@ -19,9 +22,6 @@ import dev.langchain4j.agentic.observability.AgentMonitor;
 import dev.langchain4j.agentic.observability.BeforeAgentToolExecution;
 import dev.langchain4j.agentic.observability.ComposedAgentListener;
 import dev.langchain4j.agentic.observability.MonitoredAgent;
-import dev.langchain4j.agentic.internal.AgentUtil;
-import dev.langchain4j.agentic.internal.AgenticScopeOwner;
-import dev.langchain4j.agentic.internal.Context;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.planner.AgenticSystemConfigurationException;
@@ -33,7 +33,6 @@ import dev.langchain4j.guardrail.OutputGuardrail;
 import dev.langchain4j.guardrail.config.InputGuardrailsConfig;
 import dev.langchain4j.guardrail.config.OutputGuardrailsConfig;
 import dev.langchain4j.invocation.InvocationContext;
-import dev.langchain4j.invocation.LangChain4jManaged;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
@@ -98,7 +97,7 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
     private Map<ToolSpecification, ToolExecutor> toolsMap;
     private Set<String> immediateReturnToolNames;
     private final List<ToolProvider> toolProviders = new ArrayList<>();
-    private Integer maxSequentialToolsInvocations;
+    private Integer maxToolCallingRoundTrips;
     private Function<ToolExecutionRequest, ToolExecutionResultMessage> hallucinatedToolNameStrategy;
     private boolean executeToolsConcurrently;
     private Executor concurrentToolsExecutor;
@@ -148,8 +147,8 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
         AiServiceContext context = AiServiceContext.create(agentServiceClass);
         AiServices<T> aiServices = AiServices.builder(context);
         if (model != null && streamingChatModel != null) {
-            throw new AgenticSystemConfigurationException(
-                    "Both chatModel and streamingChatModel are set for agent '" + this.name + "'. Please set only one of them.");
+            throw new AgenticSystemConfigurationException("Both chatModel and streamingChatModel are set for agent '"
+                    + this.name + "'. Please set only one of them.");
         }
         if (model != null) {
             aiServices.chatModel(model);
@@ -189,8 +188,7 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
                 aiServices.chatRequestTransformer(
                         new Context.AgenticScopeContextGenerator(agenticScope, contextProvider));
             } else {
-                aiServices.chatRequestTransformer(
-                        new Context.Summarizer(agenticScope, model, contextProvidingAgents));
+                aiServices.chatRequestTransformer(new Context.Summarizer(agenticScope, model, contextProvidingAgents));
             }
         }
 
@@ -206,8 +204,10 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
                 agentServiceClass.getClassLoader(),
                 new Class<?>[] {
                     agentServiceClass,
-                    InternalAgent.class, AgenticScopeOwner.class,
-                    ChatMemoryAccess.class, ChatMessagesAccess.class,
+                    InternalAgent.class,
+                    AgenticScopeOwner.class,
+                    ChatMemoryAccess.class,
+                    ChatMessagesAccess.class,
                     AiServiceResponseReceivedListener.class
                 },
                 new AgentInvocationHandler(context, aiServices.build(), this, agenticScopeDependent));
@@ -228,7 +228,7 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
         return (T) agent;
     }
 
-    protected void build(DefaultAgenticScope agenticScope, AiServiceContext context, AiServices<T> aiServices) { }
+    protected void build(DefaultAgenticScope agenticScope, AiServiceContext context, AiServices<T> aiServices) {}
 
     private void setupGuardrails(AiServices<T> aiServices) {
         if (inputGuardrailsConfig != null) {
@@ -265,8 +265,8 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
         if (!toolProviders.isEmpty()) {
             aiServices.toolProviders(toolProviders);
         }
-        if (maxSequentialToolsInvocations != null) {
-            aiServices.maxSequentialToolsInvocations(maxSequentialToolsInvocations);
+        if (maxToolCallingRoundTrips != null) {
+            aiServices.maxToolCallingRoundTrips(maxToolCallingRoundTrips);
         }
         if (hallucinatedToolNameStrategy != null) {
             aiServices.hallucinatedToolNameStrategy(hallucinatedToolNameStrategy);
@@ -344,9 +344,15 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
         return toolProviders(asList(toolProviders));
     }
 
-    public B maxSequentialToolsInvocations(int maxSequentialToolsInvocations) {
-        this.maxSequentialToolsInvocations = maxSequentialToolsInvocations;
+    public B maxToolCallingRoundTrips(int maxToolCallingRoundTrips) {
+        this.maxToolCallingRoundTrips = maxToolCallingRoundTrips;
         return (B) this;
+    }
+
+    /** @deprecated Use {@link #maxToolCallingRoundTrips(int)} instead. */
+    @Deprecated(forRemoval = true)
+    public B maxSequentialToolsInvocations(int maxSequentialToolsInvocations) {
+        return maxToolCallingRoundTrips(maxSequentialToolsInvocations);
     }
 
     public B hallucinatedToolNameStrategy(
@@ -375,14 +381,12 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
         return (B) this;
     }
 
-    public <I extends InputGuardrail> B inputGuardrailClasses(
-            Class<? extends I>... inputGuardrailClasses) {
+    public <I extends InputGuardrail> B inputGuardrailClasses(Class<? extends I>... inputGuardrailClasses) {
         this.inputGuardrailClasses = inputGuardrailClasses;
         return (B) this;
     }
 
-    public <O extends OutputGuardrail> B outputGuardrailClasses(
-            Class<? extends O>... outputGuardrailClasses) {
+    public <O extends OutputGuardrail> B outputGuardrailClasses(Class<? extends O>... outputGuardrailClasses) {
         this.outputGuardrailClasses = outputGuardrailClasses;
         return (B) this;
     }
@@ -503,5 +507,4 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
         }
         return (B) this;
     }
-
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -99,7 +99,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final List<String> responseBuffer = new ArrayList<>();
     private final boolean hasOutputGuardrails;
 
-    private int sequentialToolsInvocationsLeft;
+    private int toolCallingRoundTripsLeft;
 
     private record ToolRequestResult(ToolExecutionRequest request, ToolExecutionResult result) {}
 
@@ -122,7 +122,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             ChatMemory temporaryMemory,
             TokenUsage tokenUsage,
             ToolServiceContext toolServiceContext,
-            int sequentialToolsInvocationsLeft,
+            int toolCallingRoundTripsLeft,
             ToolArgumentsErrorHandler toolArgumentsErrorHandler,
             ToolExecutionErrorHandler toolExecutionErrorHandler,
             Executor toolExecutor,
@@ -158,7 +158,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
         this.hasOutputGuardrails = context.guardrailService().hasOutputGuardrails(methodKey);
 
-        this.sequentialToolsInvocationsLeft = sequentialToolsInvocationsLeft;
+        this.toolCallingRoundTripsLeft = toolCallingRoundTripsLeft;
     }
 
     @Override
@@ -283,10 +283,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
         if (aiMessage.hasToolExecutionRequests()) {
 
-            if (sequentialToolsInvocationsLeft-- == 0) {
+            if (toolCallingRoundTripsLeft-- == 0) {
                 throw runtime(
-                        "Something is wrong, exceeded %s sequential tool invocations",
-                        context.toolService.maxSequentialToolsInvocations());
+                        "Something is wrong, exceeded %s tool calling round trips",
+                        context.toolService.maxToolCallingRoundTrips());
             }
 
             if (intermediateResponseHandler != null) {
@@ -379,7 +379,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     temporaryMemory,
                     TokenUsage.sum(tokenUsage, chatResponse.metadata().tokenUsage()),
                     updatedToolContext,
-                    sequentialToolsInvocationsLeft,
+                    toolCallingRoundTripsLeft,
                     toolArgumentsErrorHandler,
                     toolExecutionErrorHandler,
                     toolExecutor,

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -285,7 +285,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
             if (toolCallingRoundTripsLeft-- == 0) {
                 throw runtime(
-                        "Something is wrong, exceeded %s tool calling round trips",
+                        "Something is wrong, exceeded %s tool calling round trips (maxToolCallingRoundTrips)",
                         context.toolService.maxToolCallingRoundTrips());
             }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.service.AiServiceParamsUtil.chatRequestParameters;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.guardrail.ChatExecutor;
 import dev.langchain4j.guardrail.GuardrailRequestParams;
@@ -13,7 +14,6 @@ import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.PartialResponse;
 import dev.langchain4j.model.chat.response.PartialResponseContext;
@@ -21,7 +21,6 @@ import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.PartialThinkingContext;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCallContext;
-import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.observability.api.event.AiServiceRequestIssuedEvent;
 import dev.langchain4j.rag.content.Content;
@@ -29,7 +28,6 @@ import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
 import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
-import dev.langchain4j.service.tool.ToolService;
 import dev.langchain4j.service.tool.ToolServiceContext;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -194,9 +192,8 @@ public class AiServiceTokenStream implements TokenStream {
     public void start() {
         validateConfiguration();
 
-        List<ToolSpecification> effectiveTools = toolServiceContext != null
-                ? toolServiceContext.effectiveTools()
-                : null;
+        List<ToolSpecification> effectiveTools =
+                toolServiceContext != null ? toolServiceContext.effectiveTools() : null;
 
         ChatRequest chatRequest = context.chatRequestTransformer.apply(
                 ChatRequest.builder()
@@ -231,7 +228,7 @@ public class AiServiceTokenStream implements TokenStream {
                 initTemporaryMemory(context, messages),
                 new TokenUsage(),
                 toolServiceContext,
-                context.toolService.maxSequentialToolsInvocations(),
+                context.toolService.maxToolCallingRoundTrips(),
                 toolArgumentsErrorHandler,
                 toolExecutionErrorHandler,
                 toolExecutor,

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -659,7 +659,7 @@ public abstract class AiServices<T> {
     /**
      * @deprecated Use {@link #maxToolCallingRoundTrips(int)} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "1.15.0")
     public AiServices<T> maxSequentialToolsInvocations(int maxSequentialToolsInvocations) {
         return maxToolCallingRoundTrips(maxSequentialToolsInvocations);
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -8,7 +8,6 @@ import static java.util.stream.Collectors.toList;
 
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ReturnBehavior;
-import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -21,6 +20,7 @@ import dev.langchain4j.guardrail.InputGuardrail;
 import dev.langchain4j.guardrail.OutputGuardrail;
 import dev.langchain4j.guardrail.config.InputGuardrailsConfig;
 import dev.langchain4j.guardrail.config.OutputGuardrailsConfig;
+import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
@@ -637,23 +637,31 @@ public abstract class AiServices<T> {
     }
 
     /**
-     * Sets the maximum number of times the LLM may respond with tool calls.
+     * Sets the maximum number of tool calling round trips (i.e. LLM responses containing tool calls).
      * If this limit is exceeded, an exception is thrown and the AI service invocation is terminated.
      *
      * <p>
-     * NOTE: This value does not represent the total number of tool calls.
-     * Each LLM response that contains one or more tool calls counts as a single invocation
+     * NOTE: This value does not represent the total number of individual tool calls.
+     * Each LLM response that contains one or more tool calls counts as a single round trip
      * and reduces this limit by one.
      *
      * <p>
      * The default value is 100.
      *
-     * @param maxSequentialToolsInvocations the maximum number of LLM responses containing tool calls
+     * @param maxToolCallingRoundTrips the maximum number of LLM responses containing tool calls
      * @return the builder instance
      */
-    public AiServices<T> maxSequentialToolsInvocations(int maxSequentialToolsInvocations) {
-        context.toolService.maxSequentialToolsInvocations(maxSequentialToolsInvocations);
+    public AiServices<T> maxToolCallingRoundTrips(int maxToolCallingRoundTrips) {
+        context.toolService.maxToolCallingRoundTrips(maxToolCallingRoundTrips);
         return this;
+    }
+
+    /**
+     * @deprecated Use {@link #maxToolCallingRoundTrips(int)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public AiServices<T> maxSequentialToolsInvocations(int maxSequentialToolsInvocations) {
+        return maxToolCallingRoundTrips(maxSequentialToolsInvocations);
     }
 
     /**

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -228,13 +228,13 @@ public class ToolService {
     }
 
     /** @deprecated Use {@link #maxToolCallingRoundTrips(int)} instead. */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "1.15.0")
     public void maxSequentialToolsInvocations(int maxSequentialToolsInvocations) {
         this.maxToolCallingRoundTrips = maxSequentialToolsInvocations;
     }
 
     /** @deprecated Use {@link #maxToolCallingRoundTrips()} instead. */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "1.15.0")
     public int maxSequentialToolsInvocations() {
         return maxToolCallingRoundTrips;
     }
@@ -375,7 +375,7 @@ public class ToolService {
         while (true) {
 
             if (roundTripsLeft-- == 0) {
-                throw runtime("Something is wrong, exceeded %s tool calling round trips", maxToolCallingRoundTrips);
+                throw runtime("Something is wrong, exceeded %s tool calling round trips (maxToolCallingRoundTrips)", maxToolCallingRoundTrips);
             }
 
             AiMessage aiMessage = chatResponse.aiMessage();

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -52,7 +52,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -77,7 +76,7 @@ public class ToolService {
     private final Map<String, ReturnBehavior> returnBehaviors = new HashMap<>();
     private final Set<ToolProvider> toolProviders = new LinkedHashSet<>();
     private Executor executor;
-    private int maxSequentialToolsInvocations = 100;
+    private int maxToolCallingRoundTrips = 100;
     private ToolArgumentsErrorHandler argumentsErrorHandler;
     private ToolExecutionErrorHandler executionErrorHandler;
     private Function<ToolExecutionRequest, ToolExecutionResultMessage> toolHallucinationStrategy =
@@ -220,12 +219,24 @@ public class ToolService {
         return DefaultExecutorProvider.getDefaultExecutorService();
     }
 
-    public void maxSequentialToolsInvocations(int maxSequentialToolsInvocations) {
-        this.maxSequentialToolsInvocations = maxSequentialToolsInvocations;
+    public void maxToolCallingRoundTrips(int maxToolCallingRoundTrips) {
+        this.maxToolCallingRoundTrips = maxToolCallingRoundTrips;
     }
 
+    public int maxToolCallingRoundTrips() {
+        return maxToolCallingRoundTrips;
+    }
+
+    /** @deprecated Use {@link #maxToolCallingRoundTrips(int)} instead. */
+    @Deprecated(forRemoval = true)
+    public void maxSequentialToolsInvocations(int maxSequentialToolsInvocations) {
+        this.maxToolCallingRoundTrips = maxSequentialToolsInvocations;
+    }
+
+    /** @deprecated Use {@link #maxToolCallingRoundTrips()} instead. */
+    @Deprecated(forRemoval = true)
     public int maxSequentialToolsInvocations() {
-        return maxSequentialToolsInvocations;
+        return maxToolCallingRoundTrips;
     }
 
     /**
@@ -277,9 +288,8 @@ public class ToolService {
         this.toolSearchService = new ToolSearchService(toolSearchStrategy);
     }
 
-    public ToolServiceContext createContext(InvocationContext invocationContext,
-                                            UserMessage userMessage,
-                                            List<ChatMessage> messages) {
+    public ToolServiceContext createContext(
+            InvocationContext invocationContext, UserMessage userMessage, List<ChatMessage> messages) {
         ToolServiceContext context = createContextFromStaticToolsAndProviders(invocationContext, userMessage, messages);
         if (toolSearchService != null) {
             context = toolSearchService.adjust(context, messages, invocationContext);
@@ -288,9 +298,8 @@ public class ToolService {
         return context;
     }
 
-    private ToolServiceContext createContextFromStaticToolsAndProviders(InvocationContext invocationContext,
-                                                                        UserMessage userMessage,
-                                                                        List<ChatMessage> messages) {
+    private ToolServiceContext createContextFromStaticToolsAndProviders(
+            InvocationContext invocationContext, UserMessage userMessage, List<ChatMessage> messages) {
         if (this.toolProviders.isEmpty()) {
             if (this.toolSpecifications.isEmpty()) {
                 return ToolServiceContext.Empty.INSTANCE;
@@ -334,10 +343,11 @@ public class ToolService {
                 .build();
     }
 
-    private static void addTools(List<AiServiceTool> tools,
-                                 Map<String, ToolExecutor> toolExecutors,
-                                 List<ToolSpecification> toolSpecifications,
-                                 Map<String, ReturnBehavior> returnBehaviors) {
+    private static void addTools(
+            List<AiServiceTool> tools,
+            Map<String, ToolExecutor> toolExecutors,
+            List<ToolSpecification> toolSpecifications,
+            Map<String, ReturnBehavior> returnBehaviors) {
         for (AiServiceTool tool : tools) {
             if (toolExecutors.putIfAbsent(tool.name(), tool.toolExecutor()) != null) {
                 throw new IllegalConfigurationException("Duplicated definition for tool: " + tool.name());
@@ -361,12 +371,11 @@ public class ToolService {
         List<ToolExecution> toolExecutions = new ArrayList<>();
         List<ChatResponse> intermediateResponses = new ArrayList<>();
 
-        int sequentialToolsInvocationsLeft = maxSequentialToolsInvocations;
+        int roundTripsLeft = maxToolCallingRoundTrips;
         while (true) {
 
-            if (sequentialToolsInvocationsLeft-- == 0) {
-                throw runtime(
-                        "Something is wrong, exceeded %s sequential tool invocations", maxSequentialToolsInvocations);
+            if (roundTripsLeft-- == 0) {
+                throw runtime("Something is wrong, exceeded %s tool calling round trips", maxToolCallingRoundTrips);
             }
 
             AiMessage aiMessage = chatResponse.aiMessage();
@@ -487,9 +496,8 @@ public class ToolService {
      *
      * @since 1.13.0
      */
-    public static ToolServiceContext refreshDynamicProviders(ToolServiceContext toolServiceContext,
-                                                             List<ChatMessage> messages,
-                                                             InvocationContext invocationContext) {
+    public static ToolServiceContext refreshDynamicProviders(
+            ToolServiceContext toolServiceContext, List<ChatMessage> messages, InvocationContext invocationContext) {
         if (toolServiceContext == null) {
             return null;
         }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
@@ -1329,7 +1329,7 @@ class AiServicesWithToolsIT {
 
         assertThatExceptionOfType(RuntimeException.class)
                 .isThrownBy(() -> assistant.chat(userMessage))
-                .withMessage("Something is wrong, exceeded 1 tool calling round trips");
+                .withMessage("Something is wrong, exceeded 1 tool calling round trips (maxToolCallingRoundTrips)");
     }
 
     @ParameterizedTest

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
@@ -57,7 +57,6 @@ import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
-
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -72,7 +71,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -662,7 +660,7 @@ class AiServicesWithToolsIT {
         assistant.chat(userMessage);
 
         // then
-        verify(stringArrayProcessor).processStrings(new String[]{"cat", "dog"});
+        verify(stringArrayProcessor).processStrings(new String[] {"cat", "dog"});
         verifyNoMoreInteractions(stringArrayProcessor);
 
         List<ChatMessage> messages = chatMemory.messages();
@@ -914,8 +912,8 @@ class AiServicesWithToolsIT {
                 .build();
 
         assertThat(assertThrows(
-                IllegalConfigurationException.class,
-                () -> assistant.chat("Apply the function xyz on the number 2027")))
+                        IllegalConfigurationException.class,
+                        () -> assistant.chat("Apply the function xyz on the number 2027")))
                 .hasMessageContaining("xyz");
     }
 
@@ -1138,7 +1136,7 @@ class AiServicesWithToolsIT {
                             public ToolExecutionResult executeWithContext(
                                     ToolExecutionRequest request, InvocationContext context) {
                                 assertThat((boolean)
-                                        context.invocationParameters().get(includeToolsKey))
+                                                context.invocationParameters().get(includeToolsKey))
                                         .isEqualTo(true);
                                 Map<String, Object> arguments = toMap(request.arguments());
                                 assertThat(arguments).containsExactly(entry("number", 2027));
@@ -1191,8 +1189,7 @@ class AiServicesWithToolsIT {
 
     private static Map<String, Object> toMap(String arguments) {
         try {
-            return new ObjectMapper().readValue(arguments, new TypeReference<>() {
-            });
+            return new ObjectMapper().readValue(arguments, new TypeReference<>() {});
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -1319,20 +1316,20 @@ class AiServicesWithToolsIT {
             ChatModel chatModel) {
 
         // given
-        int maxSequentialToolsInvocations = 1; // only one sequential tool call allowed, the test makes 3
+        int maxToolCallingRoundTrips = 1; // only one round trip allowed, the test makes 3
 
         AssistantReturningResult assistant = AiServices.builder(AssistantReturningResult.class)
                 .chatModel(chatModel)
                 .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
                 .tools(new TransactionService())
-                .maxSequentialToolsInvocations(maxSequentialToolsInvocations)
+                .maxToolCallingRoundTrips(maxToolCallingRoundTrips)
                 .build();
 
         String userMessage = "What are the amounts of transactions T001 and T002?";
 
         assertThatExceptionOfType(RuntimeException.class)
                 .isThrownBy(() -> assistant.chat(userMessage))
-                .withMessage("Something is wrong, exceeded 1 sequential tool invocations");
+                .withMessage("Something is wrong, exceeded 1 tool calling round trips");
     }
 
     @ParameterizedTest
@@ -1342,8 +1339,7 @@ class AiServicesWithToolsIT {
 
         LocalDate now = LocalDate.of(2025, 2, 24);
 
-        record ToolResult(LocalDate localDate) {
-        }
+        record ToolResult(LocalDate localDate) {}
 
         class Tools {
 
@@ -1417,12 +1413,11 @@ class AiServicesWithToolsIT {
 
     interface RouterAgent {
 
-        @dev.langchain4j.service.UserMessage(
-                """
+        @dev.langchain4j.service.UserMessage("""
                         Analyze the following user request and categorize it as 'legal', 'medical' or 'technical',
                         then forward the request as it is to the corresponding expert provided as a tool.
                         Finally return the answer that you received from the expert without any modification.
-                        
+
                         The user request is: '{{it}}'.
                         """)
         String askToExpert(String request);
@@ -1430,8 +1425,7 @@ class AiServicesWithToolsIT {
 
     interface MedicalExpert {
 
-        @dev.langchain4j.service.UserMessage(
-                """
+        @dev.langchain4j.service.UserMessage("""
                         You are a medical expert.
                         Analyze the following user request under a medical point of view and provide the best possible answer.
                         The user request is {{it}}.
@@ -1442,8 +1436,7 @@ class AiServicesWithToolsIT {
 
     interface LegalExpert {
 
-        @dev.langchain4j.service.UserMessage(
-                """
+        @dev.langchain4j.service.UserMessage("""
                         You are a legal expert.
                         Analyze the following user request under a legal point of view and provide the best possible answer.
                         The user request is {{it}}.
@@ -1454,8 +1447,7 @@ class AiServicesWithToolsIT {
 
     interface TechnicalExpert {
 
-        @dev.langchain4j.service.UserMessage(
-                """
+        @dev.langchain4j.service.UserMessage("""
                         You are a technical expert.
                         Analyze the following user request under a technical point of view and provide the best possible answer.
                         The user request is {{it}}.
@@ -1504,8 +1496,7 @@ class AiServicesWithToolsIT {
 
         LocalDate now = LocalDate.of(2025, 2, 24);
 
-        record ToolResult(LocalDate localDate) {
-        }
+        record ToolResult(LocalDate localDate) {}
 
         class Tools {
 
@@ -1543,8 +1534,7 @@ class AiServicesWithToolsIT {
 
         LocalDate now = LocalDate.of(2025, 2, 24);
 
-        record ToolResult(LocalDate localDate) {
-        }
+        record ToolResult(LocalDate localDate) {}
 
         class Tools {
 
@@ -1661,8 +1651,7 @@ class AiServicesWithToolsIT {
                         .name("getWeather")
                         .arguments("{\"city\":\"London\"}")
                         .build()),
-                AiMessage.from("It is sunny in London")
-        );
+                AiMessage.from("It is sunny in London"));
         ChatModel spyChatModel = spy(chatModel);
 
         interface SimpleAssistant {
@@ -1683,10 +1672,11 @@ class AiServicesWithToolsIT {
         verify(spyStaticProvider, times(1)).provideTools(any());
         verify(spyDynamicProvider, times(2)).provideTools(any());
 
-        verify(spyChatModel, times(2)).chat(argThat((ChatRequest request) ->
-                request.toolSpecifications().stream().anyMatch(t -> t.name().equals("getWeather"))
-                        && request.toolSpecifications().stream().anyMatch(t -> t.name().equals("getTime"))
-        ));
+        verify(spyChatModel, times(2))
+                .chat(argThat((ChatRequest request) -> request.toolSpecifications().stream()
+                                .anyMatch(t -> t.name().equals("getWeather"))
+                        && request.toolSpecifications().stream()
+                                .anyMatch(t -> t.name().equals("getTime"))));
     }
 
     @Test
@@ -1701,14 +1691,18 @@ class AiServicesWithToolsIT {
                 int call = callCount.incrementAndGet();
                 ToolProviderResult.Builder builder = ToolProviderResult.builder();
                 builder.add(
-                        ToolSpecification.builder().name("getWeather").description("Gets the weather").build(),
-                        (req, memoryId) -> "sunny"
-                );
+                        ToolSpecification.builder()
+                                .name("getWeather")
+                                .description("Gets the weather")
+                                .build(),
+                        (req, memoryId) -> "sunny");
                 if (call >= 2) {
                     builder.add(
-                            ToolSpecification.builder().name("getTime").description("Gets the time").build(),
-                            (req, memoryId) -> "12:00"
-                    );
+                            ToolSpecification.builder()
+                                    .name("getTime")
+                                    .description("Gets the time")
+                                    .build(),
+                            (req, memoryId) -> "12:00");
                 }
                 return builder.build();
             }
@@ -1725,8 +1719,7 @@ class AiServicesWithToolsIT {
                         .name("getWeather")
                         .arguments("{}")
                         .build()),
-                AiMessage.from("It is sunny and the time is 12:00")
-        );
+                AiMessage.from("It is sunny and the time is 12:00"));
         ChatModel spyChatModel = spy(chatModel);
 
         interface SimpleAssistant {
@@ -1746,15 +1739,13 @@ class AiServicesWithToolsIT {
 
         InOrder inOrder = inOrder(spyChatModel);
 
-        inOrder.verify(spyChatModel).chat(argThat((ChatRequest request) ->
-                containsTool(request, "getWeather")
-                        && !containsTool(request, "getTime")
-        ));
+        inOrder.verify(spyChatModel)
+                .chat(argThat((ChatRequest request) ->
+                        containsTool(request, "getWeather") && !containsTool(request, "getTime")));
 
-        inOrder.verify(spyChatModel).chat(argThat((ChatRequest request) ->
-                containsTool(request, "getWeather")
-                        && containsTool(request, "getTime")
-        ));
+        inOrder.verify(spyChatModel)
+                .chat(argThat((ChatRequest request) ->
+                        containsTool(request, "getWeather") && containsTool(request, "getTime")));
 
         verifyNoMoreInteractionsFor(spyChatModel);
     }
@@ -1771,15 +1762,19 @@ class AiServicesWithToolsIT {
                 int call = callCount.incrementAndGet();
                 ToolProviderResult.Builder builder = ToolProviderResult.builder();
                 builder.add(
-                        ToolSpecification.builder().name("getWeather").description("Gets the weather").build(),
-                        (req, memoryId) -> "sunny"
-                );
+                        ToolSpecification.builder()
+                                .name("getWeather")
+                                .description("Gets the weather")
+                                .build(),
+                        (req, memoryId) -> "sunny");
                 if (call == 1) {
                     // Only returned on first call
                     builder.add(
-                            ToolSpecification.builder().name("getTime").description("Gets the time").build(),
-                            (req, memoryId) -> "12:00"
-                    );
+                            ToolSpecification.builder()
+                                    .name("getTime")
+                                    .description("Gets the time")
+                                    .build(),
+                            (req, memoryId) -> "12:00");
                 }
                 return builder.build();
             }
@@ -1796,8 +1791,7 @@ class AiServicesWithToolsIT {
                         .name("getWeather")
                         .arguments("{}")
                         .build()),
-                AiMessage.from("It is sunny and the time is 12:00")
-        );
+                AiMessage.from("It is sunny and the time is 12:00"));
         ChatModel spyChatModel = spy(chatModel);
 
         interface SimpleAssistant {
@@ -1815,10 +1809,9 @@ class AiServicesWithToolsIT {
         // then
         assertThat(answer).contains("sunny");
 
-        verify(spyChatModel, times(2)).chat(argThat((ChatRequest request) ->
-                containsTool(request, "getWeather")
-                        && containsTool(request, "getTime")
-        ));
+        verify(spyChatModel, times(2))
+                .chat(argThat((ChatRequest request) ->
+                        containsTool(request, "getWeather") && containsTool(request, "getTime")));
 
         verifyNoMoreInteractionsFor(spyChatModel);
     }
@@ -1843,8 +1836,7 @@ class AiServicesWithToolsIT {
                         .name("doSomething")
                         .arguments("{}")
                         .build()),
-                AiMessage.from("OK, got null")
-        ));
+                AiMessage.from("OK, got null")));
 
         Assistant assistant = AiServices.builder(Assistant.class)
                 .chatModel(chatModel)
@@ -1878,10 +1870,7 @@ class AiServicesWithToolsIT {
 
             @Tool("Takes a photo")
             Object takePhoto() {
-                return Image.builder()
-                        .base64Data("iVBOR")
-                        .mimeType("image/png")
-                        .build();
+                return Image.builder().base64Data("iVBOR").mimeType("image/png").build();
             }
         }
 
@@ -1893,8 +1882,7 @@ class AiServicesWithToolsIT {
                         .name("takePhoto")
                         .arguments("{}")
                         .build()),
-                AiMessage.from("I see a cat")
-        ));
+                AiMessage.from("I see a cat")));
 
         Assistant assistant = AiServices.builder(Assistant.class)
                 .chatModel(chatModel)
@@ -1943,8 +1931,7 @@ class AiServicesWithToolsIT {
                         .name("takePhoto")
                         .arguments("{}")
                         .build()),
-                AiMessage.from("No photo available")
-        ));
+                AiMessage.from("No photo available")));
 
         Assistant assistant = AiServices.builder(Assistant.class)
                 .chatModel(chatModel)
@@ -1991,8 +1978,7 @@ class AiServicesWithToolsIT {
                         .name("takePhoto")
                         .arguments("{}")
                         .build()),
-                AiMessage.from("Sorry, the camera is broken")
-        ));
+                AiMessage.from("Sorry, the camera is broken")));
 
         Assistant assistant = AiServices.builder(Assistant.class)
                 .chatModel(chatModel)
@@ -2080,9 +2066,10 @@ class AiServicesWithToolsIT {
 
         assistant.chat("Please register a Labrador dog named Rex.");
 
-        verify(registry).registerAnimal(argThat(animal -> animal instanceof Dog dog
-                && dog.name().equalsIgnoreCase("Rex")
-                && dog.breed().toLowerCase().contains("labrador")));
+        verify(registry)
+                .registerAnimal(argThat(animal -> animal instanceof Dog dog
+                        && dog.name().equalsIgnoreCase("Rex")
+                        && dog.breed().toLowerCase().contains("labrador")));
     }
 
     @ParameterizedTest
@@ -2099,9 +2086,10 @@ class AiServicesWithToolsIT {
         assistant.chat("Register a batch of two animals in a single call using the registerAnimals tool "
                 + "(do NOT use registerAnimal): a Labrador dog named Rex, and an indoor cat named Whiskers.");
 
-        verify(registry).registerAnimals(argThat(animals -> animals.size() == 2
-                && animals.stream().anyMatch(Dog.class::isInstance)
-                && animals.stream().anyMatch(Cat.class::isInstance)));
+        verify(registry)
+                .registerAnimals(argThat(animals -> animals.size() == 2
+                        && animals.stream().anyMatch(Dog.class::isInstance)
+                        && animals.stream().anyMatch(Cat.class::isInstance)));
     }
 
     @ParameterizedTest
@@ -2117,10 +2105,11 @@ class AiServicesWithToolsIT {
 
         assistant.chat("Please register Alice as the owner of her Labrador dog named Rex.");
 
-        verify(registry).registerOwner(argThat(owner -> owner.name().equalsIgnoreCase("Alice")
-                && owner.pet() instanceof Dog dog
-                && dog.name().equalsIgnoreCase("Rex")
-                && dog.breed().toLowerCase().contains("labrador")));
+        verify(registry)
+                .registerOwner(argThat(owner -> owner.name().equalsIgnoreCase("Alice")
+                        && owner.pet() instanceof Dog dog
+                        && dog.name().equalsIgnoreCase("Rex")
+                        && dog.breed().toLowerCase().contains("labrador")));
     }
 
     @ParameterizedTest

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
@@ -1447,7 +1447,7 @@ class StreamingAiServicesWithToolsIT {
         // then
         assertThat(future.get(30, SECONDS))
                 .isExactlyInstanceOf(RuntimeException.class)
-                .hasMessage("Something is wrong, exceeded 1 tool calling round trips");
+                .hasMessage("Something is wrong, exceeded 1 tool calling round trips (maxToolCallingRoundTrips)");
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingAiServicesWithToolsIT.java
@@ -67,7 +67,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -341,7 +340,8 @@ class StreamingAiServicesWithToolsIT {
 
         assertThat(aiServiceHooks.beforeHookThreads).hasSize(2);
         assertThat(aiServiceHooks.beforeHookThreads.get("getCurrentTime")).isEqualTo(getCurrentTimeThread);
-        assertThat(aiServiceHooks.beforeHookThreads.get("getCurrentTemperature")).isEqualTo(getCurrentTemperatureThread);
+        assertThat(aiServiceHooks.beforeHookThreads.get("getCurrentTemperature"))
+                .isEqualTo(getCurrentTemperatureThread);
 
         assertThat(aiServiceHooks.afterHookThreads).hasSize(2);
         assertThat(aiServiceHooks.afterHookThreads.get("getCurrentTime")).isEqualTo(getCurrentTimeThread);
@@ -349,7 +349,8 @@ class StreamingAiServicesWithToolsIT {
 
         assertThat(handler.beforeToolExecutionThreads).hasSize(2);
         assertThat(handler.beforeToolExecutionThreads.get("getCurrentTime")).hasSize(1);
-        assertThat(handler.beforeToolExecutionThreads.get("getCurrentTemperature")).hasSize(1);
+        assertThat(handler.beforeToolExecutionThreads.get("getCurrentTemperature"))
+                .hasSize(1);
 
         assertThat(handler.onToolExecutedThreads).hasSize(2);
         assertThat(handler.onToolExecutedThreads.get("getCurrentTime")).hasSize(1);
@@ -691,7 +692,8 @@ class StreamingAiServicesWithToolsIT {
         CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
 
         // when
-        assistant.chat(userMessage)
+        assistant
+                .chat(userMessage)
                 .onPartialResponse(handler::onPartialResponse)
                 .onPartialToolCall(handler::onPartialToolCall)
                 .beforeToolExecution(handler::beforeToolExecution)
@@ -723,9 +725,12 @@ class StreamingAiServicesWithToolsIT {
         // then - verify callback order
         InOrder inOrder = inOrder(handler);
 
-        inOrder.verify(handler, atLeastOnce()).onPartialToolCall(argThat(ptc -> ptc.name().equals("currentTemperature")));
-        inOrder.verify(handler).beforeToolExecution(argThat(bte -> bte.request().name().equals("currentTemperature")));
-        inOrder.verify(handler).onToolExecuted(argThat(te -> te.result().equals(String.valueOf(WeatherService.TEMPERATURE))));
+        inOrder.verify(handler, atLeastOnce())
+                .onPartialToolCall(argThat(ptc -> ptc.name().equals("currentTemperature")));
+        inOrder.verify(handler)
+                .beforeToolExecution(argThat(bte -> bte.request().name().equals("currentTemperature")));
+        inOrder.verify(handler)
+                .onToolExecuted(argThat(te -> te.result().equals(String.valueOf(WeatherService.TEMPERATURE))));
 
         inOrder.verify(handler, atLeastOnce()).onPartialResponse(any());
         inOrder.verify(handler).onCompleteResponse(any());
@@ -1411,12 +1416,12 @@ class StreamingAiServicesWithToolsIT {
             StreamingChatModel model) throws Exception {
 
         // given
-        int maxSequentialToolsInvocations = 1; // only one sequential tool call allowed, the test makes 3
+        int maxToolCallingRoundTrips = 1; // only one round trip allowed, the test makes 3
 
         Assistant assistant = AiServices.builder(Assistant.class)
                 .streamingChatModel(model)
                 .tools(new TransactionService())
-                .maxSequentialToolsInvocations(maxSequentialToolsInvocations)
+                .maxToolCallingRoundTrips(maxToolCallingRoundTrips)
                 .build();
 
         AtomicInteger n = new AtomicInteger(0);
@@ -1427,11 +1432,11 @@ class StreamingAiServicesWithToolsIT {
                 .chat("What are the amounts of transactions T001 and T002?")
                 .beforeToolExecution(toolExecutionRequest -> {
                     final int index = n.incrementAndGet();
-                    assertThat(index).isLessThanOrEqualTo(maxSequentialToolsInvocations);
+                    assertThat(index).isLessThanOrEqualTo(maxToolCallingRoundTrips);
                 })
                 .onToolExecuted(toolExecutionResult -> {
                     final int index = n.get();
-                    assertThat(index).isLessThanOrEqualTo(maxSequentialToolsInvocations);
+                    assertThat(index).isLessThanOrEqualTo(maxToolCallingRoundTrips);
                 })
                 .onError(future::complete)
                 .onCompleteResponse(ignored -> {
@@ -1442,11 +1447,12 @@ class StreamingAiServicesWithToolsIT {
         // then
         assertThat(future.get(30, SECONDS))
                 .isExactlyInstanceOf(RuntimeException.class)
-                .hasMessage("Something is wrong, exceeded 1 sequential tool invocations");
+                .hasMessage("Something is wrong, exceeded 1 tool calling round trips");
     }
 
     @Test
-    void should_call_static_tool_provider_once_and_dynamic_tool_provider_before_each_chat_model_request() throws Exception {
+    void should_call_static_tool_provider_once_and_dynamic_tool_provider_before_each_chat_model_request()
+            throws Exception {
 
         // given
         ToolProvider spyStaticProvider = spy(new ToolProvider() {
@@ -1486,8 +1492,7 @@ class StreamingAiServicesWithToolsIT {
                         .name("getWeather")
                         .arguments("{\"city\":\"London\"}")
                         .build()),
-                AiMessage.from("It is sunny in London")
-        ));
+                AiMessage.from("It is sunny in London")));
         StreamingChatModel spyModel = spy(streamingModel);
 
         Assistant assistant = AiServices.builder(Assistant.class)
@@ -1511,10 +1516,11 @@ class StreamingAiServicesWithToolsIT {
         verify(spyStaticProvider, times(1)).provideTools(any());
         verify(spyDynamicProvider, times(2)).provideTools(any());
 
-        verify(spyModel, times(2)).chat(argThat((ChatRequest request) ->
-                containsTool(request, "getWeather")
-                        && containsTool(request, "getTime")
-        ), any());
+        verify(spyModel, times(2))
+                .chat(
+                        argThat((ChatRequest request) ->
+                                containsTool(request, "getWeather") && containsTool(request, "getTime")),
+                        any());
 
         verifyNoMoreInteractionsFor(spyModel);
     }
@@ -1531,14 +1537,18 @@ class StreamingAiServicesWithToolsIT {
                 int call = callCount.incrementAndGet();
                 ToolProviderResult.Builder builder = ToolProviderResult.builder();
                 builder.add(
-                        ToolSpecification.builder().name("getWeather").description("Gets the weather").build(),
-                        (req, memoryId) -> "sunny"
-                );
+                        ToolSpecification.builder()
+                                .name("getWeather")
+                                .description("Gets the weather")
+                                .build(),
+                        (req, memoryId) -> "sunny");
                 if (call >= 2) {
                     builder.add(
-                            ToolSpecification.builder().name("getTime").description("Gets the time").build(),
-                            (req, memoryId) -> "12:00"
-                    );
+                            ToolSpecification.builder()
+                                    .name("getTime")
+                                    .description("Gets the time")
+                                    .build(),
+                            (req, memoryId) -> "12:00");
                 }
                 return builder.build();
             }
@@ -1555,8 +1565,7 @@ class StreamingAiServicesWithToolsIT {
                         .name("getWeather")
                         .arguments("{}")
                         .build()),
-                AiMessage.from("It is sunny and the time is 12:00")
-        );
+                AiMessage.from("It is sunny and the time is 12:00"));
         StreamingChatModel spyModel = spy(streamingModel);
 
         Assistant assistant = AiServices.builder(Assistant.class)
@@ -1579,15 +1588,17 @@ class StreamingAiServicesWithToolsIT {
 
         InOrder inOrder = inOrder(spyModel);
 
-        verify(spyModel).chat(argThat((ChatRequest request) ->
-                containsTool(request, "getWeather")
-                        && !containsTool(request, "getTime")
-        ), any());
+        verify(spyModel)
+                .chat(
+                        argThat((ChatRequest request) ->
+                                containsTool(request, "getWeather") && !containsTool(request, "getTime")),
+                        any());
 
-        verify(spyModel).chat(argThat((ChatRequest request) ->
-                containsTool(request, "getWeather")
-                        && containsTool(request, "getTime")
-        ), any());
+        verify(spyModel)
+                .chat(
+                        argThat((ChatRequest request) ->
+                                containsTool(request, "getWeather") && containsTool(request, "getTime")),
+                        any());
 
         verifyNoMoreInteractionsFor(spyModel);
     }
@@ -1604,15 +1615,19 @@ class StreamingAiServicesWithToolsIT {
                 int call = callCount.incrementAndGet();
                 ToolProviderResult.Builder builder = ToolProviderResult.builder();
                 builder.add(
-                        ToolSpecification.builder().name("getWeather").description("Gets the weather").build(),
-                        (req, memoryId) -> "sunny"
-                );
+                        ToolSpecification.builder()
+                                .name("getWeather")
+                                .description("Gets the weather")
+                                .build(),
+                        (req, memoryId) -> "sunny");
                 if (call == 1) {
                     // Only returned on first call
                     builder.add(
-                            ToolSpecification.builder().name("getTime").description("Gets the time").build(),
-                            (req, memoryId) -> "12:00"
-                    );
+                            ToolSpecification.builder()
+                                    .name("getTime")
+                                    .description("Gets the time")
+                                    .build(),
+                            (req, memoryId) -> "12:00");
                 }
                 return builder.build();
             }
@@ -1629,8 +1644,7 @@ class StreamingAiServicesWithToolsIT {
                         .name("getWeather")
                         .arguments("{}")
                         .build()),
-                AiMessage.from("It is sunny and the time is 12:00")
-        );
+                AiMessage.from("It is sunny and the time is 12:00"));
         StreamingChatModel spyModel = spy(streamingModel);
 
         Assistant assistant = AiServices.builder(Assistant.class)
@@ -1651,10 +1665,11 @@ class StreamingAiServicesWithToolsIT {
         // then
         assertThat(response.aiMessage().text()).contains("sunny");
 
-        verify(spyModel, times(2)).chat(argThat((ChatRequest request) ->
-                containsTool(request, "getWeather")
-                        && containsTool(request, "getTime")
-        ), any());
+        verify(spyModel, times(2))
+                .chat(
+                        argThat((ChatRequest request) ->
+                                containsTool(request, "getWeather") && containsTool(request, "getTime")),
+                        any());
 
         verifyNoMoreInteractionsFor(spyModel);
     }
@@ -1667,10 +1682,7 @@ class StreamingAiServicesWithToolsIT {
 
             @Tool("Takes a photo")
             Image takePhoto() {
-                return Image.builder()
-                        .base64Data("iVBOR")
-                        .mimeType("image/png")
-                        .build();
+                return Image.builder().base64Data("iVBOR").mimeType("image/png").build();
             }
         }
 
@@ -1682,8 +1694,7 @@ class StreamingAiServicesWithToolsIT {
                         .name("takePhoto")
                         .arguments("{}")
                         .build()),
-                AiMessage.from("I see a cat")
-        ));
+                AiMessage.from("I see a cat")));
 
         Assistant assistant = AiServices.builder(Assistant.class)
                 .streamingChatModel(streamingModel)
@@ -1693,7 +1704,8 @@ class StreamingAiServicesWithToolsIT {
         CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
 
         // when
-        assistant.chat("Take a photo")
+        assistant
+                .chat("Take a photo")
                 .onCompleteResponse(futureResponse::complete)
                 .onError(futureResponse::completeExceptionally)
                 .start();
@@ -1703,27 +1715,32 @@ class StreamingAiServicesWithToolsIT {
         assertThat(response.aiMessage().text()).contains("cat");
         verify(tools).takePhoto();
 
-        verify(streamingModel, times(2)).chat(argThat((ChatRequest request) -> {
-            if (request.messages().size() < 3) {
-                return true; // first call
-            }
-            // second call should have ToolExecutionResultMessage with ImageContent
-            ToolExecutionResultMessage toolResult = request.messages().stream()
-                    .filter(ToolExecutionResultMessage.class::isInstance)
-                    .map(ToolExecutionResultMessage.class::cast)
-                    .findFirst()
-                    .orElse(null);
-            return toolResult != null
-                    && toolResult.contents().size() == 1
-                    && toolResult.contents().get(0) instanceof dev.langchain4j.data.message.ImageContent;
-        }), any());
+        verify(streamingModel, times(2))
+                .chat(
+                        argThat((ChatRequest request) -> {
+                            if (request.messages().size() < 3) {
+                                return true; // first call
+                            }
+                            // second call should have ToolExecutionResultMessage with ImageContent
+                            ToolExecutionResultMessage toolResult = request.messages().stream()
+                                    .filter(ToolExecutionResultMessage.class::isInstance)
+                                    .map(ToolExecutionResultMessage.class::cast)
+                                    .findFirst()
+                                    .orElse(null);
+                            return toolResult != null
+                                    && toolResult.contents().size() == 1
+                                    && toolResult.contents().get(0)
+                                            instanceof dev.langchain4j.data.message.ImageContent;
+                        }),
+                        any());
     }
 
     // TODO all other tests from sync version
 
     // TODO rename verifyNoMoreImportantInteractions
     private static void verifyNoMoreInteractionsFor(StreamingChatModel model) {
-        ignoreInteractions(model).chat(any(ChatRequest.class), any(ChatRequestOptions.class), any(StreamingChatResponseHandler.class));
+        ignoreInteractions(model)
+                .chat(any(ChatRequest.class), any(ChatRequestOptions.class), any(StreamingChatResponseHandler.class));
         ignoreInteractions(model).doChat(any(), any());
         ignoreInteractions(model).defaultRequestParameters();
         ignoreInteractions(model).supportedCapabilities();


### PR DESCRIPTION
## Issue
Closes #5063

## Change
Renames `maxSequentialToolsInvocations` to `maxToolCallingRoundTrips` across
`AiServices`, `ToolService`, `AgentBuilder`, `AiServiceStreamingResponseHandler`,
and `AiServiceTokenStream`.

The old name was semantically misleading — the value limits LLM request/response
round trips, not the total number of individual tool invocations. This caused
a concrete misconfiguration bug in the Quarkus extension
(quarkiverse/quarkus-langchain4j#2373).

Old methods are kept as `@Deprecated(forRemoval = true)` shims delegating to the
new names, so existing code continues to compile without changes.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
