### PR TITLE
Fix JSON extraction with braces in string values

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
@@ -1,6 +1,10 @@
 package dev.langchain4j.internal;
 
 import dev.langchain4j.Internal;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
 
 @Internal
 public class JsonParsingUtils {
@@ -16,7 +20,8 @@ public class JsonParsingUtils {
         return extractAndParseJson(text, s -> Json.fromJson(s, type));
     }
 
-    public static <T> ParsedJson<T> extractAndParseJson(String text, ThrowingFunction<String, T> parser) throws Exception {
+    public static <T> ParsedJson<T> extractAndParseJson(String text, ThrowingFunction<String, T> parser)
+            throws Exception {
         Exception parseException = null;
         try {
             return new ParsedJson<>(parser.apply(text), text);
@@ -25,50 +30,80 @@ public class JsonParsingUtils {
             parseException = ex;
         }
 
-        int index = text.length();
-        while (true) {
-
-            int jsonEnd = findJsonEnd(text, index);
-            if (jsonEnd < 0) {
-                throw parseException;
-            }
-
-            int jsonStart = findJsonStart(text, jsonEnd, text.charAt(jsonEnd));
-            if (jsonStart < 0) {
-                throw parseException;
-            }
-
+        List<String> jsonCandidates = findJsonCandidates(text);
+        for (int i = jsonCandidates.size() - 1; i >= 0; i--) {
             try {
-                String tentativeJson = text.substring(jsonStart, jsonEnd + 1);
+                String tentativeJson = jsonCandidates.get(i);
                 return new ParsedJson<>(parser.apply(tentativeJson), tentativeJson);
             } catch (Exception ignored) {
                 // If parsing fails, try to extract a JSON block from the text
             }
-            index = jsonStart; // Move to the next character after the found JSON block
         }
+
+        throw parseException;
     }
 
-    private static int findJsonEnd(String text, int fromIndex) {
-        int jsonMapEnd = text.lastIndexOf('}', fromIndex);
-        int jsonListEnd = text.lastIndexOf(']', fromIndex);
-        return Math.max(jsonMapEnd, jsonListEnd);
-    }
+    private static List<String> findJsonCandidates(String text) {
+        List<String> jsonCandidates = new ArrayList<>();
 
-    private static int findJsonStart(String text, int jsonEnd, char closingBrace) {
-        char openingBrace = closingBrace == '}' ? '{' : '[';
-        int braceCount = 0;
-
-        for (int i = jsonEnd; i >= 0; i--) {
+        for (int i = 0; i < text.length(); i++) {
             char c = text.charAt(i);
-            if (c == openingBrace) {
-                braceCount++;
-                if (braceCount == 0) {
-                    return i == 0 || text.charAt(i - 1) != openingBrace ? i : -1;
+
+            if ((c == '{' || c == '[') && isNotPartOfSameOpeningBraceSequence(text, i)) {
+                int jsonEnd = findMatchingJsonEnd(text, i);
+                if (jsonEnd >= 0) {
+                    jsonCandidates.add(text.substring(i, jsonEnd + 1));
+                    i = jsonEnd;
                 }
-            } else if (c == closingBrace) {
-                braceCount--;
             }
         }
+
+        return jsonCandidates;
+    }
+
+    private static int findMatchingJsonEnd(String text, int jsonStart) {
+        Deque<Character> stack = new ArrayDeque<>();
+        boolean inString = false;
+        boolean escaped = false;
+
+        for (int i = jsonStart; i < text.length(); i++) {
+            char c = text.charAt(i);
+
+            if (inString) {
+                if (escaped) {
+                    escaped = false;
+                } else if (c == '\\') {
+                    escaped = true;
+                } else if (c == '"') {
+                    inString = false;
+                }
+                continue;
+            }
+
+            if (c == '"') {
+                inString = true;
+            } else if (c == '{' || c == '[') {
+                stack.push(c);
+            } else if (c == '}' || c == ']') {
+                if (stack.isEmpty() || !bracesMatch(stack.peek(), c)) {
+                    return -1;
+                }
+
+                stack.pop();
+                if (stack.isEmpty()) {
+                    return i;
+                }
+            }
+        }
+
         return -1;
+    }
+
+    private static boolean isNotPartOfSameOpeningBraceSequence(String text, int index) {
+        return index == 0 || text.charAt(index - 1) != text.charAt(index);
+    }
+
+    private static boolean bracesMatch(char openingBrace, char closingBrace) {
+        return openingBrace == '{' && closingBrace == '}' || openingBrace == '[' && closingBrace == ']';
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
@@ -3,10 +3,9 @@ package dev.langchain4j.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import java.util.List;
 import java.util.Map;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -77,8 +76,7 @@ class JsonParsingUtilsTest {
     @Test
     void extract_array() throws Exception {
         String json = "[{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}]";
-        JsonParsingUtils.ParsedJson<MyPojo[]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        JsonParsingUtils.ParsedJson<MyPojo[]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isNotNull();
         assertThat(result.value().length).isEqualTo(2);
         assertThat(result.value()[0].name).isEqualTo("A");
@@ -93,8 +91,7 @@ class JsonParsingUtilsTest {
     @Test
     void extract_array_with_noise() throws Exception {
         String json = "abc [{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}] xyz";
-        JsonParsingUtils.ParsedJson<MyPojo[]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        JsonParsingUtils.ParsedJson<MyPojo[]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isNotNull();
         assertThat(result.value().length).isEqualTo(2);
     }
@@ -108,8 +105,7 @@ class JsonParsingUtilsTest {
     @Test
     void extract_nested_array() throws Exception {
         String json = "[[{\"name\":\"A\",\"age\":1}],[{\"name\":\"B\",\"age\":2}]]";
-        JsonParsingUtils.ParsedJson<MyPojo[][]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[][].class);
+        JsonParsingUtils.ParsedJson<MyPojo[][]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[][].class);
         assertThat(result).isNotNull();
         assertThat(result.value().length).isEqualTo(2);
         assertThat(result.value()[0][0].name).isEqualTo("A");
@@ -184,6 +180,22 @@ class JsonParsingUtilsTest {
         assertThat(result.value().tags).contains("[c]");
     }
 
+    @Test
+    void extract_object_with_closing_brace_in_string_and_prefix_suffix() throws Exception {
+        String json = "prefix {\"name\":\"brace } inside\",\"age\":18} suffix";
+        JsonParsingUtils.ParsedJson<MyPojo> result = JsonParsingUtils.extractAndParseJson(json, MyPojo.class);
+        assertThat(result).isNotNull();
+        assertThat(result.value().name).isEqualTo("brace } inside");
+    }
+
+    @Test
+    void extract_array_with_closing_bracket_in_string_and_prefix_suffix() throws Exception {
+        String json = "prefix [{\"name\":\"bracket ] inside\",\"age\":18}] suffix";
+        JsonParsingUtils.ParsedJson<MyPojo[]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        assertThat(result).isNotNull();
+        assertThat(result.value()[0].name).isEqualTo("bracket ] inside");
+    }
+
     /**
      * Test complex JSON array with nested objects and arrays.
      * This comprehensive test verifies that the method can handle
@@ -194,8 +206,7 @@ class JsonParsingUtilsTest {
     void extract_json_array_with_nested_objects_and_arrays() throws Exception {
         String json =
                 "[{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",\"b\"]},{\"name\":\"Jerry\",\"age\":20,\"tags\":[\"x\",\"y\"]}]";
-        JsonParsingUtils.ParsedJson<MyPojo[]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        JsonParsingUtils.ParsedJson<MyPojo[]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isNotNull();
         assertThat(result.value()[1].tags).containsExactly("x", "y");
     }


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue

<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->

Closes #5343

## Change

<!-- Please describe the changes you made. -->

Fixes JSON extraction from LLM-style outputs that contain text before or after the JSON block when quoted JSON string values include structural-looking characters such as `}` or `]`.

Previously, `JsonParsingUtils.extractAndParseJson(...)` searched for closing braces/brackets and matched braces without tracking whether the scanner was inside a JSON string. For example, this valid JSON could fail to be extracted when surrounded by text:

```text
Sure, here is the JSON:
{"log":"Unexpected character '}' at position 42"}
```

The extraction logic now scans candidate JSON blocks with a stack-based matcher that respects quoted strings and escaped characters, so `}` and `]` inside string values are ignored as JSON structure.

Added unit tests covering:

* object extraction when a string value contains `}` and the JSON has prefix/suffix text
* array extraction when a string value contains `]` and the JSON has prefix/suffix text

## General checklist

<!-- Please double-check the following points and mark them like this: [X] -->

* [x] There are no breaking changes (API, behaviour)
* [x] I have added unit and/or integration tests for my change
* [x] The tests cover both positive and negative cases
* [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
* [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green

<!-- Before adding documentation and example(s) (below), please wait until the PR is reviewed and approved. -->

* [ ] I have added/updated the documentation
* [ ] I have added an example in the examples repo (only for "big" features)
* [ ] I have added/updated Spring Boot starter(s) (if applicable)

## Checklist for adding new maven module

<!-- Please double-check the following points and mark them like this: [X] -->

* [ ] I have added my new module in the root pom.xml and langchain4j-bom/pom.xml

## Checklist for adding new embedding store integration

<!-- Please double-check the following points and mark them like this: [X] -->

* [ ] I have added a {NameOfIntegration}EmbeddingStoreIT that extends from either EmbeddingStoreIT or EmbeddingStoreWithFilteringIT
* [ ] I have added a {NameOfIntegration}EmbeddingStoreRemovalIT that extends from EmbeddingStoreWithRemovalIT

## Checklist for changing existing embedding store integration

<!-- Please double-check the following points and mark them like this: [X] -->

* [ ] I have manually verified that the {NameOfIntegration}EmbeddingStore works correctly with the data persisted using the latest released version of LangChain4j
