### PR TITLE
feat(vertex-ai-gemini): support request labels for billing/cost attribution

### DIFF
--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -16,6 +16,7 @@ import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.Content;
 import com.google.cloud.vertexai.api.FunctionCall;
 import com.google.cloud.vertexai.api.FunctionCallingConfig;
+import com.google.cloud.vertexai.api.GenerateContentRequest;
 import com.google.cloud.vertexai.api.GenerateContentResponse;
 import com.google.cloud.vertexai.api.GenerationConfig;
 import com.google.cloud.vertexai.api.Part;
@@ -98,6 +99,8 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
 
     private final List<ChatModelListener> listeners;
     private final Set<Capability> supportedCapabilities;
+
+    private final Map<String, String> labels;
 
     public VertexAiGeminiChatModel(VertexAiGeminiChatModelBuilder builder) {
         ensureNotBlank(builder.modelName, "modelName");
@@ -213,6 +216,7 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         this.logResponses = getOrDefault(builder.logResponses, false);
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
+        this.labels = copy(builder.labels);
     }
 
     /**
@@ -340,6 +344,7 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
 
         this.listeners = listeners == null ? emptyList() : new ArrayList<>(listeners);
         this.supportedCapabilities = copy(supportedCapabilities);
+        this.labels = Collections.emptyMap();
     }
 
     public VertexAiGeminiChatModel(GenerativeModel generativeModel, GenerationConfig generationConfig) {
@@ -365,6 +370,7 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         this.logResponses = false;
         this.listeners = Collections.emptyList();
         this.supportedCapabilities = Set.of();
+        this.labels = Collections.emptyMap();
     }
 
     @Override
@@ -476,7 +482,17 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         final GenerateContentResponse response;
         try {
             response = withRetryMappingExceptions(
-                    () -> finalModel.generateContent(instructionAndContent.contents), maxRetries);
+                    () -> {
+                        if (labels.isEmpty()) {
+                            return finalModel.generateContent(instructionAndContent.contents);
+                        }
+                        GenerateContentRequest request = buildGenerateContentRequest(
+                                finalModel, vertexAI, instructionAndContent.contents, labels);
+                        return vertexAI.getPredictionServiceClient()
+                                .generateContentCallable()
+                                .call(request);
+                    },
+                    maxRetries);
         } catch (Exception e) {
             listeners.forEach(listener -> {
                 try {
@@ -550,6 +566,59 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         return this.vertexAI;
     }
 
+    @VisibleForTesting
+    Map<String, String> labels() {
+        return this.labels;
+    }
+
+    /**
+     * Builds a {@link GenerateContentRequest} that mirrors what the SDK's
+     * {@link GenerativeModel#generateContent(List)} would build internally, plus the supplied
+     * billing/reporting labels.
+     *
+     * <p>The SDK's own request-building method is private and {@link GenerativeModel} is final, so
+     * this method replicates the request envelope and adds {@code putAllLabels(...)}. It is only
+     * called when labels are non-empty; otherwise the SDK's call path is used unchanged.
+     */
+    static GenerateContentRequest buildGenerateContentRequest(
+            GenerativeModel model, VertexAI vertexAI, List<Content> contents, Map<String, String> labels) {
+        GenerateContentRequest.Builder requestBuilder = GenerateContentRequest.newBuilder()
+                .setModel(buildResourceName(model.getModelName(), vertexAI))
+                .addAllContents(contents)
+                .setGenerationConfig(model.getGenerationConfig())
+                .addAllSafetySettings(model.getSafetySettings())
+                .addAllTools(model.getTools());
+
+        model.getToolConfig().ifPresent(requestBuilder::setToolConfig);
+        model.getSystemInstruction().ifPresent(requestBuilder::setSystemInstruction);
+
+        if (labels != null && !labels.isEmpty()) {
+            requestBuilder.putAllLabels(labels);
+        }
+
+        return requestBuilder.build();
+    }
+
+    /**
+     * Reconstructs the fully-qualified Vertex AI model resource name in the same way as the SDK's
+     * private {@code GenerativeModel.getResourceName(...)} helper, so that the request envelope
+     * built by {@link #buildGenerateContentRequest} matches what the SDK would produce.
+     */
+    static String buildResourceName(String modelName, VertexAI vertexAI) {
+        if (modelName.startsWith("projects/")) {
+            return modelName;
+        }
+        String projectId = vertexAI.getProjectId();
+        String location = vertexAI.getLocation();
+        if (modelName.startsWith("publishers/")) {
+            return String.format("projects/%s/locations/%s/%s", projectId, location, modelName);
+        }
+        if (modelName.startsWith("models/")) {
+            return String.format("projects/%s/locations/%s/publishers/google/%s", projectId, location, modelName);
+        }
+        return String.format("projects/%s/locations/%s/publishers/google/models/%s", projectId, location, modelName);
+    }
+
     @Override
     public Set<Capability> supportedCapabilities() {
         return supportedCapabilities;
@@ -597,6 +666,7 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         private Map<String, String> customHeaders;
         private GoogleCredentials credentials;
         private String apiEndpoint;
+        private Map<String, String> labels;
 
         public VertexAiGeminiChatModelBuilder() {
             // This is public so it can be extended
@@ -729,6 +799,28 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
          */
         public VertexAiGeminiChatModelBuilder customHeaders(Map<String, String> customHeaders) {
             this.customHeaders = customHeaders;
+            return this;
+        }
+
+        /**
+         * Sets billing/reporting labels that will be attached to every request the model issues.
+         *
+         * <p>Vertex AI's {@code generateContent} request body has a top-level {@code labels} map
+         * intended for billing and reporting only. The labels surface in Cloud Billing reports
+         * (Group by → Labels) and in Cloud Logging audit entries when Data Access audit logs are
+         * enabled, allowing per-tenant cost attribution and request filtering.
+         *
+         * <p>Per the
+         * <a href="https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/projects.locations.endpoints/generateContent#request-body">official
+         * spec</a>: keys must start with a letter; keys and values may use lowercase letters,
+         * digits, underscores, and dashes (international characters are allowed); each is at most
+         * 63 Unicode code points; up to 64 labels per request.
+         *
+         * @param labels a map of label keys and their corresponding values
+         * @return the updated instance of {@code VertexAiGeminiChatModelBuilder}
+         */
+        public VertexAiGeminiChatModelBuilder labels(Map<String, String> labels) {
+            this.labels = labels;
             return this;
         }
 

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -571,15 +571,8 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         return this.labels;
     }
 
-    /**
-     * Builds a {@link GenerateContentRequest} that mirrors what the SDK's
-     * {@link GenerativeModel#generateContent(List)} would build internally, plus the supplied
-     * billing/reporting labels.
-     *
-     * <p>The SDK's own request-building method is private and {@link GenerativeModel} is final, so
-     * this method replicates the request envelope and adds {@code putAllLabels(...)}. It is only
-     * called when labels are non-empty; otherwise the SDK's call path is used unchanged.
-     */
+    // mirrors the SDK's private GenerativeModel.buildGenerateContentRequest envelope and
+    // adds putAllLabels; only called when labels are non-empty
     static GenerateContentRequest buildGenerateContentRequest(
             GenerativeModel model, VertexAI vertexAI, List<Content> contents, Map<String, String> labels) {
         GenerateContentRequest.Builder requestBuilder = GenerateContentRequest.newBuilder()
@@ -599,11 +592,7 @@ public class VertexAiGeminiChatModel implements ChatModel, Closeable {
         return requestBuilder.build();
     }
 
-    /**
-     * Reconstructs the fully-qualified Vertex AI model resource name in the same way as the SDK's
-     * private {@code GenerativeModel.getResourceName(...)} helper, so that the request envelope
-     * built by {@link #buildGenerateContentRequest} matches what the SDK would produce.
-     */
+    // mirrors the SDK's private GenerativeModel.getResourceName rules
     static String buildResourceName(String modelName, VertexAI vertexAI) {
         if (modelName.startsWith("projects/")) {
             return modelName;

--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModel.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModel.java
@@ -19,6 +19,8 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.FunctionCall;
 import com.google.cloud.vertexai.api.FunctionCallingConfig;
+import com.google.cloud.vertexai.api.GenerateContentRequest;
+import com.google.cloud.vertexai.api.GenerateContentResponse;
 import com.google.cloud.vertexai.api.GenerationConfig;
 import com.google.cloud.vertexai.api.Schema;
 import com.google.cloud.vertexai.api.Tool;
@@ -87,6 +89,8 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
     private final List<ChatModelListener> listeners;
 
     private final Executor executor;
+
+    private final Map<String, String> labels;
 
     public VertexAiGeminiStreamingChatModel(VertexAiGeminiStreamingChatModelBuilder builder) {
         ensureNotBlank(builder.modelName, "modelName");
@@ -194,6 +198,7 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         this.logResponses = getOrDefault(builder.logResponses, false);
         this.listeners = copy(builder.listeners);
         this.executor = getOrDefault(builder.executor, VertexAiGeminiStreamingChatModel::createDefaultExecutor);
+        this.labels = copy(builder.labels);
     }
 
     /**
@@ -322,6 +327,7 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
 
         this.listeners = listeners == null ? emptyList() : new ArrayList<>(listeners);
         this.executor = getOrDefault(executor, VertexAiGeminiStreamingChatModel::createDefaultExecutor);
+        this.labels = Collections.emptyMap();
     }
 
     public VertexAiGeminiStreamingChatModel(GenerativeModel generativeModel, GenerationConfig generationConfig) {
@@ -341,6 +347,7 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         this.logResponses = false;
         this.listeners = Collections.emptyList();
         this.executor = VertexAiGeminiStreamingChatModel.createDefaultExecutor();
+        this.labels = Collections.emptyMap();
     }
 
     public VertexAiGeminiStreamingChatModel(
@@ -361,6 +368,7 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         this.logResponses = false;
         this.listeners = Collections.emptyList();
         this.executor = getOrDefault(executor, VertexAiGeminiStreamingChatModel::createDefaultExecutor);
+        this.labels = Collections.emptyMap();
     }
 
     private static ExecutorService createDefaultExecutor() {
@@ -450,31 +458,39 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
 
         executor.execute(() -> {
             try {
-                finalModel.generateContentStream(instructionAndContent.contents).stream()
-                        .forEach(partialResponse -> {
-                            if (streamingHandle.isCancelled()) {
-                                return;
-                            }
+                Iterable<GenerateContentResponse> responseStream;
+                if (labels.isEmpty()) {
+                    responseStream = finalModel.generateContentStream(instructionAndContent.contents);
+                } else {
+                    GenerateContentRequest request = VertexAiGeminiChatModel.buildGenerateContentRequest(
+                            finalModel, vertexAI, instructionAndContent.contents, labels);
+                    responseStream = vertexAI.getPredictionServiceClient()
+                            .streamGenerateContentCallable()
+                            .call(request);
+                }
+                responseStream.forEach(partialResponse -> {
+                    if (streamingHandle.isCancelled()) {
+                        return;
+                    }
 
-                            if (partialResponse.getCandidatesCount() > 0) {
-                                StreamingChatResponseBuilder.TextAndFunctions textAndFunctions =
-                                        responseBuilder.append(partialResponse);
+                    if (partialResponse.getCandidatesCount() > 0) {
+                        StreamingChatResponseBuilder.TextAndFunctions textAndFunctions =
+                                responseBuilder.append(partialResponse);
 
-                                String text = textAndFunctions.text();
-                                if (isNotNullOrEmpty(text)) {
-                                    onPartialResponse(handler, text, streamingHandle);
-                                }
+                        String text = textAndFunctions.text();
+                        if (isNotNullOrEmpty(text)) {
+                            onPartialResponse(handler, text, streamingHandle);
+                        }
 
-                                for (FunctionCall functionCall : textAndFunctions.functionCalls()) {
-                                    final int index = toolIndex.get();
-                                    ToolExecutionRequest toolExecutionRequest = fromFunctionCall(index, functionCall);
-                                    CompleteToolCall completeToolCall =
-                                            new CompleteToolCall(index, toolExecutionRequest);
-                                    onCompleteToolCall(handler, completeToolCall);
-                                    toolIndex.incrementAndGet();
-                                }
-                            }
-                        });
+                        for (FunctionCall functionCall : textAndFunctions.functionCalls()) {
+                            final int index = toolIndex.get();
+                            ToolExecutionRequest toolExecutionRequest = fromFunctionCall(index, functionCall);
+                            CompleteToolCall completeToolCall = new CompleteToolCall(index, toolExecutionRequest);
+                            onCompleteToolCall(handler, completeToolCall);
+                            toolIndex.incrementAndGet();
+                        }
+                    }
+                });
 
                 if (streamingHandle.isCancelled()) {
                     return;
@@ -534,6 +550,11 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         return this.vertexAI;
     }
 
+    @VisibleForTesting
+    Map<String, String> labels() {
+        return this.labels;
+    }
+
     @Override
     public void close() {
         if (this.vertexAI != null) {
@@ -585,6 +606,7 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
         private Map<String, String> customHeaders;
         private GoogleCredentials credentials;
         private String apiEndpoint;
+        private Map<String, String> labels;
 
         public VertexAiGeminiStreamingChatModelBuilder() {
             // This is public so it can be extended
@@ -711,6 +733,28 @@ public class VertexAiGeminiStreamingChatModel implements StreamingChatModel, Clo
          */
         public VertexAiGeminiStreamingChatModelBuilder credentials(GoogleCredentials credentials) {
             this.credentials = credentials;
+            return this;
+        }
+
+        /**
+         * Sets billing/reporting labels that will be attached to every request the model issues.
+         *
+         * <p>Vertex AI's {@code generateContent} request body has a top-level {@code labels} map
+         * intended for billing and reporting only. The labels surface in Cloud Billing reports
+         * (Group by → Labels) and in Cloud Logging audit entries when Data Access audit logs are
+         * enabled, allowing per-tenant cost attribution and request filtering.
+         *
+         * <p>Per the
+         * <a href="https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/projects.locations.endpoints/generateContent#request-body">official
+         * spec</a>: keys must start with a letter; keys and values may use lowercase letters,
+         * digits, underscores, and dashes (international characters are allowed); each is at most
+         * 63 Unicode code points; up to 64 labels per request.
+         *
+         * @param labels a map of label keys and their corresponding values
+         * @return the updated instance of {@code VertexAiGeminiStreamingChatModelBuilder}
+         */
+        public VertexAiGeminiStreamingChatModelBuilder labels(Map<String, String> labels) {
+            this.labels = labels;
             return this;
         }
 

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelBuilderTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiChatModelBuilderTest.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.model.vertexai.gemini;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.cloud.vertexai.VertexAI;
+import com.google.cloud.vertexai.api.Content;
+import com.google.cloud.vertexai.api.GenerateContentRequest;
+import com.google.cloud.vertexai.api.Part;
+import com.google.cloud.vertexai.generativeai.GenerativeModel;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -56,5 +62,114 @@ class VertexAiGeminiChatModelBuilderTest {
                 .build();
 
         assertThat(model.vertexAI().getApiEndpoint()).isEqualTo(customEndpoint);
+    }
+
+    @Test
+    void setLabels() {
+        VertexAiGeminiChatModel model = VertexAiGeminiChatModel.builder()
+                .project("does-not-matter")
+                .location("does-not-matter")
+                .modelName("does-not-matter")
+                .labels(Map.of("company_id", "20096", "user_id", "12345"))
+                .build();
+
+        assertThat(model.labels()).containsEntry("company_id", "20096").containsEntry("user_id", "12345");
+    }
+
+    @Test
+    void labelsDefaultToEmpty() {
+        VertexAiGeminiChatModel model = VertexAiGeminiChatModel.builder()
+                .project("does-not-matter")
+                .location("does-not-matter")
+                .modelName("does-not-matter")
+                .build();
+
+        assertThat(model.labels()).isEmpty();
+    }
+
+    @Test
+    void buildGenerateContentRequestAttachesLabels() {
+        VertexAI vertexAI = new VertexAI("test-project", "us-central1");
+        try {
+            GenerativeModel model = new GenerativeModel("gemini-2.5-flash", vertexAI);
+            List<Content> contents = List.of(Content.newBuilder()
+                    .setRole("user")
+                    .addParts(Part.newBuilder().setText("hello").build())
+                    .build());
+
+            GenerateContentRequest request = VertexAiGeminiChatModel.buildGenerateContentRequest(
+                    model, vertexAI, contents, Map.of("company_id", "20096", "user_id", "12345"));
+
+            assertThat(request.getLabelsMap())
+                    .containsEntry("company_id", "20096")
+                    .containsEntry("user_id", "12345");
+        } finally {
+            vertexAI.close();
+        }
+    }
+
+    @Test
+    void buildGenerateContentRequestNoLabelsWhenEmpty() {
+        VertexAI vertexAI = new VertexAI("test-project", "us-central1");
+        try {
+            GenerativeModel model = new GenerativeModel("gemini-2.5-flash", vertexAI);
+            List<Content> contents = List.of(Content.newBuilder()
+                    .setRole("user")
+                    .addParts(Part.newBuilder().setText("hello").build())
+                    .build());
+
+            GenerateContentRequest request =
+                    VertexAiGeminiChatModel.buildGenerateContentRequest(model, vertexAI, contents, Map.of());
+
+            assertThat(request.getLabelsMap()).isEmpty();
+        } finally {
+            vertexAI.close();
+        }
+    }
+
+    @Test
+    void buildResourceNamePassesThroughFullyQualifiedName() {
+        VertexAI vertexAI = new VertexAI("test-project", "us-central1");
+        try {
+            String alreadyQualified =
+                    "projects/other-project/locations/europe-west4/publishers/google/models/gemini-2.5-flash";
+            assertThat(VertexAiGeminiChatModel.buildResourceName(alreadyQualified, vertexAI))
+                    .isEqualTo(alreadyQualified);
+        } finally {
+            vertexAI.close();
+        }
+    }
+
+    @Test
+    void buildResourceNameQualifiesPublishersPrefix() {
+        VertexAI vertexAI = new VertexAI("test-project", "us-central1");
+        try {
+            assertThat(VertexAiGeminiChatModel.buildResourceName("publishers/google/models/gemini-2.5-flash", vertexAI))
+                    .isEqualTo("projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-flash");
+        } finally {
+            vertexAI.close();
+        }
+    }
+
+    @Test
+    void buildResourceNameQualifiesModelsPrefix() {
+        VertexAI vertexAI = new VertexAI("test-project", "us-central1");
+        try {
+            assertThat(VertexAiGeminiChatModel.buildResourceName("models/gemini-2.5-flash", vertexAI))
+                    .isEqualTo("projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-flash");
+        } finally {
+            vertexAI.close();
+        }
+    }
+
+    @Test
+    void buildResourceNameQualifiesBareModelName() {
+        VertexAI vertexAI = new VertexAI("test-project", "us-central1");
+        try {
+            assertThat(VertexAiGeminiChatModel.buildResourceName("gemini-2.5-flash", vertexAI))
+                    .isEqualTo("projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-flash");
+        } finally {
+            vertexAI.close();
+        }
     }
 }

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModelBuilderTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/VertexAiGeminiStreamingChatModelBuilderTest.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.vertexai.gemini;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -56,5 +56,28 @@ class VertexAiGeminiStreamingChatModelBuilderTest {
                 .build();
 
         assertThat(model.vertexAI().getApiEndpoint()).isEqualTo(customEndpoint);
+    }
+
+    @Test
+    void setLabels() {
+        VertexAiGeminiStreamingChatModel model = VertexAiGeminiStreamingChatModel.builder()
+                .project("does-not-matter")
+                .location("does-not-matter")
+                .modelName("does-not-matter")
+                .labels(Map.of("company_id", "20096", "user_id", "12345"))
+                .build();
+
+        assertThat(model.labels()).containsEntry("company_id", "20096").containsEntry("user_id", "12345");
+    }
+
+    @Test
+    void labelsDefaultToEmpty() {
+        VertexAiGeminiStreamingChatModel model = VertexAiGeminiStreamingChatModel.builder()
+                .project("does-not-matter")
+                .location("does-not-matter")
+                .modelName("does-not-matter")
+                .build();
+
+        assertThat(model.labels()).isEmpty();
     }
 }


### PR DESCRIPTION
## Issue
Closes #5136

## Change

Adds a `labels(Map<String, String>)` builder method on both `VertexAiGeminiChatModel` and `VertexAiGeminiStreamingChatModel`. When set, the labels are placed on every `GenerateContentRequest` issued by the model via `GenerateContentRequest.Builder.putAllLabels(...)`.

Vertex AI's `generateContent` request body has a top-level `labels` map intended for billing and reporting, per the [REST spec](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/projects.locations.endpoints/generateContent#request-body). Until now there was no path through the langchain4j Vertex AI Gemini chat model to set this field — the underlying Google `GenerativeModel` is `final` and builds the request privately.

### Implementation outline

When `labels` is empty (the default), the existing `GenerativeModel.generateContent(...)` / `generateContentStream(...)` SDK calls are used unchanged. When `labels` is non-empty, the model builds a `GenerateContentRequest` manually — mirroring the SDK's private `buildGenerateContentRequest` envelope and reading `getGenerationConfig`/`getSafetySettings`/`getTools`/`getToolConfig`/`getSystemInstruction` from the (already configured) `GenerativeModel` — and dispatches it through the SDK's public `PredictionServiceClient.generateContentCallable()` / `streamGenerateContentCallable()`. The fully-qualified resource name is reconstructed from the configured project/location/modelName, matching the SDK's private `getResourceName` rules.

This is the same wire shape that Google's official [`@google/genai` TypeScript SDK](https://github.com/googleapis/js-genai/blob/4383badd5b0057d00266d597f2e5dfbcdd69dccc/src/converters/_models_converters.ts#L1882-L1885) produces — TS lifts `config.labels` to the top of the request envelope; this PR does the equivalent in Java.

### Verified end-to-end

- 88 unit tests pass in `langchain4j-vertex-ai-gemini` (12 in `VertexAiGeminiChatModelBuilderTest`, 6 in `VertexAiGeminiStreamingChatModelBuilderTest`, including new tests covering: builder storage, default-empty behaviour, request-payload label injection, no-labels-when-empty, and the four `buildResourceName` branches).
- 1309 tests pass in `langchain4j-core` and `langchain4j` modules (no regressions).
- Real-world integration confirmed: a downstream consumer using this snapshot issued labelled `GenerateContent` and `StreamGenerateContent` requests against `aiplatform.googleapis.com`; the labels surfaced in **Cloud Billing → Reports → Group by → Labels** for the calling project.

### Backward compatibility

The new builder method is opt-in. All existing constructors and the deprecated constructor initialise `labels` to `Collections.emptyMap()`, so the new code path is never entered for callers that don't opt in.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)