### PR TITLE
Add reflection config for `ImageUsage` and related classes.

### DIFF
--- a/langchain4j-open-ai/src/main/resources/META-INF/native-image/dev.langchain4j/langchain4j-open-ai/reflect-config.json
+++ b/langchain4j-open-ai/src/main/resources/META-INF/native-image/dev.langchain4j/langchain4j-open-ai/reflect-config.json
@@ -414,6 +414,42 @@
     "allPublicFields": true
   },
   {
+      "name": "dev.langchain4j.model.openai.internal.image.ImageUsage",
+      "allDeclaredConstructors": true,
+      "allPublicConstructors": true,
+      "allDeclaredMethods": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true,
+      "allPublicFields": true
+  },
+  {
+      "name": "dev.langchain4j.model.openai.internal.image.ImageUsage$Builder",
+      "allDeclaredConstructors": true,
+      "allPublicConstructors": true,
+      "allDeclaredMethods": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true,
+      "allPublicFields": true
+  },
+  {
+      "name": "dev.langchain4j.model.openai.internal.image.ImageUsage$TokensDetails",
+      "allDeclaredConstructors": true,
+      "allPublicConstructors": true,
+      "allDeclaredMethods": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true,
+      "allPublicFields": true
+  },
+  {
+      "name": "dev.langchain4j.model.openai.internal.image.ImageUsage$TokensDetails$TokensDetailsBuilder",
+      "allDeclaredConstructors": true,
+      "allPublicConstructors": true,
+      "allDeclaredMethods": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true,
+      "allPublicFields": true
+  },
+  {
     "name": "dev.langchain4j.model.openai.internal.moderation.Categories",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,


### PR DESCRIPTION
This is a follow-on to #5373. These new builder classes should have been registered for reflection.