### PR TITLE
fix: swapped account and container names in Azure Blob Storage document source URL 

### DIFF
--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.data.document.loader.azure.storage.blob;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.BlobProperties;
@@ -8,13 +10,10 @@ import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentLoader;
 import dev.langchain4j.data.document.DocumentParser;
 import dev.langchain4j.data.document.source.azure.storage.blob.AzureBlobStorageSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AzureBlobStorageDocumentLoader {
 
@@ -27,10 +26,12 @@ public class AzureBlobStorageDocumentLoader {
     }
 
     public Document loadDocument(String containerName, String blobName, DocumentParser parser) {
-        BlobClient blobClient = blobServiceClient.getBlobContainerClient(containerName).getBlobClient(blobName);
+        BlobClient blobClient =
+                blobServiceClient.getBlobContainerClient(containerName).getBlobClient(blobName);
         BlobProperties properties = blobClient.getProperties();
         BlobInputStream blobInputStream = blobClient.openInputStream();
-        AzureBlobStorageSource source = new AzureBlobStorageSource(blobInputStream, containerName, blobClient.getAccountName(), blobName, properties);
+        AzureBlobStorageSource source = new AzureBlobStorageSource(
+                blobInputStream, containerName, blobClient.getAccountName(), blobName, properties);
         return DocumentLoader.load(source, parser);
     }
 
@@ -45,15 +46,14 @@ public class AzureBlobStorageDocumentLoader {
     public List<Document> loadDocuments(String containerName, DocumentParser parser) {
         List<Document> documents = new ArrayList<>();
 
-        blobServiceClient.getBlobContainerClient(containerName)
-                .listBlobs()
-                .forEach(blob -> {
-                    try {
-                        documents.add(loadDocument(containerName, blob.getName(), parser));
-                    } catch (Exception e) {
-                        log.warn("Failed to load blob '{}' from container '{}', skipping it.", blob.getName(), containerName, e);
-                    }
-                });
+        blobServiceClient.getBlobContainerClient(containerName).listBlobs().forEach(blob -> {
+            try {
+                documents.add(loadDocument(containerName, blob.getName(), parser));
+            } catch (Exception e) {
+                log.warn(
+                        "Failed to load blob '{}' from container '{}', skipping it.", blob.getName(), containerName, e);
+            }
+        });
 
         return documents;
     }

--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
@@ -30,7 +30,7 @@ public class AzureBlobStorageDocumentLoader {
         BlobClient blobClient = blobServiceClient.getBlobContainerClient(containerName).getBlobClient(blobName);
         BlobProperties properties = blobClient.getProperties();
         BlobInputStream blobInputStream = blobClient.openInputStream();
-        AzureBlobStorageSource source = new AzureBlobStorageSource(blobInputStream, blobClient.getAccountName(), containerName, blobName, properties);
+        AzureBlobStorageSource source = new AzureBlobStorageSource(blobInputStream, containerName, blobClient.getAccountName(), blobName, properties);
         return DocumentLoader.load(source, parser);
     }
 

--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/src/test/java/dev/langchain4j/data/document/loader/azure/storage/blob/LocalAzureBlobStorageDocumentLoaderIT.java
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/src/test/java/dev/langchain4j/data/document/loader/azure/storage/blob/LocalAzureBlobStorageDocumentLoaderIT.java
@@ -32,6 +32,7 @@ class LocalAzureBlobStorageDocumentLoaderIT {
                     "0.0.0.0") // remove the version check because of https://github.com/Azure/Azurite/issues/2623
             .withExposedPorts(AZURE_STORAGE_BLOB_PORT);
 
+    private static final String TEST_ACCOUNT = "devstoreaccount1";
     private static final String TEST_CONTAINER = "test-container";
     private static final String TEST_BLOB = "test-file.txt";
     private static final String TEST_BLOB_2 = "test-directory/test-file-2.txt";
@@ -70,7 +71,8 @@ class LocalAzureBlobStorageDocumentLoaderIT {
 
         assertThat(document.text()).isEqualTo(TEST_CONTENT);
         assertThat(document.metadata().toMap()).hasSize(4);
-        assertThat(document.metadata().getString("source")).endsWith("/test-file.txt");
+        assertThat(document.metadata().getString("source"))
+                .isEqualTo("https://" + TEST_ACCOUNT + ".blob.core.windows.net/" + TEST_CONTAINER + "/" + TEST_BLOB);
     }
 
     @Test
@@ -82,11 +84,13 @@ class LocalAzureBlobStorageDocumentLoaderIT {
 
         assertThat(documents.get(0).text()).isEqualTo(TEST_CONTENT_2);
         assertThat(documents.get(0).metadata().toMap()).hasSize(4);
-        assertThat(documents.get(0).metadata().getString("source")).endsWith("/test-directory/test-file-2.txt");
+        assertThat(documents.get(0).metadata().getString("source"))
+                .isEqualTo("https://" + TEST_ACCOUNT + ".blob.core.windows.net/" + TEST_CONTAINER + "/" + TEST_BLOB_2);
 
         assertThat(documents.get(1).text()).isEqualTo(TEST_CONTENT);
         assertThat(documents.get(1).metadata().toMap()).hasSize(4);
-        assertThat(documents.get(1).metadata().getString("source")).endsWith("/test-file.txt");
+        assertThat(documents.get(1).metadata().getString("source"))
+                .isEqualTo("https://" + TEST_ACCOUNT + ".blob.core.windows.net/" + TEST_CONTAINER + "/" + TEST_BLOB);
     }
 
     @AfterAll


### PR DESCRIPTION
## Issue
Closes #5429

## Change

`AzureBlobStorageDocumentLoader.loadDocument()` passed `accountName` and `containerName` in the wrong order to the `AzureBlobStorageSource` constructor, producing incorrect `source` metadata URLs.

- `AzureBlobStorageDocumentLoader.loadDocument()` (line 33): swapped 2nd/3rd arguments so they match the constructor signature `(InputStream, containerName, accountName, blobName, properties)`.
- `LocalAzureBlobStorageDocumentLoaderIT`: tightened `source` assertions from `.endsWith(...)` to `.isEqualTo(...)` with the full canonical URL `https://devstoreaccount1.blob.core.windows.net/test-container/<blob>`.
- `AzureBlobStorageSource.java` is correct and was not modified.

> **Spotless caveat:** `spotless:apply` cannot run on JDK 25; human must run `./mvnw -Pspotless spotless:apply -pl document-loaders/langchain4j-document-loader-azure-storage-blob` on JDK 17 before submitting.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases <!-- N/A — only positive assertion was strengthened; no explicit negative case added -->
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- N/A — not run by pipeline -->
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green <!-- N/A — not run by pipeline -->
- [ ] I have added/updated the documentation <!-- N/A — bug fix only, no public API change -->
- [ ] I have added an example in the examples repo (only for "big" features) <!-- N/A — bug fix, not a new feature -->
- [ ] I have added/updated Spring Boot starter(s) (if applicable) <!-- N/A — no starter affected -->

<!-- omit the "new maven module" and "embedding store integration" conditional sections — not applicable. -->
