### PR TITLE
fix(anthropic): handle malformed SSE data gracefully in streaming

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
@@ -315,7 +315,16 @@ public class DefaultAnthropicClient extends AnthropicClient {
                     streamingHandle = toStreamingHandle(context.parsingHandle());
                 }
 
-                AnthropicStreamingData data = fromJson(event.data(), AnthropicStreamingData.class);
+                // Skip events with null/empty data or data that is not a JSON object.
+                // Some proxies (e.g. Azure) send SSE keep-alive events with array or
+                // other non-object payloads that cannot be deserialized into
+                // AnthropicStreamingData. See https://github.com/langchain4j/langchain4j/issues/5353
+                String rawData = event.data();
+                if (isNullOrEmpty(rawData) || rawData.charAt(0) != '{') {
+                    return;
+                }
+
+                AnthropicStreamingData data = fromJson(rawData, AnthropicStreamingData.class);
 
                 if ("message_start".equals(event.event())) {
                     handleMessageStart(data);


### PR DESCRIPTION
Fixes #5353

## Summary

Skip SSE events with null/empty data or data that is not a JSON object (e.g. array payloads from keep-alive events). This prevents `MismatchedInputException` when proxies or Anthropic endpoints send non-object JSON in SSE events.

## Problem

When streaming with `AnthropicStreamingChatModel`, SSE keep-alive events (or events from certain proxies) may contain non-object JSON payloads (e.g. `[]`). The `onEvent()` method unconditionally calls `fromJson(event.data(), AnthropicStreamingData.class)`, which throws a `RuntimeException` wrapping `MismatchedInputException`:

```
com.fasterxml.jackson.databind.exc.MismatchedInputException: 
Cannot deserialize value of type `AnthropicStreamingData` from Array value (token `JsonToken.START_ARRAY`)
```

While this exception is caught by `ServerSentEventListenerUtils.ignoringExceptions()` and logged as WARN, it creates noisy logs and may interfere with the streaming handle lifecycle.

## Fix

Added a guard in `DefaultAnthropicClient.onEvent()` to skip events where `event.data()` is:
- null or empty (blank keep-alive events)
- not starting with `{` (non-object JSON, e.g. arrays from proxies)

This is consistent with how the SSE spec defines keep-alive events (empty data lines) and how other SSE implementations handle unexpected payloads.

## Changes

- `langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java`: Added guard clause before `fromJson()` call in `onEvent()`