### PR TITLE
Skills: add DefaultFileSystemSkill.toBuilder() and round-trip tools correctly via builder

### DIFF
--- a/langchain4j-skills/src/main/java/dev/langchain4j/skills/AbstractSkill.java
+++ b/langchain4j-skills/src/main/java/dev/langchain4j/skills/AbstractSkill.java
@@ -1,5 +1,9 @@
 package dev.langchain4j.skills;
 
+import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static java.util.Arrays.asList;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.service.tool.AiServiceTool;
@@ -7,7 +11,6 @@ import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderResult;
 import dev.langchain4j.service.tool.ToolService;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -16,10 +19,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static java.util.Arrays.asList;
-
 @Experimental
 public abstract class AbstractSkill implements Skill {
 
@@ -27,7 +26,10 @@ public abstract class AbstractSkill implements Skill {
     private final String description;
     private final String content;
     private final List<SkillResource> resources;
+    private final List<AiServiceTool> annotatedTools;
+    private final List<AiServiceTool> mapTools;
     private final List<ToolProvider> toolProviders;
+    private final List<ToolProvider> aggregatedToolProviders;
 
     protected AbstractSkill(BaseBuilder<?> builder) {
         this.name = ensureNotBlank(builder.name, "name");
@@ -35,31 +37,28 @@ public abstract class AbstractSkill implements Skill {
         this.content = ensureNotBlank(builder.content, "content");
         this.resources = copy(builder.resources);
         validateUniquePaths(this.resources);
-        this.toolProviders = buildToolProviders(builder);
+        this.annotatedTools = copy(builder.annotatedTools);
+        this.mapTools = copy(builder.mapTools);
+        this.toolProviders = copy(builder.toolProviders);
+        this.aggregatedToolProviders = aggregate(this.annotatedTools, this.mapTools, this.toolProviders);
     }
 
-    private static List<ToolProvider> buildToolProviders(BaseBuilder<?> builder) {
-        List<AiServiceTool> allTools = new ArrayList<>();
-        if (builder.annotatedTools != null) {
-            allTools.addAll(builder.annotatedTools);
-        }
-        if (builder.mapTools != null) {
-            allTools.addAll(builder.mapTools);
-        }
+    private static List<ToolProvider> aggregate(
+            List<AiServiceTool> annotatedTools,
+            List<AiServiceTool> mapTools,
+            List<ToolProvider> toolProviders) {
+
+        List<AiServiceTool> staticTools = new ArrayList<>();
+        staticTools.addAll(annotatedTools);
+        staticTools.addAll(mapTools);
 
         List<ToolProvider> result = new ArrayList<>();
-
-        if (!allTools.isEmpty()) {
-            ToolProviderResult staticResult = ToolProviderResult.builder()
-                    .addAll(allTools)
-                    .build();
+        if (!staticTools.isEmpty()) {
+            ToolProviderResult staticResult =
+                    ToolProviderResult.builder().addAll(staticTools).build();
             result.add(request -> staticResult);
         }
-
-        if (builder.toolProviders != null) {
-            result.addAll(builder.toolProviders);
-        }
-
+        result.addAll(toolProviders);
         return result;
     }
 
@@ -85,7 +84,7 @@ public abstract class AbstractSkill implements Skill {
 
     @Override
     public List<ToolProvider> toolProviders() {
-        return toolProviders;
+        return aggregatedToolProviders;
     }
 
     @Override
@@ -96,12 +95,14 @@ public abstract class AbstractSkill implements Skill {
                 && Objects.equals(description, that.description)
                 && Objects.equals(content, that.content)
                 && Objects.equals(resources, that.resources)
+                && Objects.equals(annotatedTools, that.annotatedTools)
+                && Objects.equals(mapTools, that.mapTools)
                 && Objects.equals(toolProviders, that.toolProviders);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, content, resources, toolProviders);
+        return Objects.hash(name, description, content, resources, annotatedTools, mapTools, toolProviders);
     }
 
     @Override
@@ -111,7 +112,7 @@ public abstract class AbstractSkill implements Skill {
                 + ", description = " + description
                 + ", content = " + content
                 + ", resources = " + resources
-                + ", toolProviders = " + toolProviders
+                + ", toolProviders = " + aggregatedToolProviders
                 + " }";
     }
 
@@ -120,8 +121,7 @@ public abstract class AbstractSkill implements Skill {
         for (SkillResource resource : resources) {
             String path = resource.relativePath();
             if (!seenPaths.add(path)) {
-                throw new IllegalStateException(
-                        "Duplicate skill resource path detected: '%s'".formatted(path));
+                throw new IllegalStateException("Duplicate skill resource path detected: '%s'".formatted(path));
             }
         }
     }
@@ -182,6 +182,25 @@ public abstract class AbstractSkill implements Skill {
                         .toolExecutor(entry.getValue())
                         .build());
             }
+            return (B) this;
+        }
+
+        /**
+         * Populates this builder with the values from the given skill so the original tool state
+         * (annotated tools, map tools, and user-provided tool providers) can be modified independently
+         * via subsequent {@link #tools} / {@link #toolProviders} calls — preserving the same
+         * "last call wins" semantics as a fresh builder chain.
+         * <p>
+         * Subclasses with additional fields should chain their own setters after calling this.
+         */
+        protected B copyFrom(AbstractSkill skill) {
+            this.name = skill.name;
+            this.description = skill.description;
+            this.content = skill.content;
+            this.resources = skill.resources.isEmpty() ? null : new ArrayList<>(skill.resources);
+            this.annotatedTools = skill.annotatedTools.isEmpty() ? null : new ArrayList<>(skill.annotatedTools);
+            this.mapTools = skill.mapTools.isEmpty() ? null : new ArrayList<>(skill.mapTools);
+            this.toolProviders = skill.toolProviders.isEmpty() ? null : new ArrayList<>(skill.toolProviders);
             return (B) this;
         }
     }

--- a/langchain4j-skills/src/main/java/dev/langchain4j/skills/DefaultFileSystemSkill.java
+++ b/langchain4j-skills/src/main/java/dev/langchain4j/skills/DefaultFileSystemSkill.java
@@ -46,6 +46,24 @@ public class DefaultFileSystemSkill extends AbstractSkill implements FileSystemS
                 + " }";
     }
 
+    /**
+     * Returns a new builder pre-populated with the values from this skill.
+     * Useful for creating a modified copy, e.g. attaching tools to a filesystem-loaded skill:
+     * <pre>{@code
+     * FileSystemSkill skillWithTools = skill.toBuilder().tools(new MyTools()).build();
+     * }</pre>
+     */
+    public Builder toBuilder() {
+        Builder builder = new Builder();
+        builder.name(name())
+                .description(description())
+                .content(content())
+                .resources(resources())
+                .toolProviders(toolProviders());
+        builder.basePath(basePath);
+        return builder;
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/langchain4j-skills/src/main/java/dev/langchain4j/skills/DefaultFileSystemSkill.java
+++ b/langchain4j-skills/src/main/java/dev/langchain4j/skills/DefaultFileSystemSkill.java
@@ -1,11 +1,10 @@
 package dev.langchain4j.skills;
 
-import dev.langchain4j.Experimental;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
+import dev.langchain4j.Experimental;
 import java.nio.file.Path;
 import java.util.Objects;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 @Experimental
 public class DefaultFileSystemSkill extends AbstractSkill implements FileSystemSkill {

--- a/langchain4j-skills/src/main/java/dev/langchain4j/skills/DefaultFileSystemSkill.java
+++ b/langchain4j-skills/src/main/java/dev/langchain4j/skills/DefaultFileSystemSkill.java
@@ -41,26 +41,20 @@ public class DefaultFileSystemSkill extends AbstractSkill implements FileSystemS
                 + ", description = " + description()
                 + ", content = " + content()
                 + ", resources = " + resources()
+                + ", toolProviders = " + toolProviders()
                 + ", basePath = " + basePath
                 + " }";
     }
 
     /**
      * Returns a new builder pre-populated with the values from this skill.
-     * Useful for creating a modified copy, e.g. attaching tools to a filesystem-loaded skill:
+     * Useful for creating a modified copy, e.g. adding tools to a filesystem-loaded skill:
      * <pre>{@code
      * FileSystemSkill skillWithTools = skill.toBuilder().tools(new MyTools()).build();
      * }</pre>
      */
     public Builder toBuilder() {
-        Builder builder = new Builder();
-        builder.name(name())
-                .description(description())
-                .content(content())
-                .resources(resources())
-                .toolProviders(toolProviders());
-        builder.basePath(basePath);
-        return builder;
+        return builder().copyFrom(this).basePath(basePath());
     }
 
     public static Builder builder() {

--- a/langchain4j-skills/src/main/java/dev/langchain4j/skills/DefaultSkill.java
+++ b/langchain4j-skills/src/main/java/dev/langchain4j/skills/DefaultSkill.java
@@ -17,13 +17,7 @@ public class DefaultSkill extends AbstractSkill {
      * }</pre>
      */
     public Builder toBuilder() {
-        Builder builder = new Builder();
-        builder.name(name())
-                .description(description())
-                .content(content())
-                .resources(resources())
-                .toolProviders(toolProviders());
-        return builder;
+        return builder().copyFrom(this);
     }
 
     public static Builder builder() {

--- a/langchain4j-skills/src/test/java/dev/langchain4j/skills/SkillTest.java
+++ b/langchain4j-skills/src/test/java/dev/langchain4j/skills/SkillTest.java
@@ -12,6 +12,8 @@ import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -702,6 +704,92 @@ class SkillTest {
 
         // then
         assertThat(withProvider.toolProviders()).hasSize(1);
+
+        Skills skills = Skills.from(withProvider);
+        assertThat(skills.toolProvider().isDynamic()).isTrue();
+
+        // after activation
+        ToolProviderRequest activatedRequest = requestWithMessages(List.of(
+                UserMessage.from("do stuff"),
+                skillActivatedMessage("my-skill")
+        ));
+        ToolProviderResult result = skills.toolProvider().provideTools(activatedRequest);
+        assertThat(getToolNames(result)).containsExactlyInAnyOrder("activate_skill", "dynamic_tool");
+    }
+
+    @Test
+    void defaultFileSystemSkill_toBuilder_should_copy_all_fields() {
+
+        // given
+        Path basePath = Paths.get("/tmp/skills/my-skill");
+        DefaultFileSystemSkill original = DefaultFileSystemSkill.builder()
+                .name("my-skill")
+                .description("My skill")
+                .content("Some content")
+                .basePath(basePath)
+                .build();
+
+        // when
+        DefaultFileSystemSkill copy = original.toBuilder().build();
+
+        // then
+        assertThat(copy.name()).isEqualTo("my-skill");
+        assertThat(copy.description()).isEqualTo("My skill");
+        assertThat(copy.content()).isEqualTo("Some content");
+        assertThat(copy.basePath()).isEqualTo(basePath);
+        assertThat(copy).isEqualTo(original);
+    }
+
+    @Test
+    void defaultFileSystemSkill_toBuilder_should_allow_adding_tools_to_filesystem_loaded_skill() {
+
+        // given - simulate a filesystem-loaded skill (no tools)
+        Path basePath = Paths.get("/tmp/skills/my-skill");
+        DefaultFileSystemSkill original = DefaultFileSystemSkill.builder()
+                .name("my-skill")
+                .description("My skill")
+                .content("Use sayHello")
+                .basePath(basePath)
+                .build();
+
+        assertThat(original.toolProviders()).isEmpty();
+
+        // when - add tools via toBuilder
+        DefaultFileSystemSkill withTools = original.toBuilder()
+                .tools(new MyTools())
+                .build();
+
+        // then
+        assertThat(withTools.name()).isEqualTo("my-skill");
+        assertThat(withTools.basePath()).isEqualTo(basePath);
+        assertThat(withTools.toolProviders()).hasSize(1);
+    }
+
+    @Test
+    void defaultFileSystemSkill_toBuilder_should_allow_adding_tool_provider_to_filesystem_loaded_skill() {
+
+        // given - simulate a filesystem-loaded skill (no tools)
+        Path basePath = Paths.get("/tmp/skills/my-skill");
+        DefaultFileSystemSkill original = DefaultFileSystemSkill.builder()
+                .name("my-skill")
+                .description("My skill")
+                .content("Use dynamic_tool")
+                .basePath(basePath)
+                .build();
+
+        ToolProvider mcpProvider = request -> ToolProviderResult.builder()
+                .add(ToolSpecification.builder().name("dynamic_tool").description("dynamic").build(),
+                        (req, memoryId) -> "result")
+                .build();
+
+        // when
+        DefaultFileSystemSkill withProvider = original.toBuilder()
+                .toolProviders(mcpProvider)
+                .build();
+
+        // then
+        assertThat(withProvider.toolProviders()).hasSize(1);
+        assertThat(withProvider.basePath()).isEqualTo(basePath);
 
         Skills skills = Skills.from(withProvider);
         assertThat(skills.toolProvider().isDynamic()).isTrue();

--- a/langchain4j-skills/src/test/java/dev/langchain4j/skills/SkillTest.java
+++ b/langchain4j-skills/src/test/java/dev/langchain4j/skills/SkillTest.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.skills;
 
+import static dev.langchain4j.skills.ActivateSkillToolExecutor.ACTIVATED_SKILL_ATTRIBUTE;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
@@ -10,38 +13,30 @@ import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
-import org.junit.jupiter.api.Test;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import static dev.langchain4j.skills.ActivateSkillToolExecutor.ACTIVATED_SKILL_ATTRIBUTE;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class SkillTest {
 
     @Test
     void should_generate_description_for_single_skill() {
-        Skills skills = Skills.from(
-                Skill.builder()
-                        .name("docx")
-                        .description("Edit Word documents")
-                        .content("skill content")
-                        .build()
-        );
+        Skills skills = Skills.from(Skill.builder()
+                .name("docx")
+                .description("Edit Word documents")
+                .content("skill content")
+                .build());
 
-        assertThat(skills.formatAvailableSkills()).isEqualTo(
-                """
+        assertThat(skills.formatAvailableSkills()).isEqualTo("""
                         <available_skills>
                         <skill>
                         <name>docx</name>
                         <description>Edit Word documents</description>
                         </skill>
-                        </available_skills>"""
-        );
+                        </available_skills>""");
     }
 
     @Test
@@ -56,11 +51,9 @@ class SkillTest {
                         .name("mcp-builder")
                         .description("Build MCP servers")
                         .content("mcp content")
-                        .build()
-        );
+                        .build());
 
-        assertThat(skills.formatAvailableSkills()).isEqualTo(
-                """
+        assertThat(skills.formatAvailableSkills()).isEqualTo("""
                         <available_skills>
                         <skill>
                         <name>docx</name>
@@ -70,29 +63,24 @@ class SkillTest {
                         <name>mcp-builder</name>
                         <description>Build MCP servers</description>
                         </skill>
-                        </available_skills>"""
-        );
+                        </available_skills>""");
     }
 
     @Test
     void should_escape_xml_special_characters_in_name_and_description() {
-        Skills skills = Skills.from(
-                Skill.builder()
-                        .name("skill<>&\"'")
-                        .description("desc<>&\"'")
-                        .content("content")
-                        .build()
-        );
+        Skills skills = Skills.from(Skill.builder()
+                .name("skill<>&\"'")
+                .description("desc<>&\"'")
+                .content("content")
+                .build());
 
-        assertThat(skills.formatAvailableSkills()).isEqualTo(
-                """
+        assertThat(skills.formatAvailableSkills()).isEqualTo("""
                         <available_skills>
                         <skill>
                         <name>skill&lt;&gt;&amp;&quot;&apos;</name>
                         <description>desc&lt;&gt;&amp;&quot;&apos;</description>
                         </skill>
-                        </available_skills>"""
-        );
+                        </available_skills>""");
     }
 
     @Test
@@ -104,9 +92,11 @@ class SkillTest {
                 .description("A skill with tools")
                 .content("Use my_tool to do something")
                 .tools(Map.of(
-                        ToolSpecification.builder().name("my_tool").description("Does something").build(),
-                        (request, memoryId) -> "result"
-                ))
+                        ToolSpecification.builder()
+                                .name("my_tool")
+                                .description("Does something")
+                                .build(),
+                        (request, memoryId) -> "result"))
                 .build();
 
         Skills skills = Skills.from(skill);
@@ -129,9 +119,11 @@ class SkillTest {
                 .description("A skill with tools")
                 .content("Use my_tool")
                 .tools(Map.of(
-                        ToolSpecification.builder().name("my_tool").description("Does something").build(),
-                        (request, memoryId) -> "result"
-                ))
+                        ToolSpecification.builder()
+                                .name("my_tool")
+                                .description("Does something")
+                                .build(),
+                        (request, memoryId) -> "result"))
                 .build();
 
         Skills skills = Skills.from(skill);
@@ -153,18 +145,18 @@ class SkillTest {
                 .description("A skill with tools")
                 .content("Use my_tool")
                 .tools(Map.of(
-                        ToolSpecification.builder().name("my_tool").description("Does something").build(),
-                        (request, memoryId) -> "result"
-                ))
+                        ToolSpecification.builder()
+                                .name("my_tool")
+                                .description("Does something")
+                                .build(),
+                        (request, memoryId) -> "result"))
                 .build();
 
         Skills skills = Skills.from(skill);
 
         // when - activation in messages
-        ToolProviderRequest request = requestWithMessages(List.of(
-                UserMessage.from("Do something"),
-                skillActivatedMessage("my-skill")
-        ));
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("Do something"), skillActivatedMessage("my-skill")));
 
         // then - management tools + activated skill tools
         ToolProviderResult result = skills.toolProvider().provideTools(request);
