### PR TITLE
fix: Surface failed A2A tasks as exceptions instead of empty results

### DIFF
--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilder.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilder.java
@@ -1,9 +1,11 @@
 package dev.langchain4j.agentic.a2a;
 
+import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
+
 import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.internal.A2AClientBuilder;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.observability.AgentListener;
-import dev.langchain4j.agentic.internal.A2AClientBuilder;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.planner.AgenticSystemTopology;
@@ -14,6 +16,20 @@ import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
 import dev.langchain4j.invocation.LangChain4jManaged;
 import dev.langchain4j.service.ParameterNameResolver;
 import dev.langchain4j.service.output.ServiceOutputParser;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.a2aproject.sdk.A2A;
 import org.a2aproject.sdk.client.Client;
 import org.a2aproject.sdk.client.ClientEvent;
@@ -30,28 +46,13 @@ import org.a2aproject.sdk.spec.Part;
 import org.a2aproject.sdk.spec.Task;
 import org.a2aproject.sdk.spec.TaskState;
 import org.a2aproject.sdk.spec.TextPart;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Proxy;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static dev.langchain4j.agentic.observability.ComposedAgentListener.composeWithInherited;
-
 public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, InternalAgent, InvocationHandler {
 
-    private record A2AInvocationResult(Object parsedResult, String contextIdKey, String contextId, String taskIdKey, String taskId) {}
+    private record A2AInvocationResult(
+            Object parsedResult, String contextIdKey, String contextId, String taskIdKey, String taskId) {}
 
     private final ServiceOutputParser serviceOutputParser = new ServiceOutputParser();
 
@@ -100,8 +101,7 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
         }
 
         Object agent = Proxy.newProxyInstance(
-                agentServiceClass.getClassLoader(),
-                new Class<?>[] {agentServiceClass, A2AClientInstance.class}, this);
+                agentServiceClass.getClassLoader(), new Class<?>[] {agentServiceClass, A2AClientInstance.class}, this);
 
         return (T) agent;
     }
@@ -117,8 +117,8 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
                 case "agentCard" -> agentCard;
                 case "inputKeys" -> inputKeys;
                 default ->
-                        throw new UnsupportedOperationException(
-                                "Unknown method on A2AClientInstance class : " + method.getName());
+                    throw new UnsupportedOperationException(
+                            "Unknown method on A2AClientInstance class : " + method.getName());
             };
         }
 
@@ -141,9 +141,9 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
             scope.writeState(result.taskIdKey, result.taskId);
         }
 
-        return method.getReturnType() == ResultWithAgenticScope.class ?
-                new ResultWithAgenticScope<>(scope, result.parsedResult) :
-                result.parsedResult;
+        return method.getReturnType() == ResultWithAgenticScope.class
+                ? new ResultWithAgenticScope<>(scope, result.parsedResult)
+                : result.parsedResult;
     }
 
     private static Type getReturnType(Method method) {
@@ -190,7 +190,8 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
             }
         }
 
-        Message.Builder messageBuilder = Message.builder().role(Message.Role.ROLE_USER).parts(parts);
+        Message.Builder messageBuilder =
+                Message.builder().role(Message.Role.ROLE_USER).parts(parts);
         if (contextId != null) {
             messageBuilder.contextId(contextId);
         }
@@ -236,7 +237,8 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
             String responseText = messageResponse.get();
             LOG.debug("Response: {}", responseText);
             Object parsedResult = serviceOutputParser.parseText(returnType, responseText);
-            return new A2AInvocationResult(parsedResult, finalContextIdKey, responseContextId.get(), finalTaskIdKey, responseTaskId.get());
+            return new A2AInvocationResult(
+                    parsedResult, finalContextIdKey, responseContextId.get(), finalTaskIdKey, responseTaskId.get());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOG.error("Failed to get response: {}", e.getMessage(), e);
@@ -252,12 +254,26 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
         taskId.set(task.id());
     }
 
