### PR TITLE
fix(ollama): set content type for streaming requests

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
@@ -122,6 +122,7 @@ class OllamaClient {
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(POST)
                 .url(baseUrl, "api/generate")
+                .addHeader("Content-Type", "application/json")
                 .addHeaders(buildRequestHeaders())
                 .body(toJson(request))
                 .build();
@@ -160,6 +161,7 @@ class OllamaClient {
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(POST)
                 .url(baseUrl, "api/chat")
+                .addHeader("Content-Type", "application/json")
                 .addHeaders(buildRequestHeaders())
                 .body(toJson(ollamaChatRequest))
                 .build();

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaStreamingContentTypeTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaStreamingContentTypeTest.java
@@ -1,0 +1,117 @@
+package dev.langchain4j.model.ollama;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OllamaStreamingContentTypeTest {
+
+    @Test
+    void should_send_json_content_type_for_streaming_chat_requests() {
+        // given
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        OllamaStreamingChatModel model = OllamaStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost:11434")
+                .modelName("llama3")
+                .build();
+
+        // when
+        model.chat("test", new StreamingChatResponseHandler() {
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {}
+
+            @Override
+            public void onError(Throwable error) {}
+        });
+
+        // then
+        assertThat(mockHttpClient.request().headers()).containsEntry("Content-Type", List.of("application/json"));
+    }
+
+    @Test
+    void should_send_json_content_type_for_streaming_completion_requests() {
+        // given
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        OllamaStreamingLanguageModel model = OllamaStreamingLanguageModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost:11434")
+                .modelName("llama3")
+                .build();
+
+        // when
+        model.generate("test", new StreamingResponseHandler<>() {
+
+            @Override
+            public void onNext(String token) {}
+
+            @Override
+            public void onError(Throwable error) {}
+        });
+
+        // then
+        assertThat(mockHttpClient.request().headers()).containsEntry("Content-Type", List.of("application/json"));
+    }
+
+    @Test
+    void should_allow_custom_content_type_to_override_default_for_streaming_chat_requests() {
+        // given
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        OllamaStreamingChatModel model = OllamaStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost:11434")
+                .modelName("llama3")
+                .customHeaders(Map.of("Content-Type", "application/custom"))
+                .build();
+
+        // when
+        model.chat("test", new StreamingChatResponseHandler() {
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {}
+
+            @Override
+            public void onError(Throwable error) {}
+        });
+
+        // then
+        assertThat(mockHttpClient.request().headers()).containsEntry("Content-Type", List.of("application/custom"));
+    }
+
+    @Test
+    void should_allow_custom_content_type_to_override_default_for_streaming_completion_requests() {
+        // given
+        MockHttpClient mockHttpClient = new MockHttpClient();
+
+        OllamaStreamingLanguageModel model = OllamaStreamingLanguageModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .baseUrl("http://localhost:11434")
+                .modelName("llama3")
+                .customHeaders(Map.of("Content-Type", "application/custom"))
+                .build();
+
+        // when
+        model.generate("test", new StreamingResponseHandler<>() {
+
+            @Override
+            public void onNext(String token) {}
+
+            @Override
+            public void onError(Throwable error) {}
+        });
+
+        // then
+        assertThat(mockHttpClient.request().headers()).containsEntry("Content-Type", List.of("application/custom"));
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5163

## Change
Adds `Content-Type: application/json` to Ollama streaming `/api/generate` and `/api/chat` requests.

The non-streaming Ollama request paths already set the JSON content type, but the streaming request paths did not. When those requests are sent through Spring RestClient, the JSON body is written as a `String`; without an explicit JSON content type, Spring can encode it as `text/plain;charset=ISO-8859-1`, which can replace non-ASCII characters with `?`.

This keeps the existing custom header behavior intact: custom headers are still applied after the default `Content-Type`, so users can override it if needed.

## Test Plan
- `./mvnw -pl langchain4j-ollama -DskipITs verify`

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
