### PR TITLE
Add Future AGI to Third-party Integrations in observability tutorial

### DIFF
--- a/docs/docs/tutorials/observability.md
+++ b/docs/docs/tutorials/observability.md
@@ -646,6 +646,7 @@ Details on how to integrate the Micrometer Observation API library with SpringBo
 ## Third-party Integrations
 
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix)
+- [Future AGI](https://github.com/future-agi/traceAI/tree/main/java/traceai-langchain4j)
 
 ### OpenTelemetry GenAI instrumentation
 


### PR DESCRIPTION
## Issue
No related issue — small docs-only addition to the `Third-party Integrations` section of `docs/docs/tutorials/observability.md`.

## Change
Adds a one-line bullet for [Future AGI](https://github.com/future-agi/traceAI/tree/main/java/traceai-langchain4j) under the existing `## Third-party Integrations` section, formatted identically to the existing [Arize Phoenix](https://github.com/Arize-ai/phoenix) bullet directly above it.

Future AGI ships [`traceai-langchain4j`](https://github.com/future-agi/traceAI/tree/main/java/traceai-langchain4j), a Java instrumentation package that wraps `ChatLanguageModel` and `AiServices` to emit OpenTelemetry GenAI semantic-conventions spans for the Future AGI dashboard.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change — N/A, docs-only single-line addition
- [ ] The tests cover both positive and negative cases — N/A, docs-only single-line addition
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green — N/A, docs-only single-line addition
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green — N/A, docs-only single-line addition
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) — N/A
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) — N/A