### PR TITLE
fix: drain responseBuffer to BiConsumer handler when OutputGuardrails are active

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -414,9 +414,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     if (partialResponseHandler != null) {
                         responseBuffer.forEach(partialResponseHandler::accept);
                     } else if (partialResponseWithContextHandler != null) {
+                        PartialResponseContext partialResponseContext =
+                                new PartialResponseContext(new CancellationUnsupportedStreamingHandle());
                         responseBuffer.forEach(s -> partialResponseWithContextHandler.accept(
-                                new PartialResponse(s),
-                                new PartialResponseContext(new CancellationUnsupportedStreamingHandle())));
+                                new PartialResponse(s), partialResponseContext));
                     }
                     responseBuffer.clear();
                 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -413,6 +413,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     // completing
                     if (partialResponseHandler != null) {
                         responseBuffer.forEach(partialResponseHandler::accept);
+                    } else if (partialResponseWithContextHandler != null) {
+                        responseBuffer.forEach(s -> partialResponseWithContextHandler.accept(
+                                new PartialResponse(s),
+                                new PartialResponseContext(new CancellationUnsupportedStreamingHandle())));
                     }
                     responseBuffer.clear();
                 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/guardrail/StreamingOutputGuardrailBufferDrainTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/guardrail/StreamingOutputGuardrailBufferDrainTest.java
@@ -1,0 +1,85 @@
+package dev.langchain4j.service.guardrail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.guardrail.OutputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrailRequest;
+import dev.langchain4j.guardrail.OutputGuardrailResult;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.TokenStream;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the case where output guardrails are active on a streaming AI service: when
+ * guardrails are present, partial responses are buffered until validation completes and then
+ * replayed to the caller. The replay must reach whichever partial-response handler the caller
+ * registered — both the simple {@code Consumer<String>} and the
+ * {@code BiConsumer<PartialResponse, PartialResponseContext>} variant.
+ */
+class StreamingOutputGuardrailBufferDrainTest {
+
+    interface StreamingAssistant {
+        @dev.langchain4j.service.guardrail.OutputGuardrails(PassThroughOutputGuardrail.class)
+        TokenStream chat(String message);
+    }
+
+    public static class PassThroughOutputGuardrail implements OutputGuardrail {
+        @Override
+        public OutputGuardrailResult validate(OutputGuardrailRequest request) {
+            return success();
+        }
+    }
+
+    @Test
+    void should_drain_buffered_tokens_to_BiConsumer_handler_when_output_guardrails_active() throws Exception {
+        StreamingChatModel model = StreamingChatModelMock.thatAlwaysStreams("Hello", " ", "world", "!");
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .build();
+
+        List<String> received = new CopyOnWriteArrayList<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+
+        assistant
+                .chat("hi")
+                .onPartialResponseWithContext((partial, context) -> received.add(partial.text()))
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        future.get(5, TimeUnit.SECONDS);
+
+        assertThat(String.join("", received)).isEqualTo("Hello world!");
+    }
+
+    @Test
+    void should_drain_buffered_tokens_to_Consumer_handler_when_output_guardrails_active() throws Exception {
+        StreamingChatModel model = StreamingChatModelMock.thatAlwaysStreams("Hello", " ", "world", "!");
+
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .build();
+
+        List<String> received = new CopyOnWriteArrayList<>();
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+
+        assistant
+                .chat("hi")
+                .onPartialResponse(received::add)
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        future.get(5, TimeUnit.SECONDS);
+
+        assertThat(String.join("", received)).isEqualTo("Hello world!");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5249

When `OutputGuardrails` are active, `AiServiceStreamingResponseHandler` buffers all partial response tokens and drains them after guardrail validation completes. The drain only targeted the `Consumer<String>` handler — if the caller registered a `BiConsumer<PartialResponse, PartialResponseContext>` handler instead (via `TokenStream.onPartialResponse(BiConsumer)`), the buffer was cleared without being delivered, silently dropping all streamed tokens.

This PR adds the missing else-if branch to also drain to `partialResponseWithContextHandler`.

## Change

`AiServiceStreamingResponseHandler.onCompleteResponse`:

```java
if (partialResponseHandler != null) {
    responseBuffer.forEach(partialResponseHandler::accept);
} else if (partialResponseWithContextHandler != null) {
    responseBuffer.forEach(s -> partialResponseWithContextHandler.accept(
            new PartialResponse(s),
            new PartialResponseContext(new CancellationUnsupportedStreamingHandle())));
}
responseBuffer.clear();
```

## Test plan

- [ ] Existing guardrail tests pass
- [ ] Manual verification: `TokenStream` with `onPartialResponse(BiConsumer)` + a passing `@OutputGuardrails` now correctly receives all buffered tokens