### PR TITLE
fix(azure): remove pinned azure-cosmos version (#5284)

### DIFF
--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -275,12 +275,6 @@
                 <version>3.18.0</version>
             </dependency>
 
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-cosmos</artifactId>
-                <version>4.71.0-beta.1</version>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Change

Remove the explicit version pin for `azure-cosmos` (`4.71.0-beta.1`) from `langchain4j-parent/pom.xml` dependencyManagement.

The `azure-sdk-bom` (already imported at line 239) manages the correct version of this dependency. The pinned version was outdated and in beta state, overriding the BOM-managed version.

Closes #5284

## Details

- Removed the `<dependency>` block for `com.azure:azure-cosmos` with hardcoded version `4.71.0-beta.1`
- The `azure-sdk-bom` import already manages this dependency's version

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green