### PR TITLE
fix(milvus): convert raw search score by MetricType instead of always cosine (#5251)

### DIFF
--- a/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/Mapper.java
+++ b/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/Mapper.java
@@ -1,5 +1,13 @@
 package dev.langchain4j.store.embedding.milvus;
 
+import static com.google.gson.ToNumberPolicy.LONG_OR_DOUBLE;
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.store.embedding.milvus.CollectionOperationsExecutor.queryForVectors;
+import static dev.langchain4j.store.embedding.milvus.Generator.generateEmptyJsons;
+import static dev.langchain4j.store.embedding.milvus.Generator.generateEmptyScalars;
+import static java.util.stream.Collectors.toList;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
@@ -12,10 +20,10 @@ import dev.langchain4j.store.embedding.RelevanceScore;
 import io.milvus.client.MilvusServiceClient;
 import io.milvus.common.clientenum.ConsistencyLevelEnum;
 import io.milvus.exception.ParamException;
+import io.milvus.param.MetricType;
 import io.milvus.response.QueryResultsWrapper;
 import io.milvus.response.QueryResultsWrapper.RowRecord;
 import io.milvus.response.SearchResultsWrapper;
-
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -23,27 +31,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.gson.ToNumberPolicy.LONG_OR_DOUBLE;
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
-import static dev.langchain4j.store.embedding.milvus.CollectionOperationsExecutor.queryForVectors;
-import static dev.langchain4j.store.embedding.milvus.Generator.generateEmptyJsons;
-import static dev.langchain4j.store.embedding.milvus.Generator.generateEmptyScalars;
-import static java.util.stream.Collectors.toList;
-
 class Mapper {
 
-    private static final Gson GSON = new GsonBuilder()
-            .setObjectToNumberStrategy(LONG_OR_DOUBLE)
-            .create();
+    private static final Gson GSON =
+            new GsonBuilder().setObjectToNumberStrategy(LONG_OR_DOUBLE).create();
 
-    private static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() {
-    }.getType();
+    private static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() {}.getType();
 
     static List<List<Float>> toVectors(List<Embedding> embeddings) {
-        return embeddings.stream()
-                .map(Embedding::vectorAsList)
-                .collect(toList());
+        return embeddings.stream().map(Embedding::vectorAsList).collect(toList());
     }
 
     static List<String> toScalars(List<TextSegment> textSegments, int size) {
@@ -51,30 +47,36 @@ class Mapper {
     }
 
     static List<JsonObject> toMetadataJsons(List<TextSegment> textSegments, int size) {
-        return isNullOrEmpty(textSegments) ? generateEmptyJsons(size) : textSegments.stream()
-                .map(segment -> GSON.toJsonTree(segment.metadata().toMap()).getAsJsonObject())
-                .collect(toList());
+        return isNullOrEmpty(textSegments)
+                ? generateEmptyJsons(size)
+                : textSegments.stream()
+                        .map(segment ->
+                                GSON.toJsonTree(segment.metadata().toMap()).getAsJsonObject())
+                        .collect(toList());
     }
 
     static List<String> textSegmentsToScalars(List<TextSegment> textSegments) {
-        return textSegments.stream()
-                .map(TextSegment::text)
-                .collect(toList());
+        return textSegments.stream().map(TextSegment::text).collect(toList());
     }
 
-    static List<EmbeddingMatch<TextSegment>> toEmbeddingMatches(MilvusServiceClient milvusClient,
-                                                                SearchResultsWrapper resultsWrapper,
-                                                                String collectionName,
-                                                                FieldDefinition fieldDefinition,
-                                                                ConsistencyLevelEnum consistencyLevel,
-                                                                boolean queryForVectorOnSearch) {
+    static List<EmbeddingMatch<TextSegment>> toEmbeddingMatches(
+            MilvusServiceClient milvusClient,
+            SearchResultsWrapper resultsWrapper,
+            String collectionName,
+            FieldDefinition fieldDefinition,
+            ConsistencyLevelEnum consistencyLevel,
+            boolean queryForVectorOnSearch,
+            MetricType metricType) {
         List<EmbeddingMatch<TextSegment>> matches = new ArrayList<>();
 
         Map<String, Embedding> idToEmbedding = new HashMap<>();
         if (queryForVectorOnSearch && !resultsWrapper.getRowRecords().isEmpty()) {
             try {
-                List<String> rowIds = (List<String>) resultsWrapper.getFieldWrapper(fieldDefinition.getIdFieldName()).getFieldData();
-                idToEmbedding.putAll(queryEmbeddings(milvusClient, collectionName, fieldDefinition, rowIds, consistencyLevel));
+                List<String> rowIds = (List<String>) resultsWrapper
+                        .getFieldWrapper(fieldDefinition.getIdFieldName())
+                        .getFieldData();
+                idToEmbedding.putAll(
+                        queryEmbeddings(milvusClient, collectionName, fieldDefinition, rowIds, consistencyLevel));
             } catch (ParamException e) {
                 // There is no way to check if the result is empty or not.
                 // If the result is empty, the exception will be thrown.
@@ -85,17 +87,47 @@ class Mapper {
             double score = resultsWrapper.getIDScore(0).get(i).getScore();
             String rowId = resultsWrapper.getIDScore(0).get(i).getStrID();
             Embedding embedding = idToEmbedding.get(rowId);
-            TextSegment textSegment = toTextSegment(resultsWrapper.getRowRecords().get(i), fieldDefinition);
-            EmbeddingMatch<TextSegment> embeddingMatch = new EmbeddingMatch<>(
-                    RelevanceScore.fromCosineSimilarity(score),
-                    rowId,
-                    embedding,
-                    textSegment
-            );
+            TextSegment textSegment =
+                    toTextSegment(resultsWrapper.getRowRecords().get(i), fieldDefinition);
+            EmbeddingMatch<TextSegment> embeddingMatch =
+                    new EmbeddingMatch<>(toRelevanceScore(metricType, score), rowId, embedding, textSegment);
             matches.add(embeddingMatch);
         }
 
         return matches;
+    }
+
+    /**
+     * Converts a raw Milvus score into a normalized relevance score in {@code [0, 1]}.
+     *
+     * <p>Milvus exposes a single {@code score} field on each search hit whose meaning depends on
+     * the {@link MetricType} configured on the collection's index:
+     * <ul>
+     *   <li>{@code COSINE}: similarity in {@code [-1, 1]}, higher is more similar. Converted via
+     *       {@link RelevanceScore#fromCosineSimilarity(double)}.</li>
+     *   <li>{@code IP} (inner product): for L2-normalized vectors this is equivalent to cosine
+     *       similarity, so the same conversion applies. Unnormalized IP can exceed {@code 1.0},
+     *       in which case the score is clamped to {@code [0, 1]}.</li>
+     *   <li>{@code L2} (Euclidean distance): non-negative, lower is more similar. Converted via
+     *       {@code 1 / (1 + distance)} so the result is in {@code (0, 1]}.</li>
+     * </ul>
+     *
+     * <p>For other metric types (e.g. {@code HAMMING}, {@code JACCARD}) the COSINE conversion is
+     * retained as the legacy default to preserve backwards compatibility — callers using those
+     * metrics should validate the resulting scores match their expectations.
+     */
+    static double toRelevanceScore(MetricType metricType, double score) {
+        if (metricType == MetricType.L2) {
+            // L2 returns a non-negative distance; smaller is more similar. Map to (0, 1].
+            return 1.0 / (1.0 + score);
+        }
+        if (metricType == MetricType.IP) {
+            // For normalized vectors IP == cosine similarity. For unnormalized vectors the score
+            // may exceed [-1, 1], so we clamp the relevance to [0, 1] after the cosine mapping.
+            double relevance = RelevanceScore.fromCosineSimilarity(score);
+            return Math.max(0.0, Math.min(1.0, relevance));
+        }
+        return RelevanceScore.fromCosineSimilarity(score);
     }
 
     private static TextSegment toTextSegment(RowRecord rowRecord, FieldDefinition fieldDefinition) {
@@ -125,18 +157,14 @@ class Mapper {
         return Metadata.from(metadataMap);
     }
 
-    private static Map<String, Embedding> queryEmbeddings(MilvusServiceClient milvusClient,
-                                                          String collectionName,
-                                                          FieldDefinition fieldDefinition,
-                                                          List<String> rowIds,
-                                                          ConsistencyLevelEnum consistencyLevel) {
-        QueryResultsWrapper queryResultsWrapper = queryForVectors(
-                milvusClient,
-                collectionName,
-                fieldDefinition,
-                rowIds,
-                consistencyLevel
-        );
+    private static Map<String, Embedding> queryEmbeddings(
+            MilvusServiceClient milvusClient,
+            String collectionName,
+            FieldDefinition fieldDefinition,
+            List<String> rowIds,
+            ConsistencyLevelEnum consistencyLevel) {
+        QueryResultsWrapper queryResultsWrapper =
+                queryForVectors(milvusClient, collectionName, fieldDefinition, rowIds, consistencyLevel);
 
         Map<String, Embedding> idToEmbedding = new HashMap<>();
         for (RowRecord row : queryResultsWrapper.getRowRecords()) {

--- a/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStore.java
+++ b/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStore.java
@@ -273,7 +273,8 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
                 collectionName,
                 fieldDefinition,
                 consistencyLevel,
-                retrieveEmbeddingsOnSearch);
+                retrieveEmbeddingsOnSearch,
+                metricType);
 
         List<EmbeddingMatch<TextSegment>> result = matches.stream()
                 .filter(match -> match.score() >= embeddingSearchRequest.minScore())

--- a/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MapperTest.java
+++ b/langchain4j-milvus/src/test/java/dev/langchain4j/store/embedding/milvus/MapperTest.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.store.embedding.milvus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import io.milvus.param.MetricType;
+import org.junit.jupiter.api.Test;
+
+class MapperTest {
+
+    private static final double TOLERANCE = 1e-9;
+
+    @Test
+    void cosineSimilarity_is_mapped_to_zero_to_one_range() {
+        // Cosine similarity is in [-1, 1] where 1 is most similar.
+        // RelevanceScore.fromCosineSimilarity maps that to [0, 1] via (score + 1) / 2.
+        assertThat(Mapper.toRelevanceScore(MetricType.COSINE, 1.0)).isCloseTo(1.0, within(TOLERANCE));
+        assertThat(Mapper.toRelevanceScore(MetricType.COSINE, 0.0)).isCloseTo(0.5, within(TOLERANCE));
+        assertThat(Mapper.toRelevanceScore(MetricType.COSINE, -1.0)).isCloseTo(0.0, within(TOLERANCE));
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/langchain4j/langchain4j/issues/5251">#5251</a>.
+     *
+     * <p>Before the fix, Mapper unconditionally applied {@code fromCosineSimilarity} to the raw
+     * Milvus score for every metric type. For L2, the raw score is a Euclidean distance (lower is
+     * more similar, range {@code [0, +∞)}), so feeding it to a cosine mapping inverted the
+     * semantic meaning of "relevance" — a perfect match (distance 0) scored {@code 0.5}, and a
+     * distant point (distance 1) scored {@code 1.0}. Closer is now monotonically higher.
+     */
+    @Test
+    void l2_distance_is_mapped_so_that_closer_is_higher_relevance() {
+        double exactMatch = Mapper.toRelevanceScore(MetricType.L2, 0.0);
+        double nearMatch = Mapper.toRelevanceScore(MetricType.L2, 0.1);
+        double farMatch = Mapper.toRelevanceScore(MetricType.L2, 10.0);
+
+        // Identical vectors (distance 0) should yield the maximum relevance score of 1.
+        assertThat(exactMatch).isCloseTo(1.0, within(TOLERANCE));
+
+        // Relevance must decrease monotonically as distance grows.
+        assertThat(nearMatch).isLessThan(exactMatch);
+        assertThat(farMatch).isLessThan(nearMatch);
+
+        // The output stays within the (0, 1] contract documented on Mapper.toRelevanceScore.
+        assertThat(farMatch).isGreaterThan(0.0).isLessThanOrEqualTo(1.0);
+    }
+
+    @Test
+    void inner_product_uses_cosine_mapping_for_normalized_vectors() {
+        // For L2-normalized vectors, IP == cosine similarity, so the mapping should match COSINE.
+        assertThat(Mapper.toRelevanceScore(MetricType.IP, 1.0))
+                .isCloseTo(Mapper.toRelevanceScore(MetricType.COSINE, 1.0), within(TOLERANCE));
+        assertThat(Mapper.toRelevanceScore(MetricType.IP, 0.0))
+                .isCloseTo(Mapper.toRelevanceScore(MetricType.COSINE, 0.0), within(TOLERANCE));
+    }
+
+    @Test
+    void inner_product_clamps_unnormalized_scores_to_unit_interval() {
+        // Unnormalized IP scores can exceed [-1, 1]; the relevance is clamped to [0, 1] so the
+        // EmbeddingMatch contract holds even when callers operate on unnormalized vectors.
+        assertThat(Mapper.toRelevanceScore(MetricType.IP, 5.0)).isCloseTo(1.0, within(TOLERANCE));
+        assertThat(Mapper.toRelevanceScore(MetricType.IP, -5.0)).isCloseTo(0.0, within(TOLERANCE));
+    }
+}


### PR DESCRIPTION
Fixes #5251.

## Problem

`Mapper.toEmbeddingMatches` in `langchain4j-milvus` unconditionally called `RelevanceScore.fromCosineSimilarity` on the raw score returned by Milvus, regardless of the `MetricType` configured on the collection's index. The Milvus score field has different semantics per metric:

| MetricType | Raw score meaning | Required conversion |
|---|---|---|
| `COSINE` | similarity in `[-1, 1]` (higher = more similar) | `(score + 1) / 2` |
| `IP` (inner product) | similarity, `[-1, 1]` for normalized vectors; unbounded otherwise | normalized: cosine mapping; unnormalized: clamp |
| `L2` | Euclidean **distance** in `[0, +∞)` (**lower** = more similar) | `1 / (1 + distance)` |

For `L2`, applying the cosine mapping inverted the semantic meaning of "relevance":

- A perfect match (distance `0`) was scored `0.5`.
- A distant point (distance `1`) was scored `1.0`.

Users running with `L2` (or unnormalized `IP`) saw incorrect relevance scores and result rankings.

## Fix

Introduce a `Mapper.toRelevanceScore(MetricType, double)` helper, thread the configured `metricType` from `MilvusEmbeddingStore` through `toEmbeddingMatches`, and branch on the metric:

```java
static double toRelevanceScore(MetricType metricType, double score) {
    if (metricType == MetricType.L2) {
        return 1.0 / (1.0 + score);                                // (0, 1]
    }
    if (metricType == MetricType.IP) {
        double relevance = RelevanceScore.fromCosineSimilarity(score);
        return Math.max(0.0, Math.min(1.0, relevance));            // clamp unnormalized
    }
    return RelevanceScore.fromCosineSimilarity(score);             // legacy default
}
```

- **`COSINE`**: behavior unchanged.
- **`L2`**: `1 / (1 + distance)`; identity vectors now score `1.0`, monotonically decreasing.
- **`IP`**: same as cosine for normalized vectors (the recommended Milvus pattern), clamped to `[0, 1]` so unnormalized scores can't escape the `EmbeddingMatch` contract.
- **Other metric types** (e.g. `HAMMING`, `JACCARD`): cosine conversion retained as the legacy default to preserve backwards compatibility — users on those metrics should validate scores match their expectations.

## Tests

Adds `MapperTest` (new file) with four unit tests against the helper:

| Test | What it pins |
|---|---|
| `cosineSimilarity_is_mapped_to_zero_to_one_range` | Backwards-compat: `COSINE` branch still produces `(score + 1) / 2`. |
| `l2_distance_is_mapped_so_that_closer_is_higher_relevance` | Regression for #5251: identity → `1.0`, monotonically decreasing, result stays in `(0, 1]`. |
| `inner_product_uses_cosine_mapping_for_normalized_vectors` | `IP` and `COSINE` agree on `[-1, 1]` inputs (normalized-vector case). |
| `inner_product_clamps_unnormalized_scores_to_unit_interval` | Unnormalized `IP` scores outside `[-1, 1]` are clamped to `[0, 1]`. |

All four pass; the module's existing unit tests still pass.

```
$ ./mvnw -pl langchain4j-milvus -DskipITs test
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 — MapperTest
[INFO] BUILD SUCCESS
```

`./mvnw -pl langchain4j-milvus -Pspotless spotless:check` is clean.

## Scope notes

- Only `Mapper` + the single call site in `MilvusEmbeddingStore` change; existing IT tests (`MilvusEmbeddingStoreIT`, etc.) are unchanged and continue to pass against the unchanged `COSINE` default.
- No public API change.
- This addresses the score-conversion bug specifically; users on `L2` or unnormalized `IP` will see their relevance scores change shape (which is the point — they were wrong before). The PR body documents this so existing tests/dashboards that depend on the old (incorrect) score range can be updated.

Opened as draft per CONTRIBUTING.md; happy to mark ready for review once a maintainer takes a first look.
