### PR TITLE
fix(qdrant): use Query RPC instead of legacy Search RPC to retrieve vectors

### DIFF
--- a/langchain4j-qdrant/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStore.java
+++ b/langchain4j-qdrant/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStore.java
@@ -22,6 +22,7 @@ import dev.langchain4j.store.embedding.*;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import io.qdrant.client.QdrantClient;
 import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.QueryFactory;
 import io.qdrant.client.WithVectorsSelectorFactory;
 import io.qdrant.client.grpc.Common.Filter;
 import io.qdrant.client.grpc.Common.PointId;
@@ -30,8 +31,8 @@ import io.qdrant.client.grpc.Points;
 import io.qdrant.client.grpc.Points.DeletePoints;
 import io.qdrant.client.grpc.Points.PointStruct;
 import io.qdrant.client.grpc.Points.PointsSelector;
+import io.qdrant.client.grpc.Points.QueryPoints;
 import io.qdrant.client.grpc.Points.ScoredPoint;
-import io.qdrant.client.grpc.Points.SearchPoints;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -223,22 +224,22 @@ public class QdrantEmbeddingStore implements EmbeddingStore<TextSegment> {
     @Override
     public EmbeddingSearchResult<TextSegment> search(EmbeddingSearchRequest request) {
 
-        SearchPoints.Builder searchBuilder = SearchPoints.newBuilder()
+        QueryPoints.Builder queryBuilder = QueryPoints.newBuilder()
                 .setCollectionName(collectionName)
-                .addAllVector(request.queryEmbedding().vectorAsList())
+                .setQuery(QueryFactory.nearest(request.queryEmbedding().vectorAsList()))
                 .setWithVectors(WithVectorsSelectorFactory.enable(true))
                 .setWithPayload(enable(true))
                 .setLimit(request.maxResults());
 
         if (request.filter() != null) {
             Filter filter = QdrantFilterConverter.convertExpression(request.filter());
-            searchBuilder.setFilter(filter);
+            queryBuilder.setFilter(filter);
         }
 
         List<ScoredPoint> results;
 
         try {
-            results = client.searchAsync(searchBuilder.build()).get();
+            results = client.queryAsync(queryBuilder.build()).get();
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION


<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change
<!-- Please describe the changes you made. -->


## Fix: use Query RPC instead of legacy Search RPC in `QdrantEmbeddingStore` (breaks on Qdrant ≥ 1.13)

### Problem

`QdrantEmbeddingStore.search()` was calling `client.searchAsync(SearchPoints)`, which dispatches to the legacy gRPC `Search` RPC (`PointsFutureStub.search`). In **Qdrant 1.13** the server-side behaviour of this legacy endpoint changed: it **no longer populates the `vectors` field on returned `ScoredPoint` messages**, even when `with_vectors = true` is explicitly requested.

The store then unconditionally called:
```java
Embedding embedding = toEmbedding(scoredPoint.getVectors().getVector());
```
With an empty protobuf default returned from `getVectors()`, `getDataList()` was empty, producing a **zero-dimension `Embedding`** and a downstream dimension error.

### Root cause

| Client method | gRPC stub call | Returns `vectors` in `ScoredPoint` (Qdrant ≥ 1.13) |
|---|---|---|
| `client.searchAsync(SearchPoints)` | `PointsFutureStub.search` — legacy Search RPC | **No** |
| `client.queryAsync(QueryPoints)` | `PointsFutureStub.query` — modern Query RPC | **Yes** |


- [Query API reference](https://api.qdrant.tech/api-reference/search/query-points) — full REST/gRPC spec

### Fix

Replace `SearchPoints` + `client.searchAsync()` with `QueryPoints` + `client.queryAsync()`, using `QueryFactory.nearest(List<Float>)` to supply the dense query vector ([`QueryFactory` source](https://github.com/qdrant/java-client/blob/master/src/main/java/io/qdrant/client/QueryFactory.java)). Both RPCs return `List<ScoredPoint>`, so `toEmbeddingMatch()` and the rest of the class are unchanged.


### Testing

Run `QdrantEmbeddingStoreIT` against a Qdrant ≥ 1.13 instance — this test exercises `search()` and would previously fail with a dimension error on any collection with stored vectors.

### Affected versions

Any deployment of langchain4j-qdrant against a Qdrant server ≥ 1.13. The Query gRPC RPC has been available since Qdrant 1.10, so there is no minimum server version concern for the fix.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] I have manually verified that the `{Qdrant}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
