### PR TITLE
fix: Milvus RelevanceScore now respects MetricType for L2 distance

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/RelevanceScore.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/RelevanceScore.java
@@ -1,18 +1,33 @@
 package dev.langchain4j.store.embedding;
 
 /**
- * Utility class for converting between cosine similarity and relevance score.
+ * Utility class for converting between various distance/similarity metrics and
+ * relevance score.
  */
 public class RelevanceScore {
-    private RelevanceScore() {}
+    private RelevanceScore() {
+    }
 
     /**
      * Converts cosine similarity into relevance score.
      *
-     * @param cosineSimilarity Cosine similarity in the range [-1..1] where -1 is not relevant and 1 is relevant.
-     * @return Relevance score in the range [0..1] where 0 is not relevant and 1 is relevant.
+     * @param cosineSimilarity Cosine similarity in the range [-1..1] where -1 is
+     *                         not relevant and 1 is relevant.
+     * @return Relevance score in the range [0..1] where 0 is not relevant and 1 is
+     *         relevant.
      */
     public static double fromCosineSimilarity(double cosineSimilarity) {
         return (cosineSimilarity + 1) / 2;
+    }
+
+    /**
+     * Converts L2 distance into relevance score.
+     *
+     * @param l2Distance L2 distance in the range [0..+∞) where 0 is most relevant.
+     * @return Relevance score in the range [0..1] where 0 is not relevant and 1 is
+     *         relevant.
+     */
+    public static double fromL2Distance(double l2Distance) {
+        return 1.0 / (1.0 + l2Distance);
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/RelevanceScoreTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/RelevanceScoreTest.java
@@ -3,6 +3,7 @@ package dev.langchain4j.store.embedding;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 
 class RelevanceScoreTest {
 
@@ -11,5 +12,12 @@ class RelevanceScoreTest {
         assertThat(RelevanceScore.fromCosineSimilarity(-1)).isEqualTo(0);
         assertThat(RelevanceScore.fromCosineSimilarity(0)).isEqualTo(0.5);
         assertThat(RelevanceScore.fromCosineSimilarity(1)).isEqualTo(1);
+    }
+
+    @Test
+    void should_convert_l2_distance_into_relevance_score() {
+        assertThat(RelevanceScore.fromL2Distance(0)).isEqualTo(1.0);
+        assertThat(RelevanceScore.fromL2Distance(1)).isEqualTo(0.5);
+        assertThat(RelevanceScore.fromL2Distance(999999)).isCloseTo(0, offset(0.001));
     }
 }

--- a/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/Mapper.java
+++ b/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/Mapper.java
@@ -15,6 +15,7 @@ import io.milvus.exception.ParamException;
 import io.milvus.response.QueryResultsWrapper;
 import io.milvus.response.QueryResultsWrapper.RowRecord;
 import io.milvus.response.SearchResultsWrapper;
+import io.milvus.param.MetricType;
 
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -51,9 +52,10 @@ class Mapper {
     }
 
     static List<JsonObject> toMetadataJsons(List<TextSegment> textSegments, int size) {
-        return isNullOrEmpty(textSegments) ? generateEmptyJsons(size) : textSegments.stream()
-                .map(segment -> GSON.toJsonTree(segment.metadata().toMap()).getAsJsonObject())
-                .collect(toList());
+        return isNullOrEmpty(textSegments) ? generateEmptyJsons(size)
+                : textSegments.stream()
+                        .map(segment -> GSON.toJsonTree(segment.metadata().toMap()).getAsJsonObject())
+                        .collect(toList());
     }
 
     static List<String> textSegmentsToScalars(List<TextSegment> textSegments) {
@@ -63,18 +65,21 @@ class Mapper {
     }
 
     static List<EmbeddingMatch<TextSegment>> toEmbeddingMatches(MilvusServiceClient milvusClient,
-                                                                SearchResultsWrapper resultsWrapper,
-                                                                String collectionName,
-                                                                FieldDefinition fieldDefinition,
-                                                                ConsistencyLevelEnum consistencyLevel,
-                                                                boolean queryForVectorOnSearch) {
+            SearchResultsWrapper resultsWrapper,
+            String collectionName,
+            FieldDefinition fieldDefinition,
+            ConsistencyLevelEnum consistencyLevel,
+            MetricType metricType,
+            boolean queryForVectorOnSearch) {
         List<EmbeddingMatch<TextSegment>> matches = new ArrayList<>();
 
         Map<String, Embedding> idToEmbedding = new HashMap<>();
         if (queryForVectorOnSearch && !resultsWrapper.getRowRecords().isEmpty()) {
             try {
-                List<String> rowIds = (List<String>) resultsWrapper.getFieldWrapper(fieldDefinition.getIdFieldName()).getFieldData();
-                idToEmbedding.putAll(queryEmbeddings(milvusClient, collectionName, fieldDefinition, rowIds, consistencyLevel));
+                List<String> rowIds = (List<String>) resultsWrapper.getFieldWrapper(fieldDefinition.getIdFieldName())
+                        .getFieldData();
+                idToEmbedding.putAll(
+                        queryEmbeddings(milvusClient, collectionName, fieldDefinition, rowIds, consistencyLevel));
             } catch (ParamException e) {
                 // There is no way to check if the result is empty or not.
                 // If the result is empty, the exception will be thrown.
@@ -86,12 +91,18 @@ class Mapper {
             String rowId = resultsWrapper.getIDScore(0).get(i).getStrID();
             Embedding embedding = idToEmbedding.get(rowId);
             TextSegment textSegment = toTextSegment(resultsWrapper.getRowRecords().get(i), fieldDefinition);
+            double relevanceScore;
+            if (metricType == MetricType.L2) {
+                relevanceScore = RelevanceScore.fromL2Distance(score);
+            } else {
+                relevanceScore = RelevanceScore.fromCosineSimilarity(score);
+            }
+
             EmbeddingMatch<TextSegment> embeddingMatch = new EmbeddingMatch<>(
-                    RelevanceScore.fromCosineSimilarity(score),
+                    relevanceScore,
                     rowId,
                     embedding,
-                    textSegment
-            );
+                    textSegment);
             matches.add(embeddingMatch);
         }
 
@@ -118,7 +129,8 @@ class Mapper {
         Map<String, Object> metadataMap = GSON.fromJson(metadata, MAP_TYPE);
         metadataMap.forEach((key, value) -> {
             if (value instanceof BigDecimal) {
-                // It is safe to convert. No information is lost, the "biggest" type allowed in Metadata is double.
+                // It is safe to convert. No information is lost, the "biggest" type allowed in
+                // Metadata is double.
                 metadataMap.put(key, ((BigDecimal) value).doubleValue());
             }
         });
@@ -126,17 +138,16 @@ class Mapper {
     }
 
     private static Map<String, Embedding> queryEmbeddings(MilvusServiceClient milvusClient,
-                                                          String collectionName,
-                                                          FieldDefinition fieldDefinition,
-                                                          List<String> rowIds,
-                                                          ConsistencyLevelEnum consistencyLevel) {
+            String collectionName,
+            FieldDefinition fieldDefinition,
+            List<String> rowIds,
+            ConsistencyLevelEnum consistencyLevel) {
         QueryResultsWrapper queryResultsWrapper = queryForVectors(
                 milvusClient,
                 collectionName,
                 fieldDefinition,
                 rowIds,
-                consistencyLevel
-        );
+                consistencyLevel);
 
         Map<String, Embedding> idToEmbedding = new HashMap<>();
         for (RowRecord row : queryResultsWrapper.getRowRecords()) {

--- a/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStore.java
+++ b/langchain4j-milvus/src/main/java/dev/langchain4j/store/embedding/milvus/MilvusEmbeddingStore.java
@@ -49,9 +49,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Represents an <a href="https://milvus.io/">Milvus</a> index as an embedding store.
+ * Represents an <a href="https://milvus.io/">Milvus</a> index as an embedding
+ * store.
  * <br>
- * Supports both local and <a href="https://zilliz.com/">managed</a> Milvus instances.
+ * Supports both local and <a href="https://zilliz.com/">managed</a> Milvus
+ * instances.
  * <br>
  * Supports storing {@link Metadata} and filtering by it using a {@link Filter}
  * (provided inside an {@link EmbeddingSearchRequest}).
@@ -273,6 +275,7 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
                 collectionName,
                 fieldDefinition,
                 consistencyLevel,
+                metricType,
                 retrieveEmbeddingsOnSearch);
 
         List<EmbeddingMatch<TextSegment>> result = matches.stream()
@@ -306,14 +309,24 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
 
     /**
      * Removes a single embedding from the store by ID.
-     * <p>CAUTION</p>
+     * <p>
+     * CAUTION
+     * </p>
      * <ul>
-     *     <li>Deleted entities can still be retrieved immediately after the deletion if the consistency level is set lower than {@code Strong}</li>
-     *     <li>Entities deleted beyond the pre-specified span of time for Time Travel cannot be retrieved again.</li>
-     *     <li>Frequent deletion operations will impact the system performance.</li>
-     *     <li>Before deleting entities by comlpex boolean expressions, make sure the collection has been loaded.</li>
-     *     <li>Deleting entities by complex boolean expressions is not an atomic operation. Therefore, if it fails halfway through, some data may still be deleted.</li>
-     *     <li>Deleting entities by complex boolean expressions is supported only when the consistency is set to Bounded. For details, <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see Consistency</a></li>
+     * <li>Deleted entities can still be retrieved immediately after the deletion if
+     * the consistency level is set lower than {@code Strong}</li>
+     * <li>Entities deleted beyond the pre-specified span of time for Time Travel
+     * cannot be retrieved again.</li>
+     * <li>Frequent deletion operations will impact the system performance.</li>
+     * <li>Before deleting entities by comlpex boolean expressions, make sure the
+     * collection has been loaded.</li>
+     * <li>Deleting entities by complex boolean expressions is not an atomic
+     * operation. Therefore, if it fails halfway through, some data may still be
+     * deleted.</li>
+     * <li>Deleting entities by complex boolean expressions is supported only when
+     * the consistency is set to Bounded. For details,
+     * <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see
+     * Consistency</a></li>
      * </ul>
      *
      * @param ids A collection of unique IDs of the embeddings to be removed.
@@ -329,18 +342,30 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
     }
 
     /**
-     * Removes all embeddings that match the specified {@link Filter} from the store.
-     * <p>CAUTION</p>
+     * Removes all embeddings that match the specified {@link Filter} from the
+     * store.
+     * <p>
+     * CAUTION
+     * </p>
      * <ul>
-     *     <li>Deleted entities can still be retrieved immediately after the deletion if the consistency level is set lower than {@code Strong}</li>
-     *     <li>Entities deleted beyond the pre-specified span of time for Time Travel cannot be retrieved again.</li>
-     *     <li>Frequent deletion operations will impact the system performance.</li>
-     *     <li>Before deleting entities by comlpex boolean expressions, make sure the collection has been loaded.</li>
-     *     <li>Deleting entities by complex boolean expressions is not an atomic operation. Therefore, if it fails halfway through, some data may still be deleted.</li>
-     *     <li>Deleting entities by complex boolean expressions is supported only when the consistency is set to Bounded. For details, <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see Consistency</a></li>
+     * <li>Deleted entities can still be retrieved immediately after the deletion if
+     * the consistency level is set lower than {@code Strong}</li>
+     * <li>Entities deleted beyond the pre-specified span of time for Time Travel
+     * cannot be retrieved again.</li>
+     * <li>Frequent deletion operations will impact the system performance.</li>
+     * <li>Before deleting entities by comlpex boolean expressions, make sure the
+     * collection has been loaded.</li>
+     * <li>Deleting entities by complex boolean expressions is not an atomic
+     * operation. Therefore, if it fails halfway through, some data may still be
+     * deleted.</li>
+     * <li>Deleting entities by complex boolean expressions is supported only when
+     * the consistency is set to Bounded. For details,
+     * <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see
+     * Consistency</a></li>
      * </ul>
      *
-     * @param filter The filter to be applied to the {@link Metadata} of the {@link TextSegment} during removal.
+     * @param filter The filter to be applied to the {@link Metadata} of the
+     *               {@link TextSegment} during removal.
      *               Only embeddings whose {@code TextSegment}'s {@code Metadata}
      *               match the {@code Filter} will be removed.
      * @since Milvus version 2.3.x
@@ -354,14 +379,24 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
 
     /**
      * Removes all embeddings from the store.
-     * <p>CAUTION</p>
+     * <p>
+     * CAUTION
+     * </p>
      * <ul>
-     *     <li>Deleted entities can still be retrieved immediately after the deletion if the consistency level is set lower than {@code Strong}</li>
-     *     <li>Entities deleted beyond the pre-specified span of time for Time Travel cannot be retrieved again.</li>
-     *     <li>Frequent deletion operations will impact the system performance.</li>
-     *     <li>Before deleting entities by comlpex boolean expressions, make sure the collection has been loaded.</li>
-     *     <li>Deleting entities by complex boolean expressions is not an atomic operation. Therefore, if it fails halfway through, some data may still be deleted.</li>
-     *     <li>Deleting entities by complex boolean expressions is supported only when the consistency is set to Bounded. For details, <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see Consistency</a></li>
+     * <li>Deleted entities can still be retrieved immediately after the deletion if
+     * the consistency level is set lower than {@code Strong}</li>
+     * <li>Entities deleted beyond the pre-specified span of time for Time Travel
+     * cannot be retrieved again.</li>
+     * <li>Frequent deletion operations will impact the system performance.</li>
+     * <li>Before deleting entities by comlpex boolean expressions, make sure the
+     * collection has been loaded.</li>
+     * <li>Deleting entities by complex boolean expressions is not an atomic
+     * operation. Therefore, if it fails halfway through, some data may still be
+     * deleted.</li>
+     * <li>Deleting entities by complex boolean expressions is supported only when
+     * the consistency is set to Bounded. For details,
+     * <a href="https://milvus.io/docs/v2.3.x/consistency.md#Consistency-levels">see
+     * Consistency</a></li>
      * </ul>
      *
      * @since Milvus version 2.3.x
@@ -422,7 +457,8 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
 
         /**
          * @param collectionName The name of the Milvus collection.
-         *                       If there is no such collection yet, it will be created automatically.
+         *                       If there is no such collection yet, it will be created
+         *                       automatically.
          *                       Default value: "default".
          * @return builder
          */
@@ -462,7 +498,8 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         /**
-         * @param uri The URI of the managed Milvus instance. (e.g. "https://xxx.api.gcp-us-west1.zillizcloud.com")
+         * @param uri The URI of the managed Milvus instance. (e.g.
+         *            "https://xxx.api.gcp-us-west1.zillizcloud.com")
          * @return builder
          */
         public Builder uri(String uri) {
@@ -480,7 +517,8 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         /**
-         * @param username The username. See details <a href="https://milvus.io/docs/authenticate.md">here</a>.
+         * @param username The username. See details
+         *                 <a href="https://milvus.io/docs/authenticate.md">here</a>.
          * @return builder
          */
         public Builder username(String username) {
@@ -489,7 +527,8 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         /**
-         * @param password The password. See details <a href="https://milvus.io/docs/authenticate.md">here</a>.
+         * @param password The password. See details
+         *                 <a href="https://milvus.io/docs/authenticate.md">here</a>.
          * @return builder
          */
         public Builder password(String password) {
@@ -508,11 +547,15 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         /**
-         * @param retrieveEmbeddingsOnSearch During a similarity search in Milvus (when calling search()),
+         * @param retrieveEmbeddingsOnSearch During a similarity search in Milvus (when
+         *                                   calling search()),
          *                                   the embedding itself is not retrieved.
-         *                                   To retrieve the embedding, an additional query is required.
-         *                                   Setting this parameter to "true" will ensure that embedding is retrieved.
-         *                                   Be aware that this will impact the performance of the search.
+         *                                   To retrieve the embedding, an additional
+         *                                   query is required.
+         *                                   Setting this parameter to "true" will
+         *                                   ensure that embedding is retrieved.
+         *                                   Be aware that this will impact the
+         *                                   performance of the search.
          *                                   Default value: false.
          * @return builder
          */
@@ -526,7 +569,8 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
          *                          ({@code add(...)} or {@code addAll(...)} methods).
          *                          Default value: false.
          *                          More info can be found
-         *                          <a href="https://milvus.io/api-reference/pymilvus/v2.4.x/ORM/Collection/flush.md">here</a>.
+         *                          <a href=
+         *                          "https://milvus.io/api-reference/pymilvus/v2.4.x/ORM/Collection/flush.md">here</a>.
          * @return builder
          */
         public Builder autoFlushOnInsert(Boolean autoFlushOnInsert) {
@@ -536,7 +580,8 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
 
         /**
          * @param databaseName Milvus name of database.
-         *                     Default value: null. In this case default Milvus database name will be used.
+         *                     Default value: null. In this case default Milvus database
+         *                     name will be used.
          * @return builder
          */
         public Builder databaseName(String databaseName) {
@@ -545,7 +590,8 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         /**
-         * @param idFieldName the name of the field where the ID of the {@link Embedding} is stored.
+         * @param idFieldName the name of the field where the ID of the
+         *                    {@link Embedding} is stored.
          *                    Default value: "id".
          * @return builder
          */
@@ -555,7 +601,8 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         /**
-         * @param textFieldName the name of the field where the text of the {@link TextSegment} is stored.
+         * @param textFieldName the name of the field where the text of the
+         *                      {@link TextSegment} is stored.
          *                      Default value: "text".
          * @return builder
          */
@@ -565,7 +612,8 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         /**
-         * @param metadataFieldName the name of the field where the {@link Metadata} of the {@link TextSegment} is stored.
+         * @param metadataFieldName the name of the field where the {@link Metadata} of
+         *                          the {@link TextSegment} is stored.
          *                          Default value: "metadata".
          * @return builder
          */
@@ -575,7 +623,8 @@ public class MilvusEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         /**
-         * @param vectorFieldName the name of the field where the {@link Embedding} is stored.
+         * @param vectorFieldName the name of the field where the {@link Embedding} is
+         *                        stored.
          *                        Default value: "vector".
          * @return builder
          */


### PR DESCRIPTION
Fixes #5251

## Problem
`Mapper.toEmbeddingMatches` always called `RelevanceScore.fromCosineSimilarity(score)` 
regardless of the configured `MetricType`, producing incorrect relevance scores when 
using L2 metric. For L2, the raw score is a distance (lower = more similar), but the 
cosine formula treats it as similarity (higher = more similar), completely inverting 
the ranking.

## Changes
- Added `RelevanceScore.fromL2Distance(double l2Distance)` to convert L2 distance to a [0..1] relevance score using `1.0 / (1.0 + l2Distance)`
- Updated `Mapper.toEmbeddingMatches` to accept `MetricType` as a parameter and branch on it
- Updated `MilvusEmbeddingStore.search` to pass `metricType` into `toEmbeddingMatches`
- Added unit test for `RelevanceScore.fromL2Distance`