@@ -180,9 +172,11 @@ class SkillTest {
                 .description("First skill")
                 .content("Use tool_a")
                 .tools(Map.of(
-                        ToolSpecification.builder().name("tool_a").description("Tool A").build(),
-                        (request, memoryId) -> "a"
-                ))
+                        ToolSpecification.builder()
+                                .name("tool_a")
+                                .description("Tool A")
+                                .build(),
+                        (request, memoryId) -> "a"))
                 .build();
 
         Skill skill2 = Skill.builder()
@@ -190,18 +184,18 @@ class SkillTest {
                 .description("Second skill")
                 .content("Use tool_b")
                 .tools(Map.of(
-                        ToolSpecification.builder().name("tool_b").description("Tool B").build(),
-                        (request, memoryId) -> "b"
-                ))
+                        ToolSpecification.builder()
+                                .name("tool_b")
+                                .description("Tool B")
+                                .build(),
+                        (request, memoryId) -> "b"))
                 .build();
 
         Skills skills = Skills.from(skill1, skill2);
 
         // when - only skill-1 activated
-        ToolProviderRequest request = requestWithMessages(List.of(
-                UserMessage.from("Do something"),
-                skillActivatedMessage("skill-1")
-        ));
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("Do something"), skillActivatedMessage("skill-1")));
 
         // then - only skill-1's tools appear (not skill-2's)
         ToolProviderResult result = skills.toolProvider().provideTools(request);
