### PR TITLE
Allow @Tool methods to also be inherited from superclasses and interfaces

### DIFF
--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -769,7 +769,7 @@ This way, the LLM has more information to decide whether or not to call the give
 
 ### Inheritance and tool discovery
 
-`@Tool`-annotated methods are inherited from superclasses. When you pass a tool object to an AI Service, LangChain4j discovers `@Tool` methods from the object's class and all of its superclasses (up to, but excluding, `Object`).
+Concrete `@Tool`-annotated methods are inherited from superclasses and interfaces. When you pass a tool object to an AI Service, LangChain4j discovers `@Tool` methods from the object's class, all of its superclasses (up to, but excluding, `Object`), and `default` and `static` methods from implemented interfaces.
 
 ```java
 class BaseMathTools {

--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -767,6 +767,78 @@ Depending on the tool, the LLM might understand it well even without any descrip
 but it is usually better to provide clear and meaningful names and descriptions.
 This way, the LLM has more information to decide whether or not to call the given tool, and how to do so.
 
+### Inheritance and tool discovery
+
+`@Tool`-annotated methods are inherited from superclasses. When you pass a tool object to an AI Service, LangChain4j discovers `@Tool` methods from the object's class and all of its superclasses (up to, but excluding, `Object`).
+
+```java
+class BaseMathTools {
+
+    @Tool("Calculates the sum of two numbers")
+    int sum(int a, int b) {
+        return a + b;
+    }
+}
+
+class AdvancedMathTools extends BaseMathTools {
+
+    @Tool("Calculates the product of two numbers")
+    int multiply(int a, int b) {
+        return a * b;
+    }
+}
+
+Assistant assistant = AiServices.builder(Assistant.class)
+    .chatModel(model)
+    .tools(new AdvancedMathTools()) // both "sum" and "multiply" are available
+    .build();
+```
+
+A subclass can override a `@Tool` method from its parent. In that case, only the subclass version is used — including its `@Tool` annotation:
+
+```java
+class ParentTools {
+
+    @Tool("Returns the greeting")
+    String greet(String name) {
+        return "Hello, " + name;
+    }
+}
+
+class ChildTools extends ParentTools {
+
+    @Override
+    @Tool(name = "greet_formal", value = "Returns a formal greeting")
+    String greet(String name) {
+        return "Good day, " + name;
+    }
+}
+```
+
+Here the LLM will see a single tool named `greet_formal` with description "Returns a formal greeting".
+
+If a subclass declares a method with the same name as a parent method but with different parameters (an overload, not an override), both methods are discovered. Since tool names must be unique and default to the method name, you must give at least one of them an explicit name:
+
+```java
+class ParentTools {
+
+    @Tool(name = "process_text", value = "Processes a text input")
+    String process(String input) {
+        return input.toUpperCase();
+    }
+}
+
+class ChildTools extends ParentTools {
+
+    @Tool(name = "process_number", value = "Processes a numeric input")
+    int process(int input) {
+        return input * 2;
+    }
+}
+```
+
+If both methods resolve to the same tool name, an `IllegalArgumentException` is thrown at AI Service creation time.
+
 ### `@P`
 Method parameters can optionally be annotated with `@P`.
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.agent.tool;
 
+import static dev.langchain4j.internal.Utils.allDeclaredMethods;
 import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static java.util.Arrays.stream;
@@ -60,7 +61,7 @@ public class ToolSpecifications {
      * @return the {@link ToolSpecification}s.
      */
     public static List<ToolSpecification> toolSpecificationsFrom(Class<?> classWithTools) {
-        List<ToolSpecification> toolSpecifications = stream(classWithTools.getDeclaredMethods())
+        List<ToolSpecification> toolSpecifications = allDeclaredMethods(classWithTools).stream()
                 .filter(method -> method.isAnnotationPresent(Tool.class))
                 .map(ToolSpecifications::toolSpecificationFrom)
                 .collect(toList());

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ToolSpecifications.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.agent.tool;
 
-import static dev.langchain4j.internal.Utils.allDeclaredMethods;
+import static dev.langchain4j.internal.Utils.allConcreteMethods;
 import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static java.util.Arrays.stream;
@@ -61,7 +61,7 @@ public class ToolSpecifications {
      * @return the {@link ToolSpecification}s.
      */
     public static List<ToolSpecification> toolSpecificationsFrom(Class<?> classWithTools) {
-        List<ToolSpecification> toolSpecifications = allDeclaredMethods(classWithTools).stream()
+        List<ToolSpecification> toolSpecifications = allConcreteMethods(classWithTools).stream()
                 .filter(method -> method.isAnnotationPresent(Tool.class))
                 .map(ToolSpecifications::toolSpecificationFrom)
                 .collect(toList());

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -13,6 +13,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -27,7 +28,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.HashMap;
 import java.util.HexFormat;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -557,26 +557,56 @@ public class Utils {
     private record MethodSignature(String name, List<Class<?>> params) {}
 
     /**
-     * Returns all methods declared in the given class and its superclasses, excluding {@link Object}.
-     * If a subclass overrides a superclass method, only the subclass version is included.
+     * Returns all concrete methods from the given class, its superclasses (excluding {@link Object}),
+     * and default/static methods from implemented interfaces.
+     * If a subclass overrides a method, only the subclass version is included.
      * Bridge and synthetic methods are filtered out.
      */
-    public static List<Method> allDeclaredMethods(Class<?> clazz) {
+    public static List<Method> allConcreteMethods(Class<?> clazz) {
         List<Method> allMethods = new ArrayList<>();
         Set<MethodSignature> seen = new HashSet<>();
-        while (clazz != null && clazz != Object.class) {
-            for (Method method : clazz.getDeclaredMethods()) {
-                if (method.isBridge() || method.isSynthetic()) {
+        Class<?> current = clazz;
+        while (current != null && current != Object.class) {
+            collectConcreteMethods(current, seen, allMethods);
+            current = current.getSuperclass();
+        }
+        collectInterfaceMethods(clazz, seen, allMethods, new HashSet<>());
+        return List.copyOf(allMethods);
+    }
+
+    private static void collectConcreteMethods(Class<?> clazz, Set<MethodSignature> seen, List<Method> result) {
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.isBridge() || method.isSynthetic()) {
+                continue;
+            }
+            MethodSignature sig = new MethodSignature(method.getName(), List.of(method.getParameterTypes()));
+            if (seen.add(sig)) {
+                result.add(method);
+            }
+        }
+    }
+
+    private static void collectInterfaceMethods(Class<?> clazz, Set<MethodSignature> seen,
+                                                List<Method> result, Set<Class<?>> visited) {
+        if (clazz == null) {
+            return;
+        }
+        for (Class<?> iface : clazz.getInterfaces()) {
+            if (!visited.add(iface)) {
+                continue;
+            }
+            for (Method method : iface.getDeclaredMethods()) {
+                if (method.isBridge() || method.isSynthetic() || Modifier.isAbstract(method.getModifiers())) {
                     continue;
                 }
                 MethodSignature sig = new MethodSignature(method.getName(), List.of(method.getParameterTypes()));
                 if (seen.add(sig)) {
-                    allMethods.add(method);
+                    result.add(method);
                 }
             }
-            clazz = clazz.getSuperclass();
+            collectInterfaceMethods(iface, seen, result, visited);
         }
-        return List.copyOf(allMethods);
+        collectInterfaceMethods(clazz.getSuperclass(), seen, result, visited);
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -4,7 +4,6 @@ import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.unmodifiableCollection;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
@@ -25,8 +24,10 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.HashMap;
 import java.util.HexFormat;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -551,6 +552,42 @@ public class Utils {
             }
         }
         return Optional.empty();
+    }
+
+    private static final Map<Class<?>, List<Method>> DECLARED_METHODS_CACHE = new ConcurrentHashMap<>();
+
+    /**
+     * Returns all methods declared in the given class and its superclasses, excluding {@link Object}.
+     * If a subclass overrides a superclass method, only the subclass version is included.
+     */
+    public static List<Method> allDeclaredMethods(Class<?> clazz) {
+        return DECLARED_METHODS_CACHE.computeIfAbsent(clazz, Utils::findAllDeclaredMethods);
+    }
+
+    private static List<Method> findAllDeclaredMethods(Class<?> clazz) {
+        List<Method> allMethods = new ArrayList<>();
+        Set<String> overridden = new HashSet<>();
+        while (clazz != null && clazz != Object.class) {
+            List<Method> cached = DECLARED_METHODS_CACHE.get(clazz);
+            if (cached != null) {
+                for (Method method : cached) {
+                    if (!overridden.contains(method.getName())) {
+                        allMethods.add(method);
+                    }
+                }
+                break;
+            }
+            for (Method method : clazz.getDeclaredMethods()) {
+                if (!overridden.contains(method.getName())) {
+                    allMethods.add(method);
+                }
+            }
+            for (Method method : clazz.getDeclaredMethods()) {
+                overridden.add(method.getName());
+            }
+            clazz = clazz.getSuperclass();
+        }
+        return allMethods;
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -556,9 +556,12 @@ public class Utils {
 
     private static final Map<Class<?>, List<Method>> DECLARED_METHODS_CACHE = new ConcurrentHashMap<>();
 
+    private record MethodSignature(String name, List<Class<?>> params) {}
+
     /**
      * Returns all methods declared in the given class and its superclasses, excluding {@link Object}.
      * If a subclass overrides a superclass method, only the subclass version is included.
+     * Bridge and synthetic methods are filtered out.
      */
     public static List<Method> allDeclaredMethods(Class<?> clazz) {
         return DECLARED_METHODS_CACHE.computeIfAbsent(clazz, Utils::findAllDeclaredMethods);
@@ -566,28 +569,20 @@ public class Utils {
 
     private static List<Method> findAllDeclaredMethods(Class<?> clazz) {
         List<Method> allMethods = new ArrayList<>();
-        Set<String> overridden = new HashSet<>();
+        Set<MethodSignature> seen = new HashSet<>();
         while (clazz != null && clazz != Object.class) {
-            List<Method> cached = DECLARED_METHODS_CACHE.get(clazz);
-            if (cached != null) {
-                for (Method method : cached) {
-                    if (!overridden.contains(method.getName())) {
-                        allMethods.add(method);
-                    }
-                }
-                break;
-            }
             for (Method method : clazz.getDeclaredMethods()) {
-                if (!overridden.contains(method.getName())) {
+                if (method.isBridge() || method.isSynthetic()) {
+                    continue;
+                }
+                MethodSignature sig = new MethodSignature(method.getName(), List.of(method.getParameterTypes()));
+                if (seen.add(sig)) {
                     allMethods.add(method);
                 }
             }
-            for (Method method : clazz.getDeclaredMethods()) {
-                overridden.add(method.getName());
-            }
             clazz = clazz.getSuperclass();
         }
-        return allMethods;
+        return List.copyOf(allMethods);
     }
 
     /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -554,8 +554,6 @@ public class Utils {
         return Optional.empty();
     }
 
-    private static final Map<Class<?>, List<Method>> DECLARED_METHODS_CACHE = new ConcurrentHashMap<>();
-
     private record MethodSignature(String name, List<Class<?>> params) {}
 
     /**
@@ -564,10 +562,6 @@ public class Utils {
      * Bridge and synthetic methods are filtered out.
      */
     public static List<Method> allDeclaredMethods(Class<?> clazz) {
-        return DECLARED_METHODS_CACHE.computeIfAbsent(clazz, Utils::findAllDeclaredMethods);
-    }
-
-    private static List<Method> findAllDeclaredMethods(Class<?> clazz) {
         List<Method> allMethods = new ArrayList<>();
         Set<MethodSignature> seen = new HashSet<>();
         while (clazz != null && clazz != Object.class) {

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
@@ -677,4 +677,109 @@ class ToolSpecificationsTest implements WithAssertions {
         assertThat(specs).extracting(ToolSpecification::description)
                 .containsExactlyInAnyOrder("process a string", "process an int");
     }
+
+    // --- Interface default method tests ---
+
+    public interface ToolInterface {
+        @Tool("interface tool")
+        default int interfaceMethod(int a) {
+            return a;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class ImplementsToolInterface implements ToolInterface {
+    }
+
+    @Test
+    void should_discover_tool_from_interface_default_method() {
+        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ImplementsToolInterface());
+
+        assertThat(specs).hasSize(1);
+        assertThat(specs.get(0).name()).isEqualTo("interfaceMethod");
+        assertThat(specs.get(0).description()).isEqualTo("interface tool");
+    }
+
+    @SuppressWarnings("unused")
+    public static class ClassWithOwnToolAndInterface implements ToolInterface {
+        @Tool("class tool")
+        public int classMethod(int b) {
+            return b;
+        }
+    }
+
+    @Test
+    void should_discover_tools_from_both_class_and_interface() {
+        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ClassWithOwnToolAndInterface());
+
+        assertThat(specs).hasSize(2);
+        assertThat(specs).extracting(ToolSpecification::name)
+                .containsExactlyInAnyOrder("classMethod", "interfaceMethod");
+        assertThat(specs).extracting(ToolSpecification::description)
+                .containsExactlyInAnyOrder("class tool", "interface tool");
+    }
+
+    @SuppressWarnings("unused")
+    public static class ClassOverridingInterfaceDefault implements ToolInterface {
+        @Override
+        @Tool("overridden tool")
+        public int interfaceMethod(int a) {
+            return a * 2;
+        }
+    }
+
+    @Test
+    void should_use_class_method_when_overriding_interface_default() {
+        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ClassOverridingInterfaceDefault());
+
+        assertThat(specs).hasSize(1);
+        assertThat(specs.get(0).name()).isEqualTo("interfaceMethod");
+        assertThat(specs.get(0).description()).isEqualTo("overridden tool");
+    }
+
+    public interface ToolInterfaceWithAbstractMethod {
+        @Tool("abstract tool")
+        int abstractMethod(int a);
+    }
+
+    @SuppressWarnings("unused")
+    public static class ImplementsAbstractToolMethod implements ToolInterfaceWithAbstractMethod {
+        @Override
+        public int abstractMethod(int a) {
+            return a;
+        }
+    }
+
+    @Test
+    void should_not_discover_abstract_interface_method_without_tool_on_implementation() {
+        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ImplementsAbstractToolMethod());
+
+        assertThat(specs).isEmpty();
+    }
+
+    public interface ToolInterfaceWithStaticMethod {
+        @Tool("static tool")
+        static int staticMethod(int a) {
+            return a;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class ImplementsInterfaceWithStaticTool implements ToolInterfaceWithStaticMethod {
+        @Tool("instance tool")
+        public int instanceMethod(int b) {
+            return b;
+        }
+    }
+
+    @Test
+    void should_discover_static_tool_from_interface() {
+        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ImplementsInterfaceWithStaticTool());
+
+        assertThat(specs).hasSize(2);
+        assertThat(specs).extracting(ToolSpecification::name)
+                .containsExactlyInAnyOrder("staticMethod", "instanceMethod");
+        assertThat(specs).extracting(ToolSpecification::description)
+                .containsExactlyInAnyOrder("static tool", "instance tool");
+    }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
@@ -516,4 +516,165 @@ class ToolSpecificationsTest implements WithAssertions {
         JsonStringSchema element = (JsonStringSchema) ts.parameters().properties().get("myParam");
         assertThat(element.description()).isNull();
     }
+
+    // --- Inheritance tests ---
+
+    @SuppressWarnings("unused")
+    public static class ParentTool {
+        @Tool("parent tool")
+        public int parentMethod(int a) {
+            return a;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class ChildTool extends ParentTool {
+        @Tool("child tool")
+        public int childMethod(int b) {
+            return b;
+        }
+    }
+
+    @Test
+    void should_discover_tool_from_superclass() {
+        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ChildTool());
+
+        assertThat(specs).hasSize(2);
+        assertThat(specs).extracting(ToolSpecification::name)
+                .containsExactlyInAnyOrder("childMethod", "parentMethod");
+        assertThat(specs).extracting(ToolSpecification::description)
+                .containsExactlyInAnyOrder("child tool", "parent tool");
+    }
+
+    @SuppressWarnings("unused")
+    public static class ParentWithNamedTool {
+        @Tool(name = "shared_name", value = "parent version")
+        public int doSomething(int a) {
+            return a;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class ChildWithSameToolName extends ParentWithNamedTool {
+        @Tool(name = "shared_name", value = "child version")
+        public int doSomethingElse(int b) {
+            return b;
+        }
+    }
+
+    @Test
+    void should_fail_when_parent_and_child_have_same_tool_name() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ToolSpecifications.toolSpecificationsFrom(new ChildWithSameToolName()))
+                .withMessage("Tool names must be unique. The tool 'shared_name' appears several times");
+    }
+
+    @SuppressWarnings("unused")
+    public static class ParentWithOverridableTool {
+        @Tool("parent description")
+        public int compute(int a) {
+            return a;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class ChildOverridingTool extends ParentWithOverridableTool {
+        @Override
+        @Tool("child description")
+        public int compute(int a) {
+            return a * 2;
+        }
+    }
+
+    @Test
+    void should_use_overriding_method_from_child_class() {
+        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ChildOverridingTool());
+
+        assertThat(specs).hasSize(1);
+        assertThat(specs.get(0).name()).isEqualTo("compute");
+        assertThat(specs.get(0).description()).isEqualTo("child description");
+    }
+
+    @SuppressWarnings("unused")
+    public static class ChildOverridingToolWithNewAnnotation extends ParentWithOverridableTool {
+        @Override
+        @Tool(name = "renamed_compute", value = "updated description")
+        public int compute(int a) {
+            return a * 3;
+        }
+    }
+
+    @Test
+    void should_use_updated_tool_annotation_from_overriding_child() {
+        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ChildOverridingToolWithNewAnnotation());
+
+        assertThat(specs).hasSize(1);
+        assertThat(specs.get(0).name()).isEqualTo("renamed_compute");
+        assertThat(specs.get(0).description()).isEqualTo("updated description");
+    }
+
+    @SuppressWarnings("unused")
+    public static class ParentWithProcess {
+        @Tool("process a string")
+        public String process(String input) {
+            return input;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class ChildWithOverloadedProcess extends ParentWithProcess {
+        @Tool("process an int")
+        public int process(int input) {
+            return input;
+        }
+    }
+
+    @Test
+    void should_fail_when_overloaded_methods_in_parent_and_child_default_to_same_tool_name() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ToolSpecifications.toolSpecificationsFrom(new ChildWithOverloadedProcess()))
+                .withMessage("Tool names must be unique. The tool 'process' appears several times");
+    }
+
+    @SuppressWarnings("unused")
+    public static class ParentWithNamedProcess {
+        @Tool(name = "process", value = "process a string")
+        public String process(String input) {
+            return input;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class ChildWithOverloadedSameToolName extends ParentWithNamedProcess {
+        @Tool(name = "process", value = "process an int")
+        public int process(int input) {
+            return input;
+        }
+    }
+
+    @Test
+    void should_fail_when_overloaded_methods_in_parent_and_child_have_same_tool_name() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> ToolSpecifications.toolSpecificationsFrom(new ChildWithOverloadedSameToolName()))
+                .withMessage("Tool names must be unique. The tool 'process' appears several times");
+    }
+
+    @SuppressWarnings("unused")
+    public static class ChildWithOverloadedDifferentToolNames extends ParentWithNamedProcess {
+        @Tool(name = "process_int", value = "process an int")
+        public static int process(int input) {
+            return input;
+        }
+    }
+
+    @Test
+    void should_discover_both_when_overloaded_methods_in_parent_and_child_have_different_tool_names() {
+        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ChildWithOverloadedDifferentToolNames());
+
+        assertThat(specs).hasSize(2);
+        assertThat(specs).extracting(ToolSpecification::name)
+                .containsExactlyInAnyOrder("process", "process_int");
+        assertThat(specs).extracting(ToolSpecification::description)
+                .containsExactlyInAnyOrder("process a string", "process an int");
+    }
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.service.tool;
 
-import static dev.langchain4j.internal.Utils.allDeclaredMethods;
+import static dev.langchain4j.internal.Utils.allConcreteMethods;
 import static dev.langchain4j.internal.Exceptions.unwrapRuntimeException;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
@@ -69,7 +69,7 @@ public class DefaultToolExecutor implements ToolExecutor {
     private Method findMethod(Object object, ToolExecutionRequest toolExecutionRequest) {
         String requestedMethodName = toolExecutionRequest.name();
 
-        for (Method method : allDeclaredMethods(object.getClass())) {
+        for (Method method : allConcreteMethods(object.getClass())) {
             if (method.getName().equals(requestedMethodName)) {
                 return method;
             }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.service.tool;
 
+import static dev.langchain4j.internal.Utils.allDeclaredMethods;
 import static dev.langchain4j.internal.Exceptions.unwrapRuntimeException;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.isNotNullOrBlank;
@@ -68,7 +69,7 @@ public class DefaultToolExecutor implements ToolExecutor {
     private Method findMethod(Object object, ToolExecutionRequest toolExecutionRequest) {
         String requestedMethodName = toolExecutionRequest.name();
 
-        for (Method method : object.getClass().getDeclaredMethods()) {
+        for (Method method : allDeclaredMethods(object.getClass())) {
             if (method.getName().equals(requestedMethodName)) {
                 return method;
             }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -2,6 +2,7 @@ package dev.langchain4j.service.tool;
 
 import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE;
 import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE_IF_LAST;
+import static dev.langchain4j.internal.Utils.allDeclaredMethods;
 import static dev.langchain4j.agent.tool.ToolSpecifications.toolSpecificationFrom;
 import static dev.langchain4j.internal.Exceptions.runtime;
 import static dev.langchain4j.internal.Utils.copy;
@@ -226,7 +227,7 @@ public class ToolService {
         }
 
         List<AiServiceTool> result = new ArrayList<>();
-        for (Method method : objectWithTools.getClass().getDeclaredMethods()) {
+        for (Method method : allDeclaredMethods(objectWithTools.getClass())) {
             Optional<Method> annotatedMethod = getAnnotatedMethod(method, Tool.class);
             if (annotatedMethod.isPresent()) {
                 Method toolMethod = annotatedMethod.get();

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -2,7 +2,7 @@ package dev.langchain4j.service.tool;
 
 import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE;
 import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE_IF_LAST;
-import static dev.langchain4j.internal.Utils.allDeclaredMethods;
+import static dev.langchain4j.internal.Utils.allConcreteMethods;
 import static dev.langchain4j.agent.tool.ToolSpecifications.toolSpecificationFrom;
 import static dev.langchain4j.internal.Exceptions.runtime;
 import static dev.langchain4j.internal.Utils.copy;
@@ -227,7 +227,7 @@ public class ToolService {
         }
 
         List<AiServiceTool> result = new ArrayList<>();
-        for (Method method : allDeclaredMethods(objectWithTools.getClass())) {
+        for (Method method : allConcreteMethods(objectWithTools.getClass())) {
             Optional<Method> annotatedMethod = getAnnotatedMethod(method, Tool.class);
             if (annotatedMethod.isPresent()) {
                 Method toolMethod = annotatedMethod.get();

--- a/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/AiServicesWithToolsIT.java
@@ -1573,12 +1573,13 @@ class AiServicesWithToolsIT {
     @ParameterizedTest
     @MethodSource("modelsWithoutParallelToolCalling")
     void should_rewrite_chat_request_using_tool(ChatModel chatModel) {
-        AtomicInteger result = new AtomicInteger();
+        AtomicInteger addResult = new AtomicInteger();
+        AtomicInteger mulResult = new AtomicInteger();
         AiServicesIT.UserMessageTransformer requestTransformer = userMessage -> userMessage.replace("three", "four");
 
         Counter counter = AiServices.builder(Counter.class)
                 .chatModel(chatModel)
-                .tools(new CalculatorTool(result))
+                .tools(new CalculatorTool(addResult, mulResult))
                 .chatRequestTransformer(requestTransformer)
                 .build();
 
@@ -1587,25 +1588,37 @@ class AiServicesWithToolsIT {
         int count = counter.doMath(sentence);
         assertThat(count).isEqualTo(56);
         // check that the tools have been correctly invoked
-        assertThat(result.get()).isEqualTo(56);
+        assertThat(addResult.get()).isEqualTo(14);
+        assertThat(mulResult.get()).isEqualTo(56);
     }
 
-    public static class CalculatorTool {
-        private final AtomicInteger result;
+    public static class AdderTool {
+        private final AtomicInteger addResult;
 
-        public CalculatorTool(final AtomicInteger result) {
-            this.result = result;
+        public AdderTool(final AtomicInteger addResult) {
+            this.addResult = addResult;
         }
 
         @Tool("calculates the sum of two integers")
         public int sum(int first, int second) {
-            return first + second;
+            int sum = first + second;
+            addResult.set(sum);
+            return sum;
+        }
+    }
+
+    public static class CalculatorTool extends AdderTool {
+        private final AtomicInteger mulResult;
+
+        public CalculatorTool(final AtomicInteger addResult, final AtomicInteger mulResult) {
+            super(addResult);
+            this.mulResult = mulResult;
         }
 
         @Tool("calculates the multiplication of two integers")
         public int multiply(int first, int second) {
             int prod = first * second;
-            result.set(prod);
+            mulResult.set(prod);
             return prod;
         }
     }


### PR DESCRIPTION
## Issue
Closes #5302

## Change
Allow `@Tool` methods to also be inherited from superclasses and interfaces.
See [updated documentation](https://github.com/langchain4j/langchain4j/pull/5328/changes#diff-9ca302b5805896cdeaec9345077d7d34ca9d203a9a62e017eb70c6445e869ae0) for more details

## General checklist
- [ ] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)