### PR TITLE
docs: add Javadoc to exception hierarchy in langchain4j-core

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/AuthenticationException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/AuthenticationException.java
@@ -1,5 +1,13 @@
 package dev.langchain4j.exception;
 
+/**
+ * Thrown when a request is rejected because the supplied credentials are missing,
+ * invalid, or insufficient (HTTP 401 / 403).
+ * <p>
+ * This is a {@link NonRetriableException}: retrying the same request with the same
+ * credentials will not help. The caller should verify the API key or token and
+ * reconfigure the client before retrying.
+ */
 public class AuthenticationException extends NonRetriableException {
     public AuthenticationException(String message) {
         super(message);

--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/HttpException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/HttpException.java
@@ -1,5 +1,19 @@
 package dev.langchain4j.exception;
 
+/**
+ * Represents an HTTP-level error returned by a model provider.
+ * <p>
+ * Carries the raw HTTP status code alongside the error message so that
+ * higher-level error mappers (such as {@code ExceptionMapper}) can translate
+ * specific codes into more descriptive exceptions (e.g. 429 →
+ * {@link RateLimitException}, 401 → {@link AuthenticationException}).
+ * <p>
+ * This class is typically not thrown directly by user-facing APIs; it is an
+ * intermediate representation that the HTTP client layer produces before the
+ * exception mapper converts it to a more specific type.
+ *
+ * @see dev.langchain4j.internal.ExceptionMapper
+ */
 public class HttpException extends LangChain4jException {
 
     private final int statusCode;

--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/InternalServerException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/InternalServerException.java
@@ -1,5 +1,12 @@
 package dev.langchain4j.exception;
 
+/**
+ * Thrown when the model provider returns a server-side error (HTTP 5xx).
+ * <p>
+ * This is a {@link RetriableException}: the failure is on the provider's side
+ * and the request may succeed after a brief back-off. If the error persists
+ * across multiple retries, it likely indicates an ongoing outage with the provider.
+ */
 public class InternalServerException extends RetriableException {
     public InternalServerException(String message) {
         super(message);

--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/InvalidRequestException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/InvalidRequestException.java
@@ -1,5 +1,16 @@
 package dev.langchain4j.exception;
 
+/**
+ * Thrown when the model provider rejects a request because the request itself is
+ * malformed or violates the provider's constraints (HTTP 4xx, excluding 401, 403,
+ * 404, 408, and 429).
+ * <p>
+ * This is a {@link NonRetriableException}: the same request will be rejected again
+ * without modification. The caller must correct the request (e.g. reduce the prompt
+ * length, remove unsupported parameters) before retrying.
+ *
+ * @see ContentFilteredException
+ */
 public class InvalidRequestException extends NonRetriableException {
     public InvalidRequestException(String message) {
         super(message);

--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/LangChain4jException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/LangChain4jException.java
@@ -1,5 +1,13 @@
 package dev.langchain4j.exception;
 
+/**
+ * The root unchecked exception for all LangChain4j-specific errors.
+ * <p>
+ * All library exceptions extend this class, making it the single catch point
+ * for callers that need to handle any LangChain4j error uniformly.
+ * For more targeted handling, prefer catching a specific subclass such as
+ * {@link RetriableException} or {@link NonRetriableException}.
+ */
 public class LangChain4jException extends RuntimeException {
 
     public LangChain4jException(String message) {

--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/ModelNotFoundException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/ModelNotFoundException.java
@@ -1,5 +1,12 @@
 package dev.langchain4j.exception;
 
+/**
+ * Thrown when the requested model does not exist or is not accessible by the caller
+ * (HTTP 404).
+ * <p>
+ * This is a {@link NonRetriableException}: the same request will fail again until
+ * the model name or identifier is corrected in the client configuration.
+ */
 public class ModelNotFoundException extends NonRetriableException {
     public ModelNotFoundException(String message) {
         super(message);

--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/NonRetriableException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/NonRetriableException.java
@@ -1,5 +1,18 @@
 package dev.langchain4j.exception;
 
+/**
+ * Indicates a permanent error for which retrying the same request will not help.
+ * <p>
+ * Typical causes include invalid credentials, a malformed request, or referencing
+ * a model that does not exist. Callers should inspect the specific subclass to
+ * decide how to recover (e.g. prompt the user to correct their input, or fail fast).
+ *
+ * @see RetriableException
+ * @see AuthenticationException
+ * @see InvalidRequestException
+ * @see ModelNotFoundException
+ * @see UnresolvedModelServerException
+ */
 public class NonRetriableException extends LangChain4jException {
     public NonRetriableException(String message) {
         super(message);

--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/RateLimitException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/RateLimitException.java
@@ -1,5 +1,13 @@
 package dev.langchain4j.exception;
 
+/**
+ * Thrown when the model provider rejects a request because the caller has exceeded
+ * its allowed request or token quota within a time window (HTTP 429).
+ * <p>
+ * This is a {@link RetriableException}: the request may succeed once the rate-limit
+ * window resets. Callers should implement an exponential back-off strategy before
+ * retrying.
+ */
 public class RateLimitException extends RetriableException {
     public RateLimitException(String message) {
         super(message);

--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/RetriableException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/RetriableException.java
@@ -1,5 +1,18 @@
 package dev.langchain4j.exception;
 
+/**
+ * Indicates a transient error that may succeed if the request is retried.
+ * <p>
+ * Examples include temporary network issues, upstream server errors (5xx),
+ * and rate-limit rejections. Callers that implement a retry loop should
+ * catch this exception (or one of its subclasses) and back off before
+ * re-issuing the request.
+ *
+ * @see NonRetriableException
+ * @see RateLimitException
+ * @see InternalServerException
+ * @see TimeoutException
+ */
 public class RetriableException extends LangChain4jException {
     public RetriableException(String message) {
         super(message);

--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/TimeoutException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/TimeoutException.java
@@ -1,5 +1,13 @@
 package dev.langchain4j.exception;
 
+/**
+ * Thrown when a request to the model provider does not complete within the
+ * configured time limit (HTTP 408 or a client-side read/connect timeout).
+ * <p>
+ * This is a {@link RetriableException}: a transient network condition or a
+ * temporarily overloaded provider may have caused the delay, and a retry
+ * (potentially with a longer timeout) may succeed.
+ */
 public class TimeoutException extends RetriableException {
     public TimeoutException(String message) {
         super(message);

--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/UnresolvedModelServerException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/UnresolvedModelServerException.java
@@ -1,5 +1,13 @@
 package dev.langchain4j.exception;
 
+/**
+ * Thrown when the model provider's host cannot be resolved (DNS failure or
+ * {@link java.nio.channels.UnresolvedAddressException}).
+ * <p>
+ * This is a {@link NonRetriableException}: the configured endpoint URL is
+ * either incorrect or the host is unreachable from the current network. The
+ * caller should verify the base URL in the client configuration before retrying.
+ */
 public class UnresolvedModelServerException extends NonRetriableException {
     public UnresolvedModelServerException(String message) {
         super(message);

--- a/langchain4j-core/src/main/java/dev/langchain4j/exception/UnsupportedFeatureException.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/exception/UnsupportedFeatureException.java
@@ -1,5 +1,14 @@
 package dev.langchain4j.exception;
 
+/**
+ * Thrown when a requested feature is not supported by the current model provider
+ * or the specific model being used.
+ * <p>
+ * Examples include requesting structured output from a model that does not support
+ * it, or enabling tool-use on a provider whose API does not offer function calling.
+ * The caller should either switch to a compatible model or adjust the request to
+ * avoid the unsupported feature.
+ */
 public class UnsupportedFeatureException extends LangChain4jException {
 
     public UnsupportedFeatureException(String message) {


### PR DESCRIPTION
Twelve public exception classes in the exception hierarchy had no class-level Javadoc, making it hard for integrators to understand when each type is thrown, whether a retry is safe, and how the exceptions relate to one another.

This commit adds class-level Javadoc to:
- LangChain4jException    - root exception for all library errors
- RetriableException      - transient errors safe to retry
- NonRetriableException   - permanent errors where retry will not help
- RateLimitException      - HTTP 429 / quota exceeded
- HttpException           - raw HTTP error carrying the status code
- AuthenticationException - HTTP 401 / 403 credential failures
- InvalidRequestException - malformed or policy-violating requests
- ModelNotFoundException  - HTTP 404 / unknown model identifier
- InternalServerException - HTTP 5xx server-side errors
- TimeoutException        - HTTP 408 / client-side timeouts
- UnresolvedModelServerException - DNS / unresolved host
- UnsupportedFeatureException    - feature not supported by provider

ContentFilteredException, ToolArgumentsException, and ToolExecutionException already had Javadoc and are unchanged.

No behaviour changes; documentation only.


## Issue
Added class-level Javadoc to the 12 exception classes in the exception hierarchy
that were missing it. No behaviour changes; documentation only.

Closes #

## Change
<!-- Please describe the changes you made. -->


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
