### PR TITLE
fix: swap accountName and containerName in AzureBlobStorageDocumentLoader

### DIFF
--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.data.document.loader.azure.storage.blob;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.BlobProperties;
@@ -8,13 +10,10 @@ import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentLoader;
 import dev.langchain4j.data.document.DocumentParser;
 import dev.langchain4j.data.document.source.azure.storage.blob.AzureBlobStorageSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AzureBlobStorageDocumentLoader {
 
@@ -27,10 +26,12 @@ public class AzureBlobStorageDocumentLoader {
     }
 
     public Document loadDocument(String containerName, String blobName, DocumentParser parser) {
-        BlobClient blobClient = blobServiceClient.getBlobContainerClient(containerName).getBlobClient(blobName);
+        BlobClient blobClient =
+                blobServiceClient.getBlobContainerClient(containerName).getBlobClient(blobName);
         BlobProperties properties = blobClient.getProperties();
         BlobInputStream blobInputStream = blobClient.openInputStream();
-        AzureBlobStorageSource source = new AzureBlobStorageSource(blobInputStream, containerName, blobClient.getAccountName(), blobName, properties);
+        AzureBlobStorageSource source = new AzureBlobStorageSource(
+                blobInputStream, containerName, blobClient.getAccountName(), blobName, properties);
         return DocumentLoader.load(source, parser);
     }
 
@@ -45,15 +46,14 @@ public class AzureBlobStorageDocumentLoader {
     public List<Document> loadDocuments(String containerName, DocumentParser parser) {
         List<Document> documents = new ArrayList<>();
 
-        blobServiceClient.getBlobContainerClient(containerName)
-                .listBlobs()
-                .forEach(blob -> {
-                    try {
-                        documents.add(loadDocument(containerName, blob.getName(), parser));
-                    } catch (Exception e) {
-                        log.warn("Failed to load blob '{}' from container '{}', skipping it.", blob.getName(), containerName, e);
-                    }
-                });
+        blobServiceClient.getBlobContainerClient(containerName).listBlobs().forEach(blob -> {
+            try {
+                documents.add(loadDocument(containerName, blob.getName(), parser));
+            } catch (Exception e) {
+                log.warn(
+                        "Failed to load blob '{}' from container '{}', skipping it.", blob.getName(), containerName, e);
+            }
+        });
 
         return documents;
     }

--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
@@ -30,7 +30,7 @@ public class AzureBlobStorageDocumentLoader {
         BlobClient blobClient = blobServiceClient.getBlobContainerClient(containerName).getBlobClient(blobName);
         BlobProperties properties = blobClient.getProperties();
         BlobInputStream blobInputStream = blobClient.openInputStream();
-        AzureBlobStorageSource source = new AzureBlobStorageSource(blobInputStream, blobClient.getAccountName(), containerName, blobName, properties);
+        AzureBlobStorageSource source = new AzureBlobStorageSource(blobInputStream, containerName, blobClient.getAccountName(), blobName, properties);
         return DocumentLoader.load(source, parser);
     }
 


### PR DESCRIPTION
## Fix #5429

`AzureBlobStorageDocumentLoader.loadDocument()` was passing `accountName` and `containerName` in the wrong order to the `AzureBlobStorageSource` constructor, resulting in a source metadata URL where the account and container names were swapped.

**Fix**: Swap the 2nd and 3rd arguments to match the `AzureBlobStorageSource(InputStream, String containerName, String accountName, String blobName, BlobProperties)` constructor signature.

**Before**: `new AzureBlobStorageSource(blobInputStream, blobClient.getAccountName(), containerName, blobName, properties)`
**After**: `new AzureBlobStorageSource(blobInputStream, containerName, blobClient.getAccountName(), blobName, properties)`

**Change**: 1 file, 1 insertion, 1 deletion