### PR TITLE
fix: Validate bucket and key in TencentCosDocumentLoader.loadDocument

### DIFF
--- a/document-loaders/langchain4j-document-loader-tencent-cos/src/main/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-tencent-cos/src/main/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoader.java
@@ -1,5 +1,9 @@
 package dev.langchain4j.data.document.loader.tencent.cos;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.util.stream.Collectors.toList;
+
 import com.qcloud.cos.COSClient;
 import com.qcloud.cos.ClientConfig;
 import com.qcloud.cos.auth.COSCredentialsProvider;
@@ -9,15 +13,10 @@ import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentLoader;
 import dev.langchain4j.data.document.DocumentParser;
 import dev.langchain4j.data.document.source.tencent.cos.TencentCosSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static java.util.stream.Collectors.toList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TencentCosDocumentLoader {
 
@@ -38,7 +37,8 @@ public class TencentCosDocumentLoader {
      * @return A document containing the content of the COS object.
      */
     public Document loadDocument(String bucket, String key, DocumentParser parser) {
-        GetObjectRequest getObjectRequest = new GetObjectRequest(bucket, key);
+        GetObjectRequest getObjectRequest =
+                new GetObjectRequest(ensureNotBlank(bucket, "bucket"), ensureNotBlank(key, "key"));
         COSObject cosObject = cosClient.getObject(getObjectRequest);
         TencentCosSource source = new TencentCosSource(cosObject.getObjectContent(), bucket, key);
 
@@ -149,6 +149,5 @@ public class TencentCosDocumentLoader {
             ClientConfig clientConfig = new ClientConfig(region);
             return new COSClient(cosCredentialsProvider, clientConfig);
         }
-
     }
 }

--- a/document-loaders/langchain4j-document-loader-tencent-cos/src/test/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoaderTest.java
+++ b/document-loaders/langchain4j-document-loader-tencent-cos/src/test/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoaderTest.java
@@ -1,0 +1,39 @@
+package dev.langchain4j.data.document.loader.tencent.cos;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import com.qcloud.cos.COSClient;
+import dev.langchain4j.data.document.DocumentParser;
+import org.junit.jupiter.api.Test;
+
+class TencentCosDocumentLoaderTest {
+
+    private final COSClient cosClient = mock(COSClient.class);
+    private final DocumentParser parser = mock(DocumentParser.class);
+    private final TencentCosDocumentLoader loader = new TencentCosDocumentLoader(cosClient);
+
+    @Test
+    void should_throw_when_bucket_is_null() {
+        assertThatThrownBy(() -> loader.loadDocument(null, "some-key", parser))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_throw_when_bucket_is_blank() {
+        assertThatThrownBy(() -> loader.loadDocument("   ", "some-key", parser))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_throw_when_key_is_null() {
+        assertThatThrownBy(() -> loader.loadDocument("some-bucket", null, parser))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_throw_when_key_is_blank() {
+        assertThatThrownBy(() -> loader.loadDocument("some-bucket", "   ", parser))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5433

## Change

`TencentCosDocumentLoader.loadDocument(String bucket, String key, DocumentParser parser)` built `new GetObjectRequest(bucket, key)` without validating arguments. This PR wraps both with `ensureNotBlank`:

```java
GetObjectRequest getObjectRequest = new GetObjectRequest(ensureNotBlank(bucket, "bucket"), ensureNotBlank(key, "key"));
```

- Mirrors `AmazonS3DocumentLoader.loadDocument()` and fixes an internal inconsistency: `loadDocuments()` already calls `ensureNotBlank(bucket, "bucket")` (line 73). No new imports.
- Spotless (`palantir 2.44.4`) applied; formatting-only lines in the diff are required by CI `spotless:check`.
- New unit test `TencentCosDocumentLoaderTest`: 4 negative cases (null/blank bucket, null/blank key) asserting `IllegalArgumentException`, using a Mockito-mocked `COSClient` (no stubbing — `ensureNotBlank` throws before any client call). All 4 pass on JDK 17 and 25.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases <!-- negative input assertions here; positive path covered by credential-gated TencentCosDocumentLoaderIT -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green <!-- N/A — single-module validation fix -->
- [ ] I have added/updated the documentation <!-- N/A — no public API change -->
- [ ] I have added an example in the examples repo (only for "big" features) <!-- N/A — minor fix -->
- [ ] I have added/updated Spring Boot starter(s) (if applicable) <!-- N/A — no starter covers this loader -->

---