### PR TITLE
Onnxruntime.dll: Dynamic Link Library (DLL) initialization routine failed

### DIFF
--- a/langchain4j-onnx-scoring/src/main/java/dev/langchain4j/model/scoring/onnx/OnnxScoringModel.java
+++ b/langchain4j-onnx-scoring/src/main/java/dev/langchain4j/model/scoring/onnx/OnnxScoringModel.java
@@ -11,22 +11,49 @@ public class OnnxScoringModel extends AbstractInProcessScoringModel {
     private final OnnxScoringBertCrossEncoder onnxBertBiEncoder;
 
     public OnnxScoringModel(String pathToModel, String pathToTokenizer) {
-        this.onnxBertBiEncoder = loadFromFileSystem(pathToModel, new OrtSession.SessionOptions(), pathToTokenizer, DEFAULT_MODEL_MAX_LENGTH, DEFAULT_NORMALIZE);
+        this.onnxBertBiEncoder = loadFromFileSystem(
+                pathToModel, newDefaultSessionOptions(), pathToTokenizer, DEFAULT_MODEL_MAX_LENGTH, DEFAULT_NORMALIZE);
     }
 
     public OnnxScoringModel(String pathToModel, OrtSession.SessionOptions options, String pathToTokenizer) {
-        this.onnxBertBiEncoder = loadFromFileSystem(pathToModel, options, pathToTokenizer, DEFAULT_MODEL_MAX_LENGTH, DEFAULT_NORMALIZE);
+        this.onnxBertBiEncoder =
+                loadFromFileSystem(pathToModel, options, pathToTokenizer, DEFAULT_MODEL_MAX_LENGTH, DEFAULT_NORMALIZE);
     }
 
     public OnnxScoringModel(String pathToModel, String pathToTokenizer, int modelMaxLength) {
-        this.onnxBertBiEncoder = loadFromFileSystem(pathToModel, new OrtSession.SessionOptions(), pathToTokenizer, modelMaxLength, DEFAULT_NORMALIZE);
+        this.onnxBertBiEncoder = loadFromFileSystem(
+                pathToModel, newDefaultSessionOptions(), pathToTokenizer, modelMaxLength, DEFAULT_NORMALIZE);
     }
 
-    public OnnxScoringModel(String pathToModel, OrtSession.SessionOptions options, String pathToTokenizer, int modelMaxLength, boolean normalize) {
+    public OnnxScoringModel(
+            String pathToModel,
+            OrtSession.SessionOptions options,
+            String pathToTokenizer,
+            int modelMaxLength,
+            boolean normalize) {
         this.onnxBertBiEncoder = loadFromFileSystem(pathToModel, options, pathToTokenizer, modelMaxLength, normalize);
     }
 
     protected OnnxScoringBertCrossEncoder model() {
         return this.onnxBertBiEncoder;
+    }
+
+    private static OrtSession.SessionOptions newDefaultSessionOptions() {
+        try {
+            return new OrtSession.SessionOptions();
+        } catch (UnsatisfiedLinkError | NoClassDefFoundError | ExceptionInInitializerError e) {
+            throw wrapNativeLibraryLoadFailure(e);
+        }
+    }
+
+    static RuntimeException wrapNativeLibraryLoadFailure(Throwable cause) {
+        return new RuntimeException(
+                "Failed to initialize ONNX Runtime native library. "
+                        + "On Windows, install the latest Microsoft Visual C++ Redistributable for Visual Studio 2015-2022 "
+                        + "(see https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist). "
+                        + "Also ensure your JVM architecture (x64/ARM64) matches the ONNX Runtime native binary, "
+                        + "and that no security software is blocking DLL loading from the temp directory. "
+                        + "See https://onnxruntime.ai/docs/install/ for the full list of requirements.",
+                cause);
     }
 }

--- a/langchain4j-onnx-scoring/src/test/java/dev/langchain4j/model/scoring/onnx/OnnxScoringModelTest.java
+++ b/langchain4j-onnx-scoring/src/test/java/dev/langchain4j/model/scoring/onnx/OnnxScoringModelTest.java
@@ -1,0 +1,30 @@
+package dev.langchain4j.model.scoring.onnx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class OnnxScoringModelTest {
+
+    @Test
+    void wrapNativeLibraryLoadFailure_should_preserve_cause_and_provide_actionable_message() {
+        UnsatisfiedLinkError cause = new UnsatisfiedLinkError(
+                "C:\\Users\\Administrator\\AppData\\Local\\Temp\\onnxruntime-java\\onnxruntime.dll: "
+                        + "Dynamic Link Library (DLL) initialization routine failed");
+
+        RuntimeException wrapped = OnnxScoringModel.wrapNativeLibraryLoadFailure(cause);
+
+        assertThat(wrapped.getCause()).isSameAs(cause);
+        assertThat(wrapped.getMessage()).contains("ONNX Runtime").contains("Visual C++ Redistributable");
+    }
+
+    @Test
+    void wrapNativeLibraryLoadFailure_should_handle_no_class_def_found_error() {
+        NoClassDefFoundError cause = new NoClassDefFoundError("ai/onnxruntime/OrtSession$SessionOptions");
+
+        RuntimeException wrapped = OnnxScoringModel.wrapNativeLibraryLoadFailure(cause);
+
+        assertThat(wrapped.getCause()).isSameAs(cause);
+        assertThat(wrapped.getMessage()).contains("ONNX Runtime");
+    }
+}


### PR DESCRIPTION
## Issue

Closes #5241

## Change

Routes the inline `new OrtSession.SessionOptions()` calls in `OnnxScoringModel` through a new `newDefaultSessionOptions()` helper that catches `UnsatisfiedLinkError`/`NoClassDefFoundError`/`ExceptionInInitializerError` via `wrapNativeLibraryLoadFailure(Throwable)` and rethrows a `RuntimeException` naming the missing Microsoft Visual C++ Redistributable, JVM/native architecture mismatch, and security-software DLL blocking as likely causes, with a link to the official install docs.

Replaces the opaque `Dynamic Link Library (DLL) initialization routine failed` failure on Windows with an actionable message.

## General checklist

- [x] There's an open issue for the change I want to make, and it's clear from the issue what needs to be done.
- [x] read the [Contributing Guidelines](https://github.com/langchain4j/langchain4j/blob/main/CONTRIBUTING.md).
- [x] read the [Coding Conventions](https://github.com/langchain4j/langchain4j/blob/main/CODING_CONVENTIONS.md).
- [x] followed the contribution workflow described in the [Code of Conduct](https://github.com/langchain4j/langchain4j/blob/main/CODE_OF_CONDUCT.md).
- [x] added unit tests for my change.
- [ ] added documentation for my change.
- [ ] reviewed another contributor's PR.

Closes #5241