### PR TITLE
Add CosmosAsyncClient support to Azure Cosmos NoSQL store

### DIFF
--- a/langchain4j-azure-cosmos-nosql/revapi.json
+++ b/langchain4j-azure-cosmos-nosql/revapi.json
@@ -1,0 +1,20 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "ignore": true,
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class com.azure.cosmos.CosmosAsyncClient",
+          "classQualifiedName": "com.azure.cosmos.CosmosAsyncClient",
+          "classSimpleName": "CosmosAsyncClient",
+          "package": "com.azure.cosmos",
+          "elementKind": "class",
+          "justification": "CosmosAsyncClient is intentionally exposed on the public API of this module to allow callers to provide preconfigured Cosmos clients."
+        }
+      ]
+    }
+  }
+]

--- a/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/rag/content/retriever/azure/cosmos/nosql/AzureCosmosDBNoSqlContentRetriever.java
+++ b/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/rag/content/retriever/azure/cosmos/nosql/AzureCosmosDBNoSqlContentRetriever.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
 
 import com.azure.core.credential.AzureKeyCredential;
 import com.azure.core.credential.TokenCredential;
+import com.azure.cosmos.CosmosAsyncClient;
 import com.azure.cosmos.models.CosmosFullTextPolicy;
 import com.azure.cosmos.models.CosmosVectorEmbeddingPolicy;
 import com.azure.cosmos.models.IndexingPolicy;
