### PR TITLE
Fix filtering for non-TextSegment entries in InMemoryEmbeddingStore

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
+++ b/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
@@ -12,6 +12,7 @@ import static java.util.Comparator.comparingDouble;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.spi.store.embedding.inmemory.InMemoryEmbeddingStoreJsonCodecFactory;
@@ -127,6 +128,14 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
         entries.removeIf(entry -> idSet.contains(entry.id));
     }
 
+    /**
+     * Removes all entries whose embedded object matches the given {@link Filter}.
+     * <p>
+     * Filtering is applied only to entries whose embedded object is a {@link TextSegment},
+     * by testing the filter against the segment's {@link Metadata}.
+     * Entries whose embedded object is {@code null} or is not a {@link TextSegment} are considered
+     * non-matching and are therefore never removed.
+     */
     @Override
     public void removeAll(Filter filter) {
         ensureNotNull(filter, "filter");
@@ -139,6 +148,16 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
         entries.clear();
     }
 
+    /**
+     * Searches for the embeddings most similar to the query embedding, optionally constrained by a {@link Filter}.
+     * <p>
+     * When a filter is present, it is applied only to entries whose embedded object is a {@link TextSegment},
+     * by testing the filter against the segment's {@link Metadata}.
+     * Entries whose embedded object is {@code null} or is not a {@link TextSegment} are considered
+     * non-matching and are therefore excluded from the results.
+     * <p>
+     * When no filter is present, all entries are eligible regardless of their embedded object type.
+     */
     @Override
     public EmbeddingSearchResult<Embedded> search(EmbeddingSearchRequest embeddingSearchRequest) {
 
@@ -245,6 +264,13 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
         return merge(asList(first, second));
     }
 
