### PR TITLE
Remove `style` field and related logic from `OpenAiImageModel`.

### DIFF
--- a/langchain4j-open-ai/revapi.json
+++ b/langchain4j-open-ai/revapi.json
@@ -1,0 +1,25 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.openai.OpenAiImageModel.OpenAiImageModelBuilder dev.langchain4j.model.openai.OpenAiImageModel.OpenAiImageModelBuilder::style(java.lang.String)",
+          "justification": "The 'style' parameter is not supported by the OpenAI image generation API"
+        },
+        {
+          "code": "java.field.removed",
+          "old": "field dev.langchain4j.model.openai.OpenAiImageModel.style",
+          "justification": "The 'style' parameter is not supported by the OpenAI image generation API"
+        },
+        {
+          "code": "java.field.removed",
+          "old": "field dev.langchain4j.model.openai.OpenAiImageModel.OpenAiImageModelBuilder.style",
+          "justification": "The 'style' parameter is not supported by the OpenAI image generation API"
+        }
+      ]
+    }
+  }
+]

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
@@ -7,11 +7,6 @@ import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_USER_AGE
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.time.Duration.ofSeconds;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.model.image.ImageModel;
@@ -21,6 +16,11 @@ import dev.langchain4j.model.openai.internal.image.GenerateImagesResponse;
 import dev.langchain4j.model.openai.internal.image.ImageData;
 import dev.langchain4j.model.openai.spi.OpenAiImageModelBuilderFactory;
 import dev.langchain4j.model.output.Response;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 /**

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
@@ -7,6 +7,11 @@ import static dev.langchain4j.model.openai.internal.OpenAiUtils.DEFAULT_USER_AGE
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.time.Duration.ofSeconds;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.model.image.ImageModel;
@@ -16,11 +21,6 @@ import dev.langchain4j.model.openai.internal.image.GenerateImagesResponse;
 import dev.langchain4j.model.openai.internal.image.ImageData;
 import dev.langchain4j.model.openai.spi.OpenAiImageModelBuilderFactory;
 import dev.langchain4j.model.output.Response;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 /**
@@ -32,7 +32,6 @@ public class OpenAiImageModel implements ImageModel {
     private final String modelName;
     private final String size;
     private final String quality;
-    private final String style;
     private final String user;
     private final String responseFormat;
 
@@ -62,7 +61,6 @@ public class OpenAiImageModel implements ImageModel {
         this.modelName = builder.modelName;
         this.size = builder.size;
         this.quality = builder.quality;
-        this.style = builder.style;
         this.user = builder.user;
         this.responseFormat = builder.responseFormat;
     }
@@ -110,7 +108,6 @@ public class OpenAiImageModel implements ImageModel {
         private String modelName;
         private String size;
         private String quality;
-        private String style;
         private String user;
         private String responseFormat;
         private Duration timeout;
@@ -167,11 +164,6 @@ public class OpenAiImageModel implements ImageModel {
 
         public OpenAiImageModelBuilder quality(String quality) {
             this.quality = quality;
-            return this;
-        }
-
-        public OpenAiImageModelBuilder style(String style) {
-            this.style = style;
             return this;
         }
 
@@ -256,7 +248,6 @@ public class OpenAiImageModel implements ImageModel {
                 .prompt(prompt)
                 .size(size)
                 .quality(quality)
-                .style(style)
                 .user(user)
                 .responseFormat(responseFormat);
     }


### PR DESCRIPTION
OpenAI no longer supports this, and actually breaks if you send it no matter which image model you use.

See https://developers.openai.com/api/reference/resources/images

```
- method: POST
- url: https://api.openai.com/v1/images/generations
- headers: [Accept: application/json], [Authorization: Be...oA], [Content-Type: application/json], [User-Agent: Quarkus REST Client], [content-length: 2285]
- body: {                                                                                                                                                                                                                                                                                                                                  
  "model" : "dall-e-3",                                                                                                                                                                                                                                                                                                                 
  "prompt" : "Under the shadowy skyline of Gotham City, the air crackled with tension as two formidable figures faced off in a deserted alley. The dim glow of streetlights illuminated the scene, casting long shadows that danced across the brick walls. One figure, clad in a dark cloak, wielded a crimson blade that hummed ominously, while the other, with a determined gaze, brandished a brilliant blue lightsaber that shimmered with hope. The atmosphere was thick with anticipation, as the echoes of distant sirens and the faint rustle of the night enveloped them.\n\nWith a swift motion, the dark-cloaked figure lunged forward, the red blade slicing through the air with deadly precision. But the determined warrior was ready, channeling the energy of the Force to anticipate the attack. In a fluid motion, he parried the strike, sending sparks flying as the two weapons clashed. The sound reverberated through the alley, a testament to their opposing ideals—one fueled by fear and anger, the other by courage and resolve. Each swing of the lightsaber was not just a physical battle, but a clash of wills, echoing the age-old struggle between light and darkness.\n\nAs the fight intensified, the warrior tapped deeper into the Force, his movements becoming a graceful dance of agility and strength. He dodged and weaved, countering with precise strikes that showcased his mastery. With each successful maneuver, he gained confidence, and the dark figure began to falter, his attacks growing more desperate. The alley, once a silent witness to corruption, now bore witness to a transformative moment as the tides of battle shifted, illuminating the path of righteousness.\n\nIn a final, breathtaking clash, the warrior unleashed a surge of energy, channeling the very essence of hope. With a decisive strike, he disarmed his opponent, sending the crimson blade skittering across the pavement. The dark figure, now vulnerable, fell to his knees, the weight of his choices heavy upon him. The victorious champion stood tall, a beacon of light amidst the shadows of Gotham, reminding all that even in the darkest of places, hope could prevail.",                                                                                                                                                                               
  "n" : 1,                                                                                                                                                                                                                                                                                                                                 
  "size" : "1024x1024",                                                                                                                                                                                                                                                                                                                    
  "quality" : "standard",                                                                                                                                                                                                                                                                                                                  
  "style" : "vivid",                                                                                                                                                                                                                                                                                                                       
  "response_format" : "url"                                                                                                                                                                                                                                                                                                                
}  

- status code: 400
- headers: [Date: Thu, 04 Jun 2026 00:32:31 GMT], [Content-Type: application/json], [Content-Length: 157], [Connection: keep-alive], [CF-Ray: a062d7413dea8ff3-BOS], [CF-Cache-Status: DYNAMIC], [Server: cloudflare], [Strict-Transport-Security: max-age=31536000; includeSubDomains; preload], [X-Content-Type-Options: nosniff], [access-control-expose-headers: X-Request-ID], [access-control-expose-headers: CF-Ray], [Access-Control-Expose-Headers: CF-Ray], [openai-organization: test-cwaesh], [openai-processing-ms: 8], [openai-project: proj_w1Z5fnBbC7nN0hmxF8gegoJC], [openai-version: 2020-10-01], [x-request-id: req_de9e5a118aae4a35ac69b771e8148d52], [set-cookie: __cf_bm=uj6qf1TGsykObaaS_dcb01LRDpIUiijPE.60gRkAGdE-1780533150.9200444-1.0.1.1-yHjtxZ.vFQACGLzzcC7zaAA.xDAvb0zloS9TCwPvcJ4dQbWr3LmuuznG4cid96WF73YzlGBbimjz0VKeaIZlhWcuFYszHG7U82ZLaC7wWFA9avisC9f3kst_Or2CW7K.; HttpOnly; SameSite=None; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 04 Jun 2026 01:02:31 GMT], [alt-svc: h3=":443"; ma=86400]                                                                                                                                                                                                                                                                                                                              
- body: {                                                                                                                                                                                                                                                                                                                                  
  "error": {                                                                                                                                                                                                                                                                                                                               
    "message": "Unknown parameter: 'style'.",                                                                                                                                                                                                                                                                                              
    "type": "invalid_request_error",                                                                                                                                                                                                                                                                                                       
    "param": "style",                                                                                                                                                                                                                                                                                                                      
    "code": "unknown_parameter"                                                                                                                                                                                                                                                                                                            
  }                                                                                                                                                                                                                                                                                                                                        
}                    
```