### PR TITLE
fix(anthropic): preserve raw replayed tool arguments

### DIFF
--- a/langchain4j-anthropic/revapi.json
+++ b/langchain4j-anthropic/revapi.json
@@ -8,6 +8,35 @@
           "code": "java.field.removed",
           "old": "field dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_3_HAIKU_20240307",
           "justification": "Model no longer exists and was previously deprecated; removed intentionally"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent.Builder dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent.Builder::input(===java.util.Map<java.lang.String, java.lang.Object>===)",
+          "new": "parameter dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent.Builder dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent.Builder::input(===java.lang.String===)",
+          "parameterIndex": "0",
+          "justification": "Internal serialize-only request DTO now stores raw JSON to avoid parsing and re-serializing tool arguments"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.typeChanged",
+          "old": "field dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent.input",
+          "new": "field dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent.input",
+          "justification": "Internal serialize-only request DTO now stores raw JSON to avoid parsing and re-serializing tool arguments"
+        },
+        {
+          "ignore": true,
+          "code": "java.annotation.added",
+          "new": "field dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent.input",
+          "justification": "JsonRawValue is required to serialize the internal raw JSON input as a JSON object"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter void dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent::<init>(java.lang.String, java.lang.String, ===java.util.Map<java.lang.String, java.lang.Object>===)",
+          "new": "parameter void dev.langchain4j.model.anthropic.internal.api.AnthropicToolUseContent::<init>(java.lang.String, java.lang.String, ===java.lang.String===)",
+          "parameterIndex": "2",
+          "justification": "Internal serialize-only request DTO now stores raw JSON to avoid parsing and re-serializing tool arguments"
         }
       ]
     }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolUseContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolUseContent.java