+    /**
+     * Tests whether an embedded object matches the given {@link Filter}.
+     *
+     * @return {@code true} if the filter is {@code null} (no filtering requested), or if the embedded object
+     *         is a {@link TextSegment} whose {@link Metadata} passes the filter;
+     *         {@code false} otherwise, including when the embedded object is {@code null} or not a {@link TextSegment}.
+     */
     private static boolean matchesFilter(Object embedded, Filter filter) {
         if (filter == null) {
             return true;

--- a/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
+++ b/langchain4j/src/main/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStore.java
@@ -12,7 +12,6 @@ import static java.util.Comparator.comparingDouble;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.spi.store.embedding.inmemory.InMemoryEmbeddingStoreJsonCodecFactory;
@@ -132,15 +131,7 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
     public void removeAll(Filter filter) {
         ensureNotNull(filter, "filter");
 
-        entries.removeIf(entry -> {
-            if (entry.embedded instanceof TextSegment) {
-                return filter.test(((TextSegment) entry.embedded).metadata());
-            } else if (entry.embedded == null) {
-                return false;
-            } else {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-        });
+        entries.removeIf(entry -> matchesFilter(entry.embedded, filter));
     }
 
     @Override
@@ -158,11 +149,8 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
 
         for (Entry<Embedded> entry : entries) {
 
-            if (filter != null && entry.embedded instanceof TextSegment) {
-                Metadata metadata = ((TextSegment) entry.embedded).metadata();
-                if (!filter.test(metadata)) {
-                    continue;
-                }
+            if (!matchesFilter(entry.embedded, filter)) {
+                continue;
             }
 
             double cosineSimilarity =
@@ -255,6 +243,16 @@ public class InMemoryEmbeddingStore<Embedded> implements EmbeddingStore<Embedded
     public static <Embedded> InMemoryEmbeddingStore<Embedded> merge(
             InMemoryEmbeddingStore<Embedded> first, InMemoryEmbeddingStore<Embedded> second) {
         return merge(asList(first, second));
+    }
+
+    private static boolean matchesFilter(Object embedded, Filter filter) {
+        if (filter == null) {
+            return true;
+        }
+        if (embedded instanceof TextSegment) {
+            return filter.test(((TextSegment) embedded).metadata());
+        }
+        return false;
     }
 
     static class Entry<Embedded> {

--- a/langchain4j/src/test/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStoreFilterRegressionTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStoreFilterRegressionTest.java
@@ -33,8 +33,8 @@ class InMemoryEmbeddingStoreFilterRegressionTest {
 
         // also add a raw non-TextSegment via package-private entries
         @SuppressWarnings({"rawtypes", "unchecked"})
-        InMemoryEmbeddingStore.Entry rawEntry = new InMemoryEmbeddingStore.Entry(
-                "5", dummyEmbedding(), "not-a-text-segment");
+        InMemoryEmbeddingStore.Entry rawEntry =
+                new InMemoryEmbeddingStore.Entry("5", dummyEmbedding(), "not-a-text-segment");
         store.entries.add(rawEntry);
 
         // when
@@ -83,17 +83,17 @@ class InMemoryEmbeddingStoreFilterRegressionTest {
         store.add("3", dummyEmbedding()); // null embedded
 
         @SuppressWarnings({"rawtypes", "unchecked"})
-        InMemoryEmbeddingStore.Entry rawEntry = new InMemoryEmbeddingStore.Entry(
-                "4", dummyEmbedding(), "not-a-text-segment");
+        InMemoryEmbeddingStore.Entry rawEntry =
+                new InMemoryEmbeddingStore.Entry("4", dummyEmbedding(), "not-a-text-segment");
         store.entries.add(rawEntry);
 
         // when: removeAll with filter — should not throw
-        assertThatNoException().isThrownBy(() -> store.removeAll(metadataKey("type").isEqualTo("a")));
+        assertThatNoException()
+                .isThrownBy(() -> store.removeAll(metadataKey("type").isEqualTo("a")));
 
         // then: only the matching TextSegment should be removed; others remain
         assertThat(store.entries).hasSize(3);
-        List<String> remainingIds =
-                store.entries.stream().map(e -> e.id).toList();
+        List<String> remainingIds = store.entries.stream().map(e -> e.id).toList();
         assertThat(remainingIds).containsExactlyInAnyOrder("2", "3", "4");
     }
 
@@ -107,13 +107,13 @@ class InMemoryEmbeddingStoreFilterRegressionTest {
         store.add("2", dummyEmbedding()); // null embedded
 
         @SuppressWarnings({"rawtypes", "unchecked"})
-        InMemoryEmbeddingStore.Entry rawEntry = new InMemoryEmbeddingStore.Entry(
-                "3", dummyEmbedding(), "not-a-text-segment");
+        InMemoryEmbeddingStore.Entry rawEntry =
+                new InMemoryEmbeddingStore.Entry("3", dummyEmbedding(), "not-a-text-segment");
         store.entries.add(rawEntry);
 
         // when: removeAll with filter that matches nothing
-        assertThatNoException().isThrownBy(
-                () -> store.removeAll(metadataKey("type").isEqualTo("no-such-value")));
+        assertThatNoException()
+                .isThrownBy(() -> store.removeAll(metadataKey("type").isEqualTo("no-such-value")));
 
         // then: all entries should remain
         assertThat(store.entries).hasSize(3);

--- a/langchain4j/src/test/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStoreFilterRegressionTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/store/embedding/inmemory/InMemoryEmbeddingStoreFilterRegressionTest.java
@@ -1,0 +1,121 @@
+package dev.langchain4j.store.embedding.inmemory;
+
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class InMemoryEmbeddingStoreFilterRegressionTest {
+
+    private static Embedding dummyEmbedding() {
+        return Embedding.from(new float[] {0.1f, 0.2f, 0.3f});
+    }
+
+    @Test
+    void should_not_match_non_text_segment_entries_when_filtering_in_search() {
+
+        // given
+        TextSegment matchingSegment = TextSegment.from("matching", Metadata.from("type", "a"));
+        TextSegment nonMatchingSegment = TextSegment.from("non-matching", Metadata.from("type", "b"));
+
+        InMemoryEmbeddingStore<TextSegment> store = new InMemoryEmbeddingStore<>();
+        store.add("1", dummyEmbedding(), matchingSegment);
+        store.add("2", dummyEmbedding(), nonMatchingSegment);
+        store.add("3", dummyEmbedding()); // embedded is null
+        store.add("4", dummyEmbedding(), null); // embedded is null
+
+        // also add a raw non-TextSegment via package-private entries
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        InMemoryEmbeddingStore.Entry rawEntry = new InMemoryEmbeddingStore.Entry(
+                "5", dummyEmbedding(), "not-a-text-segment");
+        store.entries.add(rawEntry);
+
+        // when
+        EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                .queryEmbedding(dummyEmbedding())
+                .filter(metadataKey("type").isEqualTo("a"))
+                .maxResults(10)
+                .build();
+        List<EmbeddingMatch<TextSegment>> matches = store.search(request).matches();
+
+        // then: only the matching TextSegment entry should be returned
+        assertThat(matches).hasSize(1);
+        assertThat(matches.get(0).embeddingId()).isEqualTo("1");
+    }
+
+    @Test
+    void should_return_all_when_no_filter() {
+
+        // given
+        TextSegment segment = TextSegment.from("text");
+        InMemoryEmbeddingStore<TextSegment> store = new InMemoryEmbeddingStore<>();
+        store.add("1", dummyEmbedding(), segment);
+        store.add("2", dummyEmbedding()); // null embedded
+
+        // when: no filter
+        EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                .queryEmbedding(dummyEmbedding())
+                .maxResults(10)
+                .build();
+        List<EmbeddingMatch<TextSegment>> matches = store.search(request).matches();
+
+        // then: all entries should be returned (filter == null matches everything)
+        assertThat(matches).hasSize(2);
+    }
+
+    @Test
+    void should_not_throw_when_remove_all_by_filter_on_mixed_store() {
+
+        // given
+        TextSegment matchingSegment = TextSegment.from("matching", Metadata.from("type", "a"));
+        TextSegment nonMatchingSegment = TextSegment.from("non-matching", Metadata.from("type", "b"));
+
+        InMemoryEmbeddingStore<TextSegment> store = new InMemoryEmbeddingStore<>();
+        store.add("1", dummyEmbedding(), matchingSegment);
+        store.add("2", dummyEmbedding(), nonMatchingSegment);
+        store.add("3", dummyEmbedding()); // null embedded
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        InMemoryEmbeddingStore.Entry rawEntry = new InMemoryEmbeddingStore.Entry(
+                "4", dummyEmbedding(), "not-a-text-segment");
+        store.entries.add(rawEntry);
+
+        // when: removeAll with filter — should not throw
+        assertThatNoException().isThrownBy(() -> store.removeAll(metadataKey("type").isEqualTo("a")));
+
+        // then: only the matching TextSegment should be removed; others remain
+        assertThat(store.entries).hasSize(3);
+        List<String> remainingIds =
+                store.entries.stream().map(e -> e.id).toList();
+        assertThat(remainingIds).containsExactlyInAnyOrder("2", "3", "4");
+    }
+
+    @Test
+    void should_not_throw_when_filter_matches_nothing_in_mixed_store() {
+
+        // given
+        TextSegment segment = TextSegment.from("text", Metadata.from("type", "b"));
+        InMemoryEmbeddingStore<TextSegment> store = new InMemoryEmbeddingStore<>();
+        store.add("1", dummyEmbedding(), segment);
+        store.add("2", dummyEmbedding()); // null embedded
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        InMemoryEmbeddingStore.Entry rawEntry = new InMemoryEmbeddingStore.Entry(
+                "3", dummyEmbedding(), "not-a-text-segment");
+        store.entries.add(rawEntry);
+
+        // when: removeAll with filter that matches nothing
+        assertThatNoException().isThrownBy(
+                () -> store.removeAll(metadataKey("type").isEqualTo("no-such-value")));
+
+        // then: all entries should remain
+        assertThat(store.entries).hasSize(3);
+    }
+}


### PR DESCRIPTION
## Issue
Fixes #5407

## Change
Fixes an inconsistency in `InMemoryEmbeddingStore` when metadata filters are used with entries whose embedded object is not a `TextSegment`.

Previously, non-`TextSegment` entries could either bypass the filter during `search()` or cause `removeAll(Filter)` to throw `UnsupportedOperationException`.

This PR:
- Extracts a shared `matchesFilter()` helper
- Returns `false` for non-`TextSegment` entries when a filter is present
- Applies the same filtering behavior to both `search()` and `removeAll(Filter)`
- Adds `InMemoryEmbeddingStoreFilterRegressionTest` covering mixed stores

## ⚠️ Potential issues for users (behavioral change)

This PR changes the behavior of **`search(...)`** for non-`TextSegment` entries when a filter is applied.

### What changed

`InMemoryEmbeddingStore<Embedded>` is generic and can hold entries whose embedded object is `null` (e.g. added via `add(id, embedding)` / `add(embedding)`) or some non-`TextSegment` type. Filters operate on `TextSegment` metadata, so they have nothing to test against for these entries.

| Operation | Entry type | Before | After |
|---|---|---|---|
| `search` (with filter) | `TextSegment` | filtered on metadata | filtered on metadata (unchanged) |
| `search` (with filter) | `null` / non-`TextSegment` | **included** in results | **excluded** from results |
| `search` (no filter) | any | included | included (unchanged) |
| `removeAll(filter)` | non-`TextSegment` (non-null) | **threw** `UnsupportedOperationException` | not removed (no throw) |
| `removeAll(filter)` | `null` | not removed | not removed (unchanged) |

### Who is affected

- The common case — `InMemoryEmbeddingStore<TextSegment>` where every entry carries metadata — is **not affected**.
- Affected only if you run a **filtered search** over a store that contains `null`-embedded entries or non-`TextSegment` embedded objects. Such entries that previously slipped through a filtered search will now be omitted, so a filtered query may return fewer (or zero) results than before.

### Why this is the intended behavior

The new semantics are consistent across both methods: an entry with no filterable metadata is treated as **not matching the filter** — so it is excluded from `search` results and left in place by `removeAll`. The previous `search` behavior (returning metadata-less entries from a metadata-filtered query) was effectively a bug, and `removeAll` previously threw for the same entries. This change unifies them.

### Migration

If you relied on filtered `search` returning non-`TextSegment`/`null`-embedded entries, either:
- run the search **without a filter** and apply your own post-filtering, or
- ensure the entries you want returned are stored as `TextSegment`s with appropriate metadata.

The behavior is now documented in the javadoc of `search`, `removeAll(Filter)`, and the `matchesFilter` helper.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
N/A

## Checklist for adding new embedding store integration
N/A

## Checklist for changing existing embedding store integration
N/A

## Verification
GitHub Actions passed:
- `compile_and_unit_test (17)`
- `compile_and_unit_test (21)`
- `compile_and_unit_test (25)`
- `integration_test (21)`
- `spotless`
- `compliance`
- `check-split-packages`
