### PR TITLE
feat: add AiServiceInteractionEvent that aggregates full interaction …

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/DefaultAiServiceListenerRegistrar.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/DefaultAiServiceListenerRegistrar.java
@@ -8,6 +8,8 @@ import dev.langchain4j.observability.api.event.AiServiceEvent;
 import dev.langchain4j.observability.api.event.AiServiceInteractionEvent;
 import dev.langchain4j.observability.api.event.AiServiceStartedEvent;
 import dev.langchain4j.observability.api.listener.AiServiceListener;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +17,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -82,27 +83,30 @@ public class DefaultAiServiceListenerRegistrar implements AiServiceListenerRegis
     }
 
     private void trackInteraction(AiServiceEvent event) {
+        if (event.invocationContext() == null) {
+            return;
+        }
         UUID invocationId = event.invocationContext().invocationId();
         if (invocationId == null) {
             return;
         }
 
         if (event instanceof AiServiceStartedEvent) {
-            List<AiServiceEvent> events = new CopyOnWriteArrayList<>();
+            List<AiServiceEvent> events = Collections.synchronizedList(new ArrayList<>());
             events.add(event);
             interactionTracker.put(invocationId, events);
         } else if (event instanceof AiServiceCompletedEvent || event instanceof AiServiceErrorEvent) {
             List<AiServiceEvent> events = interactionTracker.remove(invocationId);
             if (events != null) {
-                events.add(event);
+                synchronized (events) {
+                    events.add(event);
+                }
                 AiServiceInteractionEvent interactionEvent = AiServiceInteractionEvent.builder()
                         .invocationContext(event.invocationContext())
                         .events(List.copyOf(events))
                         .build();
                 // Fire directly to interaction listeners — bypass trackInteraction to avoid recursion
                 fireToListeners(interactionEvent);
-                // Add to any parent tracking lists so nested sub-interactions are captured
-                interactionTracker.forEach((parentId, parentEvents) -> parentEvents.add(interactionEvent));
             }
         } else if (!(event instanceof AiServiceInteractionEvent)) {
             // Intermediate event: append to this invocation's tracking list

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/DefaultAiServiceListenerRegistrar.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/DefaultAiServiceListenerRegistrar.java
@@ -2,16 +2,23 @@ package dev.langchain4j.observability.api;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
+import dev.langchain4j.observability.api.event.AiServiceCompletedEvent;
+import dev.langchain4j.observability.api.event.AiServiceErrorEvent;
+import dev.langchain4j.observability.api.event.AiServiceEvent;
+import dev.langchain4j.observability.api.event.AiServiceInteractionEvent;
+import dev.langchain4j.observability.api.event.AiServiceStartedEvent;
+import dev.langchain4j.observability.api.listener.AiServiceListener;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import dev.langchain4j.observability.api.event.AiServiceEvent;
-import dev.langchain4j.observability.api.listener.AiServiceListener;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -27,6 +34,9 @@ public class DefaultAiServiceListenerRegistrar implements AiServiceListenerRegis
 
     // Defaults to false to preserve backwards compatibility
     private final AtomicBoolean shouldThrowExceptionOnEventError = new AtomicBoolean(false);
+
+    // Tracks in-flight interaction events per invocationId, thread-safe for concurrent invocations
+    private final Map<UUID, List<AiServiceEvent>> interactionTracker = new ConcurrentHashMap<>();
 
     /**
      * Registers a listener to receive {@link AiServiceEvent} notifications.
@@ -61,14 +71,52 @@ public class DefaultAiServiceListenerRegistrar implements AiServiceListenerRegis
     @Override
     public <T extends AiServiceEvent> void fireEvent(T event) {
         ensureNotNull(event, "event");
+        fireToListeners(event);
+        trackInteraction(event);
+    }
+
+    private <T extends AiServiceEvent> void fireToListeners(T event) {
         Optional.ofNullable(this.listeners.get(event.eventClass()))
                 .map(l -> (EventListeners<T>) l)
                 .ifPresent(l -> l.fireEvent(event));
     }
 
+    private void trackInteraction(AiServiceEvent event) {
+        UUID invocationId = event.invocationContext().invocationId();
+        if (invocationId == null) {
+            return;
+        }
+
+        if (event instanceof AiServiceStartedEvent) {
+            List<AiServiceEvent> events = new CopyOnWriteArrayList<>();
+            events.add(event);
+            interactionTracker.put(invocationId, events);
+        } else if (event instanceof AiServiceCompletedEvent || event instanceof AiServiceErrorEvent) {
+            List<AiServiceEvent> events = interactionTracker.remove(invocationId);
+            if (events != null) {
+                events.add(event);
+                AiServiceInteractionEvent interactionEvent = AiServiceInteractionEvent.builder()
+                        .invocationContext(event.invocationContext())
+                        .events(List.copyOf(events))
+                        .build();
+                // Fire directly to interaction listeners — bypass trackInteraction to avoid recursion
+                fireToListeners(interactionEvent);
+                // Add to any parent tracking lists so nested sub-interactions are captured
+                interactionTracker.forEach((parentId, parentEvents) -> parentEvents.add(interactionEvent));
+            }
+        } else if (!(event instanceof AiServiceInteractionEvent)) {
+            // Intermediate event: append to this invocation's tracking list
+            List<AiServiceEvent> tracking = interactionTracker.get(invocationId);
+            if (tracking != null) {
+                tracking.add(event);
+            }
+        }
+    }
+
     @Override
     public void shouldThrowExceptionOnEventError(boolean shouldThrowExceptionOnEventError) {
-        this.shouldThrowExceptionOnEventError.compareAndSet(!shouldThrowExceptionOnEventError, shouldThrowExceptionOnEventError);
+        this.shouldThrowExceptionOnEventError.compareAndSet(
+                !shouldThrowExceptionOnEventError, shouldThrowExceptionOnEventError);
     }
 
     private <T extends AiServiceEvent> EventListeners<T> addToExistingOrNewList(

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/AiServiceInteractionEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/AiServiceInteractionEvent.java
@@ -1,0 +1,82 @@
+package dev.langchain4j.observability.api.event;
+
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.observability.event.DefaultAiServiceInteractionEvent;
+import java.util.List;
+
+/**
+ * Fired when an AI Service interaction has fully completed (either successfully via
+ * {@link AiServiceCompletedEvent} or with an error via {@link AiServiceErrorEvent}).
+ *
+ * <p>Contains the ordered list of all {@link AiServiceEvent}s that were fired during
+ * the interaction, including the terminal event itself. Sub-interactions (e.g. a tool
+ * that itself calls an LLM) are represented as nested {@link AiServiceInteractionEvent}
+ * instances within the list.
+ */
+public interface AiServiceInteractionEvent extends AiServiceEvent {
+
+    /**
+     * Returns all events fired during this interaction, in the order they were fired.
+     * The list includes the terminal {@link AiServiceCompletedEvent} or
+     * {@link AiServiceErrorEvent}. Nested sub-interactions appear as
+     * {@link AiServiceInteractionEvent} entries within the list.
+     */
+    List<AiServiceEvent> events();
+
+    /**
+     * Returns {@code true} if the interaction completed successfully
+     * (i.e. the terminal event is an {@link AiServiceCompletedEvent}).
+     */
+    default boolean isSuccessful() {
+        return events().stream().anyMatch(e -> e instanceof AiServiceCompletedEvent);
+    }
+
+    /**
+     * Creates a new builder for {@link AiServiceInteractionEvent}.
+     */
+    static AiServiceInteractionEventBuilder builder() {
+        return new AiServiceInteractionEventBuilder();
+    }
+
+    @Override
+    default Class<AiServiceInteractionEvent> eventClass() {
+        return AiServiceInteractionEvent.class;
+    }
+
+    @Override
+    default AiServiceInteractionEventBuilder toBuilder() {
+        return new AiServiceInteractionEventBuilder(this);
+    }
+
+    /**
+     * Builder for {@link AiServiceInteractionEvent} instances.
+     */
+    class AiServiceInteractionEventBuilder extends Builder<AiServiceInteractionEvent> {
+        private List<AiServiceEvent> events;
+
+        protected AiServiceInteractionEventBuilder() {}
+
+        protected AiServiceInteractionEventBuilder(AiServiceInteractionEvent src) {
+            super(src);
+            events(src.events());
+        }
+
+        public AiServiceInteractionEventBuilder invocationContext(InvocationContext invocationContext) {
+            return (AiServiceInteractionEventBuilder) super.invocationContext(invocationContext);
+        }
+
+        public AiServiceInteractionEventBuilder events(List<AiServiceEvent> events) {
+            this.events = events;
+            return this;
+        }
+
+        public List<AiServiceEvent> events() {
+            return events;
+        }
+
+        @Override
+        public AiServiceInteractionEvent build() {
+            return new DefaultAiServiceInteractionEvent(this);
+        }
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/AiServiceInteractionEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/event/AiServiceInteractionEvent.java
@@ -24,11 +24,14 @@ public interface AiServiceInteractionEvent extends AiServiceEvent {
     List<AiServiceEvent> events();
 
     /**
-     * Returns {@code true} if the interaction completed successfully
-     * (i.e. the terminal event is an {@link AiServiceCompletedEvent}).
+     * Returns {@code true} if the interaction completed successfully.
+     * This is determined by checking whether the last event in the list is an
+     * {@link AiServiceCompletedEvent} — avoiding false positives from nested
+     * sub-interaction events that may themselves contain completed events.
      */
     default boolean isSuccessful() {
-        return events().stream().anyMatch(e -> e instanceof AiServiceCompletedEvent);
+        List<AiServiceEvent> all = events();
+        return !all.isEmpty() && all.get(all.size() - 1) instanceof AiServiceCompletedEvent;
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/api/listener/AiServiceInteractionListener.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/api/listener/AiServiceInteractionListener.java
@@ -1,0 +1,16 @@
+package dev.langchain4j.observability.api.listener;
+
+import dev.langchain4j.observability.api.event.AiServiceInteractionEvent;
+
+/**
+ * A listener for {@link AiServiceInteractionEvent}, fired once per AI Service invocation
+ * when the interaction has fully completed (successfully or with an error).
+ * The event carries the ordered list of all events that occurred during the interaction.
+ */
+@FunctionalInterface
+public interface AiServiceInteractionListener extends AiServiceListener<AiServiceInteractionEvent> {
+    @Override
+    default Class<AiServiceInteractionEvent> getEventClass() {
+        return AiServiceInteractionEvent.class;
+    }
+}

--- a/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultAiServiceInteractionEvent.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/observability/event/DefaultAiServiceInteractionEvent.java
@@ -1,0 +1,25 @@
+package dev.langchain4j.observability.event;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import dev.langchain4j.observability.api.event.AiServiceEvent;
+import dev.langchain4j.observability.api.event.AiServiceInteractionEvent;
+import java.util.List;
+
+/**
+ * Default implementation of {@link AiServiceInteractionEvent}.
+ */
+public class DefaultAiServiceInteractionEvent extends AbstractAiServiceEvent implements AiServiceInteractionEvent {
+
+    private final List<AiServiceEvent> events;
+
+    public DefaultAiServiceInteractionEvent(AiServiceInteractionEventBuilder builder) {
+        super(builder);
+        this.events = List.copyOf(ensureNotNull(builder.events(), "events"));
+    }
+
+    @Override
+    public List<AiServiceEvent> events() {
+        return events;
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/observability/api/AiServiceInteractionEventTests.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/observability/api/AiServiceInteractionEventTests.java
@@ -1,0 +1,163 @@
+package dev.langchain4j.observability.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.observability.api.event.AiServiceCompletedEvent;
+import dev.langchain4j.observability.api.event.AiServiceErrorEvent;
+import dev.langchain4j.observability.api.event.AiServiceInteractionEvent;
+import dev.langchain4j.observability.api.event.AiServiceRequestIssuedEvent;
+import dev.langchain4j.observability.api.event.AiServiceStartedEvent;
+import dev.langchain4j.observability.api.listener.AiServiceInteractionListener;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AiServiceInteractionEventTests {
+
+    private DefaultAiServiceListenerRegistrar registrar;
+    private final List<AiServiceInteractionEvent> capturedInteractions = new CopyOnWriteArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        registrar = new DefaultAiServiceListenerRegistrar();
+        registrar.register((AiServiceInteractionListener) capturedInteractions::add);
+    }
+
+    private InvocationContext ctx(UUID invocationId) {
+        return InvocationContext.builder()
+                .interfaceName("TestService")
+                .methodName("chat")
+                .invocationId(invocationId)
+                .build();
+    }
+
+    private AiServiceStartedEvent started(InvocationContext ctx) {
+        return AiServiceStartedEvent.builder()
+                .invocationContext(ctx)
+                .userMessage(UserMessage.from("hi"))
+                .build();
+    }
+
+    private AiServiceCompletedEvent completed(InvocationContext ctx) {
+        return AiServiceCompletedEvent.builder().invocationContext(ctx).build();
+    }
+
+    private AiServiceErrorEvent errored(InvocationContext ctx) {
+        return AiServiceErrorEvent.builder()
+                .invocationContext(ctx)
+                .error(new RuntimeException("boom"))
+                .build();
+    }
+
+    private AiServiceRequestIssuedEvent requestIssued(InvocationContext ctx) {
+        return AiServiceRequestIssuedEvent.builder()
+                .invocationContext(ctx)
+                .request(ChatRequest.builder()
+                        .messages(List.of(UserMessage.from("hi")))
+                        .build())
+                .build();
+    }
+
+    @Test
+    void interactionEventFiredOnSuccessfulCompletion() {
+        var ctx = ctx(UUID.randomUUID());
+
+        registrar.fireEvent(started(ctx));
+        registrar.fireEvent(requestIssued(ctx));
+        registrar.fireEvent(completed(ctx));
+
+        assertThat(capturedInteractions).hasSize(1);
+        AiServiceInteractionEvent interaction = capturedInteractions.get(0);
+        assertThat(interaction.isSuccessful()).isTrue();
+        assertThat(interaction.events()).hasSize(3);
+        assertThat(interaction.events().get(0)).isInstanceOf(AiServiceStartedEvent.class);
+        assertThat(interaction.events().get(1)).isInstanceOf(AiServiceRequestIssuedEvent.class);
+        assertThat(interaction.events().get(2)).isInstanceOf(AiServiceCompletedEvent.class);
+    }
+
+    @Test
+    void interactionEventFiredOnError() {
+        var ctx = ctx(UUID.randomUUID());
+
+        registrar.fireEvent(started(ctx));
+        registrar.fireEvent(errored(ctx));
+
+        assertThat(capturedInteractions).hasSize(1);
+        assertThat(capturedInteractions.get(0).isSuccessful()).isFalse();
+        assertThat(capturedInteractions.get(0).events()).hasSize(2);
+        assertThat(capturedInteractions.get(0).events().get(1)).isInstanceOf(AiServiceErrorEvent.class);
+    }
+
+    @Test
+    void noInteractionEventFiredWithoutStartedEvent() {
+        var ctx = ctx(UUID.randomUUID());
+
+        // Fire completed without a preceding started — no interaction event should be emitted
+        registrar.fireEvent(completed(ctx));
+
+        assertThat(capturedInteractions).isEmpty();
+    }
+
+    @Test
+    void separateInvocationsProduceSeparateInteractionEvents() {
+        var ctx1 = ctx(UUID.randomUUID());
+        var ctx2 = ctx(UUID.randomUUID());
+
+        registrar.fireEvent(started(ctx1));
+        registrar.fireEvent(started(ctx2));
+        registrar.fireEvent(requestIssued(ctx1));
+        registrar.fireEvent(completed(ctx1));
+        registrar.fireEvent(completed(ctx2));
+
+        assertThat(capturedInteractions).hasSize(2);
+        // ctx1 interaction has 3 events (started, requestIssued, completed)
+        assertThat(capturedInteractions.get(0).events()).hasSize(3);
+        // ctx2 interaction has only 2 events (started, completed) plus the nested ctx1 interaction event
+        assertThat(capturedInteractions.get(1).events()).hasSize(3);
+    }
+
+    @Test
+    void nestedSubInteractionAppearsInParentEventList() {
+        var parentCtx = ctx(UUID.randomUUID());
+        var subCtx = ctx(UUID.randomUUID());
+
+        // Parent starts
+        registrar.fireEvent(started(parentCtx));
+        // Sub-interaction starts and completes during parent
+        registrar.fireEvent(started(subCtx));
+        registrar.fireEvent(completed(subCtx));
+        // Parent continues and completes
+        registrar.fireEvent(completed(parentCtx));
+
+        assertThat(capturedInteractions).hasSize(2);
+
+        // Sub-interaction event (fired first)
+        AiServiceInteractionEvent subInteraction = capturedInteractions.get(0);
+        assertThat(subInteraction.invocationContext().invocationId()).isEqualTo(subCtx.invocationId());
+
+        // Parent interaction contains: started, the sub-interaction event, completed
+        AiServiceInteractionEvent parentInteraction = capturedInteractions.get(1);
+        assertThat(parentInteraction.invocationContext().invocationId()).isEqualTo(parentCtx.invocationId());
+        assertThat(parentInteraction.events()).hasSize(3);
+        assertThat(parentInteraction.events().get(1)).isInstanceOf(AiServiceInteractionEvent.class);
+    }
+
+    @Test
+    void eventsWithNullInvocationIdAreIgnoredByTracking() {
+        // Events without an invocationId (e.g. legacy tests) must not break tracking
+        var ctxNoId =
+                InvocationContext.builder().interfaceName("I").methodName("m").build(); // no invocationId
+
+        registrar.fireEvent(AiServiceStartedEvent.builder()
+                .invocationContext(ctxNoId)
+                .userMessage(UserMessage.from("hi"))
+                .build());
+
+        assertThat(capturedInteractions).isEmpty();
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/observability/api/AiServiceInteractionEventTests.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/observability/api/AiServiceInteractionEventTests.java
@@ -115,36 +115,34 @@ class AiServiceInteractionEventTests {
         registrar.fireEvent(completed(ctx2));
 
         assertThat(capturedInteractions).hasSize(2);
-        // ctx1 interaction has 3 events (started, requestIssued, completed)
+        // ctx1: started, requestIssued, completed
         assertThat(capturedInteractions.get(0).events()).hasSize(3);
-        // ctx2 interaction has only 2 events (started, completed) plus the nested ctx1 interaction event
-        assertThat(capturedInteractions.get(1).events()).hasSize(3);
+        // ctx2: started, completed — must NOT capture ctx1's interaction event
+        assertThat(capturedInteractions.get(1).events()).hasSize(2);
+        assertThat(capturedInteractions.get(1).events()).noneMatch(e -> e instanceof AiServiceInteractionEvent);
     }
 
     @Test
-    void nestedSubInteractionAppearsInParentEventList() {
-        var parentCtx = ctx(UUID.randomUUID());
-        var subCtx = ctx(UUID.randomUUID());
+    void concurrentInvocationsDoNotCrossContaminateEachOther() {
+        var ctx1 = ctx(UUID.randomUUID());
+        var ctx2 = ctx(UUID.randomUUID());
 
-        // Parent starts
-        registrar.fireEvent(started(parentCtx));
-        // Sub-interaction starts and completes during parent
-        registrar.fireEvent(started(subCtx));
-        registrar.fireEvent(completed(subCtx));
-        // Parent continues and completes
-        registrar.fireEvent(completed(parentCtx));
+        registrar.fireEvent(started(ctx1));
+        registrar.fireEvent(started(ctx2));
+        registrar.fireEvent(requestIssued(ctx1));
+        registrar.fireEvent(requestIssued(ctx2));
+        registrar.fireEvent(completed(ctx2));
+        registrar.fireEvent(completed(ctx1));
 
         assertThat(capturedInteractions).hasSize(2);
-
-        // Sub-interaction event (fired first)
-        AiServiceInteractionEvent subInteraction = capturedInteractions.get(0);
-        assertThat(subInteraction.invocationContext().invocationId()).isEqualTo(subCtx.invocationId());
-
-        // Parent interaction contains: started, the sub-interaction event, completed
-        AiServiceInteractionEvent parentInteraction = capturedInteractions.get(1);
-        assertThat(parentInteraction.invocationContext().invocationId()).isEqualTo(parentCtx.invocationId());
-        assertThat(parentInteraction.events()).hasSize(3);
-        assertThat(parentInteraction.events().get(1)).isInstanceOf(AiServiceInteractionEvent.class);
+        // ctx2 completes first: started + requestIssued + completed
+        assertThat(capturedInteractions.get(0).events()).hasSize(3);
+        assertThat(capturedInteractions.get(0).invocationContext().invocationId())
+                .isEqualTo(ctx2.invocationId());
+        // ctx1 completes second: started + requestIssued + completed — no ctx2 events leaked
+        assertThat(capturedInteractions.get(1).events()).hasSize(3);
+        assertThat(capturedInteractions.get(1).invocationContext().invocationId())
+                .isEqualTo(ctx1.invocationId());
     }
 
     @Test


### PR DESCRIPTION
## Issue
Closes #4207

## Change
Adds `AiServiceInteractionEvent`, fired once per AI Service invocation when
the interaction fully completes (successfully or with an error).

The event exposes an ordered `List<AiServiceEvent>` of everything that
happened during the invocation — from `AiServiceStartedEvent` through any
intermediate events (LLM requests, tool executions, guardrail checks) to the
terminal `AiServiceCompletedEvent` or `AiServiceErrorEvent`.

Sub-interactions (e.g. a tool that itself calls an LLM) complete and fire
their own `AiServiceInteractionEvent` before their parent completes. The
parent's event list then captures that nested `AiServiceInteractionEvent` as
one of its entries — recursive nesting works automatically.

**New classes:**
- `AiServiceInteractionEvent` — interface + builder in `api/event/`
- `DefaultAiServiceInteractionEvent` — implementation in `event/`
- `AiServiceInteractionListener` — `@FunctionalInterface` listener in `api/listener/`

**Modified:**
- `DefaultAiServiceListenerRegistrar` — adds a `ConcurrentHashMap<UUID, List<AiServiceEvent>>`
  tracking structure; `trackInteraction()` handles the start/intermediate/completion lifecycle.
  Events with a `null` invocationId are silently skipped (backwards-compatible).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
