### PR TITLE
chore: update google-genai dependency to 1.58.0

### DIFF
--- a/langchain4j-google-genai/pom.xml
+++ b/langchain4j-google-genai/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.google.genai</groupId>
             <artifactId>google-genai</artifactId>
-            <version>1.57.0</version>
+            <version>1.58.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps `com.google.genai:google-genai` dependency version to the latest `1.58.0`.