### PR TITLE
fix: Coerce Number values to short and byte target types in agentic argument adaptation

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentUtil.java
@@ -313,6 +313,8 @@ public class AgentUtil {
                 case "long", "java.lang.Long" -> n.longValue();
                 case "double", "java.lang.Double" -> n.doubleValue();
                 case "float", "java.lang.Float" -> n.floatValue();
+                case "short", "java.lang.Short" -> n.shortValue();
+                case "byte", "java.lang.Byte" -> n.byteValue();
                 default -> value;
             };
         }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/AgentUtilTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/AgentUtilTest.java
@@ -75,6 +75,28 @@ class AgentUtilTest {
     }
 
     @Test
+    void should_coerce_integer_to_short() throws Exception {
+        DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
+        scope.writeState("count", 42);
+
+        AgentInvocationArguments args =
+                AgentUtil.agentInvocationArguments(scope, List.of(new AgentArgument(short.class, "count")));
+
+        assertThat(args.positionalArgs()[0]).isEqualTo((short) 42);
+    }
+
+    @Test
+    void should_coerce_integer_to_byte() throws Exception {
+        DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
+        scope.writeState("count", 42);
+
+        AgentInvocationArguments args =
+                AgentUtil.agentInvocationArguments(scope, List.of(new AgentArgument(byte.class, "count")));
+
+        assertThat(args.positionalArgs()[0]).isEqualTo((byte) 42);
+    }
+
+    @Test
     void should_throw_when_json_string_is_invalid_for_target_type() {
         DefaultAgenticScope scope = DefaultAgenticScope.ephemeralAgenticScope();
         scope.writeState("person", "not-valid-json");


### PR DESCRIPTION
## Issue
Closes #5468

## Change
`AgentUtil.adaptValueToType(Object, Class)` coerces a `Number` from the agentic scope to common target types, but its `switch` omitted `short`/`byte` (and their boxed forms). For those targets the `default -> value` branch returned the original boxed value (e.g. `Integer`), so reflective invocation of the agent method failed with `argument type mismatch`. The sibling `String` branch in the same method already handled a broader set, making the handling asymmetric.

This adds the two missing cases to the `Number` switch:

```java
case "short", "java.lang.Short" -> n.shortValue();
case "byte", "java.lang.Byte" -> n.byteValue();
```

No other line is touched; existing behaviour is unchanged — only previously-uncoerced targets are fixed.

Added two unit tests in `AgentUtilTest` (`should_coerce_integer_to_short`, `should_coerce_integer_to_byte`) mirroring the existing `should_coerce_string_to_integer`, exercising the public path `AgentUtil.agentInvocationArguments(...)` deterministically (no LLM/API key). Both fail before the fix (`Integer 42 != Short/Byte 42`) and pass after.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
<!-- additive coercion: positive-only (short/byte coerced correctly); no error/rejection path to cover -->

- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- core/main modules untouched -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
<!-- docs/examples added after review per guidelines; no Spring Boot starter involved -->

<!-- N/A: no new maven module -->
<!-- N/A: no new/changed embedding store integration -->
