### PR TITLE
feat: introduce AnthropicChatRequestParameters for per-invocation overrides

### DIFF
--- a/langchain4j-anthropic/revapi.json
+++ b/langchain4j-anthropic/revapi.json
@@ -8,6 +8,18 @@
           "code": "java.field.removed",
           "old": "field dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_3_HAIKU_20240307",
           "justification": "Model no longer exists and was previously deprecated; removed intentionally"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.langchain4j.model.chat.request.ChatRequestParameters dev.langchain4j.model.anthropic.AnthropicChatModel::defaultRequestParameters()",
+          "new": "method dev.langchain4j.model.anthropic.AnthropicChatRequestParameters dev.langchain4j.model.anthropic.AnthropicChatModel::defaultRequestParameters()",
+          "justification": "Narrowing the return type to the Anthropic-specific AnthropicChatRequestParameters subtype is source- and binary-compatible"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method dev.langchain4j.model.chat.request.ChatRequestParameters dev.langchain4j.model.anthropic.AnthropicStreamingChatModel::defaultRequestParameters()",
+          "new": "method dev.langchain4j.model.anthropic.AnthropicChatRequestParameters dev.langchain4j.model.anthropic.AnthropicStreamingChatModel::defaultRequestParameters()",
+          "justification": "Narrowing the return type to the Anthropic-specific AnthropicChatRequestParameters subtype is source- and binary-compatible"
         }
       ]
     }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -379,7 +379,7 @@ public class AnthropicChatModel implements ChatModel {
         /**
          * Controls how the model uses tools.
          * <p>
-         * Use {@link ToolChoice#AUTO} to let the model decide, {@link ToolChoice#ANY} to force tool use,
+         * Use {@link ToolChoice#AUTO} to let the model decide, {@link ToolChoice#REQUIRED} to force tool use,
          * or {@link ToolChoice#NONE} to disable tool use.
          *
          * @param toolChoice the tool choice strategy
@@ -391,7 +391,7 @@ public class AnthropicChatModel implements ChatModel {
         }
 
         /**
-         * Sets the name of the specific tool the model must use when {@link ToolChoice} is set to {@link ToolChoice#ANY}.
+         * Sets the name of the specific tool the model must use when {@link ToolChoice} is set to {@link ToolChoice#REQUIRED}.
          *
          * @param toolChoiceName the name of the tool to force
          * @return {@code this}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -66,8 +66,6 @@ import org.slf4j.Logger;
 public class AnthropicChatModel implements ChatModel {
 
     private final AnthropicClient client;
-    private final boolean cacheSystemMessages;
-    private final boolean cacheTools;
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
     private final String thinkingDisplay;
@@ -75,7 +73,7 @@ public class AnthropicChatModel implements ChatModel {
     private final boolean sendThinking;
     private final int maxRetries;
     private final List<ChatModelListener> listeners;
-    private final ChatRequestParameters defaultRequestParameters;
+    private final AnthropicChatRequestParameters defaultRequestParameters;
     private final String toolChoiceName;
     private final Boolean disableParallelToolUse;
     private final List<AnthropicServerTool> serverTools;
@@ -100,8 +98,6 @@ public class AnthropicChatModel implements ChatModel {
                 .customHeaders(builder.customHeadersSupplier)
                 .build();
 
-        this.cacheSystemMessages = getOrDefault(builder.cacheSystemMessages, false);
-        this.cacheTools = getOrDefault(builder.cacheTools, false);
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
         this.thinkingDisplay = builder.thinkingDisplay;
@@ -127,7 +123,13 @@ public class AnthropicChatModel implements ChatModel {
             commonParameters = DefaultChatRequestParameters.EMPTY;
         }
 
-        this.defaultRequestParameters = DefaultChatRequestParameters.builder()
+        AnthropicChatRequestParameters anthropicParameters = builder.defaultRequestParameters
+                        instanceof AnthropicChatRequestParameters anthropicChatRequestParameters
+                ? anthropicChatRequestParameters
+                : AnthropicChatRequestParameters.EMPTY;
+
+        this.defaultRequestParameters = AnthropicChatRequestParameters.builder()
+                // common parameters
                 .modelName(getOrDefault(builder.modelName, commonParameters.modelName()))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -138,6 +140,10 @@ public class AnthropicChatModel implements ChatModel {
                 .toolSpecifications(getOrDefault(builder.toolSpecifications, commonParameters.toolSpecifications()))
                 .toolChoice(getOrDefault(builder.toolChoice, commonParameters.toolChoice()))
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
+                // Anthropic-specific parameters
+                .cacheSystemMessages(
+                        getOrDefault(builder.cacheSystemMessages, anthropicParameters.cacheSystemMessages()))
+                .cacheTools(getOrDefault(builder.cacheTools, anthropicParameters.cacheTools()))
                 .build();
     }
 
@@ -468,11 +474,14 @@ public class AnthropicChatModel implements ChatModel {
         }
 
         /**
-         * Enables prompt caching for {@link SystemMessage}s.
+         * Enables prompt caching for {@link SystemMessage}s by default.
          * <p>
          * When {@code true}, system messages are sent with the {@code cache_control} header to allow
          * Anthropic to cache them across requests, reducing cost and latency for repeated prompts.
          * See the <a href="https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching">prompt caching docs</a>.
+         * <p>
+         * Can be overridden per request via
+         * {@link AnthropicChatRequestParameters.Builder#cacheSystemMessages(Boolean)}.
          *
          * @param cacheSystemMessages whether to cache system messages
          * @return {@code this}
@@ -483,11 +492,14 @@ public class AnthropicChatModel implements ChatModel {
         }
 
         /**
-         * Enables prompt caching for {@link ToolSpecification}s.
+         * Enables prompt caching for {@link ToolSpecification}s by default.
          * <p>
          * When {@code true}, tool definitions are sent with the {@code cache_control} header to allow
          * Anthropic to cache them across requests.
          * See the <a href="https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching">prompt caching docs</a>.
+         * <p>
+         * Can be overridden per request via
+         * {@link AnthropicChatRequestParameters.Builder#cacheTools(Boolean)}.
          *
          * @param cacheTools whether to cache tool definitions
          * @return {@code this}
@@ -744,14 +756,15 @@ public class AnthropicChatModel implements ChatModel {
 
     @Override
     public ChatResponse doChat(ChatRequest chatRequest) {
-        validate(chatRequest.parameters());
+        AnthropicChatRequestParameters parameters = (AnthropicChatRequestParameters) chatRequest.parameters();
+        validate(parameters);
 
         AnthropicCreateMessageRequest anthropicRequest = createAnthropicRequest(
                 chatRequest,
                 toThinking(thinkingType, thinkingBudgetTokens, thinkingDisplay),
                 sendThinking,
-                cacheSystemMessages ? EPHEMERAL : NO_CACHE,
-                cacheTools ? EPHEMERAL : NO_CACHE,
+                getOrDefault(parameters.cacheSystemMessages(), false) ? EPHEMERAL : NO_CACHE,
+                getOrDefault(parameters.cacheTools(), false) ? EPHEMERAL : NO_CACHE,
                 false,
                 toolChoiceName,
                 disableParallelToolUse,
@@ -805,7 +818,7 @@ public class AnthropicChatModel implements ChatModel {
     }
 
     @Override
-    public ChatRequestParameters defaultRequestParameters() {
+    public AnthropicChatRequestParameters defaultRequestParameters() {
         return defaultRequestParameters;
     }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
@@ -1,0 +1,135 @@
+package dev.langchain4j.model.anthropic;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import java.util.Objects;
+
+/**
+ * Anthropic-specific {@link ChatRequestParameters} that can be set per request (i.e., per {@code ChatRequest}),
+ * overriding the values configured on the {@link AnthropicChatModel} / {@link AnthropicStreamingChatModel} builder.
+ * <p>
+ * Currently supports controlling prompt caching of {@link dev.langchain4j.data.message.SystemMessage}s and
+ * {@link dev.langchain4j.agent.tool.ToolSpecification}s on a per-request basis.
+ */
+public class AnthropicChatRequestParameters extends DefaultChatRequestParameters {
+
+    public static final AnthropicChatRequestParameters EMPTY =
+            AnthropicChatRequestParameters.builder().build();
+
+    private final Boolean cacheSystemMessages;
+    private final Boolean cacheTools;
+
+    private AnthropicChatRequestParameters(Builder builder) {
+        super(builder);
+        this.cacheSystemMessages = builder.cacheSystemMessages;
+        this.cacheTools = builder.cacheTools;
+    }
+
+    public Boolean cacheSystemMessages() {
+        return cacheSystemMessages;
+    }
+
+    public Boolean cacheTools() {
+        return cacheTools;
+    }
+
+    @Override
+    public AnthropicChatRequestParameters overrideWith(ChatRequestParameters that) {
+        return AnthropicChatRequestParameters.builder()
+                .overrideWith(this)
+                .overrideWith(that)
+                .build();
+    }
+
+    @Override
+    public AnthropicChatRequestParameters defaultedBy(ChatRequestParameters that) {
+        return AnthropicChatRequestParameters.builder()
+                .overrideWith(that)
+                .overrideWith(this)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        AnthropicChatRequestParameters that = (AnthropicChatRequestParameters) o;
+        return Objects.equals(cacheSystemMessages, that.cacheSystemMessages)
+                && Objects.equals(cacheTools, that.cacheTools);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), cacheSystemMessages, cacheTools);
+    }
+
+    @Override
+    public String toString() {
+        return "AnthropicChatRequestParameters{" + "modelName="
+                + modelName() + ", temperature="
+                + temperature() + ", topP="
+                + topP() + ", topK="
+                + topK() + ", frequencyPenalty="
+                + frequencyPenalty() + ", presencePenalty="
+                + presencePenalty() + ", maxOutputTokens="
+                + maxOutputTokens() + ", stopSequences="
+                + stopSequences() + ", toolSpecifications="
+                + toolSpecifications() + ", toolChoice="
+                + toolChoice() + ", responseFormat="
+                + responseFormat() + ", cacheSystemMessages="
+                + cacheSystemMessages + ", cacheTools="
+                + cacheTools + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends DefaultChatRequestParameters.Builder<Builder> {
+
+        private Boolean cacheSystemMessages;
+        private Boolean cacheTools;
+
+        @Override
+        public Builder overrideWith(ChatRequestParameters parameters) {
+            super.overrideWith(parameters);
+            if (parameters instanceof AnthropicChatRequestParameters anthropicParameters) {
+                cacheSystemMessages(getOrDefault(anthropicParameters.cacheSystemMessages(), cacheSystemMessages));
+                cacheTools(getOrDefault(anthropicParameters.cacheTools(), cacheTools));
+            }
+            return this;
+        }
+
+        public Builder modelName(AnthropicChatModelName modelName) {
+            return super.modelName(modelName == null ? null : modelName.toString());
+        }
+
+        /**
+         * Controls whether to cache {@link dev.langchain4j.data.message.SystemMessage}s for this request.
+         *
+         * @see AnthropicChatModel.AnthropicChatModelBuilder#cacheSystemMessages(Boolean)
+         */
+        public Builder cacheSystemMessages(Boolean cacheSystemMessages) {
+            this.cacheSystemMessages = cacheSystemMessages;
+            return this;
+        }
+
+        /**
+         * Controls whether to cache {@link dev.langchain4j.agent.tool.ToolSpecification}s for this request.
+         *
+         * @see AnthropicChatModel.AnthropicChatModelBuilder#cacheTools(Boolean)
+         */
+        public Builder cacheTools(Boolean cacheTools) {
+            this.cacheTools = cacheTools;
+            return this;
+        }
+
+        @Override
+        public AnthropicChatRequestParameters build() {
+            return new AnthropicChatRequestParameters(this);
+        }
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -531,7 +531,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         /**
          * Controls how the model uses tools.
          * <p>
-         * Use {@link ToolChoice#AUTO} to let the model decide, {@link ToolChoice#ANY} to force tool use,
+         * Use {@link ToolChoice#AUTO} to let the model decide, {@link ToolChoice#REQUIRED} to force tool use,
          * or {@link ToolChoice#NONE} to disable tool use.
          *
          * @param toolChoice the tool choice strategy
@@ -543,7 +543,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         }
 
         /**
-         * Sets the name of the specific tool the model must use when {@link ToolChoice} is set to {@link ToolChoice#ANY}.
+         * Sets the name of the specific tool the model must use when {@link ToolChoice} is set to {@link ToolChoice#REQUIRED}.
          *
          * @param toolChoiceName the name of the tool to force
          * @return {@code this}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -63,15 +63,13 @@ import org.slf4j.Logger;
 public class AnthropicStreamingChatModel implements StreamingChatModel {
 
     private final AnthropicClient client;
-    private final boolean cacheSystemMessages;
-    private final boolean cacheTools;
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
     private final String thinkingDisplay;
     private final boolean returnThinking;
     private final boolean sendThinking;
     private final List<ChatModelListener> listeners;
-    private final ChatRequestParameters defaultRequestParameters;
+    private final AnthropicChatRequestParameters defaultRequestParameters;
     private final String toolChoiceName;
     private final Boolean disableParallelToolUse;
     private final List<AnthropicServerTool> serverTools;
@@ -101,7 +99,8 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
 
         ChatRequestParameters commonParameters = DefaultChatRequestParameters.EMPTY;
 
-        this.defaultRequestParameters = DefaultChatRequestParameters.builder()
+        this.defaultRequestParameters = AnthropicChatRequestParameters.builder()
+                // common parameters
                 .modelName(getOrDefault(builder.modelName, commonParameters.modelName()))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -112,10 +111,11 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 .toolSpecifications(getOrDefault(builder.toolSpecifications, commonParameters.toolSpecifications()))
                 .toolChoice(getOrDefault(builder.toolChoice, commonParameters.toolChoice()))
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
+                // Anthropic-specific parameters
+                .cacheSystemMessages(builder.cacheSystemMessages)
+                .cacheTools(builder.cacheTools)
                 .build();
 
-        this.cacheSystemMessages = getOrDefault(builder.cacheSystemMessages, false);
-        this.cacheTools = getOrDefault(builder.cacheTools, false);
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
         this.thinkingDisplay = builder.thinkingDisplay;
@@ -361,11 +361,14 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         }
 
         /**
-         * Enables prompt caching for {@link SystemMessage}s.
+         * Enables prompt caching for {@link SystemMessage}s by default.
          * <p>
          * When {@code true}, system messages are sent with the {@code cache_control} header to allow
          * Anthropic to cache them across requests, reducing cost and latency for repeated prompts.
          * See the <a href="https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching">prompt caching docs</a>.
+         * <p>
+         * Can be overridden per request via
+         * {@link AnthropicChatRequestParameters.Builder#cacheSystemMessages(Boolean)}.
          *
          * @param cacheSystemMessages whether to cache system messages
          * @return {@code this}
@@ -376,11 +379,14 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         }
 
         /**
-         * Enables prompt caching for {@link ToolSpecification}s.
+         * Enables prompt caching for {@link ToolSpecification}s by default.
          * <p>
          * When {@code true}, tool definitions are sent with the {@code cache_control} header to allow
          * Anthropic to cache them across requests.
          * See the <a href="https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching">prompt caching docs</a>.
+         * <p>
+         * Can be overridden per request via
+         * {@link AnthropicChatRequestParameters.Builder#cacheTools(Boolean)}.
          *
          * @param cacheTools whether to cache tool definitions
          * @return {@code this}
@@ -711,13 +717,14 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
     @Override
     public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
         ensureNotNull(handler, "handler");
-        validate(chatRequest.parameters());
+        AnthropicChatRequestParameters parameters = (AnthropicChatRequestParameters) chatRequest.parameters();
+        validate(parameters);
         AnthropicCreateMessageRequest anthropicRequest = createAnthropicRequest(
                 chatRequest,
                 toThinking(thinkingType, thinkingBudgetTokens, thinkingDisplay),
                 sendThinking,
-                cacheSystemMessages ? EPHEMERAL : NO_CACHE,
-                cacheTools ? EPHEMERAL : NO_CACHE,
+                getOrDefault(parameters.cacheSystemMessages(), false) ? EPHEMERAL : NO_CACHE,
+                getOrDefault(parameters.cacheTools(), false) ? EPHEMERAL : NO_CACHE,
                 true,
                 toolChoiceName,
                 disableParallelToolUse,
@@ -741,7 +748,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
     }
 
     @Override
-    public ChatRequestParameters defaultRequestParameters() {
+    public AnthropicChatRequestParameters defaultRequestParameters() {
         return defaultRequestParameters;
     }
 

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestCacheParametersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestCacheParametersTest.java
@@ -1,0 +1,147 @@
+package dev.langchain4j.model.anthropic;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnthropicChatRequestCacheParametersTest {
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(0);
+        wireMockServer.start();
+        wireMockServer.stubFor(post(anyUrl())
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                        {
+                          "id": "msg_123",
+                          "type": "message",
+                          "role": "assistant",
+                          "model": "claude-3-5-haiku-20241022",
+                          "content": [{"type": "text", "text": "Hello!"}],
+                          "stop_reason": "end_turn",
+                          "usage": {"input_tokens": 10, "output_tokens": 5}
+                        }
+                        """)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void should_enable_system_message_caching_per_request_when_model_default_is_disabled() {
+        AnthropicChatModel model = modelBuilder().build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(SystemMessage.from("You are a helpful assistant."), UserMessage.from("Hi"))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .cacheSystemMessages(true)
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        assertThat(lastRequestBody()).contains("cache_control").contains("ephemeral");
+    }
+
+    @Test
+    void should_disable_system_message_caching_per_request_when_model_default_is_enabled() {
+        AnthropicChatModel model = modelBuilder().cacheSystemMessages(true).build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(SystemMessage.from("You are a helpful assistant."), UserMessage.from("Hi"))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .cacheSystemMessages(false)
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        assertThat(lastRequestBody()).doesNotContain("cache_control");
+    }
+
+    @Test
+    void should_enable_tool_caching_per_request_when_model_default_is_disabled() {
+        AnthropicChatModel model = modelBuilder().build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("What is the weather?"))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .toolSpecifications(weatherTool())
+                        .cacheTools(true)
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        assertThat(lastRequestBody()).contains("cache_control").contains("ephemeral");
+    }
+
+    @Test
+    void should_disable_tool_caching_per_request_when_model_default_is_enabled() {
+        AnthropicChatModel model = modelBuilder().cacheTools(true).build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("What is the weather?"))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .toolSpecifications(weatherTool())
+                        .cacheTools(false)
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        assertThat(lastRequestBody()).doesNotContain("cache_control");
+    }
+
+    @Test
+    void should_fall_back_to_model_default_when_request_does_not_specify_caching() {
+        AnthropicChatModel model = modelBuilder().cacheSystemMessages(true).build();
+
+        model.chat(ChatRequest.builder()
+                .messages(SystemMessage.from("You are a helpful assistant."), UserMessage.from("Hi"))
+                .build());
+
+        assertThat(lastRequestBody()).contains("cache_control").contains("ephemeral");
+    }
+
+    private static ToolSpecification weatherTool() {
+        return ToolSpecification.builder()
+                .name("get_weather")
+                .description("Returns the current weather for a given city")
+                .build();
+    }
+
+    private AnthropicChatModel.AnthropicChatModelBuilder modelBuilder() {
+        return AnthropicChatModel.builder()
+                .baseUrl("http://localhost:" + wireMockServer.port() + "/v1")
+                .apiKey("test-key")
+                .modelName("claude-3-5-haiku-20241022");
+    }
+
+    private String lastRequestBody() {
+        List<LoggedRequest> requests = wireMockServer.findAll(postRequestedFor(urlPathEqualTo("/v1/messages")));
+        assertThat(requests).hasSize(1);
+        return requests.get(0).getBodyAsString();
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParametersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParametersTest.java
@@ -1,0 +1,80 @@
+package dev.langchain4j.model.anthropic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import org.junit.jupiter.api.Test;
+
+class AnthropicChatRequestParametersTest {
+
+    @Test
+    void should_build_with_anthropic_specific_parameters() {
+        AnthropicChatRequestParameters parameters = AnthropicChatRequestParameters.builder()
+                .temperature(0.7)
+                .cacheSystemMessages(true)
+                .cacheTools(true)
+                .build();
+
+        assertThat(parameters.temperature()).isEqualTo(0.7);
+        assertThat(parameters.cacheSystemMessages()).isTrue();
+        assertThat(parameters.cacheTools()).isTrue();
+    }
+
+    @Test
+    void should_default_anthropic_specific_parameters_to_null() {
+        assertThat(AnthropicChatRequestParameters.EMPTY.cacheSystemMessages()).isNull();
+        assertThat(AnthropicChatRequestParameters.EMPTY.cacheTools()).isNull();
+    }
+
+    @Test
+    void overrideWith_should_override_anthropic_specific_parameters() {
+        AnthropicChatRequestParameters original = AnthropicChatRequestParameters.builder()
+                .cacheSystemMessages(true)
+                .cacheTools(true)
+                .build();
+
+        AnthropicChatRequestParameters override = AnthropicChatRequestParameters.builder()
+                .cacheSystemMessages(false)
+                .build();
+
+        AnthropicChatRequestParameters result = original.overrideWith(override);
+
+        assertThat(result.cacheSystemMessages()).isFalse();
+        // not set in the override, so the original value is kept
+        assertThat(result.cacheTools()).isTrue();
+    }
+
+    @Test
+    void overrideWith_should_keep_anthropic_specific_parameters_when_overriding_with_common_parameters() {
+        AnthropicChatRequestParameters original = AnthropicChatRequestParameters.builder()
+                .cacheSystemMessages(true)
+                .cacheTools(true)
+                .build();
+
+        AnthropicChatRequestParameters result = original.overrideWith(
+                DefaultChatRequestParameters.builder().temperature(0.1).build());
+
+        assertThat(result.temperature()).isEqualTo(0.1);
+        assertThat(result.cacheSystemMessages()).isTrue();
+        assertThat(result.cacheTools()).isTrue();
+    }
+
+    @Test
+    void equals_and_hashCode() {
+        AnthropicChatRequestParameters one = AnthropicChatRequestParameters.builder()
+                .cacheSystemMessages(true)
+                .cacheTools(true)
+                .build();
+        AnthropicChatRequestParameters two = AnthropicChatRequestParameters.builder()
+                .cacheSystemMessages(true)
+                .cacheTools(true)
+                .build();
+        AnthropicChatRequestParameters different = AnthropicChatRequestParameters.builder()
+                .cacheSystemMessages(false)
+                .cacheTools(true)
+                .build();
+
+        assertThat(one).isEqualTo(two).hasSameHashCodeAs(two);
+        assertThat(one).isNotEqualTo(different);
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicChatModelIT.java
@@ -4,11 +4,9 @@ import static dev.langchain4j.internal.Utils.readBytes;
 import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_HAIKU_4_5_20251001;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Base64;
-import java.util.List;
-
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
+import dev.langchain4j.model.anthropic.AnthropicChatRequestParameters;
 import dev.langchain4j.model.anthropic.AnthropicChatResponseMetadata;
 import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
 import dev.langchain4j.model.chat.ChatModel;
@@ -16,6 +14,8 @@ import dev.langchain4j.model.chat.common.AbstractChatModelIT;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.Base64;
+import java.util.List;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -69,7 +69,7 @@ class AnthropicChatModelIT extends AbstractChatModelIT {
 
     @Override
     protected ChatRequestParameters createIntegrationSpecificParameters(int maxOutputTokens) {
-        return ChatRequestParameters.builder()
+        return AnthropicChatRequestParameters.builder()
                 .maxOutputTokens(maxOutputTokens)
                 .build();
     }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicStreamingChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/common/AnthropicStreamingChatModelIT.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeast;
 
 import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.model.anthropic.AnthropicChatRequestParameters;
 import dev.langchain4j.model.anthropic.AnthropicChatResponseMetadata;
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel;
 import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
@@ -18,7 +19,6 @@ import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.TokenUsage;
-
 import java.util.Base64;
 import java.util.List;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -77,7 +77,7 @@ class AnthropicStreamingChatModelIT extends AbstractStreamingChatModelIT {
 
     @Override
     protected ChatRequestParameters createIntegrationSpecificParameters(int maxOutputTokens) {
-        return ChatRequestParameters.builder()
+        return AnthropicChatRequestParameters.builder()
                 .maxOutputTokens(maxOutputTokens)
                 .build();
     }
@@ -113,13 +113,16 @@ class AnthropicStreamingChatModelIT extends AbstractStreamingChatModelIT {
         // Anthropic can talk before calling a tool. "atLeast(0)" is meant to ignore it.
         io.verify(handler, atLeast(0)).onPartialResponse(any(), any());
 
-        io.verify(handler, atLeast(1)).onPartialToolCall(argThat(toolCall ->
-                // Anthropic does not output same tokens consistently, so we can't easily assert partialArguments
-                toolCall.index() == 0
-                        && toolCall.id().equals(id)
-                        && toolCall.name().equals("getWeather")
-                        && !toolCall.partialArguments().isBlank()
-        ), any());
+        io.verify(handler, atLeast(1))
+                .onPartialToolCall(
+                        argThat(toolCall ->
+                                // Anthropic does not output same tokens consistently, so we can't easily assert
+                                // partialArguments
+                                toolCall.index() == 0
+                                        && toolCall.id().equals(id)
+                                        && toolCall.name().equals("getWeather")
+                                        && !toolCall.partialArguments().isBlank()),
+                        any());
         io.verify(handler).onCompleteToolCall(complete(0, id, "getWeather", "{\"city\": \"Munich\"}"));
     }
 
@@ -127,13 +130,16 @@ class AnthropicStreamingChatModelIT extends AbstractStreamingChatModelIT {
     protected void verifyToolCallbacks(StreamingChatResponseHandler handler, InOrder io, String id1, String id2) {
         verifyToolCallbacks(handler, io, id1);
 
-        io.verify(handler, atLeast(1)).onPartialToolCall(argThat(toolCall ->
-                // Anthropic does not output same tokens consistently, so we can't easily assert partialArguments
-                toolCall.index() == 1
-                        && toolCall.id().equals(id2)
-                        && toolCall.name().equals("getTime")
-                        && !toolCall.partialArguments().isBlank()
-        ), any());
+        io.verify(handler, atLeast(1))
+                .onPartialToolCall(
+                        argThat(toolCall ->
+                                // Anthropic does not output same tokens consistently, so we can't easily assert
+                                // partialArguments
+                                toolCall.index() == 1
+                                        && toolCall.id().equals(id2)
+                                        && toolCall.name().equals("getTime")
+                                        && !toolCall.partialArguments().isBlank()),
+                        any());
         io.verify(handler).onCompleteToolCall(complete(1, id2, "getTime", "{\"country\": \"France\"}"));
     }
 


### PR DESCRIPTION
## Issue

Closes #5301

## Context

`AnthropicChatModel` / `AnthropicStreamingChatModel` currently expose Anthropic-specific options (such as `cacheSystemMessages` and `cacheTools`) **only at builder time**. They are baked into the model instance and cannot be overridden per `ChatRequest`.

The concrete use case is **per-call prompt caching**: a single shared `AnthropicChatModel` that caches the system prompt + tools for long-running agent loops, but skips caching for cheap one-shot completions. Today this requires building two model instances and routing requests between them in application code.

Anthropic was also the only large provider in the codebase without a provider-specific `ChatRequestParameters` subclass — `OpenAiChatRequestParameters`, `BedrockChatRequestParameters`, `OllamaChatRequestParameters` and `WatsonxChatRequestParameters` all exist for exactly this purpose.

## What this PR does

- Adds `dev.langchain4j.model.anthropic.AnthropicChatRequestParameters extends DefaultChatRequestParameters`, modeled on `OpenAiChatRequestParameters`. It exposes the Anthropic-specific `cacheSystemMessages` and `cacheTools` options so they can be set per `ChatRequest`, overriding the builder defaults. Includes `overrideWith` / `defaultedBy` / `equals` / `hashCode` / `toString` and a fluent `Builder`.
- `AnthropicChatModel` and `AnthropicStreamingChatModel` now build their default parameters as `AnthropicChatRequestParameters` and read the cache settings from the (merged) per-request parameters in `doChat(...)`, instead of from fixed builder fields.
- The existing `cacheSystemMessages(...)` / `cacheTools(...)` builder methods are kept and now act as defaults that can be overridden per request — fully backward compatible.

## Example

```java
AnthropicChatModel model = AnthropicChatModel.builder()
        .apiKey(System.getenv("ANTHROPIC_API_KEY"))
        .modelName(CLAUDE_SONNET_4_5_20250929)
        .build();

// Long-running agent loop: cache system prompt + tools
ChatRequest cached = ChatRequest.builder()
        .messages(systemMessage, userMessage)
        .parameters(AnthropicChatRequestParameters.builder()
                .cacheSystemMessages(true)
                .cacheTools(true)
                .build())
        .build();

// Cheap one-shot on the same model instance: no caching
ChatRequest oneShot = ChatRequest.builder()
        .messages(userMessage)
        .build();
```

## Tests

- `AnthropicChatRequestParametersTest` — unit tests for the builder, defaults, `overrideWith` merge semantics, and `equals`/`hashCode`.
- `AnthropicChatRequestCacheParametersTest` — WireMock tests verifying: enabling caching per request when the model default is off, disabling it per request when the model default is on, and falling back to the model default when the request does not specify it.

## Compatibility

`defaultRequestParameters()` now returns the narrower `AnthropicChatRequestParameters` type. This narrowing is source- and binary-compatible; the corresponding revapi differences are whitelisted in `revapi.json`.