### PR TITLE
fix: validate bucket and key parameters in TencentCosDocumentLoader.loadDocument()

### DIFF
--- a/document-loaders/langchain4j-document-loader-tencent-cos/src/main/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-tencent-cos/src/main/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoader.java
@@ -38,6 +38,8 @@ public class TencentCosDocumentLoader {
      * @return A document containing the content of the COS object.
      */
     public Document loadDocument(String bucket, String key, DocumentParser parser) {
+        ensureNotBlank(bucket, "bucket");
+        ensureNotBlank(key, "key");
         GetObjectRequest getObjectRequest = new GetObjectRequest(bucket, key);
         COSObject cosObject = cosClient.getObject(getObjectRequest);
         TencentCosSource source = new TencentCosSource(cosObject.getObjectContent(), bucket, key);

--- a/document-loaders/langchain4j-document-loader-tencent-cos/src/main/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-tencent-cos/src/main/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoader.java
@@ -1,5 +1,9 @@
 package dev.langchain4j.data.document.loader.tencent.cos;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.util.stream.Collectors.toList;
+
 import com.qcloud.cos.COSClient;
 import com.qcloud.cos.ClientConfig;
 import com.qcloud.cos.auth.COSCredentialsProvider;
@@ -9,15 +13,10 @@ import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentLoader;
 import dev.langchain4j.data.document.DocumentParser;
 import dev.langchain4j.data.document.source.tencent.cos.TencentCosSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static java.util.stream.Collectors.toList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TencentCosDocumentLoader {
 
@@ -151,6 +150,5 @@ public class TencentCosDocumentLoader {
             ClientConfig clientConfig = new ClientConfig(region);
             return new COSClient(cosCredentialsProvider, clientConfig);
         }
-
     }
 }


### PR DESCRIPTION
## Fix #5433

`TencentCosDocumentLoader.loadDocument()` did not validate `bucket` and `key` parameters, producing cryptic errors on null/blank input instead of descriptive `IllegalArgumentException`. The `loadDocuments()` method already validates `bucket` with `ensureNotBlank()`.

**Fix**: Add `ensureNotBlank(bucket, "bucket")` and `ensureNotBlank(key, "key")` at the start of `loadDocument()`, consistent with the pattern used in `loadDocuments()` and `AmazonS3DocumentLoader`.

**Change**: 1 file, 2 insertions