### PR TITLE
fix: add null check for chatResponse.usage() in Watsonx models

### DIFF
--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatModel.java
@@ -107,7 +107,9 @@ public class WatsonxChatModel extends WatsonxChat implements ChatModel {
         }
 
         FinishReason finishReason = Converter.toFinishReason(choice.finishReason());
-        TokenUsage tokenUsage = new TokenUsage(usage.promptTokens(), usage.completionTokens(), usage.totalTokens());
+        TokenUsage tokenUsage = usage != null
+                ? new TokenUsage(usage.promptTokens(), usage.completionTokens(), usage.totalTokens())
+                : null;
 
         return ChatResponse.builder()
                 .aiMessage(aiMessage.build())

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModel.java
@@ -10,6 +10,7 @@ import com.ibm.watsonx.ai.chat.ChatHandler;
 import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatParameters;
+import com.ibm.watsonx.ai.chat.model.ChatUsage;
 import com.ibm.watsonx.ai.chat.model.CompletedToolCall;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
@@ -94,10 +95,10 @@ public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingC
 
                         ResultChoice choice = completeResponse.choices().get(0);
                         FinishReason finishReason = Converter.toFinishReason(choice.finishReason());
-                        TokenUsage tokenUsage = new TokenUsage(
-                                completeResponse.usage().promptTokens(),
-                                completeResponse.usage().completionTokens(),
-                                completeResponse.usage().totalTokens());
+                        ChatUsage completeUsage = completeResponse.usage();
+                        TokenUsage tokenUsage = completeUsage != null
+                                ? new TokenUsage(completeUsage.promptTokens(), completeUsage.completionTokens(), completeUsage.totalTokens())
+                                : null;
 
                         var assistantMessage = completeResponse.toAssistantMessage();
                         var aiMessage = AiMessage.builder();


### PR DESCRIPTION
Fixes #5317

## Changes

Added null check for  in both  and  to prevent  when the usage field is null.

### WatsonxChatModel.java


### WatsonxStreamingChatModel.java  
