### PR TITLE
Support A2A message context metadata

### DIFF
--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2AClientAgentInvoker.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2AClientAgentInvoker.java
@@ -1,23 +1,26 @@
 package dev.langchain4j.agentic.a2a;
 
+import static dev.langchain4j.agentic.internal.AgentUtil.agentInvocationArguments;
+import static dev.langchain4j.agentic.internal.AgentUtil.argumentsFromMethod;
+
 import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.declarative.A2AContextId;
+import dev.langchain4j.agentic.declarative.A2ATaskId;
+import dev.langchain4j.agentic.internal.AgentInvocationArguments;
+import dev.langchain4j.agentic.internal.AgentInvoker;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.observability.AgentListener;
-import dev.langchain4j.agentic.internal.AgentInvocationArguments;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.planner.AgenticSystemTopology;
 import dev.langchain4j.agentic.planner.Planner;
 import dev.langchain4j.agentic.scope.AgenticScope;
-import dev.langchain4j.agentic.internal.AgentInvoker;
 import io.a2a.spec.AgentCard;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static dev.langchain4j.agentic.internal.AgentUtil.agentInvocationArguments;
-import static dev.langchain4j.agentic.internal.AgentUtil.argumentsFromMethod;
 
 public class A2AClientAgentInvoker implements AgentInvoker {
 
@@ -27,6 +30,8 @@ public class A2AClientAgentInvoker implements AgentInvoker {
     private final A2AClientInstance a2AClientInstance;
 
     private final AgentCard agentCard;
+    private final String contextIdKey;
+    private final String taskIdKey;
     private final Method method;
 
     private InternalAgent parent;
@@ -35,16 +40,18 @@ public class A2AClientAgentInvoker implements AgentInvoker {
         this.method = method;
         this.a2AClientInstance = a2AClientInstance;
         this.agentCard = a2AClientInstance.agentCard();
+        this.contextIdKey = a2AClientInstance.contextIdKey();
+        this.taskIdKey = a2AClientInstance.taskIdKey();
         this.agentId = name();
         this.arguments = arguments(a2AClientInstance);
     }
 
     private List<AgentArgument> arguments(A2AClientInstance a2AClientInstance) {
-        return isUntyped() ?
-                Stream.of(a2AClientInstance.inputKeys())
+        return isUntyped()
+                ? Stream.of(a2AClientInstance.inputKeys())
                         .map(input -> new AgentArgument(Object.class, input))
-                        .toList() :
-                argumentsFromMethod(method);
+                        .toList()
+                : argumentsFromMethod(method, parameter -> !isA2AMessageContextParameter(parameter));
     }
 
     @Override
@@ -104,9 +111,28 @@ public class A2AClientAgentInvoker implements AgentInvoker {
 
     @Override
     public AgentInvocationArguments toInvocationArguments(AgenticScope agenticScope) {
-        return isUntyped()
-                ? new AgentInvocationArguments(agenticScope.state(), new Object[] {agenticScope.state()})
-                : agentInvocationArguments(agenticScope, arguments);
+        if (isUntyped()) {
+            return new AgentInvocationArguments(agenticScope.state(), new Object[] {agenticScope.state()});
+        }
+
+        AgentInvocationArguments invocationArguments = agentInvocationArguments(agenticScope, arguments);
+        if (!hasA2AMessageContextParameter()) {
+            return invocationArguments;
+        }
+
+        Object[] positionalArgs = new Object[method.getParameterCount()];
+        Object[] businessArgs = invocationArguments.positionalArgs();
+        Parameter[] parameters = method.getParameters();
+
+        int businessArgIndex = 0;
+        for (int i = 0; i < parameters.length; i++) {
+            Parameter parameter = parameters[i];
+            positionalArgs[i] = isA2AMessageContextParameter(parameter)
+                    ? a2aMessageContextArgument(agenticScope, parameter)
+                    : businessArgs[businessArgIndex++];
+        }
+
+        return new AgentInvocationArguments(invocationArguments.namedArgs(), positionalArgs);
     }
 
     private boolean isUntyped() {
@@ -132,6 +158,7 @@ public class A2AClientAgentInvoker implements AgentInvoker {
     public void setParent(InternalAgent parent) {
         this.parent = parent;
     }
+
     @Override
     public void registerInheritedParentListener(AgentListener parentListener) {
         a2AClientInstance.registerInheritedParentListener(parentListener);
@@ -140,5 +167,28 @@ public class A2AClientAgentInvoker implements AgentInvoker {
     @Override
     public void appendId(String idSuffix) {
         this.agentId = this.agentId + idSuffix;
+    }
+
+    private boolean hasA2AMessageContextParameter() {
+        return Stream.of(method.getParameters()).anyMatch(this::isA2AMessageContextParameter);
+    }
+
+    private boolean isA2AMessageContextParameter(Parameter parameter) {
+        return parameter.isAnnotationPresent(A2AContextId.class)
+                || parameter.isAnnotationPresent(A2ATaskId.class)
+                || isConfiguredKey(contextIdKey, parameter)
+                || isConfiguredKey(taskIdKey, parameter);
+    }
+
+    private static Object a2aMessageContextArgument(AgenticScope agenticScope, Parameter parameter) {
+        return AgentInvoker.optionalParameterName(parameter)
+                .map(agenticScope::readState)
+                .orElse(null);
+    }
+
+    private static boolean isConfiguredKey(String configuredKey, Parameter parameter) {
+        return AgentInvoker.optionalParameterName(parameter)
+                .map(key -> configuredKey != null && !configuredKey.isBlank() && configuredKey.equals(key))
+                .orElse(false);
     }
 }

--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2AClientInstance.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2AClientInstance.java
@@ -8,4 +8,12 @@ public interface A2AClientInstance extends InternalAgent {
     String[] inputKeys();
 
     AgentCard agentCard();
+
+    default String contextIdKey() {
+        return null;
+    }
+
+    default String taskIdKey() {
+        return null;
+    }
 }

--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilder.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilder.java
@@ -1,13 +1,20 @@
 package dev.langchain4j.agentic.a2a;
 
+import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
+
 import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.declarative.A2AContextId;
+import dev.langchain4j.agentic.declarative.A2ATaskId;
+import dev.langchain4j.agentic.internal.A2AClientBuilder;
+import dev.langchain4j.agentic.internal.AgentInvoker;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.observability.AgentListener;
-import dev.langchain4j.agentic.internal.A2AClientBuilder;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.planner.AgenticSystemTopology;
 import dev.langchain4j.agentic.planner.Planner;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.invocation.LangChain4jManaged;
 import dev.langchain4j.service.output.ServiceOutputParser;
 import io.a2a.A2A;
 import io.a2a.client.Client;
@@ -26,6 +33,7 @@ import io.a2a.spec.Part;
 import io.a2a.spec.TextPart;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -38,8 +46,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
 
 public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, InternalAgent, InvocationHandler {
 
@@ -57,16 +63,31 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
 
     private String[] inputKeys;
     private String outputKey;
+    private String contextIdKey;
+    private String taskIdKey;
     private boolean async;
 
     private AgentListener agentListener;
 
     DefaultA2AClientBuilder(String a2aServerUrl, Class<T> agentServiceClass) {
-        this.agentCard = agentCard(a2aServerUrl);
+        this(agentCard(a2aServerUrl), agentServiceClass);
+    }
+
+    private DefaultA2AClientBuilder(AgentCard agentCard, Class<T> agentServiceClass) {
+        this(agentCard, a2aClient(agentCard), agentServiceClass);
+    }
+
+    DefaultA2AClientBuilder(AgentCard agentCard, Client a2aClient, Class<T> agentServiceClass) {
+        this.agentCard = agentCard;
+        this.a2aClient = a2aClient;
         this.name = agentCard.name();
         this.agentId = this.name;
+        this.agentServiceClass = agentServiceClass;
+    }
+
+    private static Client a2aClient(AgentCard agentCard) {
         try {
-            this.a2aClient = Client.builder(agentCard)
+            return Client.builder(agentCard)
                     .clientConfig(new ClientConfig.Builder()
                             .setStreaming(false) // Disabling streaming
                             .build())
@@ -75,7 +96,6 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
         } catch (A2AClientException e) {
             throw new RuntimeException(e);
         }
-        this.agentServiceClass = agentServiceClass;
     }
 
     private static AgentCard agentCard(String a2aServerUrl) {
@@ -93,8 +113,7 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
         }
 
         Object agent = Proxy.newProxyInstance(
-                agentServiceClass.getClassLoader(),
-                new Class<?>[] {agentServiceClass, A2AClientInstance.class}, this);
+                agentServiceClass.getClassLoader(), new Class<?>[] {agentServiceClass, A2AClientInstance.class}, this);
 
         return (T) agent;
     }
@@ -109,13 +128,15 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
             return switch (method.getName()) {
                 case "agentCard" -> agentCard;
                 case "inputKeys" -> inputKeys;
+                case "contextIdKey" -> contextIdKey;
+                case "taskIdKey" -> taskIdKey;
                 default ->
-                        throw new UnsupportedOperationException(
-                                "Unknown method on A2AClientInstance class : " + method.getName());
+                    throw new UnsupportedOperationException(
+                            "Unknown method on A2AClientInstance class : " + method.getName());
             };
         }
 
-        return invokeAgent(getReturnType(method), args);
+        return invokeAgent(method, getReturnType(method), args);
     }
 
     private static Type getReturnType(Method method) {
@@ -123,22 +144,51 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
         return type == Object.class ? String.class : type;
     }
 
-    private Object invokeAgent(Type returnType, Object[] args) throws A2AClientException {
+    private Object invokeAgent(Method method, Type returnType, Object[] args) throws A2AClientException {
         List<Part<?>> parts = new ArrayList<>();
+        String contextId = null;
+        String taskId = null;
 
         if (agentServiceClass == UntypedAgent.class) {
             Map<String, Object> params = (Map<String, Object>) args[0];
+            contextId = valueAsString(readMap(params, contextIdKey));
+            taskId = valueAsString(readMap(params, taskIdKey));
             for (String inputKey : inputKeys) {
+                if (isA2AMessageContextKey(inputKey)) {
+                    continue;
+                }
                 parts.add(new TextPart(params.get(inputKey).toString()));
             }
         } else {
-            for (Object arg : args) {
+            Parameter[] parameters = method.getParameters();
+            for (int i = 0; i < args.length; i++) {
+                Object arg = args[i];
+                if (isContextIdParameter(parameters[i])) {
+                    contextId = valueAsString(arg);
+                    continue;
+                }
+                if (isTaskIdParameter(parameters[i])) {
+                    taskId = valueAsString(arg);
+                    continue;
+                }
                 parts.add(new TextPart(arg.toString()));
             }
         }
 
-        Message message =
-                new Message.Builder().role(Message.Role.USER).parts(parts).build();
+        AgenticScope agenticScope = LangChain4jManaged.current(AgenticScope.class);
+        if (contextId == null) {
+            contextId = valueAsString(readState(agenticScope, contextIdKey));
+        }
+        if (taskId == null) {
+            taskId = valueAsString(readState(agenticScope, taskIdKey));
+        }
+
+        Message message = new Message.Builder()
+                .role(Message.Role.USER)
+                .parts(parts)
+                .contextId(contextId)
+                .taskId(taskId)
+                .build();
 
         final CompletableFuture<String> messageResponse = new CompletableFuture<>();
         List<BiConsumer<ClientEvent, AgentCard>> consumers = List.of((event, card) -> {
@@ -198,6 +248,18 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
     @Override
     public DefaultA2AClientBuilder<T> outputKey(String outputKey) {
         this.outputKey = outputKey;
+        return this;
+    }
+
+    @Override
+    public DefaultA2AClientBuilder<T> contextIdKey(String contextIdKey) {
+        this.contextIdKey = contextIdKey;
+        return this;
+    }
+
+    @Override
+    public DefaultA2AClientBuilder<T> taskIdKey(String taskIdKey) {
+        this.taskIdKey = taskIdKey;
         return this;
     }
 
@@ -293,5 +355,38 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
     @Override
     public AgenticSystemTopology topology() {
         return AgenticSystemTopology.AI_AGENT;
+    }
+
+    private boolean isA2AMessageContextKey(String key) {
+        return isConfiguredKey(contextIdKey, key) || isConfiguredKey(taskIdKey, key);
+    }
+
+    private boolean isContextIdParameter(Parameter parameter) {
+        return parameter.isAnnotationPresent(A2AContextId.class) || isConfiguredKey(contextIdKey, parameter);
+    }
+
+    private boolean isTaskIdParameter(Parameter parameter) {
+        return parameter.isAnnotationPresent(A2ATaskId.class) || isConfiguredKey(taskIdKey, parameter);
+    }
+
+    private static boolean isConfiguredKey(String configuredKey, String key) {
+        return configuredKey != null && !configuredKey.isBlank() && configuredKey.equals(key);
+    }
+
+    private static boolean isConfiguredKey(String configuredKey, Parameter parameter) {
+        return isConfiguredKey(
+                configuredKey, AgentInvoker.optionalParameterName(parameter).orElse(null));
+    }
+
+    private static Object readMap(Map<String, Object> map, String key) {
+        return key != null && !key.isBlank() ? map.get(key) : null;
+    }
+
+    private static Object readState(AgenticScope agenticScope, String key) {
+        return agenticScope != null && key != null && !key.isBlank() ? agenticScope.readState(key) : null;
+    }
+
+    private static String valueAsString(Object value) {
+        return value == null ? null : value.toString();
     }
 }

--- a/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/A2AClientAgentMessageContextTest.java
+++ b/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/A2AClientAgentMessageContextTest.java
@@ -1,0 +1,302 @@
+package dev.langchain4j.agentic.a2a;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.agentic.declarative.A2AContextId;
+import dev.langchain4j.agentic.declarative.A2ATaskId;
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.internal.A2AClientBuilder;
+import dev.langchain4j.agentic.internal.A2AService;
+import dev.langchain4j.agentic.internal.AgentExecutor;
+import dev.langchain4j.agentic.internal.InternalAgent;
+import dev.langchain4j.agentic.planner.AgentArgument;
+import dev.langchain4j.agentic.scope.DefaultAgenticScope;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.service.V;
+import io.a2a.client.Client;
+import io.a2a.client.MessageEvent;
+import io.a2a.spec.AgentCapabilities;
+import io.a2a.spec.AgentCard;
+import io.a2a.spec.AgentSkill;
+import io.a2a.spec.Message;
+import io.a2a.spec.TextPart;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class A2AClientAgentMessageContextTest {
+
+    private static final AgentCard AGENT_CARD = new AgentCard.Builder()
+            .name("test-agent")
+            .description("Test agent")
+            .url("http://localhost:8080")
+            .version("1.0")
+            .capabilities(new AgentCapabilities.Builder().build())
+            .defaultInputModes(List.of("text"))
+            .defaultOutputModes(List.of("text"))
+            .skills(List.of(new AgentSkill.Builder()
+                    .id("test")
+                    .name("test")
+                    .description("Test skill")
+                    .tags(List.of("test"))
+                    .build()))
+            .build();
+
+    interface TypedA2AAgent {
+
+        String chat(
+                @V("question") String question,
+                @A2AContextId @V("contextId") String contextId,
+                @A2ATaskId @V("taskId") String taskId);
+    }
+
+    public interface DeclarativeA2AAgent {
+
+        @A2AClientAgent(
+                a2aServerUrl = "http://test-a2a",
+                outputKey = "answer",
+                contextIdKey = "contextId",
+                taskIdKey = "taskId")
+        String chat(@V("question") String question);
+    }
+
+    public interface DeclarativeA2AAgentWithContextParameters {
+
+        @A2AClientAgent(
+                a2aServerUrl = "http://test-a2a",
+                outputKey = "answer",
+                contextIdKey = "contextId",
+                taskIdKey = "taskId")
+        String chat(@V("question") String question, @V("contextId") String contextId, @V("taskId") String taskId);
+    }
+
+    public interface DeclarativeA2AWorkflow {
+
+        @SequenceAgent(outputKey = "answer", subAgents = DeclarativeA2AAgent.class)
+        String chat(@V("question") String question, @V("contextId") String contextId, @V("taskId") String taskId);
+    }
+
+    public interface DeclarativeA2AWorkflowWithContextParameters {
+
+        @SequenceAgent(outputKey = "answer", subAgents = DeclarativeA2AAgentWithContextParameters.class)
+        String chat(@V("question") String question, @V("contextId") String contextId, @V("taskId") String taskId);
+    }
+
+    @Test
+    void typed_agent_applies_marked_context_and_task_ids_to_message_envelope() throws Exception {
+        Client client = mockClientReturning("ok");
+
+        TypedA2AAgent agent = new DefaultA2AClientBuilder<>(AGENT_CARD, client, TypedA2AAgent.class).build();
+
+        String result = agent.chat("What changed?", "context-1", "task-1");
+
+        assertThat(result).isEqualTo("ok");
+
+        Message message = captureSentMessage(client);
+        assertThat(message.getContextId()).isEqualTo("context-1");
+        assertThat(message.getTaskId()).isEqualTo("task-1");
+        assertThat(message.getParts())
+                .singleElement()
+                .isInstanceOfSatisfying(
+                        TextPart.class, part -> assertThat(part.getText()).isEqualTo("What changed?"));
+    }
+
+    @Test
+    void typed_agent_allows_null_context_and_task_ids() throws Exception {
+        Client client = mockClientReturning("ok");
+
+        TypedA2AAgent agent = new DefaultA2AClientBuilder<>(AGENT_CARD, client, TypedA2AAgent.class).build();
+
+        String result = agent.chat("Start a new task", null, null);
+
+        assertThat(result).isEqualTo("ok");
+
+        Message message = captureSentMessage(client);
+        assertThat(message.getContextId()).isNull();
+        assertThat(message.getTaskId()).isNull();
+        assertThat(message.getParts())
+                .singleElement()
+                .isInstanceOfSatisfying(
+                        TextPart.class, part -> assertThat(part.getText()).isEqualTo("Start a new task"));
+    }
+
+    @Test
+    void untyped_agent_applies_configured_context_and_task_keys_to_message_envelope() throws Exception {
+        Client client = mockClientReturning("ok");
+
+        UntypedAgent agent = new DefaultA2AClientBuilder<>(AGENT_CARD, client, UntypedAgent.class)
+                .inputKeys("question", "contextId", "taskId")
+                .contextIdKey("contextId")
+                .taskIdKey("taskId")
+                .build();
+
+        Object result = agent.invoke(Map.of(
+                "question", "Continue the task",
+                "contextId", "context-1",
+                "taskId", "task-1"));
+
+        assertThat(result).isEqualTo("ok");
+
+        Message message = captureSentMessage(client);
+        assertThat(message.getContextId()).isEqualTo("context-1");
+        assertThat(message.getTaskId()).isEqualTo("task-1");
+        assertThat(message.getParts())
+                .singleElement()
+                .isInstanceOfSatisfying(
+                        TextPart.class, part -> assertThat(part.getText()).isEqualTo("Continue the task"));
+    }
+
+    @Test
+    void untyped_agent_keeps_context_and_task_keys_as_message_parts_when_not_configured() throws Exception {
+        Client client = mockClientReturning("ok");
+
+        UntypedAgent agent = new DefaultA2AClientBuilder<>(AGENT_CARD, client, UntypedAgent.class)
+                .inputKeys("question", "contextId", "taskId")
+                .build();
+
+        agent.invoke(Map.of(
+                "question", "Continue the task",
+                "contextId", "context-1",
+                "taskId", "task-1"));
+
+        Message message = captureSentMessage(client);
+        assertThat(message.getContextId()).isNull();
+        assertThat(message.getTaskId()).isNull();
+        assertThat(message.getParts())
+                .filteredOn(TextPart.class::isInstance)
+                .map(part -> ((TextPart) part).getText())
+                .containsExactly("Continue the task", "context-1", "task-1");
+    }
+
+    @Test
+    void declarative_agent_applies_configured_context_and_task_keys_from_agentic_scope() throws Exception {
+        Client client = mockClientReturning("ok");
+        A2AService previousA2AService = replaceA2AService(new TestA2AService(client));
+        try {
+            DeclarativeA2AWorkflow workflow =
+                    AgenticServices.createAgenticSystem(DeclarativeA2AWorkflow.class, (ChatModel) null);
+
+            String result = workflow.chat("Continue the task", "context-1", "task-1");
+
+            assertThat(result).isEqualTo("ok");
+
+            Message message = captureSentMessage(client);
+            assertThat(message.getContextId()).isEqualTo("context-1");
+            assertThat(message.getTaskId()).isEqualTo("task-1");
+            assertThat(message.getParts())
+                    .singleElement()
+                    .isInstanceOfSatisfying(
+                            TextPart.class, part -> assertThat(part.getText()).isEqualTo("Continue the task"));
+        } finally {
+            replaceA2AService(previousA2AService);
+        }
+    }
+
+    @Test
+    void declarative_agent_keeps_configured_context_and_task_key_parameters_out_of_message_parts() throws Exception {
+        Client client = mockClientReturning("ok");
+        A2AService previousA2AService = replaceA2AService(new TestA2AService(client));
+        try {
+            DeclarativeA2AWorkflowWithContextParameters workflow = AgenticServices.createAgenticSystem(
+                    DeclarativeA2AWorkflowWithContextParameters.class, (ChatModel) null);
+
+            String result = workflow.chat("Continue the task", "context-1", "task-1");
+
+            assertThat(result).isEqualTo("ok");
+
+            Message message = captureSentMessage(client);
+            assertThat(message.getContextId()).isEqualTo("context-1");
+            assertThat(message.getTaskId()).isEqualTo("task-1");
+            assertThat(message.getParts())
+                    .singleElement()
+                    .isInstanceOfSatisfying(
+                            TextPart.class, part -> assertThat(part.getText()).isEqualTo("Continue the task"));
+        } finally {
+            replaceA2AService(previousA2AService);
+        }
+    }
+
+    @Test
+    void invoker_keeps_marked_context_and_task_ids_out_of_business_arguments() throws Exception {
+        Client client = mockClientReturning("ok");
+        TypedA2AAgent agent = new DefaultA2AClientBuilder<>(AGENT_CARD, client, TypedA2AAgent.class).build();
+        Method method = TypedA2AAgent.class.getMethod("chat", String.class, String.class, String.class);
+        A2AClientAgentInvoker invoker = new A2AClientAgentInvoker((A2AClientInstance) agent, method);
+        DefaultAgenticScope agenticScope = DefaultAgenticScope.ephemeralAgenticScope();
+        agenticScope.writeState("question", "Continue the task");
+        agenticScope.writeState("contextId", "context-1");
+        agenticScope.writeState("taskId", "task-1");
+
+        var invocationArguments = invoker.toInvocationArguments(agenticScope);
+
+        assertThat(invoker.arguments()).map(AgentArgument::name).containsExactly("question");
+        assertThat(invocationArguments.namedArgs()).containsExactly(Map.entry("question", "Continue the task"));
+        assertThat(invocationArguments.positionalArgs()).containsExactly("Continue the task", "context-1", "task-1");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Client mockClientReturning(String responseText) throws Exception {
+        Client client = mock(Client.class);
+        doAnswer(invocation -> {
+                    List<BiConsumer<io.a2a.client.ClientEvent, AgentCard>> consumers = invocation.getArgument(1);
+                    Message response = new Message.Builder()
+                            .role(Message.Role.AGENT)
+                            .parts(new TextPart(responseText))
+                            .build();
+                    consumers.forEach(consumer -> consumer.accept(new MessageEvent(response), AGENT_CARD));
+                    return null;
+                })
+                .when(client)
+                .sendMessage(any(Message.class), anyList(), any(Consumer.class));
+        return client;
+    }
+
+    private static A2AService replaceA2AService(A2AService a2aService) throws Exception {
+        Field field = Class.forName("dev.langchain4j.agentic.internal.A2AService$Provider")
+                .getDeclaredField("a2aService");
+        field.setAccessible(true);
+        A2AService previousA2AService = (A2AService) field.get(null);
+        field.set(null, a2aService);
+        return previousA2AService;
+    }
+
+    private static Message captureSentMessage(Client client) throws Exception {
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(client).sendMessage(messageCaptor.capture(), anyList(), any(Consumer.class));
+        return messageCaptor.getValue();
+    }
+
+    private static class TestA2AService implements A2AService {
+
+        private final Client client;
+
+        TestA2AService(Client client) {
+            this.client = client;
+        }
+
+        @Override
+        public <T> A2AClientBuilder<T> a2aBuilder(String a2aServerUrl, Class<T> agentServiceClass) {
+            assertThat(a2aServerUrl).isEqualTo("http://test-a2a");
+            return new DefaultA2AClientBuilder<>(AGENT_CARD, client, agentServiceClass);
+        }
+
+        @Override
+        public Optional<AgentExecutor> methodToAgentExecutor(InternalAgent a2aClient, Method method) {
+            return new DefaultA2AService().methodToAgentExecutor(a2aClient, method);
+        }
+    }
+}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
@@ -16,6 +16,8 @@ import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import dev.langchain4j.agentic.agent.AgentBuilder;
 import dev.langchain4j.agentic.agent.UntypedAgentBuilder;
 import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.agentic.declarative.A2AContextId;
+import dev.langchain4j.agentic.declarative.A2ATaskId;
 import dev.langchain4j.agentic.declarative.ActivationCondition;
 import dev.langchain4j.agentic.declarative.AgentListenerSupplier;
 import dev.langchain4j.agentic.declarative.ChatModelSupplier;
@@ -53,6 +55,7 @@ import dev.langchain4j.agentic.workflow.impl.WorkflowAgentsBuilderImpl;
 import dev.langchain4j.model.chat.ChatModel;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -670,9 +673,12 @@ public class AgenticServices {
         var a2aClient = a2aMethod.getAnnotation(A2AClientAgent.class);
         var a2aClientBuilder = a2aBuilder(a2aClient.a2aServerUrl(), agentServiceClass)
                 .inputKeys(Stream.of(a2aMethod.getParameters())
+                        .filter(parameter -> !isA2AMessageContextParameter(parameter, a2aClient))
                         .map(AgentInvoker::parameterName)
                         .toArray(String[]::new))
                 .outputKey(AgentUtil.outputKey(a2aClient.outputKey(), a2aClient.typedOutputKey()))
+                .contextIdKey(a2aClient.contextIdKey())
+                .taskIdKey(a2aClient.taskIdKey())
                 .async(a2aClient.async());
 
         getAnnotatedMethodOnClass(agentServiceClass, AgentListenerSupplier.class)
@@ -682,6 +688,19 @@ public class AgenticServices {
                 });
 
         return agentToExecutor(a2aClientBuilder.build());
+    }
+
+    private static boolean isA2AMessageContextParameter(Parameter parameter, A2AClientAgent a2aClient) {
+        return parameter.isAnnotationPresent(A2AContextId.class)
+                || parameter.isAnnotationPresent(A2ATaskId.class)
+                || isConfiguredKey(a2aClient.contextIdKey(), parameter)
+                || isConfiguredKey(a2aClient.taskIdKey(), parameter);
+    }
+
+    private static boolean isConfiguredKey(String configuredKey, Parameter parameter) {
+        return AgentInvoker.optionalParameterName(parameter)
+                .map(key -> configuredKey != null && !configuredKey.isBlank() && configuredKey.equals(key))
+                .orElse(false);
     }
 
     private static AgentExecutor createMcpClientAgent(Class<?> agentServiceClass, Method mcpMethod) {

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2AClientAgent.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2AClientAgent.java
@@ -1,10 +1,9 @@
 package dev.langchain4j.agentic.declarative;
 
-import dev.langchain4j.agentic.Agent;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -51,6 +50,20 @@ public @interface A2AClientAgent {
      * @return name of the output variable.
      */
     String outputKey() default "";
+
+    /**
+     * Key of the state variable that contains the A2A message context id.
+     *
+     * @return name of the context id state variable.
+     */
+    String contextIdKey() default "";
+
+    /**
+     * Key of the state variable that contains the A2A message task id.
+     *
+     * @return name of the task id state variable.
+     */
+    String taskIdKey() default "";
 
     /**
      * Strongly typed key of the output variable that will be used to store the result of the agent's invocation.

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2AContextId.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2AContextId.java
@@ -1,0 +1,14 @@
+package dev.langchain4j.agentic.declarative;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a parameter as the A2A message context id.
+ */
+@Retention(RUNTIME)
+@Target(PARAMETER)
+public @interface A2AContextId {}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2ATaskId.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2ATaskId.java
@@ -1,0 +1,14 @@
+package dev.langchain4j.agentic.declarative;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a parameter as the A2A message task id.
+ */
+@Retention(RUNTIME)
+@Target(PARAMETER)
+public @interface A2ATaskId {}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/A2AClientBuilder.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/A2AClientBuilder.java
@@ -8,6 +8,14 @@ public interface A2AClientBuilder<T> {
 
     A2AClientBuilder<T> outputKey(String outputKey);
 
+    default A2AClientBuilder<T> contextIdKey(String contextIdKey) {
+        return this;
+    }
+
+    default A2AClientBuilder<T> taskIdKey(String taskIdKey) {
+        return this;
+    }
+
     A2AClientBuilder<T> async(boolean async);
 
     A2AClientBuilder<T> listener(AgentListener agentListener);

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class AgentUtil {
@@ -165,14 +166,24 @@ public class AgentUtil {
     }
 
     public static List<AgentArgument> argumentsFromMethod(Method method) {
-        return argumentsFromMethod(method, Map.of());
+        return argumentsFromMethod(method, p -> true);
+    }
+
+    public static List<AgentArgument> argumentsFromMethod(Method method, Predicate<Parameter> parameterFilter) {
+        return argumentsFromMethod(method, Map.of(), parameterFilter);
     }
 
     public static List<AgentArgument> argumentsFromMethod(Method method, Map<String, Object> defaultValues) {
+        return argumentsFromMethod(method, defaultValues, p -> true);
+    }
+
+    public static List<AgentArgument> argumentsFromMethod(
+            Method method, Map<String, Object> defaultValues, Predicate<Parameter> parameterFilter) {
         if (method.getDeclaringClass() == UntypedAgent.class) {
             return List.of();
         }
         return Stream.of(method.getParameters())
+                .filter(parameterFilter)
                 .map(p -> {
                     String argName = parameterName(p);
                     Object defaultValue = defaultValues.getOrDefault(argName, parameterDefaultValue(p));


### PR DESCRIPTION
## Issue
Closes #5311

## Change
Adds opt-in support for passing A2A `contextId` and `taskId` through `@A2AClientAgent`.

- adds `contextIdKey` and `taskIdKey` to `@A2AClientAgent`
- adds `@A2AContextId` and `@A2ATaskId` for typed A2A client methods
- writes configured or annotated values to the A2A message envelope
- keeps legacy behavior unchanged unless the new keys or annotations are used
- adds tests for typed, untyped, negative, and declarative wiring paths

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)