### PR TITLE
MCP: surface tool outputSchema on ToolSpecification

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpToolMetadataKeys.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpToolMetadataKeys.java
@@ -46,4 +46,11 @@ public class McpToolMetadataKeys {
      */
     public static final String OPEN_WORLD_HINT = "openWorldHint";
 
+    /**
+     * The JSON schema describing the structured output of the tool, as declared in the Tool definition.
+     * Paired with {@code structuredContent} in tool responses.
+     * See <a href="https://github.com/modelcontextprotocol/modelcontextprotocol/blob/2025-06-18/schema/2025-06-18/schema.json">schema.json</a>
+     * Value type: {@code Map<String, Object>}
+     */
+    public static final String OUTPUT_SCHEMA = "outputSchema";
 }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -51,6 +51,9 @@ class ToolSpecificationHelper {
             if (tool.has("title")) {
                 builder.addMetadata(TITLE, tool.get("title").asText());
             }
+            if (tool.has("outputSchema")) {
+                builder.addMetadata(OUTPUT_SCHEMA, OBJECT_MAPPER.convertValue(tool.get("outputSchema"), Object.class));
+            }
             result.add(builder.build());
         }
         return result;

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -3,6 +3,7 @@ package dev.langchain4j.mcp.client;
 import static dev.langchain4j.mcp.client.McpToolMetadataKeys.DESTRUCTIVE_HINT;
 import static dev.langchain4j.mcp.client.McpToolMetadataKeys.IDEMPOTENT_HINT;
 import static dev.langchain4j.mcp.client.McpToolMetadataKeys.OPEN_WORLD_HINT;
+import static dev.langchain4j.mcp.client.McpToolMetadataKeys.OUTPUT_SCHEMA;
 import static dev.langchain4j.mcp.client.McpToolMetadataKeys.READ_ONLY_HINT;
 import static dev.langchain4j.mcp.client.McpToolMetadataKeys.TITLE;
 import static dev.langchain4j.mcp.client.McpToolMetadataKeys.TITLE_ANNOTATION;
@@ -203,8 +204,7 @@ class ToolSpecificationHelperTest {
 
     @Test
     void arrayWithMultipleAllowedTypes() throws JsonProcessingException {
-        String text =
-                """
+        String text = """
                         [{
                           "name": "query",
                           "description": "Execute a SELECT query",
@@ -345,8 +345,7 @@ class ToolSpecificationHelperTest {
     @Test
     void nullTypeName() throws JsonProcessingException {
         // the 'value' parameter has an empty definition, so it can be anything
-        String text =
-                """
+        String text = """
                 [{
                    "name": "set_config_value",
                    "description": "Set a specific configuration value by key",
@@ -376,8 +375,7 @@ class ToolSpecificationHelperTest {
     void nullType() throws JsonProcessingException {
         // the 'type' parameter is "null" and so most not be present
         // trimmed version from Atalassian's MCP server
-        String text =
-                """
+        String text = """
                 [{
                   "name": "createCompassCustomFieldDefinition",
                   "description": "Create a new Compass custom field definition",
@@ -486,6 +484,68 @@ class ToolSpecificationHelperTest {
         assertThat(metadata.get(DESTRUCTIVE_HINT)).isEqualTo(true);
         assertThat(metadata.get(IDEMPOTENT_HINT)).isEqualTo(false);
         assertThat(metadata.get(OPEN_WORLD_HINT)).isEqualTo(true);
+    }
+
+    @Test
+    void toolWithOutputSchema() throws JsonProcessingException {
+        String text =
+                // language=json
+                """
+                [{
+                    "name": "get_weather",
+                    "description": "Get the weather for a location",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "location": { "type": "string" }
+                      },
+                      "required": ["location"]
+                    },
+                    "outputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "temperature": {
+                          "type": "number",
+                          "description": "Temperature in Celsius"
+                        },
+                        "conditions": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["temperature", "conditions"]
+                    }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        Map<String, Object> metadata = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0)
+                .metadata();
+
+        assertThat(metadata.get(OUTPUT_SCHEMA)).isInstanceOf(Map.class);
+        Map<String, Object> outputSchema = (Map<String, Object>) metadata.get(OUTPUT_SCHEMA);
+        assertThat(outputSchema.get("type")).isEqualTo("object");
+        assertThat(outputSchema.get("required")).isEqualTo(List.of("temperature", "conditions"));
+        assertThat(outputSchema.get("properties")).isInstanceOf(Map.class);
+        Map<String, Object> properties = (Map<String, Object>) outputSchema.get("properties");
+        assertThat(properties).containsOnlyKeys("temperature", "conditions");
+    }
+
+    @Test
+    void toolWithoutOutputSchema() throws JsonProcessingException {
+        String text =
+                // language=json
+                """
+                [{
+                    "name": "noop",
+                    "inputSchema": {}
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        Map<String, Object> metadata = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json)
+                .get(0)
+                .metadata();
+
+        assertThat(metadata).doesNotContainKey(OUTPUT_SCHEMA);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #5291.

The MCP 2025-06-18 spec adds an `outputSchema` field on Tool definitions (a JSON schema describing structured tool output, paired with `structuredContent` in tool responses). `ToolSpecificationHelper` already picks up the other 2025-06-18 Tool additions — annotations, top-level `title`, `_meta` — but `outputSchema` was the remaining field still dropped silently. `DefaultMcpToolResultExtractor` already parses `structuredContent` on the response side, so this closes the matching definition-side gap.

## Changes

- Add `OUTPUT_SCHEMA = "outputSchema"` constant to `McpToolMetadataKeys`.
- In `ToolSpecificationHelper.toolSpecificationListFromMcpResponse(...)`, when the tool node contains `outputSchema`, store it as a nested `Map<String, Object>` under that metadata key — mirrors the existing `_meta` passthrough via `OBJECT_MAPPER.convertValue(...)`.

No new top-level field on `ToolSpecification`. Storing in `metadata` matches the precedent set by annotations and `_meta`, keeps the change isolated to `langchain4j-mcp`, and avoids touching `langchain4j-core` public API.

## Test plan

- [x] New `toolWithOutputSchema()` test in `ToolSpecificationHelperTest` — fixture tool JSON with `outputSchema`, asserts metadata key is populated as `Map<String, Object>` with the expected structure.
- [x] New `toolWithoutOutputSchema()` test — asserts the metadata key is absent when the field is missing.
- [x] All 15 tests in `ToolSpecificationHelperTest` pass (`./mvnw -pl langchain4j-mcp -am test -Dtest=ToolSpecificationHelperTest`).
- [x] All 57 MCP unit tests pass.
- [x] `./mvnw -pl langchain4j-mcp spotless:check` passes.

## API impact

Additive only. One new public constant. No SPI breakage.

References:
- MCP 2025-06-18 schema: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/2025-06-18/schema/2025-06-18/schema.json