### PR TITLE
fix: isolate per-agent event listeners when SPI factory returns singl…

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/AiServiceListenerRegistrar.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/AiServiceListenerRegistrar.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.observability.api;
 
-import java.util.Arrays;
-import java.util.ServiceLoader;
 import dev.langchain4j.observability.api.event.AiServiceEvent;
 import dev.langchain4j.observability.api.listener.AiServiceListener;
 import dev.langchain4j.spi.observability.AiServiceListenerRegistrarFactory;
+import java.util.Arrays;
+import java.util.ServiceLoader;
 
 /**
  * A registrar for registering {@link AiServiceListener}s.
@@ -112,9 +112,13 @@ public interface AiServiceListenerRegistrar {
     /**
      * Retrieves an instance of {@link AiServiceListenerRegistrar}.
      *
-     * This method first attempts to load an instance of {@link AiServiceListenerRegistrar}
-     * using {@link ServiceLoader}. If no implementation is found, the default
-     * instance provided by {@link DefaultAiServiceListenerRegistrar#newInstance()} is returned.
+     * <p>This method always returns a fresh {@link DefaultAiServiceListenerRegistrar} to guarantee
+     * per-agent listener isolation. If an {@link AiServiceListenerRegistrarFactory} is registered
+     * via Java SPI, the factory-provided registrar is used as a delegate: events fired by the
+     * returned instance are forwarded to it after notifying local listeners. This allows global
+     * listeners pre-configured in the SPI registrar to receive all events, while preventing
+     * cross-agent listener leakage that would occur if the factory returned a singleton.
+     *
      * @param shouldThrowExceptionOnEventError Indicates whether to throw exceptions on event errors.
      *                                         If {@code true}, exceptions will be thrown; otherwise, errors
      *                                         will be handled silently.
@@ -122,7 +126,12 @@ public interface AiServiceListenerRegistrar {
     static AiServiceListenerRegistrar newInstance(boolean shouldThrowExceptionOnEventError) {
         var registrar = ServiceLoader.load(AiServiceListenerRegistrarFactory.class)
                 .findFirst()
-                .map(AiServiceListenerRegistrarFactory::get)
+                .map(factory -> {
+                    AiServiceListenerRegistrar delegate = factory.get();
+                    return delegate != null
+                            ? new DefaultAiServiceListenerRegistrar(delegate)
+                            : new DefaultAiServiceListenerRegistrar();
+                })
                 .orElseGet(DefaultAiServiceListenerRegistrar::new);
 
         registrar.shouldThrowExceptionOnEventError(shouldThrowExceptionOnEventError);

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/DefaultAiServiceListenerRegistrar.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/DefaultAiServiceListenerRegistrar.java
@@ -2,6 +2,8 @@ package dev.langchain4j.observability.api;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
+import dev.langchain4j.observability.api.event.AiServiceEvent;
+import dev.langchain4j.observability.api.listener.AiServiceListener;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -10,8 +12,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import dev.langchain4j.observability.api.event.AiServiceEvent;
-import dev.langchain4j.observability.api.listener.AiServiceListener;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -27,6 +27,27 @@ public class DefaultAiServiceListenerRegistrar implements AiServiceListenerRegis
 
     // Defaults to false to preserve backwards compatibility
     private final AtomicBoolean shouldThrowExceptionOnEventError = new AtomicBoolean(false);
+
+    /**
+     * An optional delegate registrar to which events are forwarded after local listeners have been notified.
+     * Used to propagate events to a global/shared registrar provided via SPI while keeping per-instance
+     * listener registration isolated.
+     */
+    @Nullable
+    private final AiServiceListenerRegistrar delegate;
+
+    public DefaultAiServiceListenerRegistrar() {
+        this.delegate = null;
+    }
+
+    /**
+     * Creates a registrar that forwards all fired events to the given {@code delegate} after notifying
+     * its own locally registered listeners. This allows a shared/global registrar (e.g. provided via
+     * SPI) to receive events without being mutated by per-agent listener registrations.
+     */
+    public DefaultAiServiceListenerRegistrar(@NonNull AiServiceListenerRegistrar delegate) {
+        this.delegate = ensureNotNull(delegate, "delegate");
+    }
 
     /**
      * Registers a listener to receive {@link AiServiceEvent} notifications.
@@ -64,11 +85,17 @@ public class DefaultAiServiceListenerRegistrar implements AiServiceListenerRegis
         Optional.ofNullable(this.listeners.get(event.eventClass()))
                 .map(l -> (EventListeners<T>) l)
                 .ifPresent(l -> l.fireEvent(event));
+        if (delegate != null) {
+            delegate.fireEvent(event);
+        }
     }
 
     @Override
     public void shouldThrowExceptionOnEventError(boolean shouldThrowExceptionOnEventError) {
-        this.shouldThrowExceptionOnEventError.compareAndSet(!shouldThrowExceptionOnEventError, shouldThrowExceptionOnEventError);
+        // Intentionally not forwarded to the delegate: the delegate may be a shared singleton
+        // and mutating its error-handling setting from a per-agent context would cause races.
+        this.shouldThrowExceptionOnEventError.compareAndSet(
+                !shouldThrowExceptionOnEventError, shouldThrowExceptionOnEventError);
     }
 
     private <T extends AiServiceEvent> EventListeners<T> addToExistingOrNewList(

--- a/langchain4j-core/src/main/java/dev/langchain4j/spi/observability/AiServiceListenerRegistrarFactory.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/spi/observability/AiServiceListenerRegistrarFactory.java
@@ -4,6 +4,14 @@ import dev.langchain4j.observability.api.AiServiceListenerRegistrar;
 import java.util.function.Supplier;
 
 /**
- * A factory for creating {@link AiServiceListenerRegistrar} instances.
+ * A factory for providing a global {@link AiServiceListenerRegistrar} via Java SPI.
+ *
+ * <p>The registrar returned by {@link #get()} is used as a <em>delegate</em>: a fresh
+ * per-agent {@link AiServiceListenerRegistrar} is always created for each agent context,
+ * and events are forwarded to the delegate after notifying the agent's own listeners.
+ * This means listeners registered on the delegate receive events from all agents, while
+ * listeners registered on individual agent registrars remain isolated.
+ *
+ * <p>Implementations may return a singleton from {@link #get()}.
  */
 public interface AiServiceListenerRegistrarFactory extends Supplier<AiServiceListenerRegistrar> {}

