### PR TITLE
Propagate the AgenticScope when calling the planner agent of the supervisor agentic pattern

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/supervisor/SupervisorPlanner.java
@@ -3,10 +3,12 @@ package dev.langchain4j.agentic.supervisor;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import dev.langchain4j.agentic.internal.Context;
 import dev.langchain4j.agentic.planner.Action;
+import dev.langchain4j.invocation.LangChain4jManaged;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.planner.ChatMemoryAccessProvider;
@@ -131,7 +133,8 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
                 ? SUPERVISOR_CONTEXT_PREFIX + "'" + agenticScope.readState(SUPERVISOR_CONTEXT_KEY, "") + "'."
                 : "";
 
-        AgentInvocation agentInvocation = planner(agenticScope).plan(agenticScope.memoryId(), agentsList, request, lastResponse, supervisorContext);
+        AgentInvocation agentInvocation = withAgenticScope(agenticScope,
+                () -> planner(agenticScope).plan(agenticScope.memoryId(), agentsList, request, lastResponse, supervisorContext));
         LOG.info("Agent Invocation: {}", agentInvocation);
 
         if (agentInvocation.getAgentName().equalsIgnoreCase("done")) {
@@ -144,6 +147,15 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
                 .filter(entry -> writeArgumentToScope(agenticScope, agent, entry.getKey(), entry.getValue()))
                 .forEach(entry -> agenticScope.writeState(entry.getKey(), entry.getValue()));
         return call(agent);
+    }
+
+    private static <T> T withAgenticScope(AgenticScope agenticScope, Supplier<T> supplier) {
+        LangChain4jManaged.setCurrent(Map.of(AgenticScope.class, agenticScope));
+        try {
+            return supplier.get();
+        } finally {
+            LangChain4jManaged.removeCurrent();
+        }
     }
 
     private AgentInstance findAgentByName(String agentName) {
@@ -201,7 +213,8 @@ public class SupervisorPlanner implements Planner, ChatMemoryAccessProvider {
             case LAST -> lastResponse;
             case SUMMARY -> doneResponse;
             case SCORED -> {
-                ResponseScore score = responseAgent.scoreResponses(request, lastResponse, doneResponse);
+                ResponseScore score = withAgenticScope(agenticScope,
+                        () -> responseAgent.scoreResponses(request, lastResponse, doneResponse));
                 LOG.info("Response scores: {}", score);
                 yield score.getScore2() > score.getScore1() ? doneResponse : lastResponse;
             }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/ListenerRegistrarFactorySPITest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/ListenerRegistrarFactorySPITest.java
@@ -1,0 +1,198 @@
+package dev.langchain4j.agentic.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.agentic.supervisor.SupervisorAgent;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces the NPE reported in <a href="https://github.com/langchain4j/langchain4j/issues/5103">#5103</a>.
+ *
+ * When an {@code AiServiceListenerRegistrarFactory} is registered via SPI and returns a shared singleton registrar,
+ * the supervisor's internal {@code PlannerAgent} fires events through the same registrar that sub-agent proxies
+ * are listening on. The sub-agent listener receives the event with null {@code managedParameters()}, causing NPE
+ * at {@code AgentInvocationHandler.invoke()} line 82.
+ */
+class ListenerRegistrarFactorySPITest {
+
+    private static final String SPI_SERVICE_FILE =
+            "META-INF/services/dev.langchain4j.spi.observability.AiServiceListenerRegistrarFactory";
+
+    @Test
+    void should_reproduce_npe_with_spi_listener_factory_and_supervisor() throws Exception {
+        try (CompiledFactory compiledFactory = compileTestFactory()) {
+            ClassLoader originalCL = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(compiledFactory.classLoader());
+            try {
+                ChatModel model = new StubChatModel();
+
+                SimpleExpert expert = AgenticServices.agentBuilder(SimpleExpert.class)
+                        .chatModel(model)
+                        .build();
+
+                SupervisorAgent supervisor = AgenticServices.supervisorBuilder()
+                        .chatModel(model)
+                        .subAgents(expert)
+                        .build();
+
+                assertThatCode(() -> supervisor.invoke("test question"))
+                        .as("Before the fix, a shared SPI registrar caused NPE in AgentInvocationHandler " +
+                            "because managedParameters() was null when PlannerAgent fired events")
+                        .doesNotThrowAnyException();
+            } finally {
+                Thread.currentThread().setContextClassLoader(originalCL);
+            }
+        }
+    }
+
+    public interface SimpleExpert {
+
+        @UserMessage("You are a simple expert. Answer: {{request}}")
+        @Agent(description = "A simple expert", outputKey = "response")
+        String answer(@V("request") String request);
+    }
+
+    private static CompiledFactory compileTestFactory() throws Exception {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertThat(compiler).as("These tests require a JDK").isNotNull();
+
+        Path tempDir = Files.createTempDirectory(dynamicTestClassesDir(), "compiled-factory-");
+
+        Path sourceFile =
+                tempDir.resolve("dev/langchain4j/agentic/internal/generated/TestListenerRegistrarFactory.java");
+        Files.createDirectories(sourceFile.getParent());
+        Files.writeString(sourceFile, testFactorySource(), StandardCharsets.UTF_8);
+
+        int result = compiler.run(
+                null,
+                null,
+                null,
+                "-classpath",
+                System.getProperty("java.class.path"),
+                "-d",
+                tempDir.toString(),
+                sourceFile.toString());
+        assertThat(result).as("Factory compilation must succeed").isZero();
+
+        Path servicesFile = tempDir.resolve(SPI_SERVICE_FILE);
+        Files.createDirectories(servicesFile.getParent());
+        Files.writeString(
+                servicesFile,
+                "dev.langchain4j.agentic.internal.generated.TestListenerRegistrarFactory",
+                StandardCharsets.UTF_8);
+
+        URLClassLoader classLoader = new URLClassLoader(
+                new URL[] {tempDir.toUri().toURL()}, ListenerRegistrarFactorySPITest.class.getClassLoader()) {
+            @Override
+            public Enumeration<URL> getResources(String name) throws IOException {
+                if (name.equals(SPI_SERVICE_FILE)) {
+                    return findResources(name);
+                }
+                return super.getResources(name);
+            }
+        };
+        return new CompiledFactory(classLoader);
+    }
+
+    private static Path dynamicTestClassesDir() throws Exception {
+        Path dir = Path.of("target", "dynamic-test-classes");
+        Files.createDirectories(dir);
+        return dir;
+    }
+
+    private static String testFactorySource() {
+        return """
+                package dev.langchain4j.agentic.internal.generated;
+
+                import dev.langchain4j.observability.api.AiServiceListenerRegistrar;
+                import dev.langchain4j.observability.api.DefaultAiServiceListenerRegistrar;
+                import dev.langchain4j.spi.observability.AiServiceListenerRegistrarFactory;
+
+                public class TestListenerRegistrarFactory implements AiServiceListenerRegistrarFactory {
+
+                    private static final AiServiceListenerRegistrar REGISTRAR = new DelegatingRegistrar();
+
+                    @Override
+                    public AiServiceListenerRegistrar get() {
+                        return REGISTRAR;
+                    }
+
+                    public static class DelegatingRegistrar implements AiServiceListenerRegistrar {
+                        private final DefaultAiServiceListenerRegistrar delegate = new DefaultAiServiceListenerRegistrar();
+
+                        public DelegatingRegistrar() {
+                            delegate.shouldThrowExceptionOnEventError(true);
+                        }
+
+                        @Override
+                        public <T extends dev.langchain4j.observability.api.event.AiServiceEvent> void register(
+                                dev.langchain4j.observability.api.listener.AiServiceListener<T> listener) {
+                            delegate.register(listener);
+                        }
+
+                        @Override
+                        public <T extends dev.langchain4j.observability.api.event.AiServiceEvent> void unregister(
+                                dev.langchain4j.observability.api.listener.AiServiceListener<T> listener) {
+                            delegate.unregister(listener);
+                        }
+
+                        @Override
+                        public <T extends dev.langchain4j.observability.api.event.AiServiceEvent> void fireEvent(T event) {
+                            delegate.fireEvent(event);
+                        }
+
+                        @Override
+                        public void shouldThrowExceptionOnEventError(boolean value) {
+                            // always keep delegate set to true
+                        }
+                    }
+                }
+                """;
+    }
+
+    private record CompiledFactory(URLClassLoader classLoader) implements AutoCloseable {
+
+        @Override
+        public void close() throws Exception {
+            classLoader.close();
+        }
+    }
+
+    static class StubChatModel implements ChatModel {
+
+        private int callCount = 0;
+
+        @Override
+        public ChatResponse doChat(ChatRequest chatRequest) {
+            callCount++;
+            String response = switch (callCount) {
+                case 1 -> """
+                        {"agentName":"answer","arguments":{"request":"test question"}}""";
+                case 2 -> "stub expert answer";
+                default -> """
+                        {"agentName":"done","arguments":{"response":"final answer"}}""";
+            };
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from(response))
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #5103

## Change

The NPE only happens when using the supervisor pattern, because it internally uses a chat model on its own. I reproduced the bug in an isolated way and fixed the supervisor to always propagate the agentic scope even when calling its own internal AiService.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
