### PR TITLE
Move parameter validation to AI service build time

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceValidation.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceValidation.java
@@ -6,7 +6,6 @@ import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -15,8 +14,6 @@ import static dev.langchain4j.service.IllegalConfigurationException.illegalConfi
 import static java.lang.reflect.Modifier.isStatic;
 
 class AiServiceValidation {
-
-    private static final Set<Method> VALID_METHODS = new HashSet<>();
 
     private AiServiceValidation() { }
 
@@ -70,12 +67,11 @@ class AiServiceValidation {
                 }
             }
         }
+
+        validateParameters(serviceClass, method);
     }
 
     static void validateParameters(Class<?> serviceClass, Method method) {
-        if (!VALID_METHODS.add(method)) {
-            return;
-        }
 
         Parameter[] parameters = method.getParameters();
         if (parameters == null || parameters.length < 2) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceValidation.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceValidation.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.service;
 
+import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
+import static java.lang.reflect.Modifier.isStatic;
+
 import dev.langchain4j.invocation.InvocationParameters;
 import dev.langchain4j.invocation.LangChain4jManaged;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -10,19 +13,16 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
-import static java.lang.reflect.Modifier.isStatic;
-
 class AiServiceValidation {
 
-    private AiServiceValidation() { }
+    private AiServiceValidation() {}
 
     static void validate(AiServiceContext context) {
         Class<?> serviceClass = context.aiServiceClass;
         validateContextMemory(serviceClass, context.hasChatMemory());
         validateClass(serviceClass);
-        Stream.of(serviceClass.getMethods()).forEach(m ->
-                validateMethod(serviceClass, m, context.hasChatMemory(), context.hasModerationModel()));
+        Stream.of(serviceClass.getMethods())
+                .forEach(m -> validateMethod(serviceClass, m, context.hasChatMemory(), context.hasModerationModel()));
     }
 
     private static void validateContextMemory(Class<?> serviceClass, boolean hasChatMemory) {
@@ -36,21 +36,20 @@ class AiServiceValidation {
     private static void validateClass(Class<?> serviceClass) {
         if (!serviceClass.isInterface()) {
             throw illegalConfiguration(
-                    "The type implemented by the AI Service must be an interface, found '%s'",
-                    serviceClass.getName());
+                    "The type implemented by the AI Service must be an interface, found '%s'", serviceClass.getName());
         }
     }
 
-    private static void validateMethod(Class<?> serviceClass, Method method, boolean hasChatMemory, boolean hasModerationModel) {
+    private static void validateMethod(
+            Class<?> serviceClass, Method method, boolean hasChatMemory, boolean hasModerationModel) {
         if (isStatic(method.getModifiers())) {
             // ignore static methods
             return;
         }
 
         if (!hasModerationModel && method.isAnnotationPresent(Moderate.class)) {
-            throw illegalConfiguration(
-                    "The @Moderate annotation is present, but the moderationModel is not set up. "
-                            + "Please ensure a valid moderationModel is configured before using the @Moderate annotation.");
+            throw illegalConfiguration("The @Moderate annotation is present, but the moderationModel is not set up. "
+                    + "Please ensure a valid moderationModel is configured before using the @Moderate annotation.");
         }
 
         Class<?> returnType = method.getReturnType();
@@ -82,11 +81,13 @@ class AiServiceValidation {
         boolean chatRequestParametersExist = false;
 
         for (Parameter p : parameters) {
-            if (checkParamTypeUniqueness(InvocationParameters.class, p, serviceClass, method, invocationParametersExist)) {
+            if (checkParamTypeUniqueness(
+                    InvocationParameters.class, p, serviceClass, method, invocationParametersExist)) {
                 invocationParametersExist = true;
                 continue;
             }
-            if (checkParamTypeUniqueness(ChatRequestParameters.class, p, serviceClass, method, chatRequestParametersExist)) {
+            if (checkParamTypeUniqueness(
+                    ChatRequestParameters.class, p, serviceClass, method, chatRequestParametersExist)) {
                 chatRequestParametersExist = true;
                 continue;
             }
@@ -95,8 +96,10 @@ class AiServiceValidation {
                 continue;
             }
 
-            if (!ParameterNameResolver.hasName(p) && p.getAnnotation(UserMessage.class) == null &&
-                    p.getAnnotation(MemoryId.class) == null && p.getAnnotation(UserName.class) == null) {
+            if (!ParameterNameResolver.hasName(p)
+                    && p.getAnnotation(UserMessage.class) == null
+                    && p.getAnnotation(MemoryId.class) == null
+                    && p.getAnnotation(UserName.class) == null) {
                 throw illegalConfiguration(
                         "The parameter '%s' in the method '%s' of the class %s must be annotated with either "
                                 + "%s, %s, %s, or %s, or it should be of type %s or %s",
@@ -113,14 +116,13 @@ class AiServiceValidation {
         }
     }
 
-    private static boolean checkParamTypeUniqueness(Class<?> paramType, Parameter p, Class<?> serviceClass, Method method, boolean paramExists) {
+    private static boolean checkParamTypeUniqueness(
+            Class<?> paramType, Parameter p, Class<?> serviceClass, Method method, boolean paramExists) {
         if (paramType.isAssignableFrom(p.getType())) {
             if (paramExists) {
                 throw illegalConfiguration(
                         "The method '%s' of the class %s has more than one parameter of type %s",
-                        method.getName(),
-                        serviceClass.getName(),
-                        paramType.getName());
+                        method.getName(), serviceClass.getName(), paramType.getName());
             }
             return true;
         }

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -527,10 +527,11 @@ class DefaultAiServices<T> extends AiServices<T> {
     }
 
     private Optional<SystemMessage> prepareSystemMessage(Object memoryId, Method method, Object[] args) {
-        return findSystemMessageTemplate(memoryId, method).map(systemMessageTemplate -> PromptTemplate.from(
-                        systemMessageTemplate)
-                .apply(InternalReflectionVariableResolver.findTemplateVariables(systemMessageTemplate, method, args))
-                .toSystemMessage());
+        return findSystemMessageTemplate(memoryId, method)
+                .map(systemMessageTemplate -> PromptTemplate.from(systemMessageTemplate)
+                        .apply(InternalReflectionVariableResolver.findTemplateVariables(
+                                systemMessageTemplate, method, args))
+                        .toSystemMessage());
     }
 
     private Optional<String> findSystemMessageTemplate(Object memoryId, Method method) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -7,7 +7,6 @@ import static dev.langchain4j.model.chat.request.ResponseFormatType.JSON;
 import static dev.langchain4j.model.output.FinishReason.TOOL_EXECUTION;
 import static dev.langchain4j.service.AiServiceParamsUtil.chatRequestParameters;
 import static dev.langchain4j.service.AiServiceParamsUtil.findArgumentOfType;
-import static dev.langchain4j.service.AiServiceValidation.validateParameters;
 import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
 import static dev.langchain4j.service.TypeUtils.getRawClass;
 import static dev.langchain4j.service.TypeUtils.isImageType;
@@ -132,9 +131,6 @@ class DefaultAiServices<T> extends AiServices<T> {
                         if (method.getDeclaringClass() == ChatMemoryAccess.class) {
                             return handleChatMemoryAccess(method, args);
                         }
-
-                        // TODO do it once, when creating AI Service?
-                        validateParameters(context.aiServiceClass, method);
 
                         InvocationParameters invocationParameters = findArgumentOfType(
                                         InvocationParameters.class, args, method.getParameters())

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesSystemAndUserMessageConfigsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesSystemAndUserMessageConfigsTest.java
@@ -1,5 +1,13 @@
 package dev.langchain4j.service;
 
+import static dev.langchain4j.data.message.SystemMessage.systemMessage;
+import static dev.langchain4j.data.message.UserMessage.userMessage;
+import static dev.langchain4j.service.AiServicesIT.verifyNoMoreInteractionsFor;
+import static dev.langchain4j.service.AiServicesUserMessageConfigTest.VALIDATION_ERROR_MESSAGE_SUFFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.mock.ChatModelMock;
 import dev.langchain4j.model.chat.request.ChatRequest;
@@ -8,14 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static dev.langchain4j.data.message.SystemMessage.systemMessage;
-import static dev.langchain4j.data.message.UserMessage.userMessage;
-import static dev.langchain4j.service.AiServicesIT.verifyNoMoreInteractionsFor;
-import static dev.langchain4j.service.AiServicesUserMessageConfigTest.VALIDATION_ERROR_MESSAGE_SUFFIX;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AiServicesSystemAndUserMessageConfigsTest {
@@ -112,11 +112,15 @@ class AiServicesSystemAndUserMessageConfigsTest {
 
         // with system and user message
         String chat22();
+    }
 
-        // illegal
+    interface IllegalAiService1 {
 
         @SystemMessage("Given a name of a country, answer with {{answerInstructions}}")
         String illegalChat1(@V("answerInstructions") String answerInstructions, String userMessage);
+    }
+
+    interface IllegalAiService2 {
 
         // with systemMessageProvider
         String illegalChat2(@V("answerInstructions") String answerInstructions, String userMessage);
@@ -126,9 +130,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_1() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatModel(model).build();
 
         // when-then
         assertThat(aiService.chat1("Country: Germany")).containsIgnoringCase("Berlin");
@@ -144,9 +147,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_2() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatModel(model).build();
 
         // when-then
         assertThat(aiService.chat2("Country: Germany")).containsIgnoringCase("Berlin");
@@ -162,9 +164,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_3() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatModel(model).build();
 
         // when-then
         assertThat(aiService.chat3("a name of it's capital", "Country: Germany"))
@@ -181,9 +182,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_4() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatModel(model).build();
 
         // when-then
         assertThat(aiService.chat4("Country: {{country}}", "Germany")).containsIgnoringCase("Berlin");
@@ -199,9 +199,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_5() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatModel(model).build();
 
         // when-then
         assertThat(aiService.chat5("a name of it's capital", "Country: {{country}}", "Germany"))
@@ -218,9 +217,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_6() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatModel(model).build();
 
         // when-then
         assertThat(aiService.chat6()).containsIgnoringCase("Berlin");
@@ -236,9 +234,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_7() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatModel(model).build();
 
         // when-then
         assertThat(aiService.chat7("a name of it's capital")).containsIgnoringCase("Berlin");
@@ -254,9 +251,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_8() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatModel(model).build();
 
         // when-then
         assertThat(aiService.chat8("Germany")).containsIgnoringCase("Berlin");
@@ -272,9 +268,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_9() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatModel(model).build();
 
         // when-then
         assertThat(aiService.chat9("Germany")).containsIgnoringCase("Berlin");
@@ -290,9 +285,8 @@ class AiServicesSystemAndUserMessageConfigsTest {
     void system_message_configuration_10() {
 
         // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .build();
+        AiService aiService =
+                AiServices.builder(AiService.class).chatModel(model).build();
 
         // when-then
         assertThat(aiService.chat10("a name of it's capital", "Germany")).containsIgnoringCase("Berlin");
@@ -558,29 +552,28 @@ class AiServicesSystemAndUserMessageConfigsTest {
     @Test
     void illegal_system_message_configuration_1() {
 
-        // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .build();
-
         // when-then
-        assertThatThrownBy(() -> aiService.illegalChat1("a name of it's capital", "Country: Germany"))
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService1.class)
+                        .chatModel(model)
+                        .build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("The parameter 'arg1' in the method 'illegalChat1' of the class dev.langchain4j.service.AiServicesSystemAndUserMessageConfigsTest$AiService" + VALIDATION_ERROR_MESSAGE_SUFFIX);
+                .hasMessage(
+                        "The parameter 'arg1' in the method 'illegalChat1' of the class dev.langchain4j.service.AiServicesSystemAndUserMessageConfigsTest$IllegalAiService1"
+                                + VALIDATION_ERROR_MESSAGE_SUFFIX);
     }
 
     @Test
     void illegal_system_message_configuration_2() {
 
-        // given
-        AiService aiService = AiServices.builder(AiService.class)
-                .chatModel(model)
-                .systemMessageProvider(chatMemoryId -> "Given a name of a country, answer with {{answerInstructions}}")
-                .build();
-
         // when-then
-        assertThatThrownBy(() -> aiService.illegalChat2("a name of it's capital", "Country: Germany"))
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService2.class)
+                        .chatModel(model)
+                        .systemMessageProvider(
+                                chatMemoryId -> "Given a name of a country, answer with {{answerInstructions}}")
+                        .build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("The parameter 'arg1' in the method 'illegalChat2' of the class dev.langchain4j.service.AiServicesSystemAndUserMessageConfigsTest$AiService" + VALIDATION_ERROR_MESSAGE_SUFFIX);
+                .hasMessage(
+                        "The parameter 'arg1' in the method 'illegalChat2' of the class dev.langchain4j.service.AiServicesSystemAndUserMessageConfigsTest$IllegalAiService2"
+                                + VALIDATION_ERROR_MESSAGE_SUFFIX);
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesUserMessageConfigTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesUserMessageConfigTest.java
@@ -131,23 +131,33 @@ class AiServicesUserMessageConfigTest {
 
         String illegalChat2(@V("country") String country);
 
-        String illegalChat3(String userMessage, String country);
-
-        String illegalChat4(@UserMessage String userMessage, String country);
-
         @UserMessage
         String illegalChat5();
 
         @UserMessage("Hello")
         String illegalChat6(@UserMessage String userMessage);
 
-        String illegalChat7(String userMessage, InvocationParameters invocationParameters);
-
-        String illegalChat8(@UserMessage String userMessage, InvocationParameters ip1, InvocationParameters ip2);
-
-        String illegalChat9(@UserMessage String userMessage, ChatRequestParameters cp1, ChatRequestParameters cp2);
-
         // TODO more tests with @UserName, @V, @MemoryId
+    }
+
+    interface IllegalAiService3 {
+        String illegalChat3(String userMessage, String country);
+    }
+
+    interface IllegalAiService4 {
+        String illegalChat4(@UserMessage String userMessage, String country);
+    }
+
+    interface IllegalAiService7 {
+        String illegalChat7(String userMessage, InvocationParameters invocationParameters);
+    }
+
+    interface IllegalAiService8 {
+        String illegalChat8(@UserMessage String userMessage, InvocationParameters ip1, InvocationParameters ip2);
+    }
+
+    interface IllegalAiService9 {
+        String illegalChat9(@UserMessage String userMessage, ChatRequestParameters cp1, ChatRequestParameters cp2);
     }
 
     class MyObject {
@@ -721,30 +731,22 @@ class AiServicesUserMessageConfigTest {
     @Test
     void illegal_user_message_configuration_3() {
 
-        // given
-        AiService aiService =
-                AiServices.builder(AiService.class).chatModel(chatModel).build();
-
         // when-then
-        assertThatThrownBy(() -> aiService.illegalChat3("What is the capital of {{it}}?", "Germany"))
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService3.class).chatModel(chatModel).build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage(
-                        "The parameter 'arg0' in the method 'illegalChat3' of the class dev.langchain4j.service.AiServicesUserMessageConfigTest$AiService"
+                        "The parameter 'arg0' in the method 'illegalChat3' of the class dev.langchain4j.service.AiServicesUserMessageConfigTest$IllegalAiService3"
                                 + VALIDATION_ERROR_MESSAGE_SUFFIX);
     }
 
     @Test
     void illegal_user_message_configuration_4() {
 
-        // given
-        AiService aiService =
-                AiServices.builder(AiService.class).chatModel(chatModel).build();
-
         // when-then
-        assertThatThrownBy(() -> aiService.illegalChat4("What is the capital of {{it}}?", "Germany"))
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService4.class).chatModel(chatModel).build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage(
-                        "The parameter 'arg1' in the method 'illegalChat4' of the class dev.langchain4j.service.AiServicesUserMessageConfigTest$AiService"
+                        "The parameter 'arg1' in the method 'illegalChat4' of the class dev.langchain4j.service.AiServicesUserMessageConfigTest$IllegalAiService4"
                                 + VALIDATION_ERROR_MESSAGE_SUFFIX);
     }
 
@@ -778,47 +780,30 @@ class AiServicesUserMessageConfigTest {
     @Test
     void illegal_user_message_configuration_7() {
 
-        // given
-        AiService aiService =
-                AiServices.builder(AiService.class).chatModel(chatModel).build();
-
         // when-then
-        assertThatThrownBy(() -> aiService.illegalChat7("Hello", new InvocationParameters()))
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService7.class).chatModel(chatModel).build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("The parameter 'arg0' in the method 'illegalChat7' of the class "
-                        + AiService.class.getName() + VALIDATION_ERROR_MESSAGE_SUFFIX);
+                        + IllegalAiService7.class.getName() + VALIDATION_ERROR_MESSAGE_SUFFIX);
     }
 
     @Test
     void illegal_user_message_configuration_8() {
 
-        // given
-        AiService aiService =
-                AiServices.builder(AiService.class).chatModel(chatModel).build();
-
-        InvocationParameters invocationParameters = new InvocationParameters();
-
         // when-then
-        assertThatThrownBy(() -> aiService.illegalChat8("Hello", invocationParameters, invocationParameters))
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService8.class).chatModel(chatModel).build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("The method 'illegalChat8' of the class " + AiService.class.getName()
+                .hasMessage("The method 'illegalChat8' of the class " + IllegalAiService8.class.getName()
                         + " has more than one parameter of type " + InvocationParameters.class.getName());
     }
 
     @Test
     void illegal_user_message_configuration_9() {
 
-        // given
-        AiService aiService =
-                AiServices.builder(AiService.class).chatModel(chatModel).build();
-
-        ChatRequestParameters chatRequestParameters =
-                ChatRequestParameters.builder().build();
-
         // when-then
-        assertThatThrownBy(() -> aiService.illegalChat9("Hello", chatRequestParameters, chatRequestParameters))
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService9.class).chatModel(chatModel).build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("The method 'illegalChat9' of the class " + AiService.class.getName()
+                .hasMessage("The method 'illegalChat9' of the class " + IllegalAiService9.class.getName()
                         + " has more than one parameter of type " + ChatRequestParameters.class.getName());
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesUserMessageConfigTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesUserMessageConfigTest.java
@@ -109,18 +109,23 @@ class AiServicesUserMessageConfigTest {
         String chat17(@ExternalAnnotation1 @ExternalAnnotation2 String msg);
 
         String chat18_1(Content content);
+
         String chat18_2(AudioContent audioContent);
 
         String chat19_1(@UserMessage Content content);
+
         String chat19_2(@UserMessage AudioContent audioContent);
 
         String chat20_1(List<Content> contents);
+
         String chat20_2(List<AudioContent> audioContents);
 
         String chat21_1(@UserMessage List<Content> contents);
+
         String chat21_2(@UserMessage List<AudioContent> audioContents);
 
         String chat22_1(@UserMessage Content content1, @UserMessage Content content2);
+
         String chat22_2(@UserMessage AudioContent audio, @UserMessage ImageContent image);
 
         String chat23_1(Map<String, ?> args);
@@ -732,7 +737,9 @@ class AiServicesUserMessageConfigTest {
     void illegal_user_message_configuration_3() {
 
         // when-then
-        assertThatThrownBy(() -> AiServices.builder(IllegalAiService3.class).chatModel(chatModel).build())
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService3.class)
+                        .chatModel(chatModel)
+                        .build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage(
                         "The parameter 'arg0' in the method 'illegalChat3' of the class dev.langchain4j.service.AiServicesUserMessageConfigTest$IllegalAiService3"
@@ -743,7 +750,9 @@ class AiServicesUserMessageConfigTest {
     void illegal_user_message_configuration_4() {
 
         // when-then
-        assertThatThrownBy(() -> AiServices.builder(IllegalAiService4.class).chatModel(chatModel).build())
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService4.class)
+                        .chatModel(chatModel)
+                        .build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage(
                         "The parameter 'arg1' in the method 'illegalChat4' of the class dev.langchain4j.service.AiServicesUserMessageConfigTest$IllegalAiService4"
@@ -781,7 +790,9 @@ class AiServicesUserMessageConfigTest {
     void illegal_user_message_configuration_7() {
 
         // when-then
-        assertThatThrownBy(() -> AiServices.builder(IllegalAiService7.class).chatModel(chatModel).build())
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService7.class)
+                        .chatModel(chatModel)
+                        .build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("The parameter 'arg0' in the method 'illegalChat7' of the class "
                         + IllegalAiService7.class.getName() + VALIDATION_ERROR_MESSAGE_SUFFIX);
@@ -791,7 +802,9 @@ class AiServicesUserMessageConfigTest {
     void illegal_user_message_configuration_8() {
 
         // when-then
-        assertThatThrownBy(() -> AiServices.builder(IllegalAiService8.class).chatModel(chatModel).build())
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService8.class)
+                        .chatModel(chatModel)
+                        .build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("The method 'illegalChat8' of the class " + IllegalAiService8.class.getName()
                         + " has more than one parameter of type " + InvocationParameters.class.getName());
@@ -801,7 +814,9 @@ class AiServicesUserMessageConfigTest {
     void illegal_user_message_configuration_9() {
 
         // when-then
-        assertThatThrownBy(() -> AiServices.builder(IllegalAiService9.class).chatModel(chatModel).build())
+        assertThatThrownBy(() -> AiServices.builder(IllegalAiService9.class)
+                        .chatModel(chatModel)
+                        .build())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("The method 'illegalChat9' of the class " + IllegalAiService9.class.getName()
                         + " has more than one parameter of type " + ChatRequestParameters.class.getName());


### PR DESCRIPTION
## Summary

- Moves `validateParameters` from invocation time to build time in `AiServiceValidation`, fulfilling the `TODO` comment in `DefaultAiServices.java`.
- Removes the now-unnecessary `private static final Set<Method> VALID_METHODS` cache that was used to avoid redundant per-invocation validation.
- Adds a call to `validateParameters(serviceClass, method)` at the end of `validateMethod`, so all parameter validation runs during `AiServices.build()`.
- Removes the `validateParameters` call (and its import) from the `invoke` handler in `DefaultAiServices`.
- Updates `AiServicesUserMessageConfigTest`: illegal-parameter tests now assert that `IllegalConfigurationException` is thrown at `.build()` time rather than at invocation time. Each test case that exercises a specific invalid parameter configuration is given its own dedicated single-method interface so the error is deterministic.

## Why

Fail-fast is better UX: developers discover misconfigured services immediately when the service is constructed, not on the first call in production. This change eliminates the static mutable cache and makes the validation lifecycle explicit and predictable.

## Test plan

- [ ] All existing tests in `AiServicesUserMessageConfigTest` continue to pass.
- [ ] Tests `illegal_user_message_configuration_3`, `_4`, `_7`, `_8`, `_9` now verify the exception is raised at `.build()` time.
- [ ] No regression in other `AiServices*Test` / `AiServices*IT` classes (validation only added, not removed).