### PR TITLE
fix: Decode Markdown as UTF-8 instead of the platform default charset

### DIFF
--- a/document-parsers/langchain4j-document-parser-markdown/src/main/java/dev/langchain4j/data/document/parser/markdown/MarkdownDocumentParser.java
+++ b/document-parsers/langchain4j-document-parser-markdown/src/main/java/dev/langchain4j/data/document/parser/markdown/MarkdownDocumentParser.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.data.document.parser.markdown;
 
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import dev.langchain4j.data.document.BlankDocumentException;
 import dev.langchain4j.data.document.Document;
@@ -22,7 +23,7 @@ public class MarkdownDocumentParser implements DocumentParser {
     public Document parse(final InputStream inputStream) {
         try {
             Parser parser = Parser.builder().build();
-            final Node node = parser.parseReader(new InputStreamReader(inputStream));
+            final Node node = parser.parseReader(new InputStreamReader(inputStream, UTF_8));
 
             // Renders nodes to plain text
             final TextContentRenderer renderer = TextContentRenderer.builder().build();

--- a/document-parsers/langchain4j-document-parser-markdown/src/test/java/dev/langchain4j/data/document/parser/markdown/MarkdownDocumentParserTest.java
+++ b/document-parsers/langchain4j-document-parser-markdown/src/test/java/dev/langchain4j/data/document/parser/markdown/MarkdownDocumentParserTest.java
@@ -1,12 +1,15 @@
 package dev.langchain4j.data.document.parser.markdown;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.langchain4j.data.document.BlankDocumentException;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentParser;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -33,5 +36,17 @@ public class MarkdownDocumentParserTest {
         InputStream inputStream = getClass().getClassLoader().getResourceAsStream(fileName);
 
         assertThatThrownBy(() -> parser.parse(inputStream)).isExactlyInstanceOf(BlankDocumentException.class);
+    }
+
+    @Test
+    void should_decode_multibyte_content_as_utf8() {
+
+        String markdown = "café 한글 🚀";
+        DocumentParser parser = new MarkdownDocumentParser();
+        InputStream inputStream = new ByteArrayInputStream(markdown.getBytes(UTF_8));
+
+        Document document = parser.parse(inputStream);
+
+        assertThat(document.text()).contains("café").contains("한글").contains("🚀");
     }
 }


### PR DESCRIPTION
## Issue
Closes #5435
<!-- Replace # with the real issue number before submitting. -->

## Change

`MarkdownDocumentParser.parse()` decoded input via `new InputStreamReader(inputStream)` — the JVM platform default charset — silently corrupting non-ASCII Markdown on non-UTF-8 platforms.

- Pass an explicit `UTF_8` to `InputStreamReader`, matching `TextDocumentParser` (UTF-8 default) and `YamlDocumentParser` (UTF-8 internally); other parsers in this module decode via backends and are unaffected.
- Test: a multibyte (café / 한글 / emoji) UTF-8 round-trip. The platform-default regression is not unit-testable — `Charset.defaultCharset()` is fixed at JVM start (UTF-8 on CI) — so this is positive coverage.


## General checklist
- [X] There are no breaking changes (API, behaviour) <!-- no API change; the only behaviour change is the bug fix (platform-default → UTF-8), a no-op where default is already UTF-8 -->
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases <!-- positive coverage only; the platform-default regression is not unit-testable without JVM-level charset flags -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green <!-- N/A — only the changed module was run locally; CI covers core+main -->
- [ ] I have added/updated the documentation <!-- N/A — no public API or behaviour change requiring docs -->
- [ ] I have added an example in the examples repo (only for "big" features) <!-- N/A — minor bug fix -->
- [ ] I have added/updated Spring Boot starter(s) (if applicable) <!-- N/A — no starter changes needed -->