### PR TITLE
fix(agentic): avoid persisting streaming outputs in scope state

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentExecutor.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentExecutor.java
@@ -11,11 +11,11 @@ import dev.langchain4j.agentic.planner.Planner;
 import dev.langchain4j.agentic.scope.AgentInvocation;
 import dev.langchain4j.agentic.scope.DefaultAgenticScope;
 import dev.langchain4j.service.TokenStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements AgentInstance, InternalAgent {
 
@@ -38,7 +38,10 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
     }
 
     private Object handleAgentFailure(
-            AgentInvocationException e, DefaultAgenticScope agenticScope, Object invokedAgent, PlannerExecutor planner) {
+            AgentInvocationException e,
+            DefaultAgenticScope agenticScope,
+            Object invokedAgent,
+            PlannerExecutor planner) {
         ErrorRecoveryResult recoveryResult = agenticScope.handleError(agentInvoker.name(), e);
         return switch (recoveryResult.type()) {
             case THROW_EXCEPTION -> throw e;
@@ -47,29 +50,40 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
         };
     }
 
-    private Object internalExecute(DefaultAgenticScope agenticScope, Object invokedAgent, PlannerExecutor planner, boolean async) {
+    private Object internalExecute(
+            DefaultAgenticScope agenticScope, Object invokedAgent, PlannerExecutor planner, boolean async) {
         try {
             AgentInvocationArguments args = null;
             try {
                 args = agentInvoker.toInvocationArguments(agenticScope);
             } catch (MissingArgumentException e) {
                 if (optional()) {
-                    LOG.info("Skipping optional agent '{}' because of missing argument '{}'", agentInvoker.name(), e.argumentName());
-                    Object response = agenticScope.readState(agentInvoker.outputKey());
+                    LOG.info(
+                            "Skipping optional agent '{}' because of missing argument '{}'",
+                            agentInvoker.name(),
+                            e.argumentName());
+                    Object response = AgenticScopeOutput.read(agenticScope, agentInvoker.outputKey(), null);
                     if (planner != null) {
-                        planner.onSubagentInvoked(new AgentInvocation(type(), name(), agentId(), Map.of(), response));
+                        planner.onSubagentInvoked(new AgentInvocation(
+                                type(), name(), agentId(), Map.of(), AgenticScopeOutput.persistentOutput(response)));
                     }
                     return response;
                 }
                 throw e;
             }
 
-            Object response = agentResponse(agenticScope, invokedAgent, planner, args, async);
+            boolean propagateStreaming = planner != null && planner.propagateStreaming();
+            Object response = agentResponse(agenticScope, invokedAgent, planner, args, async, propagateStreaming);
             String outputKey = agentInvoker.outputKey();
-            if (outputKey != null && !outputKey.isBlank()) {
-                agenticScope.writeState(outputKey, response);
-            }
-            AgentInvocation agentInvocation = new AgentInvocation(type(), name(), agentId(), args.namedArgs(), response);
+            boolean runtimeStreamingOutput =
+                    async && propagateStreaming && AgentUtil.rawType(outputType()) == TokenStream.class;
+            AgenticScopeOutput.write(agenticScope, outputKey, response, runtimeStreamingOutput);
+            AgentInvocation agentInvocation = new AgentInvocation(
+                    type(),
+                    name(),
+                    agentId(),
+                    args.namedArgs(),
+                    AgenticScopeOutput.invocationOutput(response, runtimeStreamingOutput));
             agenticScope.registerAgentInvocation(agentInvocation, invokedAgent);
             if (planner != null) {
                 planner.onSubagentInvoked(agentInvocation);
@@ -80,11 +94,21 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
         }
     }
 
-    private Object agentResponse(DefaultAgenticScope agenticScope, Object invokedAgent, PlannerExecutor planner, AgentInvocationArguments args, boolean async) {
+    private Object agentResponse(
+            DefaultAgenticScope agenticScope,
+            Object invokedAgent,
+            PlannerExecutor planner,
+            AgentInvocationArguments args,
+            boolean async,
+            boolean propagateStreaming) {
         if (async) {
             return new AsyncResponse<>(() -> {
                 try {
-                    return agentInvoker.invoke(agenticScope, invokedAgent, args);
+                    return wrapStreamingResponse(
+                            agentInvoker.invoke(agenticScope, invokedAgent, args),
+                            planner != null,
+                            propagateStreaming,
+                            true);
                 } catch (AgentInvocationException e) {
                     return handleAgentFailure(e, agenticScope, invokedAgent, planner);
                 }
@@ -92,8 +116,17 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
         }
 
         Object response = agentInvoker.invoke(agenticScope, invokedAgent, args);
-        if (planner != null && response instanceof TokenStream tokenStream) {
-            return planner.propagateStreaming() ? tokenStream : new StreamingResponse(tokenStream);
+        return wrapStreamingResponse(response, planner != null, propagateStreaming, false);
+    }
+
+    private Object wrapStreamingResponse(
+            Object response, boolean inPlanner, boolean propagateStreaming, boolean async) {
+        if (inPlanner && response instanceof TokenStream tokenStream) {
+            if (propagateStreaming) {
+                return tokenStream;
+            }
+            StreamingResponse streamingResponse = new StreamingResponse(tokenStream);
+            return async ? streamingResponse.blockingGet() : streamingResponse;
         }
         return response;
     }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgenticScopeOutput.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgenticScopeOutput.java
@@ -1,0 +1,98 @@
+package dev.langchain4j.agentic.internal;
+
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.service.TokenStream;
+
+final class AgenticScopeOutput {
+
+    private static final String STREAMING_OUTPUT_PREFIX = "__streaming_output_";
+    private static final String ROOT_CALL_MARKER_KEY = "__streaming_output_root_call_marker";
+    private static final Object NO_ROOT_CALL_MARKER = new Object();
+
+    private AgenticScopeOutput() {}
+
+    static void startRootCall(AgenticScope agenticScope) {
+        agenticScope.writeExecutionContext(ROOT_CALL_MARKER_KEY, new Object());
+    }
+
+    static void write(AgenticScope agenticScope, String outputKey, Object output) {
+        write(agenticScope, outputKey, output, false);
+    }
+
+    static void write(AgenticScope agenticScope, String outputKey, Object output, boolean runtimeStreamingOutput) {
+        if (isBlank(outputKey)) {
+            return;
+        }
+        if (output instanceof TokenStream || runtimeStreamingOutput) {
+            agenticScope.writeState(outputKey, null);
+            agenticScope.writeExecutionContext(
+                    streamingOutputKey(outputKey), new StreamingOutput(currentRootCallMarker(agenticScope), output));
+        } else {
+            agenticScope.writeState(outputKey, output);
+            agenticScope.writeExecutionContext(
+                    streamingOutputKey(outputKey), new StreamingOutput(currentRootCallMarker(agenticScope), null));
+        }
+    }
+
+    static Object read(AgenticScope agenticScope, String outputKey, Object defaultOutput) {
+        if (isBlank(outputKey)) {
+            return defaultOutput;
+        }
+        Object output = agenticScope.readState(outputKey);
+        if (output == null) {
+            output = streamingOutput(agenticScope, outputKey);
+            if (output instanceof DelayedResponse<?> delayedResponse) {
+                output = delayedResponse.blockingGet();
+                writeResolvedState(agenticScope, outputKey, output);
+            }
+        }
+        return output != null ? output : defaultOutput;
+    }
+
+    static Object persistentOutput(Object output) {
+        if (output instanceof TokenStream) {
+            return null;
+        }
+        if (output instanceof DelayedResponse<?> delayedResponse) {
+            return persistentOutput(delayedResponse.result());
+        }
+        return output;
+    }
+
+    static Object invocationOutput(Object output) {
+        return output instanceof DelayedResponse<?> ? output : persistentOutput(output);
+    }
+
+    static Object invocationOutput(Object output, boolean runtimeStreamingOutput) {
+        return runtimeStreamingOutput ? null : invocationOutput(output);
+    }
+
+    static Object writeResolvedState(AgenticScope agenticScope, String outputKey, Object output) {
+        write(agenticScope, outputKey, output);
+        return output;
+    }
+
+    private static Object streamingOutput(AgenticScope agenticScope, String outputKey) {
+        Object output = agenticScope.executionContext(streamingOutputKey(outputKey));
+        if (output instanceof StreamingOutput streamingOutput
+                && streamingOutput.rootCallMarker() == currentRootCallMarker(agenticScope)) {
+            return streamingOutput.output();
+        }
+        return null;
+    }
+
+    private static String streamingOutputKey(String outputKey) {
+        return STREAMING_OUTPUT_PREFIX + outputKey;
+    }
+
+    private static Object currentRootCallMarker(AgenticScope agenticScope) {
+        Object marker = agenticScope.executionContext(ROOT_CALL_MARKER_KEY);
+        return marker != null ? marker : NO_ROOT_CALL_MARKER;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private record StreamingOutput(Object rootCallMarker, Object output) {}
+}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PlannerBasedInvocationHandler.java
@@ -6,9 +6,35 @@ import static dev.langchain4j.agentic.internal.AgentUtil.rawType;
 import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
 import static dev.langchain4j.agentic.observability.ComposedAgentListener.listenerOfType;
 import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.afterAgentInvocation;
-import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.beforeAgentInvocation;
 import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.afterAgenticScopeCreated;
+import static dev.langchain4j.agentic.observability.ListenerNotifierUtil.beforeAgentInvocation;
 
+import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.agent.ErrorContext;
+import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
+import dev.langchain4j.agentic.observability.AgentListener;
+import dev.langchain4j.agentic.observability.AgentMonitor;
+import dev.langchain4j.agentic.observability.MonitoredAgent;
+import dev.langchain4j.agentic.planner.Action;
+import dev.langchain4j.agentic.planner.AgentArgument;
+import dev.langchain4j.agentic.planner.AgentInstance;
+import dev.langchain4j.agentic.planner.AgenticSystemTopology;
+import dev.langchain4j.agentic.planner.ChatMemoryAccessProvider;
+import dev.langchain4j.agentic.planner.InitPlanningContext;
+import dev.langchain4j.agentic.planner.Planner;
+import dev.langchain4j.agentic.planner.PlanningContext;
+import dev.langchain4j.agentic.scope.AgentInvocation;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
+import dev.langchain4j.agentic.scope.AgenticScopeRegistry;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
+import dev.langchain4j.agentic.workflow.impl.ParallelMapperServiceImpl;
+import dev.langchain4j.internal.DefaultExecutorProvider;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.ParameterNameResolver;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.memory.ChatMemoryAccess;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -27,32 +53,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import dev.langchain4j.agentic.UntypedAgent;
-import dev.langchain4j.agentic.agent.ErrorContext;
-import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
-import dev.langchain4j.agentic.observability.AgentListener;
-import dev.langchain4j.agentic.observability.AgentMonitor;
-import dev.langchain4j.agentic.observability.MonitoredAgent;
-import dev.langchain4j.agentic.planner.Action;
-import dev.langchain4j.agentic.planner.AgentArgument;
-import dev.langchain4j.agentic.planner.AgentInstance;
-import dev.langchain4j.agentic.planner.AgenticSystemTopology;
-import dev.langchain4j.agentic.planner.InitPlanningContext;
-import dev.langchain4j.agentic.planner.PlanningContext;
-import dev.langchain4j.agentic.scope.AgentInvocation;
-import dev.langchain4j.agentic.planner.ChatMemoryAccessProvider;
-import dev.langchain4j.agentic.planner.Planner;
-import dev.langchain4j.agentic.scope.AgenticScope;
-import dev.langchain4j.agentic.scope.AgenticScopeAccess;
-import dev.langchain4j.agentic.scope.AgenticScopeRegistry;
-import dev.langchain4j.agentic.scope.DefaultAgenticScope;
-import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
-import dev.langchain4j.agentic.workflow.impl.ParallelMapperServiceImpl;
-import dev.langchain4j.internal.DefaultExecutorProvider;
-import dev.langchain4j.service.MemoryId;
-import dev.langchain4j.service.ParameterNameResolver;
-import dev.langchain4j.service.TokenStream;
-import dev.langchain4j.service.memory.ChatMemoryAccess;
 
 public class PlannerBasedInvocationHandler implements InvocationHandler, InternalAgent {
     private final Executor executor;
@@ -96,7 +96,12 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         agenticSystemDataTypes(this);
     }
 
-    private PlannerBasedInvocationHandler(AbstractServiceBuilder<?, ?> service, InternalAgent parent, String agentId, Supplier<Planner> plannerSupplier, DefaultAgenticScope agenticScope) {
+    private PlannerBasedInvocationHandler(
+            AbstractServiceBuilder<?, ?> service,
+            InternalAgent parent,
+            String agentId,
+            Supplier<Planner> plannerSupplier,
+            DefaultAgenticScope agenticScope) {
         this.service = service;
         this.agentId = agentId;
         this.output = service.output;
@@ -112,11 +117,12 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         this.name = service.name;
         this.description = service.description;
         this.outputType = service.agentReturnType();
-        this.allowStreamingOutput = UntypedAgent.class.isAssignableFrom(this.type) ||
-                TokenStream.class.isAssignableFrom(rawType(this.outputType));
+        this.allowStreamingOutput = UntypedAgent.class.isAssignableFrom(this.type)
+                || TokenStream.class.isAssignableFrom(rawType(this.outputType));
         this.outputKey = service.outputKey;
         this.arguments = service.agenticMethod != null ? argumentsFromMethod(service.agenticMethod) : List.of();
-        this.subagents = service.subagents.stream().map(AgentInstance.class::cast).toList();
+        this.subagents =
+                service.subagents.stream().map(AgentInstance.class::cast).toList();
         setParent(parent);
     }
 
@@ -167,8 +173,7 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
                 case "toString" -> service.serviceType() + "<" + type.getSimpleName() + ">";
                 case "hashCode" -> System.identityHashCode(this);
                 default ->
-                        throw new UnsupportedOperationException(
-                                "Unknown method on Object class : " + method.getName());
+                    throw new UnsupportedOperationException("Unknown method on Object class : " + method.getName());
             };
         }
 
@@ -190,6 +195,9 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
     private Object executeAgentMethod(AgenticScopeRegistry registry, Method method, Object[] args) {
         DefaultAgenticScope currentScope = currentAgenticScope(registry, method, args);
         writeAgenticScope(currentScope, method, args);
+        if (isRootCall()) {
+            AgenticScopeOutput.startRootCall(currentScope);
+        }
         beforeCall.accept(currentScope);
 
         Map<String, Object> namedArgs = isRootCall() ? argToMap(method, args) : null;
@@ -201,7 +209,7 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         Planner planner = plannerSupplier.get();
         planner.init(new InitPlanningContext(currentScope, this, subagents));
         Object result = new PlannerLoop(planner, currentScope, registry).loop();
-        Object output = outputKey != null ? currentScope.readState(outputKey) : result;
+        Object output = AgenticScopeOutput.read(currentScope, outputKey, result);
 
         if (isRootCall()) {
             afterAgentInvocation(agentListener, currentScope, this, namedArgs, output);
@@ -298,7 +306,8 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
     public void registerInheritedParentListener(AgentListener parentListener) {
         if (parentListener != null && parentListener.inheritedBySubagents()) {
             agentListener = composeWithInherited(agentListener, parentListener);
-            subagents().stream().map(InternalAgent.class::cast)
+            subagents().stream()
+                    .map(InternalAgent.class::cast)
                     .forEach(agent -> agent.registerInheritedParentListener(parentListener));
         }
     }
@@ -389,7 +398,8 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         private void parallelExecution(List<AgentExecutor> agents) {
             Executor exec = executor != null ? executor : DefaultExecutorProvider.getDefaultExecutorService();
             var tasks = agents.stream()
-                    .map(agentExecutor -> CompletableFuture.supplyAsync(() -> agentExecutor.execute(agenticScope, this), exec))
+                    .map(agentExecutor ->
+                            CompletableFuture.supplyAsync(() -> agentExecutor.execute(agenticScope, this), exec))
                     .toList();
             try {
                 for (Future<?> future : tasks) {
@@ -402,15 +412,16 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
                 throw new RuntimeException(e);
             }
         }
+
         private Object result() {
             Object result = output != null ? output.apply(agenticScope) : nextAction.result();
 
             if (outputKey != null) {
                 if (result != null) {
-                    agenticScope.writeState(outputKey, result);
+                    AgenticScopeOutput.write(agenticScope, outputKey, result);
                     return result;
                 } else {
-                    return agenticScope.readState(outputKey);
+                    return AgenticScopeOutput.read(agenticScope, outputKey, null);
                 }
             }
             return result;
@@ -420,7 +431,8 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         public void onSubagentInvoked(AgentInvocation agentInvocation) {
             lock.lock();
             try {
-                this.nextAction = composeActions(this.nextAction, planner.nextAction(new PlanningContext(agenticScope, agentInvocation)));
+                this.nextAction = composeActions(
+                        this.nextAction, planner.nextAction(new PlanningContext(agenticScope, agentInvocation)));
 
                 // Save planner execution state after each agent invocation
                 Map<String, Object> execState = planner.executionState();
@@ -456,7 +468,8 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         }
 
         private static boolean isEmptyCall(Action action) {
-            return action instanceof Action.AgentCallAction aca && aca.agentsToCall().isEmpty();
+            return action instanceof Action.AgentCallAction aca
+                    && aca.agentsToCall().isEmpty();
         }
     }
 
@@ -483,7 +496,8 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
         }
 
         Object memoryId = memoryId(method, args);
-        DefaultAgenticScope newAgenticScope = memoryId != null ? getOrCreateAgenticScope(registry, memoryId) : createEphemeralAgenticScope(registry);
+        DefaultAgenticScope newAgenticScope =
+                memoryId != null ? getOrCreateAgenticScope(registry, memoryId) : createEphemeralAgenticScope(registry);
         return newAgenticScope.withErrorHandler(errorHandler);
     }
 
@@ -513,11 +527,13 @@ public class PlannerBasedInvocationHandler implements InvocationHandler, Interna
     }
 
     private Object accessChatMemory(AgenticScope agenticScope, String methodName, Object memoryId) {
-        ChatMemoryAccess chatMemoryAccess = ((ChatMemoryAccessProvider) defaultPlannerInstance).chatMemoryAccess(agenticScope);
+        ChatMemoryAccess chatMemoryAccess =
+                ((ChatMemoryAccessProvider) defaultPlannerInstance).chatMemoryAccess(agenticScope);
         return switch (methodName) {
             case "getChatMemory" -> chatMemoryAccess.getChatMemory(memoryId);
             case "evictChatMemory" -> chatMemoryAccess.evictChatMemory(memoryId);
-            default -> throw new UnsupportedOperationException("Unknown method on ChatMemoryAccess class : " + methodName);
+            default ->
+                throw new UnsupportedOperationException("Unknown method on ChatMemoryAccess class : " + methodName);
         };
     }
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgentInvocation.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgentInvocation.java
@@ -2,14 +2,39 @@ package dev.langchain4j.agentic.scope;
 
 import dev.langchain4j.agentic.internal.DelayedResponse;
 import dev.langchain4j.service.TokenStream;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public record AgentInvocation(
         Class<?> agentType, String agentName, String agentId, Map<String, Object> input, Object output) {
 
+    AgentInvocation persistentCopy() {
+        return new AgentInvocation(
+                agentType, agentName, agentId, persistentInput(), AgenticScopePersistentValue.sanitize(output));
+    }
+
+    private Map<String, Object> persistentInput() {
+        if (input == null) {
+            return null;
+        }
+        boolean changed = false;
+        Map<String, Object> persistentInput = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : input.entrySet()) {
+            Object value = entry.getValue();
+            Object persistentValue = AgenticScopePersistentValue.sanitize(value);
+            changed |= persistentValue != value;
+            persistentInput.put(entry.getKey(), persistentValue);
+        }
+        return changed ? persistentInput : input;
+    }
+
     @Override
     public Object output() {
-        Object result = output instanceof DelayedResponse<?> delayedResponse ? delayedResponse.result() : output;
+        return persistentValue(output);
+    }
+
+    private static Object persistentValue(Object value) {
+        Object result = value instanceof DelayedResponse<?> delayedResponse ? delayedResponse.result() : value;
         return result instanceof TokenStream ? null : result;
     }
 

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgentInvocation.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgentInvocation.java
@@ -1,22 +1,20 @@
 package dev.langchain4j.agentic.scope;
 
 import dev.langchain4j.agentic.internal.DelayedResponse;
-
+import dev.langchain4j.service.TokenStream;
 import java.util.Map;
 
-public record AgentInvocation(Class<?> agentType, String agentName, String agentId, Map<String, Object> input, Object output) {
+public record AgentInvocation(
+        Class<?> agentType, String agentName, String agentId, Map<String, Object> input, Object output) {
 
     @Override
     public Object output() {
-        return output instanceof DelayedResponse<?> delayedResponse ? delayedResponse.result() : output;
+        Object result = output instanceof DelayedResponse<?> delayedResponse ? delayedResponse.result() : output;
+        return result instanceof TokenStream ? null : result;
     }
 
     @Override
     public String toString() {
-        return "AgentInvocation{" +
-                "agentName=" + agentName +
-                ", input=" + input +
-                ", output=" + output +
-                '}';
+        return "AgentInvocation{" + "agentName=" + agentName + ", input=" + input + ", output=" + output + '}';
     }
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticScopePersistentValue.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticScopePersistentValue.java
@@ -1,0 +1,105 @@
+package dev.langchain4j.agentic.scope;
+
+import dev.langchain4j.agentic.internal.DelayedResponse;
+import dev.langchain4j.agentic.internal.PendingResponse;
+import dev.langchain4j.service.TokenStream;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class AgenticScopePersistentValue {
+
+    private AgenticScopePersistentValue() {}
+
+    static Object sanitize(Object value) {
+        return sanitize(value, new IdentityHashMap<>());
+    }
+
+    private static Object sanitize(Object value, IdentityHashMap<Object, Boolean> visited) {
+        if (value == null || value instanceof PendingResponse<?>) {
+            return value;
+        }
+        if (value instanceof DelayedResponse<?> delayedResponse) {
+            return delayedResponse.isDone() ? sanitize(delayedResponse.blockingGet(), visited) : null;
+        }
+        if (value instanceof TokenStream) {
+            return null;
+        }
+        if (value instanceof Map<?, ?> map) {
+            return sanitizeMap(map, visited);
+        }
+        if (value instanceof Collection<?> collection) {
+            return sanitizeCollection(collection, visited);
+        }
+        if (value.getClass().isArray()) {
+            return sanitizeArray(value, visited);
+        }
+        return value;
+    }
+
+    private static Object sanitizeMap(Map<?, ?> map, IdentityHashMap<Object, Boolean> visited) {
+        if (visited.put(map, Boolean.TRUE) != null) {
+            return null;
+        }
+        try {
+            boolean changed = false;
+            Map<Object, Object> persistentMap = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                Object value = entry.getValue();
+                Object persistentValue = sanitize(value, visited);
+                changed |= persistentValue != value;
+                if (persistentValue != null || value == null) {
+                    persistentMap.put(entry.getKey(), persistentValue);
+                }
+            }
+            return changed ? persistentMap : map;
+        } finally {
+            visited.remove(map);
+        }
+    }
+
+    private static Object sanitizeCollection(Collection<?> collection, IdentityHashMap<Object, Boolean> visited) {
+        if (visited.put(collection, Boolean.TRUE) != null) {
+            return null;
+        }
+        try {
+            boolean changed = false;
+            List<Object> persistentCollection = new ArrayList<>(collection.size());
+            for (Object value : collection) {
+                Object persistentValue = sanitize(value, visited);
+                changed |= persistentValue != value;
+                persistentCollection.add(persistentValue);
+            }
+            return changed ? persistentCollection : collection;
+        } finally {
+            visited.remove(collection);
+        }
+    }
+
+    private static Object sanitizeArray(Object array, IdentityHashMap<Object, Boolean> visited) {
+        if (array.getClass().getComponentType().isPrimitive()) {
+            return array;
+        }
+        if (visited.put(array, Boolean.TRUE) != null) {
+            return null;
+        }
+        try {
+            int length = Array.getLength(array);
+            boolean changed = false;
+            Object[] persistentArray = new Object[length];
+            for (int i = 0; i < length; i++) {
+                Object value = Array.get(array, i);
+                Object persistentValue = sanitize(value, visited);
+                changed |= persistentValue != value;
+                persistentArray[i] = persistentValue;
+            }
+            return changed ? persistentArray : array;
+        } finally {
+            visited.remove(array);
+        }
+    }
+}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
@@ -63,6 +63,23 @@ public class DefaultAgenticScope implements AgenticScope {
 
     private final Kind kind;
 
+    DefaultAgenticScope persistentCopy() {
+        DefaultAgenticScope copy = new DefaultAgenticScope(memoryId, kind);
+        state.forEach((key, value) -> {
+            Object persistentValue = AgenticScopePersistentValue.sanitize(value);
+            if (persistentValue != null) {
+                copy.state.put(key, persistentValue);
+            }
+        });
+        synchronized (agentInvocations) {
+            agentInvocations.forEach(agentInvocation -> copy.agentInvocations.add(agentInvocation.persistentCopy()));
+        }
+        synchronized (context) {
+            copy.context.addAll(context);
+        }
+        return copy;
+    }
+
     /**
      * This lock is used to ensure that the AgenticScope doesn't get concurrently modified when it is going to be persisted.
      * The internal data structures of the AgenticScope are all thread-safe, so they don't need to be guarded by a read lock

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/DefaultAgenticScope.java
@@ -18,6 +18,7 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.internal.Utils;
 import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.service.TokenStream;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -143,7 +144,7 @@ public class DefaultAgenticScope implements AgenticScope {
     private Object readStateBlocking(String key, Object state) {
         if (state instanceof DelayedResponse asyncResponse) {
             state = asyncResponse.blockingGet();
-            writeState(key, state);
+            writeState(key, state instanceof TokenStream ? null : state);
         }
         return state;
     }
@@ -168,7 +169,7 @@ public class DefaultAgenticScope implements AgenticScope {
 
     public void rootCallEnded(AgenticScopeRegistry registry, AgentListener agentListener) {
         // ensure that all pending async operations are completed before ending the root call
-        state.replaceAll(this::readStateBlocking);
+        List.copyOf(state.keySet()).forEach(this::readState);
 
         if (kind == Kind.EPHEMERAL) {
             // Ephemeral agenticScope are for single-use and can be evicted immediately

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/JacksonAgenticScopeJsonCodec.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/JacksonAgenticScopeJsonCodec.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.agentic.scope;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -11,10 +13,7 @@ import dev.langchain4j.agentic.scope.DefaultAgenticScope.AgentMessage;
 import dev.langchain4j.agentic.scope.DefaultAgenticScope.Kind;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.JacksonChatMessageJsonCodec;
-
 import java.util.Map;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Internal
 class JacksonAgenticScopeJsonCodec implements AgenticScopeJsonCodec {
@@ -30,9 +29,7 @@ class JacksonAgenticScopeJsonCodec implements AgenticScopeJsonCodec {
         ObjectMapper mapper = agenticScopeJsonMapperBuilder().build();
 
         // Configure the ObjectMapper to add type information for users types
-        mapper.activateDefaultTyping(
-                mapper.getPolymorphicTypeValidator()
-        );
+        mapper.activateDefaultTyping(mapper.getPolymorphicTypeValidator());
 
         return mapper;
     }
@@ -51,40 +48,35 @@ class JacksonAgenticScopeJsonCodec implements AgenticScopeJsonCodec {
     @Override
     public String toJson(DefaultAgenticScope agenticScope) {
         try {
-            return MAPPER.writeValueAsString(agenticScope);
+            return MAPPER.writeValueAsString(agenticScope.persistentCopy());
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Failed to serialize AgenticScope to JSON", e);
         }
     }
 
     @JsonInclude(NON_NULL)
-    private static abstract class AgenticScopeMixin {
+    private abstract static class AgenticScopeMixin {
         @JsonCreator
-        public AgenticScopeMixin(
-                @JsonProperty("memoryId") Object memoryId,
-                @JsonProperty("kind") Kind kind) {
-        }
+        public AgenticScopeMixin(@JsonProperty("memoryId") Object memoryId, @JsonProperty("kind") Kind kind) {}
     }
 
     @JsonInclude(NON_NULL)
-    private static abstract class AgentMessageMixin {
+    private abstract static class AgentMessageMixin {
         @JsonCreator
         public AgentMessageMixin(
                 @JsonProperty("agentName") String agentName,
                 @JsonProperty("agentId") String agentId,
-                @JsonProperty("message") ChatMessage message) {
-        }
+                @JsonProperty("message") ChatMessage message) {}
     }
 
     @JsonInclude(NON_NULL)
-    private static abstract class AgentInvocationMixin {
+    private abstract static class AgentInvocationMixin {
         @JsonCreator
         public AgentInvocationMixin(
                 @JsonProperty("agentType") Class<?> agentType,
                 @JsonProperty("agentName") String agentName,
                 @JsonProperty("agentId") String agentId,
                 @JsonProperty("input") Map<String, Object> input,
-                @JsonProperty("output") Object output) {
-        }
+                @JsonProperty("output") Object output) {}
     }
 }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/AgenticScopeOutputTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/AgenticScopeOutputTest.java
@@ -1,0 +1,22 @@
+package dev.langchain4j.agentic.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import dev.langchain4j.service.TokenStream;
+import org.junit.jupiter.api.Test;
+
+class AgenticScopeOutputTest {
+
+    @Test
+    void readDoesNotReturnPreviousStreamingOutputAfterOutputKeyIsCleared() {
+        DefaultAgenticScope agenticScope = DefaultAgenticScope.ephemeralAgenticScope();
+        TokenStream previousStream = mock(TokenStream.class);
+
+        AgenticScopeOutput.write(agenticScope, "result", previousStream);
+        AgenticScopeOutput.write(agenticScope, "result", null);
+
+        assertThat(AgenticScopeOutput.read(agenticScope, "result", "default")).isEqualTo("default");
+    }
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/AgenticScopeStreamingStateTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/AgenticScopeStreamingStateTest.java
@@ -1,0 +1,192 @@
+package dev.langchain4j.agentic.scope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.service.AiServiceTokenStream;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class AgenticScopeStreamingStateTest {
+
+    @AfterEach
+    void cleanup() {
+        AgenticScopePersister.setStore(null);
+    }
+
+    @Test
+    void frameworkDoesNotPersistAiServiceTokenStreamInState() {
+        JsonCapturingAgenticScopeStore store = new JsonCapturingAgenticScopeStore();
+        AgenticScopePersister.setStore(store);
+
+        AiServiceStreamingAgent streamingAgent = AgenticServices.agentBuilder(AiServiceStreamingAgent.class)
+                .streamingChatModel(new FixedStreamingChatModel())
+                .outputKey("result")
+                .build();
+
+        StreamingWorkflow workflow = AgenticServices.sequenceBuilder(StreamingWorkflow.class)
+                .subAgents(streamingAgent)
+                .beforeCall(agenticScope -> agenticScope.writeState("result", "stale"))
+                .outputKey("result")
+                .build();
+
+        TokenStream tokenStream = workflow.chat("session-1", "hello");
+
+        assertThat(tokenStream).isInstanceOf(AiServiceTokenStream.class);
+        assertThat(store.savedScope).isNotNull();
+        assertThat(store.savedScope.state()).doesNotContainKey("result");
+        assertThat(store.savedScopes)
+                .allSatisfy(scope -> assertThat(scope.state()).doesNotContainKey("result"));
+        assertThat(store.savedScope.agentInvocations())
+                .singleElement()
+                .extracting(AgentInvocation::output)
+                .isNull();
+        assertThatCode(() -> AgenticScopeSerializer.toJson(store.savedScope)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void frameworkDoesNotPersistAsyncAiServiceTokenStreamInState() {
+        JsonCapturingAgenticScopeStore store = new JsonCapturingAgenticScopeStore();
+        AgenticScopePersister.setStore(store);
+
+        AiServiceStreamingAgent streamingAgent = AgenticServices.agentBuilder(AiServiceStreamingAgent.class)
+                .streamingChatModel(new FixedStreamingChatModel())
+                .async(true)
+                .outputKey("result")
+                .build();
+
+        StreamingWorkflow workflow = AgenticServices.sequenceBuilder(StreamingWorkflow.class)
+                .subAgents(streamingAgent)
+                .beforeCall(agenticScope -> agenticScope.writeState("result", "stale"))
+                .outputKey("result")
+                .build();
+
+        TokenStream tokenStream = workflow.chat("session-async", "hello");
+
+        assertThat(tokenStream).isInstanceOf(AiServiceTokenStream.class);
+        assertThat(store.savedScope).isNotNull();
+        assertThat(store.savedScope.state()).doesNotContainKey("result");
+        assertThat(store.savedScopes)
+                .allSatisfy(scope -> assertThat(scope.state()).doesNotContainKey("result"));
+        assertThat(store.savedScope.agentInvocations())
+                .singleElement()
+                .extracting(AgentInvocation::output)
+                .isNull();
+        assertThatCode(() -> AgenticScopeSerializer.toJson(store.savedScope)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void asyncStreamingSubagentStillWritesTextWhenItIsNotFinalOutput() {
+        AiServiceStreamingAgent streamingAgent = AgenticServices.agentBuilder(AiServiceStreamingAgent.class)
+                .streamingChatModel(new FixedStreamingChatModel())
+                .async(true)
+                .outputKey("story")
+                .build();
+
+        TextWorkflow workflow = AgenticServices.sequenceBuilder(TextWorkflow.class)
+                .subAgents(streamingAgent, new TextAgent())
+                .outputKey("result")
+                .build();
+
+        assertThat(workflow.chat("hello")).isEqualTo("ok done");
+    }
+
+    @Test
+    void frameworkDoesNotReusePreviousStreamingOutputWhenOptionalStreamingAgentIsSkipped() {
+        AiServiceStreamingAgent streamingAgent = AgenticServices.agentBuilder(AiServiceStreamingAgent.class)
+                .streamingChatModel(new FixedStreamingChatModel())
+                .optional(true)
+                .outputKey("result")
+                .build();
+
+        StreamingWorkflow workflow = AgenticServices.sequenceBuilder(StreamingWorkflow.class)
+                .subAgents(streamingAgent)
+                .outputKey("result")
+                .build();
+
+        TokenStream firstTokenStream = workflow.chat("session-2", "hello");
+        TokenStream secondTokenStream = workflow.chat("session-2", null);
+
+        assertThat(firstTokenStream).isInstanceOf(AiServiceTokenStream.class);
+        assertThat(secondTokenStream).isNull();
+    }
+
+    public interface StreamingWorkflow {
+
+        @Agent(outputKey = "result")
+        TokenStream chat(@MemoryId String memoryId, @V("input") String input);
+    }
+
+    public interface AiServiceStreamingAgent {
+
+        @UserMessage("{{input}}")
+        @Agent(outputKey = "result")
+        TokenStream chat(@V("input") String input);
+    }
+
+    public interface TextWorkflow {
+
+        @Agent(outputKey = "result")
+        String chat(@V("input") String input);
+    }
+
+    public static class TextAgent {
+
+        @Agent(outputKey = "result")
+        public String append(@V("story") String story) {
+            return story + " done";
+        }
+    }
+
+    private static class FixedStreamingChatModel implements StreamingChatModel {
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            handler.onCompleteResponse(
+                    ChatResponse.builder().aiMessage(AiMessage.from("ok")).build());
+        }
+    }
+
+    private static class JsonCapturingAgenticScopeStore implements AgenticScopeStore {
+
+        private DefaultAgenticScope savedScope;
+        private final List<DefaultAgenticScope> savedScopes = new ArrayList<>();
+
+        @Override
+        public boolean save(AgenticScopeKey key, DefaultAgenticScope agenticScope) {
+            String json = AgenticScopeSerializer.toJson(agenticScope);
+            this.savedScope = AgenticScopeSerializer.fromJson(json);
+            this.savedScopes.add(this.savedScope);
+            return true;
+        }
+
+        @Override
+        public Optional<DefaultAgenticScope> load(AgenticScopeKey key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public boolean delete(AgenticScopeKey key) {
+            return false;
+        }
+
+        @Override
+        public java.util.Set<AgenticScopeKey> getAllKeys() {
+            return java.util.Set.of();
+        }
+    }
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/AgenticScopeStreamingStateTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/AgenticScopeStreamingStateTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.agentic.internal.DelayedResponse;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
@@ -19,7 +20,9 @@ import dev.langchain4j.service.V;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -108,6 +111,31 @@ class AgenticScopeStreamingStateTest {
     }
 
     @Test
+    void persistentCheckpointDoesNotPersistAsyncStreamingRuntimeObjects() {
+        JsonCapturingAgenticScopeStore store = new JsonCapturingAgenticScopeStore();
+        AgenticScopePersister.setStore(store);
+
+        AiServiceStreamingAgent streamingAgent = AgenticServices.agentBuilder(AiServiceStreamingAgent.class)
+                .streamingChatModel(new FixedStreamingChatModel())
+                .async(true)
+                .outputKey("story")
+                .build();
+
+        PersistentTextWorkflow workflow = AgenticServices.sequenceBuilder(PersistentTextWorkflow.class)
+                .subAgents(streamingAgent, new TextAgent())
+                .outputKey("result")
+                .build();
+
+        assertThat(workflow.chat("session-async-non-final", "hello")).isEqualTo("ok done");
+        assertThat(store.savedScopes)
+                .extracting(scope -> scope.state().get("story"))
+                .filteredOn(Objects::nonNull)
+                .containsOnly("ok")
+                .allSatisfy(story ->
+                        assertThat(story).isNotInstanceOf(TokenStream.class).isNotInstanceOf(DelayedResponse.class));
+    }
+
+    @Test
     void agentInvocationSerializationDoesNotPersistRawStreamingOutput() {
         DefaultAgenticScope scope = new DefaultAgenticScope(DefaultAgenticScope.Kind.PERSISTENT);
         TokenStream tokenStream = mock(TokenStream.class);
@@ -122,6 +150,115 @@ class AgenticScopeStreamingStateTest {
                 .singleElement()
                 .extracting(AgentInvocation::output)
                 .isNull();
+    }
+
+    @Test
+    void stateSerializationDoesNotPersistRawStreamingOutput() {
+        DefaultAgenticScope scope = new DefaultAgenticScope(DefaultAgenticScope.Kind.PERSISTENT);
+        TokenStream tokenStream = mock(TokenStream.class);
+
+        scope.writeState("result", tokenStream);
+
+        assertThat(scope.state()).containsEntry("result", tokenStream);
+
+        String json = AgenticScopeSerializer.toJson(scope);
+        DefaultAgenticScope deserialized = AgenticScopeSerializer.fromJson(json);
+
+        assertThat(deserialized.state()).doesNotContainKey("result");
+    }
+
+    @Test
+    void stateSerializationDoesNotPersistNestedStreamingOutput() {
+        DefaultAgenticScope scope = new DefaultAgenticScope(DefaultAgenticScope.Kind.PERSISTENT);
+        TokenStream tokenStream = mock(TokenStream.class);
+
+        scope.writeState("payload", Map.of("result", tokenStream, "request", "hello"));
+
+        String json = AgenticScopeSerializer.toJson(scope);
+        DefaultAgenticScope deserialized = AgenticScopeSerializer.fromJson(json);
+
+        assertThat(deserialized.state().get("payload"))
+                .isInstanceOf(Map.class)
+                .satisfies(payload -> assertThat((Map<Object, Object>) payload)
+                        .doesNotContainKey("result")
+                        .containsEntry("request", "hello"));
+    }
+
+    @Test
+    void stateSerializationDoesNotBlockOnUnfinishedDelayedResponse() {
+        DefaultAgenticScope scope = new DefaultAgenticScope(DefaultAgenticScope.Kind.PERSISTENT);
+
+        scope.writeState("result", new UnfinishedDelayedResponse());
+
+        String json = AgenticScopeSerializer.toJson(scope);
+        DefaultAgenticScope deserialized = AgenticScopeSerializer.fromJson(json);
+
+        assertThat(deserialized.state()).doesNotContainKey("result");
+    }
+
+    @Test
+    void checkpointDoesNotBlockOnUnfinishedDelayedResponse() {
+        JsonCapturingAgenticScopeStore store = new JsonCapturingAgenticScopeStore();
+        AgenticScopePersister.setStore(store);
+        AgenticScopeRegistry registry = new AgenticScopeRegistry("test-agent");
+        DefaultAgenticScope scope = registry.create("session-delayed-response");
+
+        scope.writeState("result", new UnfinishedDelayedResponse());
+
+        assertThatCode(() -> scope.checkpoint(registry)).doesNotThrowAnyException();
+        assertThat(store.savedScope.state()).doesNotContainKey("result");
+    }
+
+    @Test
+    void agentInvocationSerializationDoesNotPersistStreamingInputFromStateMap() {
+        DefaultAgenticScope scope = new DefaultAgenticScope(DefaultAgenticScope.Kind.PERSISTENT);
+        TokenStream tokenStream = mock(TokenStream.class);
+        Map<String, Object> input = new ConcurrentHashMap<>();
+        input.put("result", tokenStream);
+        input.put("request", "hello");
+
+        scope.agentInvocations()
+                .add(new AgentInvocation(AiServiceStreamingAgent.class, "chat", "agent-1", input, "ok"));
+
+        assertThat(scope.agentInvocations())
+                .singleElement()
+                .extracting(AgentInvocation::input)
+                .satisfies(runtimeInput -> assertThat(runtimeInput)
+                        .containsEntry("result", tokenStream)
+                        .containsEntry("request", "hello"));
+
+        String json = AgenticScopeSerializer.toJson(scope);
+        DefaultAgenticScope deserialized = AgenticScopeSerializer.fromJson(json);
+
+        assertThat(deserialized.agentInvocations())
+                .singleElement()
+                .extracting(AgentInvocation::input)
+                .satisfies(persistentInput -> assertThat(persistentInput)
+                        .containsEntry("result", null)
+                        .containsEntry("request", "hello"));
+    }
+
+    @Test
+    void agentInvocationSerializationDoesNotPersistNestedStreamingInput() {
+        DefaultAgenticScope scope = new DefaultAgenticScope(DefaultAgenticScope.Kind.PERSISTENT);
+        TokenStream tokenStream = mock(TokenStream.class);
+        Map<String, Object> input = new ConcurrentHashMap<>();
+        input.put("payload", Map.of("result", tokenStream, "request", "hello"));
+
+        scope.agentInvocations()
+                .add(new AgentInvocation(AiServiceStreamingAgent.class, "chat", "agent-1", input, "ok"));
+
+        String json = AgenticScopeSerializer.toJson(scope);
+        DefaultAgenticScope deserialized = AgenticScopeSerializer.fromJson(json);
+
+        assertThat(deserialized.agentInvocations())
+                .singleElement()
+                .extracting(AgentInvocation::input)
+                .satisfies(persistentInput -> assertThat(persistentInput.get("payload"))
+                        .isInstanceOf(Map.class)
+                        .satisfies(payload -> assertThat((Map<Object, Object>) payload)
+                                .doesNotContainKey("result")
+                                .containsEntry("request", "hello")));
     }
 
     @Test
@@ -163,6 +300,12 @@ class AgenticScopeStreamingStateTest {
         String chat(@V("input") String input);
     }
 
+    public interface PersistentTextWorkflow {
+
+        @Agent(outputKey = "result")
+        String chat(@MemoryId String memoryId, @V("input") String input);
+    }
+
     public static class TextAgent {
 
         @Agent(outputKey = "result")
@@ -177,6 +320,19 @@ class AgenticScopeStreamingStateTest {
         public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
             handler.onCompleteResponse(
                     ChatResponse.builder().aiMessage(AiMessage.from("ok")).build());
+        }
+    }
+
+    private static class UnfinishedDelayedResponse implements DelayedResponse<String> {
+
+        @Override
+        public boolean isDone() {
+            return false;
+        }
+
+        @Override
+        public String blockingGet() {
+            throw new AssertionError("Persistence must not block on an unfinished response");
         }
     }
 

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/AgenticScopeStreamingStateTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/scope/AgenticScopeStreamingStateTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.agentic.scope;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
 
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.AgenticServices;
@@ -17,6 +18,7 @@ import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -103,6 +105,23 @@ class AgenticScopeStreamingStateTest {
                 .build();
 
         assertThat(workflow.chat("hello")).isEqualTo("ok done");
+    }
+
+    @Test
+    void agentInvocationSerializationDoesNotPersistRawStreamingOutput() {
+        DefaultAgenticScope scope = new DefaultAgenticScope(DefaultAgenticScope.Kind.PERSISTENT);
+        TokenStream tokenStream = mock(TokenStream.class);
+
+        scope.agentInvocations()
+                .add(new AgentInvocation(AiServiceStreamingAgent.class, "chat", "agent-1", Map.of(), tokenStream));
+
+        String json = AgenticScopeSerializer.toJson(scope);
+        DefaultAgenticScope deserialized = AgenticScopeSerializer.fromJson(json);
+
+        assertThat(deserialized.agentInvocations())
+                .singleElement()
+                .extracting(AgentInvocation::output)
+                .isNull();
     }
 
     @Test


### PR DESCRIPTION
## Issue
Fixes #5285

## Change
This PR prevents live streaming outputs from being stored in persistent agentic scope data.

When an agent or workflow has an `outputKey` and produces a `TokenStream`, the persistent state entry for that key is cleared while the live stream is kept only in transient execution context for the current root call. This keeps final streaming workflows returning the original stream without serializing `AiServiceTokenStream` internals.

The same output policy is applied to `AgentInvocation` records, so persisted invocation history exposes a serialization-safe value for streaming outputs.

Async streaming is handled according to how the stream is used:
- if an async streaming output is the final propagated workflow output, it remains runtime-only and is not stored in any persisted checkpoint snapshot
- if an async streaming subagent is not the final output, the stream is consumed into text as before, so downstream agents can still read the `outputKey` value

Non-streaming outputs continue to be written to scope state as before. This change does not alter the public serializer/API surface.

## Verification
- [x] `mvn -pl langchain4j-agentic -Dtest=dev.langchain4j.agentic.internal.AgenticScopeOutputTest,dev.langchain4j.agentic.scope.AgenticScopeStreamingStateTest,dev.langchain4j.agentic.RecoverabilityTest test`
- [x] `mvn -pl langchain4j-agentic test`
- [x] `git diff --check`
- [x] GitHub Actions `spotless` passed on this head commit

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
