### PR TITLE
fix: infinite loop in OnnxBertBiEncoder.partition for oversized subword runs

### DIFF
--- a/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoder.java
+++ b/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoder.java
@@ -114,9 +114,13 @@ public class OnnxBertBiEncoder {
             if (to >= tokens.size() - 1) {
                 to = tokens.size() - 1;
             } else {
-                // ensure we don't split word across partitions
-                while (tokens.get(to).startsWith("##")) {
+                // ensure we don't split word across partitions, but keep at least one token of progress
+                while (to > from && tokens.get(to).startsWith("##")) {
                     to--;
+                }
+                if (to == from) {
+                    // a single word's subword run is longer than partitionSize: force a split to make progress
+                    to = from + partitionSize;
                 }
             }
 
@@ -257,12 +261,10 @@ public class OnnxBertBiEncoder {
 
     private byte[] loadModel(InputStream modelInputStream) {
         if (modelInputStream == null) {
-            throw new IllegalStateException(
-                    "Embedding model file is not available. " +
-                            "This usually happens when running LangChain4j tests from sources. " +
-                            "If you are developing LangChain4j locally, run 'mvn generate-resources' " +
-                            "from the project root to download the required model files."
-            );
+            throw new IllegalStateException("Embedding model file is not available. "
+                    + "This usually happens when running LangChain4j tests from sources. "
+                    + "If you are developing LangChain4j locally, run 'mvn generate-resources' "
+                    + "from the project root to download the required model files.");
         }
         try (InputStream inputStream = modelInputStream;
                 ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {

--- a/embeddings/langchain4j-embeddings/src/test/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoderTest.java
+++ b/embeddings/langchain4j-embeddings/src/test/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoderTest.java
@@ -6,8 +6,10 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 class OnnxBertBiEncoderTest {
 
@@ -106,5 +108,29 @@ class OnnxBertBiEncoderTest {
 
         // then - should return empty list (no content tokens between CLS and SEP)
         assertThat(partitions).isEqualTo(emptyList());
+    }
+
+    @Test
+    @Timeout(5)
+    public void testSingleWordSubwordRunLongerThanPartitionSize() {
+
+        // given - a single word whose subword run is longer than partitionSize.
+        // Previously the back-off loop that avoids splitting "##" continuations had no lower
+        // bound, so "to" descended to "from", producing an empty subList and never advancing
+        // "from" -> infinite loop / empty partitions.
+        List<String> tokens = asList("[CLS]", "super", "##cali", "##fragi", "##listic", "[SEP]");
+        int partitionSize = 1;
+
+        // when
+        List<List<String>> partitions = partition(tokens, partitionSize);
+
+        // then - terminates, no empty partition, every partition has at least one token
+        assertThat(partitions).isNotEmpty();
+        assertThat(partitions).allSatisfy(partition -> assertThat(partition).isNotEmpty());
+
+        // and - partitions cover all content tokens in order, with no loss or duplication
+        List<String> flattened = new ArrayList<>();
+        partitions.forEach(flattened::addAll);
+        assertThat(flattened).containsExactly("super", "##cali", "##fragi", "##listic");
     }
 }


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as a draft initially. Once it is reviewed and approved, we will ask you to add documentation and examples.
Please note that PRs with breaking changes or without tests will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Existing open issue #589 describes this symptom; human sets the ID (use #589, or a fresh bug issue draft is provided). -->
Closes #5453

## Change
`OnnxBertBiEncoder.partition(tokens, partitionSize)` could loop forever or emit empty partitions when a single word's subword run exceeds `partitionSize`: the `##`-back-off loop had no lower bound, so `to` descended to `from`, giving an empty `subList(from, to)` while `from = to` never advanced.

The fix bounds the back-off (keeps ≥1 token of progress) and forces a full-window split for an oversized single-word run:

```java
while (to > from && tokens.get(to).startsWith("##")) {
    to--;
}
if (to == from) {
    to = from + partitionSize;
}
```

Normal inputs are unchanged: both new conditions are inert when the back-off stops above `from`. Added a regression test (partitionSize=1, long `##` run, `@Timeout`) asserting termination, no empty partition, and full ordered token coverage.

PR #4406's `isEmpty()` guard in `embed()` masked the symptom; this fixes the root cause.

<!-- The one-line reformat of the unrelated loadModel string concat is forced by the spotless ratchet (ratchetFrom origin/main checks the whole touched file), not a gratuitous change. -->

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is isolated to the embeddings module; core/main not affected -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — internal bug fix, no public API/doc change -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A — bug fix, not a feature -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A — not applicable -->

<!-- Checklist for adding new maven module: omitted — no new module. -->
<!-- Checklist for adding/changing embedding store integration: omitted — no embedding store integration touched. -->

## Verification
- Module unit tests (JDK 17): `OnnxBertBiEncoderTest` 7 passed (6 existing + 1 new); module total 9 passed, 0 failures.
- Integration tests (`*IT`): none in this module; not run.
- spotless: `spotless:check -pl embeddings/langchain4j-embeddings` passes with JDK 17 (workaround applied: ran in main checkout because the JGit ratchet cannot resolve a linked-worktree `.git` pointer file).