### PR TITLE
Add support for IBM watsonx.ai deployed models

### DIFF
--- a/docs/docs/integrations/language-models/watsonx.md
+++ b/docs/docs/integrations/language-models/watsonx.md
@@ -123,7 +123,7 @@ You can create an API key at [https://cloud.ibm.com/iam/apikeys](https://cloud.i
 
 ## WatsonxChatModel
 
-The `WatsonxChatModel` class allows you to create an instance of the `ChatModel` interface fully encapsulated within LangChain4j.  
+The `WatsonxChatModel` class allows you to create an instance of the `ChatModel` interface fully encapsulated within LangChain4j.
 To create an instance, you must specify the mandatory parameters:
 
 - `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`);
@@ -131,9 +131,17 @@ To create an instance, you must specify the mandatory parameters:
 - `projectId(...)` – IBM Cloud Project ID (or use `spaceId(...)`);
 - `modelName(...)` – Foundation model ID for inference;
 
+Alternatively, you can use a **deployed model** by specifying:
+
+- `baseUrl(...)` – IBM Cloud endpoint URL (as `String`, `URI`, or `CloudRegion`);
+- `apiKey(...)` – IBM Cloud IAM API key;
+- `deploymentId(...)` – Deployment ID of the on-demand deployed model;
+
 > You can authenticate using either `.apiKey(...)` or a full `Authenticator` instance via `.authenticator(...)`.
 
 ### Example
+
+#### Using a foundation model from the catalog
 
 ```java
 import dev.langchain4j.model.chat.ChatModel;
@@ -153,15 +161,42 @@ String answer = chatModel.chat("Hello from watsonx.ai");
 System.out.println(answer);
 ```
 
+#### Using a deployed model (on-demand deployment)
+
+IBM watsonx.ai allows you to deploy foundation models on-demand on dedicated hardware for exclusive use by your organization. These deployed models can be accessed using their `deploymentId`.
+
+```java
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.watsonx.WatsonxChatModel;
+import com.ibm.watsonx.ai.CloudRegion;
+
+ChatModel chatModel = WatsonxChatModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .deploymentId("your-deployment-id")
+    .temperature(0.7)
+    .maxOutputTokens(0)
+    .build();
+
+String answer = chatModel.chat("Hello from watsonx.ai");
+System.out.println(answer);
+```
+
+> **Note:** When using `deploymentId`, you don't need to specify `projectId`, `spaceId`, or `modelName` as the deployment already contains this information.
+
 > 🔗 [View available models](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx#ibm-provided)
+
+> 🔗 [Learn more about deploying models on-demand](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/deploy-on-demand-overview.html?context=wx&audience=wdp)
 
 ## WatsonxStreamingChatModel
 
-The `WatsonxStreamingChatModel` provides streaming support for IBM watsonx.ai within LangChain4j. It’s useful when you want to process tokens as they are generated, ideal for real-time applications such as chat UIs or long text generation.
+The `WatsonxStreamingChatModel` provides streaming support for IBM watsonx.ai within LangChain4j. It's useful when you want to process tokens as they are generated, ideal for real-time applications such as chat UIs or long text generation.
 
 Streaming uses the same configuration structure and parameters as the non-streaming [`WatsonxChatModel`](#watsonxchatmodel). The main difference is that responses are delivered incrementally through a handler interface.
 
 ### Example
+
+#### Using a foundation model from the catalog
 
 ```java
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -197,7 +232,46 @@ model.chat("What is the capital of Italy?", new StreamingChatResponseHandler() {
 });
 ```
 
+#### Using a deployed model (on-demand deployment)
+
+```java
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.StreamingChatResponseHandler;
+import dev.langchain4j.model.chat.ChatResponse;
+import dev.langchain4j.model.watsonx.WatsonxStreamingChatModel;
+import com.ibm.watsonx.ai.CloudRegion;
+
+StreamingChatModel model = WatsonxStreamingChatModel.builder()
+    .baseUrl(CloudRegion.FRANKFURT)
+    .apiKey("your-api-key")
+    .deploymentId("your-deployment-id")
+    .maxOutputTokens(0)
+    .build();
+
+model.chat("What is the capital of Italy?", new StreamingChatResponseHandler() {
+
+    @Override
+    public void onPartialResponse(String partialResponse) {
+        System.out.println("Partial: " + partialResponse);
+    }
+
+    @Override
+    public void onCompleteResponse(ChatResponse completeResponse) {
+        System.out.println("Complete: " + completeResponse);
+    }
+
+    @Override
+    public void onError(Throwable error) {
+        error.printStackTrace();
+    }
+});
+```
+
+> **Note:** When using `deploymentId`, you don't need to specify `projectId`, `spaceId`, or `modelName` as the deployment already contains this information.
+
 > 🔗 [View available models](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx#ibm-provided)
+
+> 🔗 [Learn more about deploying models on-demand](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/deploy-on-demand-overview.html?context=wx&audience=wdp)
 
 ## Tool Integration
 

--- a/langchain4j-watsonx/pom.xml
+++ b/langchain4j-watsonx/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ibm.watsonx</groupId>
             <artifactId>watsonx-ai</artifactId>
-            <version>0.20.0</version>
+            <version>0.21.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/langchain4j-watsonx/revapi.json
+++ b/langchain4j-watsonx/revapi.json
@@ -1,0 +1,25 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.field.removed",
+          "old": "field dev.langchain4j.model.watsonx.WatsonxChat.chatService @ dev.langchain4j.model.watsonx.WatsonxChatModel",
+          "justification": "Internal field renamed from chatService to chatProvider to support deployment models; WatsonxChat is @Internal"
+        },
+        {
+          "code": "java.field.removed",
+          "old": "field dev.langchain4j.model.watsonx.WatsonxChat.chatService @ dev.langchain4j.model.watsonx.WatsonxStreamingChatModel",
+          "justification": "Internal field renamed from chatService to chatProvider to support deployment models; WatsonxChat is @Internal"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class com.ibm.watsonx.ai.chat.ChatProvider",
+          "justification": "ChatProvider is an interface from watsonx-ai SDK used internally; WatsonxChat is @Internal and the field is protected"
+        }
+      ]
+    }
+  }
+]

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
@@ -7,10 +7,12 @@ import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static java.util.Arrays.asList;
 import static java.util.Objects.nonNull;
 
+import com.ibm.watsonx.ai.chat.ChatProvider;
 import com.ibm.watsonx.ai.chat.ChatService;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.Thinking;
 import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
