### PR TITLE
Fix #5277: ToolService.shouldReturnImmediately() crashes on empty ReturnBehavior list

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -525,6 +525,9 @@ public class ToolService {
         if (anyToolErrored) {
             return false; // if any tool call failed, LLM should receive an error so that it can attempt to fix it
         }
+        if (returnBehaviors.isEmpty()) {
+            return false;
+        }
         if (returnBehaviors.get(returnBehaviors.size() - 1) == IMMEDIATE_IF_LAST) {
             return true;
         }

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
@@ -1,0 +1,16 @@
+package dev.langchain4j.service.tool;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static dev.langchain4j.service.tool.ToolService.shouldReturnImmediately;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class ToolServiceTest {
+
+    @Test
+    void shouldReturnImmediately_empty_list_should_not_crash() {
+        assertThatNoException().isThrownBy(() -> shouldReturnImmediately(false, List.of()));
+    }
+}


### PR DESCRIPTION
## Issue
Fixes #5277

## Change
Re-applies only the fix from #5279 

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)