### PR TITLE
fix: eliminate race condition in ChatMemoryService.getOrCreateChatMemory

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/memory/ChatMemoryService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/memory/ChatMemoryService.java
@@ -29,17 +29,14 @@ public class ChatMemoryService {
     }
 
     public ChatMemory getOrCreateChatMemory(Object memoryId) {
-        if (memoryId == DEFAULT) {
-            if (defaultChatMemory == null) {
-                defaultChatMemory = chatMemoryProvider.get(DEFAULT);
-            }
-            return defaultChatMemory;
+        if (chatMemoryProvider != null) {
+            return chatMemories.computeIfAbsent(memoryId, chatMemoryProvider::get);
         }
-        return chatMemories.computeIfAbsent(memoryId, chatMemoryProvider::get);
+        return defaultChatMemory;
     }
 
     public ChatMemory getChatMemory(Object memoryId) {
-        return memoryId == DEFAULT ? defaultChatMemory : chatMemories.get(memoryId);
+        return chatMemoryProvider != null ? chatMemories.get(memoryId) : defaultChatMemory;
     }
 
     public ChatMemory evictChatMemory(Object memoryId) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/memory/ChatMemoryService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/memory/ChatMemoryService.java
@@ -1,14 +1,13 @@
 package dev.langchain4j.service.memory;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import dev.langchain4j.Internal;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 @Internal
 public class ChatMemoryService {
@@ -36,7 +35,7 @@ public class ChatMemoryService {
     }
 
     public ChatMemory getChatMemory(Object memoryId) {
-        return chatMemoryProvider != null ? chatMemories.get(memoryId) : defaultChatMemory;
+        return chatMemoryProvider != null ? chatMemories.get(memoryId) : memoryId == DEFAULT ? defaultChatMemory : null;
     }
 
     public ChatMemory evictChatMemory(Object memoryId) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/memory/ChatMemoryServiceConcurrencyTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/memory/ChatMemoryServiceConcurrencyTest.java
@@ -1,0 +1,78 @@
+package dev.langchain4j.service.memory;
+
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static dev.langchain4j.service.memory.ChatMemoryService.DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChatMemoryServiceConcurrencyTest {
+
+    @Test
+    void should_create_only_one_default_chat_memory_under_concurrent_load() throws Exception {
+        List<ChatMemory> createdMemories = Collections.synchronizedList(new ArrayList<>());
+
+        ChatMemoryProvider provider = memoryId -> {
+            slowDownProvider();
+            ChatMemory memory = MessageWindowChatMemory.builder()
+                    .maxMessages(10)
+                    .build();
+            createdMemories.add(memory);
+            return memory;
+        };
+
+        ChatMemoryService service = new ChatMemoryService(provider);
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        List<ChatMemory> results = Collections.synchronizedList(new ArrayList<>());
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    results.add(service.getOrCreateChatMemory(DEFAULT));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            }));
+        }
+
+        startLatch.countDown();
+        assertThat(doneLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        for (Future<?> future : futures) {
+            future.get();
+        }
+        executor.shutdown();
+
+        assertThat(createdMemories).hasSize(1);
+        assertThat(results).hasSize(threadCount);
+        ChatMemory createdMemory = createdMemories.get(0);
+        results.forEach(result -> assertThat(result).isSameAs(createdMemory));
+    }
+
+    private static void slowDownProvider() {
+        try {
+            Thread.sleep(10);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/memory/ChatMemoryServiceConcurrencyTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/memory/ChatMemoryServiceConcurrencyTest.java
@@ -1,10 +1,11 @@
 package dev.langchain4j.service.memory;
 
+import static dev.langchain4j.service.memory.ChatMemoryService.DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -13,9 +14,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
-import static dev.langchain4j.service.memory.ChatMemoryService.DEFAULT;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class ChatMemoryServiceConcurrencyTest {
 
@@ -25,9 +24,8 @@ class ChatMemoryServiceConcurrencyTest {
 
         ChatMemoryProvider provider = memoryId -> {
             slowDownProvider();
-            ChatMemory memory = MessageWindowChatMemory.builder()
-                    .maxMessages(10)
-                    .build();
+            ChatMemory memory =
+                    MessageWindowChatMemory.builder().maxMessages(10).build();
             createdMemories.add(memory);
             return memory;
         };


### PR DESCRIPTION
## Summary

Fixes #5250

`getOrCreateChatMemory` had an asymmetry: the custom-memoryId path used `ConcurrentHashMap.computeIfAbsent` (atomic), but the DEFAULT path used a plain check-then-set on a non-volatile field:

```java
// before
if (memoryId == DEFAULT) {
    if (defaultChatMemory == null) {                           // unprotected read
        defaultChatMemory = chatMemoryProvider.get(DEFAULT);   // non-atomic write
    }
    return defaultChatMemory;
}
return chatMemories.computeIfAbsent(memoryId, chatMemoryProvider::get);
```

Two concurrent threads could both observe `null`, both call `chatMemoryProvider.get(DEFAULT)`, and one instance would be silently overwritten — dropping any messages already added to it. This affects any application using `chatMemoryProvider(...)` (no `@MemoryId`) under concurrent load.

## Fix

Unify both paths: when a `ChatMemoryProvider` is configured, all memory IDs go through `computeIfAbsent`, making initialization atomic. The direct-`ChatMemory` path is unaffected.

```java
// after
public ChatMemory getOrCreateChatMemory(Object memoryId) {
    if (chatMemoryProvider != null) {
        return chatMemories.computeIfAbsent(memoryId, chatMemoryProvider::get);
    }
    return defaultChatMemory;
}
```

This also removes the `memoryId == DEFAULT` reference-equality check, which was fragile by nature.

## Test plan

- [ ] Existing memory tests pass
- [ ] Concurrent stress test: multiple threads invoking an AI Service with `chatMemoryProvider(...)` and no `@MemoryId` — all calls should share the same `ChatMemory` instance