### PR TITLE
fix(agentic): avoid duplicate declarative tool providers

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
@@ -13,15 +13,6 @@ import static dev.langchain4j.agentic.internal.AgentUtil.nonAiAgentInvoker;
 import static dev.langchain4j.agentic.internal.AgentUtil.nonAiAgentToExecutor;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.ServiceLoader;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Stream;
 import dev.langchain4j.agentic.agent.AgentBuilder;
 import dev.langchain4j.agentic.agent.UntypedAgentBuilder;
 import dev.langchain4j.agentic.declarative.A2AClientAgent;
@@ -60,6 +51,15 @@ import dev.langchain4j.agentic.workflow.SequentialAgentService;
 import dev.langchain4j.agentic.workflow.WorkflowAgentsBuilder;
 import dev.langchain4j.agentic.workflow.impl.WorkflowAgentsBuilderImpl;
 import dev.langchain4j.model.chat.ChatModel;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * Provides static factory methods to create and configure various types of agent services.
@@ -281,8 +281,8 @@ public class AgenticServices {
     public record DefaultDeclarativeAgentCreationContext<T>(Class<T> agentServiceClass, AgentBuilder<T, ?> agentBuilder)
             implements DeclarativeAgentCreationContext<T> {}
 
-    public record AgentConfigurator(Consumer<DeclarativeAgentCreationContext<?>> configurator,
-                                    Function<Class<?>, Object> subAgentResolver) {
+    public record AgentConfigurator(
+            Consumer<DeclarativeAgentCreationContext<?>> configurator, Function<Class<?>, Object> subAgentResolver) {
         private static final AgentConfigurator EMPTY = new AgentConfigurator(ctx -> {}, null);
 
         public static AgentConfigurator empty() {
@@ -315,8 +315,7 @@ public class AgenticServices {
      * @param agentServiceClass the class of the agent service
      * @param agentConfigurator A callback to tweak the configuration of each agent created in this agentic system
      */
-    public static <T> T createAgenticSystem(
-            Class<T> agentServiceClass, AgentConfigurator agentConfigurator) {
+    public static <T> T createAgenticSystem(Class<T> agentServiceClass, AgentConfigurator agentConfigurator) {
         return createAgenticSystem(agentServiceClass, declarativeChatModel(agentServiceClass), agentConfigurator);
     }
 
@@ -328,13 +327,11 @@ public class AgenticServices {
      * @param agentConfigurator A callback to tweak the configuration of each agent created in this agentic system
      */
     public static <T> T createAgenticSystem(
-            Class<T> agentServiceClass,
-            ChatModel chatModel,
-            AgentConfigurator agentConfigurator) {
+            Class<T> agentServiceClass, ChatModel chatModel, AgentConfigurator agentConfigurator) {
         T agent = createComposedAgent(agentServiceClass, chatModel, agentConfigurator);
 
         if (agent == null) {
-            var agentBuilder = agentBuilder(agentServiceClass);
+            var agentBuilder = AgentBuilder.withoutDeclarativeConfiguration(agentServiceClass);
             configureAgent(agentServiceClass, chatModel, agentBuilder, agentConfigurator);
             agent = agentBuilder.build();
         }
@@ -357,9 +354,7 @@ public class AgenticServices {
     }
 
     private static <T> T createComposedAgent(
-            Class<T> agentServiceClass,
-            ChatModel chatModel,
-            AgentConfigurator agentConfigurator) {
+            Class<T> agentServiceClass, ChatModel chatModel, AgentConfigurator agentConfigurator) {
         Optional<Method> sequenceMethod = getAnnotatedMethodOnClass(agentServiceClass, SequenceAgent.class);
         if (sequenceMethod.isPresent()) {
             return buildSequentialAgent(agentServiceClass, sequenceMethod.get(), chatModel, agentConfigurator);
@@ -380,8 +375,7 @@ public class AgenticServices {
             return buildParallelAgent(agentServiceClass, parallelMethod.get(), chatModel, agentConfigurator);
         }
 
-        Optional<Method> parallelMapperMethod =
-                getAnnotatedMethodOnClass(agentServiceClass, ParallelMapperAgent.class);
+        Optional<Method> parallelMapperMethod = getAnnotatedMethodOnClass(agentServiceClass, ParallelMapperAgent.class);
         if (parallelMapperMethod.isPresent()) {
             return buildParallelMapperAgent(
                     agentServiceClass, parallelMapperMethod.get(), chatModel, agentConfigurator);
@@ -402,11 +396,7 @@ public class AgenticServices {
     }
 
     private static void buildAgentSpecs(
-            Method agentMethod,
-            String name,
-            String description,
-            String outputKey,
-            AgenticService<?, ?> builder) {
+            Method agentMethod, String name, String description, String outputKey, AgenticService<?, ?> builder) {
         if (!isNullOrBlank(name)) {
             builder.name(name);
         } else {
@@ -421,10 +411,7 @@ public class AgenticServices {
     }
 
     private static <T> T buildSequentialAgent(
-            Class<T> agentServiceClass,
-            Method agentMethod,
-            ChatModel chatModel,
-            AgentConfigurator agentConfigurator) {
+            Class<T> agentServiceClass, Method agentMethod, ChatModel chatModel, AgentConfigurator agentConfigurator) {
         SequenceAgent annotation = agentMethod.getAnnotation(SequenceAgent.class);
         var builder = sequenceBuilder(agentServiceClass)
                 .subAgents(createSubagents(annotation.subAgents(), chatModel, agentConfigurator));
@@ -440,10 +427,7 @@ public class AgenticServices {
     }
 
     private static <T> T buildLoopAgent(
-            Class<T> agentServiceClass,
-            Method agentMethod,
-            ChatModel chatModel,
-            AgentConfigurator agentConfigurator) {
+            Class<T> agentServiceClass, Method agentMethod, ChatModel chatModel, AgentConfigurator agentConfigurator) {
         LoopAgent annotation = agentMethod.getAnnotation(LoopAgent.class);
         var builder = loopBuilder(agentServiceClass)
                 .subAgents(createSubagents(annotation.subAgents(), chatModel, agentConfigurator))
@@ -460,10 +444,7 @@ public class AgenticServices {
     }
 
     private static <T> T buildConditionalAgent(
-            Class<T> agentServiceClass,
-            Method agentMethod,
-            ChatModel chatModel,
-            AgentConfigurator agentConfigurator) {
+            Class<T> agentServiceClass, Method agentMethod, ChatModel chatModel, AgentConfigurator agentConfigurator) {
         ConditionalAgent annotation = agentMethod.getAnnotation(ConditionalAgent.class);
         var builder = conditionalBuilder(agentServiceClass);
 
@@ -490,10 +471,7 @@ public class AgenticServices {
     }
 
     private static <T> T buildParallelAgent(
-            Class<T> agentServiceClass,
-            Method agentMethod,
-            ChatModel chatModel,
-            AgentConfigurator agentConfigurator) {
+            Class<T> agentServiceClass, Method agentMethod, ChatModel chatModel, AgentConfigurator agentConfigurator) {
         ParallelAgent annotation = agentMethod.getAnnotation(ParallelAgent.class);
         var builder = parallelBuilder(agentServiceClass)
                 .subAgents(createSubagents(annotation.subAgents(), chatModel, agentConfigurator));
@@ -509,10 +487,7 @@ public class AgenticServices {
     }
 
     private static <T> T buildParallelMapperAgent(
-            Class<T> agentServiceClass,
-            Method agentMethod,
-            ChatModel chatModel,
-            AgentConfigurator agentConfigurator) {
+            Class<T> agentServiceClass, Method agentMethod, ChatModel chatModel, AgentConfigurator agentConfigurator) {
         ParallelMapperAgent annotation = agentMethod.getAnnotation(ParallelMapperAgent.class);
         var builder = parallelMapperBuilder(agentServiceClass)
                 .subAgents(List.of(createSubagent(annotation.subAgent(), chatModel, agentConfigurator)))
@@ -529,10 +504,7 @@ public class AgenticServices {
     }
 
     private static <T> T buildPlannerAgent(
-            Class<T> agentServiceClass,
-            Method agentMethod,
-            ChatModel chatModel,
-            AgentConfigurator agentConfigurator) {
+            Class<T> agentServiceClass, Method agentMethod, ChatModel chatModel, AgentConfigurator agentConfigurator) {
         PlannerAgent annotation = agentMethod.getAnnotation(PlannerAgent.class);
         var builder = new PlannerBasedServiceImpl<>(agentServiceClass, agentMethod)
                 .subAgents(createSubagents(annotation.subAgents(), chatModel, agentConfigurator));
@@ -548,10 +520,7 @@ public class AgenticServices {
     }
 
     private static <T> T buildSupervisorAgent(
-            Class<T> agentServiceClass,
-            Method agentMethod,
-            ChatModel chatModel,
-            AgentConfigurator agentConfigurator) {
+            Class<T> agentServiceClass, Method agentMethod, ChatModel chatModel, AgentConfigurator agentConfigurator) {
         dev.langchain4j.agentic.declarative.SupervisorAgent supervisorAgent =
                 agentMethod.getAnnotation(dev.langchain4j.agentic.declarative.SupervisorAgent.class);
         var builder = new SupervisorAgentServiceImpl<>(agentServiceClass, agentMethod, chatModel)
@@ -594,20 +563,19 @@ public class AgenticServices {
             return agentExecutor;
         }
 
-        AgentBuilder<?, ?> agentBuilder = agentBuilder(subgentClass);
+        AgentBuilder<?, ?> agentBuilder = AgentBuilder.withoutDeclarativeConfiguration(subgentClass);
         configureAgent(subgentClass, chatModel, agentBuilder, agentConfigurator);
 
         return agentToExecutor(agentBuilder.build());
     }
 
     public static AgentExecutor createBuiltInAgentExecutor(Class<?> agentServiceClass) {
-        return createBuiltInAgentExecutor(agentServiceClass, declarativeChatModel(agentServiceClass), AgentConfigurator.empty());
+        return createBuiltInAgentExecutor(
+                agentServiceClass, declarativeChatModel(agentServiceClass), AgentConfigurator.empty());
     }
 
     private static AgentExecutor createBuiltInAgentExecutor(
-            Class<?> agentServiceClass,
-            ChatModel chatModel,
-            AgentConfigurator agentConfigurator) {
+            Class<?> agentServiceClass, ChatModel chatModel, AgentConfigurator agentConfigurator) {
         Optional<Method> sequenceMethod = getAnnotatedMethodOnClass(agentServiceClass, SequenceAgent.class);
         if (sequenceMethod.isPresent()) {
             Method method = sequenceMethod.get();
@@ -640,12 +608,11 @@ public class AgenticServices {
             return new AgentExecutor(AgentInvoker.fromMethod(agent, method), agent);
         }
 
-        Optional<Method> parallelMapperMethod =
-                getAnnotatedMethodOnClass(agentServiceClass, ParallelMapperAgent.class);
+        Optional<Method> parallelMapperMethod = getAnnotatedMethodOnClass(agentServiceClass, ParallelMapperAgent.class);
         if (parallelMapperMethod.isPresent()) {
             Method method = parallelMapperMethod.get();
-            InternalAgent agent = (InternalAgent)
-                    buildParallelMapperAgent(agentServiceClass, method, chatModel, agentConfigurator);
+            InternalAgent agent =
+                    (InternalAgent) buildParallelMapperAgent(agentServiceClass, method, chatModel, agentConfigurator);
             return new AgentExecutor(AgentInvoker.fromMethod(agent, method), agent);
         }
 
@@ -688,9 +655,11 @@ public class AgenticServices {
                 if (agenticMethod.getParameterCount() == 0) {
                     return agentToExecutor(new AgentAction(() -> invokeStatic(agenticMethod)));
                 }
-                return nonAiAgentToExecutor(new AgenticScopeFunction<>(scope -> invokeStatic(
-                        agenticMethod,
-                        agentInvocationArguments(scope, agenticMethod).positionalArgs())), agenticMethod);
+                return nonAiAgentToExecutor(
+                        new AgenticScopeFunction<>(scope -> invokeStatic(
+                                agenticMethod,
+                                agentInvocationArguments(scope, agenticMethod).positionalArgs())),
+                        agenticMethod);
             }
         }
 
@@ -718,14 +687,17 @@ public class AgenticServices {
     private static AgentExecutor createMcpClientAgent(Class<?> agentServiceClass, Method mcpMethod) {
         var mcpAgent = mcpMethod.getAnnotation(McpClientAgent.class);
 
-        Object mcpClient = selectMethod(agentServiceClass,
-                method -> method.isAnnotationPresent(McpClientSupplier.class)
-                        && method.getParameterCount() == 0)
+        Object mcpClient = selectMethod(
+                        agentServiceClass,
+                        method ->
+                                method.isAnnotationPresent(McpClientSupplier.class) && method.getParameterCount() == 0)
                 .map(method -> invokeStatic(method))
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "An MCP client agent requires a method annotated with @McpClientSupplier that returns the McpClient instance."));
+                .orElseThrow(
+                        () -> new IllegalArgumentException(
+                                "An MCP client agent requires a method annotated with @McpClientSupplier that returns the McpClient instance."));
 
-        var mcpClientBuilder = McpService.get().mcpBuilder(mcpClient, agentServiceClass)
+        var mcpClientBuilder = McpService.get()
+                .mcpBuilder(mcpClient, agentServiceClass)
                 .toolName(mcpAgent.toolName())
                 .inputKeys(Stream.of(mcpMethod.getParameters())
                         .map(AgentInvoker::parameterName)

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentBuilder.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/agent/AgentBuilder.java
@@ -8,11 +8,9 @@ import static dev.langchain4j.agentic.observability.ComposedAgentListener.listen
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static java.util.Arrays.asList;
 
+import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.response.ChatResponse;
-import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.declarative.TypedKey;
 import dev.langchain4j.agentic.internal.AgentUtil;
@@ -40,6 +38,9 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.observability.api.listener.AiServiceResponseReceivedListener;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
@@ -68,16 +69,16 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
     private static final ChatModel PLACEHOLDER_CHAT_MODEL = new ChatModel() {
         @Override
         public ChatResponse doChat(ChatRequest chatRequest) {
-            throw new IllegalStateException("Placeholder ChatModel should never be invoked. " +
-                    "The actual model is provided dynamically via the chatModel(Function) provider.");
+            throw new IllegalStateException("Placeholder ChatModel should never be invoked. "
+                    + "The actual model is provided dynamically via the chatModel(Function) provider.");
         }
     };
 
     private static final StreamingChatModel PLACEHOLDER_STREAMING_CHAT_MODEL = new StreamingChatModel() {
         @Override
         public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
-            throw new IllegalStateException("Placeholder StreamingChatModel should never be invoked. " +
-                    "The actual model is provided dynamically via the streamingChatModel(Function) provider.");
+            throw new IllegalStateException("Placeholder StreamingChatModel should never be invoked. "
+                    + "The actual model is provided dynamically via the streamingChatModel(Function) provider.");
         }
     };
 
@@ -129,6 +130,15 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
     AgentListener agentListener;
 
     public AgentBuilder(Class<T> agentServiceClass) {
+        this(agentServiceClass, true);
+    }
+
+    @Internal
+    public static <T> AgentBuilder<T, AgentBuilder<T, ?>> withoutDeclarativeConfiguration(Class<T> agentServiceClass) {
+        return new AgentBuilder<>(agentServiceClass, false);
+    }
+
+    private AgentBuilder(Class<T> agentServiceClass, boolean configureDeclarativeAgent) {
         this.agentServiceClass = agentServiceClass;
         this.agenticMethod = validateAgentClass(agentServiceClass);
         this.agentReturnType = agenticMethod.getReturnType();
@@ -138,7 +148,9 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
             throw new IllegalArgumentException("Method " + agenticMethod + " is not annotated with @Agent");
         }
 
-        configureAgent(agentServiceClass, this);
+        if (configureDeclarativeAgent) {
+            configureAgent(agentServiceClass, this);
+        }
 
         this.name = !isNullOrBlank(agent.name()) ? agent.name() : agenticMethod.getName();
 
@@ -259,15 +271,18 @@ public class AgentBuilder<T, B extends AgentBuilder<T, ?>> {
     }
 
     private void validateChatModel() {
-        int modelConfigCount = (model != null ? 1 : 0) + (streamingChatModel != null ? 1 : 0)
-                + (chatModelProvider != null ? 1 : 0) + (streamingChatModelProvider != null ? 1 : 0);
+        int modelConfigCount = (model != null ? 1 : 0)
+                + (streamingChatModel != null ? 1 : 0)
+                + (chatModelProvider != null ? 1 : 0)
+                + (streamingChatModelProvider != null ? 1 : 0);
         if (modelConfigCount != 1) {
             throw new AgenticSystemConfigurationException(
-                    "One and only one of chatModel, streamingChatModel, or their Function variants can be set for agent '" + this.name + "'.");
+                    "One and only one of chatModel, streamingChatModel, or their Function variants can be set for agent '"
+                            + this.name + "'.");
         }
     }
 
-    protected void build(DefaultAgenticScope agenticScope, AiServiceContext context, AiServices<T> aiServices) { }
+    protected void build(DefaultAgenticScope agenticScope, AiServiceContext context, AiServices<T> aiServices) {}
 
     private void setupGuardrails(AiServices<T> aiServices) {
         if (inputGuardrailsConfig != null) {

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ToolProviderSupplierConfigurationTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ToolProviderSupplierConfigurationTest.java
@@ -1,0 +1,89 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.agentic.declarative.ChatModelSupplier;
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.declarative.ToolProviderSupplier;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ToolProviderSupplierConfigurationTest {
+
+    private static final AtomicInteger toolProviderSupplierCalls = new AtomicInteger();
+
+    @BeforeEach
+    void reset() {
+        toolProviderSupplierCalls.set(0);
+    }
+
+    @Test
+    void should_apply_declarative_tool_provider_supplier_once_when_creating_single_agent_system() {
+        AgentWithToolProvider agent = AgenticServices.createAgenticSystem(AgentWithToolProvider.class);
+
+        String response = agent.chat("hello");
+
+        assertThat(response).isEqualTo("ok");
+        assertThat(toolProviderSupplierCalls).hasValue(1);
+    }
+
+    @Test
+    void should_apply_declarative_tool_provider_supplier_once_when_creating_sub_agent() {
+        SequenceWithToolProviderSubAgent agent = AgenticServices.createAgenticSystem(
+                SequenceWithToolProviderSubAgent.class, AgentWithToolProvider.chatModel());
+
+        String response = agent.chat("hello");
+
+        assertThat(response).isEqualTo("ok");
+        assertThat(toolProviderSupplierCalls).hasValue(1);
+    }
+
+    public interface SequenceWithToolProviderSubAgent {
+
+        @SequenceAgent(
+                outputKey = "response",
+                subAgents = {AgentWithToolProvider.class})
+        String chat(@V("message") String message);
+    }
+
+    public interface AgentWithToolProvider {
+
+        @UserMessage("Say {{message}}")
+        @Agent(outputKey = "response")
+        String chat(@V("message") String message);
+
+        @ChatModelSupplier
+        static ChatModel chatModel() {
+            return new ChatModel() {
+                @Override
+                public ChatResponse chat(ChatRequest chatRequest) {
+                    return ChatResponse.builder()
+                            .aiMessage(AiMessage.from("ok"))
+                            .build();
+                }
+            };
+        }
+
+        @ToolProviderSupplier
+        static ToolProvider toolProvider() {
+            toolProviderSupplierCalls.incrementAndGet();
+            ToolSpecification tool = ToolSpecification.builder()
+                    .name("test_tool")
+                    .description("A test tool")
+                    .build();
+            return request -> ToolProviderResult.builder()
+                    .add(tool, (toolExecutionRequest, memoryId) -> "tool result")
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## Issue
Fixes #5309

## Change
This PR fixes duplicate declarative `@ToolProviderSupplier` registration when a declarative agent is built through `AgenticServices.createAgenticSystem(...)` fallback logic or as a regular sub-agent.

The public `AgentBuilder(Class)` constructor still applies declarative configuration as before. For the two `AgenticServices` paths that already call `configureAgent(...)` explicitly, this PR adds an internal builder creation path that skips constructor-time declarative configuration, so the same declarative tool provider is applied only once.

`ToolService` duplicate-tool validation is intentionally left unchanged, so legitimate duplicate tool definitions should still fail as before.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) (not applicable for this bug fix)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) (not applicable)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) (not applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml` (not applicable)

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT` (not applicable)
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT` (not applicable)

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j (not applicable)

## Testing
- `./mvnw -pl langchain4j-agentic -Dtest=ToolProviderSupplierConfigurationTest test`
- `./mvnw -pl langchain4j-agentic test`
- `./mvnw -pl langchain4j-agentic verify`
- `./mvnw -pl langchain4j-agentic -DskipTests revapi:check`
- `git diff --check`