### PR TITLE
Migrate OpenAI image models from DALL-E to new GPT image API

### DIFF
--- a/langchain4j-open-ai-official/revapi.json
+++ b/langchain4j-open-ai-official/revapi.json
@@ -8,6 +8,26 @@
           "ignore": true,
           "code": "java.class.externalClassExposedInAPI",
           "justification": "OpenAI SDK types (e.g., ReasoningEffort, Reasoning.Summary, OpenAIClient) are intentionally exposed on the public API of this module, since wrapping the official OpenAI Java SDK is its purpose."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel.Builder dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel.Builder::style(java.lang.String)",
+          "justification": "The 'style' parameter is not supported by the new OpenAI GPT image models"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel.Builder dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel.Builder::style(com.openai.models.images.ImageGenerateParams.Style)",
+          "justification": "The 'style' parameter is not supported by the new OpenAI GPT image models"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel.Builder dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel.Builder::responseFormat(java.lang.String)",
+          "justification": "The 'response_format' parameter is not supported by the new OpenAI GPT image models"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel.Builder dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel.Builder::responseFormat(com.openai.models.images.ImageGenerateParams.ResponseFormat)",
+          "justification": "The 'response_format' parameter is not supported by the new OpenAI GPT image models"
         }
       ]
     }

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialImageModel.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/OpenAiOfficialImageModel.java
@@ -16,16 +16,22 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Represents an OpenAI image generation model.
+ * Find the parameters description <a href="https://developers.openai.com/api/reference/resources/images/methods/generate">here</a>.
+ */
 public class OpenAiOfficialImageModel implements ImageModel {
 
     private final OpenAIClient client;
     private final String modelName;
     private final ImageGenerateParams.Size size;
     private final ImageGenerateParams.Quality quality;
-    private final ImageGenerateParams.Style style;
     private final String user;
     private final Duration timeout;
-    private final ImageGenerateParams.ResponseFormat responseFormat;
+    private final ImageGenerateParams.Background background;
+    private final ImageGenerateParams.OutputFormat outputFormat;
+    private final Long outputCompression;
+    private final ImageGenerateParams.Moderation moderation;
 
     public OpenAiOfficialImageModel(Builder builder) {
 
@@ -51,10 +57,12 @@ public class OpenAiOfficialImageModel implements ImageModel {
         this.modelName = builder.modelName;
         this.size = builder.size;
         this.quality = builder.quality;
-        this.style = builder.style;
         this.user = builder.user;
         this.timeout = builder.timeout;
-        this.responseFormat = builder.responseFormat;
+        this.background = builder.background;
+        this.outputFormat = builder.outputFormat;
+        this.outputCompression = builder.outputCompression;
+        this.moderation = builder.moderation;
     }
 
     public String modelName() {
@@ -65,21 +73,23 @@ public class OpenAiOfficialImageModel implements ImageModel {
     public Response<Image> generate(String prompt) {
 
         ImageGenerateParams imageGenerateParams =
-                impageGenerateParamsBuilder(prompt).build();
+                imageGenerateParamsBuilder(prompt).build();
 
         ImagesResponse response = client.images().generate(imageGenerateParams, requestOptions());
 
         if (response.data().isEmpty() || response.data().get().isEmpty()) {
             throw new IllegalArgumentException("Image generation failed: no image returned");
         }
-        return Response.from(fromOpenAiImage(response.data().get().get(0)));
+
+        String mimeType = response.outputFormat().map(of -> "image/" + of).orElse(null);
+        return Response.from(fromOpenAiImage(response.data().get().get(0), mimeType));
     }
 
     @Override
     public Response<List<Image>> generate(String prompt, int n) {
 
         ImageGenerateParams imageGenerateParams =
-                impageGenerateParamsBuilder(prompt).n(n).build();
+                imageGenerateParamsBuilder(prompt).n(n).build();
 
         ImagesResponse response = client.images().generate(imageGenerateParams, requestOptions());
 
@@ -87,12 +97,13 @@ public class OpenAiOfficialImageModel implements ImageModel {
             throw new IllegalArgumentException("Image generation failed: no image returned");
         }
 
+        String mimeType = response.outputFormat().map(of -> "image/" + of).orElse(null);
         return Response.from(response.data().get().stream()
-                .map(OpenAiOfficialImageModel::fromOpenAiImage)
+                .map(img -> fromOpenAiImage(img, mimeType))
                 .toList());
     }
 
-    private ImageGenerateParams.Builder impageGenerateParamsBuilder(String prompt) {
+    private ImageGenerateParams.Builder imageGenerateParamsBuilder(String prompt) {
         ImageGenerateParams.Builder builder = ImageGenerateParams.builder();
         builder.model(modelName);
         builder.prompt(prompt);
@@ -103,14 +114,20 @@ public class OpenAiOfficialImageModel implements ImageModel {
         if (quality != null) {
             builder.quality(quality);
         }
-        if (style != null) {
-            builder.style(style);
-        }
-        if (responseFormat != null) {
-            builder.responseFormat(responseFormat);
-        }
         if (user != null) {
             builder.user(user);
+        }
+        if (background != null) {
+            builder.background(background);
+        }
+        if (outputFormat != null) {
+            builder.outputFormat(outputFormat);
+        }
+        if (outputCompression != null) {
+            builder.outputCompression(outputCompression);
+        }
+        if (moderation != null) {
+            builder.moderation(moderation);
         }
         return builder;
     }
@@ -123,7 +140,7 @@ public class OpenAiOfficialImageModel implements ImageModel {
         return builder.build();
     }
 
-    private static Image fromOpenAiImage(com.openai.models.images.Image openAiImage) {
+    private static Image fromOpenAiImage(com.openai.models.images.Image openAiImage, String mimeType) {
         Image.Builder imageBuilder = Image.builder();
 
         if (openAiImage.url().isPresent()) {
@@ -137,6 +154,11 @@ public class OpenAiOfficialImageModel implements ImageModel {
         if (openAiImage.revisedPrompt().isPresent()) {
             imageBuilder.revisedPrompt(openAiImage.revisedPrompt().get());
         }
+
+        if (mimeType != null) {
+            imageBuilder.mimeType(mimeType);
+        }
+
         return imageBuilder.build();
     }
 
@@ -158,13 +180,15 @@ public class OpenAiOfficialImageModel implements ImageModel {
         private String modelName;
         private ImageGenerateParams.Size size;
         private ImageGenerateParams.Quality quality;
-        private ImageGenerateParams.Style style;
         private String user;
-        private ImageGenerateParams.ResponseFormat responseFormat;
         private Duration timeout;
         private Integer maxRetries;
         private Proxy proxy;
         private Map<String, String> customHeaders;
+        private ImageGenerateParams.Background background;
+        private ImageGenerateParams.OutputFormat outputFormat;
+        private Long outputCompression;
+        private ImageGenerateParams.Moderation moderation;
 
         public Builder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
@@ -259,28 +283,43 @@ public class OpenAiOfficialImageModel implements ImageModel {
             return this;
         }
 
-        public Builder style(String style) {
-            this.style = ImageGenerateParams.Style.of(style);
-            return this;
-        }
-
-        public Builder style(ImageGenerateParams.Style style) {
-            this.style = style;
-            return this;
-        }
-
         public Builder user(String user) {
             this.user = user;
             return this;
         }
 
-        public Builder responseFormat(String responseFormat) {
-            this.responseFormat = ImageGenerateParams.ResponseFormat.of(responseFormat);
+        public Builder background(String background) {
+            this.background = ImageGenerateParams.Background.of(background);
             return this;
         }
 
-        public Builder responseFormat(ImageGenerateParams.ResponseFormat responseFormat) {
-            this.responseFormat = responseFormat;
+        public Builder background(ImageGenerateParams.Background background) {
+            this.background = background;
+            return this;
+        }
+
+        public Builder outputFormat(String outputFormat) {
+            this.outputFormat = ImageGenerateParams.OutputFormat.of(outputFormat);
+            return this;
+        }
+
+        public Builder outputFormat(ImageGenerateParams.OutputFormat outputFormat) {
+            this.outputFormat = outputFormat;
+            return this;
+        }
+
+        public Builder outputCompression(Long outputCompression) {
+            this.outputCompression = outputCompression;
+            return this;
+        }
+
+        public Builder moderation(String moderation) {
+            this.moderation = ImageGenerateParams.Moderation.of(moderation);
+            return this;
+        }
+
+        public Builder moderation(ImageGenerateParams.Moderation moderation) {
+            this.moderation = moderation;
             return this;
         }
 

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/microsoftfoundry/InternalMicrosoftFoundryTestHelper.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/microsoftfoundry/InternalMicrosoftFoundryTestHelper.java
@@ -130,7 +130,6 @@ public class InternalMicrosoftFoundryTestHelper {
                     .baseUrl(endpoint)
                     .apiKey(apiKey)
                     .modelName(IMAGE_MODEL_NAME)
-                    .responseFormat(ImageGenerateParams.ResponseFormat.B64_JSON)
                     .build();
 
         } else {

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/InternalOpenAiOfficialTestHelper.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/InternalOpenAiOfficialTestHelper.java
@@ -31,7 +31,7 @@ public class InternalOpenAiOfficialTestHelper {
     public static final com.openai.models.embeddings.EmbeddingModel EMBEDDING_MODEL_NAME =
             com.openai.models.embeddings.EmbeddingModel.TEXT_EMBEDDING_3_SMALL;
     public static final com.openai.models.images.ImageModel IMAGE_MODEL_NAME =
-            com.openai.models.images.ImageModel.DALL_E_3;
+            com.openai.models.images.ImageModel.GPT_IMAGE_1;
 
     // TODO add missing models
 

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialImageModelIT.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/openai/OpenAiOfficialImageModelIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.model.image.ImageModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel;
 import dev.langchain4j.model.output.Response;
 import java.util.List;
 import org.junit.jupiter.api.Disabled;
@@ -12,21 +13,54 @@ import org.junit.jupiter.api.Test;
 @Disabled("Run manually before release. Expensive to run very often.")
 class OpenAiOfficialImageModelIT {
 
-    protected List<ImageModel> modelsUrl() {
+    protected List<ImageModel> models() {
         return InternalOpenAiOfficialTestHelper.imageModelsUrl();
     }
 
     @Test
-    void should_generate_image_with_url() {
-        for (ImageModel model : modelsUrl()) {
+    void should_generate_image() {
+        for (ImageModel model : models()) {
             Response<Image> response = model.generate("A cup of coffee on a table in Paris, France");
 
             Image image = response.content();
             assertThat(image).isNotNull();
-            assertThat(image.url()).isNotNull();
-            assertThat(image.base64Data()).isNull();
-            assertThat(image.revisedPrompt()).isNotNull();
-            System.out.println("The image is here: " + image.url());
+            assertThat(image.base64Data()).isNotNull().isNotBlank();
+            assertThat(image.mimeType()).isNotNull();
         }
+    }
+
+    @Test
+    void should_generate_image_with_output_format() {
+        OpenAiOfficialImageModel model = OpenAiOfficialImageModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .modelName(InternalOpenAiOfficialTestHelper.IMAGE_MODEL_NAME)
+                .outputFormat("png")
+                .build();
+
+        Response<Image> response = model.generate("A cup of coffee on a table in Paris, France");
+
+        Image image = response.content();
+        assertThat(image).isNotNull();
+        assertThat(image.base64Data()).isNotNull().isNotBlank();
+        assertThat(image.mimeType()).isEqualTo("image/png");
+    }
+
+    @Test
+    void should_generate_image_with_transparent_background() {
+        OpenAiOfficialImageModel model = OpenAiOfficialImageModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .modelName(InternalOpenAiOfficialTestHelper.IMAGE_MODEL_NAME)
+                .background("transparent")
+                .outputFormat("png")
+                .build();
+
+        Response<Image> response = model.generate("A red apple");
+
+        Image image = response.content();
+        assertThat(image).isNotNull();
+        assertThat(image.base64Data()).isNotNull().isNotBlank();
+        assertThat(image.mimeType()).isEqualTo("image/png");
     }
 }

--- a/langchain4j-open-ai/revapi.json
+++ b/langchain4j-open-ai/revapi.json
@@ -1,0 +1,50 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.openai.OpenAiImageModel.OpenAiImageModelBuilder dev.langchain4j.model.openai.OpenAiImageModel.OpenAiImageModelBuilder::style(java.lang.String)",
+          "justification": "The 'style' parameter is not supported by the OpenAI image generation API"
+        },
+        {
+          "code": "java.field.removed",
+          "old": "field dev.langchain4j.model.openai.OpenAiImageModel.style",
+          "justification": "The 'style' parameter is not supported by the OpenAI image generation API"
+        },
+        {
+          "code": "java.field.removed",
+          "old": "field dev.langchain4j.model.openai.OpenAiImageModel.OpenAiImageModelBuilder.style",
+          "justification": "The 'style' parameter is not supported by the OpenAI image generation API"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.openai.OpenAiImageModel.OpenAiImageModelBuilder dev.langchain4j.model.openai.OpenAiImageModel.OpenAiImageModelBuilder::responseFormat(java.lang.String)",
+          "justification": "The 'response_format' parameter is not supported by the new OpenAI GPT image models"
+        },
+        {
+          "code": "java.field.removed",
+          "old": "field dev.langchain4j.model.openai.OpenAiImageModel.responseFormat",
+          "justification": "The 'response_format' parameter is not supported by the new OpenAI GPT image models"
+        },
+        {
+          "code": "java.field.removed",
+          "old": "field dev.langchain4j.model.openai.OpenAiImageModel.OpenAiImageModelBuilder.responseFormat",
+          "justification": "The 'response_format' parameter is not supported by the new OpenAI GPT image models"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.openai.internal.image.GenerateImagesRequest.Builder dev.langchain4j.model.openai.internal.image.GenerateImagesRequest.Builder::style(java.lang.String)",
+          "justification": "The 'style' parameter is not supported by the OpenAI image generation API"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method dev.langchain4j.model.openai.internal.image.GenerateImagesRequest.Builder dev.langchain4j.model.openai.internal.image.GenerateImagesRequest.Builder::responseFormat(java.lang.String)",
+          "justification": "The 'response_format' parameter is not supported by the new OpenAI GPT image models"
+        }
+      ]
+    }
+  }
+]

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModel.java
@@ -24,17 +24,19 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 /**
- * Represents an OpenAI DALL·E models to generate artistic images. Versions 2 and 3 (default) are supported.
- * Find the parameters description <a href="https://platform.openai.com/docs/api-reference/images/create">here</a>.
+ * Represents an OpenAI image generation model.
+ * Find the parameters description <a href="https://developers.openai.com/api/reference/resources/images/methods/generate">here</a>.
  */
 public class OpenAiImageModel implements ImageModel {
 
     private final String modelName;
     private final String size;
     private final String quality;
-    private final String style;
     private final String user;
-    private final String responseFormat;
+    private final String background;
+    private final String outputFormat;
+    private final Integer outputCompression;
+    private final String moderation;
 
     private final OpenAiClient client;
 
@@ -62,9 +64,11 @@ public class OpenAiImageModel implements ImageModel {
         this.modelName = builder.modelName;
         this.size = builder.size;
         this.quality = builder.quality;
-        this.style = builder.style;
         this.user = builder.user;
-        this.responseFormat = builder.responseFormat;
+        this.background = builder.background;
+        this.outputFormat = builder.outputFormat;
+        this.outputCompression = builder.outputCompression;
+        this.moderation = builder.moderation;
     }
 
     public String modelName() {
@@ -78,7 +82,7 @@ public class OpenAiImageModel implements ImageModel {
         GenerateImagesResponse response = withRetryMappingExceptions(() -> client.imagesGeneration(request), maxRetries)
                 .execute();
 
-        return Response.from(fromImageData(response.data().get(0)));
+        return Response.from(fromImageData(response.data().get(0), response.outputFormat()));
     }
 
     @Override
@@ -88,8 +92,10 @@ public class OpenAiImageModel implements ImageModel {
         GenerateImagesResponse response = withRetryMappingExceptions(() -> client.imagesGeneration(request), maxRetries)
                 .execute();
 
-        return Response.from(
-                response.data().stream().map(OpenAiImageModel::fromImageData).collect(Collectors.toList()));
+        String responseOutputFormat = response.outputFormat();
+        return Response.from(response.data().stream()
+                .map(data -> fromImageData(data, responseOutputFormat))
+                .collect(Collectors.toList()));
     }
 
     public static OpenAiImageModelBuilder builder() {
@@ -110,9 +116,11 @@ public class OpenAiImageModel implements ImageModel {
         private String modelName;
         private String size;
         private String quality;
-        private String style;
         private String user;
-        private String responseFormat;
+        private String background;
+        private String outputFormat;
+        private Integer outputCompression;
+        private String moderation;
         private Duration timeout;
         private Integer maxRetries;
         private Boolean logRequests;
@@ -170,18 +178,28 @@ public class OpenAiImageModel implements ImageModel {
             return this;
         }
 
-        public OpenAiImageModelBuilder style(String style) {
-            this.style = style;
-            return this;
-        }
-
         public OpenAiImageModelBuilder user(String user) {
             this.user = user;
             return this;
         }
 
-        public OpenAiImageModelBuilder responseFormat(String responseFormat) {
-            this.responseFormat = responseFormat;
+        public OpenAiImageModelBuilder background(String background) {
+            this.background = background;
+            return this;
+        }
+
+        public OpenAiImageModelBuilder outputFormat(String outputFormat) {
+            this.outputFormat = outputFormat;
+            return this;
+        }
+
+        public OpenAiImageModelBuilder outputCompression(Integer outputCompression) {
+            this.outputCompression = outputCompression;
+            return this;
+        }
+
+        public OpenAiImageModelBuilder moderation(String moderation) {
+            this.moderation = moderation;
             return this;
         }
 
@@ -242,12 +260,15 @@ public class OpenAiImageModel implements ImageModel {
         }
     }
 
-    private static Image fromImageData(ImageData data) {
-        return Image.builder()
-                .url(data.url())
-                .base64Data(data.b64Json())
-                .revisedPrompt(data.revisedPrompt())
-                .build();
+    private static Image fromImageData(ImageData data, String outputFormat) {
+        Image.Builder imageBuilder =
+                Image.builder().url(data.url()).base64Data(data.b64Json()).revisedPrompt(data.revisedPrompt());
+
+        if (outputFormat != null) {
+            imageBuilder.mimeType("image/" + outputFormat);
+        }
+
+        return imageBuilder.build();
     }
 
     private GenerateImagesRequest.Builder requestBuilder(String prompt) {
@@ -256,8 +277,10 @@ public class OpenAiImageModel implements ImageModel {
                 .prompt(prompt)
                 .size(size)
                 .quality(quality)
-                .style(style)
                 .user(user)
-                .responseFormat(responseFormat);
+                .background(background)
+                .outputFormat(outputFormat)
+                .outputCompression(outputCompression)
+                .moderation(moderation);
     }
 }

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModelName.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiImageModelName.java
@@ -1,8 +1,22 @@
 package dev.langchain4j.model.openai;
 
 public enum OpenAiImageModelName {
+    GPT_IMAGE_1("gpt-image-1"),
+    GPT_IMAGE_1_MINI("gpt-image-1-mini"),
+    GPT_IMAGE_1_5("gpt-image-1.5"),
+    GPT_IMAGE_2("gpt-image-2"),
+    CHATGPT_IMAGE_LATEST("chatgpt-image-latest"),
 
+    /**
+     * @deprecated DALL-E models have been deprecated by OpenAI. Use {@link #GPT_IMAGE_1} or other GPT image models instead.
+     */
+    @Deprecated
     DALL_E_2("dall-e-2"),
+
+    /**
+     * @deprecated DALL-E models have been deprecated by OpenAI. Use {@link #GPT_IMAGE_1} or other GPT image models instead.
+     */
+    @Deprecated
     DALL_E_3("dall-e-3");
 
     private final String stringValue;

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/GenerateImagesRequest.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/GenerateImagesRequest.java
@@ -8,12 +8,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
-
 import java.util.Objects;
 
 /**
- * Represents the request from the OpenAI DALL·E API when generating images.
- * Find description of parameters <a href="https://platform.openai.com/docs/api-reference/images/create">here</a>.
+ * Represents the request to the OpenAI image generation API.
+ * Find description of parameters <a href="https://developers.openai.com/api/reference/resources/images/methods/generate">here</a>.
  */
 @JsonDeserialize(builder = GenerateImagesRequest.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -22,20 +21,33 @@ public class GenerateImagesRequest {
 
     @JsonProperty
     private final String model;
+
     @JsonProperty
     private final String prompt;
+
     @JsonProperty
     private final int n;
+
     @JsonProperty
     private final String size;
+
     @JsonProperty
     private final String quality;
-    @JsonProperty
-    private final String style;
+
     @JsonProperty
     private final String user;
+
     @JsonProperty
-    private final String responseFormat;
+    private final String background;
+
+    @JsonProperty
+    private final String outputFormat;
+
+    @JsonProperty
+    private final Integer outputCompression;
+
+    @JsonProperty
+    private final String moderation;
 
     public GenerateImagesRequest(Builder builder) {
         this.model = builder.model;
@@ -43,9 +55,11 @@ public class GenerateImagesRequest {
         this.n = builder.n;
         this.size = builder.size;
         this.quality = builder.quality;
-        this.style = builder.style;
         this.user = builder.user;
-        this.responseFormat = builder.responseFormat;
+        this.background = builder.background;
+        this.outputFormat = builder.outputFormat;
+        this.outputCompression = builder.outputCompression;
+        this.moderation = builder.moderation;
     }
 
     @Override
@@ -57,35 +71,38 @@ public class GenerateImagesRequest {
         h += (h << 5) + n;
         h += (h << 5) + Objects.hashCode(size);
         h += (h << 5) + Objects.hashCode(quality);
-        h += (h << 5) + Objects.hashCode(style);
         h += (h << 5) + Objects.hashCode(user);
-        h += (h << 5) + Objects.hashCode(responseFormat);
+        h += (h << 5) + Objects.hashCode(background);
+        h += (h << 5) + Objects.hashCode(outputFormat);
+        h += (h << 5) + Objects.hashCode(outputCompression);
+        h += (h << 5) + Objects.hashCode(moderation);
         return h;
     }
 
     @Override
     @JacocoIgnoreCoverageGenerated
     public String toString() {
-        return (
-                "GenerateImagesRequest{" +
-                        "model=" +
-                        model +
-                        ", prompt=" +
-                        prompt +
-                        ", n=" +
-                        n +
-                        ", size=" +
-                        size +
-                        ", quality=" +
-                        quality +
-                        ", style=" +
-                        style +
-                        ", user=" +
-                        user +
-                        ", responseFormat=" +
-                        responseFormat +
-                        '}'
-        );
+        return ("GenerateImagesRequest{" + "model="
+                + model
+                + ", prompt="
+                + prompt
+                + ", n="
+                + n
+                + ", size="
+                + size
+                + ", quality="
+                + quality
+                + ", user="
+                + user
+                + ", background="
+                + background
+                + ", outputFormat="
+                + outputFormat
+                + ", outputCompression="
+                + outputCompression
+                + ", moderation="
+                + moderation
+                + '}');
     }
 
     public static Builder builder() {
@@ -102,9 +119,11 @@ public class GenerateImagesRequest {
         private int n = 1;
         private String size;
         private String quality;
-        private String style;
         private String user;
-        private String responseFormat;
+        private String background;
+        private String outputFormat;
+        private Integer outputCompression;
+        private String moderation;
 
         public Builder model(String model) {
             this.model = model;
@@ -131,18 +150,28 @@ public class GenerateImagesRequest {
             return this;
         }
 
-        public Builder style(String style) {
-            this.style = style;
-            return this;
-        }
-
         public Builder user(String user) {
             this.user = user;
             return this;
         }
 
-        public Builder responseFormat(String responseFormat) {
-            this.responseFormat = responseFormat;
+        public Builder background(String background) {
+            this.background = background;
+            return this;
+        }
+
+        public Builder outputFormat(String outputFormat) {
+            this.outputFormat = outputFormat;
+            return this;
+        }
+
+        public Builder outputCompression(Integer outputCompression) {
+            this.outputCompression = outputCompression;
+            return this;
+        }
+
+        public Builder moderation(String moderation) {
+            this.moderation = moderation;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/GenerateImagesResponse.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/GenerateImagesResponse.java
@@ -8,13 +8,12 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
-
 import java.util.List;
 import java.util.Objects;
 
 /**
- * Represents the response from the OpenAI DALL·E API when generating images.
- * Find description of parameters <a href="https://platform.openai.com/docs/api-reference/images/object">here</a>.
+ * Represents the response from the OpenAI image generation API.
+ * Find description of parameters <a href="https://developers.openai.com/api/reference/resources/images/methods/generate">here</a>.
  */
 @JsonDeserialize(builder = GenerateImagesResponse.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -22,24 +21,80 @@ import java.util.Objects;
 public class GenerateImagesResponse {
 
     @JsonProperty
+    private final Long created;
+
+    @JsonProperty
     private final List<ImageData> data;
 
+    @JsonProperty
+    private final String background;
+
+    @JsonProperty
+    private final String outputFormat;
+
+    @JsonProperty
+    private final String quality;
+
+    @JsonProperty
+    private final String size;
+
+    @JsonProperty
+    private final ImageUsage usage;
+
     public GenerateImagesResponse(Builder builder) {
+        this.created = builder.created;
         this.data = builder.data;
+        this.background = builder.background;
+        this.outputFormat = builder.outputFormat;
+        this.quality = builder.quality;
+        this.size = builder.size;
+        this.usage = builder.usage;
     }
 
     public static Builder builder() {
         return new Builder();
     }
 
+    public Long created() {
+        return created;
+    }
+
     public List<ImageData> data() {
         return data;
+    }
+
+    public String background() {
+        return background;
+    }
+
+    public String outputFormat() {
+        return outputFormat;
+    }
+
+    public String quality() {
+        return quality;
+    }
+
+    public String size() {
+        return size;
+    }
+
+    public ImageUsage usage() {
+        return usage;
     }
 
     @Override
     @JacocoIgnoreCoverageGenerated
     public String toString() {
-        return "GenerateImagesResponse{" + "data=" + data + '}';
+        return "GenerateImagesResponse{"
+                + "created=" + created
+                + ", data=" + data
+                + ", background=" + background
+                + ", outputFormat=" + outputFormat
+                + ", quality=" + quality
+                + ", size=" + size
+                + ", usage=" + usage
+                + '}';
     }
 
     @Override
@@ -47,14 +102,20 @@ public class GenerateImagesResponse {
     public boolean equals(Object another) {
         if (this == another) return true;
         if (another == null || getClass() != another.getClass()) return false;
-        GenerateImagesResponse anotherGenerateImagesResponse = (GenerateImagesResponse) another;
-        return Objects.equals(data, anotherGenerateImagesResponse.data);
+        GenerateImagesResponse that = (GenerateImagesResponse) another;
+        return Objects.equals(created, that.created)
+                && Objects.equals(data, that.data)
+                && Objects.equals(background, that.background)
+                && Objects.equals(outputFormat, that.outputFormat)
+                && Objects.equals(quality, that.quality)
+                && Objects.equals(size, that.size)
+                && Objects.equals(usage, that.usage);
     }
 
     @Override
     @JacocoIgnoreCoverageGenerated
     public int hashCode() {
-        return Objects.hash(data);
+        return Objects.hash(created, data, background, outputFormat, quality, size, usage);
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -62,10 +123,46 @@ public class GenerateImagesResponse {
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class Builder {
 
+        private Long created;
         private List<ImageData> data;
+        private String background;
+        private String outputFormat;
+        private String quality;
+        private String size;
+        private ImageUsage usage;
+
+        public Builder created(Long created) {
+            this.created = created;
+            return this;
+        }
 
         public Builder data(List<ImageData> data) {
             this.data = data;
+            return this;
+        }
+
+        public Builder background(String background) {
+            this.background = background;
+            return this;
+        }
+
+        public Builder outputFormat(String outputFormat) {
+            this.outputFormat = outputFormat;
+            return this;
+        }
+
+        public Builder quality(String quality) {
+            this.quality = quality;
+            return this;
+        }
+
+        public Builder size(String size) {
+            this.size = size;
+            return this;
+        }
+
+        public Builder usage(ImageUsage usage) {
+            this.usage = usage;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/ImageUsage.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/image/ImageUsage.java
@@ -1,0 +1,209 @@
+package dev.langchain4j.model.openai.internal.image;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
+import java.util.Objects;
+
+@JsonDeserialize(builder = ImageUsage.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ImageUsage {
+
+    @JsonProperty
+    private final Integer inputTokens;
+
+    @JsonProperty
+    private final Integer outputTokens;
+
+    @JsonProperty
+    private final Integer totalTokens;
+
+    @JsonProperty
+    private final TokensDetails inputTokensDetails;
+
+    @JsonProperty
+    private final TokensDetails outputTokensDetails;
+
+    public ImageUsage(Builder builder) {
+        this.inputTokens = builder.inputTokens;
+        this.outputTokens = builder.outputTokens;
+        this.totalTokens = builder.totalTokens;
+        this.inputTokensDetails = builder.inputTokensDetails;
+        this.outputTokensDetails = builder.outputTokensDetails;
+    }
+
+    public Integer inputTokens() {
+        return inputTokens;
+    }
+
+    public Integer outputTokens() {
+        return outputTokens;
+    }
+
+    public Integer totalTokens() {
+        return totalTokens;
+    }
+
+    public TokensDetails inputTokensDetails() {
+        return inputTokensDetails;
+    }
+
+    public TokensDetails outputTokensDetails() {
+        return outputTokensDetails;
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public boolean equals(Object another) {
+        if (this == another) return true;
+        if (another == null || getClass() != another.getClass()) return false;
+        ImageUsage that = (ImageUsage) another;
+        return Objects.equals(inputTokens, that.inputTokens)
+                && Objects.equals(outputTokens, that.outputTokens)
+                && Objects.equals(totalTokens, that.totalTokens)
+                && Objects.equals(inputTokensDetails, that.inputTokensDetails)
+                && Objects.equals(outputTokensDetails, that.outputTokensDetails);
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public int hashCode() {
+        return Objects.hash(inputTokens, outputTokens, totalTokens, inputTokensDetails, outputTokensDetails);
+    }
+
+    @Override
+    @JacocoIgnoreCoverageGenerated
+    public String toString() {
+        return "ImageUsage{"
+                + "inputTokens=" + inputTokens
+                + ", outputTokens=" + outputTokens
+                + ", totalTokens=" + totalTokens
+                + ", inputTokensDetails=" + inputTokensDetails
+                + ", outputTokensDetails=" + outputTokensDetails
+                + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Builder {
+
+        private Integer inputTokens;
+        private Integer outputTokens;
+        private Integer totalTokens;
+        private TokensDetails inputTokensDetails;
+        private TokensDetails outputTokensDetails;
+
+        public Builder inputTokens(Integer inputTokens) {
+            this.inputTokens = inputTokens;
+            return this;
+        }
+
+        public Builder outputTokens(Integer outputTokens) {
+            this.outputTokens = outputTokens;
+            return this;
+        }
+
+        public Builder totalTokens(Integer totalTokens) {
+            this.totalTokens = totalTokens;
+            return this;
+        }
+
+        public Builder inputTokensDetails(TokensDetails inputTokensDetails) {
+            this.inputTokensDetails = inputTokensDetails;
+            return this;
+        }
+
+        public Builder outputTokensDetails(TokensDetails outputTokensDetails) {
+            this.outputTokensDetails = outputTokensDetails;
+            return this;
+        }
+
+        public ImageUsage build() {
+            return new ImageUsage(this);
+        }
+    }
+
+    @JsonDeserialize(builder = TokensDetails.TokensDetailsBuilder.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class TokensDetails {
+
+        @JsonProperty
+        private final Integer imageTokens;
+
+        @JsonProperty
+        private final Integer textTokens;
+
+        public TokensDetails(TokensDetailsBuilder builder) {
+            this.imageTokens = builder.imageTokens;
+            this.textTokens = builder.textTokens;
+        }
+
+        public Integer imageTokens() {
+            return imageTokens;
+        }
+
+        public Integer textTokens() {
+            return textTokens;
+        }
+
+        @Override
+        @JacocoIgnoreCoverageGenerated
+        public boolean equals(Object another) {
+            if (this == another) return true;
+            if (another == null || getClass() != another.getClass()) return false;
+            TokensDetails that = (TokensDetails) another;
+            return Objects.equals(imageTokens, that.imageTokens) && Objects.equals(textTokens, that.textTokens);
+        }
+
+        @Override
+        @JacocoIgnoreCoverageGenerated
+        public int hashCode() {
+            return Objects.hash(imageTokens, textTokens);
+        }
+
+        @Override
+        @JacocoIgnoreCoverageGenerated
+        public String toString() {
+            return "TokensDetails{" + "imageTokens=" + imageTokens + ", textTokens=" + textTokens + '}';
+        }
+
+        public static TokensDetailsBuilder builder() {
+            return new TokensDetailsBuilder();
+        }
+
+        @JsonPOJOBuilder(withPrefix = "")
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+        public static class TokensDetailsBuilder {
+
+            private Integer imageTokens;
+            private Integer textTokens;
+
+            public TokensDetailsBuilder imageTokens(Integer imageTokens) {
+                this.imageTokens = imageTokens;
+                return this;
+            }
+
+            public TokensDetailsBuilder textTokens(Integer textTokens) {
+                this.textTokens = textTokens;
+                return this;
+            }
+
+            public TokensDetails build() {
+                return new TokensDetails(this);
+            }
+        }
+    }
+}

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiImageModelIT.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiImageModelIT.java
@@ -1,18 +1,15 @@
 package dev.langchain4j.model.openai;
 
+import static dev.langchain4j.model.openai.OpenAiImageModelName.GPT_IMAGE_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import dev.langchain4j.data.image.Image;
 import dev.langchain4j.model.output.Response;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.net.URI;
-import java.util.List;
-
-import static dev.langchain4j.model.openai.OpenAiImageModelName.DALL_E_2;
-import static dev.langchain4j.model.openai.OpenAiImageModelName.DALL_E_3;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @Disabled("Run manually before release. Expensive to run very often.")
 class OpenAiImageModelIT {
@@ -23,8 +20,7 @@ class OpenAiImageModelIT {
             .baseUrl(System.getenv("OPENAI_BASE_URL"))
             .apiKey(System.getenv("OPENAI_API_KEY"))
             .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
-            .modelName(DALL_E_2)
-            .size("256x256")
+            .modelName(GPT_IMAGE_1)
             .logRequests(true)
             .logResponses(true);
 
@@ -34,49 +30,65 @@ class OpenAiImageModelIT {
 
         Response<Image> response = model.generate("Beautiful house on country side");
 
-        URI remoteImage = response.content().url();
-        log.info("Your remote image is here: {}", remoteImage);
-        assertThat(remoteImage).isNotNull();
+        Image image = response.content();
+        assertThat(image.base64Data()).isNotNull().isNotBlank();
+        assertThat(image.mimeType()).isNotNull();
     }
 
     @Test
-    void multiple_images_generation_with_base64_works() {
-        OpenAiImageModel model = modelBuilder.responseFormat("b64_json").build();
+    void multiple_images_generation_works() {
+        OpenAiImageModel model = modelBuilder.outputFormat("png").build();
 
         Response<List<Image>> response = model.generate("Cute red parrot sings", 2);
 
         assertThat(response.content()).hasSize(2);
 
-        Image localImage1 = response.content().get(0);
-        assertThat(localImage1.base64Data()).isNotNull().isBase64();
+        Image image1 = response.content().get(0);
+        assertThat(image1.base64Data()).isNotNull().isBase64();
+        assertThat(image1.mimeType()).isEqualTo("image/png");
 
-        Image localImage2 = response.content().get(1);
-        assertThat(localImage2.base64Data()).isNotNull().isBase64();
+        Image image2 = response.content().get(1);
+        assertThat(image2.base64Data()).isNotNull().isBase64();
+        assertThat(image2.mimeType()).isEqualTo("image/png");
     }
 
     @Test
-    void image_generation_with_dalle3_works() {
+    void image_generation_with_quality_works() {
         OpenAiImageModel model = OpenAiImageModel.builder()
                 .baseUrl(System.getenv("OPENAI_BASE_URL"))
                 .apiKey(System.getenv("OPENAI_API_KEY"))
                 .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
-                .modelName(DALL_E_3)
-                .quality("hd")
+                .modelName(GPT_IMAGE_1)
+                .quality("high")
                 .logRequests(true)
                 .logResponses(true)
                 .build();
 
-        Response<Image> response = model.generate(
-                "Beautiful house on country side, cowboy plays guitar, dog sitting at the door"
-        );
+        Response<Image> response =
+                model.generate("Beautiful house on country side, cowboy plays guitar, dog sitting at the door");
 
-        URI remoteImage = response.content().url();
-        log.info("Your remote image is here: {}", remoteImage);
-        assertThat(remoteImage).isNotNull();
+        Image image = response.content();
+        assertThat(image.base64Data()).isNotNull().isNotBlank();
+    }
 
-        String revisedPrompt = response.content().revisedPrompt();
-        log.info("Your revised prompt: {}", revisedPrompt);
-        assertThat(revisedPrompt).hasSizeGreaterThan(50);
+    @Test
+    void image_generation_with_transparent_background_works() {
+        OpenAiImageModel model = OpenAiImageModel.builder()
+                .baseUrl(System.getenv("OPENAI_BASE_URL"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
+                .modelName(GPT_IMAGE_1)
+                .background("transparent")
+                .outputFormat("png")
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        Response<Image> response = model.generate("A red apple on a white background");
+
+        Image image = response.content();
+        assertThat(image.base64Data()).isNotNull().isNotBlank();
+        assertThat(image.mimeType()).isEqualTo("image/png");
     }
 
     @Test
@@ -87,7 +99,7 @@ class OpenAiImageModelIT {
                 .baseUrl(System.getenv("OPENAI_BASE_URL"))
                 .apiKey(System.getenv("OPENAI_API_KEY"))
                 .organizationId(System.getenv("OPENAI_ORGANIZATION_ID"))
-                .modelName(DALL_E_2)
+                .modelName(GPT_IMAGE_1)
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -98,8 +110,7 @@ class OpenAiImageModelIT {
         Response<Image> response = model.generate(prompt);
 
         // then
-        URI remoteImage = response.content().url();
-        log.info("Your remote image is here: {}", remoteImage);
-        assertThat(remoteImage).isNotNull();
+        Image image = response.content();
+        assertThat(image.base64Data()).isNotNull().isNotBlank();
     }
 }


### PR DESCRIPTION
## Summary

- Adds GPT image model names (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `chatgpt-image-latest`) and deprecates `DALL_E_2`/`DALL_E_3`
- Removes `style` and `response_format` parameters that are rejected by the API (see #5356 for context on the 400 error)
- Adds new GPT image model parameters: `background`, `output_format`, `output_compression`, `moderation`
- Captures full API response fields including token `usage` info
- Sets `mimeType` on `Image` from the response's `output_format`
- Updates both `langchain4j-open-ai` (legacy) and `langchain4j-open-ai-official` modules

## Test plan

- [x] Both modules compile cleanly (`mvn test-compile`)
- [ ] Run `OpenAiImageModelIT` manually with `OPENAI_API_KEY` set
- [ ] Run `OpenAiOfficialImageModelIT` manually with `OPENAI_API_KEY` set

Closes #5371