### PR TITLE
fix: skip empty tool_calls sentinel chunk in OpenAI streaming accumulator

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
@@ -164,6 +164,14 @@ public class OpenAiStreamingResponseBuilder {
 
         if (delta.toolCalls() != null) {
             for (ToolCall toolCall : delta.toolCalls()) {
+                // Skip end-of-tool-calls sentinel frames that carry no meaningful data
+                // (observed with deepseek-v4-flash on the OpenAI-compatible streaming API:
+                // a trailing chunk with empty id, no function.name and null function.arguments
+                // is emitted after all real tool_calls have streamed).
+                if (isSentinel(toolCall)) {
+                    continue;
+                }
+
                 int toolCallIndex = toolCall.index() != null ? toolCall.index() : fallbackToolCallIndex.get();
 
                 ToolExecutionRequestBuilder builder = this.indexToToolExecutionRequestBuilder.computeIfAbsent(
@@ -291,6 +299,17 @@ public class OpenAiStreamingResponseBuilder {
                 .rawHttpResponse(rawHttpResponse.get())
                 .rawServerSentEvents(new ArrayList<>(rawServerSentEvents))
                 .build();
+    }
+
+    private static boolean isSentinel(ToolCall toolCall) {
+        boolean hasId = !isNullOrBlank(toolCall.id());
+        FunctionCall functionCall = toolCall.function();
+        if (functionCall == null) {
+            return !hasId;
+        }
+        boolean hasName = !isNullOrBlank(functionCall.name());
+        boolean hasArguments = functionCall.arguments() != null;
+        return !hasId && !hasName && !hasArguments;
     }
 
     private static class ToolExecutionRequestBuilder {

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
@@ -164,10 +164,6 @@ public class OpenAiStreamingResponseBuilder {
 
         if (delta.toolCalls() != null) {
             for (ToolCall toolCall : delta.toolCalls()) {
-                // Skip end-of-tool-calls sentinel frames that carry no meaningful data
-                // (observed with deepseek-v4-flash on the OpenAI-compatible streaming API:
-                // a trailing chunk with empty id, no function.name and null function.arguments
-                // is emitted after all real tool_calls have streamed).
                 if (isSentinel(toolCall)) {
                     continue;
                 }

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
@@ -105,6 +105,83 @@ class OpenAiStreamingResponseBuilderTest {
     }
 
     @Test
+    void should_ignore_trailing_sentinel_chunk_from_deepseek_v4_flash() {
+        // Given: deepseek-v4-flash (OpenAI-compatible) emits a trailing sentinel chunk after all
+        // tool_calls have streamed:
+        //   {"index": 0, "id": "", "type": "function", "function": {"arguments": null}}
+        // It carries an empty string id, no function.name, and null arguments. The accumulator
+        // must treat this as an end-of-stream marker and not produce a ghost ToolExecutionRequest.
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+
+        // Header chunk: id + name, empty arguments
+        builder.append(chatCompletionResponse(ToolCall.builder()
+                .id("call_abc")
+                .index(0)
+                .type(ToolType.FUNCTION)
+                .function(FunctionCall.builder().name("getWeather").arguments("").build())
+                .build()));
+
+        // Argument fragments: empty id/name, partial arguments
+        builder.append(chatCompletionResponse(ToolCall.builder()
+                .id("")
+                .index(0)
+                .type(ToolType.FUNCTION)
+                .function(FunctionCall.builder().name("").arguments("{\"city\":").build())
+                .build()));
+        builder.append(chatCompletionResponse(ToolCall.builder()
+                .id("")
+                .index(0)
+                .type(ToolType.FUNCTION)
+                .function(FunctionCall.builder().name("").arguments(" \"Berlin\"}").build())
+                .build()));
+
+        // Trailing sentinel: empty id, no function.name, null arguments
+        builder.append(chatCompletionResponse(ToolCall.builder()
+                .id("")
+                .index(0)
+                .type(ToolType.FUNCTION)
+                .function(FunctionCall.builder().arguments(null).build())
+                .build()));
+
+        ChatResponse response = builder.build();
+        List<ToolExecutionRequest> requests = response.aiMessage().toolExecutionRequests();
+        assertThat(requests).hasSize(1);
+        assertThat(requests.get(0).id()).isEqualTo("call_abc");
+        assertThat(requests.get(0).name()).isEqualTo("getWeather");
+        assertThat(requests.get(0).arguments()).isEqualTo("{\"city\": \"Berlin\"}");
+    }
+
+    @Test
+    void should_not_produce_ghost_for_orphan_sentinel_chunk() {
+        // Given: a sentinel-style chunk arrives at an index that has no prior data
+        // (defensive — the deepseek sentinel carries index=0 in observed logs, but other
+        // OpenAI-compatible providers may send a sentinel with no matching index).
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+
+        // Real tool call streamed at index 0
+        builder.append(chatCompletionResponse(ToolCall.builder()
+                .id("call_xyz")
+                .index(0)
+                .type(ToolType.FUNCTION)
+                .function(FunctionCall.builder().name("getTime").arguments("{}").build())
+                .build()));
+
+        // Orphan sentinel at an unrelated index — id empty, no function.name, null arguments
+        builder.append(chatCompletionResponse(ToolCall.builder()
+                .id("")
+                .index(99)
+                .type(ToolType.FUNCTION)
+                .function(FunctionCall.builder().arguments(null).build())
+                .build()));
+
+        ChatResponse response = builder.build();
+        List<ToolExecutionRequest> requests = response.aiMessage().toolExecutionRequests();
+        assertThat(requests).hasSize(1);
+        assertThat(requests.get(0).id()).isEqualTo("call_xyz");
+        assertThat(requests.get(0).name()).isEqualTo("getTime");
+    }
+
+    @Test
     void should_keep_all_tool_calls_from_same_delta() {
 
         // given

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
@@ -118,7 +118,8 @@ class OpenAiStreamingResponseBuilderTest {
                 .id("call_abc")
                 .index(0)
                 .type(ToolType.FUNCTION)
-                .function(FunctionCall.builder().name("getWeather").arguments("").build())
+                .function(
+                        FunctionCall.builder().name("getWeather").arguments("").build())
                 .build()));
 
         // Argument fragments: empty id/name, partial arguments
@@ -126,13 +127,17 @@ class OpenAiStreamingResponseBuilderTest {
                 .id("")
                 .index(0)
                 .type(ToolType.FUNCTION)
-                .function(FunctionCall.builder().name("").arguments("{\"city\":").build())
+                .function(
+                        FunctionCall.builder().name("").arguments("{\"city\":").build())
                 .build()));
         builder.append(chatCompletionResponse(ToolCall.builder()
                 .id("")
                 .index(0)
                 .type(ToolType.FUNCTION)
-                .function(FunctionCall.builder().name("").arguments(" \"Berlin\"}").build())
+                .function(FunctionCall.builder()
+                        .name("")
+                        .arguments(" \"Berlin\"}")
+                        .build())
                 .build()));
 
         // Trailing sentinel: empty id, no function.name, null arguments
@@ -191,20 +196,16 @@ class OpenAiStreamingResponseBuilderTest {
                 .id("call_1")
                 .index(0)
                 .type(ToolType.FUNCTION)
-                .function(FunctionCall.builder()
-                        .name("tool_name")
-                        .arguments("{}")
-                        .build())
+                .function(
+                        FunctionCall.builder().name("tool_name").arguments("{}").build())
                 .build();
 
         ToolCall tc2 = ToolCall.builder()
                 .id("call_2")
                 .index(1)
                 .type(ToolType.FUNCTION)
-                .function(FunctionCall.builder()
-                        .name("tool_name")
-                        .arguments("{}")
-                        .build())
+                .function(
+                        FunctionCall.builder().name("tool_name").arguments("{}").build())
                 .build();
 
         ChatCompletionResponse partial = ChatCompletionResponse.builder()
@@ -212,9 +213,7 @@ class OpenAiStreamingResponseBuilderTest {
                 .model("openai-compatible-model")
                 .choices(List.of(ChatCompletionChoice.builder()
                         .index(0)
-                        .delta(Delta.builder()
-                                .toolCalls(List.of(tc1, tc2))
-                                .build())
+                        .delta(Delta.builder().toolCalls(List.of(tc1, tc2)).build())
                         .build()))
                 .build();
 
@@ -225,9 +224,7 @@ class OpenAiStreamingResponseBuilderTest {
         // then
         List<ToolExecutionRequest> toolExecutionRequests = response.aiMessage().toolExecutionRequests();
         assertThat(toolExecutionRequests).hasSize(2);
-        assertThat(toolExecutionRequests)
-                .extracting(ToolExecutionRequest::id)
-                .containsExactly("call_1", "call_2");
+        assertThat(toolExecutionRequests).extracting(ToolExecutionRequest::id).containsExactly("call_1", "call_2");
     }
 
     private static ChatCompletionResponse chatCompletionResponse(ToolCall toolCall) {


### PR DESCRIPTION
## Summary
Some OpenAI-compatible providers (observed with `deepseek-v4-flash`) emit a trailing sentinel chunk after all real `tool_calls` have streamed:

```json
{"index": 0, "id": "", "type": "function", "function": {"arguments": null}}
```

It carries an empty id, no `function.name`, and null `function.arguments`. When its index does not match a previously-seen tool call (e.g., arrives at a fresh `index`), the accumulator's `computeIfAbsent` creates an empty builder that surfaces as a ghost `ToolExecutionRequest { id = "", name = "", arguments = "" }` in the final result. Downstream code in `OpenAiUtils#toOpenAiMessage` then substitutes `"{}"` for the blank arguments when echoing the assistant message back, producing the well-known `ToolExecutionRequest { id = null, name = null, arguments = "{}" }` symptom in user-facing tool-execution chains.

The fix adds an `isSentinel(toolCall)` guard at the top of the `tool_calls` accumulation loop in `OpenAiStreamingResponseBuilder` that treats end-of-stream marker frames as no-ops (skipped via `continue`) before `computeIfAbsent` is invoked. Legitimate header chunks (id+name set) and argument-fragment chunks (non-null arguments) are unaffected because they have at least one of `id`, `function.name`, or non-null `function.arguments` populated.

## Test plan
- [x] New `should_ignore_trailing_sentinel_chunk_from_deepseek_v4_flash` exercises the exact stream pattern: header → argument fragments → sentinel — asserts exactly 1 `ToolExecutionRequest` with the full reconstructed arguments.
- [x] New `should_not_produce_ghost_for_orphan_sentinel_chunk` exercises a sentinel arriving at a fresh `index` with no prior data — asserts no ghost is produced. Without the fix this test produces `ToolExecutionRequest { id = "", name = "", arguments = "" }`.
- [x] All 138 existing unit tests in `langchain4j-open-ai` continue to pass.