--- a/langchain4j-core/src/test/java/dev/langchain4j/observability/api/AiServiceListenerRegistrarTests.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/observability/api/AiServiceListenerRegistrarTests.java
@@ -2,13 +2,85 @@ package dev.langchain4j.observability.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.observability.api.event.AiServiceStartedEvent;
+import dev.langchain4j.observability.api.listener.AiServiceStartedListener;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 class AiServiceListenerRegistrarTests {
+
+    private static final AiServiceStartedEvent STARTED_EVENT = AiServiceStartedEvent.builder()
+            .invocationContext(InvocationContext.builder()
+                    .interfaceName("I")
+                    .methodName("m")
+                    .build())
+            .userMessage(UserMessage.from("hi"))
+            .build();
+
     @Test
     void correctInstance() {
         assertThat(AiServiceListenerRegistrar.newInstance())
                 .isNotNull()
                 .isExactlyInstanceOf(DefaultAiServiceListenerRegistrar.class);
+    }
+
+    @Test
+    void listenerRegisteredOnOneAgentDoesNotReceiveEventsFromAnotherAgent() {
+        // Simulate a singleton SPI factory
+        AiServiceListenerRegistrar singletonDelegate = new DefaultAiServiceListenerRegistrar();
+
+        AiServiceListenerRegistrar agentA = new DefaultAiServiceListenerRegistrar(singletonDelegate);
+        AiServiceListenerRegistrar agentB = new DefaultAiServiceListenerRegistrar(singletonDelegate);
+
+        AtomicInteger agentACount = new AtomicInteger();
+        agentA.register((AiServiceStartedListener) event -> agentACount.incrementAndGet());
+
+        // Agent B fires an event — agent A's listener must NOT be triggered
+        agentB.fireEvent(STARTED_EVENT);
+
+        assertThat(agentACount).hasValue(0);
+    }
+
+    @Test
+    void delegateReceivesEventsFromAllAgents() {
+        AiServiceListenerRegistrar singletonDelegate = new DefaultAiServiceListenerRegistrar();
+        AtomicInteger delegateCount = new AtomicInteger();
+        singletonDelegate.register((AiServiceStartedListener) event -> delegateCount.incrementAndGet());
+
+        AiServiceListenerRegistrar agentA = new DefaultAiServiceListenerRegistrar(singletonDelegate);
+        AiServiceListenerRegistrar agentB = new DefaultAiServiceListenerRegistrar(singletonDelegate);
+
+        agentA.fireEvent(STARTED_EVENT);
+        agentB.fireEvent(STARTED_EVENT);
+
+        assertThat(delegateCount).hasValue(2);
+    }
+
+    @Test
+    void perAgentShouldThrowSettingDoesNotAffectDelegate() {
+        AiServiceListenerRegistrar singletonDelegate = new DefaultAiServiceListenerRegistrar();
+        singletonDelegate.register((AiServiceStartedListener) event -> {
+            throw new RuntimeException("delegate error");
+        });
+
+        AiServiceListenerRegistrar agentA = new DefaultAiServiceListenerRegistrar(singletonDelegate);
+        AiServiceListenerRegistrar agentB = new DefaultAiServiceListenerRegistrar(singletonDelegate);
+
+        // Agent A enables throw-on-error — must not mutate the delegate's setting
+        agentA.shouldThrowExceptionOnEventError(true);
+
+        // Agent B fires through the same delegate — the delegate swallows exceptions by default
+        // so no exception should propagate from agentB's fire
+        assertThat(agentB).satisfies(r -> {
+            try {
+                r.fireEvent(STARTED_EVENT);
+            } catch (RuntimeException e) {
+                // delegate exception swallowed — this path should not be reached if isolation holds
+                org.junit.jupiter.api.Assertions.fail(
+                        "delegate error propagated to unrelated agent: " + e.getMessage());
+            }
+        });
     }
 }


### PR DESCRIPTION
## Issue
Closes #5137

## Change
When `AiServiceListenerRegistrarFactory.get()` returns a singleton (a common and
reasonable implementation pattern), all agents shared the same
`AiServiceListenerRegistrar`. Every agent registered its listeners on that shared
instance, so each agent received events from every other agent.

**Fix:** `AiServiceListenerRegistrar.newInstance()` now always creates a fresh
`DefaultAiServiceListenerRegistrar` per agent context. If an SPI factory is
present, the factory-provided registrar is used as a **delegate** — events are
forwarded to it after notifying the per-agent local listeners. This means:

- Global listeners registered on the SPI registrar still receive all events from all agents (unchanged behaviour for this use case)
- Per-agent listener registrations are fully isolated — Agent A's listeners never receive Agent B's events
- SPI factory implementations may safely return a singleton

**Files changed:**
- `DefaultAiServiceListenerRegistrar` — new `delegate` constructor; `fireEvent` and `shouldThrowExceptionOnEventError` forward to delegate if present
- `AiServiceListenerRegistrar.newInstance()` — always wraps SPI result in a fresh instance
- `AiServiceListenerRegistrarFactory` — Javadoc updated to document the new delegate semantics

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
