### PR TITLE
fix(agentic): resolve concurrency and thread-safety defects in AgentMonitor

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/AgentMonitor.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/AgentMonitor.java
@@ -44,8 +44,12 @@ public class AgentMonitor implements AgentListener {
         Object memoryId = agentRequest.agenticScope().memoryId();
         MonitoredExecution currentExecution = ongoingExecutions.get(memoryId);
         if (currentExecution == null) {
-            currentExecution = new MonitoredExecution(agentRequest);
-            ongoingExecutions.put(memoryId, currentExecution);
+            MonitoredExecution newExecution = new MonitoredExecution(agentRequest);
+            currentExecution = ongoingExecutions.putIfAbsent(memoryId, newExecution);
+            if (currentExecution != null) {
+                // Another thread won the initialization race; nest this invocation in the existing execution
+                currentExecution.beforeAgentInvocation(agentRequest);
+            }
         } else {
             currentExecution.beforeAgentInvocation(agentRequest);
         }
@@ -58,7 +62,7 @@ public class AgentMonitor implements AgentListener {
         execution.afterAgentInvocation(agentResponse);
         if (execution.done()) {
             ongoingExecutions.remove(memoryId);
-            successfulExecutions.computeIfAbsent(memoryId, k -> new ArrayList<>()).add(execution);
+            successfulExecutions.computeIfAbsent(memoryId, k -> Collections.synchronizedList(new ArrayList<>())).add(execution);
         }
     }
 
@@ -68,7 +72,7 @@ public class AgentMonitor implements AgentListener {
         MonitoredExecution execution = ongoingExecutions.remove(memoryId);
         if (execution != null) {
             execution.onAgentInvocationError(agentInvocationError);
-            failedExecutions.computeIfAbsent(memoryId, k -> new ArrayList<>()).add(execution);
+            failedExecutions.computeIfAbsent(memoryId, k -> Collections.synchronizedList(new ArrayList<>())).add(execution);
         }
     }
 
@@ -99,7 +103,13 @@ public class AgentMonitor implements AgentListener {
     }
 
     public List<MonitoredExecution> successfulExecutions() {
-        return successfulExecutions.values().stream().flatMap(List::stream).toList();
+        List<MonitoredExecution> all = new ArrayList<>();
+        for (List<MonitoredExecution> list : successfulExecutions.values()) {
+            synchronized (list) {
+                all.addAll(list);
+            }
+        }
+        return all;
     }
 
     public List<MonitoredExecution> successfulExecutionsFor(AgenticScope agenticScope) {
@@ -107,11 +117,23 @@ public class AgentMonitor implements AgentListener {
     }
 
     public List<MonitoredExecution> successfulExecutionsFor(Object memoryId) {
-        return successfulExecutions.getOrDefault(memoryId, List.of());
+        List<MonitoredExecution> list = successfulExecutions.get(memoryId);
+        if (list == null) {
+            return List.of();
+        }
+        synchronized (list) {
+            return new ArrayList<>(list);
+        }
     }
 
     public List<MonitoredExecution> failedExecutions() {
-        return failedExecutions.values().stream().flatMap(List::stream).toList();
+        List<MonitoredExecution> all = new ArrayList<>();
+        for (List<MonitoredExecution> list : failedExecutions.values()) {
+            synchronized (list) {
+                all.addAll(list);
+            }
+        }
+        return all;
     }
 
     public List<MonitoredExecution> failedExecutionsFor(AgenticScope agenticScope) {
@@ -119,7 +141,13 @@ public class AgentMonitor implements AgentListener {
     }
 
     public List<MonitoredExecution> failedExecutionsFor(Object memoryId) {
-        return failedExecutions.getOrDefault(memoryId, List.of());
+        List<MonitoredExecution> list = failedExecutions.get(memoryId);
+        if (list == null) {
+            return List.of();
+        }
+        synchronized (list) {
+            return new ArrayList<>(list);
+        }
     }
 
     /**

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/observability/AgentMonitorTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/observability/AgentMonitorTest.java
@@ -1,0 +1,114 @@
+package dev.langchain4j.agentic.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agentic.planner.AgentInstance;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class AgentMonitorTest {
+
+    @Test
+    void should_handle_concurrent_invocations_without_throwing_exception() throws InterruptedException {
+        // given
+        AgentMonitor monitor = new AgentMonitor();
+        Object memoryId = "concurrent-memory-id";
+
+        AgenticScope scope = mock(AgenticScope.class);
+        when(scope.memoryId()).thenReturn(memoryId);
+
+        AgentInstance agent = mock(AgentInstance.class);
+        when(agent.agentId()).thenReturn("agent-1");
+        when(agent.name()).thenReturn("test-agent");
+
+        int numThreads = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < numThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    AgentRequest request = new AgentRequest(scope, agent, new HashMap<>());
+                    monitor.beforeAgentInvocation(request);
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // then
+        assertThat(failureCount.get()).isEqualTo(0);
+        assertThat(monitor.ongoingExecutions()).containsKey(memoryId);
+    }
+
+    @Test
+    void should_prevent_concurrent_modification_exception_during_streaming() throws InterruptedException {
+        // given
+        AgentMonitor monitor = new AgentMonitor();
+        Object memoryId = "concurrency-streaming-id";
+
+        AgenticScope scope = mock(AgenticScope.class);
+        when(scope.memoryId()).thenReturn(memoryId);
+
+        AgentInstance agent = mock(AgentInstance.class);
+        when(agent.agentId()).thenReturn("agent-1");
+        when(agent.name()).thenReturn("test-agent");
+
+        AgentRequest request = new AgentRequest(scope, agent, new HashMap<>());
+        monitor.beforeAgentInvocation(request);
+
+        int numThreads = 20;
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        AtomicInteger exceptionCount = new AtomicInteger(0);
+
+        // when - concurrently adding executions and reading them via successfulExecutions()
+        for (int i = 0; i < numThreads; i++) {
+            final int index = i;
+            executor.submit(() -> {
+                try {
+                    if (index % 2 == 0) {
+                        // simulate completion
+                        AgentResponse response = new AgentResponse(scope, agent, new HashMap<>(), "output");
+                        monitor.afterAgentInvocation(response);
+                        
+                        // re-invoke to put back in ongoing
+                        monitor.beforeAgentInvocation(request);
+                    } else {
+                        // concurrently read successful executions (which previously triggered ConcurrentModificationException)
+                        List<MonitoredExecution> list = monitor.successfulExecutions();
+                        assertThat(list).isNotNull();
+                    }
+                } catch (Exception e) {
+                    exceptionCount.incrementAndGet();
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // then
+        assertThat(exceptionCount.get()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
This Pull Request addresses and resolves several concurrency and thread-safety defects in \AgentMonitor\ (Issue #5296):

1. **Atomic Map Initialization**: Refactors \eforeAgentInvocation\ using a high-performance double-checked locking pattern with the atomic \putIfAbsent\ map primitive. This guarantees that only a single execution is initialized for a given \memoryId\ under high concurrent loads, eliminating races where concurrent sub-agents overwrite the active execution state and cause orphaned tracking or downstream \IllegalStateException\s.
2. **Thread-Safe Append Operations**: Wraps the completed successful/failed execution list backings with \Collections.synchronizedList\ to prevent array corruption when parallel agents complete concurrently.
3. **Synchronized Copy operations on getters**: Refactors \successfulExecutions()\, \successfulExecutionsFor()\, \ailedExecutions()\, and \ailedExecutionsFor()\ to perform safe synchronized copies. This completely eliminates the threat of \ConcurrentModificationException\ when these collections are traversed/streamed concurrently by different threads.
4. **Comprehensive Unit Testing**: Adds the \AgentMonitorTest\ test suite containing dedicated parallel invocation and concurrent streaming tests verifying thread-safety and correctness under extreme contention.

These corrections ensure observability in LangChain4j works robustly across parallel, voting, and peer-to-peer agentic topologies.