### PR TITLE
fix(gemini): add IMAGE_RECITATION to GeminiFinishReason enum

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FinishReasonMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FinishReasonMapper.java
@@ -7,7 +7,7 @@ class FinishReasonMapper {
     static FinishReason fromGFinishReasonToFinishReason(GeminiFinishReason geminiFinishReason) {
         return switch (geminiFinishReason) {
             case STOP -> FinishReason.STOP;
-            case BLOCKLIST, PROHIBITED_CONTENT, RECITATION, SPII, SAFETY, LANGUAGE -> FinishReason.CONTENT_FILTER;
+            case BLOCKLIST, PROHIBITED_CONTENT, RECITATION, IMAGE_RECITATION, SPII, SAFETY, LANGUAGE -> FinishReason.CONTENT_FILTER;
             case MAX_TOKENS -> FinishReason.LENGTH;
             case MALFORMED_FUNCTION_CALL, FINISH_REASON_UNSPECIFIED, OTHER -> FinishReason.OTHER;
         };

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FinishReasonMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FinishReasonMapper.java
@@ -7,7 +7,8 @@ class FinishReasonMapper {
     static FinishReason fromGFinishReasonToFinishReason(GeminiFinishReason geminiFinishReason) {
         return switch (geminiFinishReason) {
             case STOP -> FinishReason.STOP;
-            case BLOCKLIST, PROHIBITED_CONTENT, RECITATION, IMAGE_RECITATION, SPII, SAFETY, LANGUAGE -> FinishReason.CONTENT_FILTER;
+            case BLOCKLIST, PROHIBITED_CONTENT, RECITATION, IMAGE_RECITATION, SPII, SAFETY, LANGUAGE ->
+                FinishReason.CONTENT_FILTER;
             case MAX_TOKENS -> FinishReason.LENGTH;
             case MALFORMED_FUNCTION_CALL, FINISH_REASON_UNSPECIFIED, OTHER -> FinishReason.OTHER;
         };

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentResponse.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentResponse.java
@@ -29,7 +29,8 @@ record GeminiGenerateContentResponse(
             BLOCKLIST,
             PROHIBITED_CONTENT,
             SPII,
-            MALFORMED_FUNCTION_CALL
+            MALFORMED_FUNCTION_CALL,
+            IMAGE_RECITATION
         }
     }
 

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
@@ -301,6 +301,41 @@ class GoogleAiGeminiChatModelTest {
             // Then
             assertThat(chatResponse.metadata().finishReason()).isEqualTo(FinishReason.LENGTH);
         }
+
+        @Test
+        void shouldMapImageRecitationToContentFilter() {
+            // Given
+            var candidate = new GeminiCandidate(
+                    new GeminiContent(
+                            List.of(GeminiContent.GeminiPart.builder()
+                                    .text("Image response")
+                                    .build()),
+                            "model"),
+                    GeminiFinishReason.IMAGE_RECITATION,
+                    null,
+                    null);
+
+            var geminiResponse = new GeminiGenerateContentResponse(
+                    "image-recitation-id", "gemini-pro-v1", List.of(candidate), createUsageMetadata(10, 20, 30), null);
+
+            when(mockGeminiService.generateContent(eq(TEST_MODEL_NAME), any(GeminiGenerateContentRequest.class)))
+                    .thenReturn(geminiResponse);
+
+            var subject = GoogleAiGeminiChatModel.builder()
+                    .apiKey("test-api-key")
+                    .modelName(TEST_MODEL_NAME)
+                    .build(mockGeminiService);
+
+            var chatRequest = ChatRequest.builder()
+                    .messages(new UserMessage("Generate image"))
+                    .build();
+
+            // When
+            var chatResponse = subject.chat(chatRequest);
+
+            // Then
+            assertThat(chatResponse.metadata().finishReason()).isEqualTo(FinishReason.CONTENT_FILTER);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Add `IMAGE_RECITATION` to `GeminiFinishReason` enum in `GeminiGenerateContentResponse`
- Map `IMAGE_RECITATION` to `CONTENT_FILTER` in `FinishReasonMapper`

## Problem
Gemini API returns `IMAGE_RECITATION` as a finish reason when generated image content is too similar to copyrighted training data. Without this enum value, Jackson deserialization fails with:

```
InvalidFormatException: Cannot deserialize value of type `GeminiFinishReason` from String "IMAGE_RECITATION": not one of the values accepted for Enum class
```

## Test plan
- [x] Verify `IMAGE_RECITATION` deserializes correctly from Gemini API response
- [x] Verify it maps to `FinishReason.CONTENT_FILTER` as expected
- [x] Existing tests continue to pass