+import com.ibm.watsonx.ai.deployment.DeploymentService;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
@@ -31,7 +33,7 @@ import java.util.Set;
 @Internal
 abstract class WatsonxChat {
 
-    protected final ChatService chatService;
+    protected final ChatProvider chatProvider;
     protected final List<ChatModelListener> listeners;
     protected final ChatRequestParameters defaultRequestParameters;
     protected final Set<Capability> supportedCapabilities;
@@ -58,6 +60,7 @@ abstract class WatsonxChat {
         var spaceId = getOrDefault(builder.spaceId, watsonxParameters.spaceId());
         var timeout = getOrDefault(builder.timeout, watsonxParameters.timeout());
         var thinking = getOrDefault(builder.thinking, watsonxParameters.thinking());
+        var deploymentId = getOrDefault(builder.deploymentId, watsonxParameters.deploymentId());
 
         defaultRequestParameters = WatsonxChatRequestParameters.builder()
                 // Common parameters
@@ -86,24 +89,44 @@ abstract class WatsonxChat {
                 .guidedRegex(getOrDefault(builder.guidedRegex, watsonxParameters.guidedRegex()))
                 .lengthPenalty(getOrDefault(builder.lengthPenalty, watsonxParameters.lengthPenalty()))
                 .repetitionPenalty(getOrDefault(builder.repetitionPenalty, watsonxParameters.repetitionPenalty()))
+                .deploymentId(deploymentId)
                 .build();
 
-        var chatServiceBuilder = nonNull(builder.authenticator)
-                ? ChatService.builder().authenticator(builder.authenticator)
-                : ChatService.builder().apiKey(builder.apiKey);
+        if (nonNull(deploymentId)) {
 
-        chatService = chatServiceBuilder
-                .baseUrl(builder.baseUrl)
-                .modelId(modelName)
-                .version(builder.version)
-                .projectId(projectId)
-                .spaceId(spaceId)
-                .timeout(timeout)
-                .logRequests(builder.logRequests)
-                .logResponses(builder.logResponses)
-                .httpClient(builder.httpClient)
-                .verifySsl(builder.verifySsl)
-                .build();
+            var deploymentBuilder = nonNull(builder.authenticator)
+                    ? DeploymentService.builder().authenticator(builder.authenticator)
+                    : DeploymentService.builder().apiKey(builder.apiKey);
+
+            chatProvider = deploymentBuilder
+                    .baseUrl(builder.baseUrl)
+                    .version(builder.version)
+                    .timeout(timeout)
+                    .logRequests(builder.logRequests)
+                    .logResponses(builder.logResponses)
+                    .httpClient(builder.httpClient)
+                    .verifySsl(builder.verifySsl)
+                    .build();
+
+        } else {
+
+            var chatServiceBuilder = nonNull(builder.authenticator)
+                    ? ChatService.builder().authenticator(builder.authenticator)
+                    : ChatService.builder().apiKey(builder.apiKey);
+
+            chatProvider = chatServiceBuilder
+                    .baseUrl(builder.baseUrl)
+                    .modelId(modelName)
+                    .version(builder.version)
+                    .projectId(projectId)
+                    .spaceId(spaceId)
+                    .timeout(timeout)
+                    .logRequests(builder.logRequests)
+                    .logResponses(builder.logResponses)
+                    .httpClient(builder.httpClient)
+                    .verifySsl(builder.verifySsl)
+                    .build();
+        }
     }
 
     final void validateThinkingIsAllowedForGraniteModel(
@@ -151,6 +174,7 @@ abstract class WatsonxChat {
         private String guidedGrammar;
         private Double repetitionPenalty;
         private Double lengthPenalty;
+        private String deploymentId;
         private Thinking thinking;
 
         public T modelName(String modelName) {
@@ -252,6 +276,11 @@ abstract class WatsonxChat {
 
         public T defaultRequestParameters(ChatRequestParameters defaultRequestParameters) {
             this.defaultRequestParameters = defaultRequestParameters;
+            return (T) this;
+        }
+
+        public T deploymentId(String deploymentId) {
+            this.deploymentId = deploymentId;
             return (T) this;
         }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChat.java
@@ -1,9 +1,7 @@
 package dev.langchain4j.model.watsonx;
 
-import static dev.langchain4j.data.message.ChatMessageType.SYSTEM;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static java.util.Arrays.asList;
 import static java.util.Objects.nonNull;
 
@@ -15,9 +13,6 @@ import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
 import com.ibm.watsonx.ai.deployment.DeploymentService;
 import dev.langchain4j.Internal;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.exception.InvalidRequestException;
-import dev.langchain4j.exception.LangChain4jException;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
@@ -127,21 +122,6 @@ abstract class WatsonxChat {
                     .verifySsl(builder.verifySsl)
                     .build();
         }
-    }
-
-    final void validateThinkingIsAllowedForGraniteModel(
-            String modelName, List<ChatMessage> messages, List<ToolSpecification> tools) throws LangChain4jException {
-
-        if (!"ibm/granite-3-3-8b-instruct".equals(modelName)) return;
-
-        if (!isNullOrEmpty(tools))
-            throw new InvalidRequestException("The thinking/reasoning cannot be activated when tools are used");
-
-        var systemMessageIsPresent = messages.stream().map(ChatMessage::type).anyMatch(SYSTEM::equals);
-
-        if (systemMessageIsPresent)
-            throw new InvalidRequestException(
-                    "The thinking/reasoning cannot be activated when a system message is present");
     }
 
     final void validate(ChatRequestParameters parameters) {

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatModel.java
@@ -9,7 +9,6 @@ import static java.util.stream.Collectors.toCollection;
 import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
-import com.ibm.watsonx.ai.chat.model.ChatParameters;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
@@ -68,23 +67,30 @@ public class WatsonxChatModel extends WatsonxChat implements ChatModel {
                 ? toolSpecifications.stream().map(Converter::toTool).toList()
                 : null;
 
-        var watsonxChatRequest = com.ibm.watsonx.ai.chat.ChatRequest.builder();
-        ExtractionTags tags = null;
+        var watsonxChatRequestBuilder = com.ibm.watsonx.ai.chat.ChatRequest.builder();
 
-        if (chatRequest.parameters() instanceof WatsonxChatRequestParameters wcrp && nonNull(wcrp.thinking())) {
-            validateThinkingIsAllowedForGraniteModel(wcrp.modelName(), chatRequest.messages(), toolSpecifications);
-            watsonxChatRequest.thinking(wcrp.thinking());
-            tags = wcrp.thinking().extractionTags();
+        ExtractionTags tags = null;
+        String deploymentId = null;
+
+        if (chatRequest.parameters() instanceof WatsonxChatRequestParameters wcrp) {
+            deploymentId = wcrp.deploymentId();
+            if (nonNull(wcrp.thinking())) {
+                validateThinkingIsAllowedForGraniteModel(wcrp.modelName(), chatRequest.messages(), toolSpecifications);
+                watsonxChatRequestBuilder.thinking(wcrp.thinking());
+                tags = wcrp.thinking().extractionTags();
+            }
         }
 
-        ChatParameters parameters = Converter.toChatParameters(chatRequest.parameters());
+        var parameters = Converter.toChatParameters(chatRequest.parameters());
+        var watsonxChatRequest = watsonxChatRequestBuilder
+                .messages(messages)
+                .tools(tools)
+                .parameters(parameters)
+                .deploymentId(deploymentId)
+                .build();
 
         com.ibm.watsonx.ai.chat.ChatResponse chatResponse =
-                WatsonxExceptionMapper.INSTANCE.withExceptionMapper(() -> chatService.chat(watsonxChatRequest
-                        .messages(messages)
-                        .tools(tools)
-                        .parameters(parameters)
-                        .build()));
+                WatsonxExceptionMapper.INSTANCE.withExceptionMapper(() -> chatProvider.chat(watsonxChatRequest));
 
         ResultChoice choice = chatResponse.choices().get(0);
         ChatUsage usage = chatResponse.usage();

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatModel.java
@@ -75,7 +75,6 @@ public class WatsonxChatModel extends WatsonxChat implements ChatModel {
         if (chatRequest.parameters() instanceof WatsonxChatRequestParameters wcrp) {
             deploymentId = wcrp.deploymentId();
             if (nonNull(wcrp.thinking())) {
-                validateThinkingIsAllowedForGraniteModel(wcrp.modelName(), chatRequest.messages(), toolSpecifications);
                 watsonxChatRequestBuilder.thinking(wcrp.thinking());
                 tags = wcrp.thinking().extractionTags();
             }

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatModel.java
@@ -10,8 +10,6 @@ import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
-import com.ibm.watsonx.ai.chat.model.ExtractionTags;
-import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.Tool;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
@@ -69,15 +67,11 @@ public class WatsonxChatModel extends WatsonxChat implements ChatModel {
 
         var watsonxChatRequestBuilder = com.ibm.watsonx.ai.chat.ChatRequest.builder();
 
-        ExtractionTags tags = null;
         String deploymentId = null;
 
         if (chatRequest.parameters() instanceof WatsonxChatRequestParameters wcrp) {
             deploymentId = wcrp.deploymentId();
-            if (nonNull(wcrp.thinking())) {
-                watsonxChatRequestBuilder.thinking(wcrp.thinking());
-                tags = wcrp.thinking().extractionTags();
-            }
+            if (nonNull(wcrp.thinking())) watsonxChatRequestBuilder.thinking(wcrp.thinking());
         }
 
         var parameters = Converter.toChatParameters(chatRequest.parameters());
@@ -91,25 +85,24 @@ public class WatsonxChatModel extends WatsonxChat implements ChatModel {
         com.ibm.watsonx.ai.chat.ChatResponse chatResponse =
                 WatsonxExceptionMapper.INSTANCE.withExceptionMapper(() -> chatProvider.chat(watsonxChatRequest));
 
+        AssistantMessage assistantMessage = chatResponse.toAssistantMessage();
         ResultChoice choice = chatResponse.choices().get(0);
         ChatUsage usage = chatResponse.usage();
-        ResultMessage message = choice.message();
 
-        if (isNotNullOrBlank(message.refusal())) throw new ContentFilteredException(message.refusal());
+        if (isNotNullOrBlank(assistantMessage.refusal()))
+            throw new ContentFilteredException(assistantMessage.refusal());
 
         AiMessage.Builder aiMessage = AiMessage.builder();
 
-        if (nonNull(message.toolCalls()) && !message.toolCalls().isEmpty()) {
-            aiMessage.toolExecutionRequests(message.toolCalls().stream()
+        if (nonNull(assistantMessage.toolCalls())
+                && !assistantMessage.toolCalls().isEmpty()) {
+            aiMessage.toolExecutionRequests(assistantMessage.toolCalls().stream()
                     .map(Converter::toToolExecutionRequest)
                     .toList());
-        } else if (nonNull(tags)) {
-            AssistantMessage assistantMessage = chatResponse.toAssistantMessage();
-            aiMessage.thinking(assistantMessage.thinking());
-            aiMessage.text(assistantMessage.content());
-        } else {
-            aiMessage.text(message.content());
         }
+
+        aiMessage.thinking(assistantMessage.thinking());
+        aiMessage.text(assistantMessage.content());
 
         FinishReason finishReason = Converter.toFinishReason(choice.finishReason());
         TokenUsage tokenUsage = usage != null

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParameters.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParameters.java
@@ -30,24 +30,26 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
     private final String guidedGrammar;
     private final Double repetitionPenalty;
     private final Double lengthPenalty;
+    private final String deploymentId;
     private final Duration timeout;
 
     private WatsonxChatRequestParameters(Builder builder) {
         super(builder);
-        this.projectId = builder.projectId;
-        this.spaceId = builder.spaceId;
-        this.logitBias = builder.logitBias;
-        this.logprobs = builder.logprobs;
-        this.topLogprobs = builder.topLogprobs;
-        this.seed = builder.seed;
-        this.toolChoiceName = builder.toolChoiceName;
-        this.timeout = builder.timeout;
-        this.thinking = builder.thinking;
-        this.guidedChoice = builder.guidedChoice;
-        this.guidedRegex = builder.guidedRegex;
-        this.guidedGrammar = builder.guidedGrammar;
-        this.repetitionPenalty = builder.repetitionPenalty;
-        this.lengthPenalty = builder.lengthPenalty;
+        projectId = builder.projectId;
+        spaceId = builder.spaceId;
+        logitBias = builder.logitBias;
+        logprobs = builder.logprobs;
+        topLogprobs = builder.topLogprobs;
+        seed = builder.seed;
+        toolChoiceName = builder.toolChoiceName;
+        timeout = builder.timeout;
+        thinking = builder.thinking;
+        guidedChoice = builder.guidedChoice;
+        guidedRegex = builder.guidedRegex;
+        guidedGrammar = builder.guidedGrammar;
+        repetitionPenalty = builder.repetitionPenalty;
+        lengthPenalty = builder.lengthPenalty;
+        deploymentId = builder.deploymentId;
     }
 
     public String projectId() {
@@ -106,6 +108,10 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
         return lengthPenalty;
     }
 
+    public String deploymentId() {
+        return deploymentId;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -140,6 +146,7 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
         private String guidedGrammar;
         private Double repetitionPenalty;
         private Double lengthPenalty;
+        private String deploymentId;
         private Thinking thinking;
 
         @Override
@@ -160,6 +167,7 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
                 guidedGrammar(getOrDefault(watsonxParameters.guidedGrammar(), guidedGrammar));
                 repetitionPenalty(getOrDefault(watsonxParameters.repetitionPenalty(), repetitionPenalty));
                 lengthPenalty(getOrDefault(watsonxParameters.lengthPenalty(), lengthPenalty));
+                deploymentId(getOrDefault(watsonxParameters.deploymentId(), deploymentId));
             }
             return this;
         }
@@ -201,6 +209,11 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
 
         public Builder timeout(Duration timeout) {
             this.timeout = timeout;
+            return this;
+        }
+
+        public Builder deploymentId(String deploymentId) {
+            this.deploymentId = deploymentId;
             return this;
         }
 

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModel.java
@@ -9,7 +9,6 @@ import static java.util.stream.Collectors.toCollection;
 import com.ibm.watsonx.ai.chat.ChatHandler;
 import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
-import com.ibm.watsonx.ai.chat.model.ChatParameters;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
 import com.ibm.watsonx.ai.chat.model.CompletedToolCall;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
@@ -54,6 +53,8 @@ import java.util.Set;
  */
 public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingChatModel {
 
+    private record WatsonxRequestConfig(ExtractionTags tags, String deploymentId) {}
+
     private WatsonxStreamingChatModel(Builder builder) {
         super(builder);
     }
@@ -73,92 +74,93 @@ public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingC
                 ? toolSpecifications.stream().map(Converter::toTool).toList()
                 : null;
 
-        var watsonxChatRequest = com.ibm.watsonx.ai.chat.ChatRequest.builder();
-        final ExtractionTags tags;
+        var watsonxChatRequestBuilder = com.ibm.watsonx.ai.chat.ChatRequest.builder();
 
-        if (chatRequest.parameters() instanceof WatsonxChatRequestParameters wcrp && nonNull(wcrp.thinking())) {
-            validateThinkingIsAllowedForGraniteModel(wcrp.modelName(), chatRequest.messages(), toolSpecifications);
-            watsonxChatRequest.thinking(wcrp.thinking());
-            tags = wcrp.thinking().extractionTags();
-        } else tags = null;
+        var config = configureWatsonxRequest(chatRequest, watsonxChatRequestBuilder, toolSpecifications);
+        ExtractionTags tags = config.tags();
+        String deploymentId = config.deploymentId();
 
-        ChatParameters parameters = Converter.toChatParameters(chatRequest.parameters());
-        chatService.chatStreaming(
-                watsonxChatRequest
-                        .messages(messages)
-                        .tools(tools)
-                        .parameters(parameters)
-                        .build(),
-                new ChatHandler() {
-                    @Override
-                    public void onCompleteResponse(com.ibm.watsonx.ai.chat.ChatResponse completeResponse) {
+        var parameters = Converter.toChatParameters(chatRequest.parameters());
+        var watsonxChatRequest = watsonxChatRequestBuilder
+                .messages(messages)
+                .tools(tools)
+                .parameters(parameters)
+                .deploymentId(deploymentId)
+                .build();
 
-                        ResultChoice choice = completeResponse.choices().get(0);
-                        FinishReason finishReason = Converter.toFinishReason(choice.finishReason());
-                        ChatUsage completeUsage = completeResponse.usage();
-                        TokenUsage tokenUsage = completeUsage != null
-                                ? new TokenUsage(completeUsage.promptTokens(), completeUsage.completionTokens(), completeUsage.totalTokens())
-                                : null;
+        chatProvider.chatStreaming(watsonxChatRequest, new ChatHandler() {
+            @Override
+            public void onCompleteResponse(com.ibm.watsonx.ai.chat.ChatResponse completeResponse) {
 
-                        var assistantMessage = completeResponse.toAssistantMessage();
-                        var aiMessage = AiMessage.builder();
+                ResultChoice choice = completeResponse.choices().get(0);
+                FinishReason finishReason = Converter.toFinishReason(choice.finishReason());
+                ChatUsage completeUsage = completeResponse.usage();
+                TokenUsage tokenUsage = completeUsage != null
+                        ? new TokenUsage(
+                                completeUsage.promptTokens(),
+                                completeUsage.completionTokens(),
+                                completeUsage.totalTokens())
+                        : null;
 
-                        if (isNotNullOrBlank(assistantMessage.refusal()))
-                            handler.onError(new ContentFilteredException(assistantMessage.refusal()));
+                var assistantMessage = completeResponse.toAssistantMessage();
+                var aiMessage = AiMessage.builder();
 
-                        if (nonNull(tags)) {
-                            aiMessage.thinking(assistantMessage.thinking());
-                            aiMessage.text(assistantMessage.content());
-                        } else {
-                            aiMessage.text(assistantMessage.content());
-                        }
+                if (isNotNullOrBlank(assistantMessage.refusal()))
+                    handler.onError(new ContentFilteredException(assistantMessage.refusal()));
 
-                        if (nonNull(assistantMessage.toolCalls())) {
-                            aiMessage.toolExecutionRequests(assistantMessage.toolCalls().stream()
-                                    .map(Converter::toToolExecutionRequest)
-                                    .toList());
-                        }
+                if (nonNull(tags)) {
+                    aiMessage.thinking(assistantMessage.thinking());
+                    aiMessage.text(assistantMessage.content());
+                } else {
+                    aiMessage.text(assistantMessage.content());
+                }
 
-                        ChatResponse chatResponse = ChatResponse.builder()
-                                .aiMessage(aiMessage.build())
-                                .metadata(WatsonxChatResponseMetadata.builder()
-                                        .created(completeResponse.created())
-                                        .modelVersion(completeResponse.modelVersion())
-                                        .finishReason(finishReason)
-                                        .id(completeResponse.id())
-                                        .modelName(completeResponse.modelId())
-                                        .tokenUsage(tokenUsage)
-                                        .build())
-                                .build();
+                if (nonNull(assistantMessage.toolCalls())) {
+                    aiMessage.toolExecutionRequests(assistantMessage.toolCalls().stream()
+                            .map(Converter::toToolExecutionRequest)
+                            .toList());
+                }
 
-                        handler.onCompleteResponse(chatResponse);
-                    }
+                ChatResponse chatResponse = ChatResponse.builder()
+                        .aiMessage(aiMessage.build())
+                        .metadata(WatsonxChatResponseMetadata.builder()
+                                .created(completeResponse.created())
+                                .modelVersion(completeResponse.modelVersion())
+                                .finishReason(finishReason)
+                                .id(completeResponse.id())
+                                .modelName(completeResponse.modelId())
+                                .tokenUsage(tokenUsage)
+                                .build())
+                        .build();
 
-                    @Override
-                    public void onError(Throwable error) {
-                        handler.onError(WatsonxExceptionMapper.INSTANCE.mapException(error));
-                    }
+                handler.onCompleteResponse(chatResponse);
+            }
 
-                    @Override
-                    public void onPartialResponse(String partialResponse, PartialChatResponse partialChatResponse) {
-                        handler.onPartialResponse(partialResponse);
-                    }
+            @Override
+            public void onError(Throwable error) {
+                handler.onError(WatsonxExceptionMapper.INSTANCE.mapException(error));
+            }
 
-                    @Override
-                    public void onCompleteToolCall(CompletedToolCall completedToolCall) {
-                        handler.onCompleteToolCall(Converter.toCompleteToolCall(completedToolCall.toolCall()));
-                    }
+            @Override
+            public void onPartialResponse(String partialResponse, PartialChatResponse partialChatResponse) {
+                handler.onPartialResponse(partialResponse);
+            }
 
-                    @Override
-                    public void onPartialThinking(String partialThinking, PartialChatResponse partialChatResponse) {
-                        handler.onPartialThinking(new PartialThinking(partialThinking));
-                    }
+            @Override
+            public void onCompleteToolCall(CompletedToolCall completedToolCall) {
+                handler.onCompleteToolCall(Converter.toCompleteToolCall(completedToolCall.toolCall()));
+            }
 
-                    @Override
-                    public void onPartialToolCall(PartialToolCall partialToolCall) {
-                        handler.onPartialToolCall(Converter.toPartialToolCall(partialToolCall));
-                    }
-                });
+            @Override
+            public void onPartialThinking(String partialThinking, PartialChatResponse partialChatResponse) {
+                handler.onPartialThinking(new PartialThinking(partialThinking));
+            }
+
+            @Override
+            public void onPartialToolCall(PartialToolCall partialToolCall) {
+                handler.onPartialToolCall(Converter.toPartialToolCall(partialToolCall));
+            }
+        });
     }
 
     @Override
@@ -179,6 +181,26 @@ public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingC
     @Override
     public ModelProvider provider() {
         return WATSONX;
+    }
+
+    private WatsonxRequestConfig configureWatsonxRequest(
+            ChatRequest chatRequest,
+            com.ibm.watsonx.ai.chat.ChatRequest.Builder requestBuilder,
+            List<ToolSpecification> toolSpecifications) {
+
+        ExtractionTags tags = null;
+        String deploymentId = null;
+
+        if (chatRequest.parameters() instanceof WatsonxChatRequestParameters wcrp) {
+            if (nonNull(wcrp.thinking())) {
+                validateThinkingIsAllowedForGraniteModel(wcrp.modelName(), chatRequest.messages(), toolSpecifications);
+                requestBuilder.thinking(wcrp.thinking());
+                tags = wcrp.thinking().extractionTags();
+            }
+            deploymentId = wcrp.deploymentId();
+        }
+
+        return new WatsonxRequestConfig(tags, deploymentId);
     }
 
     /**

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModel.java
@@ -11,7 +11,6 @@ import com.ibm.watsonx.ai.chat.ChatResponse.ResultChoice;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
 import com.ibm.watsonx.ai.chat.model.CompletedToolCall;
-import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.PartialChatResponse;
 import com.ibm.watsonx.ai.chat.model.PartialToolCall;
 import com.ibm.watsonx.ai.chat.model.Tool;
@@ -53,8 +52,6 @@ import java.util.Set;
  */
 public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingChatModel {
 
-    private record WatsonxRequestConfig(ExtractionTags tags, String deploymentId) {}
-
     private WatsonxStreamingChatModel(Builder builder) {
         super(builder);
     }
@@ -74,11 +71,13 @@ public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingC
                 ? toolSpecifications.stream().map(Converter::toTool).toList()
                 : null;
 
+        String deploymentId = null;
         var watsonxChatRequestBuilder = com.ibm.watsonx.ai.chat.ChatRequest.builder();
 
-        var config = configureWatsonxRequest(chatRequest, watsonxChatRequestBuilder, toolSpecifications);
-        ExtractionTags tags = config.tags();
-        String deploymentId = config.deploymentId();
+        if (chatRequest.parameters() instanceof WatsonxChatRequestParameters wcrp) {
+            deploymentId = wcrp.deploymentId();
+            if (nonNull(wcrp.thinking())) watsonxChatRequestBuilder.thinking(wcrp.thinking());
+        }
 
         var parameters = Converter.toChatParameters(chatRequest.parameters());
         var watsonxChatRequest = watsonxChatRequestBuilder
@@ -108,18 +107,14 @@ public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingC
                 if (isNotNullOrBlank(assistantMessage.refusal()))
                     handler.onError(new ContentFilteredException(assistantMessage.refusal()));
 
-                if (nonNull(tags)) {
-                    aiMessage.thinking(assistantMessage.thinking());
-                    aiMessage.text(assistantMessage.content());
-                } else {
-                    aiMessage.text(assistantMessage.content());
-                }
-
                 if (nonNull(assistantMessage.toolCalls())) {
                     aiMessage.toolExecutionRequests(assistantMessage.toolCalls().stream()
                             .map(Converter::toToolExecutionRequest)
                             .toList());
                 }
+
+                aiMessage.thinking(assistantMessage.thinking());
+                aiMessage.text(assistantMessage.content());
 
                 ChatResponse chatResponse = ChatResponse.builder()
                         .aiMessage(aiMessage.build())
@@ -181,25 +176,6 @@ public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingC
     @Override
     public ModelProvider provider() {
         return WATSONX;
-    }
-
-    private WatsonxRequestConfig configureWatsonxRequest(
-            ChatRequest chatRequest,
-            com.ibm.watsonx.ai.chat.ChatRequest.Builder requestBuilder,
-            List<ToolSpecification> toolSpecifications) {
-
-        ExtractionTags tags = null;
-        String deploymentId = null;
-
-        if (chatRequest.parameters() instanceof WatsonxChatRequestParameters wcrp) {
-            if (nonNull(wcrp.thinking())) {
-                requestBuilder.thinking(wcrp.thinking());
-                tags = wcrp.thinking().extractionTags();
-            }
-            deploymentId = wcrp.deploymentId();
-        }
-
-        return new WatsonxRequestConfig(tags, deploymentId);
     }
 
     /**

--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModel.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModel.java
@@ -193,7 +193,6 @@ public class WatsonxStreamingChatModel extends WatsonxChat implements StreamingC
 
         if (chatRequest.parameters() instanceof WatsonxChatRequestParameters wcrp) {
             if (nonNull(wcrp.thinking())) {
-                validateThinkingIsAllowedForGraniteModel(wcrp.modelName(), chatRequest.messages(), toolSpecifications);
                 requestBuilder.thinking(wcrp.thinking());
                 tags = wcrp.thinking().extractionTags();
             }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
@@ -26,6 +26,7 @@ import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
 import com.ibm.watsonx.ai.chat.model.UserMessage;
+import com.ibm.watsonx.ai.deployment.DeploymentService;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.exception.ContentFilteredException;
 import dev.langchain4j.exception.LangChain4jException;
@@ -63,7 +64,13 @@ public class WatsonxChatModelTest {
     ChatService mockChatService;
 
     @Mock
+    DeploymentService deploymentService;
+
+    @Mock
     ChatService.Builder mockChatServiceBuilder;
+
+    @Mock
+    DeploymentService.Builder mockDeploymentServiceBuilder;
 
     @Captor
     ArgumentCaptor<com.ibm.watsonx.ai.chat.ChatRequest> chatRequestCaptor;
@@ -87,6 +94,17 @@ public class WatsonxChatModelTest {
         when(mockChatServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockChatServiceBuilder);
         when(mockChatServiceBuilder.build()).thenReturn(mockChatService);
 
+        when(mockDeploymentServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.timeout(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.version(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.logRequests(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.logResponses(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.authenticator(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.apiKey(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.httpClient(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.build()).thenReturn(deploymentService);
+
         var chatUsage = new ChatUsage(10, 10, 20);
         chatResponse = ChatResponse.build()
                 .id("id")
@@ -100,9 +118,9 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void testWatsonxChatModelBuilder() {
+    void should_create_create_a_watsonx_chat_model_from_a_chat_service() {
 
-        var chatModel = WatsonxChatModel.builder()
+        var chatModel = assertDoesNotThrow(() -> WatsonxChatModel.builder()
                 .baseUrl(CloudRegion.FRANKFURT)
                 .modelName("model-name")
                 .apiKey("api-key-test")
@@ -111,10 +129,16 @@ public class WatsonxChatModelTest {
                 .version("my-version")
                 .logRequests(true)
                 .logResponses(true)
-                .build();
+                .build());
 
         var defaultRequestParameters =
                 assertInstanceOf(WatsonxChatRequestParameters.class, chatModel.defaultRequestParameters());
+
+        var chatProviderField =
+                assertDoesNotThrow(() -> chatModel.getClass().getSuperclass().getDeclaredField("chatProvider"));
+        var chatProvider = assertDoesNotThrow(() -> chatProviderField.get(chatModel));
+
+        assertInstanceOf(ChatService.class, chatProvider);
         assertNull(defaultRequestParameters.frequencyPenalty());
         assertNull(defaultRequestParameters.logitBias());
         assertNull(defaultRequestParameters.logprobs());
@@ -139,18 +163,57 @@ public class WatsonxChatModelTest {
         assertNull(defaultRequestParameters.guidedRegex());
         assertNull(defaultRequestParameters.repetitionPenalty());
         assertNull(defaultRequestParameters.lengthPenalty());
-
-        assertDoesNotThrow(() -> WatsonxChatModel.builder()
-                .baseUrl("https://test.com")
-                .modelName("model-name")
-                .apiKey("api-key")
-                .projectId("project-id")
-                .spaceId("space-id")
-                .build());
     }
 
     @Test
-    void testDoChat() {
+    void should_create_create_a_watsonx_chat_model_from_a_deployment_service() {
+
+        var chatModel = assertDoesNotThrow(() -> WatsonxChatModel.builder()
+                .baseUrl(CloudRegion.FRANKFURT)
+                .apiKey("api-key-test")
+                .version("my-version")
+                .logRequests(true)
+                .logResponses(true)
+                .deploymentId("deployment-id")
+                .build());
+
+        var defaultRequestParameters =
+                assertInstanceOf(WatsonxChatRequestParameters.class, chatModel.defaultRequestParameters());
+
+        var chatProviderField =
+                assertDoesNotThrow(() -> chatModel.getClass().getSuperclass().getDeclaredField("chatProvider"));
+        var chatProvider = assertDoesNotThrow(() -> chatProviderField.get(chatModel));
+
+        assertInstanceOf(DeploymentService.class, chatProvider);
+        assertNull(defaultRequestParameters.frequencyPenalty());
+        assertNull(defaultRequestParameters.logitBias());
+        assertNull(defaultRequestParameters.logprobs());
+        assertNull(defaultRequestParameters.maxOutputTokens());
+        assertNull(defaultRequestParameters.modelName());
+        assertNull(defaultRequestParameters.presencePenalty());
+        assertNull(defaultRequestParameters.projectId());
+        assertNull(defaultRequestParameters.responseFormat());
+        assertNull(defaultRequestParameters.seed());
+        assertNull(defaultRequestParameters.spaceId());
+        assertEquals(List.of(), defaultRequestParameters.stopSequences());
+        assertNull(defaultRequestParameters.temperature());
+        assertNull(defaultRequestParameters.timeout());
+        assertNull(defaultRequestParameters.toolChoice());
+        assertNull(defaultRequestParameters.toolChoiceName());
+        assertEquals(List.of(), defaultRequestParameters.toolSpecifications());
+        assertNull(defaultRequestParameters.topK());
+        assertNull(defaultRequestParameters.topLogprobs());
+        assertNull(defaultRequestParameters.topP());
+        assertNull(defaultRequestParameters.guidedChoice());
+        assertNull(defaultRequestParameters.guidedGrammar());
+        assertNull(defaultRequestParameters.guidedRegex());
+        assertNull(defaultRequestParameters.repetitionPenalty());
+        assertNull(defaultRequestParameters.lengthPenalty());
+        assertEquals("deployment-id", defaultRequestParameters.deploymentId());
+    }
+
+    @Test
+    void should_do_chat() {
 
         var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
         var resultChoice = new ResultChoice(0, resultMessage, "stop");
@@ -170,11 +233,50 @@ public class WatsonxChatModelTest {
             assertEquals(
                     List.of(UserMessage.text("hello")),
                     chatRequestCaptor.getValue().messages());
+            assertNull(chatRequestCaptor.getValue().deploymentId());
         });
     }
 
     @Test
-    void testDoChatWithRefusal() {
+    void should_do_chat_with_deployment_service() {
+
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
+        var resultChoice = new ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+
+        when(deploymentService.chat(chatRequestCaptor.capture())).thenReturn(chatResponse.build());
+
+        withDeploymentServiceMock(() -> {
+            var chatModel = WatsonxChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .deploymentId("deployment-id")
+                    .apiKey("api-key")
+                    .build();
+
+            assertEquals("Hello", chatModel.chat("hello"));
+            assertEquals(
+                    List.of(UserMessage.text("hello")),
+                    chatRequestCaptor.getValue().messages());
+
+            var chatRequest = ChatRequest.builder()
+                    .messages(List.of(dev.langchain4j.data.message.UserMessage.from("hello")))
+                    .parameters(WatsonxChatRequestParameters.builder()
+                            .deploymentId("deployment-id-override")
+                            .build())
+                    .build();
+
+            assertNotNull(chatModel.chat(chatRequest));
+            assertEquals(2, chatRequestCaptor.getAllValues().size());
+            assertEquals(
+                    "deployment-id", chatRequestCaptor.getAllValues().get(0).deploymentId());
+            assertEquals(
+                    "deployment-id-override",
+                    chatRequestCaptor.getAllValues().get(1).deploymentId());
+        });
+    }
+
+    @Test
+    void should_do_chat_with_refusal() {
 
         var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, "refusal", null);
         var resultChoice = new ResultChoice(0, resultMessage, "stop");
@@ -195,7 +297,7 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void shouldExtractThinkingWhenConfiguredInModelBuilder() throws Exception {
+    void should_extract_thinking_when_configured_in_model_builder() throws Exception {
 
         var extractionTags = ExtractionTags.of("think", "response");
         var resultMessage = new ResultMessage(
@@ -292,7 +394,7 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void shouldExtractThinkingWhenConfiguredInRequestParameters() throws Exception {
+    void should_extract_thinking_when_configured_in_request_parameters() throws Exception {
 
         var extractionTags = ExtractionTags.of("think", "response");
         var resultMessage = new ResultMessage(
@@ -395,7 +497,7 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenThinkingUsedWithSystemMessage() {
+    void should_throw_exception_when_thinking_used_with_system_message() {
 
         withChatServiceMock(() -> {
             var chatModel = WatsonxChatModel.builder()
@@ -418,7 +520,7 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenThinkingUsedWithTools() {
+    void should_throw_exception_when_thinking_used_with_tools() {
 
         withChatServiceMock(() -> {
             var chatModel = WatsonxChatModel.builder()
@@ -440,7 +542,7 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void shouldReturnRawTextWhenThinkingIsNotEnabled() {
+    void should_return_raw_text_when_thinking_is_not_enabled() {
 
         var resultMessage = new ResultMessage(
                 AssistantMessage.ROLE,
@@ -476,7 +578,7 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void testDoChatWithTool() {
+    void should_do_chat_with_tool() {
 
         var toolCall = new ToolCall(0, "id", "function", new FunctionCall("name", "{}"));
         var resultMessage = new ResultMessage(AssistantMessage.ROLE, null, null, null, List.of(toolCall));
@@ -526,7 +628,7 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void testChatRequest() {
+    void should_handle_chat_request() {
 
         var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
         var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
@@ -591,7 +693,7 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void testChatRequestParameter() {
+    void should_handle_chat_request_parameters() {
 
         var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
         var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
@@ -895,7 +997,7 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void testChatRequestWithTopK() {
+    void should_throw_exception_for_chat_request_with_top_k() {
 
         var chatModel = WatsonxChatModel.builder()
                 .baseUrl("https://test.com")
@@ -912,19 +1014,21 @@ public class WatsonxChatModelTest {
                         .topK(10)
                         .build()));
 
-        assertThrows(UnsupportedFeatureException.class, () -> WatsonxChatModel.builder()
-                .baseUrl("https://test.com")
-                .modelName("modelId")
-                .projectId("project-id")
-                .spaceId("space-id")
-                .apiKey("api-key")
-                .defaultRequestParameters(
-                        ChatRequestParameters.builder().topK(10).build())
-                .build());
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> WatsonxChatModel.builder()
+                        .baseUrl("https://test.com")
+                        .modelName("modelId")
+                        .projectId("project-id")
+                        .spaceId("space-id")
+                        .apiKey("api-key")
+                        .defaultRequestParameters(
+                                ChatRequestParameters.builder().topK(10).build())
+                        .build());
     }
 
     @Test
-    void testSupportCapabilities() {
+    void should_support_capabilities() {
 
         var chatModel = WatsonxChatModel.builder()
                 .baseUrl("https://test.com")
@@ -942,6 +1046,13 @@ public class WatsonxChatModelTest {
     private void withChatServiceMock(Runnable action) {
         try (MockedStatic<ChatService> mockedStatic = mockStatic(ChatService.class)) {
             mockedStatic.when(ChatService::builder).thenReturn(mockChatServiceBuilder);
+            action.run();
+        }
+    }
+
+    private void withDeploymentServiceMock(Runnable action) {
+        try (MockedStatic<DeploymentService> mockedStatic = mockStatic(DeploymentService.class)) {
+            mockedStatic.when(DeploymentService::builder).thenReturn(mockDeploymentServiceBuilder);
             action.run();
         }
     }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
@@ -302,11 +302,7 @@ public class WatsonxChatModelTest {
 
         var extractionTags = ExtractionTags.of("think", "response");
         var resultMessage = new ResultMessage(
-                AssistantMessage.ROLE,
-                "<think>I'm thinking</think><response>Hello</response>",
-                "I'm thinking",
-                null,
-                null);
+                AssistantMessage.ROLE, "<think>I'm thinking</think><response>Hello</response>", null, null, null);
         var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
         chatResponse.choices(List.of(resultChoice));
         var cr = chatResponse.build();
@@ -400,11 +396,7 @@ public class WatsonxChatModelTest {
         var extractionTags =
                 ExtractionTags.of(new Think("<think>", "</think>"), new Response("<response>", "</response>"));
         var resultMessage = new ResultMessage(
-                AssistantMessage.ROLE,
-                "<think>I'm thinking</think><response>Hello</response>",
-                "I'm thinking",
-                null,
-                null);
+                AssistantMessage.ROLE, "<think>I'm thinking</think><response>Hello</response>", null, null, null);
 
         var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
         chatResponse.choices(List.of(resultChoice));
@@ -499,14 +491,9 @@ public class WatsonxChatModelTest {
     }
 
     @Test
-    void should_return_raw_text_when_thinking_is_not_enabled() {
+    void should_return_text_and_thinking_when_response_contains_reasoning_content() {
 
-        var resultMessage = new ResultMessage(
-                AssistantMessage.ROLE,
-                "<think>I'm thinking</think><response>Hello</response>",
-                "I'm thinking",
-                null,
-                null);
+        var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", "I'm thinking", null, null);
 
         var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
         chatResponse.choices(List.of(resultChoice));
@@ -523,10 +510,8 @@ public class WatsonxChatModelTest {
             var result = chatModel.chat(ChatRequest.builder()
                     .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
                     .build());
-            assertEquals(
-                    "<think>I'm thinking</think><response>Hello</response>",
-                    result.aiMessage().text());
-            assertNull(result.aiMessage().thinking());
+            assertEquals("Hello", result.aiMessage().text());
+            assertEquals("I'm thinking", result.aiMessage().thinking());
             assertEquals(1, chatRequestCaptor.getValue().messages().size());
             assertEquals(
                     UserMessage.text("Hello"),

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatModelTest.java
@@ -21,6 +21,8 @@ import com.ibm.watsonx.ai.chat.model.AssistantMessage;
 import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Response;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
 import com.ibm.watsonx.ai.chat.model.FunctionCall;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
@@ -29,7 +31,6 @@ import com.ibm.watsonx.ai.chat.model.UserMessage;
 import com.ibm.watsonx.ai.deployment.DeploymentService;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.exception.ContentFilteredException;
-import dev.langchain4j.exception.LangChain4jException;
 import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
@@ -396,7 +397,8 @@ public class WatsonxChatModelTest {
     @Test
     void should_extract_thinking_when_configured_in_request_parameters() throws Exception {
 
-        var extractionTags = ExtractionTags.of("think", "response");
+        var extractionTags =
+                ExtractionTags.of(new Think("<think>", "</think>"), new Response("<response>", "</response>"));
         var resultMessage = new ResultMessage(
                 AssistantMessage.ROLE,
                 "<think>I'm thinking</think><response>Hello</response>",
@@ -493,51 +495,6 @@ public class WatsonxChatModelTest {
                     UserMessage.text("Hello"),
                     chatRequestCaptor.getValue().messages().get(0));
             assertFalse(chatRequestCaptor.getValue().thinking().enabled());
-        });
-    }
-
-    @Test
-    void should_throw_exception_when_thinking_used_with_system_message() {
-
-        withChatServiceMock(() -> {
-            var chatModel = WatsonxChatModel.builder()
-                    .baseUrl("https://test.com")
-                    .modelName("ibm/granite-3-3-8b-instruct")
-                    .projectId("project-id")
-                    .apiKey("api-key")
-                    .thinking(ExtractionTags.of("think"))
-                    .build();
-
-            assertThrows(
-                    LangChain4jException.class,
-                    () -> chatModel.chat(ChatRequest.builder()
-                            .messages(
-                                    dev.langchain4j.data.message.SystemMessage.from("You are an helpful assistant"),
-                                    dev.langchain4j.data.message.UserMessage.from("Hello"))
-                            .build()),
-                    "The thinking/reasoning cannot be activated when a system message is present");
-        });
-    }
-
-    @Test
-    void should_throw_exception_when_thinking_used_with_tools() {
-
-        withChatServiceMock(() -> {
-            var chatModel = WatsonxChatModel.builder()
-                    .baseUrl("https://test.com")
-                    .modelName("ibm/granite-3-3-8b-instruct")
-                    .projectId("project-id")
-                    .apiKey("api-key")
-                    .thinking(ExtractionTags.of("think"))
-                    .toolSpecifications(ToolSpecification.builder().name("test").build())
-                    .build();
-
-            assertThrows(
-                    LangChain4jException.class,
-                    () -> chatModel.chat(ChatRequest.builder()
-                            .messages(dev.langchain4j.data.message.UserMessage.from("Hello"))
-                            .build()),
-                    "The thinking/reasoning cannot be activated when tools are used");
         });
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxCustomHttpClientTest.java
@@ -31,8 +31,8 @@ public class WatsonxCustomHttpClientTest {
                 .httpClient(customClient)
                 .build();
 
-        Object chatService = getFieldValue(chatModel, "chatService");
-        Object restclient = getFieldValue(chatService, "client");
+        Object chatProvider = getFieldValue(chatModel, "chatProvider");
+        Object restclient = getFieldValue(chatProvider, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
@@ -63,8 +63,8 @@ public class WatsonxCustomHttpClientTest {
                         .verifySsl(verifySsl)
                         .build();
 
-                Object chatService = getFieldValue(chatModel, "chatService");
-                Object restclient = getFieldValue(chatService, "client");
+                Object chatProvider = getFieldValue(chatModel, "chatProvider");
+                Object restclient = getFieldValue(chatProvider, "client");
                 assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
                 assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
 
@@ -94,8 +94,8 @@ public class WatsonxCustomHttpClientTest {
                 .httpClient(customClient)
                 .build();
 
-        Object chatService = getFieldValue(streamingChatModel, "chatService");
-        Object restclient = getFieldValue(chatService, "client");
+        Object chatProvider = getFieldValue(streamingChatModel, "chatProvider");
+        Object restclient = getFieldValue(chatProvider, "client");
         assertEquals(customClient, getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(true), getFieldValue(restclient, "httpClient"));
         assertNotEquals(HttpClientProvider.httpClient(false), getFieldValue(restclient, "httpClient"));
@@ -126,8 +126,8 @@ public class WatsonxCustomHttpClientTest {
                         .verifySsl(verifySsl)
                         .build();
 
-                Object chatService = getFieldValue(streamingChatModel, "chatService");
-                Object restclient = getFieldValue(chatService, "client");
+                Object chatProvider = getFieldValue(streamingChatModel, "chatProvider");
+                Object restclient = getFieldValue(chatProvider, "client");
                 assertNotEquals(customClient, getFieldValue(restclient, "httpClient"));
                 assertEquals(HttpClientProvider.httpClient(verifySsl), getFieldValue(restclient, "httpClient"));
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.watsonx;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -13,6 +14,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import com.ibm.watsonx.ai.CloudRegion;
 import com.ibm.watsonx.ai.chat.ChatHandler;
 import com.ibm.watsonx.ai.chat.ChatResponse;
 import com.ibm.watsonx.ai.chat.ChatService;
@@ -24,6 +26,7 @@ import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.FunctionCall;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
+import com.ibm.watsonx.ai.deployment.DeploymentService;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.exception.ContentFilteredException;
@@ -66,7 +69,13 @@ public class WatsonxStreamingChatModelTest {
     ChatService mockChatService;
 
     @Mock
+    DeploymentService deploymentService;
+
+    @Mock
     ChatService.Builder mockChatServiceBuilder;
+
+    @Mock
+    DeploymentService.Builder mockDeploymentServiceBuilder;
 
     @Captor
     ArgumentCaptor<com.ibm.watsonx.ai.chat.ChatRequest> chatRequestCaptor;
@@ -90,6 +99,17 @@ public class WatsonxStreamingChatModelTest {
         when(mockChatServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockChatServiceBuilder);
         when(mockChatServiceBuilder.build()).thenReturn(mockChatService);
 
+        when(mockDeploymentServiceBuilder.baseUrl(any(URI.class))).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.timeout(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.version(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.logRequests(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.logResponses(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.authenticator(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.apiKey(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.httpClient(any())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.verifySsl(anyBoolean())).thenReturn(mockDeploymentServiceBuilder);
+        when(mockDeploymentServiceBuilder.build()).thenReturn(deploymentService);
+
         var chatUsage = new ChatUsage(10, 10, 20);
         chatResponse = ChatResponse.build()
                 .id("id")
@@ -103,7 +123,99 @@ public class WatsonxStreamingChatModelTest {
     }
 
     @Test
-    public void testDoChat() throws Exception {
+    void should_create_create_a_watsonx_chat_model_from_a_chat_service() {
+
+        var streamingChatModel = assertDoesNotThrow(() -> WatsonxStreamingChatModel.builder()
+                .baseUrl(CloudRegion.FRANKFURT)
+                .modelName("model-name")
+                .apiKey("api-key-test")
+                .projectId("project-id")
+                .spaceId("space-id")
+                .version("my-version")
+                .logRequests(true)
+                .logResponses(true)
+                .build());
+
+        var defaultRequestParameters =
+                assertInstanceOf(WatsonxChatRequestParameters.class, streamingChatModel.defaultRequestParameters());
+
+        var chatProviderField = assertDoesNotThrow(
+                () -> streamingChatModel.getClass().getSuperclass().getDeclaredField("chatProvider"));
+        var chatProvider = assertDoesNotThrow(() -> chatProviderField.get(streamingChatModel));
+
+        assertInstanceOf(ChatService.class, chatProvider);
+        assertNull(defaultRequestParameters.frequencyPenalty());
+        assertNull(defaultRequestParameters.logitBias());
+        assertNull(defaultRequestParameters.logprobs());
+        assertNull(defaultRequestParameters.maxOutputTokens());
+        assertEquals("model-name", defaultRequestParameters.modelName());
+        assertNull(defaultRequestParameters.presencePenalty());
+        assertEquals("project-id", defaultRequestParameters.projectId());
+        assertNull(defaultRequestParameters.responseFormat());
+        assertNull(defaultRequestParameters.seed());
+        assertEquals("space-id", defaultRequestParameters.spaceId());
+        assertEquals(List.of(), defaultRequestParameters.stopSequences());
+        assertNull(defaultRequestParameters.temperature());
+        assertNull(defaultRequestParameters.timeout());
+        assertNull(defaultRequestParameters.toolChoice());
+        assertNull(defaultRequestParameters.toolChoiceName());
+        assertEquals(List.of(), defaultRequestParameters.toolSpecifications());
+        assertNull(defaultRequestParameters.topK());
+        assertNull(defaultRequestParameters.topLogprobs());
+        assertNull(defaultRequestParameters.topP());
+        assertNull(defaultRequestParameters.guidedChoice());
+        assertNull(defaultRequestParameters.guidedGrammar());
+        assertNull(defaultRequestParameters.guidedRegex());
+        assertNull(defaultRequestParameters.repetitionPenalty());
+        assertNull(defaultRequestParameters.lengthPenalty());
+    }
+
+    @Test
+    void should_create_create_a_watsonx_chat_model_from_a_deployment_service() {
+
+        var streamingChatModel = assertDoesNotThrow(() -> WatsonxStreamingChatModel.builder()
+                .baseUrl(CloudRegion.FRANKFURT)
+                .apiKey("api-key-test")
+                .version("my-version")
+                .logRequests(true)
+                .logResponses(true)
+                .deploymentId("deployment-id")
+                .build());
+
+        var defaultRequestParameters =
+                assertInstanceOf(WatsonxChatRequestParameters.class, streamingChatModel.defaultRequestParameters());
+
+        var chatProviderField = assertDoesNotThrow(
+                () -> streamingChatModel.getClass().getSuperclass().getDeclaredField("chatProvider"));
+        var chatProvider = assertDoesNotThrow(() -> chatProviderField.get(streamingChatModel));
+
+        assertInstanceOf(DeploymentService.class, chatProvider);
+        assertNull(defaultRequestParameters.frequencyPenalty());
+        assertNull(defaultRequestParameters.logitBias());
+        assertNull(defaultRequestParameters.logprobs());
+        assertNull(defaultRequestParameters.maxOutputTokens());
+        assertNull(defaultRequestParameters.modelName());
+        assertNull(defaultRequestParameters.presencePenalty());
+        assertNull(defaultRequestParameters.projectId());
+        assertNull(defaultRequestParameters.responseFormat());
+        assertNull(defaultRequestParameters.seed());
+        assertNull(defaultRequestParameters.spaceId());
+        assertEquals(List.of(), defaultRequestParameters.stopSequences());
+        assertNull(defaultRequestParameters.temperature());
+        assertNull(defaultRequestParameters.timeout());
+        assertNull(defaultRequestParameters.toolChoice());
+        assertNull(defaultRequestParameters.toolChoiceName());
+        assertEquals(List.of(), defaultRequestParameters.toolSpecifications());
+        assertNull(defaultRequestParameters.topK());
+        assertNull(defaultRequestParameters.topLogprobs());
+        assertNull(defaultRequestParameters.topP());
+        assertNull(defaultRequestParameters.guidedChoice());
+        assertNull(defaultRequestParameters.guidedGrammar());
+        assertNull(defaultRequestParameters.guidedRegex());
+    }
+
+    @Test
+    public void should_do_chat() throws Exception {
 
         var messages = List.<ChatMessage>of(com.ibm.watsonx.ai.chat.model.UserMessage.text("Hello"));
         doAnswer(invocation -> {
@@ -186,6 +298,8 @@ public class WatsonxStreamingChatModelTest {
                 assertNull(parameters.guidedRegex());
                 assertNull(parameters.repetitionPenalty());
                 assertNull(parameters.lengthPenalty());
+                assertNull(chatRequestCaptor.getValue().deploymentId());
+
             } catch (Exception e) {
                 fail(e);
             }
@@ -193,7 +307,85 @@ public class WatsonxStreamingChatModelTest {
     }
 
     @Test
-    void shouldExtractThinkingWhenConfiguredInModelBuilder() throws Exception {
+    public void should_do_chat_with_deployment_service() throws Exception {
+
+        var messages = List.<ChatMessage>of(com.ibm.watsonx.ai.chat.model.UserMessage.text("Hello"));
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+
+                    for (String response : List.of("Hello", "World")) handler.onPartialResponse(response, null);
+
+                    var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello World", null, null, null);
+                    var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
+                    chatResponse.choices(List.of(resultChoice));
+                    handler.onCompleteResponse(chatResponse.build());
+
+                    return CompletableFuture.completedFuture(null);
+                })
+                .when(deploymentService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withDeploymentServiceMock(() -> {
+            var streamingChatModel = WatsonxStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .deploymentId("deployment-id")
+                    .apiKey("api-key")
+                    .build();
+
+            var chatRequest =
+                    ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+
+            var receivedResponses = new ArrayList<>();
+            var latch = new CountDownLatch(1);
+
+            var streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {
+                    receivedResponses.add(partialResponse);
+                }
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    assertEquals("Hello World", completeResponse.aiMessage().text());
+                    latch.countDown();
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    fail("Unexpected error: " + error);
+                }
+            };
+
+            streamingChatModel.chat(chatRequest, streamingHandler);
+            assertEquals(messages, chatRequestCaptor.getValue().messages());
+
+            try {
+                boolean completed = latch.await(2, TimeUnit.SECONDS);
+                assertTrue(completed, "Handler did not complete in time");
+                assertEquals(List.of("Hello", "World"), receivedResponses);
+            } catch (Exception e) {
+                fail(e);
+            }
+
+            chatRequest = ChatRequest.builder()
+                    .messages(List.of(dev.langchain4j.data.message.UserMessage.from("hello")))
+                    .parameters(WatsonxChatRequestParameters.builder()
+                            .deploymentId("deployment-id-override")
+                            .build())
+                    .build();
+
+            streamingChatModel.chat(chatRequest, streamingHandler);
+            assertEquals(2, chatRequestCaptor.getAllValues().size());
+            assertEquals(
+                    "deployment-id", chatRequestCaptor.getAllValues().get(0).deploymentId());
+            assertEquals(
+                    "deployment-id-override",
+                    chatRequestCaptor.getAllValues().get(1).deploymentId());
+        });
+    }
+
+    @Test
+    void should_extract_thinking_when_configured_in_model_builder() throws Exception {
 
         var extractionTags = ExtractionTags.of("think", "response");
 
@@ -276,7 +468,7 @@ public class WatsonxStreamingChatModelTest {
     }
 
     @Test
-    void shouldExtractThinkingWhenConfiguredInRequestParameters() throws Exception {
+    void should_extract_thinking_when_configured_in_request_parameters() throws Exception {
 
         var extractionTags = ExtractionTags.of("think", "response");
         var resultMessage = new ResultMessage(
@@ -362,7 +554,7 @@ public class WatsonxStreamingChatModelTest {
     }
 
     @Test
-    void testDoChatWithRefusal() {
+    void should_do_chat_with_refusal() {
 
         var messages = List.<ChatMessage>of(com.ibm.watsonx.ai.chat.model.UserMessage.text("Hello"));
         doAnswer(invocation -> {
@@ -449,7 +641,7 @@ public class WatsonxStreamingChatModelTest {
     }
 
     @Test
-    public void testDoChatWithTool() throws Exception {
+    public void should_do_chat_with_tool() throws Exception {
 
         var toolCall = new ToolCall(0, "id", "function", new FunctionCall("name", "{}"));
         var resultMessage = new ResultMessage(AssistantMessage.ROLE, null, null, null, List.of(toolCall));
@@ -578,7 +770,7 @@ public class WatsonxStreamingChatModelTest {
     }
 
     @Test
-    void testJsonSchema() throws Exception {
+    void should_handle_json_schema() throws Exception {
 
         var resultMessage = new ResultMessage(AssistantMessage.ROLE, "Hello", null, null, null);
         var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
@@ -646,7 +838,7 @@ public class WatsonxStreamingChatModelTest {
     }
 
     @Test
-    void testChatRequestWithTopK() {
+    void should_throw_exception_for_chat_request_with_top_k() {
 
         var streamingChatModel = WatsonxStreamingChatModel.builder()
                 .baseUrl("https://test.com")
@@ -682,19 +874,21 @@ public class WatsonxStreamingChatModelTest {
                             }
                         }));
 
-        assertThrows(UnsupportedFeatureException.class, () -> WatsonxStreamingChatModel.builder()
-                .baseUrl("https://test.com")
-                .modelName("modelId")
-                .projectId("project-id")
-                .spaceId("space-id")
-                .apiKey("api-key")
-                .defaultRequestParameters(
-                        ChatRequestParameters.builder().topK(10).build())
-                .build());
+        assertThrows(
+                UnsupportedFeatureException.class,
+                () -> WatsonxStreamingChatModel.builder()
+                        .baseUrl("https://test.com")
+                        .modelName("modelId")
+                        .projectId("project-id")
+                        .spaceId("space-id")
+                        .apiKey("api-key")
+                        .defaultRequestParameters(
+                                ChatRequestParameters.builder().topK(10).build())
+                        .build());
     }
 
     @Test
-    void testSupportCapabilities() {
+    void should_support_capabilities() {
 
         var chatModel = WatsonxStreamingChatModel.builder()
                 .baseUrl("https://test.com")
@@ -712,6 +906,13 @@ public class WatsonxStreamingChatModelTest {
     private void withChatServiceMock(Runnable action) {
         try (MockedStatic<ChatService> mockedStatic = mockStatic(ChatService.class)) {
             mockedStatic.when(ChatService::builder).thenReturn(mockChatServiceBuilder);
+            action.run();
+        }
+    }
+
+    private void withDeploymentServiceMock(Runnable action) {
+        try (MockedStatic<DeploymentService> mockedStatic = mockStatic(DeploymentService.class)) {
+            mockedStatic.when(DeploymentService::builder).thenReturn(mockDeploymentServiceBuilder);
             action.run();
         }
     }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
@@ -395,7 +395,7 @@ public class WatsonxStreamingChatModelTest {
         var resultMessage = new ResultMessage(
                 AssistantMessage.ROLE,
                 "<think>I'm thinking</think><response>This is the response</response>",
-                "I'm thinking",
+                null,
                 null,
                 null);
         var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
@@ -478,7 +478,7 @@ public class WatsonxStreamingChatModelTest {
         var resultMessage = new ResultMessage(
                 AssistantMessage.ROLE,
                 "<think>I'm thinking</think><response>This is the response</response>",
-                "I'm thinking",
+                null,
                 null,
                 null);
 
@@ -552,6 +552,79 @@ public class WatsonxStreamingChatModelTest {
                         com.ibm.watsonx.ai.chat.model.UserMessage.text("Hello"),
                         chatRequestCaptor.getValue().messages().get(0));
                 assertNotNull(chatRequestCaptor.getValue().thinking());
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    void should_return_text_and_thinking_when_response_contains_reasoning_content() {
+
+        var resultMessage =
+                new ResultMessage(AssistantMessage.ROLE, "This is the response", "I'm thinking", null, null);
+
+        var resultChoice = new ChatResponse.ResultChoice(0, resultMessage, "stop");
+        chatResponse.choices(List.of(resultChoice));
+        var cr = chatResponse.build();
+
+        doAnswer(invocation -> {
+                    ChatHandler handler = invocation.getArgument(1);
+                    handler.onPartialThinking("I'm thinking", null);
+                    handler.onPartialResponse("This is", null);
+                    handler.onPartialResponse("the response", null);
+                    handler.onCompleteResponse(cr);
+                    return CompletableFuture.completedFuture(null);
+                })
+                .when(mockChatService)
+                .chatStreaming(chatRequestCaptor.capture(), any());
+
+        withChatServiceMock(() -> {
+            StreamingChatModel streamingChatModel = WatsonxStreamingChatModel.builder()
+                    .baseUrl("https://test.com")
+                    .modelName("modelId")
+                    .projectId("projectId")
+                    .spaceId("spaceId")
+                    .apiKey("api-key")
+                    .build();
+
+            ChatRequest chatRequest =
+                    ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+
+            CountDownLatch latch = new CountDownLatch(1);
+            StreamingChatResponseHandler streamingHandler = new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {
+                    assertTrue(partialResponse.equals("This is") || partialResponse.equals("the response"));
+                }
+
+                @Override
+                public void onCompleteResponse(dev.langchain4j.model.chat.response.ChatResponse completeResponse) {
+                    assertEquals("I'm thinking", completeResponse.aiMessage().thinking());
+                    assertEquals(
+                            "This is the response", completeResponse.aiMessage().text());
+                    latch.countDown();
+                }
+
+                @Override
+                public void onPartialThinking(PartialThinking partialThinking) {
+                    assertEquals("I'm thinking", partialThinking.text());
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    fail("Unexpected error: " + error);
+                }
+            };
+
+            streamingChatModel.chat(chatRequest, streamingHandler);
+
+            try {
+                boolean completed = latch.await(2, TimeUnit.SECONDS);
+                assertTrue(completed, "Handler did not complete in time");
+                assertEquals(
+                        com.ibm.watsonx.ai.chat.model.UserMessage.text("Hello"),
+                        chatRequestCaptor.getValue().messages().get(0));
             } catch (Exception e) {
                 fail(e);
             }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxStreamingChatModelTest.java
@@ -23,6 +23,8 @@ import com.ibm.watsonx.ai.chat.model.ChatMessage;
 import com.ibm.watsonx.ai.chat.model.ChatUsage;
 import com.ibm.watsonx.ai.chat.model.CompletedToolCall;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Response;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
 import com.ibm.watsonx.ai.chat.model.FunctionCall;
 import com.ibm.watsonx.ai.chat.model.ResultMessage;
 import com.ibm.watsonx.ai.chat.model.ToolCall;
@@ -323,7 +325,7 @@ public class WatsonxStreamingChatModelTest {
                     return CompletableFuture.completedFuture(null);
                 })
                 .when(deploymentService)
-                .chatStreaming(chatRequestCaptor.capture(), any());
+                .chatStreaming(chatRequestCaptor.capture(), any(ChatHandler.class));
 
         withDeploymentServiceMock(() -> {
             var streamingChatModel = WatsonxStreamingChatModel.builder()
@@ -387,7 +389,8 @@ public class WatsonxStreamingChatModelTest {
     @Test
     void should_extract_thinking_when_configured_in_model_builder() throws Exception {
 
-        var extractionTags = ExtractionTags.of("think", "response");
+        var extractionTags =
+                ExtractionTags.of(new Think("<think>", "</think>"), new Response("<response>", "</response>"));
 
         var resultMessage = new ResultMessage(
                 AssistantMessage.ROLE,
@@ -470,7 +473,8 @@ public class WatsonxStreamingChatModelTest {
     @Test
     void should_extract_thinking_when_configured_in_request_parameters() throws Exception {
 
-        var extractionTags = ExtractionTags.of("think", "response");
+        var extractionTags =
+                ExtractionTags.of(new Think("<think>", "</think>"), new Response("<response>", "</response>"));
         var resultMessage = new ResultMessage(
                 AssistantMessage.ROLE,
                 "<think>I'm thinking</think><response>This is the response</response>",
@@ -508,7 +512,8 @@ public class WatsonxStreamingChatModelTest {
             ChatRequest chatRequest = ChatRequest.builder()
                     .messages(UserMessage.from("Hello"))
                     .parameters(WatsonxChatRequestParameters.builder()
-                            .thinking(ExtractionTags.of("think", "response"))
+                            .thinking(ExtractionTags.of(
+                                    new Think("<think>", "</think>"), new Response("<response>", "</response>")))
                             .build())
                     .build();
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelIT.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.model.watsonx.it;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.common.AbstractChatModelIT;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -7,6 +9,7 @@ import dev.langchain4j.model.watsonx.WatsonxChatModel;
 import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
 import java.time.Duration;
 import java.util.List;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
@@ -17,6 +20,7 @@ public class WatsonxChatModelIT extends AbstractChatModelIT {
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
     static final String URL = System.getenv("WATSONX_URL");
+    static final String DEPLOYMENT_ID = System.getenv("WATSONX_DEPLOYMENT_ID");
 
     @Override
     protected List<ChatModel> models() {
@@ -100,6 +104,20 @@ public class WatsonxChatModelIT extends AbstractChatModelIT {
     protected void should_respect_JSON_response_format_with_schema(ChatModel model) {
         super.should_respect_JSON_response_format_with_schema(
                 createChatModel("ibm/granite-4-h-small").build());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
+    void should_use_deployed_model_with_deployment_id() {
+        var chatModel = WatsonxChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .deploymentId(DEPLOYMENT_ID)
+                .timeout(Duration.ofSeconds(30))
+                .build();
+
+        var response = chatModel.chat("Hello");
+        assertNotNull(response);
     }
 
     private WatsonxChatModel.Builder createChatModel(String model) {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelThinkingIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelThinkingIT.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags.Response;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
+import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.watsonx.WatsonxChatModel;
@@ -26,7 +27,16 @@ public class WatsonxChatModelThinkingIT {
     @Test
     public void should_return_and_send_thinking() {
 
-        ChatModel chatModel = createChatModel().build();
+        ChatModel chatModel = WatsonxChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .deploymentId(DEPLOYMENT_ID)
+                .thinking(
+                        ExtractionTags.of(new Think("<think>", "</think>"), new Response("<response>", "</response>")))
+                .maxOutputTokens(0)
+                .timeout(Duration.ofSeconds(30))
+                .build();
+
         var chatResponse = chatModel.chat(UserMessage.from("Why the sky is blue?"));
         var aiMessage = chatResponse.aiMessage();
         assertThat(aiMessage.thinking()).isNotBlank();
@@ -50,14 +60,19 @@ public class WatsonxChatModelThinkingIT {
         assertThat(aiMessage.text()).isNotBlank();
     }
 
-    private WatsonxChatModel.Builder createChatModel() {
-        return WatsonxChatModel.builder()
+    @Test
+    public void should_return_thinking_using_gpt_oss() {
+        var chatModel = WatsonxChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
-                .deploymentId(DEPLOYMENT_ID)
-                .thinking(
-                        ExtractionTags.of(new Think("<think>", "</think>"), new Response("<response>", "</response>")))
-                .maxOutputTokens(0)
-                .timeout(Duration.ofSeconds(30));
+                .projectId(PROJECT_ID)
+                .modelName("openai/gpt-oss-120b")
+                .timeout(Duration.ofSeconds(30))
+                .thinking(ThinkingEffort.MEDIUM)
+                .build();
+
+        var aiMessage = chatModel.chat(UserMessage.from("Hello!")).aiMessage();
+        assertThat(aiMessage.text()).isNotBlank();
+        assertThat(aiMessage.thinking()).isNotBlank();
     }
 }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelThinkingIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxChatModelThinkingIT.java
@@ -1,15 +1,12 @@
 package dev.langchain4j.model.watsonx.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
-import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.SystemMessage;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Response;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.exception.InvalidRequestException;
 import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.watsonx.WatsonxChatModel;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
@@ -18,16 +15,18 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GRANITE_3_3_DEPLOYMENT_ID", matches = ".+")
 public class WatsonxChatModelThinkingIT {
 
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
     static final String URL = System.getenv("WATSONX_URL");
+    static final String DEPLOYMENT_ID = System.getenv("WATSONX_GRANITE_3_3_DEPLOYMENT_ID");
 
     @Test
     public void should_return_and_send_thinking() {
 
-        ChatModel chatModel = createChatModel("ibm/granite-3-3-8b-instruct").build();
+        ChatModel chatModel = createChatModel().build();
         var chatResponse = chatModel.chat(UserMessage.from("Why the sky is blue?"));
         var aiMessage = chatResponse.aiMessage();
         assertThat(aiMessage.thinking()).isNotBlank();
@@ -42,8 +41,7 @@ public class WatsonxChatModelThinkingIT {
         ChatModel chatModel = WatsonxChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
-                .projectId(PROJECT_ID)
-                .modelName("ibm/granite-3-3-8b-instruct")
+                .deploymentId(DEPLOYMENT_ID)
                 .build();
 
         var chatResponse = chatModel.chat(UserMessage.from("Why the sky is blue?"));
@@ -52,35 +50,13 @@ public class WatsonxChatModelThinkingIT {
         assertThat(aiMessage.text()).isNotBlank();
     }
 
-    @Test
-    void should_not_send_the_thinking_request() {
-
-        ChatModel chatModel = createChatModel("ibm/granite-3-3-8b-instruct").build();
-
-        assertThrows(
-                InvalidRequestException.class,
-                () -> chatModel.chat(
-                        SystemMessage.from("You are an helpful assistant"), UserMessage.from("Why the sky is blue?")),
-                "The thinking/reasoning cannot be activated when a system message is present");
-
-        ChatRequest chatRequest = ChatRequest.builder()
-                .messages(UserMessage.from("Why the sky is blue?"))
-                .toolSpecifications(ToolSpecification.builder().name("sum").build())
-                .build();
-
-        assertThrows(
-                InvalidRequestException.class,
-                () -> chatModel.chat(chatRequest),
-                "The thinking/reasoning cannot be activated when tools are used");
-    }
-
-    private WatsonxChatModel.Builder createChatModel(String model) {
+    private WatsonxChatModel.Builder createChatModel() {
         return WatsonxChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
-                .projectId(PROJECT_ID)
-                .modelName(model)
-                .thinking(ExtractionTags.of("think", "response"))
+                .deploymentId(DEPLOYMENT_ID)
+                .thinking(
+                        ExtractionTags.of(new Think("<think>", "</think>"), new Response("<response>", "</response>")))
                 .maxOutputTokens(0)
                 .timeout(Duration.ofSeconds(30));
     }

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelIT.java
@@ -1,14 +1,22 @@
 package dev.langchain4j.model.watsonx.it;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.common.AbstractStreamingChatModelIT;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.watsonx.WatsonxChatRequestParameters;
 import dev.langchain4j.model.watsonx.WatsonxStreamingChatModel;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.InOrder;
 
@@ -20,6 +28,7 @@ public class WatsonxStreamingChatModelIT extends AbstractStreamingChatModelIT {
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
     static final String URL = System.getenv("WATSONX_URL");
+    static final String DEPLOYMENT_ID = System.getenv("WATSONX_DEPLOYMENT_ID");
 
     @Override
     protected List<StreamingChatModel> models() {
@@ -134,6 +143,36 @@ public class WatsonxStreamingChatModelIT extends AbstractStreamingChatModelIT {
         io.verify(handler).onPartialToolCall(partial(1, id2, "getTime", "France"));
         io.verify(handler).onPartialToolCall(partial(1, id2, "getTime", "\"}"));
         io.verify(handler).onCompleteToolCall(complete(1, id2, "getTime", "{\"country\": \"France\"}"));
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "WATSONX_DEPLOYMENT_ID", matches = ".+")
+    void should_use_deployed_model_with_deployment_id() {
+        var chatModel = WatsonxStreamingChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .deploymentId(DEPLOYMENT_ID)
+                .timeout(Duration.ofSeconds(30))
+                .logRequests(true)
+                .build();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ChatResponse> chatResponse = new AtomicReference<ChatResponse>(null);
+
+        chatModel.chat("Hello", new StreamingChatResponseHandler() {
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                latch.countDown();
+                chatResponse.set(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {}
+        });
+
+        assertDoesNotThrow(() -> latch.await(5, TimeUnit.SECONDS));
+        assertNotNull(chatResponse.get().aiMessage().text());
     }
 
     private WatsonxStreamingChatModel.Builder createStreamingChatModel(String model) {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelThinkingIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelThinkingIT.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags.Response;
 import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
+import com.ibm.watsonx.ai.chat.model.ThinkingEffort;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.PartialThinking;
@@ -105,6 +106,46 @@ public class WatsonxStreamingChatModelThinkingIT {
 
         var aiMessage = chatResponse.aiMessage();
         assertThat(aiMessage.thinking()).isBlank();
+        assertThat(aiMessage.text()).isNotBlank();
+    }
+
+    @Test
+    public void should_return_thinking_using_gpt_oss() {
+        var streamingChatModel = WatsonxStreamingChatModel.builder()
+                .baseUrl(URL)
+                .apiKey(API_KEY)
+                .projectId(PROJECT_ID)
+                .modelName("openai/gpt-oss-120b")
+                .timeout(Duration.ofSeconds(30))
+                .thinking(ThinkingEffort.MEDIUM)
+                .build();
+
+        CompletableFuture<ChatResponse> futureChatResponse = new CompletableFuture<>();
+        CompletableFuture<String> futureThinking = new CompletableFuture<>();
+        streamingChatModel.chat("Why the sky is blue?", new StreamingChatResponseHandler() {
+
+            @Override
+            public void onPartialResponse(String partialResponse) {}
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                futureChatResponse.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {}
+
+            @Override
+            public void onPartialThinking(PartialThinking partialThinking) {
+                futureThinking.complete(partialThinking.text());
+            }
+        });
+
+        var chatResponse = assertDoesNotThrow(() -> futureChatResponse.get(10, TimeUnit.SECONDS));
+        assertDoesNotThrow(() -> futureThinking.get(10, TimeUnit.SECONDS));
+
+        var aiMessage = chatResponse.aiMessage();
+        assertThat(aiMessage.thinking()).isNotBlank();
         assertThat(aiMessage.text()).isNotBlank();
     }
 

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelThinkingIT.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/it/WatsonxStreamingChatModelThinkingIT.java
@@ -6,19 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.ibm.watsonx.ai.chat.model.ExtractionTags;
-import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.SystemMessage;
-import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.exception.InvalidRequestException;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Response;
+import com.ibm.watsonx.ai.chat.model.ExtractionTags.Think;
 import dev.langchain4j.model.chat.StreamingChatModel;
-import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.watsonx.WatsonxStreamingChatModel;
 import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -28,17 +23,18 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 @EnabledIfEnvironmentVariable(named = "WATSONX_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_PROJECT_ID", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "WATSONX_URL", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "WATSONX_GRANITE_3_3_DEPLOYMENT_ID", matches = ".+")
 public class WatsonxStreamingChatModelThinkingIT {
 
     static final String API_KEY = System.getenv("WATSONX_API_KEY");
     static final String PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");
     static final String URL = System.getenv("WATSONX_URL");
+    static final String DEPLOYMENT_ID = System.getenv("WATSONX_GRANITE_3_3_DEPLOYMENT_ID");
 
     @Test
     public void should_return_and_send_thinking() {
 
-        StreamingChatModel streamingChatModel =
-                createStreamingChatModel("ibm/granite-3-3-8b-instruct").build();
+        StreamingChatModel streamingChatModel = createStreamingChatModel().build();
         CompletableFuture<ChatResponse> futureChatResponse = new CompletableFuture<>();
         CompletableFuture<String> futureThinking = new CompletableFuture<>();
         streamingChatModel.chat("Why the sky is blue?", new StreamingChatResponseHandler() {
@@ -62,7 +58,7 @@ public class WatsonxStreamingChatModelThinkingIT {
             }
         });
 
-        var chatResponse = assertDoesNotThrow(() -> futureChatResponse.get(10, TimeUnit.SECONDS));
+        var chatResponse = assertDoesNotThrow(() -> futureChatResponse.get(20, TimeUnit.SECONDS));
         var thinking = assertDoesNotThrow(() -> futureThinking.get(10, TimeUnit.SECONDS));
 
         var aiMessage = chatResponse.aiMessage();
@@ -80,8 +76,7 @@ public class WatsonxStreamingChatModelThinkingIT {
         StreamingChatModel streamingChatModel = WatsonxStreamingChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
-                .projectId(PROJECT_ID)
-                .modelName("ibm/granite-3-3-8b-instruct")
+                .deploymentId(DEPLOYMENT_ID)
                 .build();
 
         CompletableFuture<ChatResponse> futureChatResponse = new CompletableFuture<>();
@@ -113,56 +108,13 @@ public class WatsonxStreamingChatModelThinkingIT {
         assertThat(aiMessage.text()).isNotBlank();
     }
 
-    @Test
-    void should_not_send_the_thinking_request() {
-
-        StreamingChatModel streamingChatModel =
-                createStreamingChatModel("ibm/granite-3-3-8b-instruct").build();
-        StreamingChatResponseHandler handler = new StreamingChatResponseHandler() {
-
-            @Override
-            public void onPartialResponse(String partialResponse) {
-                throw new UnsupportedOperationException("Unimplemented method 'onPartialResponse'");
-            }
-
-            @Override
-            public void onCompleteResponse(ChatResponse completeResponse) {
-                throw new UnsupportedOperationException("Unimplemented method 'onCompleteResponse'");
-            }
-
-            @Override
-            public void onError(Throwable error) {
-                throw new UnsupportedOperationException("Unimplemented method 'onError'");
-            }
-        };
-
-        assertThrows(
-                InvalidRequestException.class,
-                () -> streamingChatModel.chat(
-                        List.<ChatMessage>of(
-                                SystemMessage.from("You are an helpful assistant"),
-                                UserMessage.from("Why the sky is blue?")),
-                        handler),
-                "The thinking/reasoning cannot be activated when a system message is present");
-
-        ChatRequest chatRequest = ChatRequest.builder()
-                .messages(UserMessage.from("Why the sky is blue?"))
-                .toolSpecifications(ToolSpecification.builder().name("sum").build())
-                .build();
-
-        assertThrows(
-                InvalidRequestException.class,
-                () -> streamingChatModel.chat(chatRequest, handler),
-                "The thinking/reasoning cannot be activated when tools are used");
-    }
-
-    private WatsonxStreamingChatModel.Builder createStreamingChatModel(String model) {
+    private WatsonxStreamingChatModel.Builder createStreamingChatModel() {
         return WatsonxStreamingChatModel.builder()
                 .baseUrl(URL)
                 .apiKey(API_KEY)
-                .projectId(PROJECT_ID)
-                .modelName("ibm/granite-3-3-8b-instruct")
-                .thinking(ExtractionTags.of("think", "response"))
+                .deploymentId(DEPLOYMENT_ID)
+                .thinking(
+                        ExtractionTags.of(new Think("<think>", "</think>"), new Response("<response>", "</response>")))
                 .maxOutputTokens(0)
                 .timeout(Duration.ofSeconds(30));
     }


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Change
This PR adds support for using deployed models (on-demand deployments) in IBM watsonx.ai through the `deploymentId` parameter, in addition to the existing catalog-based model access via `projectId`/`spaceId` + `modelName`.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)