### PR TITLE
fix: preserve Google AI Gemini tool call ids

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FunctionMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/FunctionMapper.java
@@ -70,6 +70,7 @@ class FunctionMapper {
     static List<ToolExecutionRequest> toToolExecutionRequests(List<GeminiFunctionCall> functionCalls) {
         return functionCalls.stream()
                 .map(functionCall -> ToolExecutionRequest.builder()
+                        .id(functionCall.id())
                         .name(functionCall.name())
                         .arguments(toJsonWithoutIndent(functionCall.args()))
                         .build())

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiContent.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiContent.java
@@ -131,11 +131,13 @@ record GeminiContent(
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         record GeminiFunctionCall(
+                @JsonProperty("id") String id,
                 @JsonProperty("name") String name,
                 @JsonProperty("args") Map<String, Object> args) {}
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         record GeminiFunctionResponse(
+                @JsonProperty("id") String id,
                 @JsonProperty("name") String name,
                 @JsonProperty("response") Map<String, String> response) {}
 

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
@@ -365,23 +365,28 @@ final class PartsAndContentsMapper {
                                         toolParts.add(fromContentToGPart(imageContent, mediaResolutionPerPartEnabled));
                                     } else {
                                         throw new UnsupportedFeatureException(
-                                                "Google AI Gemini does not support content type '"
-                                                        + content.type() + "' in tool results.");
+                                                "Google AI Gemini does not support content type '" + content.type()
+                                                        + "' in tool results.");
                                     }
                                 }
                                 if (responseMap.isEmpty()) {
                                     responseMap.put("response", "");
                                 }
-                                toolParts.add(0, GeminiContent.GeminiPart.builder()
-                                        .functionResponse(new GeminiFunctionResponse(
-                                                toolResultMessage.toolName(), responseMap))
-                                        .build());
+                                toolParts.add(
+                                        0,
+                                        GeminiContent.GeminiPart.builder()
+                                                .functionResponse(new GeminiFunctionResponse(
+                                                        toolResultMessage.id(),
+                                                        toolResultMessage.toolName(),
+                                                        responseMap))
+                                                .build());
                                 return new GeminiContent(toolParts, GeminiRole.USER.toString());
                             }
 
                             return new GeminiContent(
                                     List.of(GeminiContent.GeminiPart.builder()
                                             .functionResponse(new GeminiFunctionResponse(
+                                                    toolResultMessage.id(),
                                                     toolResultMessage.toolName(),
                                                     Map.of("response", toolResultMessage.text())))
                                             .build()),
@@ -422,7 +427,9 @@ final class PartsAndContentsMapper {
             boolean shouldAddThoughtSignature = i == 0 && isNotNullOrEmpty(thoughtSignature);
             GeminiContent.GeminiPart geminiPart = GeminiContent.GeminiPart.builder()
                     .functionCall(new GeminiFunctionCall(
-                            toolExecutionRequest.name(), fromJson(toolExecutionRequest.arguments(), Map.class)))
+                            toolExecutionRequest.id(),
+                            toolExecutionRequest.name(),
+                            fromJson(toolExecutionRequest.arguments(), Map.class)))
                     .thoughtSignature(shouldAddThoughtSignature ? thoughtSignature : null)
                     .build();
             geminiParts.add(geminiPart);

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/PartsAndContentsMapperTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/PartsAndContentsMapperTest.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.googleai;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.audio.Audio;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
@@ -10,6 +11,8 @@ import dev.langchain4j.data.message.AudioContent;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.PdfFileContent;
 import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.message.VideoContent;
 import dev.langchain4j.data.pdf.PdfFile;
