### PR TITLE
Fix JSON extraction with unmatched trailing bracket

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonParsingUtils.java
@@ -16,7 +16,8 @@ public class JsonParsingUtils {
         return extractAndParseJson(text, s -> Json.fromJson(s, type));
     }
 
-    public static <T> ParsedJson<T> extractAndParseJson(String text, ThrowingFunction<String, T> parser) throws Exception {
+    public static <T> ParsedJson<T> extractAndParseJson(String text, ThrowingFunction<String, T> parser)
+            throws Exception {
         Exception parseException = null;
         try {
             return new ParsedJson<>(parser.apply(text), text);
@@ -35,7 +36,10 @@ public class JsonParsingUtils {
 
             int jsonStart = findJsonStart(text, jsonEnd, text.charAt(jsonEnd));
             if (jsonStart < 0) {
-                throw parseException;
+                // No matching opening bracket for this closing bracket (e.g. a stray
+                // '}' or ']' in trailing text); skip it and keep searching earlier.
+                index = jsonEnd - 1;
+                continue;
             }
 
             try {

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
@@ -249,4 +249,31 @@ class JsonParsingUtilsTest {
         assertThat(result.value().name).isEqualTo("Tom");
         assertThat(result.value().age).isEqualTo(18);
     }
+
+    @Test
+    void extract_object_when_suffix_contains_unmatched_closing_bracket() throws Exception {
+        String text = """
+                {"name":"Tom","age":18}
+                Here is a trailing note with a stray closing bracket ]
+                """;
+
+        JsonParsingUtils.ParsedJson<MyPojo> result = JsonParsingUtils.extractAndParseJson(text, MyPojo.class);
+
+        assertThat(result.value().name).isEqualTo("Tom");
+        assertThat(result.value().age).isEqualTo(18);
+    }
+
+    @Test
+    void extract_array_when_suffix_contains_unmatched_closing_brace() throws Exception {
+        String text = """
+                [{"log":"missing '}'"},{"log":"ok"}]
+                Here is a trailing note with a stray closing brace }
+                """;
+
+        JsonParsingUtils.ParsedJson<LogEntry[]> result = JsonParsingUtils.extractAndParseJson(text, LogEntry[].class);
+
+        assertThat(result.value()).hasSize(2);
+        assertThat(result.value()[0].log).isEqualTo("missing '}'");
+        assertThat(result.value()[1].log).isEqualTo("ok");
+    }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/JsonParsingUtilsTest.java
@@ -3,10 +3,9 @@ package dev.langchain4j.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import java.util.List;
 import java.util.Map;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -77,8 +76,7 @@ class JsonParsingUtilsTest {
     @Test
     void extract_array() throws Exception {
         String json = "[{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}]";
-        JsonParsingUtils.ParsedJson<MyPojo[]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        JsonParsingUtils.ParsedJson<MyPojo[]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isNotNull();
         assertThat(result.value().length).isEqualTo(2);
         assertThat(result.value()[0].name).isEqualTo("A");
@@ -93,8 +91,7 @@ class JsonParsingUtilsTest {
     @Test
     void extract_array_with_noise() throws Exception {
         String json = "abc [{\"name\":\"A\",\"age\":1},{\"name\":\"B\",\"age\":2}] xyz";
-        JsonParsingUtils.ParsedJson<MyPojo[]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        JsonParsingUtils.ParsedJson<MyPojo[]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isNotNull();
         assertThat(result.value().length).isEqualTo(2);
     }
@@ -108,8 +105,7 @@ class JsonParsingUtilsTest {
     @Test
     void extract_nested_array() throws Exception {
         String json = "[[{\"name\":\"A\",\"age\":1}],[{\"name\":\"B\",\"age\":2}]]";
-        JsonParsingUtils.ParsedJson<MyPojo[][]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[][].class);
+        JsonParsingUtils.ParsedJson<MyPojo[][]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[][].class);
         assertThat(result).isNotNull();
         assertThat(result.value().length).isEqualTo(2);
         assertThat(result.value()[0][0].name).isEqualTo("A");
@@ -194,8 +190,7 @@ class JsonParsingUtilsTest {
     void extract_json_array_with_nested_objects_and_arrays() throws Exception {
         String json =
                 "[{\"name\":\"Tom\",\"age\":18,\"tags\":[\"a\",\"b\"]},{\"name\":\"Jerry\",\"age\":20,\"tags\":[\"x\",\"y\"]}]";
-        JsonParsingUtils.ParsedJson<MyPojo[]> result =
-                JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
+        JsonParsingUtils.ParsedJson<MyPojo[]> result = JsonParsingUtils.extractAndParseJson(json, MyPojo[].class);
         assertThat(result).isNotNull();
         assertThat(result.value()[1].tags).containsExactly("x", "y");
     }
@@ -211,8 +206,7 @@ class JsonParsingUtilsTest {
                 {"log":"Unexpected character '}' at position 42"}
                 """;
 
-        JsonParsingUtils.ParsedJson<LogEntry> result =
-                JsonParsingUtils.extractAndParseJson(text, LogEntry.class);
+        JsonParsingUtils.ParsedJson<LogEntry> result = JsonParsingUtils.extractAndParseJson(text, LogEntry.class);
 
         assertThat(result.value().log).isEqualTo("Unexpected character '}' at position 42");
     }
@@ -224,8 +218,7 @@ class JsonParsingUtilsTest {
                 {"log":"Error: unexpected ']' found"}
                 """;
 
-        JsonParsingUtils.ParsedJson<LogEntry> result =
-                JsonParsingUtils.extractAndParseJson(text, LogEntry.class);
+        JsonParsingUtils.ParsedJson<LogEntry> result = JsonParsingUtils.extractAndParseJson(text, LogEntry.class);
 
         assertThat(result.value().log).isEqualTo("Error: unexpected ']' found");
     }
@@ -237,11 +230,23 @@ class JsonParsingUtilsTest {
                 [{"log":"missing '}'"},{"log":"ok"}]
                 """;
 
-        JsonParsingUtils.ParsedJson<LogEntry[]> result =
-                JsonParsingUtils.extractAndParseJson(text, LogEntry[].class);
+        JsonParsingUtils.ParsedJson<LogEntry[]> result = JsonParsingUtils.extractAndParseJson(text, LogEntry[].class);
 
         assertThat(result.value()).hasSize(2);
         assertThat(result.value()[0].log).isEqualTo("missing '}'");
         assertThat(result.value()[1].log).isEqualTo("ok");
+    }
+
+    @Test
+    void extract_object_when_suffix_contains_unmatched_closing_brace() throws Exception {
+        String text = """
+                {"name":"Tom","age":18}
+                Here is a trailing note with a stray closing brace }
+                """;
+
+        JsonParsingUtils.ParsedJson<MyPojo> result = JsonParsingUtils.extractAndParseJson(text, MyPojo.class);
+
+        assertThat(result.value().name).isEqualTo("Tom");
+        assertThat(result.value().age).isEqualTo(18);
     }
 }


### PR DESCRIPTION
## Issue
Fixes #5406

## Change
Fixes a case where `JsonParsingUtils.extractAndParseJson()` can fail to extract a valid JSON value when the model output contains an unmatched closing bracket after the JSON.

The parser already searches backward for the last JSON-looking value. If the last closing bracket is just trailing text and does not have a matching opening bracket, it is skipped and the parser keeps searching earlier in the output.

Added regression coverage for valid JSON values followed by trailing text containing unmatched closing delimiters.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
N/A

## Checklist for adding new embedding store integration
N/A

## Checklist for changing existing embedding store integration
N/A

## Verification
- `./mvnw.cmd -pl langchain4j-core -Dtest=JsonParsingUtilsTest test`
- `./mvnw.cmd -pl langchain4j-core spotless:check`
