### PR TITLE
fix(tests): normalize JAR entry path separators for Windows compatibility

### DIFF
--- a/langchain4j-skills/src/test/java/dev/langchain4j/skills/ClassPathSkillLoaderTest.java
+++ b/langchain4j-skills/src/test/java/dev/langchain4j/skills/ClassPathSkillLoaderTest.java
@@ -144,7 +144,7 @@ class ClassPathSkillLoaderTest {
                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
                     String entryName = "skills/" + sourceDir.relativize(dir) + "/";
                     if (!entryName.equals("skills//")) {
-                        jos.putNextEntry(new JarEntry(entryName));
+                        jos.putNextEntry(new JarEntry(entryName.replaceAll("\\\\", "/")));
                         jos.closeEntry();
                     } else {
                         jos.putNextEntry(new JarEntry("skills/"));
@@ -156,7 +156,7 @@ class ClassPathSkillLoaderTest {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                     String entryName = "skills/" + sourceDir.relativize(file);
-                    jos.putNextEntry(new JarEntry(entryName));
+                    jos.putNextEntry(new JarEntry(entryName.replaceAll("\\\\", "/")));
                     Files.copy(file, jos);
                     jos.closeEntry();
                     return FileVisitResult.CONTINUE;


### PR DESCRIPTION
## Issue

Closes #

## Change

This replaces Windows backslash path separators with forward slashes in JarEntry names. This is a fix for Windows compatibility - on Windows, Path.relativize() returns paths with \ separators, but JAR entries always use /.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