@@ -105,6 +108,182 @@ class PartsAndContentsMapperTest {
         assertThat(result.thinking()).isNull();
         assertThat(result.toolExecutionRequests()).isEmpty();
         assertThat(result.attributes()).isEmpty();
+    }
+
+    @Test
+    void fromGPartsToAiMessage_preservesFunctionCallId() {
+        // Given
+        String json = """
+                {
+                  "candidates": [
+                    {
+                      "content": {
+                        "role": "model",
+                        "parts": [
+                          {
+                            "functionCall": {
+                              "id": "call-1",
+                              "name": "stringLength",
+                              "args": {
+                                "s": "hello"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """;
+        GeminiGenerateContentResponse response = Json.fromJson(json, GeminiGenerateContentResponse.class);
+        List<GeminiContent.GeminiPart> parts =
+                response.candidates().get(0).content().parts();
+
+        // When
+        AiMessage result = PartsAndContentsMapper.fromGPartsToAiMessage(parts, false, null);
+
+        // Then
+        assertThat(result.toolExecutionRequests()).hasSize(1);
+        ToolExecutionRequest toolExecutionRequest =
+                result.toolExecutionRequests().get(0);
+        assertThat(toolExecutionRequest.id()).isEqualTo("call-1");
+        assertThat(toolExecutionRequest.name()).isEqualTo("stringLength");
+        assertThat(toolExecutionRequest.arguments()).isEqualTo("{\"s\":\"hello\"}");
+    }
+
+    @Test
+    void fromGPartsToAiMessage_doesNotGenerateFunctionCallIdWhenMissing() {
+        // Given
+        String json = """
+                {
+                  "candidates": [
+                    {
+                      "content": {
+                        "role": "model",
+                        "parts": [
+                          {
+                            "functionCall": {
+                              "name": "stringLength",
+                              "args": {
+                                "s": "hello"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """;
+        GeminiGenerateContentResponse response = Json.fromJson(json, GeminiGenerateContentResponse.class);
+        List<GeminiContent.GeminiPart> parts =
+                response.candidates().get(0).content().parts();
+
+        // When
+        AiMessage result = PartsAndContentsMapper.fromGPartsToAiMessage(parts, false, null);
+
+        // Then
+        assertThat(result.toolExecutionRequests()).hasSize(1);
+        ToolExecutionRequest toolExecutionRequest =
+                result.toolExecutionRequests().get(0);
+        assertThat(toolExecutionRequest.id()).isNull();
+        assertThat(toolExecutionRequest.name()).isEqualTo("stringLength");
+        assertThat(toolExecutionRequest.arguments()).isEqualTo("{\"s\":\"hello\"}");
+    }
+
+    @Test
+    void fromMessageToGContent_preservesToolExecutionRequestId() {
+        // Given
+        ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
+                .id("call-1")
+                .name("stringLength")
+                .arguments("{\"s\":\"hello\"}")
+                .build();
+        AiMessage aiMessage = AiMessage.from(toolExecutionRequest);
+
+        // When
+        List<GeminiContent> result = PartsAndContentsMapper.fromMessageToGContent(List.of(aiMessage), null, false);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).parts()).hasSize(1);
+        assertThat(result.get(0).parts().get(0).functionCall().id()).isEqualTo("call-1");
+        assertThat(result.get(0).parts().get(0).functionCall().name()).isEqualTo("stringLength");
+    }
+
+    @Test
+    void fromMessageToGContent_omitsToolExecutionRequestIdWhenNull() {
+        // Given
+        ToolExecutionRequest toolExecutionRequest = ToolExecutionRequest.builder()
+                .name("stringLength")
+                .arguments("{\"s\":\"hello\"}")
+                .build();
+        AiMessage aiMessage = AiMessage.from(toolExecutionRequest);
+
+        // When
+        List<GeminiContent> result = PartsAndContentsMapper.fromMessageToGContent(List.of(aiMessage), null, false);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).parts()).hasSize(1);
+        assertThat(result.get(0).parts().get(0).functionCall().id()).isNull();
+        assertThat(Json.toJson(result.get(0))).doesNotContain("\"id\"");
+    }
+
+    @Test
+    void fromMessageToGContent_preservesToolExecutionResultId() {
+        // Given
+        ToolExecutionResultMessage toolExecutionResultMessage =
+                ToolExecutionResultMessage.from("call-1", "stringLength", "5");
+
+        // When
+        List<GeminiContent> result =
+                PartsAndContentsMapper.fromMessageToGContent(List.of(toolExecutionResultMessage), null, false);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).parts()).hasSize(1);
+        assertThat(result.get(0).parts().get(0).functionResponse().id()).isEqualTo("call-1");
+        assertThat(result.get(0).parts().get(0).functionResponse().name()).isEqualTo("stringLength");
+    }
+
+    @Test
+    void fromMessageToGContent_omitsToolExecutionResultIdWhenNull() {
+        // Given
+        ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.builder()
+                .toolName("stringLength")
+                .text("5")
+                .build();
+
+        // When
+        List<GeminiContent> result =
+                PartsAndContentsMapper.fromMessageToGContent(List.of(toolExecutionResultMessage), null, false);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).parts()).hasSize(1);
+        assertThat(result.get(0).parts().get(0).functionResponse().id()).isNull();
+        assertThat(Json.toJson(result.get(0))).doesNotContain("\"id\"");
+    }
+
+    @Test
+    void fromMessageToGContent_preservesToolExecutionResultIdWithMultipleContents() {
+        // Given
+        ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.builder()
+                .id("call-1")
+                .toolName("stringLength")
+                .contents(TextContent.from("5"), TextContent.from("6"))
+                .build();
+
+        // When
+        List<GeminiContent> result =
+                PartsAndContentsMapper.fromMessageToGContent(List.of(toolExecutionResultMessage), null, false);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).parts()).hasSize(1);
+        assertThat(result.get(0).parts().get(0).functionResponse().id()).isEqualTo("call-1");
+        assertThat(result.get(0).parts().get(0).functionResponse().name()).isEqualTo("stringLength");
     }
 
     @Test


### PR DESCRIPTION
## Issue

Closes #5307

## Change

This PR preserves Google AI Gemini tool call ids across the mapper layer.

- Preserve Gemini `functionCall.id` when mapping tool calls to `ToolExecutionRequest.id()`.
- Round-trip existing tool request/result ids back through Gemini `functionCall` and `functionResponse`.
- Do not generate fallback ids, so responses that do not provide an id keep the existing null-id behavior.
- Keep null ids omitted from serialized Gemini JSON through the existing non-null serialization behavior.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run the module unit tests and `verify`; integration tests that require external credentials are skipped by the existing environment guards
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] Documentation is not required for this internal mapper bug fix
- [X] Examples are not required for this bug fix
- [X] Spring Boot starter changes are not applicable

## Checklist for adding new maven module

N/A

## Checklist for adding new embedding store integration

N/A

## Checklist for changing existing embedding store integration

N/A

## Test plan

- [X] `./mvnw -pl langchain4j-google-ai-gemini -Dtest=PartsAndContentsMapperTest,GeminiStreamingResponseBuilderTest,FunctionMapperTest test`
- [X] `./mvnw -pl langchain4j-google-ai-gemini test`
- [X] `./mvnw -pl langchain4j-google-ai-gemini verify`
- [X] `./mvnw -pl langchain4j-core,langchain4j test`
- [X] `git diff --check`
- [X] Changed Google AI Gemini files pass `spotless:check`