### PR TITLE
Expose StreamingHandle on TokenStream

### DIFF
--- a/langchain4j/revapi.json
+++ b/langchain4j/revapi.json
@@ -13,6 +13,11 @@
           "code": "java.annotation.removed",
           "new": "class dev.langchain4j.service.tool.AiServiceTool",
           "justification": "@Internal removed intentionally: AiServiceTool is now part of the public API and can be constructed and passed to AiServices directly by users (e.g. via AiServices.tools(List<AiServiceTool>))."
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.chat.response.StreamingHandle",
+          "justification": "StreamingHandle is intentionally exposed by TokenStream so adapters can observe and cancel the underlying streaming request without switching from plain token callbacks to context callbacks."
         }
       ]
     }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -102,7 +103,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final List<String> responseBuffer = new ArrayList<>();
     private final boolean hasOutputGuardrails;
 
-    private StreamingHandle observedStreamingHandle;
+    private final AtomicReference<StreamingHandle> observedStreamingHandle = new AtomicReference<>();
 
     private int toolCallingRoundTripsLeft;
 
@@ -178,7 +179,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         } else if (partialResponseHandler != null) {
             partialResponseHandler.accept(partialResponse);
         } else if (partialResponseWithContextHandler != null) {
-            PartialResponseContext context = new PartialResponseContext(new CancellationUnsupportedStreamingHandle());
+            PartialResponseContext context = new PartialResponseContext(streamingHandleOrCancellationUnsupported());
             partialResponseWithContextHandler.accept(new PartialResponse(partialResponse), context);
         }
     }
@@ -201,7 +202,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         if (partialThinkingHandler != null) {
             partialThinkingHandler.accept(partialThinking);
         } else if (partialThinkingWithContextHandler != null) {
-            PartialThinkingContext context = new PartialThinkingContext(new CancellationUnsupportedStreamingHandle());
+            PartialThinkingContext context = new PartialThinkingContext(streamingHandleOrCancellationUnsupported());
             partialThinkingWithContextHandler.accept(partialThinking, context);
         }
     }
@@ -221,7 +222,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         if (partialToolCallHandler != null) {
             partialToolCallHandler.accept(partialToolCall);
         } else if (partialToolCallWithContextHandler != null) {
-            PartialToolCallContext context = new PartialToolCallContext(new CancellationUnsupportedStreamingHandle());
+            PartialToolCallContext context = new PartialToolCallContext(streamingHandleOrCancellationUnsupported());
             partialToolCallWithContextHandler.accept(partialToolCall, context);
         }
     }
@@ -442,10 +443,10 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     if (partialResponseHandler != null) {
                         responseBuffer.forEach(partialResponseHandler::accept);
                     } else if (partialResponseWithContextHandler != null) {
-                        PartialResponseContext partialResponseContext =
-                                new PartialResponseContext(new CancellationUnsupportedStreamingHandle());
-                        responseBuffer.forEach(s -> partialResponseWithContextHandler.accept(
-                                new PartialResponse(s), partialResponseContext));
+                        PartialResponseContext replayContext =
+                                new PartialResponseContext(streamingHandleOrCancellationUnsupported());
+                        responseBuffer.forEach(
+                                s -> partialResponseWithContextHandler.accept(new PartialResponse(s), replayContext));
                     }
                     responseBuffer.clear();
                 }
