### PR TITLE
feat(service): primitives for opt-in parallel tool dispatch and framework integration

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceContext.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceContext.java
@@ -14,6 +14,7 @@ import dev.langchain4j.observability.api.AiServiceListenerRegistrar;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.service.guardrail.GuardrailService;
 import dev.langchain4j.service.memory.ChatMemoryService;
+import dev.langchain4j.service.tool.StreamingToolDispatchHook;
 import dev.langchain4j.service.tool.ToolService;
 import dev.langchain4j.spi.services.AiServiceContextFactory;
 import java.util.Optional;
@@ -54,6 +55,14 @@ public class AiServiceContext {
     public BiFunction<String, InvocationContext, String> systemMessageTransformer = null;
 
     public BiFunction<ChatRequest, Object, ChatRequest> chatRequestTransformer = (req, memId) -> req;
+
+    /**
+     * Optional integration hook for the streaming response handler's tool batch dispatch.
+     * Defaults to {@link StreamingToolDispatchHook#INLINE} when {@code null}.
+     *
+     * @since 1.15.0-beta25
+     */
+    public StreamingToolDispatchHook streamingToolDispatchHook;
 
     protected AiServiceContext(Class<?> aiServiceClass) {
         this.aiServiceClass = aiServiceClass;

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -3,7 +3,6 @@ package dev.langchain4j.service;
 import static dev.langchain4j.internal.Exceptions.runtime;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.service.AiServiceParamsUtil.chatRequestParameters;
-import static dev.langchain4j.service.tool.ToolService.refreshDynamicProviders;
 
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ReturnBehavior;
@@ -364,8 +363,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
             List<ChatMessage> messages = messagesToSend(invocationContext.chatMemoryId());
 
-            ToolServiceContext updatedToolContext =
-                    refreshDynamicProviders(toolServiceContext, messages, invocationContext);
+            ToolServiceContext updatedToolContext = context.toolService.refreshDynamicProvidersWithFactory(
+                    toolServiceContext, messages, invocationContext);
             updatedToolContext = ToolSearchService.addFoundTools(updatedToolContext, toolResults);
 
             ChatRequestParameters parameters =

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -16,8 +16,10 @@ import dev.langchain4j.guardrail.GuardrailRequestParams;
 import dev.langchain4j.guardrail.OutputGuardrailRequest;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialResponse;
@@ -34,8 +36,9 @@ import dev.langchain4j.observability.api.event.AiServiceRequestIssuedEvent;
 import dev.langchain4j.observability.api.event.AiServiceResponseReceivedEvent;
 import dev.langchain4j.observability.api.event.ToolExecutedEvent;
 import dev.langchain4j.service.tool.BeforeToolExecution;
+import dev.langchain4j.service.tool.StreamingToolDispatchHook;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
-import dev.langchain4j.service.tool.ToolCallsLimitExceededException;
+import dev.langchain4j.service.tool.ToolBatchDispatcher;
 import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutionResult;
@@ -46,13 +49,7 @@ import dev.langchain4j.service.tool.search.ToolSearchService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -95,15 +92,14 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final ToolArgumentsErrorHandler toolArgumentsErrorHandler;
     private final ToolExecutionErrorHandler toolExecutionErrorHandler;
     private final Executor toolExecutor;
-    private final Queue<Future<ToolRequestResult>> toolExecutionFutures = new ConcurrentLinkedQueue<>();
-    private final AtomicInteger streamedToolCallsCount = new AtomicInteger();
+    private final StreamingChatModel streamingChatModel;
+    private final StreamingToolDispatchHook streamingDispatchHook;
+    private final ChatRequestParameters loopParameters;
 
     private final List<String> responseBuffer = new ArrayList<>();
     private final boolean hasOutputGuardrails;
 
     private int sequentialToolsInvocationsLeft;
-
-    private record ToolRequestResult(ToolExecutionRequest request, ToolExecutionResult result) {}
 
     AiServiceStreamingResponseHandler(
             ChatRequest chatRequest,
@@ -130,6 +126,64 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             Executor toolExecutor,
             GuardrailRequestParams commonGuardrailParams,
             Object methodKey) {
+        this(
+                chatRequest,
+                chatExecutor,
+                context,
+                invocationContext,
+                partialResponseHandler,
+                partialResponseWithContextHandler,
+                partialThinkingHandler,
+                partialThinkingWithContextHandler,
+                partialToolCallHandler,
+                partialToolCallWithContextHandler,
+                beforeToolExecutionHandler,
+                toolExecutionHandler,
+                intermediateResponseHandler,
+                completeResponseHandler,
+                errorHandler,
+                temporaryMemory,
+                tokenUsage,
+                toolServiceContext,
+                sequentialToolsInvocationsLeft,
+                toolArgumentsErrorHandler,
+                toolExecutionErrorHandler,
+                toolExecutor,
+                commonGuardrailParams,
+                methodKey,
+                null,
+                null,
+                null);
+    }
+
+    AiServiceStreamingResponseHandler(
+            ChatRequest chatRequest,
+            ChatExecutor chatExecutor,
+            AiServiceContext context,
+            InvocationContext invocationContext,
+            Consumer<String> partialResponseHandler,
+            BiConsumer<PartialResponse, PartialResponseContext> partialResponseWithContextHandler,
+            Consumer<PartialThinking> partialThinkingHandler,
+            BiConsumer<PartialThinking, PartialThinkingContext> partialThinkingWithContextHandler,
+            Consumer<PartialToolCall> partialToolCallHandler,
+            BiConsumer<PartialToolCall, PartialToolCallContext> partialToolCallWithContextHandler,
+            Consumer<BeforeToolExecution> beforeToolExecutionHandler,
+            Consumer<ToolExecution> toolExecutionHandler,
+            Consumer<ChatResponse> intermediateResponseHandler,
+            Consumer<ChatResponse> completeResponseHandler,
+            Consumer<Throwable> errorHandler,
+            ChatMemory temporaryMemory,
+            TokenUsage tokenUsage,
+            ToolServiceContext toolServiceContext,
+            int sequentialToolsInvocationsLeft,
+            ToolArgumentsErrorHandler toolArgumentsErrorHandler,
+            ToolExecutionErrorHandler toolExecutionErrorHandler,
+            Executor toolExecutor,
+            GuardrailRequestParams commonGuardrailParams,
+            Object methodKey,
+            StreamingChatModel streamingChatModel,
+            StreamingToolDispatchHook streamingDispatchHook,
+            ChatRequestParameters loopParameters) {
         this.chatRequest = ensureNotNull(chatRequest, "chatRequest");
         this.chatExecutor = ensureNotNull(chatExecutor, "chatExecutor");
         this.context = ensureNotNull(context, "context");
@@ -157,6 +211,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         this.toolArgumentsErrorHandler = ensureNotNull(toolArgumentsErrorHandler, "toolArgumentsErrorHandler");
         this.toolExecutionErrorHandler = ensureNotNull(toolExecutionErrorHandler, "toolExecutionErrorHandler");
         this.toolExecutor = toolExecutor;
+        this.streamingChatModel = streamingChatModel;
+        this.streamingDispatchHook = streamingDispatchHook != null ? streamingDispatchHook : StreamingToolDispatchHook.INLINE;
+        this.loopParameters = loopParameters != null ? loopParameters : chatRequest.parameters();
 
         this.hasOutputGuardrails = context.guardrailService().hasOutputGuardrails(methodKey);
 
@@ -228,24 +285,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onCompleteToolCall(CompleteToolCall completeToolCall) {
-        if (toolExecutor != null) {
-            // If the cap is configured, do not submit any future once we have already seen more
-            // tool calls than allowed. This prevents the tool from running before
-            // onCompleteResponse gets a chance to throw ToolCallsLimitExceededException.
-            int maxToolCallsPerResponse = context.toolService.maxToolCallsPerResponse();
-            int seen = streamedToolCallsCount.incrementAndGet();
-            if (maxToolCallsPerResponse > 0 && seen > maxToolCallsPerResponse) {
-                return;
-            }
-            ToolExecutionRequest toolRequest = completeToolCall.toolExecutionRequest();
-            var future = CompletableFuture.supplyAsync(
-                    () -> {
-                        ToolExecutionResult toolResult = execute(toolRequest);
-                        return new ToolRequestResult(toolRequest, toolResult);
-                    },
-                    toolExecutor);
-            toolExecutionFutures.add(future);
-        }
+        // No-op: tool calls are buffered on the AiMessage delivered via onCompleteResponse.
+        // This makes maxToolCallsPerResponse atomic — we cannot know the full count until the
+        // streamed tool-call section finishes, so dispatch is deferred to onCompleteResponse.
     }
 
     private <T> void fireInvocationComplete(T result) {
@@ -255,11 +297,11 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 .build());
     }
 
-    private void fireToolExecutedEvent(ToolRequestResult toolRequestResult) {
+    private void fireToolExecutedEvent(ToolExecutionRequest request, ToolExecutionResult result) {
         context.eventListenerRegistrar.fireEvent(ToolExecutedEvent.builder()
                 .invocationContext(invocationContext)
-                .request(toolRequestResult.request())
-                .resultContents(toolRequestResult.result().resultContents())
+                .request(request)
+                .resultContents(result.resultContents())
                 .build());
     }
 
@@ -299,112 +341,41 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                         context.toolService.maxSequentialToolsInvocations());
             }
 
+            // Atomic cap check: if the response has too many tool calls, no tool from this batch
+            // should run. Since onCompleteToolCall is now a no-op, we know nothing has been
+            // dispatched yet.
             int maxToolCallsPerResponse = context.toolService.maxToolCallsPerResponse();
-            if (maxToolCallsPerResponse > 0
-                    && aiMessage.toolExecutionRequests().size() > maxToolCallsPerResponse) {
-                throw new ToolCallsLimitExceededException(
-                        maxToolCallsPerResponse, aiMessage.toolExecutionRequests().size());
+            List<ToolExecutionRequest> toolRequests = aiMessage.toolExecutionRequests();
+            if (maxToolCallsPerResponse > 0 && toolRequests.size() > maxToolCallsPerResponse) {
+                throw new dev.langchain4j.service.tool.ToolCallsLimitExceededException(
+                        maxToolCallsPerResponse, toolRequests.size());
             }
 
             if (intermediateResponseHandler != null) {
                 intermediateResponseHandler.accept(chatResponse);
             }
 
-            List<ToolExecutionResult> toolResults = new ArrayList<>();
-            boolean anyToolErrored = false;
-            List<ReturnBehavior> returnBehaviors = new ArrayList<>();
-
-            if (toolExecutor != null) {
-                for (Future<ToolRequestResult> toolExecutionFuture : toolExecutionFutures) {
-                    try {
-                        ToolRequestResult toolRequestResult = toolExecutionFuture.get();
-                        fireToolExecutedEvent(toolRequestResult);
-                        ToolExecutionRequest toolRequest = toolRequestResult.request();
-                        ToolExecutionResult toolResult = toolRequestResult.result();
-                        toolResults.add(toolResult);
-                        ToolExecutionResultMessage toolExecutionResultMessage =
-                                toResultMessage(toolRequest, toolResult);
-                        addToMemory(toolExecutionResultMessage);
-                        anyToolErrored = anyToolErrored || toolResult.isError();
-                        returnBehaviors.add(toolServiceContext.returnBehavior(toolRequest.name()));
-                    } catch (ExecutionException e) {
-                        if (e.getCause() instanceof RuntimeException re) {
-                            throw re;
-                        } else {
-                            throw new RuntimeException(e.getCause());
+            // Dispatch the entire tool batch through the integration hook so frameworks can
+            // wrap it (worker thread, context propagation, cancellation). The default INLINE
+            // hook just runs the supplier on the calling thread.
+            streamingDispatchHook.dispatch(() -> {
+                try {
+                    runToolBatchAndContinue(chatResponse, aiMessage, toolRequests);
+                } catch (Throwable t) {
+                    if (errorHandler != null) {
+                        try {
+                            fireErrorReceived(t);
+                            errorHandler.accept(t);
+                        } catch (Exception inner) {
+                            LOG.error("While handling the following error...", t);
+                            LOG.error("...the following error happened", inner);
                         }
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        throw new RuntimeException(e);
+                    } else {
+                        LOG.warn("Ignored error", t);
                     }
                 }
-            } else {
-                for (ToolExecutionRequest toolRequest : aiMessage.toolExecutionRequests()) {
-                    ToolExecutionResult toolResult = execute(toolRequest);
-                    toolResults.add(toolResult);
-                    ToolRequestResult toolRequestResult = new ToolRequestResult(toolRequest, toolResult);
-                    fireToolExecutedEvent(toolRequestResult);
-                    ToolExecutionResultMessage toolExecutionResultMessage = toResultMessage(toolRequest, toolResult);
-                    addToMemory(toolExecutionResultMessage);
-                    anyToolErrored = anyToolErrored || toolResult.isError();
-                    returnBehaviors.add(toolServiceContext.returnBehavior(toolRequest.name()));
-                }
-            }
-
-            if (ToolService.shouldReturnImmediately(anyToolErrored, returnBehaviors)) {
-                ChatResponse finalChatResponse = finalResponse(chatResponse, aiMessage);
-                fireInvocationComplete(finalChatResponse);
-
-                if (completeResponseHandler != null) {
-                    completeResponseHandler.accept(finalChatResponse);
-                }
-                return;
-            }
-
-            List<ChatMessage> messages = messagesToSend(invocationContext.chatMemoryId());
-
-            ToolServiceContext updatedToolContext = context.toolService.refreshDynamicProvidersWithFactory(
-                    toolServiceContext, messages, invocationContext);
-            updatedToolContext = ToolSearchService.addFoundTools(updatedToolContext, toolResults);
-
-            ChatRequestParameters parameters =
-                    chatRequestParameters(invocationContext.methodArguments(), updatedToolContext.effectiveTools());
-
-            ChatRequest nextChatRequest = context.chatRequestTransformer.apply(
-                    ChatRequest.builder()
-                            .messages(messages)
-                            .parameters(parameters)
-                            .build(),
-                    invocationContext.chatMemoryId());
-
-            var handler = new AiServiceStreamingResponseHandler(
-                    nextChatRequest,
-                    chatExecutor,
-                    context,
-                    invocationContext,
-                    partialResponseHandler,
-                    partialResponseWithContextHandler,
-                    partialThinkingHandler,
-                    partialThinkingWithContextHandler,
-                    partialToolCallHandler,
-                    partialToolCallWithContextHandler,
-                    beforeToolExecutionHandler,
-                    toolExecutionHandler,
-                    intermediateResponseHandler,
-                    completeResponseHandler,
-                    errorHandler,
-                    temporaryMemory,
-                    TokenUsage.sum(tokenUsage, chatResponse.metadata().tokenUsage()),
-                    updatedToolContext,
-                    sequentialToolsInvocationsLeft,
-                    toolArgumentsErrorHandler,
-                    toolExecutionErrorHandler,
-                    toolExecutor,
-                    commonGuardrailParams,
-                    methodKey);
-
-            fireRequestIssuedEvent(nextChatRequest);
-            context.streamingChatModel.chat(nextChatRequest, handler);
+                return null;
+            });
         } else {
             ChatResponse finalChatResponse = finalResponse(chatResponse, aiMessage);
 
@@ -442,6 +413,124 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         }
     }
 
+    private void runToolBatchAndContinue(
+            ChatResponse chatResponse, AiMessage aiMessage, List<ToolExecutionRequest> toolRequests) {
+
+        // Dispatch the batch via the shared primitive. This handles serial vs. parallel,
+        // ordered gather, sibling cancellation, error-handler bypass, and callbacks.
+        Map<ToolExecutionRequest, ToolExecutionResult> results = ToolBatchDispatcher.dispatch(
+                ToolBatchDispatcher.Request.builder()
+                        .toolRequests(toolRequests)
+                        .toolExecutors(toolExecutors)
+                        .executor(toolExecutor)
+                        .invocationContext(invocationContext)
+                        .beforeToolExecution(combine(
+                                context.toolService.beforeToolExecution(), beforeToolExecutionHandler))
+                        .afterToolExecution(combine(
+                                context.toolService.afterToolExecution(), toolExecutionHandler))
+                        .errorHandlerBypass(context.toolService.errorHandlerBypass())
+                        .argumentsErrorHandler(toolArgumentsErrorHandler)
+                        .executionErrorHandler(toolExecutionErrorHandler)
+                        .hallucinationStrategy(context.toolService.hallucinatedToolNameStrategy())
+                        .maxToolCallsPerResponse(0) // already checked above
+                        .build());
+
+        List<ToolExecutionResult> toolResults = new ArrayList<>(results.size());
+        boolean anyToolErrored = false;
+        List<ReturnBehavior> returnBehaviors = new ArrayList<>(results.size());
+
+        for (ToolExecutionRequest request : toolRequests) {
+            ToolExecutionResult result = results.get(request);
+            toolResults.add(result);
+            fireToolExecutedEvent(request, result);
+            ToolExecutionResultMessage resultMessage = toResultMessage(request, result);
+            addToMemory(resultMessage);
+            anyToolErrored = anyToolErrored || result.isError();
+            returnBehaviors.add(toolServiceContext.returnBehavior(request.name()));
+        }
+
+        if (ToolService.shouldReturnImmediately(anyToolErrored, returnBehaviors)) {
+            ChatResponse finalChatResponse = finalResponse(chatResponse, aiMessage);
+            fireInvocationComplete(finalChatResponse);
+
+            if (completeResponseHandler != null) {
+                completeResponseHandler.accept(finalChatResponse);
+            }
+            return;
+        }
+
+        List<ChatMessage> messages = messagesToSend(invocationContext.chatMemoryId());
+
+        ToolServiceContext updatedToolContext = context.toolService.refreshDynamicProvidersWithFactory(
+                toolServiceContext, messages, invocationContext);
+        updatedToolContext = ToolSearchService.addFoundTools(updatedToolContext, toolResults);
+
+        ChatRequestParameters baseParameters =
+                chatRequestParameters(invocationContext.methodArguments(), updatedToolContext.effectiveTools());
+        // Apply forceToolChoiceAutoAfterFirstIteration: in streaming, every onCompleteResponse
+        // invocation that schedules a follow-up is, by definition, after the first iteration.
+        ChatRequestParameters override;
+        if (context.toolService.forceToolChoiceAutoAfterFirstIteration()
+                && loopParameters.toolChoice() == ToolChoice.REQUIRED) {
+            override = ChatRequestParameters.builder()
+                    .toolSpecifications(updatedToolContext.effectiveTools())
+                    .toolChoice(ToolChoice.AUTO)
+                    .build();
+        } else {
+            override = ChatRequestParameters.builder()
+                    .toolSpecifications(updatedToolContext.effectiveTools())
+                    .build();
+        }
+        ChatRequestParameters nextParameters = baseParameters.overrideWith(override);
+
+        ChatRequest nextChatRequest = context.chatRequestTransformer.apply(
+                ChatRequest.builder()
+                        .messages(messages)
+                        .parameters(nextParameters)
+                        .build(),
+                invocationContext.chatMemoryId());
+
+        var handler = new AiServiceStreamingResponseHandler(
+                nextChatRequest,
+                chatExecutor,
+                context,
+                invocationContext,
+                partialResponseHandler,
+                partialResponseWithContextHandler,
+                partialThinkingHandler,
+                partialThinkingWithContextHandler,
+                partialToolCallHandler,
+                partialToolCallWithContextHandler,
+                beforeToolExecutionHandler,
+                toolExecutionHandler,
+                intermediateResponseHandler,
+                completeResponseHandler,
+                errorHandler,
+                temporaryMemory,
+                TokenUsage.sum(tokenUsage, chatResponse.metadata().tokenUsage()),
+                updatedToolContext,
+                sequentialToolsInvocationsLeft,
+                toolArgumentsErrorHandler,
+                toolExecutionErrorHandler,
+                toolExecutor,
+                commonGuardrailParams,
+                methodKey,
+                streamingChatModel,
+                streamingDispatchHook,
+                nextParameters);
+
+        fireRequestIssuedEvent(nextChatRequest);
+        StreamingChatModel modelToUse = streamingChatModel != null ? streamingChatModel : context.streamingChatModel;
+        modelToUse.chat(nextChatRequest, handler);
+    }
+
+    private static <T> Consumer<T> combine(Consumer<T> first, Consumer<T> second) {
+        if (first != null && second != null) {
+            return first.andThen(second);
+        }
+        return first != null ? first : second;
+    }
+
     private ChatResponse finalResponse(ChatResponse completeResponse, AiMessage aiMessage) {
         return ChatResponse.builder()
                 .aiMessage(aiMessage)
@@ -449,11 +538,6 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                         .tokenUsage(tokenUsage.add(completeResponse.metadata().tokenUsage()))
                         .build())
                 .build();
-    }
-
-    private ToolExecutionResult execute(ToolExecutionRequest toolRequest) {
-        return context.toolService.executeTool(
-                invocationContext, toolExecutors, toolRequest, beforeToolExecutionHandler, toolExecutionHandler);
     }
 
     private static ToolExecutionResultMessage toResultMessage(

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -112,11 +112,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     private int sequentialToolsInvocationsLeft;
 
-    private final Object toolExecutionBufferLock = new Object();
-    private final ReentrantLock toolExecutionDeliveryLock = new ReentrantLock();
+    private final ReentrantLock toolExecutionLock = new ReentrantLock();
     private final Deque<ToolExecution> bufferedToolExecutions = new ArrayDeque<>();
     private boolean intermediateResponseEmitted = false;
-    private boolean drainingToolExecutions = false;
     private boolean terminated = false;
 
     private record ToolRequestResult(ToolExecutionRequest request, ToolExecutionResult result) {}
@@ -342,73 +340,50 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     }
 
     private void emitToolExecution(ToolExecution toolExecution) {
-        synchronized (toolExecutionBufferLock) {
+        toolExecutionLock.lock();
+        try {
             if (terminated) {
                 return;
             }
-            if (!intermediateResponseEmitted || drainingToolExecutions) {
+            if (!intermediateResponseEmitted) {
                 bufferedToolExecutions.add(toolExecution);
                 return;
             }
-        }
 
-        toolExecutionDeliveryLock.lock();
-        try {
-            synchronized (toolExecutionBufferLock) {
-                if (terminated) {
-                    return;
-                }
-                if (!intermediateResponseEmitted || drainingToolExecutions) {
-                    bufferedToolExecutions.add(toolExecution);
-                    return;
-                }
-            }
             toolExecutionHandler.accept(toolExecution);
         } finally {
-            toolExecutionDeliveryLock.unlock();
+            toolExecutionLock.unlock();
         }
     }
 
     private Throwable drainBufferedToolExecutions() {
-        if (toolExecutionHandler == null) {
-            markIntermediateResponseEmitted();
-            return null;
-        }
-
-        toolExecutionDeliveryLock.lock();
+        toolExecutionLock.lock();
         try {
-            synchronized (toolExecutionBufferLock) {
-                if (terminated) {
-                    bufferedToolExecutions.clear();
-                    return null;
-                }
-                intermediateResponseEmitted = true;
-                drainingToolExecutions = true;
+            if (terminated) {
+                bufferedToolExecutions.clear();
+                return null;
             }
-
+            intermediateResponseEmitted = true;
+            if (toolExecutionHandler == null) {
+                return null;
+            }
             return drainToolExecutionQueue();
         } finally {
-            synchronized (toolExecutionBufferLock) {
-                drainingToolExecutions = false;
-            }
-            toolExecutionDeliveryLock.unlock();
+            toolExecutionLock.unlock();
         }
     }
 
     private boolean terminateAndDrainVisibleToolExecutions() {
-        toolExecutionDeliveryLock.lock();
+        toolExecutionLock.lock();
         try {
-            synchronized (toolExecutionBufferLock) {
-                if (terminated) {
-                    bufferedToolExecutions.clear();
-                    return false;
-                }
-                terminated = true;
-                if (!intermediateResponseEmitted) {
-                    bufferedToolExecutions.clear();
-                    return true;
-                }
-                drainingToolExecutions = true;
+            if (terminated) {
+                bufferedToolExecutions.clear();
+                return false;
+            }
+            terminated = true;
+            if (!intermediateResponseEmitted || toolExecutionHandler == null) {
+                bufferedToolExecutions.clear();
+                return true;
             }
 
             Throwable callbackError = drainToolExecutionQueue();
@@ -417,23 +392,16 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             }
             return true;
         } finally {
-            synchronized (toolExecutionBufferLock) {
-                drainingToolExecutions = false;
-            }
-            toolExecutionDeliveryLock.unlock();
+            toolExecutionLock.unlock();
         }
     }
 
     private Throwable drainToolExecutionQueue() {
         Throwable captured = null;
         while (true) {
-            ToolExecution next;
-            synchronized (toolExecutionBufferLock) {
-                next = bufferedToolExecutions.poll();
-                if (next == null) {
-                    drainingToolExecutions = false;
-                    return captured;
-                }
+            ToolExecution next = bufferedToolExecutions.poll();
+            if (next == null) {
+                return captured;
             }
             try {
                 toolExecutionHandler.accept(next);
@@ -447,15 +415,12 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         }
     }
 
-    private void markIntermediateResponseEmitted() {
-        synchronized (toolExecutionBufferLock) {
-            intermediateResponseEmitted = true;
-        }
-    }
-
     private boolean isTerminated() {
-        synchronized (toolExecutionBufferLock) {
+        toolExecutionLock.lock();
+        try {
             return terminated;
+        } finally {
+            toolExecutionLock.unlock();
         }
     }
 
@@ -606,8 +571,6 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         if (shouldScheduleToolsEagerly()) {
             results = gatherScheduledToolResults();
         } else {
-            boolean useExecutorForSingleTool =
-                    maxToolCallsPerResponse > 0 || (toolExecutor != null && beforeToolExecutionHandler != null);
             results = ToolBatchDispatcher.dispatch(
                     ToolBatchDispatcher.Request.builder()
                             .toolRequests(toolRequests)
@@ -623,7 +586,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                             .executionErrorHandler(toolExecutionErrorHandler)
                             .hallucinationStrategy(context.toolService.hallucinatedToolNameStrategy())
                             .maxToolCallsPerResponse(0)
-                            .useExecutorForSingleTool(useExecutorForSingleTool)
+                            .useExecutorForSingleTool(shouldUseExecutorForDeferredSingleTool(
+                                    maxToolCallsPerResponse))
                             .build());
         }
 
@@ -717,6 +681,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         fireRequestIssuedEvent(nextChatRequest);
         StreamingChatModel modelToUse = streamingChatModel != null ? streamingChatModel : context.streamingChatModel;
         modelToUse.chat(nextChatRequest, handler);
+    }
+
+    private boolean shouldUseExecutorForDeferredSingleTool(int maxToolCallsPerResponse) {
+        return maxToolCallsPerResponse > 0 || (toolExecutor != null && beforeToolExecutionHandler != null);
     }
 
     private Map<ToolExecutionRequest, ToolExecutionResult> gatherScheduledToolResults() {

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -234,7 +234,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         this.toolExecutionErrorHandler = ensureNotNull(toolExecutionErrorHandler, "toolExecutionErrorHandler");
         this.toolExecutor = toolExecutor;
         this.streamingChatModel = streamingChatModel;
-        this.streamingDispatchHook = streamingDispatchHook != null ? streamingDispatchHook : StreamingToolDispatchHook.INLINE;
+        this.streamingDispatchHook =
+                streamingDispatchHook != null ? streamingDispatchHook : StreamingToolDispatchHook.INLINE;
         this.loopParameters = loopParameters != null ? loopParameters : chatRequest.parameters();
         this.loopState = ensureNotNull(loopState, "loopState");
 
@@ -361,7 +362,11 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     private ToolExecutionResult execute(ToolExecutionRequest toolRequest) {
         return context.toolService.executeTool(
-                invocationContext, toolExecutors, toolRequest, beforeToolExecutionHandler, streamToolExecutionHandler());
+                invocationContext,
+                toolExecutors,
+                toolRequest,
+                beforeToolExecutionHandler,
+                streamToolExecutionHandler());
     }
 
     private Consumer<ToolExecution> streamToolExecutionHandler() {
@@ -671,24 +676,22 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             if (shouldScheduleToolsEagerly()) {
                 results = gatherScheduledToolResults();
             } else {
-                results = ToolBatchDispatcher.dispatch(
-                        ToolBatchDispatcher.Request.builder()
-                                .toolRequests(toolRequests)
-                                .toolExecutors(toolExecutors)
-                                .executor(toolExecutor)
-                                .invocationContext(invocationContext)
-                                .beforeToolExecution(combine(
-                                        context.toolService.beforeToolExecution(), beforeToolExecutionHandler))
-                                .afterToolExecution(combine(
-                                        context.toolService.afterToolExecution(), streamToolExecutionHandler()))
-                                .errorHandlerBypass(context.toolService.errorHandlerBypass())
-                                .argumentsErrorHandler(toolArgumentsErrorHandler)
-                                .executionErrorHandler(toolExecutionErrorHandler)
-                                .hallucinationStrategy(context.toolService.hallucinatedToolNameStrategy())
-                                .maxToolCallsPerResponse(0)
-                                .useExecutorForSingleTool(shouldUseExecutorForDeferredSingleTool(
-                                        maxToolCallsPerResponse))
-                                .build());
+                results = ToolBatchDispatcher.dispatch(ToolBatchDispatcher.Request.builder()
+                        .toolRequests(toolRequests)
+                        .toolExecutors(toolExecutors)
+                        .executor(toolExecutor)
+                        .invocationContext(invocationContext)
+                        .beforeToolExecution(
+                                combine(context.toolService.beforeToolExecution(), beforeToolExecutionHandler))
+                        .afterToolExecution(
+                                combine(context.toolService.afterToolExecution(), streamToolExecutionHandler()))
+                        .errorHandlerBypass(context.toolService.errorHandlerBypass())
+                        .argumentsErrorHandler(toolArgumentsErrorHandler)
+                        .executionErrorHandler(toolExecutionErrorHandler)
+                        .hallucinationStrategy(context.toolService.hallucinatedToolNameStrategy())
+                        .maxToolCallsPerResponse(0)
+                        .useExecutorForSingleTool(shouldUseExecutorForDeferredSingleTool(maxToolCallsPerResponse))
+                        .build());
             }
         } catch (Throwable t) {
             loopState.fail(t);
@@ -751,8 +754,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         }
         List<ChatMessage> messages = messagesToSend(invocationContext.chatMemoryId());
 
-        ToolServiceContext updatedToolContext = context.toolService.refreshDynamicProvidersWithFactory(
-                toolServiceContext, messages, invocationContext);
+        ToolServiceContext updatedToolContext =
+                context.toolService.refreshDynamicProvidersWithFactory(toolServiceContext, messages, invocationContext);
         updatedToolContext = ToolSearchService.addFoundTools(updatedToolContext, toolResults);
 
         if (!loopState.canContinue()) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -360,16 +360,22 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     }
 
     private ToolExecutionResult execute(ToolExecutionRequest toolRequest) {
-        Consumer<ToolExecution> externalAfter =
-                toolExecutionHandler == null ? null : this::emitToolExecution;
         return context.toolService.executeTool(
-                invocationContext, toolExecutors, toolRequest, beforeToolExecutionHandler, externalAfter);
+                invocationContext, toolExecutors, toolRequest, beforeToolExecutionHandler, streamToolExecutionHandler());
+    }
+
+    private Consumer<ToolExecution> streamToolExecutionHandler() {
+        return toolExecutionHandler == null ? null : this::emitToolExecution;
     }
 
     private void emitToolExecution(ToolExecution toolExecution) {
         toolExecutionLock.lock();
         try {
-            if (terminated) {
+            if (terminated || loopState.isSilentlyCancelled()) {
+                if (loopState.isSilentlyCancelled()) {
+                    terminated = true;
+                }
+                bufferedToolExecutions.clear();
                 return;
             }
             if (!intermediateResponseEmitted) {
@@ -395,6 +401,21 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 return null;
             }
             return drainToolExecutionQueue();
+        } finally {
+            toolExecutionLock.unlock();
+        }
+    }
+
+    private boolean terminateAndClearVisibleToolExecutions() {
+        toolExecutionLock.lock();
+        try {
+            if (terminated) {
+                bufferedToolExecutions.clear();
+                return false;
+            }
+            terminated = true;
+            bufferedToolExecutions.clear();
+            return true;
         } finally {
             toolExecutionLock.unlock();
         }
@@ -426,6 +447,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private Throwable drainToolExecutionQueue() {
         Throwable captured = null;
         while (true) {
+            if (loopState.isSilentlyCancelled()) {
+                bufferedToolExecutions.clear();
+                return captured;
+            }
             ToolExecution next = bufferedToolExecutions.poll();
             if (next == null) {
                 return captured;
@@ -489,7 +514,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     }
 
     private void handleStreamingError(Throwable error) {
-        loopState.fail(error);
+        if (!loopState.fail(error) && !loopState.isFailed()) {
+            finishIfSilentlyCancelled();
+            return;
+        }
         terminateAndDrainVisibleToolExecutions();
         reportFailure(error);
     }
@@ -652,7 +680,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                                 .beforeToolExecution(combine(
                                         context.toolService.beforeToolExecution(), beforeToolExecutionHandler))
                                 .afterToolExecution(combine(
-                                        context.toolService.afterToolExecution(), toolExecutionHandler))
+                                        context.toolService.afterToolExecution(), streamToolExecutionHandler()))
                                 .errorHandlerBypass(context.toolService.errorHandlerBypass())
                                 .argumentsErrorHandler(toolArgumentsErrorHandler)
                                 .executionErrorHandler(toolExecutionErrorHandler)
@@ -844,7 +872,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     private void finishIfSilentlyCancelled() {
         if (loopState.isSilentlyCancelled()) {
-            terminateAndDrainVisibleToolExecutions();
+            terminateAndClearVisibleToolExecutions();
         }
     }
 
@@ -902,7 +930,12 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     }
 
     private static ToolExecutionResultMessage failedToolResultMessage(ToolExecutionRequest request) {
-        return ToolExecutionResultMessage.from(request, FAILED_TOOL_RESULT_TEXT);
+        return ToolExecutionResultMessage.builder()
+                .id(request.id())
+                .toolName(request.name())
+                .text(FAILED_TOOL_RESULT_TEXT)
+                .isError(true)
+                .build();
     }
 
     private ChatMemory getMemory() {
@@ -928,8 +961,6 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onError(Throwable error) {
-        loopState.fail(error);
-        terminateAndDrainVisibleToolExecutions();
-        reportFailure(error);
+        handleStreamingError(error);
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -63,7 +63,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,7 +106,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final StreamingChatModel streamingChatModel;
     private final StreamingToolDispatchHook streamingDispatchHook;
     private final ChatRequestParameters loopParameters;
-    private final Supplier<Boolean> cancellationSupplier;
+    private final StreamingLoopState loopState;
 
     private final List<String> responseBuffer = new ArrayList<>();
     private final Queue<Future<ToolRequestResult>> toolExecutionFutures = new ConcurrentLinkedQueue<>();
@@ -175,7 +174,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 null,
                 null,
                 null,
-                null);
+                new StreamingLoopState(null));
     }
 
     AiServiceStreamingResponseHandler(
@@ -206,7 +205,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             StreamingChatModel streamingChatModel,
             StreamingToolDispatchHook streamingDispatchHook,
             ChatRequestParameters loopParameters,
-            Supplier<Boolean> cancellationSupplier) {
+            StreamingLoopState loopState) {
         this.chatRequest = ensureNotNull(chatRequest, "chatRequest");
         this.chatExecutor = ensureNotNull(chatExecutor, "chatExecutor");
         this.context = ensureNotNull(context, "context");
@@ -237,7 +236,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         this.streamingChatModel = streamingChatModel;
         this.streamingDispatchHook = streamingDispatchHook != null ? streamingDispatchHook : StreamingToolDispatchHook.INLINE;
         this.loopParameters = loopParameters != null ? loopParameters : chatRequest.parameters();
-        this.cancellationSupplier = cancellationSupplier;
+        this.loopState = ensureNotNull(loopState, "loopState");
 
         this.hasOutputGuardrails = context.guardrailService().hasOutputGuardrails(methodKey);
 
@@ -246,6 +245,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onPartialResponse(String partialResponse) {
+        if (!loopState.canContinue()) {
+            return;
+        }
         // If we're using output guardrails, then buffer the partial response until the guardrails have completed
         if (hasOutputGuardrails) {
             responseBuffer.add(partialResponse);
@@ -259,6 +261,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onPartialResponse(PartialResponse partialResponse, PartialResponseContext context) {
+        if (!loopState.canContinue()) {
+            return;
+        }
         // If we're using output guardrails, then buffer the partial response until the guardrails have completed
         if (hasOutputGuardrails) {
             responseBuffer.add(partialResponse.text());
@@ -271,6 +276,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onPartialThinking(PartialThinking partialThinking) {
+        if (!loopState.canContinue()) {
+            return;
+        }
         if (partialThinkingHandler != null) {
             partialThinkingHandler.accept(partialThinking);
         } else if (partialThinkingWithContextHandler != null) {
@@ -281,6 +289,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onPartialThinking(PartialThinking partialThinking, PartialThinkingContext context) {
+        if (!loopState.canContinue()) {
+            return;
+        }
         if (partialThinkingHandler != null) {
             partialThinkingHandler.accept(partialThinking);
         } else if (partialThinkingWithContextHandler != null) {
@@ -290,6 +301,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onPartialToolCall(PartialToolCall partialToolCall) {
+        if (!loopState.canContinue()) {
+            return;
+        }
         if (partialToolCallHandler != null) {
             partialToolCallHandler.accept(partialToolCall);
         } else if (partialToolCallWithContextHandler != null) {
@@ -300,6 +314,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onPartialToolCall(PartialToolCall partialToolCall, PartialToolCallContext context) {
+        if (!loopState.canContinue()) {
+            return;
+        }
         if (partialToolCallHandler != null) {
             partialToolCallHandler.accept(partialToolCall);
         } else if (partialToolCallWithContextHandler != null) {
@@ -309,13 +326,17 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onCompleteToolCall(CompleteToolCall completeToolCall) {
+        if (!loopState.canContinue()) {
+            return;
+        }
         if (shouldScheduleToolsEagerly()) {
             ToolExecutionRequest toolRequest = completeToolCall.toolExecutionRequest();
             CompletableFuture<ToolRequestResult> future = new CompletableFuture<>();
             toolExecutionFutures.add(future);
+            loopState.registerToolCall(future);
             try {
                 toolExecutor.execute(() -> {
-                    if (future.isCancelled()) {
+                    if (!loopState.canContinue() || future.isCancelled()) {
                         return;
                     }
                     try {
@@ -468,8 +489,13 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     }
 
     private void handleStreamingError(Throwable error) {
-        cancelPendingToolCalls(null);
-        if (!terminateAndDrainVisibleToolExecutions()) {
+        loopState.fail(error);
+        terminateAndDrainVisibleToolExecutions();
+        reportFailure(error);
+    }
+
+    private void reportFailure(Throwable error) {
+        if (!loopState.markFailureReported()) {
             return;
         }
         if (errorHandler != null) {
@@ -487,8 +513,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onCompleteResponse(ChatResponse chatResponse) {
-        if (isCancelled()) {
-            bailOutCancelled();
+        if (!loopState.canContinue()) {
+            finishIfSilentlyCancelled();
             return;
         }
         fireResponseReceivedEvent(chatResponse);
@@ -510,10 +536,18 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 return;
             }
 
+            if (!loopState.canContinue()) {
+                finishIfSilentlyCancelled();
+                return;
+            }
             if (intermediateResponseHandler != null) {
                 intermediateResponseHandler.accept(chatResponse);
             }
 
+            if (!loopState.canContinue()) {
+                finishIfSilentlyCancelled();
+                return;
+            }
             Throwable callbackError = drainBufferedToolExecutions();
             if (callbackError != null) {
                 handleStreamingError(callbackError);
@@ -522,11 +556,15 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             if (isTerminated()) {
                 return;
             }
+            if (!loopState.canContinue()) {
+                finishIfSilentlyCancelled();
+                return;
+            }
 
             streamingDispatchHook.dispatch(() -> {
                 // Re-check after potential thread hop — avoids orphaned AiMessage(tool_calls) in memory.
-                if (isCancelled()) {
-                    bailOutCancelled();
+                if (!loopState.canContinue()) {
+                    finishIfSilentlyCancelled();
                     return null;
                 }
                 addToMemory(aiMessage);
@@ -538,7 +576,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 return null;
             });
         } else {
-            if (isTerminated()) {
+            if (isTerminated() || !loopState.canContinue()) {
+                finishIfSilentlyCancelled();
                 return;
             }
             addToMemory(aiMessage);
@@ -571,9 +610,19 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     responseBuffer.clear();
                 }
 
+                if (!loopState.canContinue()) {
+                    finishIfSilentlyCancelled();
+                    return;
+                }
+                loopState.complete();
                 fireInvocationComplete(finalChatResponse);
                 completeResponseHandler.accept(finalChatResponse);
             } else {
+                if (!loopState.canContinue()) {
+                    finishIfSilentlyCancelled();
+                    return;
+                }
+                loopState.complete();
                 fireInvocationComplete(finalChatResponse);
             }
         }
@@ -582,29 +631,47 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private void runToolBatchAndContinue(
             ChatResponse chatResponse, AiMessage aiMessage, List<ToolExecutionRequest> toolRequests) {
 
+        if (!loopState.canContinue()) {
+            writeTerminalToolResults(toolRequests, terminalToolResults());
+            finishIfSilentlyCancelled();
+            return;
+        }
+
         Map<ToolExecutionRequest, ToolExecutionResult> results;
         int maxToolCallsPerResponse = context.toolService.maxToolCallsPerResponse();
-        if (shouldScheduleToolsEagerly()) {
-            results = gatherScheduledToolResults();
-        } else {
-            results = ToolBatchDispatcher.dispatch(
-                    ToolBatchDispatcher.Request.builder()
-                            .toolRequests(toolRequests)
-                            .toolExecutors(toolExecutors)
-                            .executor(toolExecutor)
-                            .invocationContext(invocationContext)
-                            .beforeToolExecution(combine(
-                                    context.toolService.beforeToolExecution(), beforeToolExecutionHandler))
-                            .afterToolExecution(combine(
-                                    context.toolService.afterToolExecution(), toolExecutionHandler))
-                            .errorHandlerBypass(context.toolService.errorHandlerBypass())
-                            .argumentsErrorHandler(toolArgumentsErrorHandler)
-                            .executionErrorHandler(toolExecutionErrorHandler)
-                            .hallucinationStrategy(context.toolService.hallucinatedToolNameStrategy())
-                            .maxToolCallsPerResponse(0)
-                            .useExecutorForSingleTool(shouldUseExecutorForDeferredSingleTool(
-                                    maxToolCallsPerResponse))
-                            .build());
+        try {
+            if (shouldScheduleToolsEagerly()) {
+                results = gatherScheduledToolResults();
+            } else {
+                results = ToolBatchDispatcher.dispatch(
+                        ToolBatchDispatcher.Request.builder()
+                                .toolRequests(toolRequests)
+                                .toolExecutors(toolExecutors)
+                                .executor(toolExecutor)
+                                .invocationContext(invocationContext)
+                                .beforeToolExecution(combine(
+                                        context.toolService.beforeToolExecution(), beforeToolExecutionHandler))
+                                .afterToolExecution(combine(
+                                        context.toolService.afterToolExecution(), toolExecutionHandler))
+                                .errorHandlerBypass(context.toolService.errorHandlerBypass())
+                                .argumentsErrorHandler(toolArgumentsErrorHandler)
+                                .executionErrorHandler(toolExecutionErrorHandler)
+                                .hallucinationStrategy(context.toolService.hallucinatedToolNameStrategy())
+                                .maxToolCallsPerResponse(0)
+                                .useExecutorForSingleTool(shouldUseExecutorForDeferredSingleTool(
+                                        maxToolCallsPerResponse))
+                                .build());
+            }
+        } catch (Throwable t) {
+            loopState.fail(t);
+            writeTerminalToolResults(toolRequests, Map.of());
+            throw t;
+        }
+
+        if (loopState.isTerminal()) {
+            writeTerminalToolResults(toolRequests, results);
+            finishIfSilentlyCancelled();
+            return;
         }
 
         List<ToolExecutionResult> toolResults = new ArrayList<>(results.size());
@@ -613,9 +680,14 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
         for (ToolExecutionRequest request : toolRequests) {
             ToolExecutionResult result = results.get(request);
-            if (isCancelled() || result == null) {
+            if (result == null) {
                 // Placeholder keeps the tool_use/tool_result memory invariant (Anthropic rejects otherwise).
-                addToMemory(cancelledToolResultMessage(request));
+                addToMemory(terminalToolResultMessage(request));
+                returnBehaviors.add(toolServiceContext.returnBehavior(request.name()));
+                continue;
+            }
+            if (!loopState.canContinue()) {
+                addToMemory(terminalToolResultMessage(request));
                 returnBehaviors.add(toolServiceContext.returnBehavior(request.name()));
                 continue;
             }
@@ -629,13 +701,14 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
         // Bail before ReturnBehavior — IMMEDIATE would otherwise fire completeResponseHandler
         // (breaks silent-cancellation), and also skips refreshDynamicProviders / transformer hooks.
-        if (isCancelled()) {
-            bailOutCancelled();
+        if (!loopState.canContinue()) {
+            finishIfSilentlyCancelled();
             return;
         }
 
         if (ToolService.shouldReturnImmediately(anyToolErrored, returnBehaviors)) {
             ChatResponse finalChatResponse = finalResponse(chatResponse, aiMessage);
+            loopState.complete();
             fireInvocationComplete(finalChatResponse);
 
             if (completeResponseHandler != null) {
@@ -644,11 +717,20 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             return;
         }
 
+        if (!loopState.canContinue()) {
+            finishIfSilentlyCancelled();
+            return;
+        }
         List<ChatMessage> messages = messagesToSend(invocationContext.chatMemoryId());
 
         ToolServiceContext updatedToolContext = context.toolService.refreshDynamicProvidersWithFactory(
                 toolServiceContext, messages, invocationContext);
         updatedToolContext = ToolSearchService.addFoundTools(updatedToolContext, toolResults);
+
+        if (!loopState.canContinue()) {
+            finishIfSilentlyCancelled();
+            return;
+        }
 
         ChatRequestParameters baseParameters =
                 chatRequestParameters(invocationContext.methodArguments(), updatedToolContext.effectiveTools());
@@ -703,10 +785,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 streamingChatModel,
                 streamingDispatchHook,
                 nextParameters,
-                cancellationSupplier);
+                loopState);
 
-        if (isCancelled()) {
-            bailOutCancelled();
+        if (!loopState.canContinue()) {
+            finishIfSilentlyCancelled();
             return;
         }
 
@@ -727,10 +809,15 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 ToolRequestResult toolRequestResult = future.get();
                 results.put(toolRequestResult.request(), toolRequestResult.result());
             } catch (CancellationException e) {
-                // Skip — persistence loop writes a placeholder for any missing entry.
+                if (loopState.isSilentlyCancelled() || loopState.isFailed()) {
+                    // Skip — persistence loop writes a terminal-state placeholder for any missing entry.
+                    continue;
+                }
+                loopState.fail(e);
+                throw e;
             } catch (ExecutionException e) {
-                cancelPendingToolCalls(future);
                 Throwable cause = e.getCause();
+                loopState.fail(cause);
                 if (cause instanceof RuntimeException re) {
                     throw re;
                 } else if (cause instanceof Error err) {
@@ -739,8 +826,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     throw new RuntimeException(cause);
                 }
             } catch (InterruptedException e) {
-                cancelPendingToolCalls(future);
                 Thread.currentThread().interrupt();
+                loopState.fail(e);
                 throw new RuntimeException(e);
             }
         }
@@ -748,30 +835,29 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         return results;
     }
 
-    private void cancelPendingToolCalls(Future<ToolRequestResult> except) {
-        for (Future<ToolRequestResult> future : toolExecutionFutures) {
-            if (future != except && !future.isDone()) {
-                future.cancel(true);
+    private Map<ToolExecutionRequest, ToolExecutionResult> terminalToolResults() {
+        if (shouldScheduleToolsEagerly()) {
+            return gatherScheduledToolResults();
+        }
+        return Map.of();
+    }
+
+    private void finishIfSilentlyCancelled() {
+        if (loopState.isSilentlyCancelled()) {
+            terminateAndDrainVisibleToolExecutions();
+        }
+    }
+
+    private void writeTerminalToolResults(
+            List<ToolExecutionRequest> toolRequests, Map<ToolExecutionRequest, ToolExecutionResult> results) {
+        for (ToolExecutionRequest request : toolRequests) {
+            ToolExecutionResult result = results.get(request);
+            if (result == null) {
+                addToMemory(terminalToolResultMessage(request));
+            } else {
+                addToMemory(toResultMessage(request, result));
             }
         }
-    }
-
-    /** A throwing supplier is treated as "not cancelled" to keep buggy integrators from breaking the loop. */
-    private boolean isCancelled() {
-        if (cancellationSupplier == null) {
-            return false;
-        }
-        try {
-            return Boolean.TRUE.equals(cancellationSupplier.get());
-        } catch (Throwable t) {
-            LOG.warn("Cancellation supplier threw; treating as not cancelled", t);
-            return false;
-        }
-    }
-
-    private void bailOutCancelled() {
-        cancelPendingToolCalls(null);
-        terminateAndDrainVisibleToolExecutions();
     }
 
     private static <T> Consumer<T> combine(Consumer<T> first, Consumer<T> second) {
@@ -802,9 +888,21 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     }
 
     static final String CANCELLED_TOOL_RESULT_TEXT = "Tool execution was cancelled";
+    static final String FAILED_TOOL_RESULT_TEXT = "Tool execution failed before completion";
+
+    private ToolExecutionResultMessage terminalToolResultMessage(ToolExecutionRequest request) {
+        if (loopState.isFailed()) {
+            return failedToolResultMessage(request);
+        }
+        return cancelledToolResultMessage(request);
+    }
 
     private static ToolExecutionResultMessage cancelledToolResultMessage(ToolExecutionRequest request) {
         return ToolExecutionResultMessage.from(request, CANCELLED_TOOL_RESULT_TEXT);
+    }
+
+    private static ToolExecutionResultMessage failedToolResultMessage(ToolExecutionRequest request) {
+        return ToolExecutionResultMessage.from(request, FAILED_TOOL_RESULT_TEXT);
     }
 
     private ChatMemory getMemory() {
@@ -830,20 +928,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onError(Throwable error) {
-        cancelPendingToolCalls(null);
-        if (!terminateAndDrainVisibleToolExecutions()) {
-            return;
-        }
-        if (errorHandler != null) {
-            try {
-                fireErrorReceived(error);
-                errorHandler.accept(error);
-            } catch (Exception e) {
-                LOG.error("While handling the following error...", error);
-                LOG.error("...the following error happened", e);
-            }
-        } else {
-            LOG.warn("Ignored error", error);
-        }
+        loopState.fail(error);
+        terminateAndDrainVisibleToolExecutions();
+        reportFailure(error);
     }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -54,6 +54,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
@@ -62,6 +63,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,6 +107,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final StreamingChatModel streamingChatModel;
     private final StreamingToolDispatchHook streamingDispatchHook;
     private final ChatRequestParameters loopParameters;
+    private final Supplier<Boolean> cancellationSupplier;
 
     private final List<String> responseBuffer = new ArrayList<>();
     private final Queue<Future<ToolRequestResult>> toolExecutionFutures = new ConcurrentLinkedQueue<>();
@@ -171,6 +174,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 methodKey,
                 null,
                 null,
+                null,
                 null);
     }
 
@@ -201,7 +205,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             Object methodKey,
             StreamingChatModel streamingChatModel,
             StreamingToolDispatchHook streamingDispatchHook,
-            ChatRequestParameters loopParameters) {
+            ChatRequestParameters loopParameters,
+            Supplier<Boolean> cancellationSupplier) {
         this.chatRequest = ensureNotNull(chatRequest, "chatRequest");
         this.chatExecutor = ensureNotNull(chatExecutor, "chatExecutor");
         this.context = ensureNotNull(context, "context");
@@ -232,6 +237,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         this.streamingChatModel = streamingChatModel;
         this.streamingDispatchHook = streamingDispatchHook != null ? streamingDispatchHook : StreamingToolDispatchHook.INLINE;
         this.loopParameters = loopParameters != null ? loopParameters : chatRequest.parameters();
+        this.cancellationSupplier = cancellationSupplier;
 
         this.hasOutputGuardrails = context.guardrailService().hasOutputGuardrails(methodKey);
 
@@ -481,9 +487,12 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onCompleteResponse(ChatResponse chatResponse) {
+        if (isCancelled()) {
+            bailOutCancelled();
+            return;
+        }
         fireResponseReceivedEvent(chatResponse);
         AiMessage aiMessage = chatResponse.aiMessage();
-        addToMemory(aiMessage);
 
         if (aiMessage.hasToolExecutionRequests()) {
 
@@ -515,6 +524,12 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             }
 
             streamingDispatchHook.dispatch(() -> {
+                // Re-check after potential thread hop — avoids orphaned AiMessage(tool_calls) in memory.
+                if (isCancelled()) {
+                    bailOutCancelled();
+                    return null;
+                }
+                addToMemory(aiMessage);
                 try {
                     runToolBatchAndContinue(chatResponse, aiMessage, toolRequests);
                 } catch (Throwable t) {
@@ -526,6 +541,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             if (isTerminated()) {
                 return;
             }
+            addToMemory(aiMessage);
 
             ChatResponse finalChatResponse = finalResponse(chatResponse, aiMessage);
 
@@ -597,8 +613,11 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
         for (ToolExecutionRequest request : toolRequests) {
             ToolExecutionResult result = results.get(request);
-            if (result == null) {
-                throw runtime("No tool execution result was scheduled for tool request '%s'", request.name());
+            if (isCancelled() || result == null) {
+                // Placeholder keeps the tool_use/tool_result memory invariant (Anthropic rejects otherwise).
+                addToMemory(cancelledToolResultMessage(request));
+                returnBehaviors.add(toolServiceContext.returnBehavior(request.name()));
+                continue;
             }
             toolResults.add(result);
             fireToolExecutedEvent(request, result);
@@ -606,6 +625,13 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             addToMemory(resultMessage);
             anyToolErrored = anyToolErrored || result.isError();
             returnBehaviors.add(toolServiceContext.returnBehavior(request.name()));
+        }
+
+        // Bail before ReturnBehavior — IMMEDIATE would otherwise fire completeResponseHandler
+        // (breaks silent-cancellation), and also skips refreshDynamicProviders / transformer hooks.
+        if (isCancelled()) {
+            bailOutCancelled();
+            return;
         }
 
         if (ToolService.shouldReturnImmediately(anyToolErrored, returnBehaviors)) {
@@ -676,7 +702,13 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 methodKey,
                 streamingChatModel,
                 streamingDispatchHook,
-                nextParameters);
+                nextParameters,
+                cancellationSupplier);
+
+        if (isCancelled()) {
+            bailOutCancelled();
+            return;
+        }
 
         fireRequestIssuedEvent(nextChatRequest);
         StreamingChatModel modelToUse = streamingChatModel != null ? streamingChatModel : context.streamingChatModel;
@@ -694,6 +726,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             try {
                 ToolRequestResult toolRequestResult = future.get();
                 results.put(toolRequestResult.request(), toolRequestResult.result());
+            } catch (CancellationException e) {
+                // Skip — persistence loop writes a placeholder for any missing entry.
             } catch (ExecutionException e) {
                 cancelPendingToolCalls(future);
                 Throwable cause = e.getCause();
@@ -722,6 +756,24 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         }
     }
 
+    /** A throwing supplier is treated as "not cancelled" to keep buggy integrators from breaking the loop. */
+    private boolean isCancelled() {
+        if (cancellationSupplier == null) {
+            return false;
+        }
+        try {
+            return Boolean.TRUE.equals(cancellationSupplier.get());
+        } catch (Throwable t) {
+            LOG.warn("Cancellation supplier threw; treating as not cancelled", t);
+            return false;
+        }
+    }
+
+    private void bailOutCancelled() {
+        cancelPendingToolCalls(null);
+        terminateAndDrainVisibleToolExecutions();
+    }
+
     private static <T> Consumer<T> combine(Consumer<T> first, Consumer<T> second) {
         if (first != null && second != null) {
             return first.andThen(second);
@@ -747,6 +799,12 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 .isError(result.isError())
                 .attributes(result.attributes())
                 .build();
+    }
+
+    static final String CANCELLED_TOOL_RESULT_TEXT = "Tool execution was cancelled";
+
+    private static ToolExecutionResultMessage cancelledToolResultMessage(ToolExecutionRequest request) {
+        return ToolExecutionResultMessage.from(request, CANCELLED_TOOL_RESULT_TEXT);
     }
 
     private ChatMemory getMemory() {

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -47,7 +47,9 @@ import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolService;
 import dev.langchain4j.service.tool.ToolServiceContext;
 import dev.langchain4j.service.tool.search.ToolSearchService;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +59,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -108,6 +111,13 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final boolean hasOutputGuardrails;
 
     private int sequentialToolsInvocationsLeft;
+
+    private final Object toolExecutionBufferLock = new Object();
+    private final ReentrantLock toolExecutionDeliveryLock = new ReentrantLock();
+    private final Deque<ToolExecution> bufferedToolExecutions = new ArrayDeque<>();
+    private boolean intermediateResponseEmitted = false;
+    private boolean drainingToolExecutions = false;
+    private boolean terminated = false;
 
     private record ToolRequestResult(ToolExecutionRequest request, ToolExecutionResult result) {}
 
@@ -295,7 +305,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onCompleteToolCall(CompleteToolCall completeToolCall) {
-        if (context.toolService.maxToolCallsPerResponse() == 0 && toolExecutor != null) {
+        if (shouldScheduleToolsEagerly()) {
             ToolExecutionRequest toolRequest = completeToolCall.toolExecutionRequest();
             CompletableFuture<ToolRequestResult> future = new CompletableFuture<>();
             toolExecutionFutures.add(future);
@@ -313,6 +323,139 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             } catch (Throwable t) {
                 future.completeExceptionally(t);
             }
+        }
+    }
+
+    private boolean shouldScheduleToolsEagerly() {
+        // Stream-level beforeToolExecution can veto the tool body, so keep it on the
+        // post-intermediate dispatch path where its delivery order is observable.
+        return context.toolService.maxToolCallsPerResponse() == 0
+                && toolExecutor != null
+                && beforeToolExecutionHandler == null;
+    }
+
+    private ToolExecutionResult execute(ToolExecutionRequest toolRequest) {
+        Consumer<ToolExecution> externalAfter =
+                toolExecutionHandler == null ? null : this::emitToolExecution;
+        return context.toolService.executeTool(
+                invocationContext, toolExecutors, toolRequest, beforeToolExecutionHandler, externalAfter);
+    }
+
+    private void emitToolExecution(ToolExecution toolExecution) {
+        synchronized (toolExecutionBufferLock) {
+            if (terminated) {
+                return;
+            }
+            if (!intermediateResponseEmitted || drainingToolExecutions) {
+                bufferedToolExecutions.add(toolExecution);
+                return;
+            }
+        }
+
+        toolExecutionDeliveryLock.lock();
+        try {
+            synchronized (toolExecutionBufferLock) {
+                if (terminated) {
+                    return;
+                }
+                if (!intermediateResponseEmitted || drainingToolExecutions) {
+                    bufferedToolExecutions.add(toolExecution);
+                    return;
+                }
+            }
+            toolExecutionHandler.accept(toolExecution);
+        } finally {
+            toolExecutionDeliveryLock.unlock();
+        }
+    }
+
+    private Throwable drainBufferedToolExecutions() {
+        if (toolExecutionHandler == null) {
+            markIntermediateResponseEmitted();
+            return null;
+        }
+
+        toolExecutionDeliveryLock.lock();
+        try {
+            synchronized (toolExecutionBufferLock) {
+                if (terminated) {
+                    bufferedToolExecutions.clear();
+                    return null;
+                }
+                intermediateResponseEmitted = true;
+                drainingToolExecutions = true;
+            }
+
+            return drainToolExecutionQueue();
+        } finally {
+            synchronized (toolExecutionBufferLock) {
+                drainingToolExecutions = false;
+            }
+            toolExecutionDeliveryLock.unlock();
+        }
+    }
+
+    private boolean terminateAndDrainVisibleToolExecutions() {
+        toolExecutionDeliveryLock.lock();
+        try {
+            synchronized (toolExecutionBufferLock) {
+                if (terminated) {
+                    bufferedToolExecutions.clear();
+                    return false;
+                }
+                terminated = true;
+                if (!intermediateResponseEmitted) {
+                    bufferedToolExecutions.clear();
+                    return true;
+                }
+                drainingToolExecutions = true;
+            }
+
+            Throwable callbackError = drainToolExecutionQueue();
+            if (callbackError != null) {
+                LOG.error("onToolExecuted callback threw while handling a stream error", callbackError);
+            }
+            return true;
+        } finally {
+            synchronized (toolExecutionBufferLock) {
+                drainingToolExecutions = false;
+            }
+            toolExecutionDeliveryLock.unlock();
+        }
+    }
+
+    private Throwable drainToolExecutionQueue() {
+        Throwable captured = null;
+        while (true) {
+            ToolExecution next;
+            synchronized (toolExecutionBufferLock) {
+                next = bufferedToolExecutions.poll();
+                if (next == null) {
+                    drainingToolExecutions = false;
+                    return captured;
+                }
+            }
+            try {
+                toolExecutionHandler.accept(next);
+            } catch (Throwable t) {
+                if (captured == null) {
+                    captured = t;
+                } else {
+                    captured.addSuppressed(t);
+                }
+            }
+        }
+    }
+
+    private void markIntermediateResponseEmitted() {
+        synchronized (toolExecutionBufferLock) {
+            intermediateResponseEmitted = true;
+        }
+    }
+
+    private boolean isTerminated() {
+        synchronized (toolExecutionBufferLock) {
+            return terminated;
         }
     }
 
@@ -354,6 +497,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     }
 
     private void handleStreamingError(Throwable error) {
+        cancelPendingToolCalls(null);
+        if (!terminateAndDrainVisibleToolExecutions()) {
+            return;
+        }
         if (errorHandler != null) {
             try {
                 fireErrorReceived(error);
@@ -376,9 +523,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         if (aiMessage.hasToolExecutionRequests()) {
 
             if (sequentialToolsInvocationsLeft-- == 0) {
-                throw runtime(
+                handleStreamingError(runtime(
                         "Something is wrong, exceeded %s sequential tool invocations",
-                        context.toolService.maxSequentialToolsInvocations());
+                        context.toolService.maxSequentialToolsInvocations()));
+                return;
             }
 
             List<ToolExecutionRequest> toolRequests = aiMessage.toolExecutionRequests();
@@ -392,6 +540,15 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 intermediateResponseHandler.accept(chatResponse);
             }
 
+            Throwable callbackError = drainBufferedToolExecutions();
+            if (callbackError != null) {
+                handleStreamingError(callbackError);
+                return;
+            }
+            if (isTerminated()) {
+                return;
+            }
+
             streamingDispatchHook.dispatch(() -> {
                 try {
                     runToolBatchAndContinue(chatResponse, aiMessage, toolRequests);
@@ -401,6 +558,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 return null;
             });
         } else {
+            if (isTerminated()) {
+                return;
+            }
+
             ChatResponse finalChatResponse = finalResponse(chatResponse, aiMessage);
 
             if (completeResponseHandler != null) {
@@ -442,9 +603,11 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
         Map<ToolExecutionRequest, ToolExecutionResult> results;
         int maxToolCallsPerResponse = context.toolService.maxToolCallsPerResponse();
-        if (maxToolCallsPerResponse == 0 && toolExecutor != null) {
+        if (shouldScheduleToolsEagerly()) {
             results = gatherScheduledToolResults();
         } else {
+            boolean useExecutorForSingleTool =
+                    maxToolCallsPerResponse > 0 || (toolExecutor != null && beforeToolExecutionHandler != null);
             results = ToolBatchDispatcher.dispatch(
                     ToolBatchDispatcher.Request.builder()
                             .toolRequests(toolRequests)
@@ -460,7 +623,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                             .executionErrorHandler(toolExecutionErrorHandler)
                             .hallucinationStrategy(context.toolService.hallucinatedToolNameStrategy())
                             .maxToolCallsPerResponse(0)
-                            .useExecutorForSingleTool(maxToolCallsPerResponse > 0)
+                            .useExecutorForSingleTool(useExecutorForSingleTool)
                             .build());
         }
 
@@ -591,11 +754,6 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         }
     }
 
-    private ToolExecutionResult execute(ToolExecutionRequest toolRequest) {
-        return context.toolService.executeTool(
-                invocationContext, toolExecutors, toolRequest, beforeToolExecutionHandler, toolExecutionHandler);
-    }
-
     private static <T> Consumer<T> combine(Consumer<T> first, Consumer<T> second) {
         if (first != null && second != null) {
             return first.andThen(second);
@@ -646,6 +804,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onError(Throwable error) {
+        cancelPendingToolCalls(null);
+        if (!terminateAndDrainVisibleToolExecutions()) {
+            return;
+        }
         if (errorHandler != null) {
             try {
                 fireErrorReceived(error);

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -39,6 +39,7 @@ import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.StreamingToolDispatchHook;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
 import dev.langchain4j.service.tool.ToolBatchDispatcher;
+import dev.langchain4j.service.tool.ToolCallsLimitExceededException;
 import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutionResult;
@@ -47,9 +48,15 @@ import dev.langchain4j.service.tool.ToolService;
 import dev.langchain4j.service.tool.ToolServiceContext;
 import dev.langchain4j.service.tool.search.ToolSearchService;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -97,9 +104,12 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final ChatRequestParameters loopParameters;
 
     private final List<String> responseBuffer = new ArrayList<>();
+    private final Queue<Future<ToolRequestResult>> toolExecutionFutures = new ConcurrentLinkedQueue<>();
     private final boolean hasOutputGuardrails;
 
     private int sequentialToolsInvocationsLeft;
+
+    private record ToolRequestResult(ToolExecutionRequest request, ToolExecutionResult result) {}
 
     AiServiceStreamingResponseHandler(
             ChatRequest chatRequest,
@@ -285,9 +295,25 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onCompleteToolCall(CompleteToolCall completeToolCall) {
-        // No-op: tool calls are buffered on the AiMessage delivered via onCompleteResponse.
-        // This makes maxToolCallsPerResponse atomic — we cannot know the full count until the
-        // streamed tool-call section finishes, so dispatch is deferred to onCompleteResponse.
+        if (context.toolService.maxToolCallsPerResponse() == 0 && toolExecutor != null) {
+            ToolExecutionRequest toolRequest = completeToolCall.toolExecutionRequest();
+            CompletableFuture<ToolRequestResult> future = new CompletableFuture<>();
+            toolExecutionFutures.add(future);
+            try {
+                toolExecutor.execute(() -> {
+                    if (future.isCancelled()) {
+                        return;
+                    }
+                    try {
+                        future.complete(new ToolRequestResult(toolRequest, execute(toolRequest)));
+                    } catch (Throwable t) {
+                        future.completeExceptionally(t);
+                    }
+                });
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        }
     }
 
     private <T> void fireInvocationComplete(T result) {
@@ -327,6 +353,20 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 .build());
     }
 
+    private void handleStreamingError(Throwable error) {
+        if (errorHandler != null) {
+            try {
+                fireErrorReceived(error);
+                errorHandler.accept(error);
+            } catch (Exception inner) {
+                LOG.error("While handling the following error...", error);
+                LOG.error("...the following error happened", inner);
+            }
+        } else {
+            LOG.warn("Ignored error", error);
+        }
+    }
+
     @Override
     public void onCompleteResponse(ChatResponse chatResponse) {
         fireResponseReceivedEvent(chatResponse);
@@ -341,38 +381,22 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                         context.toolService.maxSequentialToolsInvocations());
             }
 
-            // Atomic cap check: if the response has too many tool calls, no tool from this batch
-            // should run. Since onCompleteToolCall is now a no-op, we know nothing has been
-            // dispatched yet.
-            int maxToolCallsPerResponse = context.toolService.maxToolCallsPerResponse();
             List<ToolExecutionRequest> toolRequests = aiMessage.toolExecutionRequests();
+            int maxToolCallsPerResponse = context.toolService.maxToolCallsPerResponse();
             if (maxToolCallsPerResponse > 0 && toolRequests.size() > maxToolCallsPerResponse) {
-                throw new dev.langchain4j.service.tool.ToolCallsLimitExceededException(
-                        maxToolCallsPerResponse, toolRequests.size());
+                handleStreamingError(new ToolCallsLimitExceededException(maxToolCallsPerResponse, toolRequests.size()));
+                return;
             }
 
             if (intermediateResponseHandler != null) {
                 intermediateResponseHandler.accept(chatResponse);
             }
 
-            // Dispatch the entire tool batch through the integration hook so frameworks can
-            // wrap it (worker thread, context propagation, cancellation). The default INLINE
-            // hook just runs the supplier on the calling thread.
             streamingDispatchHook.dispatch(() -> {
                 try {
                     runToolBatchAndContinue(chatResponse, aiMessage, toolRequests);
                 } catch (Throwable t) {
-                    if (errorHandler != null) {
-                        try {
-                            fireErrorReceived(t);
-                            errorHandler.accept(t);
-                        } catch (Exception inner) {
-                            LOG.error("While handling the following error...", t);
-                            LOG.error("...the following error happened", inner);
-                        }
-                    } else {
-                        LOG.warn("Ignored error", t);
-                    }
+                    handleStreamingError(t);
                 }
                 return null;
             });
@@ -416,24 +440,29 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private void runToolBatchAndContinue(
             ChatResponse chatResponse, AiMessage aiMessage, List<ToolExecutionRequest> toolRequests) {
 
-        // Dispatch the batch via the shared primitive. This handles serial vs. parallel,
-        // ordered gather, sibling cancellation, error-handler bypass, and callbacks.
-        Map<ToolExecutionRequest, ToolExecutionResult> results = ToolBatchDispatcher.dispatch(
-                ToolBatchDispatcher.Request.builder()
-                        .toolRequests(toolRequests)
-                        .toolExecutors(toolExecutors)
-                        .executor(toolExecutor)
-                        .invocationContext(invocationContext)
-                        .beforeToolExecution(combine(
-                                context.toolService.beforeToolExecution(), beforeToolExecutionHandler))
-                        .afterToolExecution(combine(
-                                context.toolService.afterToolExecution(), toolExecutionHandler))
-                        .errorHandlerBypass(context.toolService.errorHandlerBypass())
-                        .argumentsErrorHandler(toolArgumentsErrorHandler)
-                        .executionErrorHandler(toolExecutionErrorHandler)
-                        .hallucinationStrategy(context.toolService.hallucinatedToolNameStrategy())
-                        .maxToolCallsPerResponse(0) // already checked above
-                        .build());
+        Map<ToolExecutionRequest, ToolExecutionResult> results;
+        int maxToolCallsPerResponse = context.toolService.maxToolCallsPerResponse();
+        if (maxToolCallsPerResponse == 0 && toolExecutor != null) {
+            results = gatherScheduledToolResults();
+        } else {
+            results = ToolBatchDispatcher.dispatch(
+                    ToolBatchDispatcher.Request.builder()
+                            .toolRequests(toolRequests)
+                            .toolExecutors(toolExecutors)
+                            .executor(toolExecutor)
+                            .invocationContext(invocationContext)
+                            .beforeToolExecution(combine(
+                                    context.toolService.beforeToolExecution(), beforeToolExecutionHandler))
+                            .afterToolExecution(combine(
+                                    context.toolService.afterToolExecution(), toolExecutionHandler))
+                            .errorHandlerBypass(context.toolService.errorHandlerBypass())
+                            .argumentsErrorHandler(toolArgumentsErrorHandler)
+                            .executionErrorHandler(toolExecutionErrorHandler)
+                            .hallucinationStrategy(context.toolService.hallucinatedToolNameStrategy())
+                            .maxToolCallsPerResponse(0)
+                            .useExecutorForSingleTool(maxToolCallsPerResponse > 0)
+                            .build());
+        }
 
         List<ToolExecutionResult> toolResults = new ArrayList<>(results.size());
         boolean anyToolErrored = false;
@@ -441,6 +470,9 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
         for (ToolExecutionRequest request : toolRequests) {
             ToolExecutionResult result = results.get(request);
+            if (result == null) {
+                throw runtime("No tool execution result was scheduled for tool request '%s'", request.name());
+            }
             toolResults.add(result);
             fireToolExecutedEvent(request, result);
             ToolExecutionResultMessage resultMessage = toResultMessage(request, result);
@@ -522,6 +554,46 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         fireRequestIssuedEvent(nextChatRequest);
         StreamingChatModel modelToUse = streamingChatModel != null ? streamingChatModel : context.streamingChatModel;
         modelToUse.chat(nextChatRequest, handler);
+    }
+
+    private Map<ToolExecutionRequest, ToolExecutionResult> gatherScheduledToolResults() {
+        Map<ToolExecutionRequest, ToolExecutionResult> results = new LinkedHashMap<>();
+
+        for (Future<ToolRequestResult> future : toolExecutionFutures) {
+            try {
+                ToolRequestResult toolRequestResult = future.get();
+                results.put(toolRequestResult.request(), toolRequestResult.result());
+            } catch (ExecutionException e) {
+                cancelPendingToolCalls(future);
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException re) {
+                    throw re;
+                } else if (cause instanceof Error err) {
+                    throw err;
+                } else {
+                    throw new RuntimeException(cause);
+                }
+            } catch (InterruptedException e) {
+                cancelPendingToolCalls(future);
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+
+        return results;
+    }
+
+    private void cancelPendingToolCalls(Future<ToolRequestResult> except) {
+        for (Future<ToolRequestResult> future : toolExecutionFutures) {
+            if (future != except && !future.isDone()) {
+                future.cancel(true);
+            }
+        }
+    }
+
+    private ToolExecutionResult execute(ToolExecutionRequest toolRequest) {
+        return context.toolService.executeTool(
+                invocationContext, toolExecutors, toolRequest, beforeToolExecutionHandler, toolExecutionHandler);
     }
 
     private static <T> Consumer<T> combine(Consumer<T> first, Consumer<T> second) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -36,6 +36,7 @@ import dev.langchain4j.observability.api.event.AiServiceResponseReceivedEvent;
 import dev.langchain4j.observability.api.event.ToolExecutedEvent;
 import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
+import dev.langchain4j.service.tool.ToolCallsLimitExceededException;
 import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutionResult;
@@ -52,6 +53,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -95,6 +97,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final ToolExecutionErrorHandler toolExecutionErrorHandler;
     private final Executor toolExecutor;
     private final Queue<Future<ToolRequestResult>> toolExecutionFutures = new ConcurrentLinkedQueue<>();
+    private final AtomicInteger streamedToolCallsCount = new AtomicInteger();
 
     private final List<String> responseBuffer = new ArrayList<>();
     private final boolean hasOutputGuardrails;
@@ -227,6 +230,14 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     @Override
     public void onCompleteToolCall(CompleteToolCall completeToolCall) {
         if (toolExecutor != null) {
+            // If the cap is configured, do not submit any future once we have already seen more
+            // tool calls than allowed. This prevents the tool from running before
+            // onCompleteResponse gets a chance to throw ToolCallsLimitExceededException.
+            int maxToolCallsPerResponse = context.toolService.maxToolCallsPerResponse();
+            int seen = streamedToolCallsCount.incrementAndGet();
+            if (maxToolCallsPerResponse > 0 && seen > maxToolCallsPerResponse) {
+                return;
+            }
             ToolExecutionRequest toolRequest = completeToolCall.toolExecutionRequest();
             var future = CompletableFuture.supplyAsync(
                     () -> {
@@ -287,6 +298,13 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                 throw runtime(
                         "Something is wrong, exceeded %s sequential tool invocations",
                         context.toolService.maxSequentialToolsInvocations());
+            }
+
+            int maxToolCallsPerResponse = context.toolService.maxToolCallsPerResponse();
+            if (maxToolCallsPerResponse > 0
+                    && aiMessage.toolExecutionRequests().size() > maxToolCallsPerResponse) {
+                throw new ToolCallsLimitExceededException(
+                        maxToolCallsPerResponse, aiMessage.toolExecutionRequests().size());
             }
 
             if (intermediateResponseHandler != null) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -595,8 +595,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     finishIfSilentlyCancelled();
                     return null;
                 }
-                addToMemory(aiMessage);
                 try {
+                    addToMemory(aiMessage);
                     runToolBatchAndContinue(chatResponse, aiMessage, toolRequests);
                 } catch (Throwable t) {
                     handleStreamingError(t);
@@ -642,16 +642,16 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     finishIfSilentlyCancelled();
                     return;
                 }
-                loopState.complete();
                 fireInvocationComplete(finalChatResponse);
                 completeResponseHandler.accept(finalChatResponse);
+                loopState.complete();
             } else {
                 if (!loopState.canContinue()) {
                     finishIfSilentlyCancelled();
                     return;
                 }
-                loopState.complete();
                 fireInvocationComplete(finalChatResponse);
+                loopState.complete();
             }
         }
     }
@@ -736,12 +736,12 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
         if (ToolService.shouldReturnImmediately(anyToolErrored, returnBehaviors)) {
             ChatResponse finalChatResponse = finalResponse(chatResponse, aiMessage);
-            loopState.complete();
             fireInvocationComplete(finalChatResponse);
 
             if (completeResponseHandler != null) {
                 completeResponseHandler.accept(finalChatResponse);
             }
+            loopState.complete();
             return;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -236,7 +236,10 @@ public class AiServiceTokenStream implements TokenStream {
                 toolExecutionErrorHandler,
                 toolExecutor,
                 commonGuardrailParams,
-                methodKey);
+                methodKey,
+                null,
+                context.streamingToolDispatchHook,
+                chatRequest.parameters());
 
         if (contentsHandler != null && retrievedContents != null) {
             contentsHandler.accept(retrievedContents);

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -12,6 +12,7 @@ import dev.langchain4j.guardrail.GuardrailRequestParams;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -51,6 +52,7 @@ public class AiServiceTokenStream implements TokenStream {
     private final InvocationContext invocationContext;
     private final GuardrailRequestParams commonGuardrailParams;
     private final Object methodKey;
+    private final StreamingChatModel perCallStreamingChatModel;
 
     private Consumer<String> partialResponseHandler;
     private BiConsumer<PartialResponse, PartialResponseContext> partialResponseWithContextHandler;
@@ -97,6 +99,7 @@ public class AiServiceTokenStream implements TokenStream {
         this.invocationContext = parameters.invocationContext();
         this.commonGuardrailParams = parameters.commonGuardrailParams();
         this.methodKey = parameters.methodKey();
+        this.perCallStreamingChatModel = parameters.streamingChatModel();
     }
 
     @Override
@@ -205,7 +208,11 @@ public class AiServiceTokenStream implements TokenStream {
                         .build(),
                 invocationContext.chatMemoryId());
 
-        ChatExecutor chatExecutor = ChatExecutor.builder(context.streamingChatModel)
+        StreamingChatModel modelToUse = perCallStreamingChatModel != null
+                ? perCallStreamingChatModel
+                : context.streamingChatModel;
+
+        ChatExecutor chatExecutor = ChatExecutor.builder(modelToUse)
                 .errorHandler(errorHandler)
                 .chatRequest(chatRequest)
                 .invocationContext(invocationContext)
@@ -237,7 +244,7 @@ public class AiServiceTokenStream implements TokenStream {
                 toolExecutor,
                 commonGuardrailParams,
                 methodKey,
-                null,
+                modelToUse,
                 context.streamingToolDispatchHook,
                 chatRequest.parameters());
 
@@ -250,7 +257,7 @@ public class AiServiceTokenStream implements TokenStream {
                 .request(chatRequest)
                 .build());
 
-        context.streamingChatModel.chat(chatRequest, handler);
+        modelToUse.chat(chatRequest, handler);
     }
 
     private void validateConfiguration() {

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 @Internal
 public class AiServiceTokenStream implements TokenStream {
@@ -53,6 +54,7 @@ public class AiServiceTokenStream implements TokenStream {
     private final GuardrailRequestParams commonGuardrailParams;
     private final Object methodKey;
     private final StreamingChatModel perCallStreamingChatModel;
+    private Supplier<Boolean> perCallCancellationSupplier;
 
     private Consumer<String> partialResponseHandler;
     private BiConsumer<PartialResponse, PartialResponseContext> partialResponseWithContextHandler;
@@ -100,6 +102,7 @@ public class AiServiceTokenStream implements TokenStream {
         this.commonGuardrailParams = parameters.commonGuardrailParams();
         this.methodKey = parameters.methodKey();
         this.perCallStreamingChatModel = parameters.streamingChatModel();
+        this.perCallCancellationSupplier = parameters.cancellationSupplier();
     }
 
     @Override
@@ -194,6 +197,12 @@ public class AiServiceTokenStream implements TokenStream {
     }
 
     @Override
+    public TokenStream cancelOn(Supplier<Boolean> cancellationSupplier) {
+        this.perCallCancellationSupplier = cancellationSupplier;
+        return this;
+    }
+
+    @Override
     public void start() {
         validateConfiguration();
 
@@ -246,7 +255,8 @@ public class AiServiceTokenStream implements TokenStream {
                 methodKey,
                 modelToUse,
                 context.streamingToolDispatchHook,
-                chatRequest.parameters());
+                chatRequest.parameters(),
+                perCallCancellationSupplier);
 
         if (contentsHandler != null && retrievedContents != null) {
             contentsHandler.accept(retrievedContents);

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -228,6 +228,8 @@ public class AiServiceTokenStream implements TokenStream {
                 .eventListenerRegistrar(context.eventListenerRegistrar)
                 .build();
 
+        StreamingLoopState loopState = new StreamingLoopState(perCallCancellationSupplier);
+
         var handler = new AiServiceStreamingResponseHandler(
                 chatRequest,
                 chatExecutor,
@@ -256,7 +258,7 @@ public class AiServiceTokenStream implements TokenStream {
                 modelToUse,
                 context.streamingToolDispatchHook,
                 chatRequest.parameters(),
-                perCallCancellationSupplier);
+                loopState);
 
         if (contentsHandler != null && retrievedContents != null) {
             contentsHandler.accept(retrievedContents);

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.service.AiServiceParamsUtil.chatRequestParameters;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.guardrail.ChatExecutor;
 import dev.langchain4j.guardrail.GuardrailRequestParams;
@@ -14,7 +15,6 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.PartialResponse;
 import dev.langchain4j.model.chat.response.PartialResponseContext;
@@ -22,7 +22,6 @@ import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.PartialThinkingContext;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCallContext;
-import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.observability.api.event.AiServiceRequestIssuedEvent;
 import dev.langchain4j.rag.content.Content;
@@ -30,7 +29,6 @@ import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
 import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
-import dev.langchain4j.service.tool.ToolService;
 import dev.langchain4j.service.tool.ToolServiceContext;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -206,9 +204,8 @@ public class AiServiceTokenStream implements TokenStream {
     public void start() {
         validateConfiguration();
 
-        List<ToolSpecification> effectiveTools = toolServiceContext != null
-                ? toolServiceContext.effectiveTools()
-                : null;
+        List<ToolSpecification> effectiveTools =
+                toolServiceContext != null ? toolServiceContext.effectiveTools() : null;
 
         ChatRequest chatRequest = context.chatRequestTransformer.apply(
                 ChatRequest.builder()
@@ -217,9 +214,8 @@ public class AiServiceTokenStream implements TokenStream {
                         .build(),
                 invocationContext.chatMemoryId());
 
-        StreamingChatModel modelToUse = perCallStreamingChatModel != null
-                ? perCallStreamingChatModel
-                : context.streamingChatModel;
+        StreamingChatModel modelToUse =
+                perCallStreamingChatModel != null ? perCallStreamingChatModel : context.streamingChatModel;
 
         ChatExecutor chatExecutor = ChatExecutor.builder(modelToUse)
                 .errorHandler(errorHandler)

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStreamParameters.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStreamParameters.java
@@ -4,6 +4,7 @@ import dev.langchain4j.Internal;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.guardrail.GuardrailRequestParams;
 import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -32,6 +33,7 @@ public class AiServiceTokenStreamParameters {
     private final InvocationContext invocationContext;
     private final GuardrailRequestParams commonGuardrailParams;
     private final Object methodKey;
+    private final StreamingChatModel streamingChatModel;
 
     protected AiServiceTokenStreamParameters(Builder builder) {
         this.messages = builder.messages;
@@ -44,6 +46,7 @@ public class AiServiceTokenStreamParameters {
         this.invocationContext = builder.invocationContext;
         this.commonGuardrailParams = builder.commonGuardrailParams;
         this.methodKey = builder.methodKey;
+        this.streamingChatModel = builder.streamingChatModel;
     }
 
     /**
@@ -164,6 +167,13 @@ public class AiServiceTokenStreamParameters {
     }
 
     /**
+     * Returns the per-call {@link StreamingChatModel}, or null to use the context's default model.
+     */
+    public StreamingChatModel streamingChatModel() {
+        return streamingChatModel;
+    }
+
+    /**
      * Creates a new builder for {@link AiServiceTokenStreamParameters}.
      *
      * @return a new builder
@@ -187,6 +197,7 @@ public class AiServiceTokenStreamParameters {
         private InvocationContext invocationContext;
         private GuardrailRequestParams commonGuardrailParams;
         private Object methodKey;
+        private StreamingChatModel streamingChatModel;
 
         protected Builder() {}
 
@@ -345,6 +356,14 @@ public class AiServiceTokenStreamParameters {
          */
         public Builder methodKey(Object methodKey) {
             this.methodKey = methodKey;
+            return this;
+        }
+
+        /**
+         * Sets the per-call {@link StreamingChatModel}. When non-null, overrides the context's default model.
+         */
+        public Builder streamingChatModel(StreamingChatModel streamingChatModel) {
+            this.streamingChatModel = streamingChatModel;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStreamParameters.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStreamParameters.java
@@ -16,6 +16,7 @@ import dev.langchain4j.service.tool.search.ToolSearchStrategy;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 /**
  * Parameters for creating an {@link AiServiceTokenStream}.
@@ -34,6 +35,7 @@ public class AiServiceTokenStreamParameters {
     private final GuardrailRequestParams commonGuardrailParams;
     private final Object methodKey;
     private final StreamingChatModel streamingChatModel;
+    private final Supplier<Boolean> cancellationSupplier;
 
     protected AiServiceTokenStreamParameters(Builder builder) {
         this.messages = builder.messages;
@@ -47,6 +49,7 @@ public class AiServiceTokenStreamParameters {
         this.commonGuardrailParams = builder.commonGuardrailParams;
         this.methodKey = builder.methodKey;
         this.streamingChatModel = builder.streamingChatModel;
+        this.cancellationSupplier = builder.cancellationSupplier;
     }
 
     /**
@@ -174,6 +177,16 @@ public class AiServiceTokenStreamParameters {
     }
 
     /**
+     * Framework-integrator slot for the per-invocation cancellation supplier. End users should
+     * use {@link TokenStream#cancelOn(Supplier)} instead.
+     *
+     * @since 1.15.0-beta25
+     */
+    public Supplier<Boolean> cancellationSupplier() {
+        return cancellationSupplier;
+    }
+
+    /**
      * Creates a new builder for {@link AiServiceTokenStreamParameters}.
      *
      * @return a new builder
@@ -198,6 +211,7 @@ public class AiServiceTokenStreamParameters {
         private GuardrailRequestParams commonGuardrailParams;
         private Object methodKey;
         private StreamingChatModel streamingChatModel;
+        private Supplier<Boolean> cancellationSupplier;
 
         protected Builder() {}
 
@@ -364,6 +378,12 @@ public class AiServiceTokenStreamParameters {
          */
         public Builder streamingChatModel(StreamingChatModel streamingChatModel) {
             this.streamingChatModel = streamingChatModel;
+            return this;
+        }
+
+        /** @since 1.15.0-beta25 */
+        public Builder cancellationSupplier(Supplier<Boolean> cancellationSupplier) {
+            this.cancellationSupplier = cancellationSupplier;
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStreamParameters.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStreamParameters.java
@@ -1,13 +1,13 @@
 package dev.langchain4j.service;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.guardrail.GuardrailRequestParams;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.rag.content.Content;
-import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutor;

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -43,6 +43,7 @@ import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import dev.langchain4j.service.tool.AiServiceTool;
 import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.DefaultToolExecutor;
+import dev.langchain4j.service.tool.StreamingToolDispatchHook;
 import dev.langchain4j.service.tool.ToolArgumentsErrorHandler;
 import dev.langchain4j.service.tool.ToolErrorHandlerResult;
 import dev.langchain4j.service.tool.ToolExecution;
@@ -757,6 +758,37 @@ public abstract class AiServices<T> {
     public AiServices<T> toolProviderRequestFactory(
             Function<ToolProviderRequest.Builder, ToolProviderRequest> toolProviderRequestFactory) {
         context.toolService.toolProviderRequestFactory(toolProviderRequestFactory);
+        return this;
+    }
+
+    /**
+     * Configures an integration hook used by the streaming response handler to dispatch the
+     * batch of tool calls produced by a single LLM response.
+     *
+     * <p>This hook is intended for downstream framework integrators (e.g. {@code quarkus-langchain4j})
+     * that need to control the threading and context propagation around the tool batch:
+     * <ul>
+     *   <li>Switch to a worker thread before tool execution begins.</li>
+     *   <li>Propagate framework context (Vert.x duplicated context, MDC, security context) into
+     *       the tool dispatch and the subsequent follow-up streaming inference call.</li>
+     *   <li>Hook cancellation into framework cancellation.</li>
+     * </ul>
+     *
+     * <p>The default is {@link StreamingToolDispatchHook#INLINE}, which runs the dispatch on the
+     * thread invoking {@code onCompleteResponse}. This preserves the existing behavior.
+     *
+     * <p>This hook is independent of the per-tool {@link Executor} configured via
+     * {@link #executeToolsConcurrently(Executor)} — that executor is passed to
+     * {@code ToolBatchDispatcher} and only fans out individual tool calls. The dispatch hook
+     * wraps the whole batch (and the follow-up streaming inference) and runs once per batch.
+     *
+     * @param hook the integration hook. If {@code null}, the default {@link StreamingToolDispatchHook#INLINE}
+     *             is used.
+     * @return the builder instance
+     * @since 1.15.0-beta25
+     */
+    public AiServices<T> streamingToolDispatchHook(StreamingToolDispatchHook hook) {
+        context.streamingToolDispatchHook = hook;
         return this;
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -26,6 +26,7 @@ import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.input.structured.StructuredPrompt;
@@ -48,6 +49,7 @@ import dev.langchain4j.service.tool.ToolExecution;
 import dev.langchain4j.service.tool.ToolExecutionErrorHandler;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.search.ToolSearchStrategy;
 import dev.langchain4j.spi.services.AiServicesFactory;
 import java.util.Collection;
@@ -61,6 +63,7 @@ import java.util.concurrent.Future;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 /**
@@ -679,6 +682,81 @@ public abstract class AiServices<T> {
      */
     public AiServices<T> maxToolCallsPerResponse(int maxToolCallsPerResponse) {
         context.toolService.maxToolCallsPerResponse(maxToolCallsPerResponse);
+        return this;
+    }
+
+    /**
+     * Controls whether {@link ToolChoice#REQUIRED} is automatically rewritten to
+     * {@link ToolChoice#AUTO} after the first iteration of the inference-and-tools loop.
+     *
+     * <p>This is an opt-in self-protection hook for downstream framework integrators
+     * (e.g. {@code quarkus-langchain4j}) that set {@link ToolChoice#REQUIRED} on the
+     * first request but want to allow the LLM to terminate the loop on follow-up
+     * iterations. With this flag enabled, {@code REQUIRED} is rewritten to
+     * {@link ToolChoice#AUTO} on every iteration after the first; without it, the
+     * caller-supplied tool choice is forwarded unchanged.
+     *
+     * <p>Default is {@code false}, which preserves the existing behavior of forwarding
+     * the caller-supplied {@link ToolChoice} on every iteration.
+     *
+     * @param forceToolChoiceAutoAfterFirstIteration whether to rewrite
+     *                                               {@link ToolChoice#REQUIRED} to
+     *                                               {@link ToolChoice#AUTO} after the first iteration
+     * @return the builder instance
+     * @since 1.14.0
+     */
+    public AiServices<T> forceToolChoiceAutoAfterFirstIteration(boolean forceToolChoiceAutoAfterFirstIteration) {
+        context.toolService.forceToolChoiceAutoAfterFirstIteration(forceToolChoiceAutoAfterFirstIteration);
+        return this;
+    }
+
+    /**
+     * Configures a predicate that, when it evaluates to {@code true} for a tool execution
+     * exception, causes the exception to propagate unchanged instead of being routed
+     * through the configured {@link ToolExecutionErrorHandler}.
+     *
+     * <p>This hook is intended for downstream framework integrators that need to let
+     * specific marker-typed exceptions (e.g. authorization or guardrail violations)
+     * surface to the caller verbatim rather than be summarized into a string sent back
+     * to the LLM. The predicate is evaluated on the exception thrown by the
+     * {@link ToolExecutor}; if it returns {@code true}, the exception is rethrown
+     * unchanged (wrapped in a {@link RuntimeException} only if it is a checked exception).
+     *
+     * <p>The default predicate returns {@code false} for all throwables, which preserves
+     * the existing behavior of routing every exception through the error handler.
+     *
+     * @param errorHandlerBypass the bypass predicate. If {@code null}, the default predicate
+     *                           ({@code e -> false}) is used.
+     * @return the builder instance
+     * @since 1.14.0
+     */
+    public AiServices<T> errorHandlerBypass(Predicate<Throwable> errorHandlerBypass) {
+        context.toolService.errorHandlerBypass(errorHandlerBypass);
+        return this;
+    }
+
+    /**
+     * Configures a factory used to build the {@link ToolProviderRequest} passed to
+     * {@link ToolProvider}s, both during initial context creation and dynamic refresh.
+     *
+     * <p>This hook is intended for downstream framework integrators that need to attach
+     * additional context to the {@link ToolProviderRequest}, typically by returning a
+     * subclass enriched with framework-specific attributes. Tool providers can then
+     * downcast the request to access those attributes.
+     *
+     * <p>The default factory invokes {@link ToolProviderRequest.Builder#build()},
+     * which preserves the existing behavior of constructing a plain
+     * {@link ToolProviderRequest}.
+     *
+     * @param toolProviderRequestFactory factory consuming a fully populated builder and
+     *                                   returning the request to pass to providers.
+     *                                   If {@code null}, the default factory is used.
+     * @return the builder instance
+     * @since 1.14.0
+     */
+    public AiServices<T> toolProviderRequestFactory(
+            Function<ToolProviderRequest.Builder, ToolProviderRequest> toolProviderRequestFactory) {
+        context.toolService.toolProviderRequestFactory(toolProviderRequestFactory);
         return this;
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -609,10 +609,13 @@ public abstract class AiServices<T> {
      *             <li>When the LLM calls multiple tools, they are executed concurrently in separate threads
      *                 using the {@link Executor}.
      *                 Each tool is executed as soon as {@link StreamingChatResponseHandler#onCompleteToolCall(CompleteToolCall)}
-     *                 is called, without waiting for other tools or for the response streaming to complete.</li>
+     *                 is called, without waiting for other tools or for the response streaming to complete,
+     *                 unless {@link #maxToolCallsPerResponse(int)} is configured.</li>
      *             <li>When the LLM calls a single tool, it is executed in a separate thread using the {@link Executor}.
      *                 We cannot execute it in the same thread because, at that point,
-     *                 we do not yet know how many tools the LLM will call.</li>
+     *                 we do not yet know how many tools the LLM will call. When
+     *                 {@link #maxToolCallsPerResponse(int)} is configured, the single tool is still executed
+     *                 using the {@link Executor}, but only after the complete response passes the cap check.</li>
      *         </ul>
      *     </li>
      * </ul>
@@ -676,6 +679,16 @@ public abstract class AiServices<T> {
      *
      * <p>
      * A value of {@code 0} (the default) means unlimited — no cap is enforced.
+     * For {@link ChatModel}, the limit is strict and atomic: if the response exceeds the cap,
+     * no tool from that response is executed. For {@link StreamingChatModel}, the default
+     * {@code 0} preserves eager scheduling: when a per-tool {@link Executor} is configured via
+     * {@link #executeToolsConcurrently()} or {@link #executeToolsConcurrently(Executor)}, tools are
+     * scheduled from {@link StreamingChatResponseHandler#onCompleteToolCall(CompleteToolCall)}.
+     * Configuring a value greater than {@code 0} switches streaming tool execution to strict
+     * deferred enforcement: the full {@code onCompleteResponse} tool-call count is checked before
+     * any tool from that response is dispatched, and an over-limit response executes no tools.
+     * This strict mode may trade off streaming latency because tool execution waits for the full
+     * response.
      *
      * @param maxToolCallsPerResponse the maximum number of tool execution requests permitted
      *                                in a single LLM response, or {@code 0} for unlimited
@@ -766,25 +779,31 @@ public abstract class AiServices<T> {
     }
 
     /**
-     * Configures an integration hook used by the streaming response handler to dispatch the
+     * Configures an integration hook used by the streaming response handler to continue from the
      * batch of tool calls produced by a single LLM response.
      *
      * <p>This hook is intended for downstream framework integrators (e.g. {@code quarkus-langchain4j})
-     * that need to control the threading and context propagation around the tool batch:
+     * that need to control the threading and context propagation around the downstream continuation:
      * <ul>
-     *   <li>Switch to a worker thread before tool execution begins.</li>
+     *   <li>Switch result gathering, memory writes, follow-up streaming inference, and inline
+     *       no-executor tool execution to a worker thread.</li>
      *   <li>Propagate framework context (Vert.x duplicated context, MDC, security context) into
-     *       the tool dispatch and the subsequent follow-up streaming inference call.</li>
-     *   <li>Hook cancellation into framework cancellation.</li>
+     *       that downstream continuation.</li>
+     *   <li>Hook downstream cancellation into framework cancellation.</li>
      * </ul>
      *
      * <p>The default is {@link StreamingToolDispatchHook#INLINE}, which runs the dispatch on the
      * thread invoking {@code onCompleteResponse}. This preserves the existing behavior.
      *
-     * <p>This hook is independent of the per-tool {@link Executor} configured via
-     * {@link #executeToolsConcurrently(Executor)} — that executor is passed to
-     * {@code ToolBatchDispatcher} and only fans out individual tool calls. The dispatch hook
-     * wraps the whole batch (and the follow-up streaming inference) and runs once per batch.
+     * <p>When {@link #maxToolCallsPerResponse(int)} is left at the default {@code 0} and a per-tool
+     * {@link Executor} is configured via {@link #executeToolsConcurrently()} or
+     * {@link #executeToolsConcurrently(Executor)}, streaming tools are scheduled eagerly from
+     * {@link StreamingChatResponseHandler#onCompleteToolCall(CompleteToolCall)} before this hook is
+     * invoked. In that mode, the hook wraps result gathering, memory writes, and follow-up
+     * streaming inference, but it cannot move already-scheduled tool execution onto a different
+     * thread. When no per-tool executor is configured, or when {@code maxToolCallsPerResponse} is
+     * greater than {@code 0}, the hook wraps deferred batch dispatch from the
+     * {@code onCompleteResponse} path. The hook runs once per batch in either mode.
      *
      * @param hook the integration hook. If {@code null}, the default {@link StreamingToolDispatchHook#INLINE}
      *             is used.

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -799,11 +799,15 @@ public abstract class AiServices<T> {
      * {@link Executor} is configured via {@link #executeToolsConcurrently()} or
      * {@link #executeToolsConcurrently(Executor)}, streaming tools are scheduled eagerly from
      * {@link StreamingChatResponseHandler#onCompleteToolCall(CompleteToolCall)} before this hook is
-     * invoked. In that mode, the hook wraps result gathering, memory writes, and follow-up
-     * streaming inference, but it cannot move already-scheduled tool execution onto a different
-     * thread. When no per-tool executor is configured, or when {@code maxToolCallsPerResponse} is
-     * greater than {@code 0}, the hook wraps deferred batch dispatch from the
-     * {@code onCompleteResponse} path. The hook runs once per batch in either mode.
+     * invoked, unless the {@link TokenStream} has a stream-level
+     * {@link TokenStream#beforeToolExecution(Consumer)} callback. That stream callback can veto the
+     * tool body, so its tools are dispatched after the intermediate response instead of eagerly. In
+     * eager mode, the hook wraps result gathering, memory writes, and follow-up streaming inference,
+     * but it cannot move already-scheduled tool execution onto a different thread. When no per-tool
+     * executor is configured, when {@code maxToolCallsPerResponse} is greater than {@code 0}, or
+     * when a stream-level {@code beforeToolExecution} callback is present, the hook wraps deferred
+     * batch dispatch from the {@code onCompleteResponse} path. The hook runs once per batch in
+     * either mode.
      *
      * @param hook the integration hook. If {@code null}, the default {@link StreamingToolDispatchHook#INLINE}
      *             is used.
@@ -818,6 +822,10 @@ public abstract class AiServices<T> {
 
     /**
      * Configures a callback to be invoked before each tool execution.
+     * <p>
+     * This is an execution lifecycle callback. In streaming mode with eager tool execution, it is
+     * invoked when the tool actually starts and can therefore run before
+     * {@link TokenStream#onIntermediateResponse(Consumer)} is delivered.
      *
      * @param beforeToolExecution A {@link Consumer} that accepts a {@link BeforeToolExecution}
      *                            representing the tool execution request about to be executed.
@@ -831,6 +839,12 @@ public abstract class AiServices<T> {
 
     /**
      * Configures a callback to be invoked after each tool execution.
+     * <p>
+     * This is an execution lifecycle callback. In streaming mode with eager tool execution, it is
+     * invoked when the tool actually finishes and can therefore run before
+     * {@link TokenStream#onIntermediateResponse(Consumer)} is delivered. This differs from
+     * {@link TokenStream#onToolExecuted(Consumer)}, which is stream-delivered after the
+     * intermediate response.
      *
      * @param afterToolExecution A {@link Consumer} that accepts a {@link ToolExecution}
      *                           containing the tool execution request that was executed and its result.

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -6,6 +6,7 @@ import static dev.langchain4j.spi.ServiceHelper.loadFactory;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 
+import dev.langchain4j.Experimental;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ReturnBehavior;
 import dev.langchain4j.invocation.InvocationContext;
@@ -706,6 +707,7 @@ public abstract class AiServices<T> {
      * @return the builder instance
      * @since 1.14.0
      */
+    @Experimental
     public AiServices<T> forceToolChoiceAutoAfterFirstIteration(boolean forceToolChoiceAutoAfterFirstIteration) {
         context.toolService.forceToolChoiceAutoAfterFirstIteration(forceToolChoiceAutoAfterFirstIteration);
         return this;
@@ -731,6 +733,7 @@ public abstract class AiServices<T> {
      * @return the builder instance
      * @since 1.14.0
      */
+    @Experimental
     public AiServices<T> errorHandlerBypass(Predicate<Throwable> errorHandlerBypass) {
         context.toolService.errorHandlerBypass(errorHandlerBypass);
         return this;
@@ -755,6 +758,7 @@ public abstract class AiServices<T> {
      * @return the builder instance
      * @since 1.14.0
      */
+    @Experimental
     public AiServices<T> toolProviderRequestFactory(
             Function<ToolProviderRequest.Builder, ToolProviderRequest> toolProviderRequestFactory) {
         context.toolService.toolProviderRequestFactory(toolProviderRequestFactory);
@@ -787,6 +791,7 @@ public abstract class AiServices<T> {
      * @return the builder instance
      * @since 1.15.0-beta25
      */
+    @Experimental
     public AiServices<T> streamingToolDispatchHook(StreamingToolDispatchHook hook) {
         context.streamingToolDispatchHook = hook;
         return this;

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServices.java
@@ -657,6 +657,32 @@ public abstract class AiServices<T> {
     }
 
     /**
+     * Sets the maximum number of tool calls allowed within a single LLM response.
+     * If a single LLM response contains more tool execution requests than this limit, a
+     * {@link dev.langchain4j.service.tool.ToolCallsLimitExceededException} is thrown and the AI
+     * service invocation is terminated.
+     *
+     * <p>
+     * This is intended for cooperative truncation when an LLM returns more tool calls in
+     * a single response than the user wants to spend (for example, to bound execution
+     * cost or latency). Unlike {@link #maxSequentialToolsInvocations(int)}, which limits
+     * the number of LLM <em>responses</em> that may contain tool calls, this option
+     * limits the number of tool execution requests within a single LLM response.
+     *
+     * <p>
+     * A value of {@code 0} (the default) means unlimited — no cap is enforced.
+     *
+     * @param maxToolCallsPerResponse the maximum number of tool execution requests permitted
+     *                                in a single LLM response, or {@code 0} for unlimited
+     * @return the builder instance
+     * @since 1.14.0
+     */
+    public AiServices<T> maxToolCallsPerResponse(int maxToolCallsPerResponse) {
+        context.toolService.maxToolCallsPerResponse(maxToolCallsPerResponse);
+        return this;
+    }
+
+    /**
      * Configures a callback to be invoked before each tool execution.
      *
      * @param beforeToolExecution A {@link Consumer} that accepts a {@link BeforeToolExecution}

--- a/langchain4j/src/main/java/dev/langchain4j/service/StreamingLoopState.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/StreamingLoopState.java
@@ -1,0 +1,98 @@
+package dev.langchain4j.service;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class StreamingLoopState {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StreamingLoopState.class);
+
+    enum TerminalState {
+        RUNNING,
+        CANCELLED_SILENTLY,
+        FAILED,
+        COMPLETED
+    }
+
+    private final Supplier<Boolean> cancellationSupplier;
+    private final Queue<Future<?>> pendingToolCalls = new ConcurrentLinkedQueue<>();
+    private final AtomicReference<TerminalState> state = new AtomicReference<>(TerminalState.RUNNING);
+    private final AtomicBoolean failureReported = new AtomicBoolean(false);
+
+    StreamingLoopState(Supplier<Boolean> cancellationSupplier) {
+        this.cancellationSupplier = cancellationSupplier;
+    }
+
+    boolean canContinue() {
+        pollExternalCancellation();
+        return state.get() == TerminalState.RUNNING;
+    }
+
+    boolean isTerminal() {
+        pollExternalCancellation();
+        return state.get() != TerminalState.RUNNING;
+    }
+
+    boolean isSilentlyCancelled() {
+        pollExternalCancellation();
+        return state.get() == TerminalState.CANCELLED_SILENTLY;
+    }
+
+    boolean isFailed() {
+        return state.get() == TerminalState.FAILED;
+    }
+
+    void registerToolCall(Future<?> future) {
+        pendingToolCalls.add(future);
+        if (isTerminal()) {
+            future.cancel(true);
+        }
+    }
+
+    void cancelSilently() {
+        if (state.compareAndSet(TerminalState.RUNNING, TerminalState.CANCELLED_SILENTLY)) {
+            cancelPendingToolCalls();
+        }
+    }
+
+    void fail(Throwable ignored) {
+        if (state.compareAndSet(TerminalState.RUNNING, TerminalState.FAILED)) {
+            cancelPendingToolCalls();
+        }
+    }
+
+    void complete() {
+        state.compareAndSet(TerminalState.RUNNING, TerminalState.COMPLETED);
+    }
+
+    boolean markFailureReported() {
+        return failureReported.compareAndSet(false, true);
+    }
+
+    private void pollExternalCancellation() {
+        if (state.get() != TerminalState.RUNNING || cancellationSupplier == null) {
+            return;
+        }
+        try {
+            if (Boolean.TRUE.equals(cancellationSupplier.get())) {
+                cancelSilently();
+            }
+        } catch (Throwable t) {
+            LOG.warn("Cancellation supplier threw; treating as not cancelled", t);
+        }
+    }
+
+    private void cancelPendingToolCalls() {
+        for (Future<?> future : pendingToolCalls) {
+            if (!future.isDone()) {
+                future.cancel(true);
+            }
+        }
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/StreamingLoopState.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/StreamingLoopState.java
@@ -61,10 +61,13 @@ final class StreamingLoopState {
         }
     }
 
-    void fail(Throwable ignored) {
+    boolean fail(Throwable ignored) {
+        pollExternalCancellation();
         if (state.compareAndSet(TerminalState.RUNNING, TerminalState.FAILED)) {
             cancelPendingToolCalls();
+            return true;
         }
+        return false;
     }
 
     void complete() {

--- a/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
@@ -151,6 +151,11 @@ public interface TokenStream {
 
     /**
      * The provided consumer will be invoked right before a tool is executed.
+     * <p>
+     * In streaming mode this callback is ordered after {@link #onIntermediateResponse(Consumer)}
+     * for the response that requested the tool. Since this callback can throw and veto the tool
+     * body, registering it disables eager tool execution before the intermediate response is
+     * delivered.
      *
      * @param beforeToolExecutionHandler lambda that consumes {@link BeforeToolExecution}
      * @return token stream instance used to configure or start stream processing
@@ -163,7 +168,9 @@ public interface TokenStream {
     /**
      * The provided consumer will be invoked right after a tool is executed.
      * <p>
-     * The invocation happens after the tool method has finished and before any other tool is executed.
+     * In streaming mode, when tools are executed eagerly before an intermediate response is
+     * delivered, this callback is still delivered after
+     * {@link #onIntermediateResponse(Consumer)} for the response that requested the tool.
      *
      * @param toolExecuteHandler lambda that consumes {@link ToolExecution}
      * @return token stream instance used to configure or start stream processing

--- a/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
@@ -16,6 +16,7 @@ import dev.langchain4j.service.tool.ToolExecution;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Represents a token stream from the model to which you can subscribe and receive updates
@@ -204,6 +205,22 @@ public interface TokenStream {
      * @return token stream instance used to configure or start stream processing
      */
     TokenStream ignoreErrors();
+
+    /**
+     * Registers a per-stream cancellation flag, polled at agent-loop checkpoints. When the supplier
+     * returns {@code true}, the loop cancels pending tool futures, writes placeholder tool-result
+     * messages for any in-flight tool requests (preserving the tool_use/tool_result memory
+     * invariant), and skips both the assistant-turn memory write and the follow-up chat call.
+     * Cancellation is silent: no consumer callback fires.
+     *
+     * @param cancellationSupplier supplier returning {@code true} to cancel
+     * @return this token stream
+     * @since 1.15.0-beta25
+     */
+    @Experimental
+    default TokenStream cancelOn(Supplier<Boolean> cancellationSupplier) {
+        throw new UnsupportedOperationException("not implemented");
+    }
 
     /**
      * Completes the current token stream building and starts processing.

--- a/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
@@ -168,9 +168,8 @@ public interface TokenStream {
     /**
      * The provided consumer will be invoked right after a tool is executed.
      * <p>
-     * In streaming mode, when tools are executed eagerly before an intermediate response is
-     * delivered, this callback is still delivered after
-     * {@link #onIntermediateResponse(Consumer)} for the response that requested the tool.
+     * In streaming mode, this callback is delivered after {@link #onIntermediateResponse(Consumer)}
+     * for the response that requested the tool.
      *
      * @param toolExecuteHandler lambda that consumes {@link ToolExecution}
      * @return token stream instance used to configure or start stream processing

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/StreamingToolDispatchHook.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/StreamingToolDispatchHook.java
@@ -1,0 +1,69 @@
+package dev.langchain4j.service.tool;
+
+import dev.langchain4j.Experimental;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+/**
+ * Integration SPI that lets framework integrators (e.g. {@code quarkus-langchain4j}) control how
+ * the streaming response handler dispatches its tool batch.
+ *
+ * <p>The streaming handler invokes {@link #dispatch(Supplier)} when it is ready to run the
+ * buffered batch of tool calls produced by the LLM. The default implementation simply runs the
+ * supplied work inline on the calling thread and returns a completed {@link CompletionStage}.
+ * Frameworks can override this to:
+ * <ul>
+ *   <li>Switch to a worker thread (e.g. Vert.x worker or virtual thread).</li>
+ *   <li>Propagate framework context (e.g. Vert.x duplicated context, MDC, security context).</li>
+ *   <li>Hook cancellation into framework cancellation.</li>
+ *   <li>Control which thread the next inference request and the emission of subsequent stream
+ *       events are scheduled on.</li>
+ * </ul>
+ *
+ * <p>The supplied {@link Supplier} performs the entire downstream side-effect chain:
+ * tool execution (potentially via the inner per-tool {@link java.util.concurrent.Executor}),
+ * memory writes, follow-up streaming inference request, and event emissions. The hook should
+ * therefore avoid blocking on the resulting {@link CompletionStage}, but must ensure that any
+ * thread-context required by downstream code is established before invoking the supplier.
+ *
+ * <p>The handler does not currently use the returned {@link CompletionStage} for back-pressure
+ * or chaining; it is returned for diagnostic and testing purposes.
+ *
+ * @since 1.15.0-beta25
+ */
+@Experimental
+@FunctionalInterface
+public interface StreamingToolDispatchHook {
+
+    /**
+     * Invokes {@code work} according to the framework's preferred scheduling/dispatch policy.
+     *
+     * <p>Implementations must call {@code work.get()} exactly once. Returning without invoking
+     * {@code work} will silently drop the tool batch.
+     *
+     * @param work the encapsulated downstream work; running it executes the tool batch and
+     *             schedules the follow-up streaming request.
+     * @return a {@link CompletionStage} that completes when the supplied work has finished
+     *         (or completes exceptionally if it throws). The default implementation runs the
+     *         supplier inline and returns an already-completed stage.
+     */
+    <T> CompletionStage<T> dispatch(Supplier<T> work);
+
+    /**
+     * No-op hook that runs the supplied work on the calling thread. This is the default used
+     * when no hook is configured.
+     */
+    StreamingToolDispatchHook INLINE = new StreamingToolDispatchHook() {
+        @Override
+        public <T> CompletionStage<T> dispatch(Supplier<T> work) {
+            try {
+                return CompletableFuture.completedFuture(work.get());
+            } catch (Throwable t) {
+                CompletableFuture<T> failed = new CompletableFuture<>();
+                failed.completeExceptionally(t);
+                return failed;
+            }
+        }
+    };
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/StreamingToolDispatchHook.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/StreamingToolDispatchHook.java
@@ -7,25 +7,32 @@ import java.util.function.Supplier;
 
 /**
  * Integration SPI that lets framework integrators (e.g. {@code quarkus-langchain4j}) control how
- * the streaming response handler dispatches its tool batch.
+ * the streaming response handler continues from a tool batch.
  *
- * <p>The streaming handler invokes {@link #dispatch(Supplier)} when it is ready to run the
- * buffered batch of tool calls produced by the LLM. The default implementation simply runs the
- * supplied work inline on the calling thread and returns a completed {@link CompletionStage}.
+ * <p>The streaming handler invokes {@link #dispatch(Supplier)} when it is ready to gather results
+ * and continue from the batch of tool calls produced by the LLM. The default implementation runs
+ * the supplied work inline on the calling thread and returns a completed {@link CompletionStage}.
  * Frameworks can override this to:
  * <ul>
- *   <li>Switch to a worker thread (e.g. Vert.x worker or virtual thread).</li>
- *   <li>Propagate framework context (e.g. Vert.x duplicated context, MDC, security context).</li>
- *   <li>Hook cancellation into framework cancellation.</li>
+ *   <li>Switch result gathering, memory writes, follow-up streaming inference, and inline
+ *       no-executor tool execution to a worker thread.</li>
+ *   <li>Propagate framework context (e.g. Vert.x duplicated context, MDC, security context)
+ *       through that downstream continuation.</li>
+ *   <li>Hook downstream cancellation into framework cancellation.</li>
  *   <li>Control which thread the next inference request and the emission of subsequent stream
  *       events are scheduled on.</li>
  * </ul>
  *
- * <p>The supplied {@link Supplier} performs the entire downstream side-effect chain:
- * tool execution (potentially via the inner per-tool {@link java.util.concurrent.Executor}),
- * memory writes, follow-up streaming inference request, and event emissions. The hook should
- * therefore avoid blocking on the resulting {@link CompletionStage}, but must ensure that any
- * thread-context required by downstream code is established before invoking the supplier.
+ * <p>The supplied {@link Supplier} performs the downstream side-effect chain: tool dispatch or
+ * result gathering, memory writes, follow-up streaming inference request, and event emissions.
+ * With the default unlimited {@code maxToolCallsPerResponse} setting, a configured per-tool
+ * {@link java.util.concurrent.Executor} causes streaming tools to be scheduled eagerly from
+ * {@code onCompleteToolCall} before this hook is invoked, so the hook cannot switch threads before
+ * those tool executions begin. When no per-tool executor is configured, or when
+ * {@code maxToolCallsPerResponse} is greater than {@code 0}, the supplier executes the deferred
+ * batch dispatch after {@code onCompleteResponse}. The hook should avoid blocking on the resulting
+ * {@link CompletionStage}, but must ensure that any thread-context required by downstream code is
+ * established before invoking the supplier.
  *
  * <p>The handler does not currently use the returned {@link CompletionStage} for back-pressure
  * or chaining; it is returned for diagnostic and testing purposes.
@@ -40,10 +47,14 @@ public interface StreamingToolDispatchHook {
      * Invokes {@code work} according to the framework's preferred scheduling/dispatch policy.
      *
      * <p>Implementations must call {@code work.get()} exactly once. Returning without invoking
-     * {@code work} will silently drop the tool batch.
+     * {@code work} will silently drop result gathering, memory writes, and follow-up inference.
+     * When dispatch is deferred, this also means the tool batch is not executed. In default
+     * unlimited mode with a per-tool executor, tools may already have been scheduled eagerly before
+     * this hook is invoked.
      *
-     * @param work the encapsulated downstream work; running it executes the tool batch and
-     *             schedules the follow-up streaming request.
+     * @param work the encapsulated downstream work; running it gathers tool results, writes memory,
+     *             and schedules the follow-up streaming request. When dispatch is deferred, it also
+     *             executes the tool batch.
      * @return a {@link CompletionStage} that completes when the supplied work has finished
      *         (or completes exceptionally if it throws). The default implementation runs the
      *         supplier inline and returns an already-completed stage.

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolBatchDispatcher.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolBatchDispatcher.java
@@ -1,0 +1,305 @@
+package dev.langchain4j.service.tool;
+
+import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ReturnBehavior;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Reusable primitive for dispatching a batch of {@link ToolExecutionRequest}s against the
+ * configured {@link ToolExecutor} map and returning their results in request order.
+ *
+ * <p>This primitive centralises the logic that was previously scattered between the sync
+ * {@code ToolService.execute(...)} loop and the streaming response handler:
+ * <ul>
+ *   <li>Atomic enforcement of {@code maxToolCallsPerResponse} <em>before</em> any tool runs.</li>
+ *   <li>Serial execution when no {@link Executor} is configured or only one tool is requested.</li>
+ *   <li>Concurrent execution via {@link CompletableFuture#supplyAsync(java.util.function.Supplier, Executor)}
+ *       when an executor is configured and there are multiple tools.</li>
+ *   <li>Ordered gather of results into a {@link LinkedHashMap} keyed by the original request.</li>
+ *   <li>Best-effort sibling cancellation when a sibling future fails.</li>
+ *   <li>Routing of tool execution exceptions through the configured argument and execution
+ *       error handlers, with a caller-supplied bypass {@link Predicate} that lets specific
+ *       exception types propagate unchanged.</li>
+ *   <li>Invocation of optional {@code beforeToolExecution} and {@code afterToolExecution}
+ *       callbacks around each tool dispatch.</li>
+ * </ul>
+ *
+ * <p>This class is intended for internal reuse by {@link ToolService} and the streaming
+ * response handler. It is not part of the public API.
+ *
+ * @since 1.15.0-beta25
+ */
+@Internal
+public final class ToolBatchDispatcher {
+
+    private ToolBatchDispatcher() {}
+
+    /**
+     * Configuration for a single batch dispatch.
+     */
+    @Internal
+    public static final class Request {
+
+        private final List<ToolExecutionRequest> toolRequests;
+        private final Map<String, ToolExecutor> toolExecutors;
+        private final Executor executor;
+        private final InvocationContext invocationContext;
+        private final Consumer<BeforeToolExecution> beforeToolExecution;
+        private final Consumer<ToolExecution> afterToolExecution;
+        private final Predicate<Throwable> errorHandlerBypass;
+        private final ToolArgumentsErrorHandler argumentsErrorHandler;
+        private final ToolExecutionErrorHandler executionErrorHandler;
+        private final int maxToolCallsPerResponse;
+        private final Function<ToolExecutionRequest, ToolExecutionResultMessage> hallucinationStrategy;
+
+        private Request(Builder b) {
+            this.toolRequests = b.toolRequests == null ? List.of() : List.copyOf(b.toolRequests);
+            this.toolExecutors = b.toolExecutors == null ? Map.of() : b.toolExecutors;
+            this.executor = b.executor;
+            this.invocationContext = b.invocationContext;
+            this.beforeToolExecution = b.beforeToolExecution;
+            this.afterToolExecution = b.afterToolExecution;
+            this.errorHandlerBypass = b.errorHandlerBypass == null ? e -> false : b.errorHandlerBypass;
+            this.argumentsErrorHandler = b.argumentsErrorHandler;
+            this.executionErrorHandler = b.executionErrorHandler;
+            this.maxToolCallsPerResponse = b.maxToolCallsPerResponse;
+            this.hallucinationStrategy = b.hallucinationStrategy;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static final class Builder {
+            private List<ToolExecutionRequest> toolRequests;
+            private Map<String, ToolExecutor> toolExecutors;
+            private Executor executor;
+            private InvocationContext invocationContext;
+            private Consumer<BeforeToolExecution> beforeToolExecution;
+            private Consumer<ToolExecution> afterToolExecution;
+            private Predicate<Throwable> errorHandlerBypass;
+            private ToolArgumentsErrorHandler argumentsErrorHandler;
+            private ToolExecutionErrorHandler executionErrorHandler;
+            private int maxToolCallsPerResponse = 0;
+            private Function<ToolExecutionRequest, ToolExecutionResultMessage> hallucinationStrategy;
+
+            private Builder() {}
+
+            public Builder toolRequests(List<ToolExecutionRequest> toolRequests) {
+                this.toolRequests = toolRequests;
+                return this;
+            }
+
+            public Builder toolExecutors(Map<String, ToolExecutor> toolExecutors) {
+                this.toolExecutors = toolExecutors;
+                return this;
+            }
+
+            public Builder executor(Executor executor) {
+                this.executor = executor;
+                return this;
+            }
+
+            public Builder invocationContext(InvocationContext invocationContext) {
+                this.invocationContext = invocationContext;
+                return this;
+            }
+
+            public Builder beforeToolExecution(Consumer<BeforeToolExecution> beforeToolExecution) {
+                this.beforeToolExecution = beforeToolExecution;
+                return this;
+            }
+
+            public Builder afterToolExecution(Consumer<ToolExecution> afterToolExecution) {
+                this.afterToolExecution = afterToolExecution;
+                return this;
+            }
+
+            public Builder errorHandlerBypass(Predicate<Throwable> errorHandlerBypass) {
+                this.errorHandlerBypass = errorHandlerBypass;
+                return this;
+            }
+
+            public Builder argumentsErrorHandler(ToolArgumentsErrorHandler argumentsErrorHandler) {
+                this.argumentsErrorHandler = argumentsErrorHandler;
+                return this;
+            }
+
+            public Builder executionErrorHandler(ToolExecutionErrorHandler executionErrorHandler) {
+                this.executionErrorHandler = executionErrorHandler;
+                return this;
+            }
+
+            public Builder maxToolCallsPerResponse(int maxToolCallsPerResponse) {
+                this.maxToolCallsPerResponse = maxToolCallsPerResponse;
+                return this;
+            }
+
+            public Builder hallucinationStrategy(Function<ToolExecutionRequest, ToolExecutionResultMessage> strategy) {
+                this.hallucinationStrategy = strategy;
+                return this;
+            }
+
+            public Request build() {
+                return new Request(this);
+            }
+        }
+    }
+
+    /**
+     * Dispatches the configured batch of tool calls.
+     *
+     * <p>If {@link Request#maxToolCallsPerResponse} is {@code > 0} and the batch contains more than
+     * that many requests, a {@link ToolCallsLimitExceededException} is thrown <em>before</em> any
+     * tool is executed.
+     *
+     * <p>If {@link Request#executor} is non-{@code null} and the batch contains more than one
+     * request, tools are dispatched concurrently using the supplied executor. Otherwise tools are
+     * executed sequentially on the calling thread.
+     *
+     * <p>The returned map preserves the order of the original {@code toolRequests} list.
+     *
+     * @return a map of {@link ToolExecutionRequest} to its {@link ToolExecutionResult}, keyed by
+     *         the original request and ordered consistently with the input list.
+     * @throws ToolCallsLimitExceededException if the cap is configured and exceeded
+     */
+    public static Map<ToolExecutionRequest, ToolExecutionResult> dispatch(Request request) {
+        // Atomic cap check. No tool from this batch must run if the cap is exceeded.
+        if (request.maxToolCallsPerResponse > 0
+                && request.toolRequests.size() > request.maxToolCallsPerResponse) {
+            throw new ToolCallsLimitExceededException(
+                    request.maxToolCallsPerResponse, request.toolRequests.size());
+        }
+
+        if (request.toolRequests.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        // Serial path: no executor or only one tool.
+        if (request.executor == null || request.toolRequests.size() == 1) {
+            return executeSerially(request);
+        }
+
+        return executeConcurrently(request);
+    }
+
+    private static Map<ToolExecutionRequest, ToolExecutionResult> executeSerially(Request request) {
+        Map<ToolExecutionRequest, ToolExecutionResult> results = new LinkedHashMap<>();
+        for (ToolExecutionRequest toolRequest : request.toolRequests) {
+            results.put(toolRequest, executeOne(request, toolRequest));
+        }
+        return results;
+    }
+
+    private static Map<ToolExecutionRequest, ToolExecutionResult> executeConcurrently(Request request) {
+        Map<ToolExecutionRequest, CompletableFuture<ToolExecutionResult>> futures = new LinkedHashMap<>();
+        List<CompletableFuture<ToolExecutionResult>> futureList = new ArrayList<>();
+
+        for (ToolExecutionRequest toolRequest : request.toolRequests) {
+            CompletableFuture<ToolExecutionResult> future = CompletableFuture.supplyAsync(
+                    () -> executeOne(request, toolRequest), request.executor);
+            futures.put(toolRequest, future);
+            futureList.add(future);
+        }
+
+        Map<ToolExecutionRequest, ToolExecutionResult> results = new LinkedHashMap<>();
+        for (Map.Entry<ToolExecutionRequest, CompletableFuture<ToolExecutionResult>> entry : futures.entrySet()) {
+            try {
+                results.put(entry.getKey(), entry.getValue().get());
+            } catch (ExecutionException e) {
+                cancelSiblings(futureList, entry.getValue());
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException re) {
+                    throw re;
+                } else if (cause instanceof Error err) {
+                    throw err;
+                } else {
+                    throw new RuntimeException(cause);
+                }
+            } catch (InterruptedException e) {
+                cancelSiblings(futureList, entry.getValue());
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+        return results;
+    }
+
+    private static void cancelSiblings(
+            List<CompletableFuture<ToolExecutionResult>> all,
+            CompletableFuture<ToolExecutionResult> failed) {
+        for (CompletableFuture<ToolExecutionResult> future : all) {
+            if (future != failed && !future.isDone()) {
+                future.cancel(true);
+            }
+        }
+    }
+
+    private static ToolExecutionResult executeOne(Request request, ToolExecutionRequest toolRequest) {
+        if (request.beforeToolExecution != null) {
+            request.beforeToolExecution.accept(BeforeToolExecution.builder()
+                    .request(toolRequest)
+                    .invocationContext(request.invocationContext)
+                    .build());
+        }
+
+        LocalDateTime startTime = LocalDateTime.now();
+
+        ToolExecutor toolExecutor = request.toolExecutors.get(toolRequest.name());
+        ToolExecutionResult toolResult;
+        if (toolExecutor == null) {
+            toolResult = applyHallucinationStrategy(request, toolRequest);
+        } else {
+            toolResult = ToolService.executeWithErrorHandling(
+                    toolRequest,
+                    toolExecutor,
+                    request.invocationContext,
+                    request.argumentsErrorHandler,
+                    request.executionErrorHandler,
+                    request.errorHandlerBypass);
+        }
+
+        if (request.afterToolExecution != null) {
+            request.afterToolExecution.accept(ToolExecution.builder()
+                    .request(toolRequest)
+                    .result(toolResult)
+                    .startTime(startTime)
+                    .finishTime(LocalDateTime.now())
+                    .invocationContext(request.invocationContext)
+                    .build());
+        }
+        return toolResult;
+    }
+
+    private static ToolExecutionResult applyHallucinationStrategy(Request request, ToolExecutionRequest toolRequest) {
+        Function<ToolExecutionRequest, ToolExecutionResultMessage> strategy =
+                request.hallucinationStrategy != null
+                        ? request.hallucinationStrategy
+                        : HallucinatedToolNameStrategy.THROW_EXCEPTION;
+        ToolExecutionResultMessage message = strategy.apply(toolRequest);
+        return ToolExecutionResult.builder().resultText(message.text()).build();
+    }
+
+    /**
+     * Convenience helper used by callers that don't need to participate in the full
+     * {@link Request} configuration. Computes whether the loop should return immediately based on
+     * the resulting batch's {@link ReturnBehavior}s.
+     */
+    public static boolean shouldReturnImmediately(boolean anyToolErrored, List<ReturnBehavior> returnBehaviors) {
+        return ToolService.shouldReturnImmediately(anyToolErrored, returnBehaviors);
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolBatchDispatcher.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolBatchDispatcher.java
@@ -26,9 +26,11 @@ import java.util.function.Predicate;
  * {@code ToolService.execute(...)} loop and the streaming response handler:
  * <ul>
  *   <li>Atomic enforcement of {@code maxToolCallsPerResponse} <em>before</em> any tool runs.</li>
- *   <li>Serial execution when no {@link Executor} is configured or only one tool is requested.</li>
+ *   <li>Serial execution when no {@link Executor} is configured, or only one tool is requested
+ *       and the caller has not opted into executor dispatch for single-tool batches.</li>
  *   <li>Concurrent execution via {@link CompletableFuture#supplyAsync(java.util.function.Supplier, Executor)}
- *       when an executor is configured and there are multiple tools.</li>
+ *       when an executor is configured and there are multiple tools, or when the caller explicitly
+ *       opts into executor dispatch for a single-tool batch.</li>
  *   <li>Ordered gather of results into a {@link LinkedHashMap} keyed by the original request.</li>
  *   <li>Best-effort sibling cancellation when a sibling future fails.</li>
  *   <li>Routing of tool execution exceptions through the configured argument and execution
@@ -64,6 +66,7 @@ public final class ToolBatchDispatcher {
         private final ToolArgumentsErrorHandler argumentsErrorHandler;
         private final ToolExecutionErrorHandler executionErrorHandler;
         private final int maxToolCallsPerResponse;
+        private final boolean useExecutorForSingleTool;
         private final Function<ToolExecutionRequest, ToolExecutionResultMessage> hallucinationStrategy;
 
         private Request(Builder b) {
@@ -77,6 +80,7 @@ public final class ToolBatchDispatcher {
             this.argumentsErrorHandler = b.argumentsErrorHandler;
             this.executionErrorHandler = b.executionErrorHandler;
             this.maxToolCallsPerResponse = b.maxToolCallsPerResponse;
+            this.useExecutorForSingleTool = b.useExecutorForSingleTool;
             this.hallucinationStrategy = b.hallucinationStrategy;
         }
 
@@ -95,6 +99,7 @@ public final class ToolBatchDispatcher {
             private ToolArgumentsErrorHandler argumentsErrorHandler;
             private ToolExecutionErrorHandler executionErrorHandler;
             private int maxToolCallsPerResponse = 0;
+            private boolean useExecutorForSingleTool = false;
             private Function<ToolExecutionRequest, ToolExecutionResultMessage> hallucinationStrategy;
 
             private Builder() {}
@@ -149,6 +154,11 @@ public final class ToolBatchDispatcher {
                 return this;
             }
 
+            public Builder useExecutorForSingleTool(boolean useExecutorForSingleTool) {
+                this.useExecutorForSingleTool = useExecutorForSingleTool;
+                return this;
+            }
+
             public Builder hallucinationStrategy(Function<ToolExecutionRequest, ToolExecutionResultMessage> strategy) {
                 this.hallucinationStrategy = strategy;
                 return this;
@@ -168,8 +178,9 @@ public final class ToolBatchDispatcher {
      * tool is executed.
      *
      * <p>If {@link Request#executor} is non-{@code null} and the batch contains more than one
-     * request, tools are dispatched concurrently using the supplied executor. Otherwise tools are
-     * executed sequentially on the calling thread.
+     * request, tools are dispatched concurrently using the supplied executor. Single-tool batches
+     * use the executor only when {@link Request#useExecutorForSingleTool} is {@code true}.
+     * Otherwise tools are executed sequentially on the calling thread.
      *
      * <p>The returned map preserves the order of the original {@code toolRequests} list.
      *
@@ -189,8 +200,9 @@ public final class ToolBatchDispatcher {
             return Collections.emptyMap();
         }
 
-        // Serial path: no executor or only one tool.
-        if (request.executor == null || request.toolRequests.size() == 1) {
+        // Serial path: no executor, or a single tool whose caller did not opt into executor dispatch.
+        if (request.executor == null
+                || (request.toolRequests.size() == 1 && !request.useExecutorForSingleTool)) {
             return executeSerially(request);
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolCallsLimitExceededException.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolCallsLimitExceededException.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.service.tool;
+
+/**
+ * Thrown when an LLM response contains more tool execution requests than the configured
+ * {@code maxToolCallsPerResponse} limit allows.
+ *
+ * <p>
+ * This is intended for cooperative truncation when an LLM returns more tool calls in a
+ * single response than the user wants to spend (for example, to bound execution cost or latency).
+ *
+ * @see dev.langchain4j.service.AiServices#maxToolCallsPerResponse(int)
+ * @since 1.14.0
+ */
+public class ToolCallsLimitExceededException extends RuntimeException {
+
+    private final int limit;
+    private final int attempted;
+
+    public ToolCallsLimitExceededException(int limit, int attempted) {
+        super(String.format(
+                "Exceeded maximum tool calls per response: %d (attempted: %d)",
+                limit, attempted));
+        this.limit = limit;
+        this.attempted = attempted;
+    }
+
+    /**
+     * @return the configured maximum number of tool calls per response
+     */
+    public int getLimit() {
+        return limit;
+    }
+
+    /**
+     * @return the number of tool calls present in the offending LLM response
+     */
+    public int getAttempted() {
+        return attempted;
+    }
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -429,7 +429,38 @@ public class ToolService {
     public ToolServiceContext createContext(InvocationContext invocationContext,
                                             UserMessage userMessage,
                                             List<ChatMessage> messages) {
-        ToolServiceContext context = createContextFromStaticToolsAndProviders(invocationContext, userMessage, messages);
+        return createContext(invocationContext, userMessage, messages, null);
+    }
+
+    /**
+     * Variant of {@link #createContext(InvocationContext, UserMessage, List)} that merges a
+     * caller-supplied set of <i>base tools</i> with this service's configured static tools and
+     * applies the same provider/refresh pipeline (static {@link ToolProvider}s, optional
+     * {@link ToolSearchService}, and dynamic provider refresh) on top of that merged set.
+     *
+     * <p>This overload is intended for downstream framework integrators (e.g. {@code quarkus-langchain4j})
+     * that resolve additional method-scoped tools per AI service method invocation (for example, via a
+     * {@code @ToolBox}-style annotation) and need them to participate in the same provider semantics
+     * as the AI-service-level tools — including dynamic provider invocation on the first request.
+     *
+     * <p>The {@code baseTools} are added to the {@code effectiveTools} / {@code availableTools} /
+     * {@code toolExecutors} / {@code returnBehaviors} of the returned context BEFORE static and dynamic
+     * providers contribute their tools, so providers may add to the merged set but not replace base
+     * tools. Tool-name collisions are resolved using the same precedence as
+     * {@link #tools(List)}: a duplicate tool name from a provider throws
+     * {@link IllegalConfigurationException}.
+     *
+     * @param baseTools method-scoped tools to merge into the resolved context. May be {@code null}
+     *                  or empty, in which case this overload behaves identically to
+     *                  {@link #createContext(InvocationContext, UserMessage, List)}.
+     * @since 1.15.0-beta25
+     */
+    public ToolServiceContext createContext(InvocationContext invocationContext,
+                                            UserMessage userMessage,
+                                            List<ChatMessage> messages,
+                                            List<AiServiceTool> baseTools) {
+        ToolServiceContext context = createContextFromStaticToolsAndProviders(
+                invocationContext, userMessage, messages, baseTools);
         if (toolSearchService != null) {
             context = toolSearchService.adjust(context, messages, invocationContext);
         }
@@ -439,17 +470,33 @@ public class ToolService {
 
     private ToolServiceContext createContextFromStaticToolsAndProviders(InvocationContext invocationContext,
                                                                         UserMessage userMessage,
-                                                                        List<ChatMessage> messages) {
+                                                                        List<ChatMessage> messages,
+                                                                        List<AiServiceTool> baseTools) {
+        boolean hasBaseTools = baseTools != null && !baseTools.isEmpty();
+
         if (this.toolProviders.isEmpty()) {
-            if (this.toolSpecifications.isEmpty()) {
+            if (this.toolSpecifications.isEmpty() && !hasBaseTools) {
                 return ToolServiceContext.Empty.INSTANCE;
             }
 
+            if (!hasBaseTools) {
+                return ToolServiceContext.builder()
+                        .effectiveTools(this.toolSpecifications)
+                        .availableTools(this.toolSpecifications)
+                        .toolExecutors(this.toolExecutors)
+                        .returnBehaviors(this.returnBehaviors)
+                        .build();
+            }
+
+            List<ToolSpecification> mergedSpecs = new ArrayList<>(this.toolSpecifications);
+            Map<String, ToolExecutor> mergedExecutors = new HashMap<>(this.toolExecutors);
+            Map<String, ReturnBehavior> mergedReturnBehaviors = new HashMap<>(this.returnBehaviors);
+            addTools(baseTools, mergedExecutors, mergedSpecs, mergedReturnBehaviors);
             return ToolServiceContext.builder()
-                    .effectiveTools(this.toolSpecifications)
-                    .availableTools(this.toolSpecifications)
-                    .toolExecutors(this.toolExecutors)
-                    .returnBehaviors(this.returnBehaviors)
+                    .effectiveTools(mergedSpecs)
+                    .availableTools(mergedSpecs)
+                    .toolExecutors(mergedExecutors)
+                    .returnBehaviors(mergedReturnBehaviors)
                     .build();
         }
 
@@ -457,6 +504,10 @@ public class ToolService {
         Map<String, ToolExecutor> toolExecutors = new HashMap<>(this.toolExecutors);
         Map<String, ReturnBehavior> returnBehaviors = new HashMap<>(this.returnBehaviors);
         List<ToolProvider> dynamicToolProviders = new ArrayList<>();
+
+        if (hasBaseTools) {
+            addTools(baseTools, toolExecutors, toolSpecifications, returnBehaviors);
+        }
 
         ToolProviderRequest toolProviderRequest = toolProviderRequestFactory.apply(ToolProviderRequest.builder()
                 .invocationContext(invocationContext)

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -45,14 +45,11 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
 import java.util.function.Consumer;
@@ -274,10 +271,31 @@ public class ToolService {
     }
 
     /**
+     * @since 1.15.0-beta25
+     */
+    public Consumer<BeforeToolExecution> beforeToolExecution() {
+        return beforeToolExecution;
+    }
+
+    /**
      * @since 1.11.0
      */
     public void afterToolExecution(Consumer<ToolExecution> afterToolExecution) {
         this.afterToolExecution = afterToolExecution;
+    }
+
+    /**
+     * @since 1.15.0-beta25
+     */
+    public Consumer<ToolExecution> afterToolExecution() {
+        return afterToolExecution;
+    }
+
+    /**
+     * @since 1.15.0-beta25
+     */
+    public Function<ToolExecutionRequest, ToolExecutionResultMessage> hallucinatedToolNameStrategy() {
+        return toolHallucinationStrategy;
     }
 
     /**
@@ -795,54 +813,21 @@ public class ToolService {
             List<ToolExecutionRequest> toolRequests,
             Map<String, ToolExecutor> toolExecutors,
             InvocationContext invocationContext) {
-        if (executor != null && toolRequests.size() > 1) {
-            return executeConcurrently(toolRequests, toolExecutors, invocationContext);
-        } else {
-            // when there is only one tool to execute, it doesn't make sense to do it in a separate thread
-            return executeSequentially(toolRequests, toolExecutors, invocationContext);
-        }
-    }
-
-    private Map<ToolExecutionRequest, ToolExecutionResult> executeConcurrently(
-            List<ToolExecutionRequest> toolRequests,
-            Map<String, ToolExecutor> toolExecutors,
-            InvocationContext invocationContext) {
-        Map<ToolExecutionRequest, CompletableFuture<ToolExecutionResult>> futures = new LinkedHashMap<>();
-
-        for (ToolExecutionRequest toolRequest : toolRequests) {
-            CompletableFuture<ToolExecutionResult> future = CompletableFuture.supplyAsync(
-                    () -> executeTool(invocationContext, toolExecutors, toolRequest), executor);
-            futures.put(toolRequest, future);
-        }
-
-        Map<ToolExecutionRequest, ToolExecutionResult> results = new LinkedHashMap<>();
-        for (Map.Entry<ToolExecutionRequest, CompletableFuture<ToolExecutionResult>> entry : futures.entrySet()) {
-            try {
-                results.put(entry.getKey(), entry.getValue().get());
-            } catch (ExecutionException e) {
-                if (e.getCause() instanceof RuntimeException re) {
-                    throw re;
-                } else {
-                    throw new RuntimeException(e.getCause());
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            }
-        }
-
-        return results;
-    }
-
-    private Map<ToolExecutionRequest, ToolExecutionResult> executeSequentially(
-            List<ToolExecutionRequest> toolRequests,
-            Map<String, ToolExecutor> toolExecutors,
-            InvocationContext invocationContext) {
-        Map<ToolExecutionRequest, ToolExecutionResult> toolResults = new LinkedHashMap<>();
-        for (ToolExecutionRequest toolRequest : toolRequests) {
-            toolResults.put(toolRequest, executeTool(invocationContext, toolExecutors, toolRequest));
-        }
-        return toolResults;
+        return ToolBatchDispatcher.dispatch(ToolBatchDispatcher.Request.builder()
+                .toolRequests(toolRequests)
+                .toolExecutors(toolExecutors)
+                .executor(executor)
+                .invocationContext(invocationContext)
+                .beforeToolExecution(beforeToolExecution)
+                .afterToolExecution(afterToolExecution)
+                .errorHandlerBypass(errorHandlerBypass)
+                .argumentsErrorHandler(argumentsErrorHandler())
+                .executionErrorHandler(executionErrorHandler())
+                .hallucinationStrategy(toolHallucinationStrategy)
+                // The cap is enforced at the loop level (see executeInferenceAndToolsLoop)
+                // so we do not configure it here; passing 0 keeps the dispatcher's check inert.
+                .maxToolCallsPerResponse(0)
+                .build());
     }
 
     private ToolExecutionResult executeTool(

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -24,8 +24,10 @@ import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.observability.api.AiServiceListenerRegistrar;
@@ -55,6 +57,7 @@ import java.util.concurrent.Executor;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 @Internal
 public class ToolService {
@@ -87,6 +90,11 @@ public class ToolService {
 
     private Consumer<BeforeToolExecution> beforeToolExecution = null;
     private Consumer<ToolExecution> afterToolExecution = null;
+
+    private boolean forceToolChoiceAutoAfterFirstIteration = false;
+    private Predicate<Throwable> errorHandlerBypass = e -> false;
+    private Function<ToolProviderRequest.Builder, ToolProviderRequest> toolProviderRequestFactory =
+            ToolProviderRequest.Builder::build;
 
     public void hallucinatedToolNameStrategy(
             Function<ToolExecutionRequest, ToolExecutionResultMessage> toolHallucinationStrategy) {
@@ -301,6 +309,99 @@ public class ToolService {
     }
 
     /**
+     * Controls whether {@link ToolChoice#REQUIRED} is automatically rewritten to {@link ToolChoice#AUTO}
+     * after the first iteration of {@link #executeInferenceAndToolsLoop}.
+     *
+     * <p>When the LLM↔tools loop reuses the original {@link ChatRequestParameters} on follow-up
+     * iterations, a caller-supplied {@link ToolChoice#REQUIRED} would force the model to keep
+     * calling tools forever. This flag is intended for downstream framework integrators
+     * (e.g. {@code quarkus-langchain4j}) that want to set {@code REQUIRED} once on the very
+     * first request but allow the model to terminate the loop on subsequent iterations.
+     *
+     * <p>Default is {@code false}, which preserves the original behavior of forwarding the
+     * caller-supplied {@link ToolChoice} on every iteration.
+     *
+     * @param forceToolChoiceAutoAfterFirstIteration if {@code true}, the loop rewrites
+     *                                               {@link ToolChoice#REQUIRED} to {@link ToolChoice#AUTO}
+     *                                               on every iteration after the first.
+     * @since 1.14.0
+     */
+    public void forceToolChoiceAutoAfterFirstIteration(boolean forceToolChoiceAutoAfterFirstIteration) {
+        this.forceToolChoiceAutoAfterFirstIteration = forceToolChoiceAutoAfterFirstIteration;
+    }
+
+    /**
+     * @return whether {@link ToolChoice#REQUIRED} is rewritten to {@link ToolChoice#AUTO}
+     *         after the first iteration of the inference loop.
+     * @since 1.14.0
+     */
+    public boolean forceToolChoiceAutoAfterFirstIteration() {
+        return forceToolChoiceAutoAfterFirstIteration;
+    }
+
+    /**
+     * Configures a predicate that, when it evaluates to {@code true} for a tool execution
+     * exception, causes the exception to propagate unchanged instead of being routed
+     * through the configured {@link ToolExecutionErrorHandler}.
+     *
+     * <p>This hook is intended for downstream framework integrators that need to let
+     * specific marker-typed exceptions (e.g. authorization or guardrail violations)
+     * surface to the caller verbatim rather than be summarized into a string sent back
+     * to the LLM.
+     *
+     * <p>The default predicate returns {@code false} for all throwables, which preserves
+     * the original behavior of routing every exception through the error handler.
+     *
+     * @param errorHandlerBypass a predicate; when {@code true} the exception is rethrown
+     *                           unchanged. Must not be {@code null}.
+     * @since 1.14.0
+     */
+    public void errorHandlerBypass(Predicate<Throwable> errorHandlerBypass) {
+        this.errorHandlerBypass = errorHandlerBypass == null ? e -> false : errorHandlerBypass;
+    }
+
+    /**
+     * @return the predicate that controls whether a tool execution exception bypasses
+     *         the error handler. The default predicate returns {@code false} for all throwables.
+     * @since 1.14.0
+     */
+    public Predicate<Throwable> errorHandlerBypass() {
+        return errorHandlerBypass;
+    }
+
+    /**
+     * Configures a factory used to build the {@link ToolProviderRequest} passed to
+     * {@link ToolProvider}s, both during initial context creation and dynamic refresh.
+     *
+     * <p>This hook is intended for downstream framework integrators that need to attach
+     * additional context to the {@link ToolProviderRequest}, typically by returning a
+     * subclass enriched with framework-specific attributes. Tool providers can then
+     * downcast the request to access those attributes.
+     *
+     * <p>The default factory invokes {@link ToolProviderRequest.Builder#build()},
+     * which preserves the original behavior of constructing a plain {@link ToolProviderRequest}.
+     *
+     * @param toolProviderRequestFactory a factory that consumes a fully populated
+     *                                   {@link ToolProviderRequest.Builder} and returns the
+     *                                   {@link ToolProviderRequest} to pass to tool providers.
+     *                                   Must not be {@code null}.
+     * @since 1.14.0
+     */
+    public void toolProviderRequestFactory(
+            Function<ToolProviderRequest.Builder, ToolProviderRequest> toolProviderRequestFactory) {
+        this.toolProviderRequestFactory =
+                toolProviderRequestFactory == null ? ToolProviderRequest.Builder::build : toolProviderRequestFactory;
+    }
+
+    /**
+     * @return the factory used to build the {@link ToolProviderRequest} passed to tool providers.
+     * @since 1.14.0
+     */
+    public Function<ToolProviderRequest.Builder, ToolProviderRequest> toolProviderRequestFactory() {
+        return toolProviderRequestFactory;
+    }
+
+    /**
      * @since 1.12.0
      */
     public void toolSearchStrategy(ToolSearchStrategy toolSearchStrategy) {
@@ -314,7 +415,7 @@ public class ToolService {
         if (toolSearchService != null) {
             context = toolSearchService.adjust(context, messages, invocationContext);
         }
-        context = refreshDynamicProviders(context, messages, invocationContext);
+        context = refreshDynamicProvidersWithFactory(context, messages, invocationContext);
         return context;
     }
 
@@ -339,11 +440,10 @@ public class ToolService {
         Map<String, ReturnBehavior> returnBehaviors = new HashMap<>(this.returnBehaviors);
         List<ToolProvider> dynamicToolProviders = new ArrayList<>();
 
-        ToolProviderRequest toolProviderRequest = ToolProviderRequest.builder()
+        ToolProviderRequest toolProviderRequest = toolProviderRequestFactory.apply(ToolProviderRequest.builder()
                 .invocationContext(invocationContext)
                 .userMessage(userMessage)
-                .messages(messages)
-                .build();
+                .messages(messages));
         toolProviders.forEach(toolProvider -> {
             if (toolProvider.isDynamic()) {
                 dynamicToolProviders.add(toolProvider);
@@ -387,6 +487,48 @@ public class ToolService {
             InvocationContext invocationContext,
             ToolServiceContext toolServiceContext,
             boolean isReturnTypeResult) {
+        return executeInferenceAndToolsLoop(
+                context,
+                context == null ? null : context.chatModel,
+                memoryId,
+                chatResponse,
+                parameters,
+                messages,
+                chatMemory,
+                invocationContext,
+                toolServiceContext,
+                isReturnTypeResult);
+    }
+
+    /**
+     * Variant of {@link #executeInferenceAndToolsLoop(AiServiceContext, Object, ChatResponse,
+     * ChatRequestParameters, List, ChatMemory, InvocationContext, ToolServiceContext, boolean)}
+     * that uses an explicit {@link ChatModel} for follow-up inference requests inside the loop,
+     * instead of {@code context.chatModel}.
+     *
+     * <p>This overload is intended for downstream framework integrators (e.g. {@code quarkus-langchain4j})
+     * that select the {@link ChatModel} per AI service method via mechanisms such as a
+     * {@code @ModelName} qualifier resolved against the method's arguments. The chat model
+     * supplied here is used for every iteration after the initial response that the caller
+     * already passed in via {@code chatResponse}.
+     *
+     * @param chatModel the {@link ChatModel} to use for follow-up inference requests inside
+     *                  the loop. If {@code null}, falls back to {@code context.chatModel}.
+     * @since 1.14.0
+     */
+    public ToolServiceResult executeInferenceAndToolsLoop(
+            AiServiceContext context,
+            ChatModel chatModel,
+            Object memoryId,
+            ChatResponse chatResponse,
+            ChatRequestParameters parameters,
+            List<ChatMessage> messages,
+            ChatMemory chatMemory,
+            InvocationContext invocationContext,
+            ToolServiceContext toolServiceContext,
+            boolean isReturnTypeResult) {
+        ChatModel effectiveChatModel = chatModel != null ? chatModel : context.chatModel;
+
         TokenUsage aggregateTokenUsage = chatResponse.metadata().tokenUsage();
         List<ToolExecution> toolExecutions = new ArrayList<>();
         List<ChatResponse> intermediateResponses = new ArrayList<>();
@@ -471,13 +613,27 @@ public class ToolService {
                 }
             }
 
-            toolServiceContext = refreshDynamicProviders(toolServiceContext, messages, invocationContext);
+            toolServiceContext = refreshDynamicProvidersWithFactory(toolServiceContext, messages, invocationContext);
             if (toolSearchService != null) {
                 toolServiceContext = ToolSearchService.addFoundTools(toolServiceContext, toolResults.values());
             }
-            parameters = parameters.overrideWith(ChatRequestParameters.builder()
-                    .toolSpecifications(toolServiceContext.effectiveTools())
-                    .build());
+
+            // Hook 2: opt-in self-protection against infinite loops when the caller set
+            // ToolChoice.REQUIRED. Iteration 0 has just completed (we are about to send
+            // iteration 1), so from this point on the original REQUIRED is rewritten to AUTO
+            // to let the LLM terminate the loop.
+            ChatRequestParameters override;
+            if (forceToolChoiceAutoAfterFirstIteration && parameters.toolChoice() == ToolChoice.REQUIRED) {
+                override = ChatRequestParameters.builder()
+                        .toolSpecifications(toolServiceContext.effectiveTools())
+                        .toolChoice(ToolChoice.AUTO)
+                        .build();
+            } else {
+                override = ChatRequestParameters.builder()
+                        .toolSpecifications(toolServiceContext.effectiveTools())
+                        .build();
+            }
+            parameters = parameters.overrideWith(override);
 
             ChatRequest chatRequest = context.chatRequestTransformer.apply(
                     ChatRequest.builder()
@@ -487,7 +643,7 @@ public class ToolService {
                     memoryId);
 
             fireRequestIssuedEvent(chatRequest, invocationContext, context.eventListenerRegistrar);
-            chatResponse = context.chatModel.chat(chatRequest);
+            chatResponse = effectiveChatModel.chat(chatRequest);
             fireResponseReceivedEvent(chatRequest, chatResponse, invocationContext, context.eventListenerRegistrar);
             aggregateTokenUsage =
                     TokenUsage.sum(aggregateTokenUsage, chatResponse.metadata().tokenUsage());
@@ -519,11 +675,39 @@ public class ToolService {
      * Tools returned by dynamic providers are only added, never removed: once a tool
      * is present in the context, it stays for the remainder of the AI service invocation.
      *
+     * <p>This static variant uses a default {@link ToolProviderRequest.Builder#build()} factory.
+     * Frameworks that need to inject a custom {@link ToolProviderRequest} subclass should use
+     * {@link #refreshDynamicProvidersWithFactory(ToolServiceContext, List, InvocationContext)} on a
+     * configured {@link ToolService} instance instead.
+     *
      * @since 1.13.0
      */
     public static ToolServiceContext refreshDynamicProviders(ToolServiceContext toolServiceContext,
                                                              List<ChatMessage> messages,
                                                              InvocationContext invocationContext) {
+        return doRefreshDynamicProviders(
+                toolServiceContext, messages, invocationContext, ToolProviderRequest.Builder::build);
+    }
+
+    /**
+     * Instance variant of {@link #refreshDynamicProviders(ToolServiceContext, List, InvocationContext)}
+     * that uses the {@link #toolProviderRequestFactory()} configured on this service to build the
+     * {@link ToolProviderRequest} passed to dynamic providers.
+     *
+     * @since 1.14.0
+     */
+    public ToolServiceContext refreshDynamicProvidersWithFactory(ToolServiceContext toolServiceContext,
+                                                                 List<ChatMessage> messages,
+                                                                 InvocationContext invocationContext) {
+        return doRefreshDynamicProviders(
+                toolServiceContext, messages, invocationContext, toolProviderRequestFactory);
+    }
+
+    private static ToolServiceContext doRefreshDynamicProviders(
+            ToolServiceContext toolServiceContext,
+            List<ChatMessage> messages,
+            InvocationContext invocationContext,
+            Function<ToolProviderRequest.Builder, ToolProviderRequest> requestFactory) {
         if (toolServiceContext == null) {
             return null;
         }
@@ -534,11 +718,10 @@ public class ToolService {
         }
 
         UserMessage userMessage = UserMessage.findLast(messages).orElseThrow();
-        ToolProviderRequest request = ToolProviderRequest.builder()
+        ToolProviderRequest request = requestFactory.apply(ToolProviderRequest.builder()
                 .invocationContext(invocationContext)
                 .userMessage(userMessage)
-                .messages(messages)
-                .build();
+                .messages(messages));
 
         List<ToolSpecification> newEffectiveTools = new ArrayList<>(toolServiceContext.effectiveTools());
         List<ToolSpecification> newAvailableTools = new ArrayList<>(toolServiceContext.availableTools());
@@ -710,7 +893,12 @@ public class ToolService {
         ToolExecutionResult toolResult = executor == null
                 ? applyToolHallucinationStrategy(toolRequest)
                 : executeWithErrorHandling(
-                        toolRequest, executor, invocationContext, argumentsErrorHandler(), executionErrorHandler());
+                        toolRequest,
+                        executor,
+                        invocationContext,
+                        argumentsErrorHandler(),
+                        executionErrorHandler(),
+                        errorHandlerBypass);
 
         if (afterToolExecution != null) {
             afterToolExecution.accept(ToolExecution.builder()
@@ -730,9 +918,41 @@ public class ToolService {
             InvocationContext invocationContext,
             ToolArgumentsErrorHandler argumentsErrorHandler,
             ToolExecutionErrorHandler executionErrorHandler) {
+        return executeWithErrorHandling(
+                toolRequest, toolExecutor, invocationContext, argumentsErrorHandler, executionErrorHandler, e -> false);
+    }
+
+    /**
+     * Variant of {@link #executeWithErrorHandling(ToolExecutionRequest, ToolExecutor, InvocationContext,
+     * ToolArgumentsErrorHandler, ToolExecutionErrorHandler)} that also accepts a predicate which,
+     * when it evaluates to {@code true} for a thrown exception, causes that exception to propagate
+     * unchanged instead of being routed through the configured error handlers.
+     *
+     * <p>This overload is intended for downstream framework integrators that need to let
+     * specific marker-typed exceptions surface to the caller verbatim.
+     *
+     * @param errorHandlerBypass a predicate; when {@code true} for the thrown exception, the
+     *                           exception is rethrown unchanged. May be {@code null}, in which
+     *                           case no exception bypasses the error handlers.
+     * @since 1.14.0
+     */
+    public static ToolExecutionResult executeWithErrorHandling(
+            ToolExecutionRequest toolRequest,
+            ToolExecutor toolExecutor,
+            InvocationContext invocationContext,
+            ToolArgumentsErrorHandler argumentsErrorHandler,
+            ToolExecutionErrorHandler executionErrorHandler,
+            Predicate<Throwable> errorHandlerBypass) {
         try {
             return toolExecutor.executeWithContext(toolRequest, invocationContext);
         } catch (Exception e) {
+            if (errorHandlerBypass != null && errorHandlerBypass.test(e)) {
+                if (e instanceof RuntimeException re) {
+                    throw re;
+                }
+                throw new RuntimeException(e);
+            }
+
             ToolErrorContext errorContext = ToolErrorContext.builder()
                     .toolExecutionRequest(toolRequest)
                     .invocationContext(invocationContext)

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -878,6 +878,7 @@ public class ToolService {
                 // The cap is enforced at the loop level (see executeInferenceAndToolsLoop)
                 // so we do not configure it here; passing 0 keeps the dispatcher's check inert.
                 .maxToolCallsPerResponse(0)
+                .useExecutorForSingleTool(false)
                 .build());
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -78,6 +78,7 @@ public class ToolService {
     private final Set<ToolProvider> toolProviders = new LinkedHashSet<>();
     private Executor executor;
     private int maxSequentialToolsInvocations = 100;
+    private int maxToolCallsPerResponse = 0;
     private ToolArgumentsErrorHandler argumentsErrorHandler;
     private ToolExecutionErrorHandler executionErrorHandler;
     private Function<ToolExecutionRequest, ToolExecutionResultMessage> toolHallucinationStrategy =
@@ -226,6 +227,35 @@ public class ToolService {
 
     public int maxSequentialToolsInvocations() {
         return maxSequentialToolsInvocations;
+    }
+
+    /**
+     * Sets the maximum number of tool execution requests allowed within a single LLM response.
+     *
+     * <p>
+     * Intended for cooperative truncation when an LLM returns more tool calls in a single
+     * response than the user wants to spend. When an LLM response contains more than this
+     * many tool execution requests, a {@link ToolCallsLimitExceededException} is thrown
+     * before any tool is executed for that response.
+     *
+     * <p>
+     * A value of {@code 0} (the default) means unlimited — no cap is enforced.
+     *
+     * @param maxToolCallsPerResponse the maximum number of tool execution requests permitted
+     *                                in a single LLM response, or {@code 0} for unlimited
+     * @since 1.14.0
+     */
+    public void maxToolCallsPerResponse(int maxToolCallsPerResponse) {
+        this.maxToolCallsPerResponse = maxToolCallsPerResponse;
+    }
+
+    /**
+     * @return the maximum number of tool execution requests permitted in a single LLM response,
+     *         or {@code 0} for unlimited
+     * @since 1.14.0
+     */
+    public int maxToolCallsPerResponse() {
+        return maxToolCallsPerResponse;
     }
 
     /**
@@ -382,9 +412,13 @@ public class ToolService {
                 break;
             }
 
+            List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
+            if (maxToolCallsPerResponse > 0 && toolExecutionRequests.size() > maxToolCallsPerResponse) {
+                throw new ToolCallsLimitExceededException(maxToolCallsPerResponse, toolExecutionRequests.size());
+            }
+
             intermediateResponses.add(chatResponse);
 
-            List<ToolExecutionRequest> toolExecutionRequests = aiMessage.toolExecutionRequests();
             Map<ToolExecutionRequest, ToolExecutionResult> toolResults =
                     execute(toolExecutionRequests, toolServiceContext.toolExecutors(), invocationContext);
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerCancellationTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerCancellationTest.java
@@ -63,7 +63,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .executeToolsConcurrently(toolExecutor)
                     .build();
 
-            assistant.chat("hi")
+            assistant
+                    .chat("hi")
                     .cancelOn(cancelled::get)
                     .onCompleteResponse(r -> {})
                     .onError(t -> {})
@@ -110,7 +111,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .executeToolsConcurrently(toolExecutor)
                     .build();
 
-            assistant.chat("hi")
+            assistant
+                    .chat("hi")
                     .cancelOn(cancelled::get)
                     .onCompleteResponse(r -> completeFired.set(true))
                     .onError(t -> {})
@@ -146,7 +148,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .chatMemory(memory)
                     .build();
 
-            assistant.chat("hi")
+            assistant
+                    .chat("hi")
                     .cancelOn(cancelled::get)
                     .onCompleteResponse(r -> completes.incrementAndGet())
                     .onError(t -> errors.incrementAndGet())
@@ -213,7 +216,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .streamingToolDispatchHook(settle.hook())
                     .build();
 
-            assistant.chat("hi")
+            assistant
+                    .chat("hi")
                     .cancelOn(cancelled::get)
                     .onCompleteResponse(r -> {})
                     .onError(t -> {})
@@ -278,8 +282,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                 .arguments("{\"arg0\": \"b\"}")
                 .build();
 
-        var model = new ScriptedStreamingChatModel(
-                List.of(req1, req2), handler -> completeToolTurn(handler, req1, req2));
+        var model =
+                new ScriptedStreamingChatModel(List.of(req1, req2), handler -> completeToolTurn(handler, req1, req2));
 
         // Flip cancellation right after alpha's persistence-loop event fires; beta's
         // iteration then observes terminal loop state and must write the placeholder.
@@ -303,7 +307,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .streamingToolDispatchHook(settle.hook())
                     .build();
 
-            assistant.chat("hi")
+            assistant
+                    .chat("hi")
                     .cancelOn(cancelled::get)
                     .onCompleteResponse(r -> {})
                     .onError(t -> {})
@@ -387,8 +392,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                 .arguments("{\"arg0\": \"b\"}")
                 .build();
 
-        var model = new ScriptedStreamingChatModel(
-                List.of(req1, req2), handler -> completeToolTurn(handler, req1, req2));
+        var model =
+                new ScriptedStreamingChatModel(List.of(req1, req2), handler -> completeToolTurn(handler, req1, req2));
         SettleSignal settle = new SettleSignal();
 
         try {
@@ -399,7 +404,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .streamingToolDispatchHook(settle.hook())
                     .build();
 
-            assistant.chat("hi")
+            assistant
+                    .chat("hi")
                     .cancelOn(cancelled::get)
                     .onToolExecuted(execution -> {
                         streamToolCallbacks.incrementAndGet();
@@ -533,7 +539,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .streamingToolDispatchHook(hook)
                     .build();
 
-            assistant.chat("hi")
+            assistant
+                    .chat("hi")
                     .onCompleteResponse(r -> {})
                     .onError(t -> {
                         errorReceived.set(t);
@@ -603,8 +610,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
     void eager_path_future_cancelled_by_silent_cancel_writes_cancellation_placeholder_and_does_not_continue()
             throws Exception {
         AtomicBoolean cancelled = new AtomicBoolean(false);
-        ChatMemory memory = new CancelAfterAssistantToolMessageMemory(
-                MessageWindowChatMemory.withMaxMessages(10), cancelled);
+        ChatMemory memory =
+                new CancelAfterAssistantToolMessageMemory(MessageWindowChatMemory.withMaxMessages(10), cancelled);
         CountDownLatch slowToolStarted = new CountDownLatch(1);
         CountDownLatch slowToolProceed = new CountDownLatch(1);
 
@@ -641,7 +648,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .executeToolsConcurrently(toolExecutor)
                     .build();
 
-            assistant.chat("hi")
+            assistant
+                    .chat("hi")
                     .cancelOn(cancelled::get)
                     .onCompleteResponse(r -> {})
                     .onError(t -> {})
@@ -682,7 +690,9 @@ class AiServiceStreamingResponseHandlerCancellationTest {
             // No tool calls — the model goes straight to a final text response.
             onCompleteResponse(
                     handler,
-                    ChatResponse.builder().aiMessage(AiMessage.from("hello back")).build());
+                    ChatResponse.builder()
+                            .aiMessage(AiMessage.from("hello back"))
+                            .build());
         });
 
         try {
@@ -692,7 +702,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .chatMemory(memory)
                     .build();
 
-            assistant.chat("hi")
+            assistant
+                    .chat("hi")
                     .cancelOn(cancelled::get)
                     .onCompleteResponse(r -> done.countDown())
                     .onError(t -> done.countDown())
@@ -701,8 +712,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
             assertThat(done.await(5, SECONDS)).as("loop should complete").isTrue();
 
             List<ChatMessage> stored = memory.messages();
-            boolean hasAssistantTurn = stored.stream()
-                    .anyMatch(m -> m instanceof AiMessage ai && "hello back".equals(ai.text()));
+            boolean hasAssistantTurn =
+                    stored.stream().anyMatch(m -> m instanceof AiMessage ai && "hello back".equals(ai.text()));
             assertThat(hasAssistantTurn)
                     .as("non-tool response must still be persisted (the addToMemory move keeps both branches)")
                     .isTrue();
@@ -724,7 +735,9 @@ class AiServiceStreamingResponseHandlerCancellationTest {
         var model = new ScriptedStreamingChatModel(List.of(), handler -> {
             onCompleteResponse(
                     handler,
-                    ChatResponse.builder().aiMessage(AiMessage.from("hello back")).build());
+                    ChatResponse.builder()
+                            .aiMessage(AiMessage.from("hello back"))
+                            .build());
         });
 
         try {
@@ -736,7 +749,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .chatMemory(memory)
                     .build();
 
-            assistant.chat("hi")
+            assistant
+                    .chat("hi")
                     .onCompleteResponse(r -> {
                         throw boom;
                     })
@@ -785,7 +799,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .executeToolsConcurrently(toolExecutor)
                     .build();
 
-            assistant.chat("hi")
+            assistant
+                    .chat("hi")
                     .onCompleteResponse(r -> {})
                     .onError(t -> {
                         captured.set(t);
@@ -891,7 +906,8 @@ class AiServiceStreamingResponseHandlerCancellationTest {
 
     private static void completeToolTurn(StreamingChatResponseHandler handler, ToolExecutionRequest... requests) {
         onCompleteResponse(
-                handler, ChatResponse.builder().aiMessage(AiMessage.from(requests)).build());
+                handler,
+                ChatResponse.builder().aiMessage(AiMessage.from(requests)).build());
     }
 
     private static void awaitOrThrow(CountDownLatch latch, String what) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerCancellationTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerCancellationTest.java
@@ -128,6 +128,43 @@ class AiServiceStreamingResponseHandlerCancellationTest {
     }
 
     @Test
+    void on_error_after_silent_cancellation_is_ignored() throws Exception {
+        var memory = MessageWindowChatMemory.withMaxMessages(10);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        AtomicInteger errors = new AtomicInteger();
+        AtomicInteger completes = new AtomicInteger();
+        RuntimeException streamError = new RuntimeException("transport closed after cancel");
+
+        var model = new ScriptedStreamingChatModel(List.of(), handler -> {
+            cancelled.set(true);
+            handler.onError(streamError);
+        });
+
+        try {
+            var assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(memory)
+                    .build();
+
+            assistant.chat("hi")
+                    .cancelOn(cancelled::get)
+                    .onCompleteResponse(r -> completes.incrementAndGet())
+                    .onError(t -> errors.incrementAndGet())
+                    .start();
+            model.awaitFirstInvocationDone();
+
+            assertThat(errors.get())
+                    .as("provider onError after silent cancellation must stay silent")
+                    .isZero();
+            assertThat(completes.get())
+                    .as("silent cancellation must not be converted to completion")
+                    .isZero();
+        } finally {
+            model.shutdown();
+        }
+    }
+
+    @Test
     void cancel_during_dispatch_hook_thread_hop_does_not_orphan_assistant_turn() throws Exception {
         var memory = MessageWindowChatMemory.withMaxMessages(10);
         AtomicBoolean cancelled = new AtomicBoolean(false);
@@ -318,6 +355,75 @@ class AiServiceStreamingResponseHandlerCancellationTest {
         }
     }
 
+    @Test
+    void silent_cancellation_suppresses_stream_level_tool_callbacks_after_it_is_observed() throws Exception {
+        var memory = MessageWindowChatMemory.withMaxMessages(10);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        AtomicInteger streamToolCallbacks = new AtomicInteger();
+        AtomicInteger toolBodies = new AtomicInteger();
+
+        class TwoTools {
+            @Tool
+            String alpha(String arg) {
+                toolBodies.incrementAndGet();
+                return "alpha-done";
+            }
+
+            @Tool
+            String beta(String arg) {
+                toolBodies.incrementAndGet();
+                return "beta-done";
+            }
+        }
+
+        ToolExecutionRequest req1 = ToolExecutionRequest.builder()
+                .id("stream-cb-1")
+                .name("alpha")
+                .arguments("{\"arg0\": \"a\"}")
+                .build();
+        ToolExecutionRequest req2 = ToolExecutionRequest.builder()
+                .id("stream-cb-2")
+                .name("beta")
+                .arguments("{\"arg0\": \"b\"}")
+                .build();
+
+        var model = new ScriptedStreamingChatModel(
+                List.of(req1, req2), handler -> completeToolTurn(handler, req1, req2));
+        SettleSignal settle = new SettleSignal();
+
+        try {
+            var assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(memory)
+                    .tools(new TwoTools())
+                    .streamingToolDispatchHook(settle.hook())
+                    .build();
+
+            assistant.chat("hi")
+                    .cancelOn(cancelled::get)
+                    .onToolExecuted(execution -> {
+                        streamToolCallbacks.incrementAndGet();
+                        cancelled.set(true);
+                    })
+                    .onCompleteResponse(r -> {})
+                    .onError(t -> {})
+                    .start();
+            settle.awaitSettled();
+
+            assertThat(toolBodies.get())
+                    .as("deferred dispatch has already entered the batch when cancellation is observed")
+                    .isEqualTo(2);
+            assertThat(streamToolCallbacks.get())
+                    .as("stream-level tool callbacks after silent cancellation must be suppressed")
+                    .isEqualTo(1);
+            assertThat(model.invocations())
+                    .as("silent cancellation must skip the follow-up call")
+                    .isEqualTo(1);
+        } finally {
+            model.shutdown();
+        }
+    }
+
     /**
      * Exercises the failure-driven {@code catch (CancellationException)} branch in
      * {@code AiServiceStreamingResponseHandler.gatherScheduledToolResults}. With eager
@@ -339,7 +445,9 @@ class AiServiceStreamingResponseHandlerCancellationTest {
      */
     @Test
     void eager_path_future_cancelled_by_on_error_writes_failure_placeholder_and_does_not_continue() throws Exception {
-        var memory = MessageWindowChatMemory.withMaxMessages(10);
+        CountDownLatch assistantToolMessagePersisted = new CountDownLatch(1);
+        ChatMemory memory = new SignalOnAssistantToolMessageMemory(
+                MessageWindowChatMemory.withMaxMessages(10), assistantToolMessagePersisted);
         CountDownLatch slowToolStarted = new CountDownLatch(1);
         CountDownLatch slowToolProceed = new CountDownLatch(1);
         CountDownLatch errorDelivered = new CountDownLatch(1);
@@ -411,6 +519,7 @@ class AiServiceStreamingResponseHandlerCancellationTest {
             // CancellationException) or while parked in get(slow) (the blocked get wakes
             // with CancellationException). Either ordering exercises the catch.
             awaitOrThrow(dispatchStarted, "dispatch worker to start");
+            awaitOrThrow(assistantToolMessagePersisted, "assistant tool message to be persisted");
             handler.onError(new RuntimeException("simulated stream abort"));
         });
 
@@ -476,6 +585,9 @@ class AiServiceStreamingResponseHandlerCancellationTest {
             assertThat(slowResult.text())
                     .as("slow's future was cancelled by onError, so it must not look like silent cancellation")
                     .isEqualTo(AiServiceStreamingResponseHandler.FAILED_TOOL_RESULT_TEXT);
+            assertThat(slowResult.isError())
+                    .as("failed terminal placeholders must be marked as tool errors")
+                    .isTrue();
             assertThat(model.invocations())
                     .as("failed stream must skip the follow-up call")
                     .isEqualTo(1);
@@ -716,6 +828,39 @@ class AiServiceStreamingResponseHandlerCancellationTest {
             delegate.add(message);
             if (message instanceof AiMessage aiMessage && aiMessage.hasToolExecutionRequests()) {
                 cancelled.set(true);
+            }
+        }
+
+        @Override
+        public List<ChatMessage> messages() {
+            return delegate.messages();
+        }
+
+        @Override
+        public void clear() {
+            delegate.clear();
+        }
+    }
+
+    private static class SignalOnAssistantToolMessageMemory implements ChatMemory {
+        private final ChatMemory delegate;
+        private final CountDownLatch assistantToolMessagePersisted;
+
+        SignalOnAssistantToolMessageMemory(ChatMemory delegate, CountDownLatch assistantToolMessagePersisted) {
+            this.delegate = delegate;
+            this.assistantToolMessagePersisted = assistantToolMessagePersisted;
+        }
+
+        @Override
+        public Object id() {
+            return delegate.id();
+        }
+
+        @Override
+        public void add(ChatMessage message) {
+            delegate.add(message);
+            if (message instanceof AiMessage aiMessage && aiMessage.hasToolExecutionRequests()) {
+                assistantToolMessagePersisted.countDown();
             }
         }
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerCancellationTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerCancellationTest.java
@@ -11,6 +11,7 @@ import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
@@ -244,7 +245,7 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                 List.of(req1, req2), handler -> completeToolTurn(handler, req1, req2));
 
         // Flip cancellation right after alpha's persistence-loop event fires; beta's
-        // iteration then observes isCancelled()=true and must write the placeholder.
+        // iteration then observes terminal loop state and must write the placeholder.
         ToolExecutedEventListener flipOnAlpha = event -> {
             if ("alpha".equals(event.request().name())) {
                 cancelled.set(true);
@@ -303,7 +304,7 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .as("alpha completed before cancel flipped, so its real result must survive")
                     .isEqualTo("alpha-done");
             assertThat(betaResult.text())
-                    .as("beta's persistence iteration sees isCancelled()=true and must write the placeholder")
+                    .as("beta's persistence iteration sees terminal loop state and must write the placeholder")
                     .isEqualTo(AiServiceStreamingResponseHandler.CANCELLED_TOOL_RESULT_TEXT);
 
             assertThat(toolCallCount.get())
@@ -318,12 +319,11 @@ class AiServiceStreamingResponseHandlerCancellationTest {
     }
 
     /**
-     * Exercises the {@code catch (CancellationException)} branch in
+     * Exercises the failure-driven {@code catch (CancellationException)} branch in
      * {@code AiServiceStreamingResponseHandler.gatherScheduledToolResults}. With eager
-     * scheduling, an in-flight tool future can be cancelled (here via {@code onError}
-     * arriving during dispatch) while {@code gatherScheduledToolResults} is iterating —
-     * {@code future.get()} then throws {@code CancellationException}, the catch swallows
-     * it, and the persistence loop fills the missing entry with a placeholder.
+     * scheduling, an in-flight tool future can be cancelled by {@code onError} while
+     * {@code gatherScheduledToolResults} is iterating. That cancellation must be treated as
+     * failure termination, not silent cancellation.
      *
      * <p>The test pins this end-to-end:
      * <ul>
@@ -331,25 +331,18 @@ class AiServiceStreamingResponseHandlerCancellationTest {
      *   <li>beta is eagerly scheduled and completes normally (real result).</li>
      *   <li>A custom dispatch hook hops the post-{@code onCompleteResponse} work to a worker
      *       thread, so the model driver thread is free to fire {@code onError} concurrently.</li>
-     *   <li>{@code onError} calls {@code cancelPendingToolCalls(null)} which cancels alpha's
-     *       future. {@code gather}'s {@code future.get(alpha)} hits the
-     *       {@code CancellationException} branch and alpha ends up absent from the results map.</li>
-     *   <li>A {@code ToolExecutedEventListener} on beta flips the cancellation supplier after
-     *       beta's persistence iteration, so checkpoint #3 bails and there is no follow-up
-     *       chat call.</li>
+     *   <li>{@code onError} marks the loop failed and cancels slow's future. {@code gather}'s
+     *       {@code future.get(slow)} hits the {@code CancellationException} branch.</li>
+     *   <li>The completed fast result is preserved, slow gets a failure placeholder, and no
+     *       follow-up chat call is issued.</li>
      * </ul>
-     *
-     * <p>This test fails if the {@code catch (CancellationException)} branch is removed —
-     * {@code future.get()} would surface a {@code CancellationException} out of
-     * {@code gatherScheduledToolResults}, abort the persistence loop, and either lose beta's
-     * real result, the alpha placeholder, or both.
      */
     @Test
-    void eager_path_cancelled_in_flight_future_falls_through_to_placeholder_via_gather() throws Exception {
+    void eager_path_future_cancelled_by_on_error_writes_failure_placeholder_and_does_not_continue() throws Exception {
         var memory = MessageWindowChatMemory.withMaxMessages(10);
-        AtomicBoolean cancelled = new AtomicBoolean(false);
         CountDownLatch slowToolStarted = new CountDownLatch(1);
         CountDownLatch slowToolProceed = new CountDownLatch(1);
+        CountDownLatch errorDelivered = new CountDownLatch(1);
         AtomicReference<Throwable> errorReceived = new AtomicReference<>();
 
         class TwoEagerTools {
@@ -421,16 +414,6 @@ class AiServiceStreamingResponseHandlerCancellationTest {
             handler.onError(new RuntimeException("simulated stream abort"));
         });
 
-        // Flip the cancellation supplier after fast's persistence iteration fires its event.
-        // This is the only place to flip it post-gather and pre-checkpoint #3 deterministically:
-        // fireToolExecutedEvent only runs for real results, and slow's placeholder iteration
-        // continues without firing, so fast is the only trigger.
-        ToolExecutedEventListener flipAfterFast = event -> {
-            if ("fast".equals(event.request().name())) {
-                cancelled.set(true);
-            }
-        };
-
         ExecutorService toolExecutor = Executors.newSingleThreadExecutor();
         try {
             var assistant = AiServices.builder(Assistant.class)
@@ -439,13 +422,14 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .tools(new TwoEagerTools())
                     .executeToolsConcurrently(toolExecutor)
                     .streamingToolDispatchHook(hook)
-                    .registerListener(flipAfterFast)
                     .build();
 
             assistant.chat("hi")
-                    .cancelOn(cancelled::get)
                     .onCompleteResponse(r -> {})
-                    .onError(errorReceived::set)
+                    .onError(t -> {
+                        errorReceived.set(t);
+                        errorDelivered.countDown();
+                    })
                     .start();
 
             // Wait for the dispatch worker to finish — that's when memory writes for the
@@ -455,9 +439,10 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .isTrue();
             slowToolProceed.countDown();
 
-            assertThat(errorReceived.get())
+            assertThat(errorDelivered.await(5, SECONDS))
                     .as("the simulated onError should surface to the consumer")
-                    .isNotNull();
+                    .isTrue();
+            assertThat(errorReceived.get()).isNotNull();
 
             List<ChatMessage> stored = memory.messages();
             long requests = stored.stream()
@@ -486,18 +471,87 @@ class AiServiceStreamingResponseHandlerCancellationTest {
                     .orElseThrow();
 
             assertThat(fastResult.text())
-                    .as("fast completed before cancellation → its real result is preserved")
+                    .as("fast completed before failure termination, so its real result is preserved")
                     .isEqualTo("fast-done");
             assertThat(slowResult.text())
-                    .as("slow's future was cancelled mid-flight → CancellationException catch → placeholder")
-                    .isEqualTo(AiServiceStreamingResponseHandler.CANCELLED_TOOL_RESULT_TEXT);
+                    .as("slow's future was cancelled by onError, so it must not look like silent cancellation")
+                    .isEqualTo(AiServiceStreamingResponseHandler.FAILED_TOOL_RESULT_TEXT);
             assertThat(model.invocations())
-                    .as("checkpoint #3 (post-gather, pre-next-chat) must skip the follow-up call")
+                    .as("failed stream must skip the follow-up call")
                     .isEqualTo(1);
         } finally {
             slowToolProceed.countDown();
             toolExecutor.shutdownNow();
             dispatchExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
+    @Test
+    void eager_path_future_cancelled_by_silent_cancel_writes_cancellation_placeholder_and_does_not_continue()
+            throws Exception {
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        ChatMemory memory = new CancelAfterAssistantToolMessageMemory(
+                MessageWindowChatMemory.withMaxMessages(10), cancelled);
+        CountDownLatch slowToolStarted = new CountDownLatch(1);
+        CountDownLatch slowToolProceed = new CountDownLatch(1);
+
+        class SlowEagerTool {
+            @Tool
+            String slow(String arg) {
+                slowToolStarted.countDown();
+                try {
+                    slowToolProceed.await(5, SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return "slow-done";
+            }
+        }
+
+        ToolExecutionRequest slowRequest = ToolExecutionRequest.builder()
+                .id("silent-slow-id")
+                .name("slow")
+                .arguments("{\"arg0\": \"b\"}")
+                .build();
+
+        var model = new ScriptedStreamingChatModel(List.of(slowRequest), handler -> {
+            awaitOrThrow(slowToolStarted, "slow tool to start");
+            completeToolTurn(handler, slowRequest);
+        });
+
+        ExecutorService toolExecutor = Executors.newSingleThreadExecutor();
+        try {
+            var assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(memory)
+                    .tools(new SlowEagerTool())
+                    .executeToolsConcurrently(toolExecutor)
+                    .build();
+
+            assistant.chat("hi")
+                    .cancelOn(cancelled::get)
+                    .onCompleteResponse(r -> {})
+                    .onError(t -> {})
+                    .start();
+
+            model.awaitFirstInvocationDone();
+
+            List<ToolExecutionResultMessage> resultMessages = memory.messages().stream()
+                    .filter(m -> m instanceof ToolExecutionResultMessage)
+                    .map(m -> (ToolExecutionResultMessage) m)
+                    .toList();
+
+            assertThat(resultMessages).hasSize(1);
+            assertThat(resultMessages.get(0).text())
+                    .as("silent cancellation after assistant persistence writes cancellation placeholder")
+                    .isEqualTo(AiServiceStreamingResponseHandler.CANCELLED_TOOL_RESULT_TEXT);
+            assertThat(model.invocations())
+                    .as("silent cancellation must skip the follow-up call")
+                    .isEqualTo(1);
+        } finally {
+            slowToolProceed.countDown();
+            toolExecutor.shutdownNow();
             model.shutdown();
         }
     }
@@ -640,6 +694,39 @@ class AiServiceStreamingResponseHandlerCancellationTest {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new AssertionError("interrupted waiting for " + what, e);
+        }
+    }
+
+    private static class CancelAfterAssistantToolMessageMemory implements ChatMemory {
+        private final ChatMemory delegate;
+        private final AtomicBoolean cancelled;
+
+        CancelAfterAssistantToolMessageMemory(ChatMemory delegate, AtomicBoolean cancelled) {
+            this.delegate = delegate;
+            this.cancelled = cancelled;
+        }
+
+        @Override
+        public Object id() {
+            return delegate.id();
+        }
+
+        @Override
+        public void add(ChatMessage message) {
+            delegate.add(message);
+            if (message instanceof AiMessage aiMessage && aiMessage.hasToolExecutionRequests()) {
+                cancelled.set(true);
+            }
+        }
+
+        @Override
+        public List<ChatMessage> messages() {
+            return delegate.messages();
+        }
+
+        @Override
+        public void clear() {
+            delegate.clear();
         }
     }
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerCancellationTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerCancellationTest.java
@@ -1,0 +1,682 @@
+package dev.langchain4j.service;
+
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteResponse;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteToolCall;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ReturnBehavior;
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.observability.api.listener.ToolExecutedEventListener;
+import dev.langchain4j.service.tool.StreamingToolDispatchHook;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class AiServiceStreamingResponseHandlerCancellationTest {
+
+    interface Assistant {
+        TokenStream chat(String userMessage);
+    }
+
+    @Test
+    void cancel_before_response_completion_skips_memory_writes_and_follow_up_chat() throws Exception {
+        var memory = MessageWindowChatMemory.withMaxMessages(10);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        var tool = new FastTool();
+        var toolRequest = toolCall("toolu_checkpoint1");
+
+        // Flip cancel after the tool body runs but before onCompleteResponse fires —
+        // checkpoint #1 must observe it and bail before addToMemory(aiMessage).
+        var model = new ScriptedStreamingChatModel(List.of(toolRequest), handler -> {
+            awaitOrThrow(tool.bodyFinished, "tool body");
+            cancelled.set(true);
+            completeToolTurn(handler, toolRequest);
+        });
+
+        ExecutorService toolExecutor = Executors.newCachedThreadPool();
+        try {
+            var assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(memory)
+                    .tools(tool)
+                    .executeToolsConcurrently(toolExecutor)
+                    .build();
+
+            assistant.chat("hi")
+                    .cancelOn(cancelled::get)
+                    .onCompleteResponse(r -> {})
+                    .onError(t -> {})
+                    .start();
+            model.awaitFirstInvocationDone();
+
+            List<ChatMessage> stored = memory.messages();
+            assertThat(stored.stream().noneMatch(m -> m instanceof AiMessage))
+                    .as("checkpoint #1 must skip addToMemory(aiMessage)")
+                    .isTrue();
+            assertThat(stored.stream().noneMatch(m -> m instanceof ToolExecutionResultMessage))
+                    .as("checkpoint #1 must skip the tool-result memory writes")
+                    .isTrue();
+            assertThat(model.invocations())
+                    .as("checkpoint #1 must skip the follow-up chat call")
+                    .isEqualTo(1);
+        } finally {
+            toolExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
+    /** Regression: IMMEDIATE-return short-circuit must not fire onCompleteResponse after cancel. */
+    @Test
+    void cancel_with_immediate_return_tool_does_not_fire_complete_response_handler() throws Exception {
+        var memory = MessageWindowChatMemory.withMaxMessages(10);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        AtomicBoolean completeFired = new AtomicBoolean(false);
+        var tool = new ImmediateTool();
+        var toolRequest = toolCall("toolu_immediate");
+
+        var model = new ScriptedStreamingChatModel(List.of(toolRequest), handler -> {
+            awaitOrThrow(tool.bodyFinished, "tool body");
+            cancelled.set(true);
+            completeToolTurn(handler, toolRequest);
+        });
+
+        ExecutorService toolExecutor = Executors.newCachedThreadPool();
+        try {
+            var assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(memory)
+                    .tools(tool)
+                    .executeToolsConcurrently(toolExecutor)
+                    .build();
+
+            assistant.chat("hi")
+                    .cancelOn(cancelled::get)
+                    .onCompleteResponse(r -> completeFired.set(true))
+                    .onError(t -> {})
+                    .start();
+            model.awaitFirstInvocationDone();
+
+            assertThat(completeFired.get())
+                    .as("silent cancellation: onCompleteResponse must NOT fire")
+                    .isFalse();
+            assertThat(model.invocations()).isEqualTo(1);
+        } finally {
+            toolExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
+    @Test
+    void cancel_during_dispatch_hook_thread_hop_does_not_orphan_assistant_turn() throws Exception {
+        var memory = MessageWindowChatMemory.withMaxMessages(10);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        var tool = new FastTool();
+        var toolRequest = toolCall("toolu_threadhop");
+
+        // Dispatch hook hops to a worker thread; the test gates the hop with a latch so
+        // it can flip cancellation precisely WHILE the work is parked — exactly the window
+        // that closed when addToMemory(aiMessage) was moved inside the lambda.
+        ExecutorService dispatchExecutor = Executors.newSingleThreadExecutor();
+        CountDownLatch hookInvoked = new CountDownLatch(1);
+        CountDownLatch holdDispatch = new CountDownLatch(1);
+        StreamingToolDispatchHook hook = new StreamingToolDispatchHook() {
+            @Override
+            public <T> CompletionStage<T> dispatch(Supplier<T> work) {
+                hookInvoked.countDown();
+                CompletableFuture<T> future = new CompletableFuture<>();
+                dispatchExecutor.submit(() -> {
+                    try {
+                        if (!holdDispatch.await(5, SECONDS)) {
+                            future.completeExceptionally(new AssertionError("dispatch hold latch timed out"));
+                            return;
+                        }
+                        future.complete(work.get());
+                    } catch (Throwable t) {
+                        future.completeExceptionally(t);
+                    }
+                });
+                return future;
+            }
+        };
+
+        var model = new ScriptedStreamingChatModel(List.of(toolRequest), handler -> {
+            completeToolTurn(handler, toolRequest);
+        });
+
+        SettleSignal settle = new SettleSignal(hook);
+
+        ExecutorService toolExecutor = Executors.newCachedThreadPool();
+        try {
+            var assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(memory)
+                    .tools(tool)
+                    .executeToolsConcurrently(toolExecutor)
+                    .streamingToolDispatchHook(settle.hook())
+                    .build();
+
+            assistant.chat("hi")
+                    .cancelOn(cancelled::get)
+                    .onCompleteResponse(r -> {})
+                    .onError(t -> {})
+                    .start();
+
+            // Wait for the dispatch hook to be invoked (worker is parked on holdDispatch).
+            assertThat(hookInvoked.await(5, SECONDS))
+                    .as("dispatch hook should be invoked")
+                    .isTrue();
+
+            // Flip cancellation while the work is parked, then release the hop.
+            cancelled.set(true);
+            holdDispatch.countDown();
+
+            settle.awaitSettled();
+
+            List<ChatMessage> stored = memory.messages();
+            assertThat(stored.stream().noneMatch(m -> m instanceof AiMessage))
+                    .as("cancellation during dispatch thread-hop must NOT orphan AiMessage(tool_calls) in memory")
+                    .isTrue();
+            assertThat(stored.stream().noneMatch(m -> m instanceof ToolExecutionResultMessage))
+                    .as("no tool results should be in memory after the bail")
+                    .isTrue();
+            assertThat(model.invocations())
+                    .as("follow-up chat call must NOT be issued after cancellation")
+                    .isEqualTo(1);
+        } finally {
+            toolExecutor.shutdownNow();
+            dispatchExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
+    @Test
+    void cancellation_during_tool_batch_writes_mixed_real_and_placeholder_results() throws Exception {
+        var memory = MessageWindowChatMemory.withMaxMessages(10);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        AtomicInteger toolCallCount = new AtomicInteger();
+
+        class TwoTools {
+            @Tool
+            String alpha(String arg) {
+                toolCallCount.incrementAndGet();
+                return "alpha-done";
+            }
+
+            @Tool
+            String beta(String arg) {
+                toolCallCount.incrementAndGet();
+                return "beta-done";
+            }
+        }
+
+        ToolExecutionRequest req1 = ToolExecutionRequest.builder()
+                .id("c1")
+                .name("alpha")
+                .arguments("{\"arg0\": \"a\"}")
+                .build();
+        ToolExecutionRequest req2 = ToolExecutionRequest.builder()
+                .id("c2")
+                .name("beta")
+                .arguments("{\"arg0\": \"b\"}")
+                .build();
+
+        var model = new ScriptedStreamingChatModel(
+                List.of(req1, req2), handler -> completeToolTurn(handler, req1, req2));
+
+        // Flip cancellation right after alpha's persistence-loop event fires; beta's
+        // iteration then observes isCancelled()=true and must write the placeholder.
+        ToolExecutedEventListener flipOnAlpha = event -> {
+            if ("alpha".equals(event.request().name())) {
+                cancelled.set(true);
+            }
+        };
+
+        SettleSignal settle = new SettleSignal();
+
+        try {
+            var assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(memory)
+                    .tools(new TwoTools())
+                    // Deferred batch path (no executeToolsConcurrently) — both tools complete
+                    // through ToolBatchDispatcher before the persistence loop starts, so the
+                    // listener-triggered flip falls cleanly between persistence iterations.
+                    .registerListener(flipOnAlpha)
+                    .streamingToolDispatchHook(settle.hook())
+                    .build();
+
+            assistant.chat("hi")
+                    .cancelOn(cancelled::get)
+                    .onCompleteResponse(r -> {})
+                    .onError(t -> {})
+                    .start();
+            settle.awaitSettled();
+
+            List<ChatMessage> stored = memory.messages();
+
+            long requests = stored.stream()
+                    .filter(m -> m instanceof AiMessage)
+                    .map(m -> (AiMessage) m)
+                    .filter(AiMessage::hasToolExecutionRequests)
+                    .mapToLong(m -> m.toolExecutionRequests().size())
+                    .sum();
+            List<ToolExecutionResultMessage> resultMessages = stored.stream()
+                    .filter(m -> m instanceof ToolExecutionResultMessage)
+                    .map(m -> (ToolExecutionResultMessage) m)
+                    .toList();
+
+            assertThat(resultMessages)
+                    .as("memory invariant: every tool_use request must have a matching tool_result")
+                    .hasSize((int) requests)
+                    .hasSize(2);
+
+            ToolExecutionResultMessage alphaResult = resultMessages.stream()
+                    .filter(m -> "c1".equals(m.id()))
+                    .findFirst()
+                    .orElseThrow();
+            ToolExecutionResultMessage betaResult = resultMessages.stream()
+                    .filter(m -> "c2".equals(m.id()))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(alphaResult.text())
+                    .as("alpha completed before cancel flipped, so its real result must survive")
+                    .isEqualTo("alpha-done");
+            assertThat(betaResult.text())
+                    .as("beta's persistence iteration sees isCancelled()=true and must write the placeholder")
+                    .isEqualTo(AiServiceStreamingResponseHandler.CANCELLED_TOOL_RESULT_TEXT);
+
+            assertThat(toolCallCount.get())
+                    .as("both tool bodies execute through the dispatcher before the persistence loop runs")
+                    .isEqualTo(2);
+            assertThat(model.invocations())
+                    .as("checkpoint #3 must skip the follow-up chat call")
+                    .isEqualTo(1);
+        } finally {
+            model.shutdown();
+        }
+    }
+
+    /**
+     * Exercises the {@code catch (CancellationException)} branch in
+     * {@code AiServiceStreamingResponseHandler.gatherScheduledToolResults}. With eager
+     * scheduling, an in-flight tool future can be cancelled (here via {@code onError}
+     * arriving during dispatch) while {@code gatherScheduledToolResults} is iterating —
+     * {@code future.get()} then throws {@code CancellationException}, the catch swallows
+     * it, and the persistence loop fills the missing entry with a placeholder.
+     *
+     * <p>The test pins this end-to-end:
+     * <ul>
+     *   <li>alpha is eagerly scheduled and parks on a latch (its future is in-flight).</li>
+     *   <li>beta is eagerly scheduled and completes normally (real result).</li>
+     *   <li>A custom dispatch hook hops the post-{@code onCompleteResponse} work to a worker
+     *       thread, so the model driver thread is free to fire {@code onError} concurrently.</li>
+     *   <li>{@code onError} calls {@code cancelPendingToolCalls(null)} which cancels alpha's
+     *       future. {@code gather}'s {@code future.get(alpha)} hits the
+     *       {@code CancellationException} branch and alpha ends up absent from the results map.</li>
+     *   <li>A {@code ToolExecutedEventListener} on beta flips the cancellation supplier after
+     *       beta's persistence iteration, so checkpoint #3 bails and there is no follow-up
+     *       chat call.</li>
+     * </ul>
+     *
+     * <p>This test fails if the {@code catch (CancellationException)} branch is removed —
+     * {@code future.get()} would surface a {@code CancellationException} out of
+     * {@code gatherScheduledToolResults}, abort the persistence loop, and either lose beta's
+     * real result, the alpha placeholder, or both.
+     */
+    @Test
+    void eager_path_cancelled_in_flight_future_falls_through_to_placeholder_via_gather() throws Exception {
+        var memory = MessageWindowChatMemory.withMaxMessages(10);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        CountDownLatch slowToolStarted = new CountDownLatch(1);
+        CountDownLatch slowToolProceed = new CountDownLatch(1);
+        AtomicReference<Throwable> errorReceived = new AtomicReference<>();
+
+        class TwoEagerTools {
+            @Tool
+            String fast(String arg) {
+                return "fast-done";
+            }
+
+            @Tool
+            String slow(String arg) {
+                slowToolStarted.countDown();
+                try {
+                    // Stay in-flight until the test releases us. The future is cancelled while
+                    // this body is parked, so the returned value is discarded by the
+                    // CompletableFuture (cancel makes future.complete(...) a no-op).
+                    slowToolProceed.await(5, SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return "slow-done";
+            }
+        }
+
+        // Schedule fast first, slow second. With a single-threaded tool executor, fast runs
+        // to completion (its future.complete is called) BEFORE slow starts; once slowToolStarted
+        // fires, fast's future is guaranteed done and onError will not cancel it.
+        ToolExecutionRequest fastRequest = ToolExecutionRequest.builder()
+                .id("fast-id")
+                .name("fast")
+                .arguments("{\"arg0\": \"a\"}")
+                .build();
+        ToolExecutionRequest slowRequest = ToolExecutionRequest.builder()
+                .id("slow-id")
+                .name("slow")
+                .arguments("{\"arg0\": \"b\"}")
+                .build();
+
+        ExecutorService dispatchExecutor = Executors.newSingleThreadExecutor();
+        CountDownLatch dispatchStarted = new CountDownLatch(1);
+        CountDownLatch dispatchWorkDone = new CountDownLatch(1);
+        StreamingToolDispatchHook hook = new StreamingToolDispatchHook() {
+            @Override
+            public <T> CompletionStage<T> dispatch(Supplier<T> work) {
+                CompletableFuture<T> future = new CompletableFuture<>();
+                dispatchExecutor.submit(() -> {
+                    dispatchStarted.countDown();
+                    try {
+                        future.complete(work.get());
+                    } catch (Throwable t) {
+                        future.completeExceptionally(t);
+                    } finally {
+                        dispatchWorkDone.countDown();
+                    }
+                });
+                return future;
+            }
+        };
+
+        var model = new ScriptedStreamingChatModel(List.of(fastRequest, slowRequest), handler -> {
+            // The single-threaded tool executor ran fast first, so by the time slowToolStarted
+            // fires, fast's future.complete has already been called and that future is DONE.
+            awaitOrThrow(slowToolStarted, "slow tool to start");
+            completeToolTurn(handler, fastRequest, slowRequest);
+            // Wait for the dispatch hook's worker to enter the work supplier. From this point
+            // slow's future will either be cancelled before gather's get(slow) (immediate
+            // CancellationException) or while parked in get(slow) (the blocked get wakes
+            // with CancellationException). Either ordering exercises the catch.
+            awaitOrThrow(dispatchStarted, "dispatch worker to start");
+            handler.onError(new RuntimeException("simulated stream abort"));
+        });
+
+        // Flip the cancellation supplier after fast's persistence iteration fires its event.
+        // This is the only place to flip it post-gather and pre-checkpoint #3 deterministically:
+        // fireToolExecutedEvent only runs for real results, and slow's placeholder iteration
+        // continues without firing, so fast is the only trigger.
+        ToolExecutedEventListener flipAfterFast = event -> {
+            if ("fast".equals(event.request().name())) {
+                cancelled.set(true);
+            }
+        };
+
+        ExecutorService toolExecutor = Executors.newSingleThreadExecutor();
+        try {
+            var assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(memory)
+                    .tools(new TwoEagerTools())
+                    .executeToolsConcurrently(toolExecutor)
+                    .streamingToolDispatchHook(hook)
+                    .registerListener(flipAfterFast)
+                    .build();
+
+            assistant.chat("hi")
+                    .cancelOn(cancelled::get)
+                    .onCompleteResponse(r -> {})
+                    .onError(errorReceived::set)
+                    .start();
+
+            // Wait for the dispatch worker to finish — that's when memory writes for the
+            // first iteration are settled and checkpoint #3 has had a chance to bail.
+            assertThat(dispatchWorkDone.await(5, SECONDS))
+                    .as("dispatch work should complete")
+                    .isTrue();
+            slowToolProceed.countDown();
+
+            assertThat(errorReceived.get())
+                    .as("the simulated onError should surface to the consumer")
+                    .isNotNull();
+
+            List<ChatMessage> stored = memory.messages();
+            long requests = stored.stream()
+                    .filter(m -> m instanceof AiMessage)
+                    .map(m -> (AiMessage) m)
+                    .filter(AiMessage::hasToolExecutionRequests)
+                    .mapToLong(m -> m.toolExecutionRequests().size())
+                    .sum();
+            List<ToolExecutionResultMessage> resultMessages = stored.stream()
+                    .filter(m -> m instanceof ToolExecutionResultMessage)
+                    .map(m -> (ToolExecutionResultMessage) m)
+                    .toList();
+
+            assertThat(resultMessages)
+                    .as("memory invariant: every tool_use request must have a matching tool_result")
+                    .hasSize((int) requests)
+                    .hasSize(2);
+
+            ToolExecutionResultMessage fastResult = resultMessages.stream()
+                    .filter(m -> "fast-id".equals(m.id()))
+                    .findFirst()
+                    .orElseThrow();
+            ToolExecutionResultMessage slowResult = resultMessages.stream()
+                    .filter(m -> "slow-id".equals(m.id()))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(fastResult.text())
+                    .as("fast completed before cancellation → its real result is preserved")
+                    .isEqualTo("fast-done");
+            assertThat(slowResult.text())
+                    .as("slow's future was cancelled mid-flight → CancellationException catch → placeholder")
+                    .isEqualTo(AiServiceStreamingResponseHandler.CANCELLED_TOOL_RESULT_TEXT);
+            assertThat(model.invocations())
+                    .as("checkpoint #3 (post-gather, pre-next-chat) must skip the follow-up call")
+                    .isEqualTo(1);
+        } finally {
+            slowToolProceed.countDown();
+            toolExecutor.shutdownNow();
+            dispatchExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
+    /**
+     * Sanity check that the non-tool branch still persists the assistant message — the move
+     * of {@code addToMemory(aiMessage)} into branch-specific positions must not lose the
+     * write for a plain text response.
+     */
+    @Test
+    void plain_text_response_without_tools_still_writes_assistant_message_to_memory() throws Exception {
+        var memory = MessageWindowChatMemory.withMaxMessages(10);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        var model = new ScriptedStreamingChatModel(List.of(), handler -> {
+            // No tool calls — the model goes straight to a final text response.
+            onCompleteResponse(
+                    handler,
+                    ChatResponse.builder().aiMessage(AiMessage.from("hello back")).build());
+        });
+
+        try {
+            CountDownLatch done = new CountDownLatch(1);
+            var assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(memory)
+                    .build();
+
+            assistant.chat("hi")
+                    .cancelOn(cancelled::get)
+                    .onCompleteResponse(r -> done.countDown())
+                    .onError(t -> done.countDown())
+                    .start();
+
+            assertThat(done.await(5, SECONDS)).as("loop should complete").isTrue();
+
+            List<ChatMessage> stored = memory.messages();
+            boolean hasAssistantTurn = stored.stream()
+                    .anyMatch(m -> m instanceof AiMessage ai && "hello back".equals(ai.text()));
+            assertThat(hasAssistantTurn)
+                    .as("non-tool response must still be persisted (the addToMemory move keeps both branches)")
+                    .isTrue();
+        } finally {
+            model.shutdown();
+        }
+    }
+
+    private static class FastTool {
+        final CountDownLatch bodyFinished = new CountDownLatch(1);
+
+        @Tool
+        String now() {
+            bodyFinished.countDown();
+            return "12:00";
+        }
+    }
+
+    private static class ImmediateTool {
+        final CountDownLatch bodyFinished = new CountDownLatch(1);
+
+        @Tool(returnBehavior = ReturnBehavior.IMMEDIATE)
+        String now() {
+            bodyFinished.countDown();
+            return "12:00";
+        }
+    }
+
+    /**
+     * First invocation emits the tool calls then runs {@code afterToolCalls} (where tests inject
+     * cancellation timing). Any later invocation would return a plain "done" response — used to
+     * detect that the follow-up chat call was issued.
+     */
+    private static class ScriptedStreamingChatModel implements StreamingChatModel {
+        private final List<ToolExecutionRequest> toolRequests;
+        private final Consumer<StreamingChatResponseHandler> afterToolCalls;
+        private final ExecutorService driver = Executors.newCachedThreadPool();
+        private final AtomicInteger invocations = new AtomicInteger();
+        private final CompletableFuture<Void> firstInvocationDone = new CompletableFuture<>();
+
+        ScriptedStreamingChatModel(
+                List<ToolExecutionRequest> toolRequests, Consumer<StreamingChatResponseHandler> afterToolCalls) {
+            this.toolRequests = toolRequests;
+            this.afterToolCalls = afterToolCalls;
+        }
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            int invocation = invocations.incrementAndGet();
+            driver.execute(() -> {
+                try {
+                    if (invocation == 1) {
+                        for (int i = 0; i < toolRequests.size(); i++) {
+                            onCompleteToolCall(handler, new CompleteToolCall(i, toolRequests.get(i)));
+                        }
+                        afterToolCalls.accept(handler);
+                    } else {
+                        onCompleteResponse(
+                                handler,
+                                ChatResponse.builder()
+                                        .aiMessage(AiMessage.from("done"))
+                                        .build());
+                    }
+                } catch (Throwable t) {
+                    handler.onError(t);
+                } finally {
+                    if (invocation == 1) firstInvocationDone.complete(null);
+                }
+            });
+        }
+
+        int invocations() {
+            return invocations.get();
+        }
+
+        void awaitFirstInvocationDone() throws Exception {
+            try {
+                firstInvocationDone.get(5, SECONDS);
+            } catch (java.util.concurrent.TimeoutException e) {
+                throw new AssertionError("first invocation did not settle within 5s", e);
+            }
+        }
+
+        void shutdown() {
+            driver.shutdownNow();
+        }
+    }
+
+    private static ToolExecutionRequest toolCall(String id) {
+        return ToolExecutionRequest.builder().id(id).name("now").arguments("{}").build();
+    }
+
+    private static void completeToolTurn(StreamingChatResponseHandler handler, ToolExecutionRequest... requests) {
+        onCompleteResponse(
+                handler, ChatResponse.builder().aiMessage(AiMessage.from(requests)).build());
+    }
+
+    private static void awaitOrThrow(CountDownLatch latch, String what) {
+        try {
+            if (!latch.await(5, SECONDS)) throw new AssertionError("timed out waiting for " + what);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("interrupted waiting for " + what, e);
+        }
+    }
+
+    /** Completes only after the dispatch lambda returns — used in place of bounded-sleep polls. */
+    private static class SettleSignal {
+        private final CompletableFuture<Void> settled = new CompletableFuture<>();
+        private final StreamingToolDispatchHook delegate;
+
+        SettleSignal() {
+            this(null);
+        }
+
+        SettleSignal(StreamingToolDispatchHook delegate) {
+            this.delegate = delegate;
+        }
+
+        StreamingToolDispatchHook hook() {
+            return new StreamingToolDispatchHook() {
+                @Override
+                public <T> CompletionStage<T> dispatch(Supplier<T> work) {
+                    CompletionStage<T> stage = delegate != null
+                            ? delegate.dispatch(work)
+                            : StreamingToolDispatchHook.INLINE.dispatch(work);
+                    return stage.whenComplete((r, t) -> {
+                        if (t != null) settled.completeExceptionally(t);
+                        else settled.complete(null);
+                    });
+                }
+            };
+        }
+
+        void awaitSettled() throws Exception {
+            try {
+                settled.get(5, SECONDS);
+            } catch (java.util.concurrent.TimeoutException e) {
+                throw new AssertionError("dispatch lambda did not settle within 5s", e);
+            }
+        }
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerCancellationTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerCancellationTest.java
@@ -711,6 +711,100 @@ class AiServiceStreamingResponseHandlerCancellationTest {
         }
     }
 
+    /**
+     * Regression: a throw from {@code completeResponseHandler} must reach {@code errorHandler}.
+     * Pre-fix {@code loopState.complete()} ran before the user callback, so the resulting
+     * {@code onError} round-trip hit a COMPLETED state machine and was silently dropped.
+     */
+    @Test
+    void complete_response_handler_throw_is_reported_to_error_handler() throws Exception {
+        var memory = MessageWindowChatMemory.withMaxMessages(10);
+        RuntimeException boom = new RuntimeException("boom from complete handler");
+
+        var model = new ScriptedStreamingChatModel(List.of(), handler -> {
+            onCompleteResponse(
+                    handler,
+                    ChatResponse.builder().aiMessage(AiMessage.from("hello back")).build());
+        });
+
+        try {
+            CountDownLatch errorFired = new CountDownLatch(1);
+            AtomicReference<Throwable> captured = new AtomicReference<>();
+
+            var assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(memory)
+                    .build();
+
+            assistant.chat("hi")
+                    .onCompleteResponse(r -> {
+                        throw boom;
+                    })
+                    .onError(t -> {
+                        captured.set(t);
+                        errorFired.countDown();
+                    })
+                    .start();
+
+            assertThat(errorFired.await(5, SECONDS))
+                    .as("errorHandler must observe the throw from completeResponseHandler")
+                    .isTrue();
+            assertThat(captured.get())
+                    .as("the throwable from completeResponseHandler must be reported verbatim")
+                    .isSameAs(boom);
+        } finally {
+            model.shutdown();
+        }
+    }
+
+    /**
+     * Regression: a throw from {@code addToMemory(aiMessage)} inside the dispatch lambda must reach
+     * {@code errorHandler}. Pre-fix the call sat outside the lambda's try/catch, and even the default
+     * INLINE hook would swallow the throw into an unobserved failed CompletionStage.
+     */
+    @Test
+    void add_to_memory_throw_inside_dispatch_lambda_is_reported_to_error_handler() throws Exception {
+        RuntimeException boom = new RuntimeException("boom from memory");
+        var memory = new ThrowingMemory(MessageWindowChatMemory.withMaxMessages(10), boom);
+        var tool = new FastTool();
+        var toolRequest = toolCall("toolu_throw_memory");
+
+        var model = new ScriptedStreamingChatModel(List.of(toolRequest), handler -> {
+            completeToolTurn(handler, toolRequest);
+        });
+
+        ExecutorService toolExecutor = Executors.newCachedThreadPool();
+        try {
+            CountDownLatch errorFired = new CountDownLatch(1);
+            AtomicReference<Throwable> captured = new AtomicReference<>();
+
+            var assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(memory)
+                    .tools(tool)
+                    .executeToolsConcurrently(toolExecutor)
+                    .build();
+
+            assistant.chat("hi")
+                    .onCompleteResponse(r -> {})
+                    .onError(t -> {
+                        captured.set(t);
+                        errorFired.countDown();
+                    })
+                    .start();
+
+            assertThat(errorFired.await(5, SECONDS))
+                    .as("errorHandler must observe the throw from addToMemory inside the dispatch lambda")
+                    .isTrue();
+            assertThat(captured.get())
+                    .as("the throwable from the memory must be reported verbatim")
+                    .isSameAs(boom);
+        } finally {
+            toolExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
     private static class FastTool {
         final CountDownLatch bodyFinished = new CountDownLatch(1);
 
@@ -862,6 +956,39 @@ class AiServiceStreamingResponseHandlerCancellationTest {
             if (message instanceof AiMessage aiMessage && aiMessage.hasToolExecutionRequests()) {
                 assistantToolMessagePersisted.countDown();
             }
+        }
+
+        @Override
+        public List<ChatMessage> messages() {
+            return delegate.messages();
+        }
+
+        @Override
+        public void clear() {
+            delegate.clear();
+        }
+    }
+
+    private static class ThrowingMemory implements ChatMemory {
+        private final ChatMemory delegate;
+        private final RuntimeException toThrow;
+
+        ThrowingMemory(ChatMemory delegate, RuntimeException toThrow) {
+            this.delegate = delegate;
+            this.toThrow = toThrow;
+        }
+
+        @Override
+        public Object id() {
+            return delegate.id();
+        }
+
+        @Override
+        public void add(ChatMessage message) {
+            if (message instanceof AiMessage aiMessage && aiMessage.hasToolExecutionRequests()) {
+                throw toThrow;
+            }
+            delegate.add(message);
         }
 
         @Override

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerEagerToolOrderingTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceStreamingResponseHandlerEagerToolOrderingTest.java
@@ -1,0 +1,560 @@
+package dev.langchain4j.service;
+
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteResponse;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteToolCall;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class AiServiceStreamingResponseHandlerEagerToolOrderingTest {
+
+    interface Assistant {
+
+        TokenStream chat(String userMessage);
+    }
+
+    @Test
+    void without_stream_before_tool_body_runs_before_intermediate_but_stream_tool_output_waits_until_after_intermediate()
+            throws Exception {
+        ConcurrentLinkedQueue<String> events = new ConcurrentLinkedQueue<>();
+        FastTool tool = new FastTool(events);
+        ToolExecutionRequest toolRequest = toolCall("toolu_order", "now");
+
+        ScriptedStreamingChatModel model = new ScriptedStreamingChatModel(List.of(toolRequest), handler -> {
+            awaitOrThrow(tool.bodyFinished, "tool body to finish");
+            spinUntil(() -> events.contains(streamAfter(toolRequest)), 250, MILLISECONDS);
+            completeToolTurn(handler, toolRequest);
+        });
+
+        ExecutorService toolExecutor = Executors.newCachedThreadPool();
+        try {
+            Assistant assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                    .tools(tool)
+                    .executeToolsConcurrently(toolExecutor)
+                    .build();
+
+            CompletableFuture<ChatResponse> done = new CompletableFuture<>();
+            assistant.chat("what time is it?")
+                    .onToolExecuted(execution -> events.add(streamAfter(execution.request())))
+                    .onIntermediateResponse(ignored -> events.add("intermediate"))
+                    .onCompleteResponse(done::complete)
+                    .onError(done::completeExceptionally)
+                    .start();
+
+            done.get(10, SECONDS);
+
+            List<String> captured = List.copyOf(events);
+            assertThat(indexOf(captured, "toolBody:now")).isLessThan(indexOf(captured, "intermediate"));
+            assertThat(indexOf(captured, "intermediate")).isLessThan(indexOf(captured, streamAfter(toolRequest)));
+            assertThat(captured).filteredOn(streamAfter(toolRequest)::equals).hasSize(1);
+        } finally {
+            toolExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
+    @Test
+    void stream_beforeToolExecution_runs_after_intermediate_and_before_tool_body() throws Exception {
+        ConcurrentLinkedQueue<String> events = new ConcurrentLinkedQueue<>();
+        FastTool tool = new FastTool(events);
+        ToolExecutionRequest toolRequest = toolCall("toolu_stream_before", "now");
+
+        ScriptedStreamingChatModel model =
+                new ScriptedStreamingChatModel(List.of(toolRequest), handler -> completeToolTurn(handler, toolRequest));
+
+        ExecutorService toolExecutor =
+                Executors.newSingleThreadExecutor(command -> new Thread(command, "stream-before-tool-executor"));
+        try {
+            Assistant assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                    .tools(tool)
+                    .executeToolsConcurrently(toolExecutor)
+                    .build();
+
+            CompletableFuture<ChatResponse> done = new CompletableFuture<>();
+            assistant.chat("what time is it?")
+                    .beforeToolExecution(before -> events.add(streamBefore(before.request())))
+                    .onToolExecuted(execution -> events.add(streamAfter(execution.request())))
+                    .onIntermediateResponse(ignored -> events.add("intermediate"))
+                    .onCompleteResponse(done::complete)
+                    .onError(done::completeExceptionally)
+                    .start();
+
+            done.get(10, SECONDS);
+
+            List<String> captured = List.copyOf(events);
+            assertThat(indexOf(captured, "intermediate")).isLessThan(indexOf(captured, streamBefore(toolRequest)));
+            assertThat(indexOf(captured, streamBefore(toolRequest))).isLessThan(indexOf(captured, "toolBody:now"));
+            assertThat(indexOf(captured, "toolBody:now")).isLessThan(indexOf(captured, streamAfter(toolRequest)));
+            assertThat(tool.bodyThread.get()).isNotNull();
+            assertThat(tool.bodyThread.get().getName()).isEqualTo("stream-before-tool-executor");
+        } finally {
+            toolExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
+    @Test
+    void throwing_stream_beforeToolExecution_runs_after_intermediate_prevents_tool_body_and_delivers_one_error()
+            throws Exception {
+        ConcurrentLinkedQueue<String> events = new ConcurrentLinkedQueue<>();
+        FastTool tool = new FastTool(events);
+        ToolExecutionRequest toolRequest = toolCall("toolu_before_failure", "now");
+        RuntimeException beforeFailure = new RuntimeException("before-boom");
+
+        ScriptedStreamingChatModel model =
+                new ScriptedStreamingChatModel(List.of(toolRequest), handler -> completeToolTurn(handler, toolRequest));
+
+        ExecutorService toolExecutor = Executors.newCachedThreadPool();
+        try {
+            Assistant assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                    .tools(tool)
+                    .executeToolsConcurrently(toolExecutor)
+                    .build();
+
+            CompletableFuture<Void> done = new CompletableFuture<>();
+            AtomicInteger errorCount = new AtomicInteger();
+            AtomicReference<Throwable> error = new AtomicReference<>();
+            assistant.chat("what time is it?")
+                    .beforeToolExecution(before -> {
+                        events.add(streamBefore(before.request()));
+                        throw beforeFailure;
+                    })
+                    .onToolExecuted(execution -> events.add(streamAfter(execution.request())))
+                    .onIntermediateResponse(ignored -> events.add("intermediate"))
+                    .onCompleteResponse(ignored -> done.complete(null))
+                    .onError(t -> {
+                        events.add(error(t));
+                        error.set(t);
+                        errorCount.incrementAndGet();
+                        done.complete(null);
+                    })
+                    .start();
+
+            done.get(10, SECONDS);
+
+            List<String> captured = List.copyOf(events);
+            assertThat(tool.bodyStarted.getCount())
+                    .as("throwing beforeToolExecution must stop the tool body. Captured: %s", captured)
+                    .isEqualTo(1);
+            assertThat(indexOf(captured, "intermediate")).isLessThan(indexOf(captured, streamBefore(toolRequest)));
+            assertThat(captured).doesNotContain("toolBody:now", streamAfter(toolRequest));
+            assertThat(errorCount).hasValue(1);
+            assertThat(error.get()).isSameAs(beforeFailure);
+        } finally {
+            toolExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
+    @Test
+    void builder_tool_callbacks_run_at_actual_execution_time_in_eager_mode_while_stream_output_waits()
+            throws Exception {
+        ConcurrentLinkedQueue<String> events = new ConcurrentLinkedQueue<>();
+        FastTool tool = new FastTool(events);
+        ToolExecutionRequest toolRequest = toolCall("toolu_builder_after", "now");
+        CountDownLatch builderBefore = new CountDownLatch(1);
+        CountDownLatch builderAfter = new CountDownLatch(1);
+
+        ScriptedStreamingChatModel model = new ScriptedStreamingChatModel(List.of(toolRequest), handler -> {
+            awaitOrThrow(tool.bodyFinished, "tool body to finish");
+            awaitBriefly(builderBefore);
+            awaitBriefly(builderAfter);
+            completeToolTurn(handler, toolRequest);
+        });
+
+        ExecutorService toolExecutor = Executors.newCachedThreadPool();
+        try {
+            Assistant assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                    .tools(tool)
+                    .executeToolsConcurrently(toolExecutor)
+                    .beforeToolExecution(before -> {
+                        events.add(builderBefore(before.request()));
+                        builderBefore.countDown();
+                    })
+                    .afterToolExecution(execution -> {
+                        events.add(builderAfter(execution.request()));
+                        builderAfter.countDown();
+                    })
+                    .build();
+
+            CompletableFuture<ChatResponse> done = new CompletableFuture<>();
+            assistant.chat("what time is it?")
+                    .onToolExecuted(execution -> events.add(streamAfter(execution.request())))
+                    .onIntermediateResponse(ignored -> events.add("intermediate"))
+                    .onCompleteResponse(done::complete)
+                    .onError(done::completeExceptionally)
+                    .start();
+
+            done.get(10, SECONDS);
+
+            List<String> captured = List.copyOf(events);
+            assertThat(indexOf(captured, builderBefore(toolRequest))).isLessThan(indexOf(captured, "toolBody:now"));
+            assertThat(indexOf(captured, "toolBody:now")).isLessThan(indexOf(captured, builderAfter(toolRequest)));
+            assertThat(indexOf(captured, builderAfter(toolRequest))).isLessThan(indexOf(captured, "intermediate"));
+            assertThat(indexOf(captured, "intermediate")).isLessThan(indexOf(captured, streamAfter(toolRequest)));
+        } finally {
+            toolExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
+    @Test
+    void terminal_model_error_prevents_late_stream_tool_output_after_error_handler() throws Exception {
+        ConcurrentLinkedQueue<String> events = new ConcurrentLinkedQueue<>();
+        BlockingTool tool = new BlockingTool(events);
+        ToolExecutionRequest toolRequest = toolCall("toolu_terminal_error", "slowNow");
+        RuntimeException streamError = new RuntimeException("stream-boom");
+
+        ScriptedStreamingChatModel model = new ScriptedStreamingChatModel(List.of(toolRequest), handler -> {
+            awaitOrThrow(tool.bodyStarted, "tool body to start");
+            handler.onError(streamError);
+        });
+
+        ExecutorService toolExecutor = Executors.newCachedThreadPool();
+        try {
+            Assistant assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                    .tools(tool)
+                    .executeToolsConcurrently(toolExecutor)
+                    .build();
+
+            CompletableFuture<Void> done = new CompletableFuture<>();
+            CountDownLatch outputAfterError = new CountDownLatch(1);
+            CountDownLatch errorDelivered = new CountDownLatch(1);
+            AtomicReference<Throwable> error = new AtomicReference<>();
+            assistant.chat("what time is it?")
+                    .onToolExecuted(execution -> {
+                        events.add(streamAfter(execution.request()));
+                        if (errorDelivered.getCount() == 0) {
+                            outputAfterError.countDown();
+                        }
+                    })
+                    .onIntermediateResponse(ignored -> events.add("intermediate"))
+                    .onCompleteResponse(ignored -> done.complete(null))
+                    .onError(t -> {
+                        events.add(error(t));
+                        error.set(t);
+                        errorDelivered.countDown();
+                        done.complete(null);
+                    })
+                    .start();
+
+            done.get(10, SECONDS);
+            tool.release.countDown();
+            awaitOrThrow(tool.bodyFinished, "tool body to finish");
+
+            assertThat(outputAfterError.await(250, MILLISECONDS))
+                    .as("late stream tool output must not arrive after errorHandler")
+                    .isFalse();
+            List<String> captured = List.copyOf(events);
+            assertThat(error.get()).isSameAs(streamError);
+            assertNoStreamOutputAfterError(captured);
+        } finally {
+            toolExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
+    @Test
+    void throwing_buffered_stream_tool_output_delivers_one_error_and_no_later_tool_output() throws Exception {
+        ConcurrentLinkedQueue<String> events = new ConcurrentLinkedQueue<>();
+        TwoFastTools tools = new TwoFastTools(events);
+        ToolExecutionRequest first = toolCall("toolu_first", "first");
+        ToolExecutionRequest second = toolCall("toolu_second", "second");
+        RuntimeException callbackFailure = new RuntimeException("callback-boom");
+        CountDownLatch builderAfterBoth = new CountDownLatch(2);
+
+        ScriptedStreamingChatModel model = new ScriptedStreamingChatModel(List.of(first, second), handler -> {
+            awaitOrThrow(tools.firstFinished, "first tool body to finish");
+            awaitOrThrow(tools.secondFinished, "second tool body to finish");
+            awaitBriefly(builderAfterBoth);
+            completeToolTurn(handler, first, second);
+        });
+
+        ExecutorService toolExecutor = Executors.newFixedThreadPool(2);
+        try {
+            Assistant assistant = AiServices.builder(Assistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                    .tools(tools)
+                    .executeToolsConcurrently(toolExecutor)
+                    .afterToolExecution(execution -> builderAfterBoth.countDown())
+                    .build();
+
+            CompletableFuture<Void> done = new CompletableFuture<>();
+            AtomicInteger errorCount = new AtomicInteger();
+            AtomicReference<Throwable> error = new AtomicReference<>();
+            CountDownLatch errorDelivered = new CountDownLatch(1);
+            CountDownLatch outputAfterError = new CountDownLatch(1);
+
+            assistant.chat("run both tools")
+                    .onToolExecuted(execution -> {
+                        events.add(streamAfter(execution.request()));
+                        if (errorDelivered.getCount() == 0) {
+                            outputAfterError.countDown();
+                        }
+                        if (execution.request().name().equals(first.name())) {
+                            throw callbackFailure;
+                        }
+                    })
+                    .onIntermediateResponse(ignored -> events.add("intermediate"))
+                    .onCompleteResponse(ignored -> done.complete(null))
+                    .onError(t -> {
+                        events.add(error(t));
+                        error.set(t);
+                        errorCount.incrementAndGet();
+                        errorDelivered.countDown();
+                        done.complete(null);
+                    })
+                    .start();
+
+            done.get(10, SECONDS);
+
+            assertThat(outputAfterError.await(250, MILLISECONDS))
+                    .as("no stream tool output should arrive after the terminal error")
+                    .isFalse();
+            List<String> captured = List.copyOf(events);
+            assertThat(indexOf(captured, "intermediate")).isLessThan(indexOf(captured, streamAfter(first)));
+            assertThat(errorCount).hasValue(1);
+            assertThat(error.get()).isSameAs(callbackFailure);
+            assertNoStreamOutputAfterError(captured);
+        } finally {
+            toolExecutor.shutdownNow();
+            model.shutdown();
+        }
+    }
+
+    private static class FastTool {
+
+        final ConcurrentLinkedQueue<String> events;
+        final CountDownLatch bodyStarted = new CountDownLatch(1);
+        final CountDownLatch bodyFinished = new CountDownLatch(1);
+        final AtomicReference<Thread> bodyThread = new AtomicReference<>();
+        final CountDownLatch eagerSignal;
+
+        FastTool(ConcurrentLinkedQueue<String> events) {
+            this(events, null);
+        }
+
+        FastTool(ConcurrentLinkedQueue<String> events, CountDownLatch eagerSignal) {
+            this.events = events;
+            this.eagerSignal = eagerSignal;
+        }
+
+        @Tool
+        String now() {
+            bodyThread.set(Thread.currentThread());
+            events.add("toolBody:now");
+            bodyStarted.countDown();
+            if (eagerSignal != null) {
+                eagerSignal.countDown();
+            }
+            bodyFinished.countDown();
+            return "12:00";
+        }
+    }
+
+    private static class BlockingTool {
+
+        final ConcurrentLinkedQueue<String> events;
+        final CountDownLatch bodyStarted = new CountDownLatch(1);
+        final CountDownLatch bodyFinished = new CountDownLatch(1);
+        final CountDownLatch release = new CountDownLatch(1);
+
+        BlockingTool(ConcurrentLinkedQueue<String> events) {
+            this.events = events;
+        }
+
+        @Tool
+        String slowNow() throws InterruptedException {
+            events.add("toolBody:slowNow");
+            bodyStarted.countDown();
+            release.await();
+            bodyFinished.countDown();
+            return "12:00";
+        }
+    }
+
+    private static class TwoFastTools {
+
+        final ConcurrentLinkedQueue<String> events;
+        final CountDownLatch firstFinished = new CountDownLatch(1);
+        final CountDownLatch secondFinished = new CountDownLatch(1);
+
+        TwoFastTools(ConcurrentLinkedQueue<String> events) {
+            this.events = events;
+        }
+
+        @Tool
+        String first() {
+            events.add("toolBody:first");
+            firstFinished.countDown();
+            return "first-result";
+        }
+
+        @Tool
+        String second() {
+            events.add("toolBody:second");
+            secondFinished.countDown();
+            return "second-result";
+        }
+    }
+
+    private static class ScriptedStreamingChatModel implements StreamingChatModel {
+
+        private final List<ToolExecutionRequest> toolRequests;
+        private final Consumer<StreamingChatResponseHandler> afterToolCalls;
+        private final ExecutorService driver = Executors.newCachedThreadPool();
+        private final AtomicInteger invocations = new AtomicInteger();
+
+        ScriptedStreamingChatModel(
+                List<ToolExecutionRequest> toolRequests, Consumer<StreamingChatResponseHandler> afterToolCalls) {
+            this.toolRequests = toolRequests;
+            this.afterToolCalls = afterToolCalls;
+        }
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            int invocation = invocations.incrementAndGet();
+            driver.execute(() -> {
+                try {
+                    if (invocation == 1) {
+                        for (int i = 0; i < toolRequests.size(); i++) {
+                            onCompleteToolCall(handler, new CompleteToolCall(i, toolRequests.get(i)));
+                        }
+                        afterToolCalls.accept(handler);
+                    } else {
+                        onCompleteResponse(
+                                handler,
+                                ChatResponse.builder()
+                                        .aiMessage(AiMessage.from("done"))
+                                        .build());
+                    }
+                } catch (Throwable t) {
+                    handler.onError(t);
+                }
+            });
+        }
+
+        void shutdown() {
+            driver.shutdownNow();
+        }
+    }
+
+    private static ToolExecutionRequest toolCall(String id, String name) {
+        return ToolExecutionRequest.builder()
+                .id(id)
+                .name(name)
+                .arguments("{}")
+                .build();
+    }
+
+    private static void completeToolTurn(
+            StreamingChatResponseHandler handler, ToolExecutionRequest... toolRequests) {
+        onCompleteResponse(
+                handler,
+                ChatResponse.builder()
+                        .aiMessage(AiMessage.from(toolRequests))
+                        .build());
+    }
+
+    private static void awaitOrThrow(CountDownLatch latch, String description) {
+        try {
+            if (!latch.await(5, SECONDS)) {
+                throw new AssertionError("Timed out waiting for " + description);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for " + description, e);
+        }
+    }
+
+    private static void awaitBriefly(CountDownLatch latch) {
+        try {
+            latch.await(250, MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting briefly", e);
+        }
+    }
+
+    private static void spinUntil(BooleanSupplier condition, long timeout, java.util.concurrent.TimeUnit unit) {
+        long deadline = System.nanoTime() + unit.toNanos(timeout);
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.onSpinWait();
+        }
+    }
+
+    private static int indexOf(List<String> events, String event) {
+        assertThat(events).as("Captured events").contains(event);
+        return events.indexOf(event);
+    }
+
+    private static void assertNoStreamOutputAfterError(List<String> events) {
+        int errorIndex = firstIndexStartingWith(events, "error:");
+        List<String> afterError = events.subList(errorIndex + 1, events.size());
+        assertThat(afterError.stream().noneMatch(event -> event.startsWith("streamAfter:")))
+                .as("Captured events: %s", events)
+                .isTrue();
+    }
+
+    private static int firstIndexStartingWith(List<String> events, String prefix) {
+        for (int i = 0; i < events.size(); i++) {
+            if (events.get(i).startsWith(prefix)) {
+                return i;
+            }
+        }
+        assertThat(events).as("Captured events").anyMatch(event -> event.startsWith(prefix));
+        return -1;
+    }
+
+    private static String streamBefore(ToolExecutionRequest request) {
+        return "streamBefore:" + request.id();
+    }
+
+    private static String streamAfter(ToolExecutionRequest request) {
+        return "streamAfter:" + request.id();
+    }
+
+    private static String builderBefore(ToolExecutionRequest request) {
+        return "builderBefore:" + request.id();
+    }
+
+    private static String builderAfter(ToolExecutionRequest request) {
+        return "builderAfter:" + request.id();
+    }
+
+    private static String error(Throwable error) {
+        return "error:" + error.getMessage();
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingPerCallChatModelTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingPerCallChatModelTest.java
@@ -118,7 +118,7 @@ class StreamingPerCallChatModelTest {
                 perCallModel,
                 null,
                 initialRequest.parameters(),
-                null);
+                new StreamingLoopState(null));
 
         // Synthesize the first onCompleteResponse with a tool call — same as if the initial
         // streamed response from the default model had carried it.

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingPerCallChatModelTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingPerCallChatModelTest.java
@@ -117,7 +117,8 @@ class StreamingPerCallChatModelTest {
                 null,
                 perCallModel,
                 null,
-                initialRequest.parameters());
+                initialRequest.parameters(),
+                null);
 
         // Synthesize the first onCompleteResponse with a tool call — same as if the initial
         // streamed response from the default model had carried it.

--- a/langchain4j/src/test/java/dev/langchain4j/service/StreamingPerCallChatModelTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/StreamingPerCallChatModelTest.java
@@ -1,0 +1,141 @@
+package dev.langchain4j.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.guardrail.ChatExecutor;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.service.tool.ToolService;
+import dev.langchain4j.service.tool.ToolServiceContext;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates that downstream framework integrators can supply an explicit per-call
+ * {@link StreamingChatModel} to {@link AiServiceStreamingResponseHandler}, mirroring the
+ * sync overload of {@link ToolService#executeInferenceAndToolsLoop} that takes an explicit
+ * {@code ChatModel}.
+ *
+ * <p>This test lives in the {@code dev.langchain4j.service} package so it can reach the
+ * package-private {@code AiServiceStreamingResponseHandler}.
+ */
+class StreamingPerCallChatModelTest {
+
+    interface Service {
+        // Placeholder service interface; the handler is exercised directly.
+    }
+
+    static class Echo {
+        @Tool
+        String echo(String arg) {
+            return "echo:" + arg;
+        }
+    }
+
+    @Test
+    void per_call_streaming_chat_model_is_used_for_follow_up_request() throws Exception {
+        // Default model would respond "from-default-model"; per-call model responds "from-per-call".
+        // The handler should use the per-call model on its recursive follow-up call.
+
+        StreamingChatModelMock defaultModel =
+                StreamingChatModelMock.thatAlwaysStreams(AiMessage.from("from-default-model"));
+        StreamingChatModelMock perCallModel =
+                StreamingChatModelMock.thatAlwaysStreams(AiMessage.from("from-per-call-model"));
+
+        ToolService toolService = new ToolService();
+        toolService.tools(java.util.Collections.singletonList(new Echo()));
+
+        AiServiceContext context = AiServiceContext.create(Service.class);
+        context.streamingChatModel = defaultModel;
+        context.toolService = toolService;
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+        context.initChatMemories(chatMemory);
+        dev.langchain4j.data.message.UserMessage userMessage = dev.langchain4j.data.message.UserMessage.from("go");
+
+        InvocationContext invocationContext = InvocationContext.builder()
+                .interfaceName(Service.class.getName())
+                .methodName("chat")
+                .userMessage(userMessage)
+                .chatMemoryId("default")
+                .timestampNow()
+                .build();
+
+        ToolServiceContext toolServiceContext =
+                toolService.createContext(invocationContext, userMessage, new java.util.ArrayList<>());
+
+        // Fabricate the FIRST chat response: a tool call. The handler will run the tool, then
+        // call the LLM again to get the final answer — that's the call that should hit the
+        // per-call model.
+        ChatRequest initialRequest = ChatRequest.builder()
+                .messages(java.util.List.of(userMessage))
+                .parameters(ChatRequestParameters.builder().build())
+                .build();
+        ChatExecutor chatExecutor = ChatExecutor.builder(defaultModel)
+                .chatRequest(initialRequest)
+                .invocationContext(invocationContext)
+                .eventListenerRegistrar(context.eventListenerRegistrar)
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+
+        AiServiceStreamingResponseHandler handler = new AiServiceStreamingResponseHandler(
+                initialRequest,
+                chatExecutor,
+                context,
+                invocationContext,
+                ignored -> {},
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                future::complete,
+                future::completeExceptionally,
+                chatMemory,
+                new TokenUsage(),
+                toolServiceContext,
+                10,
+                toolService.argumentsErrorHandler(),
+                toolService.executionErrorHandler(),
+                null,
+                null,
+                null,
+                perCallModel,
+                null,
+                initialRequest.parameters());
+
+        // Synthesize the first onCompleteResponse with a tool call — same as if the initial
+        // streamed response from the default model had carried it.
+        ToolExecutionRequest toolCall = ToolExecutionRequest.builder()
+                .id("c1")
+                .name("echo")
+                .arguments("{\"arg0\":\"hi\"}")
+                .build();
+        ChatResponse firstResponse =
+                ChatResponse.builder().aiMessage(AiMessage.from(toolCall)).build();
+        handler.onCompleteResponse(firstResponse);
+
+        ChatResponse finalResponse = future.get(10, TimeUnit.SECONDS);
+        assertThat(finalResponse.aiMessage().text()).isEqualTo("from-per-call-model");
+
+        // Confirm the per-call model received the follow-up request and the default model was
+        // not invoked (we never invoked the initial request through it in this test).
+        assertThat(perCallModel.requests()).hasSize(1);
+        assertThat(defaultModel.requests()).isEmpty();
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/CreateContextWithBaseToolsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/CreateContextWithBaseToolsTest.java
@@ -1,0 +1,198 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.service.IllegalConfigurationException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates {@link ToolService#createContext(InvocationContext, UserMessage, List, List)} — the
+ * overload that merges a caller-supplied list of method-scoped <i>base tools</i> with the
+ * service's configured static tools and providers.
+ *
+ * <p>This overload is the integration point used by downstream framework integrators
+ * (e.g. {@code quarkus-langchain4j}) that resolve additional method-scoped tools per AI service
+ * method invocation and need them to participate in the same provider semantics as
+ * AI-service-level tools.
+ */
+class CreateContextWithBaseToolsTest {
+
+    private static final InvocationContext INVOCATION_CONTEXT = InvocationContext.builder()
+            .interfaceName("TestService")
+            .methodName("chat")
+            .userMessage(UserMessage.from("hi"))
+            .chatMemoryId("default")
+            .timestampNow()
+            .build();
+
+    private static final UserMessage USER_MESSAGE = UserMessage.from("hi");
+    private static final List<ChatMessage> MESSAGES = List.of(USER_MESSAGE);
+
+    private static AiServiceTool aiServiceTool(String name, String description) {
+        return AiServiceTool.builder()
+                .toolSpecification(ToolSpecification.builder()
+                        .name(name)
+                        .description(description)
+                        .build())
+                .toolExecutor((ToolExecutionRequest req, Object memId) -> "result-" + name)
+                .build();
+    }
+
+    @Test
+    void merges_baseTools_with_static_tools() {
+        ToolService toolService = new ToolService();
+        AiServiceTool staticTool = aiServiceTool("static", "static tool");
+        List<AiServiceTool> staticTools = List.of(staticTool);
+        toolService.tools(staticTools);
+
+        AiServiceTool baseTool = aiServiceTool("scoped", "method-scoped tool");
+
+        ToolServiceContext context =
+                toolService.createContext(INVOCATION_CONTEXT, USER_MESSAGE, new ArrayList<>(MESSAGES), List.of(baseTool));
+
+        assertThat(context.effectiveTools())
+                .extracting(ToolSpecification::name)
+                .containsExactlyInAnyOrder("static", "scoped");
+        assertThat(context.availableTools())
+                .extracting(ToolSpecification::name)
+                .containsExactlyInAnyOrder("static", "scoped");
+        assertThat(context.toolExecutors()).containsKeys("static", "scoped");
+        assertThat(context.toolExecutors().get("scoped")).isSameAs(baseTool.toolExecutor());
+        assertThat(context.toolExecutors().get("static")).isSameAs(staticTool.toolExecutor());
+    }
+
+    @Test
+    void merges_baseTools_with_dynamic_provider_tools() {
+        ToolService toolService = new ToolService();
+        AiServiceTool providerTool = aiServiceTool("from-provider", "provider tool");
+        toolService.toolProvider(request -> ToolProviderResult.builder()
+                .add(providerTool)
+                .build());
+
+        AiServiceTool baseTool = aiServiceTool("scoped", "method-scoped tool");
+
+        ToolServiceContext context =
+                toolService.createContext(INVOCATION_CONTEXT, USER_MESSAGE, new ArrayList<>(MESSAGES), List.of(baseTool));
+
+        assertThat(context.effectiveTools())
+                .extracting(ToolSpecification::name)
+                .containsExactlyInAnyOrder("from-provider", "scoped");
+        assertThat(context.toolExecutors()).containsKeys("from-provider", "scoped");
+        assertThat(context.toolExecutors().get("scoped")).isSameAs(baseTool.toolExecutor());
+        assertThat(context.toolExecutors().get("from-provider")).isSameAs(providerTool.toolExecutor());
+    }
+
+    @Test
+    void collision_with_static_tool_throws_illegal_configuration() {
+        ToolService toolService = new ToolService();
+        List<AiServiceTool> firstTools = List.of(aiServiceTool("dup", "first"));
+        toolService.tools(firstTools);
+
+        AiServiceTool conflicting = aiServiceTool("dup", "second");
+
+        assertThatExceptionOfType(IllegalConfigurationException.class)
+                .isThrownBy(() -> toolService.createContext(
+                        INVOCATION_CONTEXT, USER_MESSAGE, new ArrayList<>(MESSAGES), List.of(conflicting)))
+                .withMessageContaining("Duplicated definition for tool: dup");
+    }
+
+    @Test
+    void collision_with_provider_supplied_tool_throws_illegal_configuration() {
+        ToolService toolService = new ToolService();
+        // baseTools are merged BEFORE the provider runs. The provider returns a tool whose name
+        // collides with one of the baseTools — this collision must be detected.
+        toolService.toolProvider(request -> ToolProviderResult.builder()
+                .add(aiServiceTool("dup", "from provider"))
+                .build());
+
+        AiServiceTool baseTool = aiServiceTool("dup", "from base");
+
+        assertThatExceptionOfType(IllegalConfigurationException.class)
+                .isThrownBy(() -> toolService.createContext(
+                        INVOCATION_CONTEXT, USER_MESSAGE, new ArrayList<>(MESSAGES), List.of(baseTool)))
+                .withMessageContaining("Duplicated definition for tool: dup");
+    }
+
+    @Test
+    void empty_baseTools_behaves_identically_to_no_baseTools_overload() {
+        ToolService toolService = new ToolService();
+        AiServiceTool staticTool = aiServiceTool("static", "static tool");
+        List<AiServiceTool> staticTools = List.of(staticTool);
+        toolService.tools(staticTools);
+
+        ToolServiceContext withEmpty = toolService.createContext(
+                INVOCATION_CONTEXT, USER_MESSAGE, new ArrayList<>(MESSAGES), List.of());
+        ToolServiceContext withoutBase =
+                toolService.createContext(INVOCATION_CONTEXT, USER_MESSAGE, new ArrayList<>(MESSAGES));
+
+        // Same set of tools, executors, return behaviors — the empty-list path must not allocate
+        // a divergent merged collection.
+        assertThat(withEmpty.effectiveTools())
+                .extracting(ToolSpecification::name)
+                .containsExactlyElementsOf(
+                        withoutBase.effectiveTools().stream().map(ToolSpecification::name).toList());
+        assertThat(withEmpty.toolExecutors().keySet()).isEqualTo(withoutBase.toolExecutors().keySet());
+        assertThat(withEmpty.toolExecutors().get("static")).isSameAs(withoutBase.toolExecutors().get("static"));
+    }
+
+    @Test
+    void null_baseTools_behaves_identically_to_no_baseTools_overload() {
+        ToolService toolService = new ToolService();
+        AiServiceTool staticTool = aiServiceTool("static", "static tool");
+        List<AiServiceTool> staticTools = List.of(staticTool);
+        toolService.tools(staticTools);
+
+        ToolServiceContext withNull =
+                toolService.createContext(INVOCATION_CONTEXT, USER_MESSAGE, new ArrayList<>(MESSAGES), null);
+        ToolServiceContext withoutBase =
+                toolService.createContext(INVOCATION_CONTEXT, USER_MESSAGE, new ArrayList<>(MESSAGES));
+
+        assertThat(withNull.effectiveTools())
+                .extracting(ToolSpecification::name)
+                .containsExactlyElementsOf(
+                        withoutBase.effectiveTools().stream().map(ToolSpecification::name).toList());
+        assertThat(withNull.toolExecutors().keySet()).isEqualTo(withoutBase.toolExecutors().keySet());
+        assertThat(withNull.toolExecutors().get("static")).isSameAs(withoutBase.toolExecutors().get("static"));
+    }
+
+    @Test
+    void no_static_no_providers_with_baseTools_only_returns_merged_context() {
+        // Ensures the "no providers, no static tools, but baseTools present" branch in
+        // createContextFromStaticToolsAndProviders builds a non-Empty context with only the
+        // baseTools merged in. This is the framework-integration happy path when the service
+        // has no AI-service-level tools and method-scoped tools are the only ones.
+        ToolService toolService = new ToolService();
+        AiServiceTool baseTool = aiServiceTool("scoped", "method-scoped tool");
+
+        ToolServiceContext context =
+                toolService.createContext(INVOCATION_CONTEXT, USER_MESSAGE, new ArrayList<>(MESSAGES), List.of(baseTool));
+
+        assertThat(context).isNotSameAs(ToolServiceContext.Empty.INSTANCE);
+        assertThat(context.effectiveTools()).extracting(ToolSpecification::name).containsExactly("scoped");
+        assertThat(context.toolExecutors()).containsOnlyKeys("scoped");
+        assertThat(context.toolExecutors().get("scoped")).isSameAs(baseTool.toolExecutor());
+    }
+
+    @Test
+    void no_static_no_providers_no_baseTools_returns_empty_context() {
+        // Parity guard: when nothing is configured AND no baseTools are supplied, we should
+        // still get back the singleton Empty context (not a freshly allocated empty one).
+        ToolService toolService = new ToolService();
+
+        ToolServiceContext withNull =
+                toolService.createContext(INVOCATION_CONTEXT, USER_MESSAGE, new ArrayList<>(MESSAGES), null);
+        ToolServiceContext withEmpty = toolService.createContext(
+                INVOCATION_CONTEXT, USER_MESSAGE, new ArrayList<>(MESSAGES), List.of());
+
+        assertThat(withNull).isSameAs(ToolServiceContext.Empty.INSTANCE);
+        assertThat(withEmpty).isSameAs(ToolServiceContext.Empty.INSTANCE);
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ErrorHandlerBypassTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ErrorHandlerBypassTest.java
@@ -87,8 +87,7 @@ class ErrorHandlerBypassTest {
                 // DefaultToolExecutor wraps tool-thrown RuntimeExceptions in ToolExecutionException,
                 // so the predicate inspects the cause. This mirrors how Quarkus's predicate is
                 // typically structured against its PreventsErrorHandlerExecution marker.
-                .errorHandlerBypass(e -> e instanceof ToolExecutionException
-                        && e.getCause() instanceof MarkerException)
+                .errorHandlerBypass(e -> e instanceof ToolExecutionException && e.getCause() instanceof MarkerException)
                 .build();
 
         // DefaultToolExecutor wraps the tool's RuntimeException in ToolExecutionException; the

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ErrorHandlerBypassTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ErrorHandlerBypassTest.java
@@ -1,0 +1,127 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.exception.ToolExecutionException;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.service.AiServices;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates {@link AiServices#errorHandlerBypass(java.util.function.Predicate)}: when the
+ * configured predicate returns {@code true} for an exception thrown by a tool, the exception
+ * propagates unchanged to the caller instead of being routed through the
+ * {@link ToolExecutionErrorHandler}.
+ *
+ * <p>This is the hook downstream framework integrators (e.g. Quarkus) use to surface
+ * marker-typed exceptions (authorization or guardrail violations) verbatim.
+ */
+class ErrorHandlerBypassTest {
+
+    interface Assistant {
+        String chat(String message);
+    }
+
+    /** A marker-typed RuntimeException used by the test. */
+    static class MarkerException extends RuntimeException {
+        MarkerException(String msg) {
+            super(msg);
+        }
+    }
+
+    static class ExplodingTool {
+        @Tool
+        public String boom(String arg) {
+            throw new MarkerException("kaboom:" + arg);
+        }
+    }
+
+    @Test
+    void without_bypass_predicate_exceptions_are_routed_through_error_handler() {
+        ExplodingTool tool = new ExplodingTool();
+        // 1st response: tool call. 2nd response (after error handler turns the exception into
+        // text): a final text answer "ok".
+        AiMessage toolCall = AiMessage.from(ToolExecutionRequest.builder()
+                .id("c1")
+                .name("boom")
+                .arguments("{\"arg0\": \"x\"}")
+                .build());
+        AiMessage finalAnswer = AiMessage.from("ok");
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(toolCall, finalAnswer);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .build();
+
+        // Default behaviour: the exception is captured by the default ToolExecutionErrorHandler
+        // and turned into a string sent back to the LLM. The LLM then produces "ok".
+        assertThatNoException().isThrownBy(() -> {
+            String result = assistant.chat("go");
+            assertThat(result).isEqualTo("ok");
+        });
+    }
+
+    @Test
+    void with_bypass_predicate_matching_exceptions_propagate_unchanged() {
+        ExplodingTool tool = new ExplodingTool();
+        AiMessage toolCall = AiMessage.from(ToolExecutionRequest.builder()
+                .id("c1")
+                .name("boom")
+                .arguments("{\"arg0\": \"x\"}")
+                .build());
+        AiMessage finalAnswer = AiMessage.from("ok");
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(toolCall, finalAnswer);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                // DefaultToolExecutor wraps tool-thrown RuntimeExceptions in ToolExecutionException,
+                // so the predicate inspects the cause. This mirrors how Quarkus's predicate is
+                // typically structured against its PreventsErrorHandlerExecution marker.
+                .errorHandlerBypass(e -> e instanceof ToolExecutionException
+                        && e.getCause() instanceof MarkerException)
+                .build();
+
+        // DefaultToolExecutor wraps the tool's RuntimeException in ToolExecutionException; the
+        // bypass hook rethrows that wrapper unchanged. The MarkerException is preserved as the
+        // cause, exactly as it would be without the hook — but importantly the error handler did
+        // not run and turn it into a string sent to the LLM.
+        assertThatExceptionOfType(ToolExecutionException.class)
+                .isThrownBy(() -> assistant.chat("go"))
+                .withCauseInstanceOf(MarkerException.class)
+                .havingCause()
+                .withMessageContaining("kaboom:x");
+    }
+
+    @Test
+    void with_bypass_predicate_non_matching_exceptions_still_route_through_error_handler() {
+        // Predicate returns false: error handler intercepts and the loop proceeds normally.
+        ExplodingTool tool = new ExplodingTool();
+        AiMessage toolCall = AiMessage.from(ToolExecutionRequest.builder()
+                .id("c1")
+                .name("boom")
+                .arguments("{\"arg0\": \"x\"}")
+                .build());
+        AiMessage finalAnswer = AiMessage.from("ok");
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(toolCall, finalAnswer);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .errorHandlerBypass(e -> false)
+                .build();
+
+        String result = assistant.chat("go");
+        assertThat(result).isEqualTo("ok");
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ExecuteToolsConcurrentlyTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ExecuteToolsConcurrentlyTest.java
@@ -1,0 +1,118 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.service.AiServices;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Wall-clock validation that {@link AiServices#executeToolsConcurrently(java.util.concurrent.Executor)}
+ * actually parallelizes per-tool execution when the LLM returns multiple tool calls in one response.
+ *
+ * <p>Pattern: 3 tools each sleeping 200 ms. Serial would take >= 600 ms; parallel should finish well
+ * under 500 ms (with generous slack for CI noise).
+ */
+class ExecuteToolsConcurrentlyTest {
+
+    interface Assistant {
+        String chat(String message);
+    }
+
+    static class SleepingTool {
+
+        final AtomicInteger calls = new AtomicInteger();
+
+        @Tool
+        public String slow(String arg) throws InterruptedException {
+            calls.incrementAndGet();
+            Thread.sleep(200);
+            return "done-" + arg;
+        }
+    }
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        executor = Executors.newFixedThreadPool(8);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void should_execute_multiple_tools_in_parallel_when_executor_provided() {
+
+        SleepingTool tool = new SleepingTool();
+        AiMessage threeToolCalls = AiMessage.from(toolCall("c1", "a"), toolCall("c2", "b"), toolCall("c3", "c"));
+        AiMessage finalAnswer = AiMessage.from("all done");
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(threeToolCalls, finalAnswer);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .executeToolsConcurrently(executor)
+                .build();
+
+        long start = System.currentTimeMillis();
+        String reply = assistant.chat("go");
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(reply).isEqualTo("all done");
+        assertThat(tool.calls.get()).isEqualTo(3);
+        // Serial would be >= 600ms (3 * 200ms). Parallel must be substantially less.
+        assertThat(elapsed)
+                .as("Three 200ms tools should run concurrently; observed %dms", elapsed)
+                .isLessThan(500);
+    }
+
+    @Test
+    void should_execute_sequentially_when_no_executor_provided() {
+
+        SleepingTool tool = new SleepingTool();
+        AiMessage threeToolCalls = AiMessage.from(toolCall("c1", "a"), toolCall("c2", "b"), toolCall("c3", "c"));
+        AiMessage finalAnswer = AiMessage.from("all done");
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(threeToolCalls, finalAnswer);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                // intentionally do NOT call executeToolsConcurrently(...)
+                .build();
+
+        long start = System.currentTimeMillis();
+        String reply = assistant.chat("go");
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(reply).isEqualTo("all done");
+        assertThat(tool.calls.get()).isEqualTo(3);
+        // Serial baseline: 3 * 200ms = 600ms minimum.
+        assertThat(elapsed)
+                .as("Without an executor, tools should run serially; observed %dms", elapsed)
+                .isGreaterThanOrEqualTo(600);
+    }
+
+    private static ToolExecutionRequest toolCall(String id, String arg) {
+        return ToolExecutionRequest.builder()
+                .id(id)
+                .name("slow")
+                .arguments("{\"arg0\": \"" + arg + "\"}")
+                .build();
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/MaxToolCallsPerResponseTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/MaxToolCallsPerResponseTest.java
@@ -204,10 +204,10 @@ class MaxToolCallsPerResponseTest {
         ToolCallsLimitExceededException ex = (ToolCallsLimitExceededException) error;
         assertThat(ex.getLimit()).isEqualTo(2);
         assertThat(ex.getAttempted()).isEqualTo(5);
-        // With a concurrent executor onCompleteToolCall fires per tool as the stream arrives
-        // and dispatches eagerly. Calls beyond the cap must not be submitted, so at most 'limit'
-        // tools may have executed, never more.
-        assertThat(tool.calls.get()).isLessThanOrEqualTo(2);
+        // Atomic streaming cap: tool calls are buffered until onCompleteResponse, so a response
+        // that exceeds the cap rejects the entire batch before any tool runs — even when a
+        // concurrent executor is configured.
+        assertThat(tool.calls.get()).isZero();
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/MaxToolCallsPerResponseTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/MaxToolCallsPerResponseTest.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.service.tool;
 
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteResponse;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteToolCall;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -8,13 +10,20 @@ import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.mock.ChatModelMock;
 import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.TokenStream;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -35,10 +44,12 @@ class MaxToolCallsPerResponseTest {
     static class CountingTool {
 
         final AtomicInteger calls = new AtomicInteger();
+        final List<String> args = new CopyOnWriteArrayList<>();
 
         @Tool
         public String doWork(String arg) {
             calls.incrementAndGet();
+            args.add(arg);
             return "ok-" + arg;
         }
     }
@@ -131,11 +142,14 @@ class MaxToolCallsPerResponseTest {
     }
 
     @Test
-    void should_throw_when_response_has_more_tool_calls_than_limit__streaming() throws Exception {
+    void should_throw_before_inline_dispatch_when_response_has_more_tool_calls_than_limit__streaming() throws Exception {
 
         CountingTool tool = new CountingTool();
-        AiMessage threeToolCallResponse = AiMessage.from(toolCall("c1", "a"), toolCall("c2", "b"), toolCall("c3", "c"));
-        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(threeToolCallResponse);
+        StreamingChatModel model = StreamingToolCallModel.withToolCalls(
+                toolCall("c1", "a"),
+                toolCall("c2", "b"),
+                toolCall("c3", "c"),
+                toolCall("c4", "d"));
 
         StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
                 .streamingChatModel(model)
@@ -157,30 +171,30 @@ class MaxToolCallsPerResponseTest {
         assertThat(error).isInstanceOf(ToolCallsLimitExceededException.class);
         ToolCallsLimitExceededException ex = (ToolCallsLimitExceededException) error;
         assertThat(ex.getLimit()).isEqualTo(2);
-        assertThat(ex.getAttempted()).isEqualTo(3);
-        // Without an executor the streaming path defers tool execution to onCompleteResponse,
-        // which throws before any tool runs.
+        assertThat(ex.getAttempted()).isEqualTo(4);
+        // Without an executor, streaming tools still run inline during onCompleteResponse.
+        // The limit is observed before that inline dispatch happens, so no tool runs.
         assertThat(tool.calls.get()).isZero();
+        assertThat(tool.args).isEmpty();
     }
 
     @Test
-    void should_throw_and_not_execute_over_cap_tools_with_concurrent_executor__streaming() throws Exception {
+    void should_throw_before_any_tool_runs_with_tool_executor__streaming() throws Exception {
 
         CountingTool tool = new CountingTool();
-        AiMessage fiveToolCallResponse = AiMessage.from(
+        StreamingChatModel model = StreamingToolCallModel.withToolCalls(
                 toolCall("c1", "a"),
                 toolCall("c2", "b"),
                 toolCall("c3", "c"),
                 toolCall("c4", "d"),
                 toolCall("c5", "e"));
-        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(fiveToolCallResponse);
 
         StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
                 .streamingChatModel(model)
                 .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
                 .tools(tool)
                 .maxToolCallsPerResponse(2)
-                .executeToolsConcurrently()
+                .executeToolsConcurrently(Runnable::run)
                 .build();
 
         CompletableFuture<Throwable> futureError = new CompletableFuture<>();
@@ -197,10 +211,8 @@ class MaxToolCallsPerResponseTest {
         ToolCallsLimitExceededException ex = (ToolCallsLimitExceededException) error;
         assertThat(ex.getLimit()).isEqualTo(2);
         assertThat(ex.getAttempted()).isEqualTo(5);
-        // Atomic streaming cap: tool calls are buffered until onCompleteResponse, so a response
-        // that exceeds the cap rejects the entire batch before any tool runs — even when a
-        // concurrent executor is configured.
         assertThat(tool.calls.get()).isZero();
+        assertThat(tool.args).isEmpty();
     }
 
     @Test
@@ -231,11 +243,74 @@ class MaxToolCallsPerResponseTest {
         assertThat(tool.calls.get()).isEqualTo(2);
     }
 
+    @Test
+    void should_use_tool_executor_for_single_tool_when_streaming_cap_is_configured() throws Exception {
+
+        CountingTool tool = new CountingTool();
+        AtomicBoolean executorUsed = new AtomicBoolean();
+        AiMessage oneToolCall = AiMessage.from(toolCall("c1", "a"));
+        AiMessage finalAnswer = AiMessage.from("done");
+        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(oneToolCall, finalAnswer);
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .maxToolCallsPerResponse(1)
+                .executeToolsConcurrently(command -> {
+                    executorUsed.set(true);
+                    command.run();
+                })
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        ChatResponse response = future.get(10, TimeUnit.SECONDS);
+        assertThat(response.aiMessage().text()).isEqualTo("done");
+        assertThat(tool.calls.get()).isEqualTo(1);
+        assertThat(executorUsed.get()).isTrue();
+    }
+
     private static ToolExecutionRequest toolCall(String id, String arg) {
         return ToolExecutionRequest.builder()
                 .id(id)
                 .name("doWork")
                 .arguments("{\"arg0\": \"" + arg + "\"}")
                 .build();
+    }
+
+    private static class StreamingToolCallModel implements StreamingChatModel {
+
+        private final List<ToolExecutionRequest> toolCalls;
+
+        private StreamingToolCallModel(List<ToolExecutionRequest> toolCalls) {
+            this.toolCalls = toolCalls;
+        }
+
+        static StreamingToolCallModel withToolCalls(ToolExecutionRequest... toolCalls) {
+            return new StreamingToolCallModel(List.of(toolCalls));
+        }
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            Thread thread = new Thread(() -> {
+                for (int i = 0; i < toolCalls.size(); i++) {
+                    onCompleteToolCall(handler, new CompleteToolCall(i, toolCalls.get(i)));
+                }
+                onCompleteResponse(
+                        handler,
+                        ChatResponse.builder()
+                                .aiMessage(AiMessage.from(toolCalls))
+                                .build());
+            }, "test-streaming-tool-call-model");
+            thread.setDaemon(true);
+            thread.start();
+        }
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/MaxToolCallsPerResponseTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/MaxToolCallsPerResponseTest.java
@@ -1,0 +1,248 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.TokenStream;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates {@link AiServices#maxToolCallsPerResponse(int)} cooperative truncation when an LLM
+ * response contains more tool calls than the user wants to spend.
+ */
+class MaxToolCallsPerResponseTest {
+
+    interface Assistant {
+        String chat(String message);
+    }
+
+    interface StreamingAssistant {
+        TokenStream chat(String message);
+    }
+
+    static class CountingTool {
+
+        final AtomicInteger calls = new AtomicInteger();
+
+        @Tool
+        public String doWork(String arg) {
+            calls.incrementAndGet();
+            return "ok-" + arg;
+        }
+    }
+
+    @Test
+    void should_throw_when_response_has_more_tool_calls_than_limit__sync() {
+
+        // given
+        CountingTool tool = new CountingTool();
+        // LLM returns a single response with 3 tool calls; limit is 2
+        AiMessage threeToolCallResponse = AiMessage.from(
+                toolCall("c1", "a"),
+                toolCall("c2", "b"),
+                toolCall("c3", "c"));
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(threeToolCallResponse);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .maxToolCallsPerResponse(2)
+                .build();
+
+        // when / then
+        assertThatExceptionOfType(ToolCallsLimitExceededException.class)
+                .isThrownBy(() -> assistant.chat("go"))
+                .matches(ex -> ex.getLimit() == 2 && ex.getAttempted() == 3);
+
+        // No tools should have been executed since the cap is enforced before dispatch.
+        assertThat(tool.calls.get()).isZero();
+    }
+
+    @Test
+    void should_not_throw_when_response_has_exactly_limit_tool_calls__sync() {
+
+        CountingTool tool = new CountingTool();
+        AiMessage twoToolCalls = AiMessage.from(toolCall("c1", "a"), toolCall("c2", "b"));
+        AiMessage finalAnswer = AiMessage.from("done");
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(twoToolCalls, finalAnswer);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .maxToolCallsPerResponse(2)
+                .build();
+
+        assertThatNoException().isThrownBy(() -> assistant.chat("go"));
+        assertThat(tool.calls.get()).isEqualTo(2);
+    }
+
+    @Test
+    void should_be_unlimited_when_default_zero__sync() {
+
+        CountingTool tool = new CountingTool();
+        AiMessage manyToolCalls = AiMessage.from(
+                toolCall("c1", "a"),
+                toolCall("c2", "b"),
+                toolCall("c3", "c"),
+                toolCall("c4", "d"),
+                toolCall("c5", "e"));
+        AiMessage finalAnswer = AiMessage.from("done");
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(manyToolCalls, finalAnswer);
+
+        // No maxToolCallsPerResponse set => unlimited (default 0).
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .build();
+
+        assertThatNoException().isThrownBy(() -> assistant.chat("go"));
+        assertThat(tool.calls.get()).isEqualTo(5);
+    }
+
+    @Test
+    void explicit_zero_means_unlimited__sync() {
+
+        CountingTool tool = new CountingTool();
+        AiMessage manyToolCalls = AiMessage.from(toolCall("c1", "a"), toolCall("c2", "b"), toolCall("c3", "c"));
+        AiMessage finalAnswer = AiMessage.from("done");
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(manyToolCalls, finalAnswer);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .maxToolCallsPerResponse(0)
+                .build();
+
+        assertThatNoException().isThrownBy(() -> assistant.chat("go"));
+        assertThat(tool.calls.get()).isEqualTo(3);
+    }
+
+    @Test
+    void should_throw_when_response_has_more_tool_calls_than_limit__streaming() throws Exception {
+
+        CountingTool tool = new CountingTool();
+        AiMessage threeToolCallResponse = AiMessage.from(
+                toolCall("c1", "a"),
+                toolCall("c2", "b"),
+                toolCall("c3", "c"));
+        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(threeToolCallResponse);
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .maxToolCallsPerResponse(2)
+                .build();
+
+        CompletableFuture<Throwable> futureError = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(r -> futureError.completeExceptionally(
+                        new IllegalStateException("onCompleteResponse should not be called")))
+                .onError(futureError::complete)
+                .start();
+
+        Throwable error = futureError.get(10, TimeUnit.SECONDS);
+        assertThat(error).isInstanceOf(ToolCallsLimitExceededException.class);
+        ToolCallsLimitExceededException ex = (ToolCallsLimitExceededException) error;
+        assertThat(ex.getLimit()).isEqualTo(2);
+        assertThat(ex.getAttempted()).isEqualTo(3);
+        // Without an executor the streaming path defers tool execution to onCompleteResponse,
+        // which throws before any tool runs.
+        assertThat(tool.calls.get()).isZero();
+    }
+
+    @Test
+    void should_throw_and_not_execute_over_cap_tools_with_concurrent_executor__streaming() throws Exception {
+
+        CountingTool tool = new CountingTool();
+        AiMessage fiveToolCallResponse = AiMessage.from(
+                toolCall("c1", "a"),
+                toolCall("c2", "b"),
+                toolCall("c3", "c"),
+                toolCall("c4", "d"),
+                toolCall("c5", "e"));
+        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(fiveToolCallResponse);
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .maxToolCallsPerResponse(2)
+                .executeToolsConcurrently()
+                .build();
+
+        CompletableFuture<Throwable> futureError = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(r -> futureError.completeExceptionally(
+                        new IllegalStateException("onCompleteResponse should not be called")))
+                .onError(futureError::complete)
+                .start();
+
+        Throwable error = futureError.get(10, TimeUnit.SECONDS);
+        assertThat(error).isInstanceOf(ToolCallsLimitExceededException.class);
+        ToolCallsLimitExceededException ex = (ToolCallsLimitExceededException) error;
+        assertThat(ex.getLimit()).isEqualTo(2);
+        assertThat(ex.getAttempted()).isEqualTo(5);
+        // With a concurrent executor onCompleteToolCall fires per tool as the stream arrives
+        // and dispatches eagerly. Calls beyond the cap must not be submitted, so at most 'limit'
+        // tools may have executed, never more.
+        assertThat(tool.calls.get()).isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void should_not_throw_when_response_under_limit__streaming() throws Exception {
+
+        CountingTool tool = new CountingTool();
+        AiMessage twoToolCalls = AiMessage.from(toolCall("c1", "a"), toolCall("c2", "b"));
+        AiMessage finalAnswer = AiMessage.from("done");
+        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(twoToolCalls, finalAnswer);
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .maxToolCallsPerResponse(2)
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        ChatResponse response = future.get(10, TimeUnit.SECONDS);
+        assertThat(response.aiMessage().text()).isEqualTo("done");
+        assertThat(tool.calls.get()).isEqualTo(2);
+    }
+
+    private static ToolExecutionRequest toolCall(String id, String arg) {
+        return ToolExecutionRequest.builder()
+                .id(id)
+                .name("doWork")
+                .arguments("{\"arg0\": \"" + arg + "\"}")
+                .build();
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/MaxToolCallsPerResponseTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/MaxToolCallsPerResponseTest.java
@@ -13,7 +13,6 @@ import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.TokenStream;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -50,10 +49,7 @@ class MaxToolCallsPerResponseTest {
         // given
         CountingTool tool = new CountingTool();
         // LLM returns a single response with 3 tool calls; limit is 2
-        AiMessage threeToolCallResponse = AiMessage.from(
-                toolCall("c1", "a"),
-                toolCall("c2", "b"),
-                toolCall("c3", "c"));
+        AiMessage threeToolCallResponse = AiMessage.from(toolCall("c1", "a"), toolCall("c2", "b"), toolCall("c3", "c"));
         ChatModelMock model = ChatModelMock.thatAlwaysResponds(threeToolCallResponse);
 
         Assistant assistant = AiServices.builder(Assistant.class)
@@ -138,10 +134,7 @@ class MaxToolCallsPerResponseTest {
     void should_throw_when_response_has_more_tool_calls_than_limit__streaming() throws Exception {
 
         CountingTool tool = new CountingTool();
-        AiMessage threeToolCallResponse = AiMessage.from(
-                toolCall("c1", "a"),
-                toolCall("c2", "b"),
-                toolCall("c3", "c"));
+        AiMessage threeToolCallResponse = AiMessage.from(toolCall("c1", "a"), toolCall("c2", "b"), toolCall("c3", "c"));
         StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(threeToolCallResponse);
 
         StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/PerCallChatModelTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/PerCallChatModelTest.java
@@ -1,0 +1,158 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.service.AiServiceContext;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates the per-call {@link ChatModel} overload of
+ * {@link ToolService#executeInferenceAndToolsLoop(AiServiceContext, ChatModel, Object, ChatResponse,
+ * ChatRequestParameters, java.util.List, ChatMemory, InvocationContext, ToolServiceContext, boolean)}.
+ *
+ * <p>Downstream framework integrators (e.g. {@code quarkus-langchain4j}) need this overload to
+ * route follow-up inference requests to a method-specific {@code ChatModel}, e.g. when
+ * {@code @ModelName} resolves to a different model than the one stored on the {@link AiServiceContext}.
+ */
+class PerCallChatModelTest {
+
+    static class Echo {
+        @Tool
+        String echo(String arg) {
+            return "echo:" + arg;
+        }
+    }
+
+    @Test
+    void per_call_chat_model_overload_uses_supplied_model_for_follow_up_requests() {
+        // given
+        // The caller already has the FIRST chatResponse in hand (it contains a tool call).
+        // The loop will execute the tool, then call the LLM again — that follow-up should use
+        // the per-call model, not context.chatModel.
+        ChatModel defaultModel = ChatModelMock.thatAlwaysResponds(AiMessage.from("from-default-model"));
+        ChatModel perCallModel = ChatModelMock.thatAlwaysResponds(AiMessage.from("from-per-call-model"));
+
+        ToolService toolService = new ToolService();
+        toolService.tools(java.util.Collections.singletonList(new Echo()));
+
+        AiServiceContext context = AiServiceContext.create(SomeAiService.class);
+        context.chatModel = defaultModel;
+        context.toolService = toolService;
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+        UserMessage userMessage = UserMessage.from("go");
+        chatMemory.add(userMessage);
+
+        InvocationContext invocationContext = InvocationContext.builder()
+                .interfaceName(SomeAiService.class.getName())
+                .methodName("chat")
+                .userMessage(userMessage)
+                .chatMemoryId("default")
+                .timestampNow()
+                .build();
+
+        // Initial response with a tool call — caller would normally have produced this from the
+        // per-call ChatModel, but for this test we synthesize it so we can probe just the loop.
+        ChatResponse initialResponse = ChatResponse.builder()
+                .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                        .id("c1")
+                        .name("echo")
+                        .arguments("{\"arg0\": \"hi\"}")
+                        .build()))
+                .metadata(ChatResponseMetadata.builder().build())
+                .build();
+
+        ChatRequestParameters parameters = ChatRequestParameters.builder().build();
+        ToolServiceContext toolServiceContext = toolService.createContext(invocationContext, userMessage, new ArrayList<>(chatMemory.messages()));
+
+        // when — invoke the new overload, passing the per-call model explicitly.
+        ToolServiceResult result = toolService.executeInferenceAndToolsLoop(
+                context,
+                perCallModel,
+                "default",
+                initialResponse,
+                parameters,
+                new ArrayList<>(chatMemory.messages()),
+                chatMemory,
+                invocationContext,
+                toolServiceContext,
+                false);
+
+        // then — only the per-call model should have been invoked for follow-up inference;
+        // the default model must not have been touched.
+        assertThat(((ChatModelMock) perCallModel).requests()).hasSize(1);
+        assertThat(((ChatModelMock) defaultModel).requests()).isEmpty();
+        assertThat(result.finalResponse().aiMessage().text()).isEqualTo("from-per-call-model");
+        assertThat(result.toolExecutions()).hasSize(1);
+    }
+
+    @Test
+    void existing_overload_falls_back_to_context_chat_model() {
+        // Sanity check: the original (no per-call model) overload should still use context.chatModel.
+        ChatModel defaultModel = ChatModelMock.thatAlwaysResponds(AiMessage.from("from-default-model"));
+
+        ToolService toolService = new ToolService();
+        toolService.tools(java.util.Collections.singletonList(new Echo()));
+
+        AiServiceContext context = AiServiceContext.create(SomeAiService.class);
+        context.chatModel = defaultModel;
+        context.toolService = toolService;
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+        UserMessage userMessage = UserMessage.from("go");
+        chatMemory.add(userMessage);
+
+        InvocationContext invocationContext = InvocationContext.builder()
+                .interfaceName(SomeAiService.class.getName())
+                .methodName("chat")
+                .userMessage(userMessage)
+                .chatMemoryId("default")
+                .timestampNow()
+                .build();
+
+        ChatResponse initialResponse = ChatResponse.builder()
+                .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                        .id("c1")
+                        .name("echo")
+                        .arguments("{\"arg0\": \"hi\"}")
+                        .build()))
+                .metadata(ChatResponseMetadata.builder().build())
+                .build();
+
+        ChatRequestParameters parameters = ChatRequestParameters.builder().build();
+        ToolServiceContext toolServiceContext = toolService.createContext(invocationContext, userMessage, new ArrayList<>(chatMemory.messages()));
+
+        ToolServiceResult result = toolService.executeInferenceAndToolsLoop(
+                context,
+                "default",
+                initialResponse,
+                parameters,
+                new ArrayList<>(chatMemory.messages()),
+                chatMemory,
+                invocationContext,
+                toolServiceContext,
+                false);
+
+        assertThat(((ChatModelMock) defaultModel).requests()).hasSize(1);
+        assertThat(result.finalResponse().aiMessage().text()).isEqualTo("from-default-model");
+    }
+
+    interface SomeAiService {
+        String chat(String message);
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolChoiceAutoProtectionTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolChoiceAutoProtectionTest.java
@@ -80,9 +80,10 @@ class StreamingToolChoiceAutoProtectionTest {
                     if (n == 0) {
                         return ChatRequest.builder()
                                 .messages(req.messages())
-                                .parameters(req.parameters().overrideWith(ChatRequestParameters.builder()
-                                        .toolChoice(ToolChoice.REQUIRED)
-                                        .build()))
+                                .parameters(req.parameters()
+                                        .overrideWith(ChatRequestParameters.builder()
+                                                .toolChoice(ToolChoice.REQUIRED)
+                                                .build()))
                                 .build();
                     }
                     // Capture the toolChoice on the follow-up request — proves the rewrite happened.
@@ -132,9 +133,10 @@ class StreamingToolChoiceAutoProtectionTest {
                     if (n == 0) {
                         return ChatRequest.builder()
                                 .messages(req.messages())
-                                .parameters(req.parameters().overrideWith(ChatRequestParameters.builder()
-                                        .toolChoice(ToolChoice.REQUIRED)
-                                        .build()))
+                                .parameters(req.parameters()
+                                        .overrideWith(ChatRequestParameters.builder()
+                                                .toolChoice(ToolChoice.REQUIRED)
+                                                .build()))
                                 .build();
                     }
                     if (req.parameters().toolChoice() == ToolChoice.AUTO) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolChoiceAutoProtectionTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolChoiceAutoProtectionTest.java
@@ -1,0 +1,164 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.TokenStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates that {@link AiServices#forceToolChoiceAutoAfterFirstIteration(boolean)} also
+ * applies in the streaming response handler — on follow-up streamed inference requests, a
+ * caller-supplied {@link ToolChoice#REQUIRED} must be rewritten to {@link ToolChoice#AUTO}
+ * so the LLM can terminate the loop.
+ */
+class StreamingToolChoiceAutoProtectionTest {
+
+    interface StreamingAssistant {
+        TokenStream chat(String message);
+    }
+
+    static class StickyTool {
+        final AtomicInteger calls = new AtomicInteger();
+
+        @Tool
+        public String stick(String arg) {
+            calls.incrementAndGet();
+            return "ok";
+        }
+    }
+
+    /**
+     * Returns a tool call when ToolChoice.REQUIRED, a final text message when AUTO/null.
+     */
+    private static StreamingChatModelMock toolChoiceAwareModel() {
+        // This mock returns a single response tied to the first chat call. To distinguish
+        // iterations 0 vs 1, we pre-queue both responses: iter 0 returns a tool call, iter 1
+        // returns a final text. We rely on the test's transformer to produce REQUIRED only on
+        // iter 0 and on the loop to rewrite REQUIRED -> AUTO between iterations when the flag
+        // is on. The mock itself doesn't inspect the request — but we still observe that the
+        // loop terminates after iteration 1 (i.e. the model produces a final text), proving
+        // that the loop did not continue calling tools forever.
+        AiMessage iter0 = AiMessage.from(ToolExecutionRequest.builder()
+                .id("c1")
+                .name("stick")
+                .arguments("{\"arg0\":\"x\"}")
+                .build());
+        AiMessage iter1 = AiMessage.from("done");
+        return StreamingChatModelMock.thatAlwaysStreams(iter0, iter1);
+    }
+
+    @Test
+    void with_flag_required_tool_choice_is_rewritten_to_auto_after_first_iteration() throws Exception {
+        // The first chat request transformer sets REQUIRED only on iteration 0. With the flag
+        // on, the loop's rewrite then carries AUTO forward and the loop terminates.
+        StickyTool tool = new StickyTool();
+        StreamingChatModelMock model = toolChoiceAwareModel();
+
+        AtomicInteger transformerCalls = new AtomicInteger();
+        AtomicInteger followUpToolChoiceObserved = new AtomicInteger();
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(50))
+                .tools(tool)
+                .maxSequentialToolsInvocations(5)
+                .forceToolChoiceAutoAfterFirstIteration(true)
+                .chatRequestTransformer((req, memId) -> {
+                    int n = transformerCalls.getAndIncrement();
+                    if (n == 0) {
+                        return ChatRequest.builder()
+                                .messages(req.messages())
+                                .parameters(req.parameters().overrideWith(ChatRequestParameters.builder()
+                                        .toolChoice(ToolChoice.REQUIRED)
+                                        .build()))
+                                .build();
+                    }
+                    // Capture the toolChoice on the follow-up request — proves the rewrite happened.
+                    if (req.parameters().toolChoice() == ToolChoice.AUTO) {
+                        followUpToolChoiceObserved.set(1);
+                    } else if (req.parameters().toolChoice() == ToolChoice.REQUIRED) {
+                        followUpToolChoiceObserved.set(2);
+                    }
+                    return req;
+                })
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        ChatResponse response = future.get(10, TimeUnit.SECONDS);
+        assertThat(response.aiMessage().text()).isEqualTo("done");
+        assertThat(tool.calls.get()).isEqualTo(1);
+        assertThat(followUpToolChoiceObserved.get())
+                .as("follow-up streaming request must carry ToolChoice.AUTO after first iteration")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void without_flag_streaming_follow_up_does_not_inject_tool_choice_auto() throws Exception {
+        // Without the flag, the streaming handler does NOT inject ToolChoice.AUTO on follow-up.
+        // (The historical behavior is that toolChoice is not carried forward by the streaming
+        // handler at all, so the follow-up request's toolChoice is simply unset/null.)
+        StickyTool tool = new StickyTool();
+        StreamingChatModelMock model = toolChoiceAwareModel();
+
+        AtomicInteger transformerCalls = new AtomicInteger();
+        AtomicInteger followUpAutoObserved = new AtomicInteger();
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(50))
+                .tools(tool)
+                .maxSequentialToolsInvocations(5)
+                // forceToolChoiceAutoAfterFirstIteration NOT set — defaults to false.
+                .chatRequestTransformer((req, memId) -> {
+                    int n = transformerCalls.getAndIncrement();
+                    if (n == 0) {
+                        return ChatRequest.builder()
+                                .messages(req.messages())
+                                .parameters(req.parameters().overrideWith(ChatRequestParameters.builder()
+                                        .toolChoice(ToolChoice.REQUIRED)
+                                        .build()))
+                                .build();
+                    }
+                    if (req.parameters().toolChoice() == ToolChoice.AUTO) {
+                        followUpAutoObserved.incrementAndGet();
+                    }
+                    return req;
+                })
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        ChatResponse response = future.get(10, TimeUnit.SECONDS);
+        assertThat(response.aiMessage().text()).isEqualTo("done");
+        // Without the flag, the handler must NOT inject ToolChoice.AUTO into the follow-up
+        // request (some downstream callers may want to set REQUIRED on follow-up via their
+        // own transformer; the handler should not pre-empt them).
+        assertThat(followUpAutoObserved.get())
+                .as("without flag, the streaming handler must not inject ToolChoice.AUTO on follow-up")
+                .isZero();
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolDispatchHookTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolDispatchHookTest.java
@@ -1,0 +1,129 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.TokenStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates {@link AiServices#streamingToolDispatchHook(StreamingToolDispatchHook)} — the
+ * integration SPI used by downstream framework integrators (e.g. {@code quarkus-langchain4j})
+ * to control threading and context propagation around the streaming tool batch dispatch.
+ */
+class StreamingToolDispatchHookTest {
+
+    interface StreamingAssistant {
+        TokenStream chat(String message);
+    }
+
+    static class CountingTool {
+        final AtomicInteger calls = new AtomicInteger();
+
+        @Tool
+        public String doWork(String arg) {
+            calls.incrementAndGet();
+            return "ok-" + arg;
+        }
+    }
+
+    @Test
+    void framework_dispatch_hook_receives_the_tool_batch_dispatch() throws Exception {
+        CountingTool tool = new CountingTool();
+
+        AiMessage twoToolCalls =
+                AiMessage.from(toolCall("c1", "a"), toolCall("c2", "b"));
+        AiMessage finalAnswer = AiMessage.from("done");
+        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(twoToolCalls, finalAnswer);
+
+        AtomicInteger hookInvocations = new AtomicInteger();
+        AtomicReference<Thread> hookThread = new AtomicReference<>();
+        StreamingToolDispatchHook hook = new StreamingToolDispatchHook() {
+            @Override
+            public <T> CompletionStage<T> dispatch(Supplier<T> work) {
+                hookInvocations.incrementAndGet();
+                hookThread.set(Thread.currentThread());
+                // Run inline (just like INLINE) so the test stays deterministic, but record
+                // that the hook was invoked.
+                try {
+                    return CompletableFuture.completedFuture(work.get());
+                } catch (Throwable t) {
+                    CompletableFuture<T> failed = new CompletableFuture<>();
+                    failed.completeExceptionally(t);
+                    return failed;
+                }
+            }
+        };
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .streamingToolDispatchHook(hook)
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        ChatResponse response = future.get(10, TimeUnit.SECONDS);
+        assertThat(response.aiMessage().text()).isEqualTo("done");
+        assertThat(tool.calls.get()).isEqualTo(2);
+        // The hook is invoked once per LLM response that contains tool calls.
+        assertThat(hookInvocations.get())
+                .as("hook should be invoked once for the response that contains tool calls")
+                .isEqualTo(1);
+        assertThat(hookThread.get()).isNotNull();
+    }
+
+    @Test
+    void without_hook_default_inline_dispatch_runs_tools() throws Exception {
+        CountingTool tool = new CountingTool();
+        AiMessage oneToolCall = AiMessage.from(toolCall("c1", "a"));
+        AiMessage finalAnswer = AiMessage.from("done");
+        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(oneToolCall, finalAnswer);
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                // No hook configured — the INLINE default runs inline.
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        ChatResponse response = future.get(10, TimeUnit.SECONDS);
+        assertThat(response.aiMessage().text()).isEqualTo("done");
+        assertThat(tool.calls.get()).isEqualTo(1);
+    }
+
+    private static ToolExecutionRequest toolCall(String id, String arg) {
+        return ToolExecutionRequest.builder()
+                .id(id)
+                .name("doWork")
+                .arguments("{\"arg0\": \"" + arg + "\"}")
+                .build();
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolDispatchHookTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolDispatchHookTest.java
@@ -230,11 +230,10 @@ class StreamingToolDispatchHookTest {
 
     @Test
     void hook_returning_without_invoking_work_silently_drops_the_batch() throws Exception {
-        // Per Javadoc: "Returning without invoking work will silently drop the tool batch."
-        // Validates that contract — if the hook never invokes work.get(), no tool executor runs
-        // and no follow-up streaming inference is issued. The test must NOT hang waiting for a
-        // final response (since none will arrive), so it uses a short timeout and asserts the
-        // future remains incomplete.
+        // Without a per-tool executor, tools run inside the hook's work supplier. If the hook
+        // drops that supplier, no tool executor runs and no follow-up streaming inference is issued.
+        // The test must NOT hang waiting for a final response (since none will arrive), so it uses
+        // a short timeout and asserts the future remains incomplete.
         CountingTool tool = new CountingTool();
         AiMessage oneToolCall = AiMessage.from(toolCall("c1", "a"));
         AiMessage finalAnswer = AiMessage.from("done");
@@ -283,6 +282,57 @@ class StreamingToolDispatchHookTest {
         assertThat(tool.calls.get())
                 .as("tool executor must not run when the hook drops the batch")
                 .isZero();
+        assertThat(future).as("no final response should have been delivered").isNotDone();
+    }
+
+    @Test
+    void hook_returning_without_invoking_work_does_not_cancel_already_scheduled_tool_executor_work()
+            throws Exception {
+        CountingTool tool = new CountingTool();
+        AiMessage oneToolCall = AiMessage.from(toolCall("c1", "a"));
+        AiMessage finalAnswer = AiMessage.from("done");
+        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(oneToolCall, finalAnswer);
+
+        AtomicInteger hookInvocations = new AtomicInteger();
+        StreamingToolDispatchHook droppingHook = new StreamingToolDispatchHook() {
+            @Override
+            public <T> CompletionStage<T> dispatch(Supplier<T> work) {
+                hookInvocations.incrementAndGet();
+                // Deliberately do NOT invoke work.get().
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .executeToolsConcurrently(Runnable::run)
+                .streamingToolDispatchHook(droppingHook)
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        try {
+            future.get(1, TimeUnit.SECONDS);
+            throw new AssertionError(
+                    "Final response future completed even though hook dropped follow-up work: " + future.get());
+        } catch (TimeoutException expected) {
+            // Expected: no follow-up response when batch result gathering is dropped.
+        }
+
+        assertThat(hookInvocations.get())
+                .as("hook should have been invoked for the tool-call response")
+                .isEqualTo(1);
+        assertThat(tool.calls.get())
+                .as("per-tool executor work is scheduled eagerly before the hook runs")
+                .isEqualTo(1);
         assertThat(future).as("no final response should have been delivered").isNotDone();
     }
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolDispatchHookTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolDispatchHookTest.java
@@ -12,7 +12,12 @@ import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.TokenStream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -117,6 +122,168 @@ class StreamingToolDispatchHookTest {
         ChatResponse response = future.get(10, TimeUnit.SECONDS);
         assertThat(response.aiMessage().text()).isEqualTo("done");
         assertThat(tool.calls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void framework_dispatch_hook_can_switch_to_a_worker_thread() throws Exception {
+        // Validates the SPI's primary use case: a framework integrator submits the supplied
+        // work to its own executor (e.g. a Vert.x worker pool or a virtual thread) and the tool
+        // executor runs on that thread — NOT on the calling/streaming-callback thread.
+        //
+        // The streaming flow continues after the worker thread runs the supplier, so the test
+        // must wait for the entire stream (including the follow-up final response) to complete.
+        CountingTool tool = new CountingTool();
+        AtomicReference<Thread> toolThread = new AtomicReference<>();
+        // Wrap @Tool to capture the executing thread.
+        class ThreadCapturingTool {
+            @Tool
+            public String doWork(String arg) {
+                toolThread.set(Thread.currentThread());
+                return tool.doWork(arg);
+            }
+        }
+        ThreadCapturingTool threadCapturingTool = new ThreadCapturingTool();
+
+        AiMessage twoToolCalls = AiMessage.from(toolCall("c1", "a"), toolCall("c2", "b"));
+        AiMessage finalAnswer = AiMessage.from("done");
+        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(twoToolCalls, finalAnswer);
+
+        ThreadFactory workerThreadFactory = r -> {
+            Thread t = new Thread(r, "test-dispatch-hook-worker");
+            t.setDaemon(true);
+            return t;
+        };
+        ExecutorService workerExecutor = Executors.newSingleThreadExecutor(workerThreadFactory);
+        try {
+            AtomicInteger hookInvocations = new AtomicInteger();
+            AtomicReference<Thread> hookSubmitThread = new AtomicReference<>();
+            AtomicReference<Thread> workerThreadFromHook = new AtomicReference<>();
+            CountDownLatch workSubmittedLatch = new CountDownLatch(1);
+
+            StreamingToolDispatchHook hook = new StreamingToolDispatchHook() {
+                @Override
+                public <T> CompletionStage<T> dispatch(Supplier<T> work) {
+                    hookInvocations.incrementAndGet();
+                    hookSubmitThread.set(Thread.currentThread());
+                    CompletableFuture<T> future = new CompletableFuture<>();
+                    workerExecutor.submit(() -> {
+                        workerThreadFromHook.set(Thread.currentThread());
+                        try {
+                            future.complete(work.get());
+                        } catch (Throwable t) {
+                            future.completeExceptionally(t);
+                        } finally {
+                            workSubmittedLatch.countDown();
+                        }
+                    });
+                    return future;
+                }
+            };
+
+            StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                    .streamingChatModel(model)
+                    .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                    .tools(threadCapturingTool)
+                    .streamingToolDispatchHook(hook)
+                    .build();
+
+            CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+            assistant
+                    .chat("go")
+                    .onPartialResponse(ignored -> {})
+                    .onCompleteResponse(future::complete)
+                    .onError(future::completeExceptionally)
+                    .start();
+
+            ChatResponse response = future.get(10, TimeUnit.SECONDS);
+            // Worker thread accepted the submission.
+            assertThat(workSubmittedLatch.await(5, TimeUnit.SECONDS))
+                    .as("worker should have run the submitted supplier")
+                    .isTrue();
+
+            assertThat(response.aiMessage().text()).isEqualTo("done");
+            assertThat(tool.calls.get()).isEqualTo(2);
+
+            // Hook was invoked exactly once for the single tool-call response.
+            assertThat(hookInvocations.get())
+                    .as("hook should be invoked once per tool-call response")
+                    .isEqualTo(1);
+
+            // The tool executor must have run on the framework's worker thread, NOT on the
+            // thread that invoked the hook (which would be the streaming callback thread).
+            assertThat(toolThread.get())
+                    .as("tool should have executed on the worker thread")
+                    .isNotNull()
+                    .isEqualTo(workerThreadFromHook.get());
+            assertThat(toolThread.get().getName()).isEqualTo("test-dispatch-hook-worker");
+            assertThat(toolThread.get())
+                    .as("tool must not have executed on the hook-submit (streaming-callback) thread")
+                    .isNotEqualTo(hookSubmitThread.get());
+            assertThat(toolThread.get())
+                    .as("tool must not have executed on the main/test thread")
+                    .isNotEqualTo(Thread.currentThread());
+        } finally {
+            workerExecutor.shutdownNow();
+            workerExecutor.awaitTermination(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void hook_returning_without_invoking_work_silently_drops_the_batch() throws Exception {
+        // Per Javadoc: "Returning without invoking work will silently drop the tool batch."
+        // Validates that contract — if the hook never invokes work.get(), no tool executor runs
+        // and no follow-up streaming inference is issued. The test must NOT hang waiting for a
+        // final response (since none will arrive), so it uses a short timeout and asserts the
+        // future remains incomplete.
+        CountingTool tool = new CountingTool();
+        AiMessage oneToolCall = AiMessage.from(toolCall("c1", "a"));
+        AiMessage finalAnswer = AiMessage.from("done");
+        StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(oneToolCall, finalAnswer);
+
+        AtomicInteger hookInvocations = new AtomicInteger();
+        StreamingToolDispatchHook droppingHook = new StreamingToolDispatchHook() {
+            @Override
+            public <T> CompletionStage<T> dispatch(Supplier<T> work) {
+                hookInvocations.incrementAndGet();
+                // Deliberately do NOT invoke work.get().
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .streamingToolDispatchHook(droppingHook)
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        // Give the streaming pipeline ample time to (a) deliver the tool-call response,
+        // (b) invoke the hook, and (c) finish. Since work was never invoked, no follow-up
+        // inference is issued and the final-response future should never complete.
+        try {
+            future.get(1, TimeUnit.SECONDS);
+            // If we reach here, the future completed — that's a contract violation.
+            throw new AssertionError(
+                    "Final response future completed even though hook dropped the batch: " + future.get());
+        } catch (TimeoutException expected) {
+            // Expected: no final response when batch is dropped.
+        }
+
+        assertThat(hookInvocations.get())
+                .as("hook should have been invoked for the tool-call response")
+                .isEqualTo(1);
+        assertThat(tool.calls.get())
+                .as("tool executor must not run when the hook drops the batch")
+                .isZero();
+        assertThat(future).as("no final response should have been delivered").isNotDone();
     }
 
     private static ToolExecutionRequest toolCall(String id, String arg) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolExecutionSchedulingTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/StreamingToolExecutionSchedulingTest.java
@@ -1,0 +1,172 @@
+package dev.langchain4j.service.tool;
+
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteResponse;
+import static dev.langchain4j.internal.InternalStreamingChatResponseHandlerUtils.onCompleteToolCall;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.CompleteToolCall;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.TokenStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StreamingToolExecutionSchedulingTest {
+
+    interface StreamingAssistant {
+        TokenStream chat(String message);
+    }
+
+    static class ThreadCapturingTool {
+
+        final CountDownLatch started = new CountDownLatch(1);
+        final AtomicReference<Thread> thread = new AtomicReference<>();
+
+        @Tool
+        public String doWork(String arg) {
+            thread.set(Thread.currentThread());
+            started.countDown();
+            return "ok-" + arg;
+        }
+    }
+
+    private ExecutorService toolExecutor;
+
+    @BeforeEach
+    void setUp() {
+        ThreadFactory threadFactory = r -> {
+            Thread thread = new Thread(r, "test-streaming-tool-executor");
+            thread.setDaemon(true);
+            return thread;
+        };
+        toolExecutor = Executors.newSingleThreadExecutor(threadFactory);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (toolExecutor != null) {
+            toolExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void default_zero_max_starts_tool_from_on_complete_tool_call_before_on_complete_response() throws Exception {
+        ThreadCapturingTool tool = new ThreadCapturingTool();
+        ToolExecutionRequest toolCall = toolCall("c1", "a");
+        BlockingAfterFirstToolCallStreamingModel model =
+                new BlockingAfterFirstToolCallStreamingModel(toolCall, tool.started);
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .executeToolsConcurrently(toolExecutor)
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        ChatResponse response = future.get(10, TimeUnit.SECONDS);
+        assertThat(response.aiMessage().text()).isEqualTo("done");
+        assertThat(model.toolStartedBeforeCompleteResponse.get())
+                .as("the tool should be scheduled from onCompleteToolCall before onCompleteResponse is emitted")
+                .isTrue();
+    }
+
+    @Test
+    void single_streaming_tool_uses_tool_executor_when_concurrent_execution_is_configured() throws Exception {
+        ThreadCapturingTool tool = new ThreadCapturingTool();
+        ToolExecutionRequest toolCall = toolCall("c1", "a");
+        BlockingAfterFirstToolCallStreamingModel model =
+                new BlockingAfterFirstToolCallStreamingModel(toolCall, tool.started);
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .tools(tool)
+                .executeToolsConcurrently(toolExecutor)
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        ChatResponse response = future.get(10, TimeUnit.SECONDS);
+        assertThat(response.aiMessage().text()).isEqualTo("done");
+        assertThat(tool.thread.get()).isNotNull();
+        assertThat(tool.thread.get().getName()).isEqualTo("test-streaming-tool-executor");
+    }
+
+    private static ToolExecutionRequest toolCall(String id, String arg) {
+        return ToolExecutionRequest.builder()
+                .id(id)
+                .name("doWork")
+                .arguments("{\"arg0\": \"" + arg + "\"}")
+                .build();
+    }
+
+    private static class BlockingAfterFirstToolCallStreamingModel implements StreamingChatModel {
+
+        private final ToolExecutionRequest toolCall;
+        private final CountDownLatch toolStarted;
+        private final AtomicInteger invocations = new AtomicInteger();
+        private final AtomicBoolean toolStartedBeforeCompleteResponse = new AtomicBoolean();
+
+        private BlockingAfterFirstToolCallStreamingModel(ToolExecutionRequest toolCall, CountDownLatch toolStarted) {
+            this.toolCall = toolCall;
+            this.toolStarted = toolStarted;
+        }
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            int invocation = invocations.incrementAndGet();
+            Thread thread = new Thread(() -> {
+                if (invocation == 1) {
+                    onCompleteToolCall(handler, new CompleteToolCall(0, toolCall));
+                    try {
+                        toolStartedBeforeCompleteResponse.set(toolStarted.await(500, TimeUnit.MILLISECONDS));
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    onCompleteResponse(
+                            handler,
+                            ChatResponse.builder()
+                                    .aiMessage(AiMessage.from(toolCall))
+                                    .build());
+                } else {
+                    onCompleteResponse(
+                            handler,
+                            ChatResponse.builder().aiMessage(AiMessage.from("done")).build());
+                }
+            }, "test-streaming-model");
+            thread.setDaemon(true);
+            thread.start();
+        }
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolBatchDispatcherTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolBatchDispatcherTest.java
@@ -124,6 +124,28 @@ class ToolBatchDispatcherTest {
     }
 
     @Test
+    void single_request_uses_executor_when_explicitly_enabled() {
+        Thread caller = Thread.currentThread();
+        AtomicBoolean otherThread = new AtomicBoolean(false);
+        ToolExecutor te = (request, memId) -> {
+            if (Thread.currentThread() != caller) {
+                otherThread.set(true);
+            }
+            return "ok";
+        };
+
+        Map<ToolExecutionRequest, ToolExecutionResult> results = ToolBatchDispatcher.dispatch(baseReq()
+                .toolRequests(List.of(req("a", "t", "1")))
+                .toolExecutors(exec("t", te))
+                .executor(executor)
+                .useExecutorForSingleTool(true)
+                .build());
+
+        assertThat(results).hasSize(1);
+        assertThat(otherThread).as("explicit opt-in should dispatch a single tool on the executor").isTrue();
+    }
+
+    @Test
     void parallel_path_when_executor_and_multiple_requests_runs_concurrently_and_preserves_order()
             throws InterruptedException {
         AtomicInteger inFlight = new AtomicInteger();

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolBatchDispatcherTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolBatchDispatcherTest.java
@@ -1,0 +1,322 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates {@link ToolBatchDispatcher}: the reusable primitive shared between sync and streaming
+ * tool batch dispatch.
+ */
+class ToolBatchDispatcherTest {
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        executor = Executors.newFixedThreadPool(8);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    private static ToolExecutionRequest req(String id, String name, String arg) {
+        return ToolExecutionRequest.builder()
+                .id(id)
+                .name(name)
+                .arguments("{\"arg0\":\"" + arg + "\"}")
+                .build();
+    }
+
+    private static Map<String, ToolExecutor> exec(String name, ToolExecutor toolExecutor) {
+        Map<String, ToolExecutor> m = new HashMap<>();
+        m.put(name, toolExecutor);
+        return m;
+    }
+
+    private static InvocationContext invocationContext() {
+        return InvocationContext.builder()
+                .interfaceName("TestService")
+                .methodName("chat")
+                .userMessage(UserMessage.from("test"))
+                .chatMemoryId("default")
+                .timestampNow()
+                .build();
+    }
+
+    private static ToolBatchDispatcher.Request.Builder baseReq() {
+        return ToolBatchDispatcher.Request.builder()
+                .invocationContext(invocationContext())
+                .argumentsErrorHandler((err, ctx) -> {
+                    throw err instanceof RuntimeException re ? re : new RuntimeException(err);
+                })
+                .executionErrorHandler((err, ctx) -> ToolErrorHandlerResult.text(err.getMessage()));
+    }
+
+    @Test
+    void serial_path_when_executor_is_null_runs_in_calling_thread_and_preserves_order() {
+        List<String> orderRun = new ArrayList<>();
+        Thread caller = Thread.currentThread();
+        AtomicBoolean otherThread = new AtomicBoolean(false);
+
+        ToolExecutor te = (request, memId) -> {
+            if (Thread.currentThread() != caller) {
+                otherThread.set(true);
+            }
+            orderRun.add(request.id());
+            return "ok-" + request.id();
+        };
+        Map<String, ToolExecutor> executors = exec("t", te);
+        List<ToolExecutionRequest> requests =
+                List.of(req("a", "t", "1"), req("b", "t", "2"), req("c", "t", "3"));
+
+        Map<ToolExecutionRequest, ToolExecutionResult> results = ToolBatchDispatcher.dispatch(
+                baseReq().toolRequests(requests).toolExecutors(executors).build());
+
+        // Ordered gather: keys preserve original order.
+        List<String> resultIdsInOrder = new ArrayList<>();
+        results.keySet().forEach(r -> resultIdsInOrder.add(r.id()));
+        assertThat(resultIdsInOrder).containsExactly("a", "b", "c");
+        assertThat(orderRun).containsExactly("a", "b", "c");
+        assertThat(otherThread).isFalse();
+    }
+
+    @Test
+    void serial_path_when_only_one_request_even_with_executor_runs_in_calling_thread() {
+        Thread caller = Thread.currentThread();
+        AtomicBoolean otherThread = new AtomicBoolean(false);
+        ToolExecutor te = (request, memId) -> {
+            if (Thread.currentThread() != caller) {
+                otherThread.set(true);
+            }
+            return "ok";
+        };
+
+        Map<ToolExecutionRequest, ToolExecutionResult> results = ToolBatchDispatcher.dispatch(baseReq()
+                .toolRequests(List.of(req("a", "t", "1")))
+                .toolExecutors(exec("t", te))
+                .executor(executor)
+                .build());
+
+        assertThat(results).hasSize(1);
+        assertThat(otherThread).as("single-request batch should not switch threads").isFalse();
+    }
+
+    @Test
+    void parallel_path_when_executor_and_multiple_requests_runs_concurrently_and_preserves_order()
+            throws InterruptedException {
+        AtomicInteger inFlight = new AtomicInteger();
+        AtomicInteger maxInFlight = new AtomicInteger();
+        ToolExecutor te = (request, memId) -> {
+            int now = inFlight.incrementAndGet();
+            maxInFlight.accumulateAndGet(now, Math::max);
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            inFlight.decrementAndGet();
+            return "ok-" + request.id();
+        };
+
+        List<ToolExecutionRequest> requests = List.of(
+                req("a", "t", "1"), req("b", "t", "2"), req("c", "t", "3"), req("d", "t", "4"));
+
+        Map<ToolExecutionRequest, ToolExecutionResult> results = ToolBatchDispatcher.dispatch(baseReq()
+                .toolRequests(requests)
+                .toolExecutors(exec("t", te))
+                .executor(executor)
+                .build());
+
+        // Order preserved.
+        List<String> ids = new ArrayList<>();
+        results.keySet().forEach(r -> ids.add(r.id()));
+        assertThat(ids).containsExactly("a", "b", "c", "d");
+        // Concurrency observed (parallel execution).
+        assertThat(maxInFlight.get()).isGreaterThan(1);
+    }
+
+    @Test
+    void cap_check_is_atomic_no_tool_runs_when_cap_exceeded() {
+        AtomicInteger calls = new AtomicInteger();
+        ToolExecutor te = (request, memId) -> {
+            calls.incrementAndGet();
+            return "ok";
+        };
+
+        List<ToolExecutionRequest> requests =
+                List.of(req("a", "t", "1"), req("b", "t", "2"), req("c", "t", "3"));
+
+        assertThatExceptionOfType(ToolCallsLimitExceededException.class)
+                .isThrownBy(() -> ToolBatchDispatcher.dispatch(baseReq()
+                        .toolRequests(requests)
+                        .toolExecutors(exec("t", te))
+                        .executor(executor)
+                        .maxToolCallsPerResponse(2)
+                        .build()))
+                .matches(ex -> ex.getLimit() == 2 && ex.getAttempted() == 3);
+
+        assertThat(calls.get()).as("no tool must run when cap is exceeded").isZero();
+    }
+
+    @Test
+    void on_first_failure_dispatch_propagates_and_does_not_block_on_slow_siblings() throws Exception {
+        // Use errorHandlerBypass to force the failer's exception to propagate up out of the
+        // dispatcher (instead of being routed through the execution error handler and turned
+        // into a tool-result text). This is the path on which sibling cancellation fires.
+        //
+        // CompletableFuture.cancel(true) does not interrupt running tasks on a supplyAsync
+        // executor; this is a documented JDK limitation. The dispatcher's contract is that
+        // it (a) returns promptly with the bypassed exception and (b) marks sibling futures
+        // cancelled (best-effort). Tasks already running on the executor may continue to run.
+        ExecutorService pool = Executors.newFixedThreadPool(8);
+        try {
+            ToolExecutor failer = (request, memId) -> {
+                // Brief delay so the dispatcher sees siblings in flight.
+                try {
+                    Thread.sleep(20);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                throw new RuntimeException("boom");
+            };
+            CountDownLatch siblingsRelease = new CountDownLatch(1);
+            ToolExecutor slowSibling = (request, memId) -> {
+                try {
+                    siblingsRelease.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return "done";
+            };
+            Map<String, ToolExecutor> executors = new HashMap<>();
+            executors.put("fail", failer);
+            executors.put("slow", slowSibling);
+
+            List<ToolExecutionRequest> requests =
+                    List.of(req("a", "fail", "1"), req("b", "slow", "2"), req("c", "slow", "3"));
+
+            long start = System.nanoTime();
+            assertThatThrownBy(() -> ToolBatchDispatcher.dispatch(baseReq()
+                            .toolRequests(requests)
+                            .toolExecutors(executors)
+                            .executor(pool)
+                            .errorHandlerBypass(
+                                    t -> t instanceof RuntimeException && t.getMessage().equals("boom"))
+                            .build()))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("boom");
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+            // The key cancellation-related assertion: dispatch must not wait for slow siblings
+            // to finish. Without sibling cancellation, dispatch would block on .get() of every
+            // sibling and only return once the 5s release happened.
+            assertThat(elapsedMs)
+                    .as("dispatch must not wait for slow siblings after first failure (was %d ms)", elapsedMs)
+                    .isLessThan(1000);
+        } finally {
+            pool.shutdownNow();
+            pool.awaitTermination(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void error_handler_bypass_propagates_marker_exception_unchanged() {
+        class GuardrailViolation extends RuntimeException {
+            GuardrailViolation(String msg) {
+                super(msg);
+            }
+        }
+
+        ToolExecutor failer = (request, memId) -> {
+            throw new GuardrailViolation("denied");
+        };
+
+        AtomicBoolean errorHandlerInvoked = new AtomicBoolean();
+        ToolExecutionErrorHandler eeh = (err, ctx) -> {
+            errorHandlerInvoked.set(true);
+            return ToolErrorHandlerResult.text("handled");
+        };
+
+        // Without bypass: error handler is invoked, exception is converted to a tool-result text.
+        Map<ToolExecutionRequest, ToolExecutionResult> swallowed = ToolBatchDispatcher.dispatch(baseReq()
+                .toolRequests(List.of(req("a", "t", "x")))
+                .toolExecutors(exec("t", failer))
+                .executionErrorHandler(eeh)
+                .build());
+        assertThat(errorHandlerInvoked).isTrue();
+        assertThat(swallowed.values().iterator().next().resultText()).isEqualTo("handled");
+
+        // With bypass: the marker exception propagates unchanged.
+        errorHandlerInvoked.set(false);
+        assertThatThrownBy(() -> ToolBatchDispatcher.dispatch(baseReq()
+                        .toolRequests(List.of(req("a", "t", "x")))
+                        .toolExecutors(exec("t", failer))
+                        .executionErrorHandler(eeh)
+                        .errorHandlerBypass(GuardrailViolation.class::isInstance)
+                        .build()))
+                .isInstanceOf(GuardrailViolation.class)
+                .hasMessage("denied");
+        assertThat(errorHandlerInvoked).isFalse();
+    }
+
+    @Test
+    void before_and_after_callbacks_fire_for_each_tool() {
+        AtomicInteger before = new AtomicInteger();
+        AtomicInteger after = new AtomicInteger();
+        ToolExecutor te = (request, memId) -> "ok";
+
+        ToolBatchDispatcher.dispatch(baseReq()
+                .toolRequests(List.of(req("a", "t", "1"), req("b", "t", "2")))
+                .toolExecutors(exec("t", te))
+                .beforeToolExecution(b -> before.incrementAndGet())
+                .afterToolExecution(b -> after.incrementAndGet())
+                .build());
+
+        assertThat(before.get()).isEqualTo(2);
+        assertThat(after.get()).isEqualTo(2);
+    }
+
+    @Test
+    void empty_request_list_returns_empty_map() {
+        Map<ToolExecutionRequest, ToolExecutionResult> results = ToolBatchDispatcher.dispatch(
+                baseReq().toolRequests(List.of()).build());
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void unknown_tool_uses_hallucination_strategy() {
+        ToolExecutor te = (request, memId) -> "should-not-run";
+
+        Map<ToolExecutionRequest, ToolExecutionResult> results = ToolBatchDispatcher.dispatch(baseReq()
+                .toolRequests(List.of(req("a", "missing", "1")))
+                .toolExecutors(exec("present", te))
+                .hallucinationStrategy(r ->
+                        dev.langchain4j.data.message.ToolExecutionResultMessage.from(r, "hallucinated:" + r.name()))
+                .build());
+
+        assertThat(results).hasSize(1);
+        assertThat(results.values().iterator().next().resultText()).isEqualTo("hallucinated:missing");
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolChoiceAutoProtectionTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolChoiceAutoProtectionTest.java
@@ -1,0 +1,323 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.ChatResponseMetadata;
+import dev.langchain4j.service.AiServiceContext;
+import dev.langchain4j.service.AiServices;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates {@link AiServices#forceToolChoiceAutoAfterFirstIteration(boolean)}: when set,
+ * a caller-supplied {@link ToolChoice#REQUIRED} is rewritten to {@link ToolChoice#AUTO}
+ * on follow-up iterations of the inference-and-tools loop. This prevents an infinite loop
+ * when the LLM honours {@code REQUIRED} on every iteration.
+ *
+ * <p>The tests inject {@link ToolChoice#REQUIRED} via a one-shot {@code chatRequestTransformer}
+ * that runs only on the very first chat call — mirroring how downstream framework integrators
+ * (e.g. Quarkus) bind the choice to the initial request rather than every follow-up.
+ */
+class ToolChoiceAutoProtectionTest {
+
+    interface Assistant {
+        String chat(String message);
+    }
+
+    static class StickyTool {
+        final AtomicInteger calls = new AtomicInteger();
+
+        @Tool
+        public String stick(String arg) {
+            calls.incrementAndGet();
+            return "ok";
+        }
+    }
+
+    /**
+     * A model that responds with a tool call whenever the request's tool choice is
+     * {@link ToolChoice#REQUIRED}, and with a final text message once the tool choice
+     * is {@link ToolChoice#AUTO} (or unset).
+     */
+    private static AiMessage respondBasedOnToolChoice(ChatRequest request) {
+        ToolChoice toolChoice = request.parameters().toolChoice();
+        if (toolChoice == ToolChoice.REQUIRED) {
+            return AiMessage.from(ToolExecutionRequest.builder()
+                    .id("c-" + System.nanoTime())
+                    .name("stick")
+                    .arguments("{\"arg0\": \"x\"}")
+                    .build());
+        }
+        return AiMessage.from("done");
+    }
+
+    @Test
+    void without_flag_required_tool_choice_loops_until_max_invocations() {
+        // Without the flag, the loop's parameters.overrideWith(...) carries forward the
+        // caller-supplied ToolChoice.REQUIRED on every iteration, so the model keeps emitting
+        // tool calls until ToolService aborts at maxSequentialToolsInvocations.
+        StickyTool tool = new StickyTool();
+        ChatModelMock model = ChatModelMock.thatResponds(ToolChoiceAutoProtectionTest::respondBasedOnToolChoice);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(50))
+                .tools(tool)
+                .maxSequentialToolsInvocations(5)
+                .chatRequestTransformer((req, memId) -> ChatRequest.builder()
+                        .messages(req.messages())
+                        .parameters(req.parameters().overrideWith(ChatRequestParameters.builder()
+                                .toolChoice(ToolChoice.REQUIRED)
+                                .build()))
+                        .build())
+                .build();
+
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> assistant.chat("go"))
+                .withMessageContaining("sequential tool invocations");
+    }
+
+    @Test
+    void with_flag_required_tool_choice_is_rewritten_to_auto_after_first_iteration() {
+        // With forceToolChoiceAutoAfterFirstIteration(true), the loop rewrites REQUIRED to AUTO
+        // before each follow-up chat call. Our one-shot transformer only sets REQUIRED on the
+        // very first request — so the loop's rewrite then carries AUTO forward and the model
+        // produces a final text message, breaking the loop.
+        StickyTool tool = new StickyTool();
+        ChatModelMock model = ChatModelMock.thatResponds(ToolChoiceAutoProtectionTest::respondBasedOnToolChoice);
+
+        AtomicInteger transformerCalls = new AtomicInteger();
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(50))
+                .tools(tool)
+                .maxSequentialToolsInvocations(5)
+                .forceToolChoiceAutoAfterFirstIteration(true)
+                .chatRequestTransformer((req, memId) -> {
+                    if (transformerCalls.getAndIncrement() == 0) {
+                        return ChatRequest.builder()
+                                .messages(req.messages())
+                                .parameters(req.parameters().overrideWith(ChatRequestParameters.builder()
+                                        .toolChoice(ToolChoice.REQUIRED)
+                                        .build()))
+                                .build();
+                    }
+                    return req;
+                })
+                .build();
+
+        assertThatNoException().isThrownBy(() -> assistant.chat("go"));
+        // Iteration 0: REQUIRED -> tool called once. Iteration 1: AUTO (rewritten) -> "done".
+        assertThat(tool.calls.get()).isEqualTo(1);
+    }
+
+    interface SomeService {
+        String chat(String message);
+    }
+
+    /**
+     * Drives the loop directly with {@code parameters.toolChoice() == REQUIRED} to lock down the
+     * exact Hook 2 rewrite contract: when the flag is on, the second iteration's chat request
+     * must carry {@link ToolChoice#AUTO}; when the flag is off, it must keep {@link ToolChoice#REQUIRED}.
+     * Other parameters (e.g. modelName, temperature) must be preserved across the rewrite.
+     */
+    @Test
+    void rewrite_fires_only_when_flag_is_on_and_preserves_other_parameters() {
+        // The mock returns a tool call on iteration 1 (so the loop sends a 2nd chat request),
+        // and a final text on iteration 2.
+        // Always responds with a final text — limits the loop to a single follow-up chat call.
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(AiMessage.from("done"));
+
+        StickyTool tool = new StickyTool();
+        ToolService toolService = new ToolService();
+        toolService.tools(Collections.singletonList(tool));
+        toolService.forceToolChoiceAutoAfterFirstIteration(true);
+
+        AiServiceContext context = AiServiceContext.create(SomeService.class);
+        context.chatModel = model;
+        context.toolService = toolService;
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+        UserMessage userMessage = UserMessage.from("go");
+        chatMemory.add(userMessage);
+
+        InvocationContext invocationContext = InvocationContext.builder()
+                .interfaceName(SomeService.class.getName())
+                .methodName("chat")
+                .userMessage(userMessage)
+                .chatMemoryId("default")
+                .timestampNow()
+                .build();
+
+        // Iteration 0's response is synthesized — caller would normally produce this via the chat model.
+        ChatResponse iterationZero = ChatResponse.builder()
+                .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                        .id("c0")
+                        .name("stick")
+                        .arguments("{\"arg0\": \"x\"}")
+                        .build()))
+                .metadata(ChatResponseMetadata.builder().build())
+                .build();
+
+        // The caller-supplied parameters carry REQUIRED, modelName, and a temperature — the rewrite
+        // must touch only toolChoice.
+        ChatRequestParameters parameters = ChatRequestParameters.builder()
+                .modelName("test-model")
+                .temperature(0.42)
+                .toolChoice(ToolChoice.REQUIRED)
+                .build();
+
+        ToolServiceContext toolServiceContext =
+                toolService.createContext(invocationContext, userMessage, new ArrayList<>(chatMemory.messages()));
+
+        toolService.executeInferenceAndToolsLoop(
+                context,
+                "default",
+                iterationZero,
+                parameters,
+                new ArrayList<>(chatMemory.messages()),
+                chatMemory,
+                invocationContext,
+                toolServiceContext,
+                false);
+
+        // Exactly one follow-up chat call was issued (loop terminated after the final text).
+        assertThat(model.requests()).hasSize(1);
+        ChatRequest followUp = model.requests().get(0);
+        // Hook 2: second iteration sees AUTO, not REQUIRED.
+        assertThat(followUp.parameters().toolChoice()).isEqualTo(ToolChoice.AUTO);
+        // Other parameters preserved through overrideWith.
+        assertThat(followUp.parameters().modelName()).isEqualTo("test-model");
+        assertThat(followUp.parameters().temperature()).isEqualTo(0.42);
+    }
+
+    @Test
+    void without_flag_required_tool_choice_is_preserved_into_second_iteration() {
+        // Always responds with a final text — limits the loop to a single follow-up chat call.
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(AiMessage.from("done"));
+
+        StickyTool tool = new StickyTool();
+        ToolService toolService = new ToolService();
+        toolService.tools(Collections.singletonList(tool));
+        // Default: forceToolChoiceAutoAfterFirstIteration is false.
+
+        AiServiceContext context = AiServiceContext.create(SomeService.class);
+        context.chatModel = model;
+        context.toolService = toolService;
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+        UserMessage userMessage = UserMessage.from("go");
+        chatMemory.add(userMessage);
+
+        InvocationContext invocationContext = InvocationContext.builder()
+                .interfaceName(SomeService.class.getName())
+                .methodName("chat")
+                .userMessage(userMessage)
+                .chatMemoryId("default")
+                .timestampNow()
+                .build();
+
+        ChatResponse iterationZero = ChatResponse.builder()
+                .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                        .id("c0")
+                        .name("stick")
+                        .arguments("{\"arg0\": \"x\"}")
+                        .build()))
+                .metadata(ChatResponseMetadata.builder().build())
+                .build();
+
+        ChatRequestParameters parameters =
+                ChatRequestParameters.builder().toolChoice(ToolChoice.REQUIRED).build();
+
+        ToolServiceContext toolServiceContext =
+                toolService.createContext(invocationContext, userMessage, new ArrayList<>(chatMemory.messages()));
+
+        toolService.executeInferenceAndToolsLoop(
+                context,
+                "default",
+                iterationZero,
+                parameters,
+                new ArrayList<>(chatMemory.messages()),
+                chatMemory,
+                invocationContext,
+                toolServiceContext,
+                false);
+
+        // Default behavior: REQUIRED is forwarded unchanged on subsequent iterations.
+        assertThat(model.requests()).hasSize(1);
+        assertThat(model.requests().get(0).parameters().toolChoice()).isEqualTo(ToolChoice.REQUIRED);
+    }
+
+    @Test
+    void with_flag_auto_and_none_pass_through_unchanged() {
+        // Flag is on, but parameters.toolChoice() != REQUIRED — the rewrite branch must NOT fire.
+        // Always responds with a final text — limits the loop to a single follow-up chat call.
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(AiMessage.from("done"));
+
+        StickyTool tool = new StickyTool();
+        ToolService toolService = new ToolService();
+        toolService.tools(Collections.singletonList(tool));
+        toolService.forceToolChoiceAutoAfterFirstIteration(true);
+
+        AiServiceContext context = AiServiceContext.create(SomeService.class);
+        context.chatModel = model;
+        context.toolService = toolService;
+
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(10);
+        UserMessage userMessage = UserMessage.from("go");
+        chatMemory.add(userMessage);
+
+        InvocationContext invocationContext = InvocationContext.builder()
+                .interfaceName(SomeService.class.getName())
+                .methodName("chat")
+                .userMessage(userMessage)
+                .chatMemoryId("default")
+                .timestampNow()
+                .build();
+
+        ChatResponse iterationZero = ChatResponse.builder()
+                .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                        .id("c0")
+                        .name("stick")
+                        .arguments("{\"arg0\": \"x\"}")
+                        .build()))
+                .metadata(ChatResponseMetadata.builder().build())
+                .build();
+
+        ChatRequestParameters parameters =
+                ChatRequestParameters.builder().toolChoice(ToolChoice.AUTO).build();
+
+        ToolServiceContext toolServiceContext =
+                toolService.createContext(invocationContext, userMessage, new ArrayList<>(chatMemory.messages()));
+
+        toolService.executeInferenceAndToolsLoop(
+                context,
+                "default",
+                iterationZero,
+                parameters,
+                new ArrayList<>(chatMemory.messages()),
+                chatMemory,
+                invocationContext,
+                toolServiceContext,
+                false);
+
+        assertThat(model.requests()).hasSize(1);
+        assertThat(model.requests().get(0).parameters().toolChoice()).isEqualTo(ToolChoice.AUTO);
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolProviderRequestFactoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolProviderRequestFactoryTest.java
@@ -1,0 +1,96 @@
+package dev.langchain4j.service.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.service.AiServices;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates {@link AiServices#toolProviderRequestFactory(java.util.function.Function)}: the
+ * factory is consulted when constructing the {@link ToolProviderRequest} passed to a
+ * {@link ToolProvider}, and a custom subclass returned by the factory is the exact instance
+ * the provider receives.
+ *
+ * <p>Downstream framework integrators (e.g. Quarkus) use this hook to attach extra context
+ * (such as MCP client filtering hints) to the provider request without modifying upstream.
+ */
+class ToolProviderRequestFactoryTest {
+
+    interface Assistant {
+        String chat(String message);
+    }
+
+    /** A custom request subclass carrying an extra field. */
+    static class CustomToolProviderRequest extends ToolProviderRequest {
+        final String tag;
+
+        CustomToolProviderRequest(Builder builder, String tag) {
+            super(builder);
+            this.tag = tag;
+        }
+    }
+
+    @Test
+    void factory_is_invoked_and_subclass_reaches_provider() {
+        AtomicReference<ToolProviderRequest> seenByProvider = new AtomicReference<>();
+
+        ToolProvider provider = request -> {
+            seenByProvider.set(request);
+            // Return a single tool. We don't actually need to execute it; we just need the
+            // provider to be invoked once.
+            return ToolProviderResult.builder()
+                    .add(
+                            ToolSpecification.builder().name("noop").description("noop").build(),
+                            (ToolExecutor) (ToolExecutionRequest req, Object memId) -> "ok")
+                    .build();
+        };
+
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(AiMessage.from("done"));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .toolProvider(provider)
+                .toolProviderRequestFactory(builder -> new CustomToolProviderRequest(builder, "tag-42"))
+                .build();
+
+        assistant.chat("hello");
+
+        assertThat(seenByProvider.get()).isInstanceOf(CustomToolProviderRequest.class);
+        assertThat(((CustomToolProviderRequest) seenByProvider.get()).tag).isEqualTo("tag-42");
+    }
+
+    @Test
+    void without_factory_provider_receives_a_plain_request() {
+        AtomicReference<ToolProviderRequest> seenByProvider = new AtomicReference<>();
+
+        ToolProvider provider = request -> {
+            seenByProvider.set(request);
+            return ToolProviderResult.builder()
+                    .add(
+                            ToolSpecification.builder().name("noop").description("noop").build(),
+                            (ToolExecutor) (ToolExecutionRequest req, Object memId) -> "ok")
+                    .build();
+        };
+
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(AiMessage.from("done"));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+                .toolProvider(provider)
+                .build();
+
+        assistant.chat("hello");
+
+        // No factory configured: the request is a plain ToolProviderRequest, not a subclass.
+        assertThat(seenByProvider.get()).isInstanceOf(ToolProviderRequest.class);
+        assertThat(seenByProvider.get()).isNotInstanceOf(CustomToolProviderRequest.class);
+    }
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

Adds primitives that quarkus-langchain4j needs to delegate tool dispatch back to langchain4j: so Quarkus can drop its own tool loops and turn on opt-in parallel tool execution (virtual threads or vert.x worker pool) without forking core behavior.

This PR attempts to address [@dliubarskyi's comment that execution should not be duplicated](https://github.com/quarkiverse/quarkus-langchain4j/pull/2418#issuecomment-4395252183) and ideally be concentrated upstream (langchain4j).

Disclosure: AI generated (GPT-5.5/Opus 4.7) with human-in-the-loop.

## Change
<!-- Please describe the changes you made. -->

Adds core primitives and experimental integration hooks that allow framework integrations, especially for **quarkus-langchain4j**, to delegate more of the tool execution loop back to LangChain4j instead of duplicating that logic downstream. The goal is to support opt-in parallel tool execution while still allowing frameworks to manage threading, context propagation, per-call model selection, and framework-specific error handling.

Currently, on `main`, the non-streaming path executes tool calls serially by default and can fan out a batch when `executeToolsConcurrently(Executor)` is configured. The streaming path already supports per-tool executor scheduling, but the continuation after tool calls still runs on the model callback thread. That continuation includes result gathering, memory updates, dynamic-provider refresh, and the follow-up streaming request. Also, `maxSequentialToolsInvocations` limits the number of tool-calling responses, but there is no cap on how many tool calls a single response can contain.

This PR introduces `ToolBatchDispatcher` as a shared internal primitive for serial and concurrent tool batch execution. The non-streaming path now routes batch execution through it. Streaming uses the same dispatcher for inline or deferred dispatch, such as when no per-tool executor is configured or when `maxToolCallsPerResponse` is set. In the default streaming mode with a configured per-tool executor and no cap, tools are still scheduled eagerly from `onCompleteToolCall`; the hook then wraps result gathering, memory updates, dynamic-provider refresh, and follow-up streaming inference.

For streaming, this PR adds `StreamingToolDispatchHook`. The default hook runs inline on the callback thread, preserving the existing behavior. Frameworks can provide their own hook to move the continuation onto a managed worker thread and propagate framework context. In eager streaming mode, the hook does not move tool bodies that have already been scheduled; it wraps the downstream continuation.

This PR also adds `maxToolCallsPerResponse(int)` to cap the number of tool calls in a single model response. Non-streaming enforcement is strict and atomic. Streaming preserves eager scheduling by default, but when a positive cap is configured, dispatch is deferred until the full response is available so an over-limit response runs no tools.

The remaining hooks are aimed at framework integrations, specifically Quarkus compatibility:
- `forceToolChoiceAutoAfterFirstIteration(boolean)` preserves Quarkus behavior of forcing the first tool call, then allowing follow-up requests to either call another tool or produce the final answer
- `errorHandlerBypass(Predicate<Throwable>)` lets selected marker exceptions propagate instead of being converted into tool-result text
- `toolProviderRequestFactory(...)` lets integrations pass a custom `ToolProviderRequest` subtype to providers

_All public behavior is unchanged unless these new options are explicitly configured_. The default streaming hook is inline, the per-response cap is disabled by default, the tool-choice rewrite is off by default, the error-handler bypass predicate matches nothing by default, and the provider request factory builds the standard `ToolProviderRequest`.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
