### PR TITLE
Fix broken Anthropic documentation links

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -4,8 +4,8 @@ sidebar_position: 2
 
 # Anthropic
 
-- [Anthropic Documentation](https://docs.anthropic.com/claude/docs)
-- [Anthropic API Reference](https://docs.anthropic.com/claude/reference)
+- [Anthropic Documentation](https://docs.anthropic.com/en/home)
+- [Anthropic API Reference](https://docs.anthropic.com/en/api/overview)
 
 ## Maven Dependency
 
@@ -66,7 +66,7 @@ AnthropicChatModel model = AnthropicChatModel.builder()
     .customParameters(...)
     .build();
 ```
-See the description of some of the parameters above [here](https://docs.anthropic.com/claude/reference/messages_post).
+See the description of some of the parameters above [here](https://docs.anthropic.com/en/api/messages).
 
 ## AnthropicStreamingChatModel
 ```java
@@ -102,7 +102,7 @@ Identical to the `AnthropicChatModel`, see above.
 
 Anthropic supports [tools](/tutorials/tools) in both streaming and non-streaming mode.
 
-Anthropic documentation on tools can be found [here](https://docs.anthropic.com/claude/docs/tool-use).
+Anthropic documentation on tools can be found [here](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview).
 
 
 ## Tool Choice


### PR DESCRIPTION
## Issue
<!-- No dedicated issue: this is a trivial documentation fix for broken links. -->
N/A — trivial documentation fix (broken links).

## Change

The Anthropic integration page links to Anthropic's documentation using the old `docs.anthropic.com/claude/...` URL structure. Anthropic has migrated their docs, and these old URLs now redirect to pages that return **404**. This updates the four remaining old-style links to the current `docs.anthropic.com/en/...` structure, which is already used elsewhere in the same file (e.g. the prompt-caching and pdf-support links).

| Link text | Old (broken) | New (verified working) |
|---|---|---|
| Anthropic Documentation | `/claude/docs` | `/en/home` |
| Anthropic API Reference | `/claude/reference` | `/en/api/overview` |
| (parameter description) | `/claude/reference/messages_post` | `/en/api/messages` |
| (tool use docs) | `/claude/docs/tool-use` | `/en/docs/agents-and-tools/tool-use/overview` |

Each new URL was manually verified to load successfully, and each old URL was confirmed to resolve to a 404 after the redirect.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change <!-- N/A: documentation-only change -->
- [ ] The tests cover both positive and negative cases <!-- N/A: documentation-only change -->
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- N/A: documentation-only change -->
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green <!-- N/A: documentation-only change -->
- [X] I have added/updated the documentation <!-- this PR is the documentation update -->