@@ -492,10 +493,15 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     }
 
     private void observeStreamingHandle(StreamingHandle streamingHandle) {
-        if (streamingHandleHandler != null && streamingHandle != observedStreamingHandle) {
-            observedStreamingHandle = streamingHandle;
+        StreamingHandle previousStreamingHandle = observedStreamingHandle.getAndSet(streamingHandle);
+        if (streamingHandleHandler != null && previousStreamingHandle != streamingHandle) {
             streamingHandleHandler.accept(streamingHandle);
         }
+    }
+
+    private StreamingHandle streamingHandleOrCancellationUnsupported() {
+        StreamingHandle streamingHandle = observedStreamingHandle.get();
+        return streamingHandle != null ? streamingHandle : new CancellationUnsupportedStreamingHandle();
     }
 
     private ChatResponse finalResponse(ChatResponse completeResponse, AiMessage aiMessage) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -28,6 +28,7 @@ import dev.langchain4j.model.chat.response.PartialThinkingContext;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCallContext;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.observability.api.event.AiServiceCompletedEvent;
 import dev.langchain4j.observability.api.event.AiServiceErrorEvent;
@@ -79,6 +80,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final BiConsumer<PartialThinking, PartialThinkingContext> partialThinkingWithContextHandler;
     private final Consumer<PartialToolCall> partialToolCallHandler;
     private final BiConsumer<PartialToolCall, PartialToolCallContext> partialToolCallWithContextHandler;
+    private final Consumer<StreamingHandle> streamingHandleHandler;
     private final Consumer<BeforeToolExecution> beforeToolExecutionHandler;
     private final Consumer<Object> rawEventHandler;
     private final Consumer<ToolExecution> toolExecutionHandler;
@@ -100,6 +102,8 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
     private final List<String> responseBuffer = new ArrayList<>();
     private final boolean hasOutputGuardrails;
 
+    private StreamingHandle observedStreamingHandle;
+
     private int toolCallingRoundTripsLeft;
 
     private record ToolRequestResult(ToolExecutionRequest request, ToolExecutionResult result) {}
@@ -115,6 +119,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             BiConsumer<PartialThinking, PartialThinkingContext> partialThinkingWithContextHandler,
             Consumer<PartialToolCall> partialToolCallHandler,
             BiConsumer<PartialToolCall, PartialToolCallContext> partialToolCallWithContextHandler,
+            Consumer<StreamingHandle> streamingHandleHandler,
             Consumer<BeforeToolExecution> beforeToolExecutionHandler,
             Consumer<Object> rawEventHandler,
             Consumer<ToolExecution> toolExecutionHandler,
@@ -142,6 +147,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         this.partialThinkingWithContextHandler = partialThinkingWithContextHandler;
         this.partialToolCallHandler = partialToolCallHandler;
         this.partialToolCallWithContextHandler = partialToolCallWithContextHandler;
+        this.streamingHandleHandler = streamingHandleHandler;
         this.intermediateResponseHandler = intermediateResponseHandler;
         this.completeResponseHandler = completeResponseHandler;
         this.beforeToolExecutionHandler = beforeToolExecutionHandler;
@@ -179,6 +185,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onPartialResponse(PartialResponse partialResponse, PartialResponseContext context) {
+        observeStreamingHandle(context.streamingHandle());
         // If we're using output guardrails, then buffer the partial response until the guardrails have completed
         if (hasOutputGuardrails) {
             responseBuffer.add(partialResponse.text());
@@ -201,6 +208,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onPartialThinking(PartialThinking partialThinking, PartialThinkingContext context) {
+        observeStreamingHandle(context.streamingHandle());
         if (partialThinkingHandler != null) {
             partialThinkingHandler.accept(partialThinking);
         } else if (partialThinkingWithContextHandler != null) {
@@ -220,6 +228,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
 
     @Override
     public void onPartialToolCall(PartialToolCall partialToolCall, PartialToolCallContext context) {
+        observeStreamingHandle(context.streamingHandle());
         if (partialToolCallHandler != null) {
             partialToolCallHandler.accept(partialToolCall);
         } else if (partialToolCallWithContextHandler != null) {
@@ -381,6 +390,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     partialThinkingWithContextHandler,
                     partialToolCallHandler,
                     partialToolCallWithContextHandler,
+                    streamingHandleHandler,
                     beforeToolExecutionHandler,
                     rawEventHandler,
                     toolExecutionHandler,
@@ -478,6 +488,13 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
+        }
+    }
+
+    private void observeStreamingHandle(StreamingHandle streamingHandle) {
+        if (streamingHandleHandler != null && streamingHandle != observedStreamingHandle) {
+            observedStreamingHandle = streamingHandle;
+            streamingHandleHandler.accept(streamingHandle);
         }
     }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceTokenStream.java
@@ -21,6 +21,7 @@ import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.PartialThinkingContext;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCallContext;
+import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.observability.api.event.AiServiceRequestIssuedEvent;
 import dev.langchain4j.rag.content.Content;
@@ -56,6 +57,7 @@ public class AiServiceTokenStream implements TokenStream {
     private BiConsumer<PartialThinking, PartialThinkingContext> partialThinkingWithContextHandler;
     private Consumer<PartialToolCall> partialToolCallHandler;
     private BiConsumer<PartialToolCall, PartialToolCallContext> partialToolCallWithContextHandler;
+    private Consumer<StreamingHandle> streamingHandleHandler;
     private Consumer<List<Content>> contentsHandler;
     private Consumer<ChatResponse> intermediateResponseHandler;
     private Consumer<BeforeToolExecution> beforeToolExecutionHandler;
@@ -70,6 +72,7 @@ public class AiServiceTokenStream implements TokenStream {
     private int onPartialThinkingWithContextInvoked;
     private int onPartialToolCallInvoked;
     private int onPartialToolCallWithContextInvoked;
+    private int onStreamingHandleInvoked;
     private int onIntermediateResponseInvoked;
     private int onCompleteResponseInvoked;
     private int onRetrievedInvoked;
@@ -138,6 +141,13 @@ public class AiServiceTokenStream implements TokenStream {
     public TokenStream onPartialToolCallWithContext(BiConsumer<PartialToolCall, PartialToolCallContext> handler) {
         this.partialToolCallWithContextHandler = handler;
         this.onPartialToolCallWithContextInvoked++;
+        return this;
+    }
+
+    @Override
+    public TokenStream onStreamingHandle(Consumer<StreamingHandle> handler) {
+        this.streamingHandleHandler = handler;
+        this.onStreamingHandleInvoked++;
         return this;
     }
 
@@ -229,6 +239,7 @@ public class AiServiceTokenStream implements TokenStream {
                 partialThinkingWithContextHandler,
                 partialToolCallHandler,
                 partialToolCallWithContextHandler,
+                streamingHandleHandler,
                 beforeToolExecutionHandler,
                 rawEventHandler,
                 toolExecutionHandler,
@@ -269,6 +280,9 @@ public class AiServiceTokenStream implements TokenStream {
         if (onPartialToolCallInvoked + onPartialToolCallWithContextInvoked > 1) {
             throw new IllegalConfigurationException("One of [onPartialToolCall, onPartialToolCallWithContext] can be "
                     + "invoked on TokenStream at most 1 time");
+        }
+        if (onStreamingHandleInvoked > 1) {
+            throw new IllegalConfigurationException("onStreamingHandle can be invoked on TokenStream at most 1 time");
         }
         if (onIntermediateResponseInvoked > 1) {
             throw new IllegalConfigurationException(

--- a/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
@@ -9,6 +9,7 @@ import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.PartialThinkingContext;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCallContext;
+import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.service.tool.BeforeToolExecution;
@@ -121,6 +122,25 @@ public interface TokenStream {
     @Experimental
     default TokenStream onPartialToolCallWithContext(BiConsumer<PartialToolCall, PartialToolCallContext> handler) {
         throw new UnsupportedOperationException("not implemented");
+    }
+
+    /**
+     * The provided consumer will be invoked when a {@link StreamingHandle} becomes available.
+     * <p>
+     * This callback is independent from partial response, thinking and tool call callbacks and can be used together with
+     * any of them. It can be used to cancel the underlying streaming request without switching from a plain partial
+     * response callback to a context callback.
+     * <p>
+     * Please note that not all streaming model implementations provide a cancellable {@link StreamingHandle}.
+     * Implementations may ignore this callback when no streaming handle is available.
+     *
+     * @param handler lambda that consumes the streaming handle
+     * @return token stream instance used to configure or start stream processing
+     * @since 1.16.0
+     */
+    @Experimental
+    default TokenStream onStreamingHandle(Consumer<StreamingHandle> handler) {
+        return this;
     }
 
     /**

--- a/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/TokenStream.java
@@ -136,7 +136,7 @@ public interface TokenStream {
      *
      * @param handler lambda that consumes the streaming handle
      * @return token stream instance used to configure or start stream processing
-     * @since 1.16.0
+     * @since 1.20.0
      */
     @Experimental
     default TokenStream onStreamingHandle(Consumer<StreamingHandle> handler) {

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamStreamingHandleTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamStreamingHandleTest.java
@@ -75,6 +75,25 @@ class AiServiceTokenStreamStreamingHandleTest {
     }
 
     @Test
+    void should_reuse_observed_streaming_handle_for_partial_response_without_context() {
+        TestStreamingHandle streamingHandle = new TestStreamingHandle();
+
+        Assistant assistant = AiServices.create(Assistant.class, new MixedContextStreamingChatModel(streamingHandle));
+
+        List<StreamingHandle> contextStreamingHandles = new ArrayList<>();
+
+        assistant
+                .chat("Hello")
+                .onPartialResponseWithContext(
+                        (partialResponse, context) -> contextStreamingHandles.add(context.streamingHandle()))
+                .onCompleteResponse(ignored -> {})
+                .onError(error -> fail(error.getMessage()))
+                .start();
+
+        assertThat(contextStreamingHandles).containsExactly(streamingHandle, streamingHandle);
+    }
+
+    @Test
     void should_observe_streaming_handle_from_thinking_and_tool_call_contexts() {
         TestStreamingHandle streamingHandle = new TestStreamingHandle();
 
@@ -126,6 +145,17 @@ class AiServiceTokenStreamStreamingHandleTest {
                     new PartialToolCallContext(streamingHandle));
             handler.onCompleteResponse(
                     ChatResponse.builder().aiMessage(AiMessage.from("done")).build());
+        }
+    }
+
+    private record MixedContextStreamingChatModel(StreamingHandle streamingHandle) implements StreamingChatModel {
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            handler.onPartialResponse(new PartialResponse("hello"), new PartialResponseContext(streamingHandle));
+            handler.onPartialResponse("!");
+            handler.onCompleteResponse(
+                    ChatResponse.builder().aiMessage(AiMessage.from("hello!")).build());
         }
     }
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamStreamingHandleTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamStreamingHandleTest.java
@@ -1,0 +1,146 @@
+package dev.langchain4j.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialResponse;
+import dev.langchain4j.model.chat.response.PartialResponseContext;
+import dev.langchain4j.model.chat.response.PartialThinking;
+import dev.langchain4j.model.chat.response.PartialThinkingContext;
+import dev.langchain4j.model.chat.response.PartialToolCall;
+import dev.langchain4j.model.chat.response.PartialToolCallContext;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.StreamingHandle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class AiServiceTokenStreamStreamingHandleTest {
+
+    interface Assistant {
+
+        TokenStream chat(String userMessage);
+    }
+
+    @Test
+    void should_observe_streaming_handle_while_using_plain_partial_response_handler() {
+        TestStreamingHandle streamingHandle = new TestStreamingHandle();
+
+        Assistant assistant = AiServices.create(Assistant.class, new TestStreamingChatModel(streamingHandle));
+
+        List<String> partialResponses = new ArrayList<>();
+        AtomicReference<StreamingHandle> observedStreamingHandle = new AtomicReference<>();
+        AtomicReference<ChatResponse> completeResponse = new AtomicReference<>();
+
+        assistant
+                .chat("Hello")
+                .onStreamingHandle(observedStreamingHandle::set)
+                .onPartialResponse(partialResponses::add)
+                .onCompleteResponse(completeResponse::set)
+                .onError(error -> fail(error.getMessage()))
+                .start();
+
+        assertThat(observedStreamingHandle).hasValue(streamingHandle);
+        assertThat(partialResponses).containsExactly("hello", "!");
+        assertThat(completeResponse.get())
+                .isNotNull()
+                .extracting(response -> response.aiMessage().text())
+                .isEqualTo("hello!");
+    }
+
+    @Test
+    void should_observe_streaming_handle_only_once_for_the_same_handle() {
+        TestStreamingHandle streamingHandle = new TestStreamingHandle();
+
+        Assistant assistant = AiServices.create(Assistant.class, new TestStreamingChatModel(streamingHandle));
+
+        List<StreamingHandle> observedStreamingHandles = new ArrayList<>();
+        List<String> partialResponses = new ArrayList<>();
+
+        assistant
+                .chat("Hello")
+                .onStreamingHandle(observedStreamingHandles::add)
+                .onPartialResponse(partialResponses::add)
+                .onCompleteResponse(ignored -> {})
+                .onError(error -> fail(error.getMessage()))
+                .start();
+
+        assertThat(observedStreamingHandles).containsExactly(streamingHandle);
+        assertThat(partialResponses).containsExactly("hello", "!");
+    }
+
+    @Test
+    void should_observe_streaming_handle_from_thinking_and_tool_call_contexts() {
+        TestStreamingHandle streamingHandle = new TestStreamingHandle();
+
+        Assistant assistant =
+                AiServices.create(Assistant.class, new ThinkingAndToolCallStreamingChatModel(streamingHandle));
+
+        List<StreamingHandle> observedStreamingHandles = new ArrayList<>();
+        List<PartialThinking> partialThinkings = new ArrayList<>();
+        List<PartialToolCall> partialToolCalls = new ArrayList<>();
+
+        assistant
+                .chat("Hello")
+                .onStreamingHandle(observedStreamingHandles::add)
+                .onPartialThinking(partialThinkings::add)
+                .onPartialToolCall(partialToolCalls::add)
+                .onCompleteResponse(ignored -> {})
+                .onError(error -> fail(error.getMessage()))
+                .start();
+
+        assertThat(observedStreamingHandles).containsExactly(streamingHandle);
+        assertThat(partialThinkings).extracting(PartialThinking::text).containsExactly("thinking");
+        assertThat(partialToolCalls).extracting(PartialToolCall::name).containsExactly("search");
+    }
+
+    private record TestStreamingChatModel(StreamingHandle streamingHandle) implements StreamingChatModel {
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            handler.onPartialResponse(new PartialResponse("hello"), new PartialResponseContext(streamingHandle));
+            handler.onPartialResponse(new PartialResponse("!"), new PartialResponseContext(streamingHandle));
+            handler.onCompleteResponse(
+                    ChatResponse.builder().aiMessage(AiMessage.from("hello!")).build());
+        }
+    }
+
+    private record ThinkingAndToolCallStreamingChatModel(StreamingHandle streamingHandle)
+            implements StreamingChatModel {
+
+        @Override
+        public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+            handler.onPartialThinking(new PartialThinking("thinking"), new PartialThinkingContext(streamingHandle));
+            handler.onPartialToolCall(
+                    PartialToolCall.builder()
+                            .index(0)
+                            .id("tool-call-id")
+                            .name("search")
+                            .partialArguments("{")
+                            .build(),
+                    new PartialToolCallContext(streamingHandle));
+            handler.onCompleteResponse(
+                    ChatResponse.builder().aiMessage(AiMessage.from("done")).build());
+        }
+    }
+
+    private static class TestStreamingHandle implements StreamingHandle {
+
+        private boolean cancelled;
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamStreamingHandleTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamStreamingHandleTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.guardrail.OutputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrailRequest;
+import dev.langchain4j.guardrail.OutputGuardrailResult;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -51,6 +54,34 @@ class AiServiceTokenStreamStreamingHandleTest {
                 .isNotNull()
                 .extracting(response -> response.aiMessage().text())
                 .isEqualTo("hello!");
+    }
+
+    @Test
+    void should_observe_streaming_handle_before_output_guardrails_run() {
+        TestStreamingHandle streamingHandle = new TestStreamingHandle();
+        AtomicReference<StreamingHandle> observedStreamingHandle = new AtomicReference<>();
+        AtomicReference<StreamingHandle> streamingHandleSeenByGuardrail = new AtomicReference<>();
+        OutputGuardrail outputGuardrail = new OutputGuardrail() {
+            @Override
+            public OutputGuardrailResult validate(OutputGuardrailRequest request) {
+                streamingHandleSeenByGuardrail.set(observedStreamingHandle.get());
+                return OutputGuardrailResult.success();
+            }
+        };
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .streamingChatModel(new TestStreamingChatModel(streamingHandle))
+                .outputGuardrails(outputGuardrail)
+                .build();
+
+        assistant
+                .chat("Hello")
+                .onStreamingHandle(observedStreamingHandle::set)
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(ignored -> {})
+                .onError(error -> fail(error.getMessage()))
+                .start();
+
+        assertThat(streamingHandleSeenByGuardrail).hasValue(streamingHandle);
     }
 
     @Test

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServiceTokenStreamTest.java
@@ -22,6 +22,7 @@ import dev.langchain4j.model.chat.response.PartialThinkingContext;
 import dev.langchain4j.model.chat.response.PartialToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCallContext;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.service.tool.BeforeToolExecution;
 import dev.langchain4j.service.tool.ToolErrorHandlerResult;
@@ -57,6 +58,7 @@ class AiServiceTokenStreamTest {
     static Consumer<PartialToolCall> DUMMY_PARTIAL_TOOL_CALL_HANDLER = (partialToolCall) -> {};
     static BiConsumer<PartialToolCall, PartialToolCallContext> DUMMY_PARTIAL_TOOL_CALL_WITH_CONTEXT_HANDLER =
             (partialToolCall, partialToolCallContext) -> {};
+    static Consumer<StreamingHandle> DUMMY_STREAMING_HANDLE_HANDLER = (streamingHandle) -> {};
     static Consumer<Throwable> DUMMY_ERROR_HANDLER = (error) -> {};
     static Consumer<ChatResponse> DUMMY_CHAT_RESPONSE_HANDLER = (chatResponse) -> {};
     static Consumer<BeforeToolExecution> DUMMY_BEFORE_TOOL_EXECUTION_HANDLER = (beforeToolExecution) -> {};
@@ -283,6 +285,18 @@ class AiServiceTokenStreamTest {
         assertThatThrownBy(() -> tokenStream.start())
                 .isExactlyInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("onCompleteResponse can be invoked on TokenStream at most 1 time");
+    }
+
+    @Test
+    void start_onStreamingHandleInvokedMultipleTimes_shouldThrowException() {
+        tokenStream
+                .onStreamingHandle(DUMMY_STREAMING_HANDLE_HANDLER)
+                .onStreamingHandle(DUMMY_STREAMING_HANDLE_HANDLER)
+                .ignoreErrors();
+
+        assertThatThrownBy(() -> tokenStream.start())
+                .isExactlyInstanceOf(IllegalConfigurationException.class)
+                .hasMessage("onStreamingHandle can be invoked on TokenStream at most 1 time");
     }
 
     @Test


### PR DESCRIPTION
## Issue
Part of #5275

## Change
This PR adds an opt-in `TokenStream.onStreamingHandle(...)` callback so adapters can observe the existing `StreamingHandle` without changing the current plain token callback path.

The callback is a default no-op, so existing `TokenStream` implementations keep their current behavior unless they choose to expose a handle.

Changes included:
- add `TokenStream.onStreamingHandle(...)`;
- support the callback in `AiServiceTokenStream`;
- observe the handle in `AiServiceStreamingResponseHandler` from context-bearing partial response, thinking, and tool-call callbacks;
- preserve the existing `onPartialResponse(...)` token path;
- add tests for handle observation, duplicate callback registration, deduplication, and thinking/tool-call context propagation.

This is intended to support a companion `langchain4j-spring` PR that propagates Reactor `Flux` cancellation to `StreamingHandle.cancel()`.

## Verification
- [x] `./mvnw -pl langchain4j -Dtest=AiServiceTokenStreamStreamingHandleTest,AiServiceTokenStreamTest#start_onStreamingHandleInvokedMultipleTimes_shouldThrowException test`
- [x] `./mvnw -pl langchain4j -DskipTests install`
- [x] `mvn -Pspotless validate`
- [x] `git diff --check origin/main...HEAD`

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
