### PR TITLE
fix: remove double python prefix in Gemini code execution output

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/PartsAndContentsMapper.java
@@ -195,15 +195,11 @@ final class PartsAndContentsMapper {
             GeminiExecutableCode executableCode = part.executableCode();
             if (executableCode != null && includeCodeExecutionOutput) {
                 fullText.append("Code executed:\n")
-                        .append("```python")
-                        .append(
-                                executableCode.programmingLanguage() != null
-                                        ? // TODO check below why programming language is null
-                                        // TODO: Is this correct? This would result in: ```pythonpythonCODE```
-                                        executableCode.programmingLanguage().toString()
-                                        : "")
+                        .append("```")
+                        .append(executableCode.programmingLanguage().toString())
+                        .append("\n")
                         .append(executableCode.code())
-                        .append("```\n");
+                        .append("\n```\n");
             }
 
             GeminiCodeExecutionResult codeExecutionResult = part.codeExecutionResult();


### PR DESCRIPTION
  Change

  Fix double "python" prefix in Gemini code execution output.

  Before:
  Code executed:
  ```pythonpythonprint("hello")```

  After:
  Code executed:
  ```python
  print("hello")

  **Root cause:** `PartsAndContentsMapper.java` hardcodes `"```python"` as a literal string, then appends
  `executableCode.programmingLanguage().toString()` which also returns `"python"` (since `GeminiLanguage.PYTHON.toString()` returns
  `name().toLowerCase()`). The compact constructor of `GeminiExecutableCode` guarantees `programmingLanguage` is never null (defaults
  to `PYTHON`), making the null check dead code.

  **Fix:** Use only the programming language from the API response and add proper newlines for correct markdown rendering. Removed
  dead null check and associated TODO comments.

  ## General checklist
  - [X] There are no breaking changes (API, behaviour)
  - [ ] I have added unit and/or integration tests for my change — *existing integration tests pass; formatting was not previously
  tested*
  - [ ] The tests cover both positive and negative cases
  - [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
  - [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
  - [ ] I have added/updated the documentation
  - [ ] I have added an example in the examples repo
  - [ ] I have added/updated Spring Boot starter(s)