@@ -217,9 +211,11 @@ class SkillTest {
                 .description("First skill")
                 .content("Use tool_a")
                 .tools(Map.of(
-                        ToolSpecification.builder().name("tool_a").description("Tool A").build(),
-                        (request, memoryId) -> "a"
-                ))
+                        ToolSpecification.builder()
+                                .name("tool_a")
+                                .description("Tool A")
+                                .build(),
+                        (request, memoryId) -> "a"))
                 .build();
 
         Skill skill2 = Skill.builder()
@@ -227,19 +223,18 @@ class SkillTest {
                 .description("Second skill")
                 .content("Use tool_b")
                 .tools(Map.of(
-                        ToolSpecification.builder().name("tool_b").description("Tool B").build(),
-                        (request, memoryId) -> "b"
-                ))
+                        ToolSpecification.builder()
+                                .name("tool_b")
+                                .description("Tool B")
+                                .build(),
+                        (request, memoryId) -> "b"))
                 .build();
 
         Skills skills = Skills.from(skill1, skill2);
 
         // when - both skills activated
         ToolProviderRequest request = requestWithMessages(List.of(
-                UserMessage.from("Do something"),
-                skillActivatedMessage("skill-1"),
-                skillActivatedMessage("skill-2")
-        ));
+                UserMessage.from("Do something"), skillActivatedMessage("skill-1"), skillActivatedMessage("skill-2")));
 
         // then - both skills' tools appear
         ToolProviderResult result = skills.toolProvider().provideTools(request);