@@ -16,6 +16,7 @@ public class AnthropicToolUseContent extends AnthropicMessageContent {
 
     public String id;
     public String name;
+
     @JsonRawValue
     public String input;
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolUseContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolUseContent.java
@@ -4,9 +4,9 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import java.util.Map;
 import java.util.Objects;
 
 @JsonInclude(NON_NULL)
@@ -16,9 +16,10 @@ public class AnthropicToolUseContent extends AnthropicMessageContent {
 
     public String id;
     public String name;
-    public Map<String, Object> input;
+    @JsonRawValue
+    public String input;
 
-    public AnthropicToolUseContent(String id, String name, Map<String, Object> input) {
+    public AnthropicToolUseContent(String id, String name, String input) {
         super("tool_use");
         this.id = id;
         this.name = name;
@@ -54,7 +55,7 @@ public class AnthropicToolUseContent extends AnthropicMessageContent {
 
         private String id;
         private String name;
-        private Map<String, Object> input;
+        private String input;
 
         public Builder id(String id) {
             this.id = id;
@@ -66,7 +67,7 @@ public class AnthropicToolUseContent extends AnthropicMessageContent {
             return this;
         }
 
-        public Builder input(Map<String, Object> input) {
+        public Builder input(String input) {
             this.input = input;
             return this;
         }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -230,7 +230,11 @@ public class AnthropicMapper {
             return Map.of();
         }
 
-        return fromJson(arguments, Map.class);
+        try {
+            return fromJson(arguments, Map.class);
+        } catch (Exception e) {
+            return Map.of();
+        }
     }
 
     public static List<AnthropicTextContent> toAnthropicSystemPrompt(

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -10,7 +10,6 @@ import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.ASSISTANT;
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.USER;
-import static dev.langchain4j.model.anthropic.internal.client.Json.fromJson;
 import static dev.langchain4j.model.anthropic.internal.client.Json.toJson;
 import static dev.langchain4j.model.output.FinishReason.LENGTH;
 import static dev.langchain4j.model.output.FinishReason.OTHER;
@@ -20,6 +19,9 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.joining;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -59,6 +61,7 @@ import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -77,6 +80,8 @@ public class AnthropicMapper {
     public static final String SERVER_TOOL_RESULTS_KEY =
             "server_tool_results"; // do not change, will break backward compatibility!
     public static final String CACHE_CONTROL = "cache_control";
+
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
     public static List<AnthropicMessage> toAnthropicMessages(List<ChatMessage> messages) {
         return toAnthropicMessages(messages, false);
@@ -224,16 +229,24 @@ public class AnthropicMapper {
         return contents;
     }
 
-    private static Map<String, Object> toAnthropicInput(ToolExecutionRequest toolExecutionRequest) {
+    private static String toAnthropicInput(ToolExecutionRequest toolExecutionRequest) {
         String arguments = toolExecutionRequest.arguments();
         if (isNullOrBlank(arguments)) {
-            return Map.of();
+            return "{}";
         }
 
-        try {
-            return fromJson(arguments, Map.class);
-        } catch (Exception e) {
-            return Map.of();
+        return isJsonObject(arguments) ? arguments : "{}";
+    }
+
+    private static boolean isJsonObject(String json) {
+        try (JsonParser parser = JSON_FACTORY.createParser(json)) {
+            if (parser.nextToken() != JsonToken.START_OBJECT) {
+                return false;
+            }
+            parser.skipChildren();
+            return parser.nextToken() == null;
+        } catch (IOException e) {
+            return false;
         }
     }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -19,9 +19,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.joining;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -61,7 +58,6 @@ import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.TokenUsage;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -80,8 +76,6 @@ public class AnthropicMapper {
     public static final String SERVER_TOOL_RESULTS_KEY =
             "server_tool_results"; // do not change, will break backward compatibility!
     public static final String CACHE_CONTROL = "cache_control";
-
-    private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
     public static List<AnthropicMessage> toAnthropicMessages(List<ChatMessage> messages) {
         return toAnthropicMessages(messages, false);
@@ -235,19 +229,7 @@ public class AnthropicMapper {
             return "{}";
         }
 
-        return isJsonObject(arguments) ? arguments : "{}";
-    }
-
-    private static boolean isJsonObject(String json) {
-        try (JsonParser parser = JSON_FACTORY.createParser(json)) {
-            if (parser.nextToken() != JsonToken.START_OBJECT) {
-                return false;
-            }
-            parser.skipChildren();
-            return parser.nextToken() == null;
-        } catch (IOException e) {
-            return false;
-        }
+        return arguments;
     }
 
     public static List<AnthropicTextContent> toAnthropicSystemPrompt(

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -70,7 +70,7 @@ class AnthropicMapperTest {
     }
 
     @Test
-    void should_fallback_to_empty_input_when_replaying_malformed_tool_arguments() {
+    void should_preserve_raw_input_when_replaying_malformed_tool_arguments() {
         // given
         String malformedArguments = "{\"value\":\"bad \"quote\"\"}";
         List<ChatMessage> messages = asList(
@@ -112,7 +112,7 @@ class AnthropicMapperTest {
                                         AnthropicToolUseContent.builder()
                                                 .id("call_01")
                                                 .name("updateScene")
-                                                .input("{}")
+                                                .input(malformedArguments)
                                                 .build())),
                         new AnthropicMessage(
                                 USER,
@@ -145,7 +145,28 @@ class AnthropicMapperTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"[]", "\"value\"", "null", "true", "1", "{\"first\":2} true"})
-    void should_fallback_to_empty_input_when_replaying_non_object_tool_arguments(String arguments) {
+    void should_pass_through_non_blank_tool_arguments(String arguments) {
+        // given
+        List<ChatMessage> messages = asList(
+                UserMessage.from("Please calculate"),
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("12345")
+                        .name("calculator")
+                        .arguments(arguments)
+                        .build()));
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(messages);
+
+        // then
+        AnthropicToolUseContent toolUseContent =
+                (AnthropicToolUseContent) anthropicMessages.get(1).content.get(0);
+        assertThat(toolUseContent.input).isEqualTo(arguments);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "\n\t"})
+    void should_fallback_to_empty_input_when_replaying_blank_tool_arguments(String arguments) {
         // given
         List<ChatMessage> messages = asList(
                 UserMessage.from("Please calculate"),

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -13,10 +13,10 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -44,7 +44,6 @@ import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
 import java.net.URI;
-import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,6 +52,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class AnthropicMapperTest {
 
@@ -107,12 +107,12 @@ class AnthropicMapperTest {
                                         AnthropicToolUseContent.builder()
                                                 .id("call_00")
                                                 .name("updateScene")
-                                                .input(mapOf(entry("sceneId", "scene_30")))
+                                                .input("{\"sceneId\":\"scene_30\"}")
                                                 .build(),
                                         AnthropicToolUseContent.builder()
                                                 .id("call_01")
                                                 .name("updateScene")
-                                                .input(emptyMap())
+                                                .input("{}")
                                                 .build())),
                         new AnthropicMessage(
                                 USER,
@@ -120,6 +120,48 @@ class AnthropicMapperTest {
                                         new AnthropicToolResultContent("call_00", "updated", null),
                                         new AnthropicToolResultContent(
                                                 "call_01", "Something is wrong with tool arguments", true))));
+    }
+
+    @Test
+    void should_serialize_tool_use_input_as_raw_json_object() throws JsonProcessingException {
+        // given
+        ObjectMapper objectMapper = new ObjectMapper();
+        AnthropicToolUseContent content = AnthropicToolUseContent.builder()
+                .id("12345")
+                .name("calculator")
+                .input("{\"first\": 2, \"second\": 2}")
+                .build();
+
+        // when
+        String json = objectMapper.writeValueAsString(content);
+        JsonNode root = objectMapper.readTree(json);
+
+        // then
+        assertThat(json).doesNotContain("\"input\":\"");
+        assertThat(root.get("input").isObject()).isTrue();
+        assertThat(root.get("input").get("first").asInt()).isEqualTo(2);
+        assertThat(root.get("input").get("second").asInt()).isEqualTo(2);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"[]", "\"value\"", "null", "true", "1", "{\"first\":2} true"})
+    void should_fallback_to_empty_input_when_replaying_non_object_tool_arguments(String arguments) {
+        // given
+        List<ChatMessage> messages = asList(
+                UserMessage.from("Please calculate"),
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("12345")
+                        .name("calculator")
+                        .arguments(arguments)
+                        .build()));
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(messages);
+
+        // then
+        AnthropicToolUseContent toolUseContent =
+                (AnthropicToolUseContent) anthropicMessages.get(1).content.get(0);
+        assertThat(toolUseContent.input).isEqualTo("{}");
     }
 
     static Stream<Arguments> test_toAnthropicMessages() {
@@ -155,7 +197,7 @@ class AnthropicMapperTest {
                                         singletonList(AnthropicToolUseContent.builder()
                                                 .id("12345")
                                                 .name("calculator")
-                                                .input(mapOf(entry("first", 2), entry("second", 2)))
+                                                .input("{\"first\": 2, \"second\": 2}")
                                                 .build())),
                                 new AnthropicMessage(
                                         USER, singletonList(new AnthropicToolResultContent("12345", "4", null))))),
@@ -180,7 +222,7 @@ class AnthropicMapperTest {
                                                 AnthropicToolUseContent.builder()
                                                         .id("12345")
                                                         .name("calculator")
-                                                        .input(mapOf(entry("first", 2), entry("second", 2)))
+                                                        .input("{\"first\": 2, \"second\": 2}")
                                                         .build())),
                                 new AnthropicMessage(
                                         USER, singletonList(new AnthropicToolResultContent("12345", "4", null))))),
@@ -209,12 +251,12 @@ class AnthropicMapperTest {
                                                 AnthropicToolUseContent.builder()
                                                         .id("12345")
                                                         .name("calculator")
-                                                        .input(mapOf(entry("first", 2), entry("second", 2)))
+                                                        .input("{\"first\": 2, \"second\": 2}")
                                                         .build(),
                                                 AnthropicToolUseContent.builder()
                                                         .id("67890")
                                                         .name("calculator")
-                                                        .input(mapOf(entry("first", 3), entry("second", 3)))
+                                                        .input("{\"first\": 3, \"second\": 3}")
                                                         .build())),
                                 new AnthropicMessage(
                                         USER,
@@ -244,7 +286,7 @@ class AnthropicMapperTest {
                                         singletonList(AnthropicToolUseContent.builder()
                                                 .id("12345")
                                                 .name("calculator")
-                                                .input(mapOf(entry("first", 2), entry("second", 2)))
+                                                .input("{\"first\": 2, \"second\": 2}")
                                                 .build())),
                                 new AnthropicMessage(
                                         USER, singletonList(new AnthropicToolResultContent("12345", "4", null))),
@@ -253,7 +295,7 @@ class AnthropicMapperTest {
                                         singletonList(AnthropicToolUseContent.builder()
                                                 .id("67890")
                                                 .name("calculator")
-                                                .input(mapOf(entry("first", 3), entry("second", 3)))
+                                                .input("{\"first\": 3, \"second\": 3}")
                                                 .build())),
                                 new AnthropicMessage(
                                         USER, singletonList(new AnthropicToolResultContent("67890", "6", null))))),
@@ -621,12 +663,4 @@ class AnthropicMapperTest {
         assertThat(second.cacheControl).extracting("type").isEqualTo("ephemeral");
     }
 
-    @SafeVarargs
-    private static <K, V> Map<K, V> mapOf(Map.Entry<K, V>... entries) {
-        return Stream.of(entries).collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
-    private static <K, V> Map.Entry<K, V> entry(K key, V value) {
-        return new AbstractMap.SimpleEntry<>(key, value);
-    }
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -662,5 +662,4 @@ class AnthropicMapperTest {
         assertThat(second.cacheControl).isNotNull();
         assertThat(second.cacheControl).extracting("type").isEqualTo("ephemeral");
     }
-
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -69,6 +69,59 @@ class AnthropicMapperTest {
         assertThat(anthropicMessages).containsExactlyElementsOf(expectedAnthropicMessages);
     }
 
+    @Test
+    void should_fallback_to_empty_input_when_replaying_malformed_tool_arguments() {
+        // given
+        String malformedArguments = "{\"value\":\"bad \"quote\"\"}";
+        List<ChatMessage> messages = asList(
+                UserMessage.from("Please update the scene"),
+                AiMessage.from(
+                        ToolExecutionRequest.builder()
+                                .id("call_00")
+                                .name("updateScene")
+                                .arguments("{\"sceneId\":\"scene_30\"}")
+                                .build(),
+                        ToolExecutionRequest.builder()
+                                .id("call_01")
+                                .name("updateScene")
+                                .arguments(malformedArguments)
+                                .build()),
+                ToolExecutionResultMessage.from("call_00", "updateScene", "updated"),
+                ToolExecutionResultMessage.builder()
+                        .id("call_01")
+                        .toolName("updateScene")
+                        .text("Something is wrong with tool arguments")
+                        .isError(true)
+                        .build());
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(messages);
+
+        // then
+        assertThat(anthropicMessages)
+                .containsExactly(
+                        new AnthropicMessage(USER, singletonList(new AnthropicTextContent("Please update the scene"))),
+                        new AnthropicMessage(
+                                ASSISTANT,
+                                asList(
+                                        AnthropicToolUseContent.builder()
+                                                .id("call_00")
+                                                .name("updateScene")
+                                                .input(mapOf(entry("sceneId", "scene_30")))
+                                                .build(),
+                                        AnthropicToolUseContent.builder()
+                                                .id("call_01")
+                                                .name("updateScene")
+                                                .input(emptyMap())
+                                                .build())),
+                        new AnthropicMessage(
+                                USER,
+                                asList(
+                                        new AnthropicToolResultContent("call_00", "updated", null),
+                                        new AnthropicToolResultContent(
+                                                "call_01", "Something is wrong with tool arguments", true))));
+    }
+
     static Stream<Arguments> test_toAnthropicMessages() {
         return Stream.of(
                 Arguments.of(


### PR DESCRIPTION
## Issue
Addresses the Anthropic replay case reported in #5227.

## Change
This PR updates how the Anthropic mapper replays historical tool calls with `ToolExecutionRequest.arguments`.

`ToolExecutionRequest.arguments()` is already a JSON string. The previous flow parsed it into a `Map` and then let Jackson serialize it back to JSON, which added an unnecessary string -> map -> string roundtrip and could fail while replaying historical malformed arguments.

`AnthropicToolUseContent.input` is now a raw JSON `String` annotated with `@JsonRawValue`. `toAnthropicInput()` now only falls back to `{}` for blank arguments; otherwise it passes through `ToolExecutionRequest.arguments()` unchanged.

This preserves the original arguments payload when replaying historical `tool_use` messages, including malformed JSON, and lets Jackson write valid JSON object inputs as objects instead of quoted strings.

## Verification
- [X] `mvn -pl langchain4j-anthropic -Dtest=AnthropicMapperTest test`
- [X] `mvn -pl langchain4j-anthropic revapi:check`
- [X] `git diff --check`
- [X] GitHub compile/unit, spotless, compliance, and split-package checks are passing

Note: one `integration_test (21)` job is currently red in `langchain4j-mcp-docker`; it failed while reaching Docker Hub and appears unrelated to this Anthropic change.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j