### PR TITLE
ChatRequest: allow individual setters to override parameters

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ChatRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ChatRequest.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.model.chat.request;
 
 import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static java.util.Arrays.asList;
 
@@ -20,58 +19,21 @@ public class ChatRequest {
     protected ChatRequest(Builder builder) {
         this.messages = copy(ensureNotEmpty(builder.messages, "messages"));
 
-        DefaultChatRequestParameters.Builder<?> parametersBuilder = ChatRequestParameters.builder();
+        ChatRequestParameters overrides = ChatRequestParameters.builder()
+                .modelName(builder.modelName)
+                .temperature(builder.temperature)
+                .topP(builder.topP)
+                .topK(builder.topK)
+                .frequencyPenalty(builder.frequencyPenalty)
+                .presencePenalty(builder.presencePenalty)
+                .maxOutputTokens(builder.maxOutputTokens)
+                .stopSequences(builder.stopSequences)
+                .toolSpecifications(builder.toolSpecifications)
+                .toolChoice(builder.toolChoice)
+                .responseFormat(builder.responseFormat)
+                .build();
 
-        if (builder.modelName != null) {
-            validate(builder, "modelName");
-            parametersBuilder.modelName(builder.modelName);
-        }
-        if (builder.temperature != null) {
-            validate(builder, "temperature");
-            parametersBuilder.temperature(builder.temperature);
-        }
-        if (builder.topP != null) {
-            validate(builder, "topP");
-            parametersBuilder.topP(builder.topP);
-        }
-        if (builder.topK != null) {
-            validate(builder, "topK");
-            parametersBuilder.topK(builder.topK);
-        }
-        if (builder.frequencyPenalty != null) {
-            validate(builder, "frequencyPenalty");
-            parametersBuilder.frequencyPenalty(builder.frequencyPenalty);
-        }
-        if (builder.presencePenalty != null) {
-            validate(builder, "presencePenalty");
-            parametersBuilder.presencePenalty(builder.presencePenalty);
-        }
-        if (builder.maxOutputTokens != null) {
-            validate(builder, "maxOutputTokens");
-            parametersBuilder.maxOutputTokens(builder.maxOutputTokens);
-        }
-        if (!isNullOrEmpty(builder.stopSequences)) {
-            validate(builder, "stopSequences");
-            parametersBuilder.stopSequences(builder.stopSequences);
-        }
-        if (!isNullOrEmpty(builder.toolSpecifications)) {
-            validate(builder, "toolSpecifications");
-            parametersBuilder.toolSpecifications(builder.toolSpecifications);
-        }
-        if (builder.toolChoice != null) {
-            validate(builder, "toolChoice");
-            parametersBuilder.toolChoice(builder.toolChoice);
-        }
-        if (builder.responseFormat != null) {
-            validate(builder, "responseFormat");
-            parametersBuilder.responseFormat(builder.responseFormat);
-        }
-
-        if (builder.parameters != null) {
-            this.parameters = builder.parameters;
-        } else {
-            this.parameters = parametersBuilder.build();
-        }
+        this.parameters = builder.parameters != null ? builder.parameters.overrideWith(overrides) : overrides;
     }
 
     public List<ChatMessage> messages() {
@@ -148,7 +110,17 @@ public class ChatRequest {
     }
 
     /**
-     * Transforms this instance to a {@link Builder} with all of the same field values
+     * Transforms this instance to a {@link Builder} with all of the same field values.
+     * <p>
+     * Individual setters on the returned {@link Builder} (e.g., {@link Builder#modelName(String)},
+     * {@link Builder#temperature(Double)}, etc.) can be used to override specific fields of the existing
+     * {@link #parameters()} without rebuilding them from scratch. For example:
+     * <pre>{@code
+     * ChatRequest modified = chatRequest.toBuilder()
+     *         .temperature(0.0)
+     *         .build();
+     * }</pre>
+     * See {@link Builder} for details on the override semantics.
      */
     public Builder toBuilder() {
         return new Builder(this);
@@ -158,6 +130,22 @@ public class ChatRequest {
         return new Builder();
     }
 
+    /**
+     * Builder for {@link ChatRequest}.
+     * <p>
+     * <b>Override semantics</b>: when {@link #parameters(ChatRequestParameters)} is set together with
+     * one or more individual setters (e.g., {@link #modelName(String)},
+     * {@link #temperature(Double)}, etc.), the values from the individual
+     * setters take precedence over the corresponding fields of {@code parameters}, while all other
+     * fields of {@code parameters} (including provider-specific fields on subclasses of
+     * {@link ChatRequestParameters}) are preserved. Merging is performed via
+     * {@link ChatRequestParameters#overrideWith(ChatRequestParameters)}, which only overrides with
+     * non-null (and, for collections, non-empty) values — setting a field back to {@code null} via
+     * an individual setter will <em>not</em> clear an existing value on {@code parameters}.
+     * <p>
+     * This makes it easy to modify a single field of an existing {@link ChatRequest} via
+     * {@link ChatRequest#toBuilder()} without losing any other configuration.
+     */
     public static class Builder {
 
         private List<ChatMessage> messages;
@@ -191,6 +179,14 @@ public class ChatRequest {
             return messages(asList(messages));
         }
 
+        /**
+         * Sets the {@link ChatRequestParameters} to be used as the base for this request.
+         * <p>
+         * Any individual setters called on this {@link Builder} (e.g., {@link #modelName(String)},
+         * {@link #temperature(Double)}, etc.) will override the corresponding fields of the supplied
+         * {@code parameters}; all other fields of {@code parameters} are preserved.
+         * See {@link Builder} for full override semantics.
+         */
         public Builder parameters(ChatRequestParameters parameters) {
             this.parameters = parameters;
             return this;
@@ -257,12 +253,6 @@ public class ChatRequest {
 
         public ChatRequest build() {
             return new ChatRequest(this);
-        }
-    }
-
-    private static void validate(Builder builder, String name) {
-        if (builder.parameters != null) {
-            throw new IllegalArgumentException("Cannot set both 'parameters' and '%s' on ChatRequest".formatted(name));
         }
     }
 }

--- a/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ChatRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/model/chat/request/ChatRequest.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.model.chat.request;
 
 import static dev.langchain4j.internal.Utils.copy;
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static java.util.Arrays.asList;
 
@@ -18,6 +19,23 @@ public class ChatRequest {
 
     protected ChatRequest(Builder builder) {
         this.messages = copy(ensureNotEmpty(builder.messages, "messages"));
+
+        boolean individualParametersAreSpecified = builder.modelName != null
+                || builder.temperature != null
+                || builder.topP != null
+                || builder.topK != null
+                || builder.frequencyPenalty != null
+                || builder.presencePenalty != null
+                || builder.maxOutputTokens != null
+                || !isNullOrEmpty(builder.stopSequences)
+                || !isNullOrEmpty(builder.toolSpecifications)
+                || builder.toolChoice != null
+                || builder.responseFormat != null;
+
+        if (!individualParametersAreSpecified) {
+            this.parameters = builder.parameters != null ? builder.parameters : DefaultChatRequestParameters.EMPTY;
+            return;
+        }
 
         ChatRequestParameters overrides = ChatRequestParameters.builder()
                 .modelName(builder.modelName)

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/ChatRequestTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/ChatRequestTest.java
@@ -448,6 +448,7 @@ class ChatRequestTest {
 
         // then
         assertThat(modified).isEqualTo(original);
+        assertThat(modified.parameters()).isSameAs(parameters);
     }
 
     @Test
@@ -640,10 +641,9 @@ class ChatRequestTest {
         // when
         ChatRequest modified = original.toBuilder().build();
 
-        // then: result still has the provider-specific subclass parameters
-        assertThat(modified.parameters()).isInstanceOf(TestProviderChatRequestParameters.class);
-        assertThat(((TestProviderChatRequestParameters) modified.parameters()).customField())
-                .isEqualTo("custom-value");
+        // then: original parameters object passed through as-is (identity preserved,
+        // so subclasses that do not override overrideWith still keep their type)
+        assertThat(modified.parameters()).isSameAs(parameters);
     }
 
     public static class TestProviderChatRequestParameters extends DefaultChatRequestParameters {

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/ChatRequestTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/ChatRequestTest.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.chat.request;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -8,6 +9,7 @@ import dev.langchain4j.data.message.UserMessage;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Objects;
 
 class ChatRequestTest {
 
@@ -446,5 +448,265 @@ class ChatRequestTest {
 
         // then
         assertThat(modified).isEqualTo(original);
+    }
+
+    @Test
+    void should_not_clear_existing_responseFormat_when_setter_called_with_null() {
+        // given
+        ChatRequest original = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(ChatRequestParameters.builder()
+                        .responseFormat(ResponseFormat.JSON)
+                        .build())
+                .build();
+
+        // when
+        ChatRequest modified = original.toBuilder()
+                .responseFormat(null)
+                .build();
+
+        // then: overrideWith skips null overrides, so existing value is preserved
+        assertThat(modified.responseFormat()).isEqualTo(ResponseFormat.JSON);
+    }
+
+    @Test
+    void should_not_clear_existing_toolSpecifications_when_setter_called_with_empty() {
+        // given
+        ToolSpecification tool = ToolSpecification.builder().name("tool").build();
+        ChatRequest original = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(ChatRequestParameters.builder()
+                        .toolSpecifications(tool)
+                        .build())
+                .build();
+
+        // when
+        ChatRequest modified = original.toBuilder()
+                .toolSpecifications()
+                .build();
+
+        // then: overrideWith skips empty list overrides, so existing tools are preserved
+        assertThat(modified.toolSpecifications()).containsExactly(tool);
+    }
+
+    @Test
+    void should_apply_zero_value_via_setter() {
+        // given: 0.0 must not be treated as null/default
+        ChatRequest original = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(ChatRequestParameters.builder()
+                        .temperature(0.7)
+                        .build())
+                .build();
+
+        // when
+        ChatRequest modified = original.toBuilder()
+                .temperature(0.0)
+                .build();
+
+        // then
+        assertThat(modified.temperature()).isEqualTo(0.0);
+    }
+
+    @Test
+    void should_last_setter_call_win_on_individual_field() {
+        // when
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .temperature(0.1)
+                .temperature(0.2)
+                .temperature(0.3)
+                .build();
+
+        // then
+        assertThat(chatRequest.temperature()).isEqualTo(0.3);
+    }
+
+    @Test
+    void should_be_independent_of_setter_order_parameters_then_individual() {
+        // given
+        ChatRequestParameters parameters = ChatRequestParameters.builder()
+                .responseFormat(ResponseFormat.JSON)
+                .build();
+
+        // when: .parameters() called before .responseFormat()
+        ChatRequest a = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(parameters)
+                .responseFormat(ResponseFormat.TEXT)
+                .build();
+
+        // when: .responseFormat() called before .parameters()
+        ChatRequest b = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .responseFormat(ResponseFormat.TEXT)
+                .parameters(parameters)
+                .build();
+
+        // then
+        assertThat(a).isEqualTo(b);
+        assertThat(a.responseFormat()).isEqualTo(ResponseFormat.TEXT);
+    }
+
+    @Test
+    void should_fully_replace_parameters_when_parameters_called_again() {
+        // given
+        ChatRequest original = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(ChatRequestParameters.builder()
+                        .modelName("gpt-4")
+                        .temperature(0.7)
+                        .build())
+                .build();
+
+        ChatRequestParameters replacement = ChatRequestParameters.builder()
+                .maxOutputTokens(50)
+                .build();
+
+        // when
+        ChatRequest modified = original.toBuilder()
+                .parameters(replacement)
+                .build();
+
+        // then: original modelName/temperature are gone, only replacement fields remain
+        assertThat(modified.modelName()).isNull();
+        assertThat(modified.temperature()).isNull();
+        assertThat(modified.maxOutputTokens()).isEqualTo(50);
+    }
+
+    @Test
+    void should_clear_parameters_when_parameters_called_with_null() {
+        // given
+        ChatRequest original = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(ChatRequestParameters.builder()
+                        .modelName("gpt-4")
+                        .temperature(0.7)
+                        .responseFormat(ResponseFormat.JSON)
+                        .build())
+                .build();
+
+        // when
+        ChatRequest modified = original.toBuilder()
+                .parameters(null)
+                .build();
+
+        // then: all parameters cleared (result has empty default parameters)
+        assertThat(modified.modelName()).isNull();
+        assertThat(modified.temperature()).isNull();
+        assertThat(modified.responseFormat()).isNull();
+    }
+
+    @Test
+    void should_preserve_provider_specific_subclass_fields_via_toBuilder() {
+        // given: provider-specific subclass with an extra field
+        TestProviderChatRequestParameters parameters = TestProviderChatRequestParameters.builder()
+                .modelName("test-model")
+                .temperature(0.5)
+                .customField("custom-value")
+                .build();
+
+        ChatRequest original = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(parameters)
+                .build();
+
+        // when: override a common field via toBuilder
+        ChatRequest modified = original.toBuilder()
+                .temperature(0.9)
+                .build();
+
+        // then: provider-specific field is preserved, base field is overridden
+        assertThat(modified.parameters()).isInstanceOf(TestProviderChatRequestParameters.class);
+        TestProviderChatRequestParameters modifiedParams =
+                (TestProviderChatRequestParameters) modified.parameters();
+        assertThat(modifiedParams.customField()).isEqualTo("custom-value");
+        assertThat(modifiedParams.modelName()).isEqualTo("test-model");
+        assertThat(modifiedParams.temperature()).isEqualTo(0.9);
+    }
+
+    @Test
+    void should_preserve_provider_specific_subclass_type_when_toBuilder_used_without_setters() {
+        // given
+        TestProviderChatRequestParameters parameters = TestProviderChatRequestParameters.builder()
+                .customField("custom-value")
+                .build();
+
+        ChatRequest original = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(parameters)
+                .build();
+
+        // when
+        ChatRequest modified = original.toBuilder().build();
+
+        // then: result still has the provider-specific subclass parameters
+        assertThat(modified.parameters()).isInstanceOf(TestProviderChatRequestParameters.class);
+        assertThat(((TestProviderChatRequestParameters) modified.parameters()).customField())
+                .isEqualTo("custom-value");
+    }
+
+    public static class TestProviderChatRequestParameters extends DefaultChatRequestParameters {
+
+        private final String customField;
+
+        private TestProviderChatRequestParameters(Builder builder) {
+            super(builder);
+            this.customField = builder.customField;
+        }
+
+        public String customField() {
+            return customField;
+        }
+
+        @Override
+        public TestProviderChatRequestParameters overrideWith(ChatRequestParameters that) {
+            return TestProviderChatRequestParameters.builder()
+                    .overrideWith(this)
+                    .overrideWith(that)
+                    .build();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            TestProviderChatRequestParameters that = (TestProviderChatRequestParameters) o;
+            return Objects.equals(customField, that.customField);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), customField);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static class Builder extends DefaultChatRequestParameters.Builder<Builder> {
+
+            private String customField;
+
+            @Override
+            public Builder overrideWith(ChatRequestParameters parameters) {
+                super.overrideWith(parameters);
+                if (parameters instanceof TestProviderChatRequestParameters testParameters) {
+                    customField(getOrDefault(testParameters.customField(), customField));
+                }
+                return this;
+            }
+
+            public Builder customField(String customField) {
+                this.customField = customField;
+                return this;
+            }
+
+            @Override
+            public TestProviderChatRequestParameters build() {
+                return new TestProviderChatRequestParameters(this);
+            }
+        }
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/ChatRequestTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/model/chat/request/ChatRequestTest.java
@@ -61,28 +61,29 @@ class ChatRequestTest {
     }
 
     @Test
-    void should_fail_when_both_request_parameters_and_response_format_are_set() {
+    void should_override_response_format_when_both_parameters_and_response_format_are_set() {
 
-        assertThatThrownBy(() -> ChatRequest.builder()
-                        .messages(UserMessage.from("hi"))
-                        .parameters(DefaultChatRequestParameters.EMPTY)
-                        .responseFormat(ResponseFormat.JSON)
-                        .build())
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot set both 'parameters' and 'responseFormat' on ChatRequest");
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(DefaultChatRequestParameters.EMPTY)
+                .responseFormat(ResponseFormat.JSON)
+                .build();
+
+        assertThat(chatRequest.responseFormat()).isEqualTo(ResponseFormat.JSON);
     }
 
     @Test
-    void should_fail_when_both_request_parameters_and_toolSpecifications_are_set() {
+    void should_override_tool_specifications_when_both_parameters_and_toolSpecifications_are_set() {
 
-        assertThatThrownBy(() -> ChatRequest.builder()
-                        .messages(UserMessage.from("hi"))
-                        .parameters(DefaultChatRequestParameters.EMPTY)
-                        .toolSpecifications(
-                                ToolSpecification.builder().name("tool").build())
-                        .build())
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot set both 'parameters' and 'toolSpecifications' on ChatRequest");
+        ToolSpecification tool = ToolSpecification.builder().name("tool").build();
+
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(DefaultChatRequestParameters.EMPTY)
+                .toolSpecifications(tool)
+                .build();
+
+        assertThat(chatRequest.toolSpecifications()).containsExactly(tool);
     }
 
     @Test
@@ -197,32 +198,36 @@ class ChatRequestTest {
     }
 
     @Test
-    void should_fail_when_both_parameters_and_response_format_are_non_null() {
+    void should_override_response_format_when_both_parameters_and_response_format_are_non_null() {
         // given
         ChatRequestParameters parameters = ChatRequestParameters.builder().build();
 
-        assertThatThrownBy(() -> ChatRequest.builder()
-                        .messages(UserMessage.from("hi"))
-                        .parameters(parameters)
-                        .responseFormat(ResponseFormat.JSON)
-                        .build())
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot set both 'parameters' and 'responseFormat' on ChatRequest");
+        // when
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(parameters)
+                .responseFormat(ResponseFormat.JSON)
+                .build();
+
+        // then
+        assertThat(chatRequest.responseFormat()).isEqualTo(ResponseFormat.JSON);
     }
 
     @Test
-    void should_fail_when_both_parameters_and_tool_specifications_are_non_null() {
+    void should_override_tool_specifications_when_both_parameters_and_tool_specifications_are_non_null() {
         // given
         ChatRequestParameters parameters = ChatRequestParameters.builder().build();
         ToolSpecification tool = ToolSpecification.builder().name("tool").build();
 
-        assertThatThrownBy(() -> ChatRequest.builder()
-                        .messages(UserMessage.from("hi"))
-                        .parameters(parameters)
-                        .toolSpecifications(tool)
-                        .build())
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot set both 'parameters' and 'toolSpecifications' on ChatRequest");
+        // when
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(parameters)
+                .toolSpecifications(tool)
+                .build();
+
+        // then
+        assertThat(chatRequest.toolSpecifications()).containsExactly(tool);
     }
 
     @Test
@@ -242,7 +247,7 @@ class ChatRequestTest {
     }
 
     @Test
-    void should_fail_when_parameters_contains_conflicting_tool_specifications() {
+    void should_override_tool_specifications_from_parameters() {
         // given
         ToolSpecification paramTool =
                 ToolSpecification.builder().name("paramTool").build();
@@ -252,14 +257,15 @@ class ChatRequestTest {
         ChatRequestParameters parameters =
                 ChatRequestParameters.builder().toolSpecifications(paramTool).build();
 
-        // when/then
-        assertThatThrownBy(() -> ChatRequest.builder()
+        // when
+        ChatRequest chatRequest = ChatRequest.builder()
                 .messages(UserMessage.from("hi"))
                 .parameters(parameters)
                 .toolSpecifications(builderTool)
-                .build())
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot set both 'parameters' and 'toolSpecifications' on ChatRequest");
+                .build();
+
+        // then
+        assertThat(chatRequest.toolSpecifications()).containsExactly(builderTool);
     }
 
     @Test
@@ -283,83 +289,162 @@ class ChatRequestTest {
     }
 
     @Test
-    void should_fail_when_parameters_and_modelName_are_both_set() {
-        assertThatThrownBy(() ->
-                ChatRequest.builder()
-                        .messages(UserMessage.from("hello"))
-                        .parameters(ChatRequestParameters.builder().modelName("gpt-4").build())
-                        .modelName("gpt-3.5")
-                        .build()
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("parameters")
-                .hasMessageContaining("modelName");
+    void should_override_modelName_when_both_parameters_and_modelName_are_set() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("hello"))
+                .parameters(ChatRequestParameters.builder().modelName("gpt-4").build())
+                .modelName("gpt-3.5")
+                .build();
+
+        assertThat(chatRequest.modelName()).isEqualTo("gpt-3.5");
     }
 
     @Test
-    void should_fail_when_parameters_and_temperature_are_both_set() {
-        assertThatThrownBy(() ->
-                ChatRequest.builder()
-                        .messages(UserMessage.from("hello"))
-                        .parameters(ChatRequestParameters.builder().temperature(0.5).build())
-                        .temperature(0.7)
-                        .build()
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("parameters")
-                .hasMessageContaining("temperature");
+    void should_override_temperature_when_both_parameters_and_temperature_are_set() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("hello"))
+                .parameters(ChatRequestParameters.builder().temperature(0.5).build())
+                .temperature(0.7)
+                .build();
+
+        assertThat(chatRequest.temperature()).isEqualTo(0.7);
     }
 
     @Test
-    void should_fail_when_parameters_and_stopSequences_are_both_set() {
-        assertThatThrownBy(() ->
-                ChatRequest.builder()
-                        .messages(UserMessage.from("hello"))
-                        .parameters(ChatRequestParameters.builder()
-                                .stopSequences(List.of("STOP"))
-                                .build())
-                        .stopSequences(List.of("END"))
-                        .build()
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("parameters")
-                .hasMessageContaining("stopSequences");
+    void should_override_stopSequences_when_both_parameters_and_stopSequences_are_set() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("hello"))
+                .parameters(ChatRequestParameters.builder()
+                        .stopSequences(List.of("STOP"))
+                        .build())
+                .stopSequences(List.of("END"))
+                .build();
+
+        assertThat(chatRequest.stopSequences()).containsExactly("END");
     }
 
     @Test
-    void should_fail_when_parameters_and_toolSpecifications_are_both_set() {
-        ToolSpecification tool = ToolSpecification.builder()
-                .name("tool")
+    void should_override_toolSpecifications_when_both_parameters_and_toolSpecifications_are_set() {
+        ToolSpecification paramTool = ToolSpecification.builder()
+                .name("paramTool")
+                .description("desc")
+                .build();
+        ToolSpecification builderTool = ToolSpecification.builder()
+                .name("builderTool")
                 .description("desc")
                 .build();
 
-        assertThatThrownBy(() ->
-                ChatRequest.builder()
-                        .messages(UserMessage.from("hello"))
-                        .parameters(ChatRequestParameters.builder()
-                                .toolSpecifications(List.of(tool))
-                                .build())
-                        .toolSpecifications(tool)
-                        .build()
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("parameters")
-                .hasMessageContaining("toolSpecifications");
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("hello"))
+                .parameters(ChatRequestParameters.builder()
+                        .toolSpecifications(List.of(paramTool))
+                        .build())
+                .toolSpecifications(builderTool)
+                .build();
+
+        assertThat(chatRequest.toolSpecifications()).containsExactly(builderTool);
     }
 
     @Test
-    void should_fail_when_parameters_and_responseFormat_are_both_set() {
-        assertThatThrownBy(() ->
-                ChatRequest.builder()
-                        .messages(UserMessage.from("hello"))
-                        .parameters(ChatRequestParameters.builder()
-                                .responseFormat(ResponseFormat.JSON)
-                                .build())
+    void should_override_responseFormat_when_both_parameters_and_responseFormat_are_set() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("hello"))
+                .parameters(ChatRequestParameters.builder()
+                        .responseFormat(ResponseFormat.JSON)
+                        .build())
+                .responseFormat(ResponseFormat.TEXT)
+                .build();
+
+        assertThat(chatRequest.responseFormat()).isEqualTo(ResponseFormat.TEXT);
+    }
+
+    @Test
+    void should_override_responseFormat_via_toBuilder() {
+        // given
+        ChatRequest original = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(ChatRequestParameters.builder()
+                        .modelName("gpt-4")
+                        .temperature(0.7)
+                        .build())
+                .build();
+
+        // when
+        ChatRequest modified = original.toBuilder()
+                .responseFormat(ResponseFormat.JSON)
+                .build();
+
+        // then
+        assertThat(modified.responseFormat()).isEqualTo(ResponseFormat.JSON);
+        assertThat(modified.modelName()).isEqualTo("gpt-4");
+        assertThat(modified.temperature()).isEqualTo(0.7);
+        assertThat(modified.messages()).containsExactly(UserMessage.from("hi"));
+    }
+
+    @Test
+    void should_override_existing_responseFormat_via_toBuilder() {
+        // given
+        ChatRequest original = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(ChatRequestParameters.builder()
                         .responseFormat(ResponseFormat.TEXT)
-                        .build()
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("parameters")
-                .hasMessageContaining("responseFormat");
+                        .build())
+                .build();
+
+        // when
+        ChatRequest modified = original.toBuilder()
+                .responseFormat(ResponseFormat.JSON)
+                .build();
+
+        // then
+        assertThat(modified.responseFormat()).isEqualTo(ResponseFormat.JSON);
+    }
+
+    @Test
+    void should_override_multiple_fields_via_toBuilder() {
+        // given
+        ToolSpecification tool = ToolSpecification.builder().name("tool").build();
+        ChatRequest original = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(ChatRequestParameters.builder()
+                        .modelName("gpt-4")
+                        .temperature(0.7)
+                        .maxOutputTokens(100)
+                        .build())
+                .build();
+
+        // when
+        ChatRequest modified = original.toBuilder()
+                .temperature(0.2)
+                .responseFormat(ResponseFormat.JSON)
+                .toolSpecifications(tool)
+                .build();
+
+        // then
+        assertThat(modified.modelName()).isEqualTo("gpt-4");
+        assertThat(modified.temperature()).isEqualTo(0.2);
+        assertThat(modified.maxOutputTokens()).isEqualTo(100);
+        assertThat(modified.responseFormat()).isEqualTo(ResponseFormat.JSON);
+        assertThat(modified.toolSpecifications()).containsExactly(tool);
+    }
+
+    @Test
+    void should_not_modify_anything_when_toBuilder_used_without_setters() {
+        // given
+        ChatRequestParameters parameters = ChatRequestParameters.builder()
+                .modelName("gpt-4")
+                .temperature(0.7)
+                .responseFormat(ResponseFormat.JSON)
+                .build();
+        ChatRequest original = ChatRequest.builder()
+                .messages(UserMessage.from("hi"))
+                .parameters(parameters)
+                .build();
+
+        // when
+        ChatRequest modified = original.toBuilder().build();
+
+        // then
+        assertThat(modified).isEqualTo(original);
     }
 }


### PR DESCRIPTION
## Issue
Triggered by https://github.com/langchain4j/langchain4j/issues/5280#issuecomment-4572579268

## Change
Previously, calling `ChatRequest.builder().parameters(p).responseFormat(rf).build()` (or any other individual setter combined with `parameters(...)`) threw
  `IllegalArgumentException: Cannot set both 'parameters' and 'responseFormat' on ChatRequest`. This made `chatRequest.toBuilder().responseFormat(rf).build()` unusable — a natural
  pattern when modifying a single field of an existing `ChatRequest` (e.g. inside a `chatRequestTransformer` on `AiServices`):

  ```java
  AiServices.builder(MyService.class)
      .chatModel(chatModel)
      .chatRequestTransformer(req -> req.toBuilder().responseFormat(responseFormat).build())
      .build();
  ```
  Individual setters now override the corresponding fields of parameters via ChatRequestParameters.overrideWith(...). All other fields of parameters — including provider-specific
  fields on subclasses (e.g. OpenAiChatRequestParameters) — are preserved.

  Notes:
  - When only .parameters(p) is set without any individual setters, p is passed through unchanged (identity preserved). This ensures mocked ChatRequestParameters keep working, and
  subclasses that don't override overrideWith keep their concrete type.
  - When individual setters ARE used together with .parameters(p), merging is performed via overrideWith — provider-specific subclasses that properly override overrideWith keep
  their type and their extra fields.
  - Null / empty-collection overrides are skipped (existing values kept) — same semantics as overrideWith. Documented in the Builder javadoc.
  - The per-field validation throws are gone; the constructor branches once on whether any individual setter was used.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)