### PR TITLE
Fix empty ReturnBehavior list crash and add ReturnBehavior to ToolSpecification

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecification.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecification.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.mutableCopy;
 import static dev.langchain4j.internal.Utils.quoted;
 
+import dev.langchain4j.Experimental;
 import dev.langchain4j.internal.ToolSpecificationJsonUtils;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
@@ -25,6 +26,7 @@ public class ToolSpecification {
     private final JsonObjectSchema parameters;
     private final Map<String, Object> metadata;
     private final Boolean strict;
+    private final ReturnBehavior returnBehavior;
 
     /**
      * Creates a {@link ToolSpecification} from a {@link Builder}.
@@ -37,6 +39,7 @@ public class ToolSpecification {
         this.parameters = builder.parameters;
         this.metadata = copy(builder.metadata);
         this.strict = builder.strict;
+        this.returnBehavior = builder.returnBehavior;
     }
 
     /**
@@ -92,6 +95,19 @@ public class ToolSpecification {
         return strict;
     }
 
+    /**
+     * Returns the {@link ReturnBehavior} for this tool, or {@code null} if not set.
+     * <p>
+     * When {@code null}, the AI Service default ({@link ReturnBehavior#TO_LLM}) is used.
+     * This field is not sent to the LLM provider — it controls client-side behavior only.
+     *
+     * @since 1.16.0
+     */
+    @Experimental
+    public ReturnBehavior returnBehavior() {
+        return returnBehavior;
+    }
+
     @Override
     public boolean equals(Object another) {
         if (this == another) return true;
@@ -103,7 +119,8 @@ public class ToolSpecification {
                 && Objects.equals(description, another.description)
                 && Objects.equals(parameters, another.parameters)
                 && Objects.equals(metadata, another.metadata)
-                && Objects.equals(strict, another.strict);
+                && Objects.equals(strict, another.strict)
+                && returnBehavior == another.returnBehavior;
     }
 
     @Override
@@ -114,6 +131,7 @@ public class ToolSpecification {
         h += (h << 5) + Objects.hashCode(parameters);
         h += (h << 5) + Objects.hashCode(metadata);
         h += (h << 5) + Objects.hashCode(strict);
+        h += (h << 5) + Objects.hashCode(returnBehavior);
         return h;
     }
 
@@ -125,6 +143,7 @@ public class ToolSpecification {
                 + ", parameters = " + parameters
                 + ", metadata = " + metadata
                 + ", strict = " + strict
+                + ", returnBehavior = " + returnBehavior
                 + " }";
     }
 
@@ -155,7 +174,8 @@ public class ToolSpecification {
                 .description(description)
                 .parameters(parameters)
                 .metadata(mutableCopy(metadata))
-                .strict(strict);
+                .strict(strict)
+                .returnBehavior(returnBehavior);
     }
 
     /**
@@ -177,6 +197,7 @@ public class ToolSpecification {
         private JsonObjectSchema parameters;
         private Map<String, Object> metadata;
         private Boolean strict;
+        private ReturnBehavior returnBehavior;
 
         /**
          * Creates a {@link Builder}.
@@ -249,6 +270,25 @@ public class ToolSpecification {
          */
         public Builder strict(Boolean strict) {
             this.strict = strict;
+            return this;
+        }
+
+        /**
+         * Sets the {@link ReturnBehavior} for this tool.
+         * <p>
+         * When set, this value is used by the AI Service to determine whether to return
+         * tool results immediately to the caller or send them back to the LLM for further processing.
+         * This field is not sent to the LLM provider — it controls client-side behavior only.
+         * <p>
+         * When {@code null} (default), the AI Service default ({@link ReturnBehavior#TO_LLM}) is used.
+         *
+         * @param returnBehavior the return behavior for this tool
+         * @return {@code this}
+         * @since 1.16.0
+         */
+        @Experimental
+        public Builder returnBehavior(ReturnBehavior returnBehavior) {
+            this.returnBehavior = returnBehavior;
             return this;
         }
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/ToolSpecificationJsonUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/ToolSpecificationJsonUtils.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ReturnBehavior;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.agent.tool.ToolSpecificationJsonCodec;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
@@ -52,6 +53,9 @@ public class ToolSpecificationJsonUtils {
         if (toolSpecification.strict() != null) {
             map.put("strict", toolSpecification.strict());
         }
+        if (toolSpecification.returnBehavior() != null) {
+            map.put("returnBehavior", toolSpecification.returnBehavior().name());
+        }
         return CODEC.toJson(map);
     }
 
@@ -97,6 +101,14 @@ public class ToolSpecificationJsonUtils {
         } else if (strictObj != null) {
             throw new IllegalArgumentException("\"strict\" must be a boolean, but was: "
                     + strictObj.getClass().getSimpleName());
+        }
+
+        Object returnBehaviorObj = map.get("returnBehavior");
+        if (returnBehaviorObj instanceof String) {
+            builder.returnBehavior(ReturnBehavior.valueOf((String) returnBehaviorObj));
+        } else if (returnBehaviorObj != null) {
+            throw new IllegalArgumentException("\"returnBehavior\" must be a string, but was: "
+                    + returnBehaviorObj.getClass().getSimpleName());
         }
 
         return builder.build();

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -15,12 +15,12 @@ import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.ReturnBehavior;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolMemoryId;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.agent.tool.ToolMemoryId;
 import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.internal.DefaultExecutorProvider;
 import dev.langchain4j.invocation.InvocationContext;
@@ -165,9 +165,7 @@ public class ToolService {
                 throw illegalConfiguration(
                         "Parameter '%s' of tool '%s.%s' has @P(defaultValue = ...) and is Optional<T>. "
                                 + "Optional<T> already represents \"absent\"; use one mechanism or the other.",
-                        parameter.getName(),
-                        toolMethod.getDeclaringClass().getName(),
-                        toolMethod.getName());
+                        parameter.getName(), toolMethod.getDeclaringClass().getName(), toolMethod.getName());
             }
 
             if (parameter.isAnnotationPresent(ToolMemoryId.class)
@@ -177,9 +175,7 @@ public class ToolService {
                 throw illegalConfiguration(
                         "Parameter '%s' of tool '%s.%s' has @P(defaultValue = ...) but is a framework-injected parameter; "
                                 + "default values are not supported on framework-injected parameters.",
-                        parameter.getName(),
-                        toolMethod.getDeclaringClass().getName(),
-                        toolMethod.getName());
+                        parameter.getName(), toolMethod.getDeclaringClass().getName(), toolMethod.getName());
             }
 
             try {
@@ -423,7 +419,9 @@ public class ToolService {
         while (true) {
 
             if (roundTripsLeft-- == 0) {
-                throw runtime("Something is wrong, exceeded %s tool calling round trips (maxToolCallingRoundTrips)", maxToolCallingRoundTrips);
+                throw runtime(
+                        "Something is wrong, exceeded %s tool calling round trips (maxToolCallingRoundTrips)",
+                        maxToolCallingRoundTrips);
             }
 
             AiMessage aiMessage = chatResponse.aiMessage();

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -113,6 +113,9 @@ public class ToolService {
         tools.forEach((toolSpecification, toolExecutor) -> {
             toolSpecifications.add(toolSpecification);
             toolExecutors.put(toolSpecification.name(), toolExecutor);
+            if (toolSpecification.returnBehavior() != null) {
+                returnBehaviors.put(toolSpecification.name(), toolSpecification.returnBehavior());
+            }
         });
     }
 
@@ -524,6 +527,9 @@ public class ToolService {
     public static boolean shouldReturnImmediately(boolean anyToolErrored, List<ReturnBehavior> returnBehaviors) {
         if (anyToolErrored) {
             return false; // if any tool call failed, LLM should receive an error so that it can attempt to fix it
+        }
+        if (returnBehaviors.isEmpty()) {
+            return false;
         }
         if (returnBehaviors.get(returnBehaviors.size() - 1) == IMMEDIATE_IF_LAST) {
             return true;

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ProgrammaticCreatedImmediateReturnToolTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ProgrammaticCreatedImmediateReturnToolTest.java
@@ -9,7 +9,9 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.mock.ChatModelMock;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.Result;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
@@ -116,6 +118,93 @@ public class ProgrammaticCreatedImmediateReturnToolTest {
         assertThat(toolExecutions.get(0).result()).isEqualTo("4");
         assertThat(llmCallCount.get()).isEqualTo(2);
         assertThat(result.content()).contains("Therefore");
+    }
+
+    @Test
+    void should_use_return_behavior_from_tool_specification_via_map_api() {
+        AtomicBoolean toolExecuted = new AtomicBoolean(false);
+        AtomicInteger llmCallCount = new AtomicInteger(0);
+
+        ToolSpecification tool = ToolSpecification.builder()
+                .name("calculate")
+                .description("Performs calculation")
+                .returnBehavior(ReturnBehavior.IMMEDIATE)
+                .build();
+
+        ToolExecutor executor = (toolExecutionRequest, memoryId) -> {
+            toolExecuted.set(true);
+            return "4";
+        };
+
+        ChatModelMock mockModel = new ChatModelMock(request -> {
+            llmCallCount.incrementAndGet();
+            return AiMessage.from(ToolExecutionRequest.builder()
+                    .id("calc-1")
+                    .name("calculate")
+                    .arguments("{\"expression\": \"2+2\"}")
+                    .build());
+        });
+
+        Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
+        tools.put(tool, executor);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockModel)
+                .tools(tools)
+                .build();
+
+        Result<String> result = assistant.chat("What is 2+2?");
+
+        assertThat(toolExecuted.get()).isTrue();
+        assertThat(llmCallCount.get()).isEqualTo(1);
+        assertThat(result.content()).isNull();
+        assertThat(result.toolExecutions()).hasSize(1);
+        assertThat(result.toolExecutions().get(0).result()).isEqualTo("4");
+    }
+
+    @Test
+    void should_default_to_TO_LLM_when_return_behavior_not_set_on_tool_specification() {
+        AtomicBoolean toolExecuted = new AtomicBoolean(false);
+        AtomicInteger llmCallCount = new AtomicInteger(0);
+
+        ToolSpecification tool = ToolSpecification.builder()
+                .name("calculate")
+                .description("Performs calculation")
+                .build();
+
+        assertThat(tool.returnBehavior()).isNull();
+
+        ToolExecutor executor = (toolExecutionRequest, memoryId) -> {
+            toolExecuted.set(true);
+            return "4";
+        };
+
+        ChatModelMock mockModel = new ChatModelMock(request -> {
+            int callNumber = llmCallCount.incrementAndGet();
+            if (callNumber == 1) {
+                return AiMessage.from(ToolExecutionRequest.builder()
+                        .id("calc-1")
+                        .name("calculate")
+                        .arguments("{\"expression\": \"2+2\"}")
+                        .build());
+            } else {
+                return AiMessage.from("The answer is 4.");
+            }
+        });
+
+        Map<ToolSpecification, ToolExecutor> tools = new LinkedHashMap<>();
+        tools.put(tool, executor);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(mockModel)
+                .tools(tools)
+                .build();
+
+        Result<String> result = assistant.chat("What is 2+2?");
+
+        assertThat(toolExecuted.get()).isTrue();
+        assertThat(llmCallCount.get()).isEqualTo(2);
+        assertThat(result.content()).isEqualTo("The answer is 4.");
     }
 
     interface Assistant {

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ReturnBehaviorCombinationsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ReturnBehaviorCombinationsTest.java
@@ -1,5 +1,16 @@
 package dev.langchain4j.service.tool;
 
+import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE;
+import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE_IF_LAST;
+import static dev.langchain4j.agent.tool.ReturnBehavior.TO_LLM;
+import static dev.langchain4j.service.tool.ReturnBehaviorCombinationsTest.Outcome.REPROCESS;
+import static dev.langchain4j.service.tool.ReturnBehaviorCombinationsTest.Outcome.RETURN_IMMEDIATELY;
+import static dev.langchain4j.service.tool.ReturnBehaviorCombinationsTest.ToolStep.err;
+import static dev.langchain4j.service.tool.ReturnBehaviorCombinationsTest.ToolStep.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
 import dev.langchain4j.agent.tool.ReturnBehavior;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -10,27 +21,15 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.Result;
 import dev.langchain4j.service.TokenStream;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-
-import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE;
-import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE_IF_LAST;
-import static dev.langchain4j.agent.tool.ReturnBehavior.TO_LLM;
-import static dev.langchain4j.service.tool.ReturnBehaviorCombinationsTest.Outcome.RETURN_IMMEDIATELY;
-import static dev.langchain4j.service.tool.ReturnBehaviorCombinationsTest.Outcome.REPROCESS;
-import static dev.langchain4j.service.tool.ReturnBehaviorCombinationsTest.ToolStep.err;
-import static dev.langchain4j.service.tool.ReturnBehaviorCombinationsTest.ToolStep.ok;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Parameterized verification of the immediate-return/reprocess decision for every interesting combination
@@ -139,17 +138,25 @@ class ReturnBehaviorCombinationsTest {
 
                 // single tool errors (the only call in the response errors)
                 arguments(List.of(err(TO_LLM)), REPROCESS),
-                arguments(List.of(err(IMMEDIATE)), REPROCESS),                // would return immediately without error
-                arguments(List.of(err(IMMEDIATE_IF_LAST)), REPROCESS),        // would return immediately without error
+                arguments(List.of(err(IMMEDIATE)), REPROCESS), // would return immediately without error
+                arguments(List.of(err(IMMEDIATE_IF_LAST)), REPROCESS), // would return immediately without error
 
                 // two tools, one errors — covers both first-errors and last-errors positions
                 arguments(List.of(err(IMMEDIATE), ok(IMMEDIATE)), REPROCESS), // would return immediately without error
                 arguments(List.of(ok(IMMEDIATE), err(IMMEDIATE)), REPROCESS), // would return immediately without error
-                arguments(List.of(err(TO_LLM), ok(IMMEDIATE_IF_LAST)), REPROCESS),  // would return immediately without error
-                arguments(List.of(ok(TO_LLM), err(IMMEDIATE_IF_LAST)), REPROCESS),  // would return immediately without error (last itself errors)
-                arguments(List.of(err(IMMEDIATE_IF_LAST), ok(TO_LLM)), REPROCESS),  // already REPROCESS without error
-                arguments(List.of(err(IMMEDIATE), ok(IMMEDIATE_IF_LAST)), REPROCESS),  // would return immediately without error
-                arguments(List.of(ok(IMMEDIATE), err(IMMEDIATE_IF_LAST)), REPROCESS),  // would return immediately without error (last itself errors)
+                arguments(
+                        List.of(err(TO_LLM), ok(IMMEDIATE_IF_LAST)),
+                        REPROCESS), // would return immediately without error
+                arguments(
+                        List.of(ok(TO_LLM), err(IMMEDIATE_IF_LAST)),
+                        REPROCESS), // would return immediately without error (last itself errors)
+                arguments(List.of(err(IMMEDIATE_IF_LAST), ok(TO_LLM)), REPROCESS), // already REPROCESS without error
+                arguments(
+                        List.of(err(IMMEDIATE), ok(IMMEDIATE_IF_LAST)),
+                        REPROCESS), // would return immediately without error
+                arguments(
+                        List.of(ok(IMMEDIATE), err(IMMEDIATE_IF_LAST)),
+                        REPROCESS), // would return immediately without error (last itself errors)
 
                 // three tools, error in any position — would-return-immediately mixes
                 arguments(List.of(err(TO_LLM), ok(IMMEDIATE), ok(IMMEDIATE_IF_LAST)), REPROCESS),
@@ -166,8 +173,7 @@ class ReturnBehaviorCombinationsTest {
         // First LLM response: the tool calls under test.
         // Second LLM response: a final text answer, consumed only when the loop reprocesses.
         ChatModelMock model = ChatModelMock.thatAlwaysResponds(
-                AiMessage.from(toolRequests.toArray(new ToolExecutionRequest[0])),
-                AiMessage.from("final answer"));
+                AiMessage.from(toolRequests.toArray(new ToolExecutionRequest[0])), AiMessage.from("final answer"));
 
         Assistant assistant = AiServices.builder(Assistant.class)
                 .chatModel(model)
@@ -202,8 +208,7 @@ class ReturnBehaviorCombinationsTest {
         // First LLM response: the tool calls under test.
         // Second LLM response: a final text answer, consumed only when the loop reprocesses.
         StreamingChatModelMock model = StreamingChatModelMock.thatAlwaysStreams(
-                AiMessage.from(toolRequests.toArray(new ToolExecutionRequest[0])),
-                AiMessage.from("final answer"));
+                AiMessage.from(toolRequests.toArray(new ToolExecutionRequest[0])), AiMessage.from("final answer"));
 
         StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
                 .streamingChatModel(model)
@@ -211,9 +216,9 @@ class ReturnBehaviorCombinationsTest {
                 .build();
 
         CompletableFuture<ChatResponse> future = new CompletableFuture<>();
-        assistant.chat("go")
-                .onPartialResponse(ignored -> {
-                })
+        assistant
+                .chat("go")
+                .onPartialResponse(ignored -> {})
                 .onCompleteResponse(future::complete)
                 .onError(future::completeExceptionally)
                 .start();
@@ -250,18 +255,18 @@ class ReturnBehaviorCombinationsTest {
     }
 
     private static String toolNameFor(ToolStep step) {
-        String prefix = switch (step.behavior()) {
-            case TO_LLM -> "to_llm";
-            case IMMEDIATE -> "immediate";
-            case IMMEDIATE_IF_LAST -> "immediate_if_last";
-        };
+        String prefix =
+                switch (step.behavior()) {
+                    case TO_LLM -> "to_llm";
+                    case IMMEDIATE -> "immediate";
+                    case IMMEDIATE_IF_LAST -> "immediate_if_last";
+                };
         return prefix + (step.errors() ? "_err" : "_ok");
     }
 
     @Test
     void shouldReturnImmediately_empty_list_should_not_crash() {
-        assertThatNoException().isThrownBy(() ->
-                ToolService.shouldReturnImmediately(false, List.of()));
+        assertThatNoException().isThrownBy(() -> ToolService.shouldReturnImmediately(false, List.of()));
         assertThat(ToolService.shouldReturnImmediately(false, List.of())).isFalse();
         assertThat(ToolService.shouldReturnImmediately(true, List.of())).isFalse();
     }

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ReturnBehaviorCombinationsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ReturnBehaviorCombinationsTest.java
@@ -10,6 +10,7 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.Result;
 import dev.langchain4j.service.TokenStream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,6 +29,7 @@ import static dev.langchain4j.service.tool.ReturnBehaviorCombinationsTest.Outcom
 import static dev.langchain4j.service.tool.ReturnBehaviorCombinationsTest.ToolStep.err;
 import static dev.langchain4j.service.tool.ReturnBehaviorCombinationsTest.ToolStep.ok;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
@@ -254,5 +256,13 @@ class ReturnBehaviorCombinationsTest {
             case IMMEDIATE_IF_LAST -> "immediate_if_last";
         };
         return prefix + (step.errors() ? "_err" : "_ok");
+    }
+
+    @Test
+    void shouldReturnImmediately_empty_list_should_not_crash() {
+        assertThatNoException().isThrownBy(() ->
+                ToolService.shouldReturnImmediately(false, List.of()));
+        assertThat(ToolService.shouldReturnImmediately(false, List.of())).isFalse();
+        assertThat(ToolService.shouldReturnImmediately(true, List.of())).isFalse();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #5277

**Bug fix — empty list crash in `shouldReturnImmediately()`**

`ToolService.shouldReturnImmediately()` crashes with `IndexOutOfBoundsException` when the `returnBehaviors` list is empty, because `list.get(list.size() - 1)` becomes `list.get(-1)`. This happens when programmatically created tools (via `ToolSpecification` + `ToolExecutor`) are used with dynamic tool providers that return no tools for a given request.

Added an `isEmpty()` guard that returns `false` (semantically equivalent to all tools having `TO_LLM` behavior).

**Enhancement — `ToolSpecification` now supports `ReturnBehavior`**

`ToolSpecification` had no `returnBehavior` field, so users registering tools via `AiServices.builder().tools(Map<ToolSpecification, ToolExecutor>)` had no way to set `ReturnBehavior`. The only programmatic path was through `ToolProviderResult.Builder.add(ToolSpecification, ToolExecutor, ReturnBehavior)`.

Added a `returnBehavior` field to `ToolSpecification` (nullable, defaults to `null` → `TO_LLM`). When set, `ToolService.tools(Map<ToolSpecification, ToolExecutor>)` now extracts it automatically.

### Changes

- **`ToolSpecification.java`**: Added `returnBehavior` field, getter (`@Experimental`), builder method, updated `equals`/`hashCode`/`toString`/`toBuilder`
- **`ToolSpecificationJsonUtils.java`**: Serialize/deserialize `returnBehavior` in JSON
- **`ToolService.java`**: Empty list guard in `shouldReturnImmediately()`; extract `returnBehavior` from `ToolSpecification` in `tools(Map)` method
- **`ReturnBehaviorCombinationsTest.java`**: Added test for empty list case
- **`ProgrammaticCreatedImmediateReturnToolTest.java`**: Added tests for `ToolSpecification.returnBehavior` via the `Map` API (immediate return + default TO_LLM)

## Test plan

- [x] `ReturnBehaviorCombinationsTest` — all existing combinations still pass + new empty list test
- [x] `ProgrammaticCreatedImmediateReturnToolTest` — new tests for `returnBehavior` on `ToolSpecification` via Map API
- [x] `StreamingProgrammaticCreatedImmediateReturnToolTest` — existing streaming tests still pass
- [x] `ToolSpecificationsTest` — existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)