### PR TITLE
fix(elasticsearch): apply hybrid filters to full-text retriever

### DIFF
--- a/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationHybrid.java
+++ b/langchain4j-elasticsearch/src/main/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationHybrid.java
@@ -4,7 +4,8 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.KnnRetriever;
 import co.elastic.clients.elasticsearch._types.RRFRetrieverEntry;
-import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.StandardRetriever;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.SourceConfig;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
@@ -88,8 +89,10 @@ public class ElasticsearchConfigurationHybrid implements ElasticsearchConfigurat
                 .field(VECTOR_FIELD)
                 .queryVector(embeddingSearchRequest.queryEmbedding().vectorAsList());
 
+        Query filter = null;
         if (embeddingSearchRequest.filter() != null) {
-            krb.filter(ElasticsearchMetadataFilterMapper.map(embeddingSearchRequest.filter()));
+            filter = ElasticsearchMetadataFilterMapper.map(embeddingSearchRequest.filter());
+            krb.filter(filter);
         }
 
         // k and numCandidates are required in KnnRetriever, calculating default values similarly to how elasticsearch
@@ -105,8 +108,14 @@ public class ElasticsearchConfigurationHybrid implements ElasticsearchConfigurat
         KnnRetriever knn = krb.build();
 
         // Building full text part of the hybrid query
-        MatchQuery matchQuery =
-                new MatchQuery.Builder().field(TEXT_FIELD).query(textQuery).build();
+        Query matchQuery = Query.of(q -> q.match(m -> m.field(TEXT_FIELD).query(textQuery)));
+        StandardRetriever.Builder srb = new StandardRetriever.Builder().query(matchQuery);
+
+        if (filter != null) {
+            srb.filter(filter);
+        }
+
+        StandardRetriever standard = srb.build();
 
         log.trace("Searching for embeddings in index [{}] with hybrid query [{}], [{}].", indexName, knn, matchQuery);
 
@@ -119,8 +128,7 @@ public class ElasticsearchConfigurationHybrid implements ElasticsearchConfigurat
                         })
                         .index(indexName)
                         .retriever(r -> r.rrf(rf -> rf.retrievers(List.of(
-                                RRFRetrieverEntry.of(
-                                        rre -> rre.retriever(rt -> rt.standard(st -> st.query(matchQuery)))),
+                                RRFRetrieverEntry.of(rre -> rre.retriever(rt -> rt.standard(standard))),
                                 RRFRetrieverEntry.of(rre -> rre.retriever(rt -> rt.knn(knn)))))))
                         .size(embeddingSearchRequest.maxResults())
                         .minScore(embeddingSearchRequest.minScore()),

--- a/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationHybridTest.java
+++ b/langchain4j-elasticsearch/src/test/java/dev/langchain4j/store/embedding/elasticsearch/ElasticsearchConfigurationHybridTest.java
@@ -1,0 +1,102 @@
+package dev.langchain4j.store.embedding.elasticsearch;
+
+import static co.elastic.clients.elasticsearch.core.search.TotalHitsRelation.Eq;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.DefaultTransportOptions;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.Endpoint;
+import co.elastic.clients.transport.TransportOptions;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchConfigurationHybridTest {
+
+    @Test
+    void should_apply_filter_to_standard_and_knn_retrievers() throws IOException {
+        CapturingTransport transport = new CapturingTransport();
+        ElasticsearchClient client = new ElasticsearchClient(transport);
+        EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(Embedding.from(new float[] {0.1f, 0.2f}))
+                .maxResults(3)
+                .filter(new IsEqualTo("year", 2023))
+                .build();
+
+        ElasticsearchConfigurationHybrid.builder()
+                .build()
+                .hybridSearch(client, "movies", searchRequest, "movies about space battles");
+
+        assertThat(transport.capturedRequest).isNotNull();
+        assertThat(transport.capturedRequest.retriever().rrf().retrievers()).hasSize(2);
+
+        var standardRetriever = transport
+                .capturedRequest
+                .retriever()
+                .rrf()
+                .retrievers()
+                .get(0)
+                .retriever()
+                .standard();
+        assertThat(standardRetriever.query().match().field()).isEqualTo(ElasticsearchConfiguration.TEXT_FIELD);
+        assertThat(standardRetriever.query().match().query().stringValue()).isEqualTo("movies about space battles");
+        assertThat(standardRetriever.filter()).hasSize(1);
+
+        var knnRetriever = transport
+                .capturedRequest
+                .retriever()
+                .rrf()
+                .retrievers()
+                .get(1)
+                .retriever()
+                .knn();
+        assertThat(knnRetriever.filter()).hasSize(1);
+        assertThat(knnRetriever.filter().get(0))
+                .isEqualTo(standardRetriever.filter().get(0));
+    }
+
+    private static class CapturingTransport implements ElasticsearchTransport {
+
+        private final JsonpMapper jsonpMapper = new JacksonJsonpMapper();
+        private SearchRequest capturedRequest;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <RequestT, ResponseT, ErrorT> ResponseT performRequest(
+                RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, TransportOptions options) {
+            capturedRequest = (SearchRequest) request;
+            return (ResponseT) SearchResponse.of(sr -> sr.took(0)
+                    .timedOut(false)
+                    .shards(s -> s.total(1).successful(1).failed(0))
+                    .hits(h -> h.total(t -> t.value(0).relation(Eq)).hits(emptyList())));
+        }
+
+        @Override
+        public <RequestT, ResponseT, ErrorT> CompletableFuture<ResponseT> performRequestAsync(
+                RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, TransportOptions options) {
+            return CompletableFuture.completedFuture(performRequest(request, endpoint, options));
+        }
+
+        @Override
+        public JsonpMapper jsonpMapper() {
+            return jsonpMapper;
+        }
+
+        @Override
+        public TransportOptions options() {
+            return DefaultTransportOptions.EMPTY;
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
## Summary

- apply the metadata filter to the Elasticsearch hybrid full-text retriever
- keep the same filter on the KNN retriever so both RRF inputs are constrained
- add a unit test that captures the generated SearchRequest and verifies both retrievers carry the filter

Fixes #5383

## Test Plan

- ./mvnw -pl langchain4j-elasticsearch -Dtest=ElasticsearchConfigurationHybridTest test
- ./mvnw -pl langchain4j-elasticsearch verify
- ./mvnw -pl langchain4j-elasticsearch spotless:check
- git diff --check
