### PR TITLE
fix: Omit blank/null Content-Type part header in Apache multipart body

### DIFF
--- a/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/MultipartBodyPublisher.java
+++ b/http-clients/langchain4j-http-client-apache/src/main/java/dev/langchain4j/http/client/apache/MultipartBodyPublisher.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.http.client.apache;
 
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import dev.langchain4j.Experimental;
@@ -34,9 +35,12 @@ class MultipartBodyPublisher {
     }
 
     void addFile(String name, FormDataFile file) {
-        String header = "--" + BOUNDARY + CRLF + "Content-Disposition: form-data; name=\""
-                + name + "\"; filename=\"" + file.fileName() + "\"" + CRLF + "Content-Type: "
-                + file.contentType() + CRLF + CRLF;
+        String header = "--" + BOUNDARY + CRLF + "Content-Disposition: form-data; name=\"" + name + "\"; filename=\""
+                + file.fileName() + "\"" + CRLF;
+        if (!isNullOrBlank(file.contentType())) {
+            header += "Content-Type: " + file.contentType() + CRLF;
+        }
+        header += CRLF;
 
         parts.add(header.getBytes(UTF_8));
         parts.add(file.content());

--- a/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/MultipartBodyPublisherTest.java
+++ b/http-clients/langchain4j-http-client-apache/src/test/java/dev/langchain4j/http/client/apache/MultipartBodyPublisherTest.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.http.client.apache;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import dev.langchain4j.http.client.FormDataFile;
@@ -19,8 +20,7 @@ class MultipartBodyPublisherTest {
 
         String body = bodyAsString(publisher.parts());
 
-        String expected =
-                """
+        String expected = """
                         ------LangChain4j
                         Content-Disposition: form-data; name="field1"
 
@@ -42,8 +42,7 @@ class MultipartBodyPublisherTest {
 
         String body = bodyAsString(publisher.parts());
 
-        String expected =
-                """
+        String expected = """
                         ------LangChain4j
                         Content-Disposition: form-data; name="file"; filename="test.txt"
                         Content-Type: text/plain
@@ -67,8 +66,7 @@ class MultipartBodyPublisherTest {
 
         String body = bodyAsString(publisher.parts());
 
-        String expected =
-                """
+        String expected = """
                         ------LangChain4j
                         Content-Disposition: form-data; name="field1"
 
@@ -76,6 +74,80 @@ class MultipartBodyPublisherTest {
                         ------LangChain4j
                         Content-Disposition: form-data; name="file"; filename="test.txt"
                         Content-Type: text/plain
+
+                        hello
+                        ------LangChain4j--
+                        """;
+
+        assertEquals(normalize(expected), body);
+    }
+
+    @Test
+    void should_omit_content_type_header_when_content_type_is_null() {
+        MultipartBodyPublisher publisher = new MultipartBodyPublisher();
+
+        FormDataFile file = new FormDataFile("audio.wav", null, "hello".getBytes(UTF_8));
+
+        publisher.addFile("file", file);
+        publisher.build();
+
+        String body = bodyAsString(publisher.parts());
+
+        assertThat(body).doesNotContain("Content-Type:");
+        assertThat(body).doesNotContain("Content-Type: null");
+
+        String expected = """
+                        ------LangChain4j
+                        Content-Disposition: form-data; name="file"; filename="audio.wav"
+
+                        hello
+                        ------LangChain4j--
+                        """;
+
+        assertEquals(normalize(expected), body);
+    }
+
+    @Test
+    void should_omit_content_type_header_when_content_type_is_blank() {
+        MultipartBodyPublisher publisher = new MultipartBodyPublisher();
+
+        FormDataFile file = new FormDataFile("audio.wav", "", "hello".getBytes(UTF_8));
+
+        publisher.addFile("file", file);
+        publisher.build();
+
+        String body = bodyAsString(publisher.parts());
+
+        assertThat(body).doesNotContain("Content-Type:");
+
+        String expected = """
+                        ------LangChain4j
+                        Content-Disposition: form-data; name="file"; filename="audio.wav"
+
+                        hello
+                        ------LangChain4j--
+                        """;
+
+        assertEquals(normalize(expected), body);
+    }
+
+    @Test
+    void should_keep_content_type_header_when_content_type_is_present() {
+        MultipartBodyPublisher publisher = new MultipartBodyPublisher();
+
+        FormDataFile file = new FormDataFile("audio.wav", "audio/wav", "hello".getBytes(UTF_8));
+
+        publisher.addFile("file", file);
+        publisher.build();
+
+        String body = bodyAsString(publisher.parts());
+
+        assertThat(body).contains("Content-Type: audio/wav");
+
+        String expected = """
+                        ------LangChain4j
+                        Content-Disposition: form-data; name="file"; filename="audio.wav"
+                        Content-Type: audio/wav
 
                         hello
                         ------LangChain4j--


### PR DESCRIPTION
## Issue
Closes #5466

## Change
`MultipartBodyPublisher.addFile` in `langchain4j-http-client-apache` concatenated `"Content-Type: " + file.contentType()` into the part header unguarded, emitting a literal `Content-Type: null` line for null and an empty `Content-Type:` for blank — both malformed multipart. This is reachable on a normal path: `Audio.mimeType()` is null when unset and `DefaultOpenAiClient.audioTranscription()` forwards `file.mimeType()` unguarded.

Fix: omit the `Content-Type:` line when null or blank via `dev.langchain4j.internal.Utils.isNullOrBlank`, mirroring OkHttp. The valid-content-type path is unchanged (backward compatible).

Tests: three `MultipartBodyPublisherTest` cases — null and blank (no `Content-Type:` line) and a valid regression (`Content-Type: audio/wav` still emitted).

Only the Apache client changes; the JDK client (`langchain4j-http-client-jdk`) has the identical bug, held for a follow-up after this merges (probe-first).

Note: Spotless ratchet reindented a few text blocks (CI-required), not an unrelated change.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is confined to langchain4j-http-client-apache; core built transitively via -am and passed -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — no user-facing API/doc change; internal multipart wire format -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A — bug fix, not a big feature -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A — not applicable -->

<!-- Checklist for adding new maven module: skipped — no new module. -->
<!-- Checklist for adding/changing embedding store integration: skipped — not an embedding store. -->