### PR TITLE
Fix: Log exceptions when tool execution fails

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -118,7 +118,7 @@ public class DefaultToolExecutor implements ToolExecutor {
                     throw new ToolExecutionException(e2.getCause());
                 } else {
                     Throwable cause = e2.getCause();
-                    log.error("Error executing tool '{}': {}", methodToInvoke.getName(), cause.getMessage(), cause);
+                    log.warn("Error executing tool '{}': {}", request.name(), cause.getMessage(), cause);
                     return ToolExecutionResult.builder()
                             .isError(true)
                             .resultText(errorMessage(cause))
@@ -130,7 +130,7 @@ public class DefaultToolExecutor implements ToolExecutor {
                 throw new ToolExecutionException(e.getCause());
             } else {
                 Throwable cause = e.getCause();
-                log.error("Error executing tool '{}': {}", methodToInvoke.getName(), cause.getMessage(), cause);
+                log.warn("Error executing tool '{}': {}", request.name(), cause.getMessage(), cause);
                 return ToolExecutionResult.builder()
                         .isError(true)
                         .resultText(errorMessage(cause))

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -32,8 +32,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultToolExecutor implements ToolExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultToolExecutor.class);
 
     private final Object object;
     private final Method originalMethod;
@@ -113,9 +117,11 @@ public class DefaultToolExecutor implements ToolExecutor {
                 if (propagateToolExecutionExceptions) {
                     throw new ToolExecutionException(e2.getCause());
                 } else {
+                    Throwable cause = e2.getCause();
+                    log.error("Error executing tool '{}': {}", methodToInvoke.getName(), cause.getMessage(), cause);
                     return ToolExecutionResult.builder()
                             .isError(true)
-                            .resultText(errorMessage(e2.getCause()))
+                            .resultText(errorMessage(cause))
                             .build();
                 }
             }
@@ -123,9 +129,11 @@ public class DefaultToolExecutor implements ToolExecutor {
             if (propagateToolExecutionExceptions) {
                 throw new ToolExecutionException(e.getCause());
             } else {
+                Throwable cause = e.getCause();
+                log.error("Error executing tool '{}': {}", methodToInvoke.getName(), cause.getMessage(), cause);
                 return ToolExecutionResult.builder()
                         .isError(true)
-                        .resultText(errorMessage(e.getCause()))
+                        .resultText(errorMessage(cause))
                         .build();
             }
         }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -32,12 +32,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DefaultToolExecutor implements ToolExecutor {
-
-    private static final Logger log = LoggerFactory.getLogger(DefaultToolExecutor.class);
 
     private final Object object;
     private final Method originalMethod;
@@ -117,11 +113,9 @@ public class DefaultToolExecutor implements ToolExecutor {
                 if (propagateToolExecutionExceptions) {
                     throw new ToolExecutionException(e2.getCause());
                 } else {
-                    Throwable cause = e2.getCause();
-                    log.warn("Error executing tool '{}': {}", request.name(), cause.getMessage(), cause);
                     return ToolExecutionResult.builder()
                             .isError(true)
-                            .resultText(errorMessage(cause))
+                            .resultText(errorMessage(e2.getCause()))
                             .build();
                 }
             }
@@ -129,11 +123,9 @@ public class DefaultToolExecutor implements ToolExecutor {
             if (propagateToolExecutionExceptions) {
                 throw new ToolExecutionException(e.getCause());
             } else {
-                Throwable cause = e.getCause();
-                log.warn("Error executing tool '{}': {}", request.name(), cause.getMessage(), cause);
                 return ToolExecutionResult.builder()
                         .isError(true)
-                        .resultText(errorMessage(cause))
+                        .resultText(errorMessage(e.getCause()))
                         .build();
             }
         }

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolArgumentsErrorHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolArgumentsErrorHandler.java
@@ -1,8 +1,8 @@
 package dev.langchain4j.service.tool;
 
-import java.util.function.Function;
 import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.service.AiServices;
+import java.util.function.Function;
 
 /**
  * Handler for {@link ToolArgumentsException}s thrown by a {@link ToolExecutor}.

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolErrorContext.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolErrorContext.java
@@ -2,10 +2,10 @@ package dev.langchain4j.service.tool;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
-import java.util.Objects;
-import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.invocation.InvocationParameters;
+import java.util.Objects;
 
 /**
  * @since 1.4.0
@@ -71,11 +71,10 @@ public class ToolErrorContext {
 
     @Override
     public String toString() {
-        return "ToolErrorContext{" +
-                "toolExecutionRequest=" + toolExecutionRequest +
-                ", invocationContext=" + invocationContext +
-                ", rawError=" + rawError +
-                '}';
+        return "ToolErrorContext{" + "toolExecutionRequest="
+                + toolExecutionRequest + ", invocationContext="
+                + invocationContext + ", rawError="
+                + rawError + '}';
     }
 
     public static Builder builder() {
@@ -113,9 +112,8 @@ public class ToolErrorContext {
          */
         @Deprecated(since = "1.5.0")
         public Builder memoryId(Object memoryId) {
-            this.invocationContext = InvocationContext.builder()
-                    .chatMemoryId(memoryId)
-                    .build();
+            this.invocationContext =
+                    InvocationContext.builder().chatMemoryId(memoryId).build();
             return this;
         }
 

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionErrorHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionErrorHandler.java
@@ -1,8 +1,8 @@
 package dev.langchain4j.service.tool;
 
-import java.util.function.Function;
 import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.service.AiServices;
+import java.util.function.Function;
 
 /**
  * Handler for {@link ToolExecutionException}s thrown by a {@link ToolExecutor}.

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -57,9 +57,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Internal
 public class ToolService {
+
+    private static final Logger log = LoggerFactory.getLogger(ToolService.class);
 
     private static final ToolArgumentsErrorHandler DEFAULT_TOOL_ARGUMENTS_ERROR_HANDLER = (error, context) -> {
         if (error instanceof RuntimeException re) {
@@ -772,7 +776,9 @@ public class ToolService {
             if (e instanceof ToolArgumentsException) {
                 errorHandlerResult = argumentsErrorHandler.handle(getCause(e), errorContext);
             } else {
-                errorHandlerResult = executionErrorHandler.handle(getCause(e), errorContext);
+                Throwable cause = getCause(e);
+                log.error("Error executing tool '{}': {}", toolRequest.name(), errorMessage(cause), e);
+                errorHandlerResult = executionErrorHandler.handle(cause, errorContext);
             }
 
             return ToolExecutionResult.builder()
@@ -795,6 +801,15 @@ public class ToolService {
     private static Throwable getCause(Exception e) {
         Throwable cause = e.getCause();
         return cause != null ? cause : e;
+    }
+
+    private static String errorMessage(Throwable throwable) {
+        if (throwable == null) {
+            return "unknown error";
+        }
+
+        String message = throwable.getMessage();
+        return isNullOrBlank(message) ? throwable.getClass().getName() : message;
     }
 
     public ToolExecutionResult applyToolHallucinationStrategy(ToolExecutionRequest toolRequest) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -73,8 +73,14 @@ public class ToolService {
         }
     };
     private static final ToolExecutionErrorHandler DEFAULT_TOOL_EXECUTION_ERROR_HANDLER = (error, context) -> {
-        String errorMessage =
-                isNullOrBlank(error.getMessage()) ? error.getClass().getName() : error.getMessage();
+        String errorMessage = errorMessage(error);
+        log.warn(
+                "Tool '{}' execution failed. The error message is being returned to the LLM. "
+                        + "To customize this behavior (and silence this log), configure a custom "
+                        + "ToolExecutionErrorHandler via AiServices.toolExecutionErrorHandler(...). Error: {}",
+                context.toolExecutionRequest().name(),
+                errorMessage,
+                error);
         return ToolErrorHandlerResult.text(errorMessage);
     };
 
@@ -776,9 +782,7 @@ public class ToolService {
             if (e instanceof ToolArgumentsException) {
                 errorHandlerResult = argumentsErrorHandler.handle(getCause(e), errorContext);
             } else {
-                Throwable cause = getCause(e);
-                log.error("Error executing tool '{}': {}", toolRequest.name(), errorMessage(cause), e);
-                errorHandlerResult = executionErrorHandler.handle(cause, errorContext);
+                errorHandlerResult = executionErrorHandler.handle(getCause(e), errorContext);
             }
 
             return ToolExecutionResult.builder()

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -718,7 +718,7 @@ class DefaultToolExecutorTest implements WithAssertions {
     }
 
     @Test
-    void should_log_exception_when_tool_execution_fails() throws Exception {
+    void should_return_error_result_when_tool_execution_fails() throws Exception {
         ToolWithException tool = new ToolWithException();
         Method method = ToolWithException.class.getMethod("throwingTool", String.class);
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -709,4 +709,31 @@ class DefaultToolExecutorTest implements WithAssertions {
                 .isThrownBy(() -> executor.execute(request, "DEFAULT"))
                 .withCauseInstanceOf(IllegalArgumentException.class);
     }
+
+    static class ToolWithException {
+        @Tool("Tool that throws exception")
+        public String throwingTool(String input) {
+            throw new RuntimeException("Test exception with details");
+        }
+    }
+
+    @Test
+    void should_log_exception_when_tool_execution_fails() throws Exception {
+        ToolWithException tool = new ToolWithException();
+        Method method = ToolWithException.class.getMethod("throwingTool", String.class);
+
+        DefaultToolExecutor executor = new DefaultToolExecutor(tool, method);
+
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .id("1")
+                .name("throwingTool")
+                .arguments("{\"arg0\": \"test\"}")
+                .build();
+
+        ToolExecutionResult result =
+                executor.executeWithContext(request, InvocationContext.builder().build());
+
+        assertThat(result.isError()).isTrue();
+        assertThat(result.resultText()).isEqualTo("Test exception with details");
+    }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolErrorLoggingTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolErrorLoggingTest.java
@@ -1,0 +1,85 @@
+package dev.langchain4j.service.tool;
+
+import static dev.langchain4j.service.tool.ToolService.executeWithErrorHandling;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+
+/**
+ * Verifies that tool execution errors are logged only in the default configuration (when the exception
+ * is also sent to the LLM), and not when the user customizes the error-handling behavior.
+ * <p>
+ * These tests capture {@link System#err} (the default tinylog destination for WARN), so the whole class
+ * runs {@link Isolated} and single-threaded to avoid races with the otherwise parallel test suite.
+ */
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class ToolErrorLoggingTest {
+
+    private static final ToolExecutionRequest DUMMY_REQUEST =
+            ToolExecutionRequest.builder().name("test").arguments("{}").build();
+
+    private static final InvocationContext DUMMY_CONTEXT =
+            InvocationContext.builder().build();
+
+    private static final ToolArgumentsErrorHandler DEFAULT_ARGS_HANDLER = (error, ctx) -> {
+        if (error instanceof RuntimeException re) throw re;
+        throw new RuntimeException(error);
+    };
+
+    @Test
+    void default_execution_error_handler_logs_exception_at_warn() {
+        ToolExecutor executor = (req, ctx) -> {
+            throw new IllegalStateException("default-handler-failure");
+        };
+        ToolExecutionErrorHandler defaultHandler = new ToolService().executionErrorHandler();
+
+        String logOutput = captureStdErr(() ->
+                executeWithErrorHandling(DUMMY_REQUEST, executor, DUMMY_CONTEXT, DEFAULT_ARGS_HANDLER, defaultHandler));
+
+        assertThat(logOutput)
+                .as(
+                        "default behavior must log the exception (with stack trace) so the user sees what was sent to the LLM")
+                .contains("WARN")
+                .contains("test")
+                .contains("default-handler-failure")
+                .contains(IllegalStateException.class.getName());
+    }
+
+    @Test
+    void custom_execution_error_handler_does_not_log() {
+        ToolExecutor executor = (req, ctx) -> {
+            throw new IllegalStateException("custom-handler-failure");
+        };
+        ToolExecutionErrorHandler customHandler = (error, ctx) -> ToolErrorHandlerResult.text("handled by custom");
+
+        String logOutput = captureStdErr(() ->
+                executeWithErrorHandling(DUMMY_REQUEST, executor, DUMMY_CONTEXT, DEFAULT_ARGS_HANDLER, customHandler));
+
+        assertThat(logOutput)
+                .as("when the user customizes the error handler, the framework must not log the exception")
+                .doesNotContain("custom-handler-failure")
+                .doesNotContain(IllegalStateException.class.getName());
+    }
+
+    private static String captureStdErr(Supplier<?> action) {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            action.get();
+        } finally {
+            System.setErr(originalErr);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
@@ -1,32 +1,30 @@
 package dev.langchain4j.service.tool;
 
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
-import dev.langchain4j.invocation.InvocationContext;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.function.Consumer;
-
 import static dev.langchain4j.service.tool.ToolService.executeWithErrorHandling;
 import static dev.langchain4j.service.tool.ToolService.shouldReturnImmediately;
 import static org.assertj.core.api.Assertions.*;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
 class ToolServiceTest {
 
-    private static final ToolExecutionRequest DUMMY_REQUEST = ToolExecutionRequest.builder()
-            .name("test")
-            .arguments("{}")
-            .build();
+    private static final ToolExecutionRequest DUMMY_REQUEST =
+            ToolExecutionRequest.builder().name("test").arguments("{}").build();
 
-    private static final InvocationContext DUMMY_CONTEXT = InvocationContext.builder().build();
+    private static final InvocationContext DUMMY_CONTEXT =
+            InvocationContext.builder().build();
 
     private static final ToolArgumentsErrorHandler DEFAULT_ARGS_HANDLER = (error, ctx) -> {
         if (error instanceof RuntimeException re) throw re;
         throw new RuntimeException(error);
     };
 
-    private static final ToolExecutionErrorHandler DEFAULT_EXEC_HANDLER = (error, ctx) ->
-            ToolErrorHandlerResult.text(error.getMessage());
+    private static final ToolExecutionErrorHandler DEFAULT_EXEC_HANDLER =
+            (error, ctx) -> ToolErrorHandlerResult.text(error.getMessage());
 
     @Test
     void shouldReturnImmediately_empty_list_should_not_crash() {
@@ -38,7 +36,9 @@ class ToolServiceTest {
     @Test
     void text_factory_returns_error_result() {
         RuntimeException original = new RuntimeException("fail");
-        ToolExecutor executor = (req, ctx) -> { throw original; };
+        ToolExecutor executor = (req, ctx) -> {
+            throw original;
+        };
 
         ToolExecutionResult result = executeWithErrorHandling(
                 DUMMY_REQUEST, executor, DUMMY_CONTEXT, DEFAULT_ARGS_HANDLER, DEFAULT_EXEC_HANDLER);
@@ -52,7 +52,9 @@ class ToolServiceTest {
     @Test
     void rawError_available_in_context() {
         RuntimeException original = new RuntimeException("outer", new IllegalArgumentException("inner"));
-        ToolExecutor executor = (req, ctx) -> { throw original; };
+        ToolExecutor executor = (req, ctx) -> {
+            throw original;
+        };
 
         ToolExecutionErrorHandler handler = (error, ctx) -> {
             assertThat(ctx.rawError()).isSameAs(original);
@@ -60,8 +62,8 @@ class ToolServiceTest {
             return ToolErrorHandlerResult.text("handled");
         };
 
-        ToolExecutionResult result = executeWithErrorHandling(
-                DUMMY_REQUEST, executor, DUMMY_CONTEXT, DEFAULT_ARGS_HANDLER, handler);
+        ToolExecutionResult result =
+                executeWithErrorHandling(DUMMY_REQUEST, executor, DUMMY_CONTEXT, DEFAULT_ARGS_HANDLER, handler);
 
         assertThat(result.isError()).isTrue();
     }
@@ -80,7 +82,9 @@ class ToolServiceTest {
     void rawError_differs_from_cause() {
         IllegalArgumentException cause = new IllegalArgumentException("bad arg");
         RuntimeException wrapper = new RuntimeException("wrapper", cause);
-        ToolExecutor executor = (req, ctx) -> { throw wrapper; };
+        ToolExecutor executor = (req, ctx) -> {
+            throw wrapper;
+        };
 
         ToolExecutionErrorHandler handler = (error, ctx) -> {
             assertThat(error).isSameAs(cause);
@@ -94,14 +98,16 @@ class ToolServiceTest {
     @Test
     void rawError_allows_handler_to_throw_directly() {
         RuntimeException original = new IllegalStateException("critical");
-        ToolExecutor executor = (req, ctx) -> { throw original; };
+        ToolExecutor executor = (req, ctx) -> {
+            throw original;
+        };
 
         ToolExecutionErrorHandler handler = (error, ctx) -> {
             throw (RuntimeException) ctx.rawError();
         };
 
-        assertThatThrownBy(() -> executeWithErrorHandling(
-                DUMMY_REQUEST, executor, DUMMY_CONTEXT, DEFAULT_ARGS_HANDLER, handler))
+        assertThatThrownBy(() ->
+                        executeWithErrorHandling(DUMMY_REQUEST, executor, DUMMY_CONTEXT, DEFAULT_ARGS_HANDLER, handler))
                 .isSameAs(original);
     }
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.service.tool.ToolService.shouldReturnImmediately;
 import static org.assertj.core.api.Assertions.*;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.invocation.InvocationContext;
 import java.util.List;
 import java.util.function.Consumer;
@@ -45,6 +46,26 @@ class ToolServiceTest {
 
         assertThat(result.isError()).isTrue();
         assertThat(result.resultText()).isEqualTo("fail");
+    }
+
+    @Test
+    void propagated_tool_execution_exception_is_unwrapped() {
+        RuntimeException original = new RuntimeException("boom");
+        ToolExecutor executor = (req, ctx) -> {
+            throw new ToolExecutionException(original);
+        };
+
+        ToolExecutionErrorHandler handler = (error, ctx) -> {
+            assertThat(error).isSameAs(original);
+            assertThat(ctx.rawError()).isInstanceOf(ToolExecutionException.class).hasCause(original);
+            return ToolErrorHandlerResult.text(error.getMessage());
+        };
+
+        ToolExecutionResult result =
+                executeWithErrorHandling(DUMMY_REQUEST, executor, DUMMY_CONTEXT, DEFAULT_ARGS_HANDLER, handler);
+
+        assertThat(result.isError()).isTrue();
+        assertThat(result.resultText()).isEqualTo("boom");
     }
 
     // --- rawError tests ---

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolServiceTest.java
@@ -57,7 +57,9 @@ class ToolServiceTest {
 
         ToolExecutionErrorHandler handler = (error, ctx) -> {
             assertThat(error).isSameAs(original);
-            assertThat(ctx.rawError()).isInstanceOf(ToolExecutionException.class).hasCause(original);
+            assertThat(ctx.rawError())
+                    .isInstanceOf(ToolExecutionException.class)
+                    .hasCause(original);
             return ToolErrorHandlerResult.text(error.getMessage());
         };
 


### PR DESCRIPTION
## Issue
Fixes #5402

## Change
When a `@Tool` method throws an exception and the default tool-execution error handling is in effect (the default configuration), the exception was silently swallowed — only its message was forwarded to the LLM, with no logging — making debugging extremely difficult.

This PR adds error logging with full stack traces when tool execution fails in the default configuration. The behavior for the LLM remains unchanged — it still receives the error message as before. Only developers now get proper logging to debug issues.

Crucially, logging happens only in the default configuration. When the user customizes error handling by configuring a `ToolExecutionErrorHandler` (via `AiServices.toolExecutionErrorHandler(...)`), the framework does not log — the custom handler is fully responsible for how errors are reported. This is enforced structurally: the logging lives inside the default handler itself, so a custom handler cannot trigger it.

Changes:
- Log tool execution failures with full stack traces at `WARN` level in the default `ToolExecutionErrorHandler` (`ToolService`)
- No framework logging when a custom `ToolExecutionErrorHandler` is configured
- Added tests verifying that the default configuration logs the exception (with stack trace) and that a custom handler does not

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)