@@ -34,17 +35,9 @@ public class AzureCosmosDBNoSqlContentRetriever extends AbstractAzureCosmosDBNoS
     private final Filter filter;
 
     public AzureCosmosDBNoSqlContentRetriever(Builder builder) {
-        ensureNotNull(builder.endpoint, "endpoint");
-        ensureTrue(
-                (builder.keyCredential != null && builder.tokenCredential == null)
-                        || (builder.keyCredential == null && builder.tokenCredential != null),
-                "either keyCredential or tokenCredential must be set");
-
-        if (builder.keyCredential != null) {
+        if (builder.cosmosAsyncClient != null) {
             this.initialize(
-                    builder.endpoint,
-                    builder.keyCredential,
-                    null,
+                    builder.cosmosAsyncClient,
                     builder.databaseName,
                     builder.containerName,
                     builder.partitionKeyPath,
@@ -55,9 +48,15 @@ public class AzureCosmosDBNoSqlContentRetriever extends AbstractAzureCosmosDBNoS
                     builder.azureCosmosDBSearchQueryType,
                     null);
         } else {
+            ensureNotNull(builder.endpoint, "endpoint");
+            ensureTrue(
+                    (builder.keyCredential != null && builder.tokenCredential == null)
+                            || (builder.keyCredential == null && builder.tokenCredential != null),
+                    "either keyCredential or tokenCredential must be set");
+
             this.initialize(
                     builder.endpoint,
-                    null,
+                    builder.keyCredential,
                     builder.tokenCredential,
                     builder.databaseName,
                     builder.containerName,
@@ -209,6 +208,7 @@ public class AzureCosmosDBNoSqlContentRetriever extends AbstractAzureCosmosDBNoS
     }
 
     public static class Builder {
+        private CosmosAsyncClient cosmosAsyncClient;
         private String endpoint;
         private AzureKeyCredential keyCredential;
         private TokenCredential tokenCredential;
@@ -224,6 +224,19 @@ public class AzureCosmosDBNoSqlContentRetriever extends AbstractAzureCosmosDBNoS
         private Integer maxResults;
         private Double minScore;
         private Filter filter;
+
+        /**
+         * Sets the {@link CosmosAsyncClient}.
+         * The provided client remains caller-owned and is not closed by this retriever.
+         * When configured, this client takes precedence over endpoint and credentials.
+         *
+         * @param cosmosAsyncClient the Azure Cosmos DB async client.
+         * @return builder
+         */
+        public Builder cosmosAsyncClient(CosmosAsyncClient cosmosAsyncClient) {
+            this.cosmosAsyncClient = cosmosAsyncClient;
+            return this;
+        }
 
         public Builder endpoint(String endpoint) {
             this.endpoint = endpoint;

--- a/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AbstractAzureCosmosDBNoSqlEmbeddingStore.java
+++ b/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AbstractAzureCosmosDBNoSqlEmbeddingStore.java
@@ -67,6 +67,7 @@ public class AbstractAzureCosmosDBNoSqlEmbeddingStore implements EmbeddingStore<
     private static final Logger logger = LoggerFactory.getLogger(AbstractAzureCosmosDBNoSqlEmbeddingStore.class);
     protected AzureCosmosDBNoSqlFilterMapper filterMapper;
     private CosmosAsyncClient cosmosClient;
+    private boolean closeCosmosClient;
     private String databaseName;
     private String containerName;
     private String partitionKeyPath;
@@ -92,20 +93,16 @@ public class AbstractAzureCosmosDBNoSqlEmbeddingStore implements EmbeddingStore<
             AzureCosmosDBNoSqlFilterMapper filterMapper) {
         ensureNotNull(endpoint, "%s", "endpoint cannot be null or empty for Azure CosmosDB NoSql Embedding Store.");
 
-        if (filterMapper == null) {
-            this.filterMapper = new DefaultAzureCosmosDBNoSqlFilterMapper();
-        } else {
-            this.filterMapper = filterMapper;
-        }
+        CosmosAsyncClient cosmosClient;
         try {
             if (keyCredential != null) {
-                this.cosmosClient = new CosmosClientBuilder()
+                cosmosClient = new CosmosClientBuilder()
                         .endpoint(endpoint)
                         .credential(keyCredential)
                         .userAgentSuffix(USER_AGENT)
                         .buildAsyncClient();
             } else {
-                this.cosmosClient = new CosmosClientBuilder()
+                cosmosClient = new CosmosClientBuilder()
                         .endpoint(endpoint)
                         .credential(tokenCredential)
                         .userAgentSuffix(USER_AGENT)
@@ -114,6 +111,65 @@ public class AbstractAzureCosmosDBNoSqlEmbeddingStore implements EmbeddingStore<
 
         } catch (Exception e) {
             throw new RuntimeException("Error creating cosmosClient: {}", e);
+        }
+
+        initialize(
+                cosmosClient,
+                databaseName,
+                containerName,
+                partitionKeyPath,
+                indexingPolicy,
+                cosmosVectorEmbeddingPolicy,
+                cosmosFullTextPolicy,
+                vectorStoreThroughput,
+                searchQueryType,
+                filterMapper,
+                true);
+    }
+
+    protected void initialize(
+            CosmosAsyncClient cosmosClient,
+            String databaseName,
+            String containerName,
+            String partitionKeyPath,
+            IndexingPolicy indexingPolicy,
+            CosmosVectorEmbeddingPolicy cosmosVectorEmbeddingPolicy,
+            CosmosFullTextPolicy cosmosFullTextPolicy,
+            Integer vectorStoreThroughput,
+            AzureCosmosDBSearchQueryType searchQueryType,
+            AzureCosmosDBNoSqlFilterMapper filterMapper) {
+        initialize(
+                cosmosClient,
+                databaseName,
+                containerName,
+                partitionKeyPath,
+                indexingPolicy,
+                cosmosVectorEmbeddingPolicy,
+                cosmosFullTextPolicy,
+                vectorStoreThroughput,
+                searchQueryType,
+                filterMapper,
+                false);
+    }
+
+    private void initialize(
+            CosmosAsyncClient cosmosClient,
+            String databaseName,
+            String containerName,
+            String partitionKeyPath,
+            IndexingPolicy indexingPolicy,
+            CosmosVectorEmbeddingPolicy cosmosVectorEmbeddingPolicy,
+            CosmosFullTextPolicy cosmosFullTextPolicy,
+            Integer vectorStoreThroughput,
+            AzureCosmosDBSearchQueryType searchQueryType,
+            AzureCosmosDBNoSqlFilterMapper filterMapper,
+            boolean closeCosmosClient) {
+        this.cosmosClient = ensureNotNull(cosmosClient, "cosmosClient");
+        this.closeCosmosClient = closeCosmosClient;
+        if (filterMapper == null) {
+            this.filterMapper = new DefaultAzureCosmosDBNoSqlFilterMapper();
+        } else {
+            this.filterMapper = filterMapper;
         }
 
         this.databaseName = getOrDefault(databaseName, DEFAULT_DATABASE_NAME);
@@ -536,11 +592,11 @@ public class AbstractAzureCosmosDBNoSqlEmbeddingStore implements EmbeddingStore<
     }
 
     /**
-     * Closes the CosmosDB client and releases resources.
-     * This method should be called when the store is no longer needed to prevent resource leaks.
+     * Closes the CosmosDB client created by this store and releases resources.
+     * Caller-provided clients remain caller-owned and are not closed by this method.
      */
     public void close() {
-        if (this.cosmosClient != null) {
+        if (this.closeCosmosClient && this.cosmosClient != null) {
             this.cosmosClient.close();
         }
     }

--- a/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AzureCosmosDbNoSqlEmbeddingStore.java
+++ b/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AzureCosmosDbNoSqlEmbeddingStore.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
 
 import com.azure.core.credential.AzureKeyCredential;
 import com.azure.core.credential.TokenCredential;
+import com.azure.cosmos.CosmosAsyncClient;
 import com.azure.cosmos.models.CosmosFullTextPolicy;
 import com.azure.cosmos.models.CosmosVectorEmbeddingPolicy;
 import com.azure.cosmos.models.IndexingPolicy;
@@ -76,11 +77,36 @@ public class AzureCosmosDbNoSqlEmbeddingStore extends AbstractAzureCosmosDBNoSql
                 filterMapper);
     }
 
+    public AzureCosmosDbNoSqlEmbeddingStore(
+            CosmosAsyncClient cosmosAsyncClient,
+            String databaseName,
+            String containerName,
+            String partitionKeyPath,
+            IndexingPolicy indexingPolicy,
+            CosmosVectorEmbeddingPolicy cosmosVectorEmbeddingPolicy,
+            CosmosFullTextPolicy cosmosFullTextPolicy,
+            Integer vectorStoreThroughput,
+            AzureCosmosDBSearchQueryType azureCosmosDBSearchQueryType,
+            AzureCosmosDBNoSqlFilterMapper filterMapper) {
+        this.initialize(
+                cosmosAsyncClient,
+                databaseName,
+                containerName,
+                partitionKeyPath,
+                indexingPolicy,
+                cosmosVectorEmbeddingPolicy,
+                cosmosFullTextPolicy,
+                vectorStoreThroughput,
+                azureCosmosDBSearchQueryType,
+                filterMapper);
+    }
+
     public static Builder builder() {
         return new Builder();
     }
 
     public static class Builder {
+        private CosmosAsyncClient cosmosAsyncClient;
         private String endpoint;
         private TokenCredential tokenCredential;
         private AzureKeyCredential keyCredential;
@@ -95,6 +121,19 @@ public class AzureCosmosDbNoSqlEmbeddingStore extends AbstractAzureCosmosDBNoSql
         private AzureCosmosDBNoSqlFilterMapper filterMapper;
 
         /**
+         * Sets the {@link CosmosAsyncClient}.
+         * The provided client remains caller-owned and is not closed by this store.
+         * When configured, this client takes precedence over endpoint and credentials.
+         *
+         * @param cosmosAsyncClient the Azure Cosmos DB async client.
+         * @return builder
+         */
+        public Builder cosmosAsyncClient(CosmosAsyncClient cosmosAsyncClient) {
+            this.cosmosAsyncClient = cosmosAsyncClient;
+            return this;
+        }
+
+        /**
          * Sets the Cosmos DB endpoint.
          *
          * @param endpoint the Cosmos DB endpoint
@@ -106,9 +145,9 @@ public class AzureCosmosDbNoSqlEmbeddingStore extends AbstractAzureCosmosDBNoSql
         }
 
         /**
-         * Sets the Azure AI Search API key.
+         * Sets the Azure Cosmos DB API key.
          *
-         * @param apiKey The Azure AI Search API key.
+         * @param apiKey the Azure Cosmos DB API key.
          * @return builder
          */
         public Builder apiKey(String apiKey) {
@@ -117,9 +156,9 @@ public class AzureCosmosDbNoSqlEmbeddingStore extends AbstractAzureCosmosDBNoSql
         }
 
         /**
-         * Used to authenticate to Azure OpenAI with Azure Active Directory credentials.
+         * Used to authenticate to Azure Cosmos DB with Azure Active Directory credentials.
          *
-         * @param tokenCredential the credentials to authenticate with Azure Active Directory
+         * @param tokenCredential the credentials to authenticate with Azure Active Directory.
          * @return builder
          */
         public Builder tokenCredential(TokenCredential tokenCredential) {
@@ -190,6 +229,20 @@ public class AzureCosmosDbNoSqlEmbeddingStore extends AbstractAzureCosmosDBNoSql
          * @return a new AzureCosmosDbNoSqlEmbeddingStore instance
          */
         public AzureCosmosDbNoSqlEmbeddingStore build() {
+            if (cosmosAsyncClient != null) {
+                return new AzureCosmosDbNoSqlEmbeddingStore(
+                        this.cosmosAsyncClient,
+                        this.databaseName,
+                        this.containerName,
+                        this.partitionKeyPath,
+                        this.indexingPolicy,
+                        this.cosmosVectorEmbeddingPolicy,
+                        this.cosmosFullTextPolicy,
+                        this.vectorStoreThroughput,
+                        this.searchQueryType,
+                        this.filterMapper);
+            }
+
             ensureNotNull(endpoint, "endpoint");
             ensureTrue(
                     keyCredential != null || tokenCredential != null, "either apiKey or tokenCredential must be set");

--- a/langchain4j-azure-cosmos-nosql/src/test/java/dev/langchain4j/rag/content/retriever/azure/cosmos/nosql/AzureCosmosDBNoSqlContentRetrieverBuilderTest.java
+++ b/langchain4j-azure-cosmos-nosql/src/test/java/dev/langchain4j/rag/content/retriever/azure/cosmos/nosql/AzureCosmosDBNoSqlContentRetrieverBuilderTest.java
@@ -1,0 +1,187 @@
+package dev.langchain4j.rag.content.retriever.azure.cosmos.nosql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.cosmos.CosmosAsyncClient;
+import com.azure.cosmos.CosmosAsyncContainer;
+import com.azure.cosmos.CosmosAsyncDatabase;
+import com.azure.cosmos.models.CosmosContainerProperties;
+import com.azure.cosmos.models.CosmosVectorDataType;
+import com.azure.cosmos.models.CosmosVectorDistanceFunction;
+import com.azure.cosmos.models.CosmosVectorEmbedding;
+import com.azure.cosmos.models.CosmosVectorEmbeddingPolicy;
+import com.azure.cosmos.models.CosmosVectorIndexSpec;
+import com.azure.cosmos.models.CosmosVectorIndexType;
+import com.azure.cosmos.models.IncludedPath;
+import com.azure.cosmos.models.IndexingMode;
+import com.azure.cosmos.models.IndexingPolicy;
+import com.azure.cosmos.models.ThroughputProperties;
+import dev.langchain4j.store.embedding.azure.cosmos.nosql.AzureCosmosDBSearchQueryType;
+import dev.langchain4j.store.embedding.azure.cosmos.nosql.TestEmbeddingModel;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+class AzureCosmosDBNoSqlContentRetrieverBuilderTest {
+
+    private static final String DATABASE_NAME = "test_database_langchain_java";
+    private static final String CONTAINER_NAME = "test_retriever_container";
+
+    @Test
+    void should_build_with_cosmos_async_client_without_endpoint_or_credentials() {
+        CosmosAsyncClient cosmosAsyncClient = mockCosmosAsyncClient();
+
+        AzureCosmosDBNoSqlContentRetriever contentRetriever = AzureCosmosDBNoSqlContentRetriever.builder()
+                .cosmosAsyncClient(cosmosAsyncClient)
+                .embeddingModel(new TestEmbeddingModel())
+                .databaseName(DATABASE_NAME)
+                .containerName(CONTAINER_NAME)
+                .indexingPolicy(getIndexingPolicy())
+                .cosmosVectorEmbeddingPolicy(getCosmosVectorEmbeddingPolicy())
+                .searchQueryType(AzureCosmosDBSearchQueryType.VECTOR)
+                .maxResults(10)
+                .minScore(0.0)
+                .build();
+
+        assertThat(contentRetriever).isNotNull();
+        verify(cosmosAsyncClient).createDatabaseIfNotExists(DATABASE_NAME);
+    }
+
+    @Test
+    void should_prefer_cosmos_async_client_over_endpoint_and_credentials() {
+        CosmosAsyncClient cosmosAsyncClient = mockCosmosAsyncClient();
+
+        AzureCosmosDBNoSqlContentRetriever contentRetriever = AzureCosmosDBNoSqlContentRetriever.builder()
+                .cosmosAsyncClient(cosmosAsyncClient)
+                .endpoint("ignored")
+                .apiKey("ignored")
+                .tokenCredential(mock(TokenCredential.class))
+                .embeddingModel(new TestEmbeddingModel())
+                .databaseName(DATABASE_NAME)
+                .containerName(CONTAINER_NAME)
+                .indexingPolicy(getIndexingPolicy())
+                .cosmosVectorEmbeddingPolicy(getCosmosVectorEmbeddingPolicy())
+                .searchQueryType(AzureCosmosDBSearchQueryType.VECTOR)
+                .maxResults(10)
+                .minScore(0.0)
+                .build();
+
+        assertThat(contentRetriever).isNotNull();
+        verify(cosmosAsyncClient).createDatabaseIfNotExists(DATABASE_NAME);
+    }
+
+    @Test
+    void should_not_close_provided_cosmos_async_client() {
+        CosmosAsyncClient cosmosAsyncClient = mockCosmosAsyncClient();
+
+        AzureCosmosDBNoSqlContentRetriever contentRetriever = AzureCosmosDBNoSqlContentRetriever.builder()
+                .cosmosAsyncClient(cosmosAsyncClient)
+                .embeddingModel(new TestEmbeddingModel())
+                .databaseName(DATABASE_NAME)
+                .containerName(CONTAINER_NAME)
+                .indexingPolicy(getIndexingPolicy())
+                .cosmosVectorEmbeddingPolicy(getCosmosVectorEmbeddingPolicy())
+                .searchQueryType(AzureCosmosDBSearchQueryType.VECTOR)
+                .maxResults(10)
+                .minScore(0.0)
+                .build();
+
+        contentRetriever.close();
+
+        verify(cosmosAsyncClient, never()).close();
+    }
+
+    @Test
+    void should_still_require_endpoint_when_cosmos_async_client_is_not_provided() {
+        assertThatThrownBy(() -> AzureCosmosDBNoSqlContentRetriever.builder()
+                        .embeddingModel(new TestEmbeddingModel())
+                        .indexingPolicy(getIndexingPolicy())
+                        .cosmosVectorEmbeddingPolicy(getCosmosVectorEmbeddingPolicy())
+                        .searchQueryType(AzureCosmosDBSearchQueryType.VECTOR)
+                        .maxResults(10)
+                        .minScore(0.0)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("endpoint cannot be null");
+    }
+
+    @Test
+    void should_still_require_credentials_when_cosmos_async_client_is_not_provided() {
+        assertThatThrownBy(() -> AzureCosmosDBNoSqlContentRetriever.builder()
+                        .endpoint("https://example.documents.azure.com:443/")
+                        .embeddingModel(new TestEmbeddingModel())
+                        .indexingPolicy(getIndexingPolicy())
+                        .cosmosVectorEmbeddingPolicy(getCosmosVectorEmbeddingPolicy())
+                        .searchQueryType(AzureCosmosDBSearchQueryType.VECTOR)
+                        .maxResults(10)
+                        .minScore(0.0)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("either keyCredential or tokenCredential must be set");
+    }
+
+    @Test
+    void should_still_reject_both_credentials_when_cosmos_async_client_is_not_provided() {
+        assertThatThrownBy(() -> AzureCosmosDBNoSqlContentRetriever.builder()
+                        .endpoint("https://example.documents.azure.com:443/")
+                        .apiKey("api-key")
+                        .tokenCredential(mock(TokenCredential.class))
+                        .embeddingModel(new TestEmbeddingModel())
+                        .indexingPolicy(getIndexingPolicy())
+                        .cosmosVectorEmbeddingPolicy(getCosmosVectorEmbeddingPolicy())
+                        .searchQueryType(AzureCosmosDBSearchQueryType.VECTOR)
+                        .maxResults(10)
+                        .minScore(0.0)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("either keyCredential or tokenCredential must be set");
+    }
+
+    private static CosmosAsyncClient mockCosmosAsyncClient() {
+        CosmosAsyncClient cosmosAsyncClient = mock(CosmosAsyncClient.class);
+        CosmosAsyncDatabase cosmosAsyncDatabase = mock(CosmosAsyncDatabase.class);
+        CosmosAsyncContainer cosmosAsyncContainer = mock(CosmosAsyncContainer.class);
+
+        when(cosmosAsyncClient.createDatabaseIfNotExists(DATABASE_NAME)).thenReturn(Mono.empty());
+        when(cosmosAsyncClient.getDatabase(DATABASE_NAME)).thenReturn(cosmosAsyncDatabase);
+        when(cosmosAsyncDatabase.createContainerIfNotExists(
+                        any(CosmosContainerProperties.class), any(ThroughputProperties.class)))
+                .thenReturn(Mono.empty());
+        when(cosmosAsyncDatabase.getContainer(CONTAINER_NAME)).thenReturn(cosmosAsyncContainer);
+
+        return cosmosAsyncClient;
+    }
+
+    private static IndexingPolicy getIndexingPolicy() {
+        IndexingPolicy indexingPolicy = new IndexingPolicy();
+        indexingPolicy.setIndexingMode(IndexingMode.CONSISTENT);
+        IncludedPath includedPath = new IncludedPath("/*");
+        indexingPolicy.setIncludedPaths(Collections.singletonList(includedPath));
+
+        CosmosVectorIndexSpec cosmosVectorIndexSpec = new CosmosVectorIndexSpec();
+        cosmosVectorIndexSpec.setPath("/embedding");
+        cosmosVectorIndexSpec.setType(CosmosVectorIndexType.DISK_ANN.toString());
+        indexingPolicy.setVectorIndexes(Collections.singletonList(cosmosVectorIndexSpec));
+
+        return indexingPolicy;
+    }
+
+    private static CosmosVectorEmbeddingPolicy getCosmosVectorEmbeddingPolicy() {
+        CosmosVectorEmbeddingPolicy vectorEmbeddingPolicy = new CosmosVectorEmbeddingPolicy();
+        CosmosVectorEmbedding embedding = new CosmosVectorEmbedding();
+        embedding.setPath("/embedding");
+        embedding.setDataType(CosmosVectorDataType.FLOAT32);
+        embedding.setEmbeddingDimensions(1536);
+        embedding.setDistanceFunction(CosmosVectorDistanceFunction.COSINE);
+        vectorEmbeddingPolicy.setCosmosVectorEmbeddings(List.of(embedding));
+        return vectorEmbeddingPolicy;
+    }
+}

--- a/langchain4j-azure-cosmos-nosql/src/test/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AzureCosmosDbNoSqlEmbeddingStoreBuilderTest.java
+++ b/langchain4j-azure-cosmos-nosql/src/test/java/dev/langchain4j/store/embedding/azure/cosmos/nosql/AzureCosmosDbNoSqlEmbeddingStoreBuilderTest.java
@@ -1,0 +1,148 @@
+package dev.langchain4j.store.embedding.azure.cosmos.nosql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.cosmos.CosmosAsyncClient;
+import com.azure.cosmos.CosmosAsyncContainer;
+import com.azure.cosmos.CosmosAsyncDatabase;
+import com.azure.cosmos.models.CosmosContainerProperties;
+import com.azure.cosmos.models.CosmosVectorDataType;
+import com.azure.cosmos.models.CosmosVectorDistanceFunction;
+import com.azure.cosmos.models.CosmosVectorEmbedding;
+import com.azure.cosmos.models.CosmosVectorEmbeddingPolicy;
+import com.azure.cosmos.models.CosmosVectorIndexSpec;
+import com.azure.cosmos.models.CosmosVectorIndexType;
+import com.azure.cosmos.models.IncludedPath;
+import com.azure.cosmos.models.IndexingMode;
+import com.azure.cosmos.models.IndexingPolicy;
+import com.azure.cosmos.models.ThroughputProperties;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+class AzureCosmosDbNoSqlEmbeddingStoreBuilderTest {
+
+    private static final String DATABASE_NAME = "test_database_langchain_java";
+    private static final String CONTAINER_NAME = "test_embedding_container";
+
+    @Test
+    void should_build_with_cosmos_async_client_without_endpoint_or_credentials() {
+        CosmosAsyncClient cosmosAsyncClient = mockCosmosAsyncClient();
+
+        AzureCosmosDbNoSqlEmbeddingStore store = AzureCosmosDbNoSqlEmbeddingStore.builder()
+                .cosmosAsyncClient(cosmosAsyncClient)
+                .databaseName(DATABASE_NAME)
+                .containerName(CONTAINER_NAME)
+                .indexingPolicy(getIndexingPolicy())
+                .cosmosVectorEmbeddingPolicy(getCosmosVectorEmbeddingPolicy())
+                .build();
+
+        assertThat(store).isNotNull();
+        verify(cosmosAsyncClient).createDatabaseIfNotExists(DATABASE_NAME);
+    }
+
+    @Test
+    void should_prefer_cosmos_async_client_over_endpoint_and_credentials() {
+        CosmosAsyncClient cosmosAsyncClient = mockCosmosAsyncClient();
+
+        AzureCosmosDbNoSqlEmbeddingStore store = AzureCosmosDbNoSqlEmbeddingStore.builder()
+                .cosmosAsyncClient(cosmosAsyncClient)
+                .endpoint("ignored")
+                .apiKey("ignored")
+                .tokenCredential(mock(TokenCredential.class))
+                .databaseName(DATABASE_NAME)
+                .containerName(CONTAINER_NAME)
+                .indexingPolicy(getIndexingPolicy())
+                .cosmosVectorEmbeddingPolicy(getCosmosVectorEmbeddingPolicy())
+                .build();
+
+        assertThat(store).isNotNull();
+        verify(cosmosAsyncClient).createDatabaseIfNotExists(DATABASE_NAME);
+    }
+
+    @Test
+    void should_not_close_provided_cosmos_async_client() {
+        CosmosAsyncClient cosmosAsyncClient = mockCosmosAsyncClient();
+
+        AzureCosmosDbNoSqlEmbeddingStore store = AzureCosmosDbNoSqlEmbeddingStore.builder()
+                .cosmosAsyncClient(cosmosAsyncClient)
+                .databaseName(DATABASE_NAME)
+                .containerName(CONTAINER_NAME)
+                .indexingPolicy(getIndexingPolicy())
+                .cosmosVectorEmbeddingPolicy(getCosmosVectorEmbeddingPolicy())
+                .build();
+
+        store.close();
+
+        verify(cosmosAsyncClient, never()).close();
+    }
+
+    @Test
+    void should_still_require_endpoint_when_cosmos_async_client_is_not_provided() {
+        assertThatThrownBy(() -> AzureCosmosDbNoSqlEmbeddingStore.builder()
+                        .indexingPolicy(getIndexingPolicy())
+                        .cosmosVectorEmbeddingPolicy(getCosmosVectorEmbeddingPolicy())
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("endpoint cannot be null");
+    }
+
+    @Test
+    void should_still_require_credentials_when_cosmos_async_client_is_not_provided() {
+        assertThatThrownBy(() -> AzureCosmosDbNoSqlEmbeddingStore.builder()
+                        .endpoint("https://example.documents.azure.com:443/")
+                        .indexingPolicy(getIndexingPolicy())
+                        .cosmosVectorEmbeddingPolicy(getCosmosVectorEmbeddingPolicy())
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("either apiKey or tokenCredential must be set");
+    }
+
+    private static CosmosAsyncClient mockCosmosAsyncClient() {
+        CosmosAsyncClient cosmosAsyncClient = mock(CosmosAsyncClient.class);
+        CosmosAsyncDatabase cosmosAsyncDatabase = mock(CosmosAsyncDatabase.class);
+        CosmosAsyncContainer cosmosAsyncContainer = mock(CosmosAsyncContainer.class);
+
+        when(cosmosAsyncClient.createDatabaseIfNotExists(DATABASE_NAME)).thenReturn(Mono.empty());
+        when(cosmosAsyncClient.getDatabase(DATABASE_NAME)).thenReturn(cosmosAsyncDatabase);
+        when(cosmosAsyncDatabase.createContainerIfNotExists(
+                        any(CosmosContainerProperties.class), any(ThroughputProperties.class)))
+                .thenReturn(Mono.empty());
+        when(cosmosAsyncDatabase.getContainer(CONTAINER_NAME)).thenReturn(cosmosAsyncContainer);
+
+        return cosmosAsyncClient;
+    }
+
+    private static IndexingPolicy getIndexingPolicy() {
+        IndexingPolicy indexingPolicy = new IndexingPolicy();
+        indexingPolicy.setIndexingMode(IndexingMode.CONSISTENT);
+        IncludedPath includedPath = new IncludedPath("/*");
+        indexingPolicy.setIncludedPaths(Collections.singletonList(includedPath));
+
+        CosmosVectorIndexSpec cosmosVectorIndexSpec = new CosmosVectorIndexSpec();
+        cosmosVectorIndexSpec.setPath("/embedding");
+        cosmosVectorIndexSpec.setType(CosmosVectorIndexType.DISK_ANN.toString());
+        indexingPolicy.setVectorIndexes(Collections.singletonList(cosmosVectorIndexSpec));
+
+        return indexingPolicy;
+    }
+
+    private static CosmosVectorEmbeddingPolicy getCosmosVectorEmbeddingPolicy() {
+        CosmosVectorEmbeddingPolicy vectorEmbeddingPolicy = new CosmosVectorEmbeddingPolicy();
+        CosmosVectorEmbedding embedding = new CosmosVectorEmbedding();
+        embedding.setPath("/embedding");
+        embedding.setDataType(CosmosVectorDataType.FLOAT32);
+        embedding.setEmbeddingDimensions(1536);
+        embedding.setDistanceFunction(CosmosVectorDistanceFunction.COSINE);
+        vectorEmbeddingPolicy.setCosmosVectorEmbeddings(List.of(embedding));
+        return vectorEmbeddingPolicy;
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5304

## Change
- Add an opt-in `CosmosAsyncClient` builder path for `AzureCosmosDbNoSqlEmbeddingStore` and `AzureCosmosDBNoSqlContentRetriever`.
- Keep the existing endpoint/credential path unchanged for backwards compatibility.
- Make client ownership explicit: internally created clients are still closed by `close()`, while caller-provided clients remain caller-owned.
- Add focused builder tests covering provided-client construction, precedence over endpoint/credentials, lifecycle ownership, and existing validation behavior.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

## Verification
- `./mvnw -pl langchain4j-azure-cosmos-nosql -DskipITs test` (39 tests, 0 failures, 0 errors, 6 skipped)
- `git diff --check`
- `./mvnw -pl langchain4j-azure-cosmos-nosql spotless:check` (verified in a normal clone because Spotless/JGit does not resolve this linked worktree's `.git` file layout)