-    private static void completeFromTask(Task task, CompletableFuture<String> messageResponse) {
-        if (!isTerminalState(task.status().state()) && task.artifacts().isEmpty()) {
+    static void completeFromTask(Task task, CompletableFuture<String> messageResponse) {
+        TaskState state = task.status().state();
+        if (!isTerminalState(state) && task.artifacts().isEmpty()) {
+            return;
+        }
+        if (isFailureState(state)) {
+            Message statusMessage = task.status().message();
+            String reason = statusMessage != null ? extractTextFromParts(statusMessage.parts()) : "";
+            messageResponse.completeExceptionally(new RuntimeException("A2A task " + task.id()
+                    + " ended in terminal state " + state + (reason.isEmpty() ? "" : ": " + reason)));
             return;
         }
         messageResponse.complete(extractTextFromParts(
                 task.artifacts().stream().flatMap(a -> a.parts().stream()).toList()));
+    }
+
+    private static boolean isFailureState(TaskState state) {
+        return state == TaskState.TASK_STATE_FAILED
+                || state == TaskState.TASK_STATE_CANCELED
+                || state == TaskState.TASK_STATE_REJECTED;
     }
 
     private static boolean isTerminalState(TaskState state) {

--- a/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
+++ b/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
@@ -1,0 +1,94 @@
+package dev.langchain4j.agentic.a2a;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.a2aproject.sdk.spec.Artifact;
+import org.a2aproject.sdk.spec.Message;
+import org.a2aproject.sdk.spec.Part;
+import org.a2aproject.sdk.spec.Task;
+import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TaskStatus;
+import org.a2aproject.sdk.spec.TextPart;
+import org.junit.jupiter.api.Test;
+
+class DefaultA2AClientBuilderTest {
+
+    @Test
+    void completeFromTask_failedTaskWithReason_completesExceptionally() {
+        Message failureMessage = Message.builder()
+                .role(Message.Role.ROLE_AGENT)
+                .parts(List.of(new TextPart("upstream model unavailable")))
+                .build();
+        Task failedTask = Task.builder()
+                .id("task-123")
+                .contextId("ctx-1")
+                .status(new TaskStatus(TaskState.TASK_STATE_FAILED, failureMessage, null))
+                .artifacts(List.of())
+                .build();
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        DefaultA2AClientBuilder.completeFromTask(failedTask, future);
+
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get)
+                .hasCauseInstanceOf(RuntimeException.class)
+                .hasMessageContaining("task-123")
+                .hasMessageContaining("TASK_STATE_FAILED")
+                .hasMessageContaining("upstream model unavailable");
+    }
+
+    @Test
+    void completeFromTask_failedTaskWithoutReason_completesExceptionally() {
+        Task failedTask = Task.builder()
+                .id("task-456")
+                .contextId("ctx-2")
+                .status(new TaskStatus(TaskState.TASK_STATE_CANCELED))
+                .artifacts(List.of())
+                .build();
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        DefaultA2AClientBuilder.completeFromTask(failedTask, future);
+
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get).hasMessageContaining("task-456").hasMessageContaining("TASK_STATE_CANCELED");
+    }
+
+    @Test
+    void completeFromTask_completedTaskWithArtifact_completesNormally() throws Exception {
+        Artifact artifact = Artifact.builder()
+                .artifactId("artifact-1")
+                .parts(List.<Part<?>>of(new TextPart("the answer")))
+                .build();
+        Task completedTask = Task.builder()
+                .id("task-789")
+                .contextId("ctx-3")
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
+                .artifacts(List.of(artifact))
+                .build();
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        DefaultA2AClientBuilder.completeFromTask(completedTask, future);
+
+        assertThat(future).isCompleted();
+        assertThat(future.get()).isEqualTo("the answer");
+    }
+
+    @Test
+    void completeFromTask_completedTaskWithEmptyArtifacts_completesNormallyWithEmptyString() throws Exception {
+        Task completedTask = Task.builder()
+                .id("task-000")
+                .contextId("ctx-4")
+                .status(new TaskStatus(TaskState.TASK_STATE_COMPLETED))
+                .artifacts(List.of())
+                .build();
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        DefaultA2AClientBuilder.completeFromTask(completedTask, future);
+
+        assertThat(future).isCompleted();
+        assertThat(future.get()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5470

## Change
`DefaultA2AClientBuilder.completeFromTask` completed the response future with an empty string for a remote A2A Task that ended in a terminal failure state (`TASK_STATE_FAILED`, `TASK_STATE_CANCELED`, `TASK_STATE_REJECTED`) with no artifacts, masking a remote failure as an empty success.

This adds a failure-state branch that completes the future exceptionally with a message containing the task id, the terminal state, and the failure reason from `task.status().message()` (null-guarded) when present. SUCCESS handling is unchanged: a `TASK_STATE_COMPLETED` task, including one with empty artifacts, still completes normally (preserving the #3867 tolerance).

`completeFromTask` was widened from `private` to package-private `static` to allow a deterministic unit test to invoke it without a live server. This is not a public API change.

A new `DefaultA2AClientBuilderTest` builds Tasks via the public a2a SDK builders (no network) and covers: failed task with reason, canceled task without reason, completed task with a text artifact, and completed task with empty artifacts.

Note: `DefaultA2AClientBuilder.java` predates the palantir format, so the spotless ratchet (`ratchetFrom=origin/main`) reformatted the whole file (import reordering, rewrapping) on touch, as required by CI.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is isolated to langchain4j-agentic-a2a; core/main built transitively via -am -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — bug fix, no doc change; docs added post-approval per CONTRIBUTING -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A — not a big feature -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A — no Spring Boot surface -->

<!-- N/A — no new maven module added -->
<!-- N/A — no embedding store integration involved -->
