### PR TITLE
Document Tuning Engines OpenAI-compatible endpoint

### DIFF
--- a/docs/docs/integrations/language-models/openai-compatible.md
+++ b/docs/docs/integrations/language-models/openai-compatible.md
@@ -44,11 +44,12 @@ StreamingChatModel model = OpenAiStreamingChatModel.builder()
         .modelName("deepseek-chat")
         .accumulateToolCallId(false) // Set to false for DeepSeek, Qwen, etc.
         .build();
-```
-Below we provide specific examples for popular OpenAI-compatible APIs, including Groq, Docker Model Runner, GPT4All, Ollama, and LM Studio.
+    ```
+Below we provide specific examples for popular OpenAI-compatible APIs, including Tuning Engines, Groq, Docker Model Runner, GPT4All, Ollama, and LM Studio.
 
 ### Contents:
 - [Prerequisites for Using OpenAI-Compatible Language Models](#prerequisites-for-using-openai-compatible-language-models)
+- [Tuning Engines](#tuning-engines)
 - [Groq](#groq)
 - [Docker Model Runner](#docker-model-runner)
 - [GPT4All](#gpt4all)
@@ -77,6 +78,20 @@ First, make sure you have the OpenAI module in your `pom.xml` or Gradle build fi
     <artifactId>langchain4j-open-ai-spring-boot-starter</artifactId>
     <version>1.15.1-beta25</version>
 </dependency>
+```
+
+## Tuning Engines
+
+**Deployment:** SaaS (key required)
+
+**Description:** [Tuning Engines](https://www.tuningengines.com/) exposes an OpenAI-compatible endpoint that can sit in front of your model providers. LangChain4j keeps the application and agent logic, while the endpoint can centralize routing, policy controls, audit logs, traces, approvals, and cost visibility.
+
+```java
+ChatModel model = OpenAiChatModel.builder()
+        .baseUrl("https://api.tuningengines.com/v1")
+        .apiKey(System.getenv("TUNING_ENGINES_API_KEY"))
+        .modelName("gpt-4o-mini")
+        .build();
 ```
 
 ## Groq
@@ -205,4 +220,3 @@ ChatModel model = OpenAiChatModel.builder()
         .httpClientBuilder(jdkHttpClientBuilder)
         .build();
 ```
-


### PR DESCRIPTION
## Summary

- Adds a small documentation example showing how to point this project’s existing OpenAI-compatible configuration at Tuning Engines.
- Keeps this project’s APIs and runtime behavior unchanged: no new dependency, adapter, or code path.
- Shows a path for teams to keep this framework in charge of app, agent, tool, workflow, or retrieval logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI applications.

This project already supports OpenAI-compatible endpoints. The docs change makes that existing capability discoverable for users who want governance and observability without rewriting their application around a separate SDK or changing this project’s runtime behavior.

## Testing

- `git diff --check`
