### PR TITLE
MCP: handle inbound notifications/cancelled from server

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java
@@ -184,7 +184,8 @@ public class DefaultMcpClient implements McpClient {
                         notifyListeners(l -> l.onNotificationProgress(notification));
                     },
                     () -> notifyListeners(l -> l.onServerPing()),
-                    () -> notifyListeners(l -> l.onServerRootsList()));
+                    () -> notifyListeners(l -> l.onServerRootsList()),
+                    (requestId, reason) -> notifyListeners(l -> l.onNotificationCancelled(requestId, reason)));
             ((ObjectNode) RESULT_TIMEOUT)
                     .putObject("result")
                     .putArray("content")

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClientListener.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/McpClientListener.java
@@ -242,6 +242,16 @@ public interface McpClientListener {
      */
     default void onNotificationProgress(McpProgressNotification notification) {}
 
+    /**
+     * Called when the server sends a {@code notifications/cancelled} notification to abort
+     * a previously accepted request. The corresponding pending operation, if any, is
+     * completed exceptionally before this listener is invoked.
+     *
+     * @param requestId the id of the cancelled request, as supplied by the server
+     * @param reason    an optional server-supplied reason for the cancellation; may be {@code null}
+     */
+    default void onNotificationCancelled(long requestId, String reason) {}
+
     // ========== Server-initiated requests ==========
 
     /**

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/McpOperationHandler.java
@@ -10,7 +10,9 @@ import dev.langchain4j.mcp.protocol.McpRootsListResponse;
 import dev.langchain4j.mcp.protocol.McpServerMethod;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -36,6 +38,7 @@ public class McpOperationHandler {
     private final McpProgressHandler progressHandler;
     private final Runnable onServerPing;
     private final Runnable onServerRootsList;
+    private final BiConsumer<Long, String> onServerCancelled;
 
     public McpOperationHandler(
             Map<Long, CompletableFuture<JsonNode>> pendingOperations,
@@ -48,7 +51,8 @@ public class McpOperationHandler {
             Consumer<String> onResourceUpdate,
             McpProgressHandler progressHandler,
             Runnable onServerPing,
-            Runnable onServerRootsList) {
+            Runnable onServerRootsList,
+            BiConsumer<Long, String> onServerCancelled) {
         this.pendingOperations = pendingOperations;
         this.transport = transport;
         this.logMessageConsumer = logMessageConsumer;
@@ -60,6 +64,7 @@ public class McpOperationHandler {
         this.progressHandler = progressHandler;
         this.onServerPing = onServerPing;
         this.onServerRootsList = onServerRootsList;
+        this.onServerCancelled = onServerCancelled;
     }
 
     public void handle(JsonNode message) {
@@ -137,8 +142,36 @@ public class McpOperationHandler {
             case NOTIFICATION_PROGRESS:
                 handleProgressNotification(message);
                 break;
+            case NOTIFICATION_CANCELLED:
+                handleCancelledNotification(message);
+                break;
             default:
                 log.warn("Received unknown message: {}", message);
+        }
+    }
+
+    private void handleCancelledNotification(JsonNode message) {
+        JsonNode params = message.get("params");
+        if (params == null || !params.has("requestId")) {
+            log.warn("Received cancelled notification without requestId: {}", message);
+            return;
+        }
+        long requestId = params.get("requestId").asLong();
+        String reason = params.has("reason") ? params.get("reason").asText() : null;
+        CompletableFuture<JsonNode> pending = pendingOperations.remove(requestId);
+        if (pending != null) {
+            String message1 = reason != null
+                    ? "Request " + requestId + " was cancelled by the server: " + reason
+                    : "Request " + requestId + " was cancelled by the server";
+            pending.completeExceptionally(new CancellationException(message1));
+        } else {
+            log.debug(
+                    "Received cancelled notification for unknown or already completed request id: {} (reason: {})",
+                    requestId,
+                    reason);
+        }
+        if (onServerCancelled != null) {
+            onServerCancelled.accept(requestId, reason);
         }
     }
 

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpServerMethod.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/protocol/McpServerMethod.java
@@ -16,7 +16,8 @@ public enum McpServerMethod {
     NOTIFICATION_RESOURCES_LIST_CHANGED("notifications/resources/list_changed"),
     NOTIFICATION_PROMPTS_LIST_CHANGED("notifications/prompts/list_changed"),
     NOTIFICATION_RESOURCES_UPDATED("notifications/resources/updated"),
-    NOTIFICATION_PROGRESS("notifications/progress");
+    NOTIFICATION_PROGRESS("notifications/progress"),
+    NOTIFICATION_CANCELLED("notifications/cancelled");
 
     private final String value;
 

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerTest.java
@@ -1,0 +1,142 @@
+package dev.langchain4j.mcp.client.transport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class McpOperationHandlerTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void should_complete_pending_operation_exceptionally_on_server_cancelled() throws JsonProcessingException {
+        Map<Long, CompletableFuture<JsonNode>> pending = new ConcurrentHashMap<>();
+        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+        pending.put(42L, future);
+
+        AtomicReference<Long> cancelledId = new AtomicReference<>();
+        AtomicReference<String> cancelledReason = new AtomicReference<>();
+        McpOperationHandler handler = new McpOperationHandler(
+                pending,
+                java.util.Collections::emptyList,
+                Mockito.mock(McpTransport.class),
+                msg -> {},
+                () -> {},
+                () -> {},
+                () -> {},
+                uri -> {},
+                null,
+                () -> {},
+                () -> {},
+                (id, reason) -> {
+                    cancelledId.set(id);
+                    cancelledReason.set(reason);
+                });
+
+        JsonNode notification = OBJECT_MAPPER.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "method": "notifications/cancelled",
+                  "params": {
+                    "requestId": 42,
+                    "reason": "user aborted"
+                  }
+                }
+                """);
+
+        handler.handle(notification);
+
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get)
+                .isInstanceOf(CancellationException.class)
+                .hasMessageContaining("42")
+                .hasMessageContaining("user aborted");
+        assertThat(pending).doesNotContainKey(42L);
+        assertThat(cancelledId.get()).isEqualTo(42L);
+        assertThat(cancelledReason.get()).isEqualTo("user aborted");
+    }
+
+    @Test
+    void should_invoke_listener_even_when_request_id_is_unknown() throws JsonProcessingException {
+        Map<Long, CompletableFuture<JsonNode>> pending = new ConcurrentHashMap<>();
+        AtomicReference<Long> cancelledId = new AtomicReference<>();
+        AtomicReference<String> cancelledReason = new AtomicReference<>();
+        McpOperationHandler handler = new McpOperationHandler(
+                pending,
+                java.util.Collections::emptyList,
+                Mockito.mock(McpTransport.class),
+                msg -> {},
+                () -> {},
+                () -> {},
+                () -> {},
+                uri -> {},
+                null,
+                () -> {},
+                () -> {},
+                (id, reason) -> {
+                    cancelledId.set(id);
+                    cancelledReason.set(reason);
+                });
+
+        JsonNode notification = OBJECT_MAPPER.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "method": "notifications/cancelled",
+                  "params": {
+                    "requestId": 7
+                  }
+                }
+                """);
+
+        handler.handle(notification);
+
+        assertThat(cancelledId.get()).isEqualTo(7L);
+        assertThat(cancelledReason.get()).isNull();
+    }
+
+    @Test
+    void should_ignore_cancelled_notification_without_request_id() throws JsonProcessingException {
+        Map<Long, CompletableFuture<JsonNode>> pending = new ConcurrentHashMap<>();
+        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+        pending.put(99L, future);
+
+        AtomicReference<Long> cancelledId = new AtomicReference<>();
+        McpOperationHandler handler = new McpOperationHandler(
+                pending,
+                java.util.Collections::emptyList,
+                Mockito.mock(McpTransport.class),
+                msg -> {},
+                () -> {},
+                () -> {},
+                () -> {},
+                uri -> {},
+                null,
+                () -> {},
+                () -> {},
+                (id, reason) -> cancelledId.set(id));
+
+        JsonNode notification = OBJECT_MAPPER.readTree("""
+                {
+                  "jsonrpc": "2.0",
+                  "method": "notifications/cancelled",
+                  "params": {}
+                }
+                """);
+
+        handler.handle(notification);
+
+        assertThat(future).isNotCompleted();
+        assertThat(pending).containsKey(99L);
+        assertThat(cancelledId.get()).isNull();
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/McpOperationHandlerTest.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.mcp.client.transport;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -57,7 +56,12 @@ class McpOperationHandlerTest {
         handler.handle(notification);
 
         assertThat(future).isCompletedExceptionally();
-        assertThatThrownBy(future::get)
+        // Inspect the throwable stored on the future via handle() rather than calling
+        // future.get(): JDK 25 changed CompletableFuture.reportGet() to throw a fresh
+        // CancellationException with a generic message instead of re-throwing the one we
+        // supplied. handle() returns the stored throwable as-is on every JDK.
+        Throwable stored = future.handle((v, e) -> e).join();
+        assertThat(stored)
                 .isInstanceOf(CancellationException.class)
                 .hasMessageContaining("42")
                 .hasMessageContaining("user aborted");


### PR DESCRIPTION
## Summary

Closes #5292.

The MCP base protocol defines `notifications/cancelled` as **bidirectional**: both the client and the server can cancel a previously accepted request (see [spec, cancellation](https://modelcontextprotocol.io/specification/2025-06-18/basic#cancellation)). The client already sends these outbound on tool timeout ([`DefaultMcpClient.java:319-321`](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/DefaultMcpClient.java#L319-L321)) — but when the **server** sends one to abort a long-running request, `McpOperationHandler.handleNotification` fell into the default branch and only logged a warning. The pending `CompletableFuture` then blocked until the configured timeout fired instead of failing fast with the server-supplied reason.

## Changes

1. **`McpServerMethod`** — add `NOTIFICATION_CANCELLED("notifications/cancelled")`.
2. **`McpOperationHandler`** — add a new `BiConsumer<Long, String> onServerCancelled` callback parameter and a `handleCancelledNotification(...)` branch in the switch. When the notification arrives, the matching pending operation (if any) is removed from `pendingOperations` and completed with a `CancellationException` carrying the server's reason. If the request id is unknown or already completed, the listener is still notified (debug-logged).
3. **`DefaultMcpClient`** — wire the new callback to fan out to listeners via `McpClientListener.onNotificationCancelled(...)`.
4. **`McpClientListener`** — new default no-op method `onNotificationCancelled(long requestId, String reason)`. Non-breaking; follows the same extension pattern as commit [`c908ea4c`](https://github.com/langchain4j/langchain4j/commit/c908ea4c) ("support additional event types in McpClientListener").

## Why `CancellationException`

`java.util.concurrent.CancellationException` is the JDK-standard signal for "this future was cancelled," propagates cleanly through `CompletableFuture#get()` (no `ExecutionException` wrapping), and matches user expectations. The existing `cancelAllPendingOperations` uses `IllegalStateException` for transport teardown — but that's a different signal (the connection died), whereas this is a clean protocol-level cancellation.

## Test plan

- [x] New `McpOperationHandlerTest` (3 tests):
  - completes the pending operation exceptionally with the server-supplied reason
  - invokes the listener even when the request id is unknown
  - ignores a malformed notification without `requestId`
- [x] All 65 MCP unit tests pass (`./mvnw -pl langchain4j-mcp -am test`).
- [x] `./mvnw -pl langchain4j-mcp spotless:check` passes.

## API impact

Additive only:

- one new enum entry on `McpServerMethod`
- one new optional method on `McpClientListener` (with a default no-op)
- one new constructor parameter on `McpOperationHandler` — internal; only `DefaultMcpClient` constructs it (verified via repo-wide grep)

No SPI break for downstream users.