@@ -285,17 +280,19 @@ class SkillTest {
         Skills skills = Skills.from(skill);
 
         // when - call with activation
-        ToolProviderRequest request = requestWithMessages(List.of(
-                UserMessage.from("greet"),
-                skillActivatedMessage("greeting-skill")
-        ));
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("greet"), skillActivatedMessage("greeting-skill")));
         ToolProviderResult result = skills.toolProvider().provideTools(request);
         ToolExecutor resolvedExecutor = result.toolExecutorByName("greet");
 
         // then
         assertThat(resolvedExecutor).isNotNull();
         assertThat(resolvedExecutor.execute(
-                ToolExecutionRequest.builder().name("greet").arguments("{}").build(), null))
+                        ToolExecutionRequest.builder()
+                                .name("greet")
+                                .arguments("{}")
+                                .build(),
+                        null))
                 .isEqualTo("Hello, World!");
     }
 
@@ -343,10 +340,8 @@ class SkillTest {
                 .containsExactly("activate_skill");
 
         // after activation: management + skill tools
-        ToolProviderRequest activatedRequest = requestWithMessages(List.of(
-                UserMessage.from("greet"),
-                skillActivatedMessage("greeting-skill")
-        ));
+        ToolProviderRequest activatedRequest =
+                requestWithMessages(List.of(UserMessage.from("greet"), skillActivatedMessage("greeting-skill")));
         assertThat(getToolNames(skills.toolProvider().provideTools(activatedRequest)))
                 .containsExactlyInAnyOrder("activate_skill", "sayHello");
     }
