### PR TITLE
fix(agentic): accept @A2AClientAgent as root of agentic system

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
@@ -333,6 +333,21 @@ public class AgenticServices {
         T agent = createComposedAgent(agentServiceClass, chatModel, agentConfigurator);
 
         if (agent == null) {
+            // A class annotated only with @A2AClientAgent is not a composed agent,
+            // but it is still a valid root of an agentic system. Detect it here and
+            // delegate to the A2AService SPI so we build the T proxy through the
+            // existing A2A client builder, rather than falling through to the
+            // AgentBuilder path that requires @Agent. See issue #5310.
+            Optional<Method> a2aRootMethod = getAnnotatedMethodOnClass(agentServiceClass, A2AClientAgent.class);
+            if (a2aRootMethod.isPresent()) {
+                A2AClientAgent a2aAnnotation = a2aRootMethod.get().getAnnotation(A2AClientAgent.class);
+                return A2AService.get()
+                        .a2aBuilder(a2aAnnotation.a2aServerUrl(), agentServiceClass)
+                        .outputKey(AgentUtil.outputKey(a2aAnnotation.outputKey(), a2aAnnotation.typedOutputKey()))
+                        .async(a2aAnnotation.async())
+                        .build();
+            }
+
             var agentBuilder = AgentBuilder.withoutDeclarativeConfiguration(agentServiceClass);
             configureAgent(agentServiceClass, chatModel, agentBuilder, agentConfigurator);
             agent = agentBuilder.build();

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/A2AAgentIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/A2AAgentIT.java
@@ -1,7 +1,10 @@
 package dev.langchain4j.agentic;
 
+import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.service.V;
 import org.junit.jupiter.api.Test;
 
+import static dev.langchain4j.agentic.Models.baseModel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -14,6 +17,27 @@ public class A2AAgentIT {
         assertThat(
                 assertThrows(UnsupportedOperationException.class,
                         () -> AgenticServices.a2aBuilder(A2A_SERVER_URL))
+        ).hasMessageContaining("langchain4j-agentic-a2a");
+    }
+
+    public interface RootA2AClientAgent {
+        @A2AClientAgent(a2aServerUrl = A2A_SERVER_URL, outputKey = "story")
+        String generateStory(@V("topic") String topic);
+    }
+
+    /**
+     * Regression test for issue #5310: an interface annotated only with
+     * {@code @A2AClientAgent} should be a valid root of an agentic system
+     * when passed to {@link AgenticServices#createAgenticSystem(Class, dev.langchain4j.model.chat.ChatModel)}.
+     * It must be routed through the A2AService SPI (which throws
+     * {@link UnsupportedOperationException} when the A2A module is missing),
+     * not fall through to the AgentBuilder path that requires {@code @Agent}.
+     */
+    @Test
+    void createAgenticSystem_should_accept_a2aClientAgent_root() {
+        assertThat(
+                assertThrows(UnsupportedOperationException.class,
+                        () -> AgenticServices.createAgenticSystem(RootA2AClientAgent.class, baseModel()))
         ).hasMessageContaining("langchain4j-agentic-a2a");
     }
 }


### PR DESCRIPTION
Fixes #5310.

When an interface annotated only with `@A2AClientAgent` is passed to `AgenticServices.createAgenticSystem(...)`, the method fell through to `AgentBuilder.withoutDeclarativeConfiguration`, which calls `validateAgentClass` and throws `IllegalArgumentException: No agent method found in class: <name>` because the method is not annotated with `@Agent`. This breaks Quarkus (and any other runtime) that wires `@A2AClientAgent` interfaces into the agentic system factory.

This change detects the `@A2AClientAgent` root case in `AgenticServices.createAgenticSystem` and delegates to the existing `A2AService` SPI to build the T proxy through `a2aBuilder(...)`, matching how `@A2AClientAgent` sub-agents are already handled inside composed agents.