### PR TITLE
fix: Throw typed exception for null-valued required shell tool argument

### DIFF
--- a/experimental/langchain4j-experimental-skills-shell/src/main/java/dev/langchain4j/skills/shell/RunShellCommandToolExecutor.java
+++ b/experimental/langchain4j-experimental-skills-shell/src/main/java/dev/langchain4j/skills/shell/RunShellCommandToolExecutor.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.skills.shell;
 
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.exception.ToolExecutionException;
@@ -8,13 +11,9 @@ import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.skills.shell.ShellCommandRunner.Result;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
-
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
 class RunShellCommandToolExecutor implements ToolExecutor {
 
@@ -49,9 +48,7 @@ class RunShellCommandToolExecutor implements ToolExecutor {
                             <stdout>%s</stdout>
                             <stderr>%s</stderr>""".formatted(workingDir, stdOut, stdErr);
                 }
-                return ToolExecutionResult.builder()
-                        .resultText(resultText)
-                        .build();
+                return ToolExecutionResult.builder().resultText(resultText).build();
             } else {
                 String stdErr = formatStdErr(result.stdErr());
                 String resultText = """
@@ -95,10 +92,11 @@ class RunShellCommandToolExecutor implements ToolExecutor {
     }
 
     private String getRequiredArgument(String argumentName, Map<String, Object> arguments) {
-        if (isNullOrEmpty(arguments) || !arguments.containsKey(argumentName)) {
+        Object value = isNullOrEmpty(arguments) ? null : arguments.get(argumentName);
+        if (value == null) {
             throwException("Missing required tool argument '%s'".formatted(argumentName));
         }
-        return arguments.get(argumentName).toString();
+        return value.toString();
     }
 
     private void throwException(String message) {
@@ -107,13 +105,9 @@ class RunShellCommandToolExecutor implements ToolExecutor {
 
     private void throwException(String message, Exception e) {
         if (config.throwToolArgumentsExceptions) {
-            throw e == null
-                    ? new ToolArgumentsException(message)
-                    : new ToolArgumentsException(message, e);
+            throw e == null ? new ToolArgumentsException(message) : new ToolArgumentsException(message, e);
         } else {
-            throw e == null
-                    ? new ToolExecutionException(message)
-                    : new ToolExecutionException(message, e);
+            throw e == null ? new ToolExecutionException(message) : new ToolExecutionException(message, e);
         }
     }
 

--- a/experimental/langchain4j-experimental-skills-shell/src/test/java/dev/langchain4j/skills/shell/RunShellCommandToolExecutorTest.java
+++ b/experimental/langchain4j-experimental-skills-shell/src/test/java/dev/langchain4j/skills/shell/RunShellCommandToolExecutorTest.java
@@ -1,16 +1,17 @@
 package dev.langchain4j.skills.shell;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.exception.ToolArgumentsException;
+import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-
-import java.util.Map;
-import java.util.concurrent.Executors;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class RunShellCommandToolExecutorTest {
 
@@ -21,8 +22,28 @@ class RunShellCommandToolExecutorTest {
         RunShellCommandToolExecutor executor = executor(1, 1);
 
         assertThat(executor.resolveTimeout(Map.of())).isNull();
-        assertThat(executor.resolveTimeout(Map.of(timeoutSecondsParameterName, 1))).isEqualTo(1);
-        assertThat(executor.resolveTimeout(Map.of(timeoutSecondsParameterName, "1"))).isEqualTo(1);
+        assertThat(executor.resolveTimeout(Map.of(timeoutSecondsParameterName, 1)))
+                .isEqualTo(1);
+        assertThat(executor.resolveTimeout(Map.of(timeoutSecondsParameterName, "1")))
+                .isEqualTo(1);
+    }
+
+    @Test
+    void should_throw_ToolExecutionException_when_command_argument_value_is_null() {
+        RunShellCommandToolExecutor executor = executor(false);
+
+        assertThatThrownBy(() -> executor.executeWithContext(requestWithRawArguments("{\"command\": null}"), null))
+                .isInstanceOf(ToolExecutionException.class)
+                .hasMessageContaining("Missing required tool argument");
+    }
+
+    @Test
+    void should_throw_ToolArgumentsException_when_command_argument_value_is_null() {
+        RunShellCommandToolExecutor executor = executor(true);
+
+        assertThatThrownBy(() -> executor.executeWithContext(requestWithRawArguments("{\"command\": null}"), null))
+                .isInstanceOf(ToolArgumentsException.class)
+                .hasMessageContaining("Missing required tool argument");
     }
 
     @Test
@@ -60,8 +81,8 @@ class RunShellCommandToolExecutorTest {
     @Test
     @EnabledOnOs(OS.WINDOWS)
     void should_truncate_stdout_on_success_when_exceeds_limit_on_windows() {
-        ToolExecutionResult result = executor(20, 100)
-                .executeWithContext(request("for /l %i in (1,1,100) do @echo %i"), null);
+        ToolExecutionResult result =
+                executor(20, 100).executeWithContext(request("for /l %i in (1,1,100) do @echo %i"), null);
 
         assertThat(result.isError()).isFalse();
         assertThat(result.resultText()).contains("[truncated:");
@@ -71,8 +92,7 @@ class RunShellCommandToolExecutorTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void should_truncate_stdout_on_error_when_exceeds_limit_on_unix() {
-        ToolExecutionResult result = executor(20, 100)
-                .executeWithContext(request("seq 1 100; exit 1"), null);
+        ToolExecutionResult result = executor(20, 100).executeWithContext(request("seq 1 100; exit 1"), null);
 
         assertThat(result.isError()).isTrue();
         assertThat(result.resultText()).contains("<stdout>");
@@ -83,8 +103,8 @@ class RunShellCommandToolExecutorTest {
     @Test
     @EnabledOnOs(OS.WINDOWS)
     void should_truncate_stdout_on_error_when_exceeds_limit_on_windows() {
-        ToolExecutionResult result = executor(20, 100)
-                .executeWithContext(request("(for /l %i in (1,1,100) do @echo %i) & exit /b 1"), null);
+        ToolExecutionResult result =
+                executor(20, 100).executeWithContext(request("(for /l %i in (1,1,100) do @echo %i) & exit /b 1"), null);
 
         assertThat(result.isError()).isTrue();
         assertThat(result.resultText()).contains("<stdout>");
@@ -95,8 +115,7 @@ class RunShellCommandToolExecutorTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void should_not_truncate_stderr_on_error_when_within_limit_on_unix() {
-        ToolExecutionResult result = executor(100, 100)
-                .executeWithContext(request("echo err >&2; exit 1"), null);
+        ToolExecutionResult result = executor(100, 100).executeWithContext(request("echo err >&2; exit 1"), null);
 
         assertThat(result.isError()).isTrue();
         assertThat(result.resultText()).contains("<stderr>");
@@ -107,8 +126,7 @@ class RunShellCommandToolExecutorTest {
     @Test
     @EnabledOnOs(OS.WINDOWS)
     void should_not_truncate_stderr_on_error_when_within_limit_on_windows() {
-        ToolExecutionResult result = executor(100, 100)
-                .executeWithContext(request("echo err 1>&2 & exit /b 1"), null);
+        ToolExecutionResult result = executor(100, 100).executeWithContext(request("echo err 1>&2 & exit /b 1"), null);
 
         assertThat(result.isError()).isTrue();
         assertThat(result.resultText()).contains("<stderr>");
@@ -119,8 +137,7 @@ class RunShellCommandToolExecutorTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void should_truncate_stderr_on_error_when_exceeds_limit_on_unix() {
-        ToolExecutionResult result = executor(100, 20)
-                .executeWithContext(request("seq 1 100 >&2; exit 1"), null);
+        ToolExecutionResult result = executor(100, 20).executeWithContext(request("seq 1 100 >&2; exit 1"), null);
 
         assertThat(result.isError()).isTrue();
         assertThat(result.resultText()).contains("<stderr>");
@@ -141,12 +158,16 @@ class RunShellCommandToolExecutorTest {
     }
 
     private RunShellCommandToolExecutor executor(int maxStdOutChars, int maxStdErrChars) {
-        return new RunShellCommandToolExecutor(
-                RunShellCommandToolConfig.builder()
-                        .maxStdOutChars(maxStdOutChars)
-                        .maxStdErrChars(maxStdErrChars)
-                        .build()
-        );
+        return new RunShellCommandToolExecutor(RunShellCommandToolConfig.builder()
+                .maxStdOutChars(maxStdOutChars)
+                .maxStdErrChars(maxStdErrChars)
+                .build());
+    }
+
+    private RunShellCommandToolExecutor executor(boolean throwToolArgumentsExceptions) {
+        return new RunShellCommandToolExecutor(RunShellCommandToolConfig.builder()
+                .throwToolArgumentsExceptions(throwToolArgumentsExceptions)
+                .build());
     }
 
     private ToolExecutionRequest request(String command) {
@@ -154,6 +175,14 @@ class RunShellCommandToolExecutorTest {
                 .id("1")
                 .name("run_shell_command")
                 .arguments("{\"command\": \"" + command + "\"}")
+                .build();
+    }
+
+    private ToolExecutionRequest requestWithRawArguments(String arguments) {
+        return ToolExecutionRequest.builder()
+                .id("1")
+                .name("run_shell_command")
+                .arguments(arguments)
                 .build();
     }
 }


### PR DESCRIPTION
## Issue
Closes #5455

## Change
`RunShellCommandToolExecutor.getRequiredArgument` guarded a missing argument key, not a present-but-null value.
An LLM emitting `{"command": null}` produced `{command=null}`, so `containsKey` passed the guard and `arguments.get(name).toString()` threw a raw `NullPointerException`. That call runs before the `try` in `executeWithContext`, so it escaped un-wrapped, bypassing the typed `ToolExecutionException`/`ToolArgumentsException` selected by `throwToolArgumentsExceptions`.
The fix resolves the value once and null-checks it, treating a null value like a missing key with the same message. Backward compatible: missing-key behavior and message unchanged; no signature change.

```java
private String getRequiredArgument(String argumentName, Map<String, Object> arguments) {
    Object value = isNullOrEmpty(arguments) ? null : arguments.get(argumentName);
    if (value == null) {
        throwException("Missing required tool argument '%s'".formatted(argumentName));
    }
    return value.toString();
}
```

Added two negative-case unit tests to `RunShellCommandToolExecutorTest`: `{"command": null}` yields `ToolExecutionException` (default) and `ToolArgumentsException` (when `throwToolArgumentsExceptions(true)`).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
<!-- Negative cases are the essential coverage for this fix (null value -> typed exception). The pre-existing happy-path command execution is already covered by existing tests; no new positive case was added. -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
<!-- N/A: this change is in experimental/langchain4j-experimental-skills-shell, not core/main. -->
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
<!-- Docs/examples to be added after review, per project policy. -->

<!-- N/A: no new maven module added. -->
<!-- N/A: no embedding store integration added or changed. -->