### PR TITLE
chore: remove unused imports across multiple modules

### DIFF
--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
@@ -2,7 +2,6 @@ package dev.langchain4j.data.document.loader.azure.storage.blob;
 
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.specialized.BlobInputStream;
 import dev.langchain4j.data.document.Document;

--- a/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/DefaultMcpClientBuilder.java
+++ b/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/DefaultMcpClientBuilder.java
@@ -24,7 +24,6 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticScopeRegistry.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/scope/AgenticScopeRegistry.java
@@ -2,7 +2,6 @@ package dev.langchain4j.agentic.scope;
 
 import dev.langchain4j.Internal;
 import dev.langchain4j.agentic.observability.AgentListener;
-import org.jspecify.annotations.NonNull;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 
 import static dev.langchain4j.internal.Utils.*;
 import static dev.langchain4j.internal.ValidationUtils.*;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 

--- a/langchain4j-cassandra/src/main/java/dev/langchain4j/store/embedding/astradb/AstraDbEmbeddingStore.java
+++ b/langchain4j-cassandra/src/main/java/dev/langchain4j/store/embedding/astradb/AstraDbEmbeddingStore.java
@@ -14,7 +14,6 @@ import io.stargate.sdk.data.domain.JsonDocumentResult;
 import io.stargate.sdk.data.domain.odm.Document;
 import io.stargate.sdk.data.domain.query.Filter;
 import org.jspecify.annotations.NonNull;
-import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.internal;
 
 import dev.langchain4j.Internal;
-import java.util.Optional;
 
 @Internal
 public class JsonParsingUtils {

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/Utils.java
@@ -4,7 +4,6 @@ import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.unmodifiableCollection;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/DefaultRetrievalAugmentor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/DefaultRetrievalAugmentor.java
@@ -34,7 +34,6 @@ import static java.util.Collections.singletonMap;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
 
 /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregator.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/rag/content/aggregator/ReRankingContentAggregator.java
@@ -3,7 +3,6 @@ package dev.langchain4j.rag.content.aggregator;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.scoring.ScoringModel;
 import dev.langchain4j.rag.content.Content;
-import dev.langchain4j.rag.content.ContentMetadata;
 import dev.langchain4j.rag.query.Query;
 import dev.langchain4j.rag.query.transformer.ExpandingQueryTransformer;
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/web/search/WebSearchRequest.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/web/search/WebSearchRequest.java
@@ -1,13 +1,11 @@
 package dev.langchain4j.web.search;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-
 
 /**
  * Represents a search request that can be made by the user to perform searches in any implementation of {@link WebSearchEngine}.

--- a/langchain4j-core/src/main/java/dev/langchain4j/web/search/WebSearchResults.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/web/search/WebSearchResults.java
@@ -3,13 +3,11 @@ package dev.langchain4j.web.search;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.segment.TextSegment;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static java.util.stream.Collectors.toList;
 

--- a/langchain4j-couchbase/src/main/java/dev/langchain4j/store/embedding/couchbase/CouchbaseEmbeddingStore.java
+++ b/langchain4j-couchbase/src/main/java/dev/langchain4j/store/embedding/couchbase/CouchbaseEmbeddingStore.java
@@ -13,7 +13,6 @@ import com.couchbase.client.java.search.vector.VectorSearch;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.internal.ValidationUtils;
 import dev.langchain4j.store.embedding.*;
 import reactor.util.annotation.NonNull;
 import reactor.util.annotation.Nullable;
@@ -183,7 +182,6 @@ public class CouchbaseEmbeddingStore implements EmbeddingStore<TextSegment> {
         metadata.put("fields", new ArrayList<>());
         return metadata;
     }
-
 
     private Map<String, Object> embedding(Integer dimensions) {
         Map<String, Object> embedding = new HashMap<>();

--- a/langchain4j-local-ai/src/main/java/dev/langchain4j/model/localai/LocalAiStreamingChatModel.java
+++ b/langchain4j-local-ai/src/main/java/dev/langchain4j/model/localai/LocalAiStreamingChatModel.java
@@ -27,7 +27,6 @@ import java.time.Duration;
 import java.util.List;
 
 import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.chat.request.ToolChoice.REQUIRED;

--- a/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/spi/WorkersAiImageModelBuilderFactory.java
+++ b/langchain4j-workers-ai/src/main/java/dev/langchain4j/model/workersai/spi/WorkersAiImageModelBuilderFactory.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.model.workersai.spi;
 
 import dev.langchain4j.model.workersai.WorkersAiImageModel;
-import dev.langchain4j.model.workersai.WorkersAiLanguageModel;
 
 import java.util.function.Supplier;
 

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -13,7 +13,6 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
@@ -14,7 +14,6 @@ import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.store.memory.chat.ChatMemoryStore;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;

--- a/langchain4j/src/main/java/dev/langchain4j/service/Result.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/Result.java
@@ -10,7 +10,6 @@ import dev.langchain4j.service.tool.ToolExecution;
 import java.util.List;
 
 import static dev.langchain4j.internal.Utils.copy;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 /**
  * Represents the result of an AI Service invocation.


### PR DESCRIPTION
## Summary

Removed 18 unused import statements from 17 source files across multiple modules.

### Modules affected
- `langchain4j-core` (6 files)
- `langchain4j` (3 files)
- `langchain4j-azure-ai-search`
- `langchain4j-cassandra`
- `langchain4j-couchbase`
- `langchain4j-agentic`
- `langchain4j-agentic-mcp`
- `langchain4j-local-ai`
- `langchain4j-workers-ai`
- `document-loaders/langchain4j-document-loader-azure-storage-blob`

### Verification

Each import was verified to be unused — the imported symbol does not appear in any non-import line of its file (including javadoc `@link` and `@see` tags).