### PR TITLE
fix(azure): rely on Azure SDK BOM for cosmos dependency

### DIFF
--- a/langchain4j-azure-cosmos-nosql/pom.xml
+++ b/langchain4j-azure-cosmos-nosql/pom.xml
@@ -23,11 +23,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-core-http-netty</artifactId>
-                <version>1.16.2</version>
-            </dependency>
-            <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-core</artifactId>
                 <version>3.7.14</version>
@@ -35,7 +30,12 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.2.10</version>
+                <version>1.2.13</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hdrhistogram</groupId>
+                <artifactId>HdrHistogram</artifactId>
+                <version>2.2.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -275,12 +275,6 @@
                 <version>3.18.0</version>
             </dependency>
 
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-cosmos</artifactId>
-                <version>4.71.0-beta.1</version>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 
@@ -531,13 +525,6 @@
                     <groupId>org.revapi</groupId>
                     <artifactId>revapi-maven-plugin</artifactId>
                     <version>0.15.1</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.revapi</groupId>
-                            <artifactId>revapi-java</artifactId>
-                            <version>0.28.4</version>
-                        </dependency>
-                    </dependencies>
                     <configuration>
                         <oldVersion>RELEASE</oldVersion>
                         <analysisConfigurationFiles>
@@ -571,6 +558,13 @@
                             </revapi.differences>
                         </analysisConfiguration>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.revapi</groupId>
+                            <artifactId>revapi-java</artifactId>
+                            <version>0.28.4</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Fixes #5284

## Changes
- Remove the explicit `azure-cosmos` dependency management entry from `langchain4j-parent`, allowing `azure-sdk-bom` to manage the Cosmos SDK version.
- Remove the Cosmos NoSQL module override for `azure-core-http-netty`.
- Align Cosmos NoSQL dependency management for `reactor-netty-http` and `HdrHistogram` to keep dependency convergence passing with the BOM-managed Cosmos SDK.
- Apply Spotless ordering to the parent POM.

## Verification
- `xmllint --noout langchain4j-parent/pom.xml`
- `xmllint --noout langchain4j-azure-cosmos-nosql/pom.xml`
- `./mvnw -Pspotless -pl langchain4j-parent validate`
- `./mvnw -pl langchain4j-azure-cosmos-nosql -DskipTests validate`
- `./mvnw -pl langchain4j-azure-cosmos-nosql -DskipTests dependency:tree -Dincludes=com.azure:azure-cosmos`
- `./mvnw -Pspotless validate`