@@ -356,7 +351,11 @@ class SkillTest {
 
         // given
         ToolProvider myProvider = request -> ToolProviderResult.builder()
-                .add(ToolSpecification.builder().name("dynamic_tool").description("A dynamic tool").build(),
+                .add(
+                        ToolSpecification.builder()
+                                .name("dynamic_tool")
+                                .description("A dynamic tool")
+                                .build(),
                         (req, memoryId) -> "dynamic result")
                 .build();
 
@@ -376,7 +375,11 @@ class SkillTest {
 
         // given
         ToolProvider myProvider = request -> ToolProviderResult.builder()
-                .add(ToolSpecification.builder().name("dynamic_tool").description("A dynamic tool").build(),
+                .add(
+                        ToolSpecification.builder()
+                                .name("dynamic_tool")
+                                .description("A dynamic tool")
+                                .build(),
                         (req, memoryId) -> "dynamic result")
                 .build();
 
@@ -402,7 +405,11 @@ class SkillTest {
 
         // given
         ToolProvider mcpProvider = request -> ToolProviderResult.builder()
-                .add(ToolSpecification.builder().name("mcp_tool").description("An MCP tool").build(),
+                .add(
+                        ToolSpecification.builder()
+                                .name("mcp_tool")
+                                .description("An MCP tool")
+                                .build(),
                         (req, memoryId) -> "mcp result")
                 .build();
 
@@ -420,10 +427,8 @@ class SkillTest {
         Skills skills = Skills.from(skill);
 
         // after activation: management + both skill tools
-        ToolProviderRequest activatedRequest = requestWithMessages(List.of(
-                UserMessage.from("do stuff"),
-                skillActivatedMessage("combo-skill")
-        ));
+        ToolProviderRequest activatedRequest =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("combo-skill")));
         ToolProviderResult result = skills.toolProvider().provideTools(activatedRequest);
         assertThat(getToolNames(result)).containsExactlyInAnyOrder("activate_skill", "sayHello", "mcp_tool");
     }
@@ -457,10 +462,8 @@ class SkillTest {
         Skills skills = Skills.from(skill);
 
         // when - activate the skill
-        ToolProviderRequest request = requestWithMessages(List.of(
-                UserMessage.from("do stuff"),
-                skillActivatedMessage("my-skill")
-        ));
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
         ToolProviderResult result = skills.toolProvider().provideTools(request);
 
         // then - both @Tool method and Map tool are present
@@ -488,10 +491,8 @@ class SkillTest {
         Skills skills = Skills.from(skill);
 
         // when
-        ToolProviderRequest request = requestWithMessages(List.of(
-                UserMessage.from("do stuff"),
-                skillActivatedMessage("my-skill")
-        ));
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
         ToolProviderResult result = skills.toolProvider().provideTools(request);
 
         // then
@@ -513,10 +514,8 @@ class SkillTest {
         Skills skills = Skills.from(skill);
 
         // when
-        ToolProviderRequest request = requestWithMessages(List.of(
-                UserMessage.from("do stuff"),
-                skillActivatedMessage("my-skill")
-        ));
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
         ToolProviderResult result = skills.toolProvider().provideTools(request);
 
         // then - second call overrides first
@@ -527,8 +526,10 @@ class SkillTest {
     void second_tools_map_call_should_override_first() {
 
         // given
-        ToolSpecification tool1 = ToolSpecification.builder().name("tool_1").description("Tool 1").build();
-        ToolSpecification tool2 = ToolSpecification.builder().name("tool_2").description("Tool 2").build();
+        ToolSpecification tool1 =
+                ToolSpecification.builder().name("tool_1").description("Tool 1").build();
+        ToolSpecification tool2 =
+                ToolSpecification.builder().name("tool_2").description("Tool 2").build();
 
         Skill skill = Skill.builder()
                 .name("my-skill")
@@ -541,10 +542,8 @@ class SkillTest {
         Skills skills = Skills.from(skill);
 
         // when
-        ToolProviderRequest request = requestWithMessages(List.of(
-                UserMessage.from("do stuff"),
-                skillActivatedMessage("my-skill")
-        ));
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
         ToolProviderResult result = skills.toolProvider().provideTools(request);
 
         // then - second call overrides first
@@ -556,11 +555,19 @@ class SkillTest {
 
         // given
         ToolProvider provider1 = request -> ToolProviderResult.builder()
-                .add(ToolSpecification.builder().name("provider1_tool").description("P1").build(),
+                .add(
+                        ToolSpecification.builder()
+                                .name("provider1_tool")
+                                .description("P1")
+                                .build(),
                         (req, memoryId) -> "p1")
                 .build();
         ToolProvider provider2 = request -> ToolProviderResult.builder()
-                .add(ToolSpecification.builder().name("provider2_tool").description("P2").build(),
+                .add(
+                        ToolSpecification.builder()
+                                .name("provider2_tool")
+                                .description("P2")
+                                .build(),
                         (req, memoryId) -> "p2")
                 .build();
 
@@ -587,7 +594,11 @@ class SkillTest {
         ToolExecutor manualExecutor = (request, memoryId) -> "manual";
 
         ToolProvider dynamicProvider = request -> ToolProviderResult.builder()
-                .add(ToolSpecification.builder().name("dynamic_tool").description("Dynamic").build(),
+                .add(
+                        ToolSpecification.builder()
+                                .name("dynamic_tool")
+                                .description("Dynamic")
+                                .build(),
                         (req, memoryId) -> "dynamic")
                 .build();
 
@@ -606,14 +617,13 @@ class SkillTest {
         Skills skills = Skills.from(skill);
 
         // when - activate the skill
-        ToolProviderRequest request = requestWithMessages(List.of(
-                UserMessage.from("do stuff"),
-                skillActivatedMessage("my-skill")
-        ));
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
         ToolProviderResult result = skills.toolProvider().provideTools(request);
 
         // then - all three tools present
-        assertThat(getToolNames(result)).containsExactlyInAnyOrder("activate_skill", "sayHello", "manual_tool", "dynamic_tool");
+        assertThat(getToolNames(result))
+                .containsExactlyInAnyOrder("activate_skill", "sayHello", "manual_tool", "dynamic_tool");
     }
 
     @Test
@@ -621,11 +631,19 @@ class SkillTest {
 
         // given
         ToolProvider provider1 = request -> ToolProviderResult.builder()
-                .add(ToolSpecification.builder().name("vararg_tool").description("Vararg").build(),
+                .add(
+                        ToolSpecification.builder()
+                                .name("vararg_tool")
+                                .description("Vararg")
+                                .build(),
                         (req, memoryId) -> "vararg")
                 .build();
         ToolProvider provider2 = request -> ToolProviderResult.builder()
-                .add(ToolSpecification.builder().name("collection_tool").description("Collection").build(),
+                .add(
+                        ToolSpecification.builder()
+                                .name("collection_tool")
+                                .description("Collection")
+                                .build(),
                         (req, memoryId) -> "collection")
                 .build();
 
@@ -673,9 +691,7 @@ class SkillTest {
         assertThat(original.toolProviders()).isEmpty();
 
         // when - add tools via toBuilder
-        DefaultSkill withTools = original.toBuilder()
-                .tools(new MyTools())
-                .build();
+        DefaultSkill withTools = original.toBuilder().tools(new MyTools()).build();
 
         // then
         assertThat(withTools.name()).isEqualTo("my-skill");
@@ -693,14 +709,17 @@ class SkillTest {
                 .build();
 
         ToolProvider mcpProvider = request -> ToolProviderResult.builder()
-                .add(ToolSpecification.builder().name("dynamic_tool").description("dynamic").build(),
+                .add(
+                        ToolSpecification.builder()
+                                .name("dynamic_tool")
+                                .description("dynamic")
+                                .build(),
                         (req, memoryId) -> "result")
                 .build();
 
         // when
-        DefaultSkill withProvider = original.toBuilder()
-                .toolProviders(mcpProvider)
-                .build();
+        DefaultSkill withProvider =
+                original.toBuilder().toolProviders(mcpProvider).build();
 
         // then
         assertThat(withProvider.toolProviders()).hasSize(1);
@@ -709,10 +728,8 @@ class SkillTest {
         assertThat(skills.toolProvider().isDynamic()).isTrue();
 
         // after activation
-        ToolProviderRequest activatedRequest = requestWithMessages(List.of(
-                UserMessage.from("do stuff"),
-                skillActivatedMessage("my-skill")
-        ));
+        ToolProviderRequest activatedRequest =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
         ToolProviderResult result = skills.toolProvider().provideTools(activatedRequest);
         assertThat(getToolNames(result)).containsExactlyInAnyOrder("activate_skill", "dynamic_tool");
     }
@@ -755,9 +772,8 @@ class SkillTest {
         assertThat(original.toolProviders()).isEmpty();
 
         // when - add tools via toBuilder
-        DefaultFileSystemSkill withTools = original.toBuilder()
-                .tools(new MyTools())
-                .build();
+        DefaultFileSystemSkill withTools =
+                original.toBuilder().tools(new MyTools()).build();
 
         // then
         assertThat(withTools.name()).isEqualTo("my-skill");
@@ -778,14 +794,17 @@ class SkillTest {
                 .build();
 
         ToolProvider mcpProvider = request -> ToolProviderResult.builder()
-                .add(ToolSpecification.builder().name("dynamic_tool").description("dynamic").build(),
+                .add(
+                        ToolSpecification.builder()
+                                .name("dynamic_tool")
+                                .description("dynamic")
+                                .build(),
                         (req, memoryId) -> "result")
                 .build();
 
         // when
-        DefaultFileSystemSkill withProvider = original.toBuilder()
-                .toolProviders(mcpProvider)
-                .build();
+        DefaultFileSystemSkill withProvider =
+                original.toBuilder().toolProviders(mcpProvider).build();
 
         // then
         assertThat(withProvider.toolProviders()).hasSize(1);
@@ -795,10 +814,8 @@ class SkillTest {
         assertThat(skills.toolProvider().isDynamic()).isTrue();
 
         // after activation
-        ToolProviderRequest activatedRequest = requestWithMessages(List.of(
-                UserMessage.from("do stuff"),
-                skillActivatedMessage("my-skill")
-        ));
+        ToolProviderRequest activatedRequest =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
         ToolProviderResult result = skills.toolProvider().provideTools(activatedRequest);
         assertThat(getToolNames(result)).containsExactlyInAnyOrder("activate_skill", "dynamic_tool");
     }
@@ -827,7 +844,6 @@ class SkillTest {
     }
 
     private static Stream<String> getToolNames(ToolProviderResult result) {
-        return result.tools().keySet().stream()
-                .map(ToolSpecification::name);
+        return result.tools().keySet().stream().map(ToolSpecification::name);
     }
 }

--- a/langchain4j-skills/src/test/java/dev/langchain4j/skills/SkillTest.java
+++ b/langchain4j-skills/src/test/java/dev/langchain4j/skills/SkillTest.java
@@ -820,6 +820,210 @@ class SkillTest {
         assertThat(getToolNames(result)).containsExactlyInAnyOrder("activate_skill", "dynamic_tool");
     }
 
+    @Test
+    void toBuilder_then_tools_should_replace_existing_annotated_tools() {
+
+        // given - skill already has annotated tools
+        DefaultSkill original = Skill.builder()
+                .name("my-skill")
+                .description("My skill")
+                .content("Use sayHello")
+                .tools(new MyTools())
+                .build();
+
+        // when - replace tools via toBuilder
+        DefaultSkill replaced = original.toBuilder().tools(new AnotherTools()).build();
+
+        Skills skills = Skills.from(replaced);
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
+        ToolProviderResult result = skills.toolProvider().provideTools(request);
+
+        // then - same "last call wins" semantics as a fresh builder chain
+        assertThat(replaced.toolProviders()).hasSize(1);
+        assertThat(getToolNames(result)).containsExactlyInAnyOrder("activate_skill", "sayGoodbye");
+    }
+
+    @Test
+    void toBuilder_then_tools_map_should_replace_existing_map_tools() {
+
+        // given
+        ToolSpecification tool1 =
+                ToolSpecification.builder().name("tool_1").description("Tool 1").build();
+        ToolSpecification tool2 =
+                ToolSpecification.builder().name("tool_2").description("Tool 2").build();
+
+        DefaultSkill original = Skill.builder()
+                .name("my-skill")
+                .description("My skill")
+                .content("Use tools")
+                .tools(Map.of(tool1, (request, memoryId) -> "1"))
+                .build();
+
+        // when
+        DefaultSkill replaced = original.toBuilder()
+                .tools(Map.of(tool2, (request, memoryId) -> "2"))
+                .build();
+
+        Skills skills = Skills.from(replaced);
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
+        ToolProviderResult result = skills.toolProvider().provideTools(request);
+
+        // then
+        assertThat(replaced.toolProviders()).hasSize(1);
+        assertThat(getToolNames(result)).containsExactlyInAnyOrder("activate_skill", "tool_2");
+    }
+
+    @Test
+    void toBuilder_then_toolProviders_should_not_wipe_out_static_tools() {
+
+        // given - skill has BOTH annotated tools and a tool provider
+        ToolProvider originalProvider = request -> ToolProviderResult.builder()
+                .add(
+                        ToolSpecification.builder()
+                                .name("original_dynamic")
+                                .description("Original")
+                                .build(),
+                        (req, memoryId) -> "original")
+                .build();
+        DefaultSkill original = Skill.builder()
+                .name("my-skill")
+                .description("My skill")
+                .content("Use tools")
+                .tools(new MyTools())
+                .toolProviders(originalProvider)
+                .build();
+
+        ToolProvider newProvider = request -> ToolProviderResult.builder()
+                .add(
+                        ToolSpecification.builder()
+                                .name("new_dynamic")
+                                .description("New")
+                                .build(),
+                        (req, memoryId) -> "new")
+                .build();
+
+        // when - swap providers via toBuilder
+        DefaultSkill modified = original.toBuilder().toolProviders(newProvider).build();
+
+        Skills skills = Skills.from(modified);
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
+        ToolProviderResult result = skills.toolProvider().provideTools(request);
+
+        // then - static tools survived; the old provider was replaced by the new one (same as a fresh chain)
+        assertThat(modified.toolProviders()).hasSize(2);
+        assertThat(getToolNames(result)).containsExactlyInAnyOrder("activate_skill", "sayHello", "new_dynamic");
+    }
+
+    @Test
+    void toBuilder_roundtrip_should_preserve_all_three_tool_types() {
+
+        // given
+        ToolSpecification manualTool = ToolSpecification.builder()
+                .name("manual_tool")
+                .description("A manual tool")
+                .build();
+        ToolProvider dynamicProvider = request -> ToolProviderResult.builder()
+                .add(
+                        ToolSpecification.builder()
+                                .name("dynamic_tool")
+                                .description("Dynamic")
+                                .build(),
+                        (req, memoryId) -> "dynamic")
+                .build();
+
+        DefaultSkill original = Skill.builder()
+                .name("my-skill")
+                .description("My skill")
+                .content("Use tools")
+                .tools(new MyTools())
+                .tools(Map.of(manualTool, (request, memoryId) -> "manual"))
+                .toolProviders(dynamicProvider)
+                .build();
+
+        // when - round-trip
+        DefaultSkill copy = original.toBuilder().build();
+
+        // then - same provider count, same tools, equal
+        assertThat(copy.toolProviders()).hasSize(2);
+        assertThat(copy).isEqualTo(original);
+
+        Skills skills = Skills.from(copy);
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
+        ToolProviderResult result = skills.toolProvider().provideTools(request);
+        assertThat(getToolNames(result))
+                .containsExactlyInAnyOrder("activate_skill", "sayHello", "manual_tool", "dynamic_tool");
+    }
+
+    @Test
+    void defaultFileSystemSkill_toBuilder_then_tools_should_replace_existing_annotated_tools() {
+
+        // given
+        Path basePath = Paths.get("/tmp/skills/my-skill");
+        DefaultFileSystemSkill original = DefaultFileSystemSkill.builder()
+                .name("my-skill")
+                .description("My skill")
+                .content("Use sayHello")
+                .basePath(basePath)
+                .tools(new MyTools())
+                .build();
+
+        // when
+        DefaultFileSystemSkill replaced =
+                original.toBuilder().tools(new AnotherTools()).build();
+
+        Skills skills = Skills.from(replaced);
+        ToolProviderRequest request =
+                requestWithMessages(List.of(UserMessage.from("do stuff"), skillActivatedMessage("my-skill")));
+        ToolProviderResult result = skills.toolProvider().provideTools(request);
+
+        // then
+        assertThat(replaced.basePath()).isEqualTo(basePath);
+        assertThat(replaced.toolProviders()).hasSize(1);
+        assertThat(getToolNames(result)).containsExactlyInAnyOrder("activate_skill", "sayGoodbye");
+    }
+
+    @Test
+    void defaultFileSystemSkill_toBuilder_roundtrip_should_be_equal_for_skill_with_tools() {
+
+        // given
+        Path basePath = Paths.get("/tmp/skills/my-skill");
+        DefaultFileSystemSkill original = DefaultFileSystemSkill.builder()
+                .name("my-skill")
+                .description("My skill")
+                .content("Use tools")
+                .basePath(basePath)
+                .tools(new MyTools())
+                .build();
+
+        // when
+        DefaultFileSystemSkill copy = original.toBuilder().build();
+
+        // then
+        assertThat(copy).isEqualTo(original);
+        assertThat(copy.hashCode()).isEqualTo(original.hashCode());
+        assertThat(copy.basePath()).isEqualTo(basePath);
+    }
+
+    @Test
+    void defaultFileSystemSkill_toString_should_include_toolProviders() {
+
+        // given
+        DefaultFileSystemSkill skill = DefaultFileSystemSkill.builder()
+                .name("my-skill")
+                .description("My skill")
+                .content("Use sayHello")
+                .basePath(Paths.get("/tmp/skills/my-skill"))
+                .tools(new MyTools())
+                .build();
+
+        // then
+        assertThat(skill.toString()).contains("toolProviders").contains("basePath");
+    }
+
     private static ToolProviderRequest dummyRequest() {
         return ToolProviderRequest.builder()
                 .invocationContext(InvocationContext.builder().build())


### PR DESCRIPTION
## Issue
Closes #5267

`DefaultSkill` already exposed `toBuilder()`, but its filesystem variant
  `DefaultFileSystemSkill` did not. This made it awkward to attach tools or
  tool-providers to a skill freshly loaded by `FileSystemSkillLoader` — you had
  to hand-rebuild the skill, manually re-copying `name`, `description`,
  `content`, `resources`, and `basePath`.

  While adding `toBuilder()` it became clear that the existing tool handling in
  `AbstractSkill` could not round-trip faithfully: the builder's three separate
  tool "buckets" (annotated tools, map tools, and user-supplied tool providers)
  were eagerly flattened into a single `toolProviders` list in the constructor,
  so there was no way to reconstruct the original builder state — or to preserve
  the "last call wins" replacement semantics of `tools()` / `toolProviders()`.

  ## Changes

  - **`DefaultFileSystemSkill`**
    - Add `toBuilder()`, pre-populating a new builder from the current skill
      (including the `basePath` unique to this subclass).
    - Include `toolProviders` in `toString()` (was previously omitted).

  - **`AbstractSkill`**
    - Store `annotatedTools`, `mapTools`, and `toolProviders` as separate fields
      instead of flattening them at construction time; expose the combined view
      lazily via a precomputed `aggregatedToolProviders` returned from
      `toolProviders()`.
    - Add a shared, protected `BaseBuilder.copyFrom(AbstractSkill)` that
      repopulates all fields so subclasses can build `toBuilder()` by chaining
      their own extra setters (e.g. `basePath`).
    - Include `annotatedTools` and `mapTools` in `equals()` / `hashCode()`.

  - **`DefaultSkill`**
    - Reimplement `toBuilder()` on top of the shared `copyFrom(...)`.

  ## Behavior

  `toBuilder()` round-trips faithfully and keeps fresh-builder semantics:

  - A round-tripped skill is `equals()` to the original (all three tool types,
    resources, and `basePath` preserved).
  - A subsequent `tools(...)` / `toolProviders(...)` call after `toBuilder()`
    *replaces* the corresponding bucket (same "last call wins" behavior as a
    fresh builder chain) without wiping out the other tool types.

  ```java
  FileSystemSkill skillWithTools = skill.toBuilder()
          .tools(new MyTools())
          .build();
  ```

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green (`mvn -pl langchain4j-skills test` → 80/80 green, including the 3 new tests)
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)