### PR TITLE
feat(bedrock): add enableAdaptiveReasoning for Claude Opus 4.7+

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatRequestParameters.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/BedrockChatRequestParameters.java
@@ -131,6 +131,31 @@ public class BedrockChatRequestParameters extends DefaultChatRequestParameters {
         }
 
         /**
+         * Enables <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/inference-reasoning.html">adaptive reasoning</a>,
+         * required for Claude Opus 4.7+ where the legacy {@code budget_tokens} reasoning configuration is no longer accepted.
+         * Older models (e.g. Claude Opus 4.6, Sonnet 4.6) continue to work with {@link #enableReasoning(Integer)}.
+         *
+         * @param effort controls reasoning intensity, serialized to Bedrock's {@code output_config.effort} field.
+         *               Accepted values: {@code "low"}, {@code "medium"}, {@code "high"}.
+         *               If {@code null}, only {@code reasoning_config.type = "adaptive"} is set and Bedrock applies its default.
+         * @see BedrockChatModel.Builder#returnThinking(Boolean)
+         * @see BedrockChatModel.Builder#sendThinking(Boolean)
+         */
+        public Builder enableAdaptiveReasoning(String effort) {
+            if (additionalModelRequestFields == null) {
+                additionalModelRequestFields = new HashMap<>();
+            }
+            Map<?, ?> reasoningConfig = Map.ofEntries(Map.entry("type", "adaptive"));
+            additionalModelRequestFields.put("reasoning_config", reasoningConfig);
+
+            if (effort != null) {
+                Map<?, ?> outputConfig = Map.ofEntries(Map.entry("effort", effort));
+                additionalModelRequestFields.put("output_config", outputConfig);
+            }
+            return this;
+        }
+
+        /**
          * Enables prompt caching and sets where to place the cache point in the conversation.
          * Cache points mark where to cache content for reuse across API calls.
          * The cache has a 5-minute TTL by default which resets on each cache hit.

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatRequestParametersTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/BedrockChatRequestParametersTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.bedrock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class BedrockChatRequestParametersTest {
@@ -280,5 +281,45 @@ class BedrockChatRequestParametersTest {
         assertThat(params.serviceTier()).isEqualTo(BedrockServiceTier.FLEX);
         assertThat(params.cachePointPlacement()).isEqualTo(BedrockCachePointPlacement.AFTER_SYSTEM);
         assertThat(params.bedrockGuardrailConfiguration().guardrailIdentifier()).isEqualTo("12345");
+    }
+
+    @Test
+    void enableAdaptiveReasoning_with_effort_should_set_reasoning_config_and_output_config() {
+        // Given & When
+        BedrockChatRequestParameters params = BedrockChatRequestParameters.builder()
+                .enableAdaptiveReasoning("low")
+                .build();
+
+        // Then
+        assertThat(params.additionalModelRequestFields())
+                .isNotNull()
+                .containsKey("reasoning_config")
+                .containsKey("output_config");
+
+        Map<String, Object> reasoningConfig =
+                (Map<String, Object>) params.additionalModelRequestFields().get("reasoning_config");
+        assertThat(reasoningConfig).containsEntry("type", "adaptive").doesNotContainKey("budget_tokens");
+
+        Map<String, Object> outputConfig =
+                (Map<String, Object>) params.additionalModelRequestFields().get("output_config");
+        assertThat(outputConfig).containsEntry("effort", "low");
+    }
+
+    @Test
+    void enableAdaptiveReasoning_without_effort_should_only_set_reasoning_config() {
+        // Given & When
+        BedrockChatRequestParameters params = BedrockChatRequestParameters.builder()
+                .enableAdaptiveReasoning(null)
+                .build();
+
+        // Then
+        assertThat(params.additionalModelRequestFields())
+                .isNotNull()
+                .containsKey("reasoning_config")
+                .doesNotContainKey("output_config");
+
+        Map<String, Object> reasoningConfig =
+                (Map<String, Object>) params.additionalModelRequestFields().get("reasoning_config");
+        assertThat(reasoningConfig).containsEntry("type", "adaptive");
     }
 }


### PR DESCRIPTION
## Issue
Closes #5138

## Change
Adds `BedrockChatRequestParameters.Builder.enableAdaptiveReasoning(String effort)`,
which serializes to `reasoning_config: {type: "adaptive"}` and, when effort is
non-null, `output_config: {effort: "..."}`. This is the payload @jfigueiras-denodo
confirmed working against Claude Opus 4.7 in #5138, where the legacy `budget_tokens`
reasoning config now returns a 400.

The existing `enableReasoning(Integer budgetTokens)` is left unchanged, so
Opus 4.6 / Sonnet 4.6 users keep working — matching the deprecation/migration path
described in the issue. Added two unit tests covering adaptive-with-effort and
adaptive-without-effort (null) serialization.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)