### PR TITLE
fix: declarative agentic Javadoc. replace removed `@SubAgent` with the array form

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/ActivationCondition.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/ActivationCondition.java
@@ -15,11 +15,8 @@ import java.lang.annotation.Target;
  * {@code
  *     public interface ExpertsAgent {
  *
- *         @ConditionalAgent(outputKey = "response", subAgents = {
- *                 @SubAgent(type = MedicalExpert.class, outputKey = "response"),
- *                 @SubAgent(type = TechnicalExpert.class, outputKey = "response"),
- *                 @SubAgent(type = LegalExpert.class, outputKey = "response")
- *         })
+ *         @ConditionalAgent(outputKey = "response",
+ *                 subAgents = { MedicalExpert.class, TechnicalExpert.class, LegalExpert.class })
  *         String askExpert(@V("request") String request);
  *
  *         @ActivationCondition(value = MedicalExpert.class, description = "category is medical")

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/ChatModelSupplier.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/ChatModelSupplier.java
@@ -1,11 +1,11 @@
 package dev.langchain4j.agentic.declarative;
 
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import dev.langchain4j.model.chat.ChatModel;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Marks a method as a supplier of the chat model to be used by an agent.
@@ -21,10 +21,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * {@code
  *      public interface SupervisorBanker {
  *
- *         @SupervisorAgent(responseStrategy = SupervisorResponseStrategy.SUMMARY, subAgents = {
- *                 @SubAgent(type = WithdrawAgent.class),
- *                 @SubAgent(type = CreditAgent.class)
- *         })
+ *         @SupervisorAgent(responseStrategy = SupervisorResponseStrategy.SUMMARY,
+ *                 subAgents = { WithdrawAgent.class, CreditAgent.class })
  *         String invoke(@V("request") String request);
  *
  *         @ChatModelSupplier
@@ -53,5 +51,4 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Retention(RUNTIME)
 @Target({METHOD})
-public @interface ChatModelSupplier {
-}
+public @interface ChatModelSupplier {}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/ErrorHandler.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/ErrorHandler.java
@@ -18,11 +18,8 @@ import java.lang.annotation.Target;
  * {@code
  *     public interface StoryCreatorWithErrorRecovery {
  *
- *         @SequenceAgent(outputKey = "story", subAgents = {
- *                 @SubAgent(type = CreativeWriter.class, outputKey = "story"),
- *                 @SubAgent(type = AudienceEditor.class, outputKey = "story"),
- *                 @SubAgent(type = StyleEditor.class, outputKey = "story")
- *         })
+ *         @SequenceAgent(outputKey = "story",
+ *                 subAgents = { CreativeWriter.class, AudienceEditor.class, StyleEditor.class })
  *         String write(@V("topic") String topic, @V("style") String style, @V("audience") String audience);
  *
  *         @ErrorHandler

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/ExitCondition.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/ExitCondition.java
@@ -18,11 +18,7 @@ import java.lang.annotation.Target;
  *         @LoopAgent(
  *                 description = "Review the given story to ensure it aligns with the specified style",
  *                 outputKey = "story", maxIterations = 5,
- *                 subAgents = {
- *                     @SubAgent(type = StyleScorer.class, outputKey = "score"),
- *                     @SubAgent(type = StyleEditor.class, outputKey = "story")
- *             }
- *         )
+ *                 subAgents = { StyleScorer.class, StyleEditor.class })
  *         String write(@V("story") String story);
  *
  *         @ExitCondition(testExitAtLoopEnd = true, description = "score greater than 0.8")

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/LoopCounter.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/LoopCounter.java
@@ -18,11 +18,7 @@ import java.lang.annotation.Target;
  *         @LoopAgent(
  *                 description = "Review the given story to ensure it aligns with the specified style",
  *                 outputKey = "story", maxIterations = 5,
- *                 subAgents = {
- *                     @SubAgent(type = StyleScorer.class, outputKey = "score"),
- *                     @SubAgent(type = StyleEditor.class, outputKey = "story")
- *             }
- *         )
+ *                 subAgents = { StyleScorer.class, StyleEditor.class })
  *         String write(@V("story") String story, @LoopCounter int iteration);
  *
  *         @ExitCondition

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/Output.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/Output.java
@@ -17,10 +17,8 @@ import java.lang.annotation.Target;
  * {@code
  *     public interface EveningPlannerAgent {
  *
- *         @ParallelAgent(outputKey = "plans", subAgents = {
- *                 @SubAgent(type = FoodExpert.class, outputKey = "meals"),
- *                 @SubAgent(type = MovieExpert.class, outputKey = "movies")
- *         })
+ *         @ParallelAgent(outputKey = "plans",
+ *                 subAgents = { FoodExpert.class, MovieExpert.class })
  *         List<EveningPlan> plan(@V("mood") String mood);
  *
  *         @Output

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/ParallelExecutor.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/ParallelExecutor.java
@@ -17,10 +17,8 @@ import java.lang.annotation.Target;
  * {@code
  *     public interface EveningPlannerAgent {
  *
- *         @ParallelAgent(outputKey = "plans", subAgents = {
- *                 @SubAgent(type = FoodExpert.class, outputKey = "meals"),
- *                 @SubAgent(type = MovieExpert.class, outputKey = "movies")
- *         })
+ *         @ParallelAgent(outputKey = "plans",
+ *                 subAgents = { FoodExpert.class, MovieExpert.class })
  *         List<EveningPlan> plan(@V("mood") String mood);
  *
  *         @ParallelExecutor

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/PlannerSupplier.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/PlannerSupplier.java
@@ -1,10 +1,10 @@
 package dev.langchain4j.agentic.declarative;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 /**
  * Marks a method as a supplier of the planner for a planner based agent.
@@ -16,11 +16,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  *         @PlannerAgent(
  *                 outputKey = "story",
- *                 subAgents = {
- *                     @SubAgent(type = CreativeWriter.class, outputKey = "story"),
- *                     @SubAgent(type = AudienceEditor.class, outputKey = "story"),
- *                     @SubAgent(type = StyleEditor.class, outputKey = "story")
- *                 })
+ *                 subAgents = { CreativeWriter.class, AudienceEditor.class, StyleEditor.class })
  *         String write(@V("topic") String topic, @V("style") String style, @V("audience") String audience);
  *
  *         @PlannerSupplier
@@ -33,5 +29,4 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Retention(RUNTIME)
 @Target({METHOD})
-public @interface PlannerSupplier {
-}
+public @interface PlannerSupplier {}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/SupervisorRequest.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/SupervisorRequest.java
@@ -14,10 +14,8 @@ import java.lang.annotation.Target;
  * {@code
  *     public interface SupervisorStoryCreator {
  *
- *         @SupervisorAgent(outputKey = "story", subAgents = {
- *                 @SubAgent(type = CreativeWriter.class, outputKey = "story"),
- *                 @SubAgent(type = StyleReviewLoopAgent.class, outputKey = "story")
- *         })
+ *         @SupervisorAgent(outputKey = "story",
+ *                 subAgents = { CreativeWriter.class, StyleReviewLoopAgent.class })
  *         String write(@V("topic") String topic, @V("style") String style);
  *
  *         @SupervisorRequest


### PR DESCRIPTION
## Issue
Closes #5472

## Change
PR #4081 (commit `e5fde130f`) removed the `@SubAgent` annotation and updated the six main declarative annotations to the `subAgents = { X.class, ... }` array form, but nine helper annotations in `langchain4j-agentic/.../declarative/` still show the old `@SubAgent(type = X.class, outputKey = "...")` in their Javadoc `{@code}` examples, so copying them no longer compiles. This PR updates those 9 files (`ErrorHandler`, `Output`, `ParallelExecutor`, `ChatModelSupplier`, `PlannerSupplier`, `SupervisorRequest`, `ActivationCondition`, `LoopCounter`, `ExitCondition`) to the array form, matching `SequenceAgent`. Javadoc-only; no API/behaviour change, no tests needed. Two of these files (`ChatModelSupplier`, `PlannerSupplier`) additionally pick up Spotless `ratchetFrom` formatting (static-import ordering, empty-body `{}`) that editing them mandates for green CI — no functional effect.

```java
// before
@SequenceAgent(outputKey = "story", subAgents = {
        @SubAgent(type = CreativeWriter.class, outputKey = "story"),
        @SubAgent(type = AudienceEditor.class, outputKey = "story") })
// after
@SequenceAgent(outputKey = "story",
        subAgents = { CreativeWriter.class, AudienceEditor.class })
```

## General checklist
<!-- new-module / embedding-store checklist sections are N/A for a docs-only change and were removed -->
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [X] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
