### PR TITLE
feat(google-ai-gemini): support attaching cachedContent to generateContent requests

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
@@ -56,6 +56,7 @@ class BaseGeminiChatModel {
     protected final GeminiMediaResolutionLevel mediaResolution;
     protected final boolean mediaResolutionPerPartEnabled;
     protected final GeminiGenerationConfig.GeminiImageConfig imageConfig;
+    protected final String cachedContentName;
 
     protected final ChatRequestParameters defaultRequestParameters;
 
@@ -81,6 +82,7 @@ class BaseGeminiChatModel {
         this.mediaResolution = builder.mediaResolution;
         this.mediaResolutionPerPartEnabled = getOrDefault(builder.mediaResolutionPerPartEnabled, false);
         this.imageConfig = buildImageConfig(builder.aspectRatio, builder.imageSize);
+        this.cachedContentName = builder.cachedContentName;
 
         ChatRequestParameters parameters;
         if (builder.defaultRequestParameters != null) {
@@ -169,6 +171,7 @@ class BaseGeminiChatModel {
                         this.allowGoogleMaps,
                         this.retrieveGoogleMapsWidgetToken))
                 .toolConfig(toToolConfig(parameters.toolChoice(), this.functionCallingConfig))
+                .cachedContent(this.cachedContentName)
                 .build();
     }
 
@@ -347,6 +350,7 @@ class BaseGeminiChatModel {
         protected Boolean mediaResolutionPerPartEnabled;
         protected String aspectRatio;
         protected String imageSize;
+        protected String cachedContentName;
         protected Supplier<Map<String, String>> customHeadersSupplier;
 
         @SuppressWarnings("unchecked")
@@ -744,6 +748,22 @@ class BaseGeminiChatModel {
          */
         public B imageSize(String imageSize) {
             this.imageSize = imageSize;
+            return builder();
+        }
+
+        /**
+         * Sets the resource name of a previously created cache (e.g. {@code "cachedContents/abc123"}) to attach
+         * to every {@code generateContent} / {@code streamGenerateContent} request issued by this model. The cached
+         * context (system instructions, documents, etc.) will be reused server-side, reducing latency and token
+         * cost.
+         *
+         * <p>This integration does not manage the cache lifecycle (create / list / delete); callers are expected
+         * to create the cache out of band via the
+         * <a href="https://ai.google.dev/gemini-api/docs/caching">Gemini context caching API</a> and pass the
+         * returned resource name here.</p>
+         */
+        public B cachedContentName(String cachedContentName) {
+            this.cachedContentName = cachedContentName;
             return builder();
         }
 

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentRequest.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiGenerateContentRequest.java
@@ -12,7 +12,8 @@ record GeminiGenerateContentRequest(
         @JsonProperty("toolConfig") GeminiToolConfig toolConfig,
         @JsonProperty("safetySettings") List<GeminiSafetySetting> safetySettings,
         @JsonProperty("systemInstruction") GeminiContent systemInstruction,
-        @JsonProperty("generationConfig") GeminiGenerationConfig generationConfig) {
+        @JsonProperty("generationConfig") GeminiGenerationConfig generationConfig,
+        @JsonProperty("cachedContent") String cachedContent) {
 
     static GeminiGenerateContentRequestBuilder builder() {
         return new GeminiGenerateContentRequestBuilder();
@@ -26,6 +27,7 @@ record GeminiGenerateContentRequest(
         private List<GeminiSafetySetting> safetySettings;
         private GeminiContent systemInstruction;
         private GeminiGenerationConfig generationConfig;
+        private String cachedContent;
 
         GeminiGenerateContentRequestBuilder() {}
 
@@ -64,6 +66,11 @@ record GeminiGenerateContentRequest(
             return this;
         }
 
+        GeminiGenerateContentRequestBuilder cachedContent(String cachedContent) {
+            this.cachedContent = cachedContent;
+            return this;
+        }
+
         public GeminiGenerateContentRequest build() {
             return new GeminiGenerateContentRequest(
                     this.model,
@@ -72,7 +79,8 @@ record GeminiGenerateContentRequest(
                     this.toolConfig,
                     this.safetySettings,
                     this.systemInstruction,
-                    this.generationConfig);
+                    this.generationConfig,
+                    this.cachedContent);
         }
     }
 

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.googleai;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCharSequence;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -44,6 +45,31 @@ class GoogleAiGeminiStreamingChatModelTest {
             GeminiGenerateContentRequest result = chatModel.createGenerateContentRequest(DEFAULT_REQUEST);
 
             assertThatCharSequence(Json.toJson(result.generationConfig())).doesNotContain("\"seed\"");
+        }
+
+        @Test
+        void cachedContentNameInContentRequest() {
+            GoogleAiGeminiStreamingChatModel chatModel = GoogleAiGeminiStreamingChatModel.builder()
+                    .apiKey("ApiKey")
+                    .modelName("ModelName")
+                    .cachedContentName("cachedContents/abc123")
+                    .build();
+            GeminiGenerateContentRequest result = chatModel.createGenerateContentRequest(DEFAULT_REQUEST);
+
+            assertThat(result.cachedContent()).isEqualTo("cachedContents/abc123");
+            assertThatCharSequence(Json.toJson(result)).contains("\"cachedContent\" : \"cachedContents/abc123\"");
+        }
+
+        @Test
+        void defaultCachedContentNameInContentRequest() {
+            GoogleAiGeminiStreamingChatModel chatModel = GoogleAiGeminiStreamingChatModel.builder()
+                    .apiKey("ApiKey")
+                    .modelName("ModelName")
+                    .build();
+            GeminiGenerateContentRequest result = chatModel.createGenerateContentRequest(DEFAULT_REQUEST);
+
+            assertThat(result.cachedContent()).isNull();
+            assertThatCharSequence(Json.toJson(result)).doesNotContain("\"cachedContent\"");
         }
     }
 }


### PR DESCRIPTION
## Issue
Closes #5288 
Subset of #3774

## Change
Gemini's [context caching API](https://ai.google.dev/gemini-api/docs/caching) allows a previously created cache (`cachedContents/*`) to be attached to a `generateContent` or `streamGenerateContent` call via the request's `cachedContent` field. This reuses the cached context (system instructions, large documents, etc.) server-side, reducing latency and token cost across repeated calls.

Previously, `GeminiGenerateContentRequest` did not expose this field, so the cache could not be used through the langchain4j Google AI Gemini integration.

This PR is intentionally a **minimal, non-breaking addition** — it does **not** implement cache lifecycle management (create / list / delete). Callers are expected to create the cache out of band (via the REST API, Python SDK, etc.) and pass the returned resource name here.

**Files changed:**
- `GeminiGenerateContentRequest` — added `cachedContent` record component and corresponding builder method
- `BaseGeminiChatModel` — added `cachedContentName` field; threaded into `createGenerateContentRequest()`; exposed `cachedContentName(String)` on `GoogleAiGeminiChatModelBaseBuilder` so both `GoogleAiGeminiChatModel` and `GoogleAiGeminiStreamingChatModel` inherit it

**Usage:**
```java
ChatModel model = GoogleAiGeminiChatModel.builder()
    .apiKey(System.getenv("GEMINI_AI_KEY"))
    .modelName("gemini-1.5-flash-001")
    .cachedContentName("cachedContents/abc123")
    .build();
```

When `cachedContentName` is null (default), the field is omitted from the request body — existing requests are byte-identical.

**Tests:**
Added two unit tests in `GoogleAiGeminiStreamingChatModelTest` (following the existing `seedParameterInContentRequest` / `defaultSeedInContentRequest` pattern right above them):
- `cachedContentNameInContentRequest` — verifies the `cachedContent` field is set on the request and serialized to JSON when `cachedContentName(...)` is configured on the builder
- `defaultCachedContentNameInContentRequest` — verifies the field is null and omitted from JSON when the builder method is not called (no breaking change to existing requests)

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)