### PR TITLE
fix: MarkdownDocumentParser uses UTF-8 instead of platform default charset

### DIFF
--- a/document-parsers/langchain4j-document-parser-markdown/src/main/java/dev/langchain4j/data/document/parser/markdown/MarkdownDocumentParser.java
+++ b/document-parsers/langchain4j-document-parser-markdown/src/main/java/dev/langchain4j/data/document/parser/markdown/MarkdownDocumentParser.java
@@ -8,6 +8,7 @@ import dev.langchain4j.data.document.DocumentParser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.text.TextContentRenderer;
@@ -22,7 +23,7 @@ public class MarkdownDocumentParser implements DocumentParser {
     public Document parse(final InputStream inputStream) {
         try {
             Parser parser = Parser.builder().build();
-            final Node node = parser.parseReader(new InputStreamReader(inputStream));
+            final Node node = parser.parseReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
 
             // Renders nodes to plain text
             final TextContentRenderer renderer = TextContentRenderer.builder().build();


### PR DESCRIPTION
## Fix #5435

`MarkdownDocumentParser.parse()` was using `new InputStreamReader(inputStream)` without specifying a charset, causing non-ASCII content to be silently corrupted on non-UTF-8 platforms. `TextDocumentParser` already correctly defaults to UTF-8.

**Fix**: Use `new InputStreamReader(inputStream, StandardCharsets.UTF_8)`.

**Change**: 1 file, 2 insertions, 1 deletion