### PR TITLE
fix: LoopAgent subAgents() Javadoc: sub-agents run in sequence, not in parallel

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/LoopAgent.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/LoopAgent.java
@@ -1,10 +1,9 @@
 package dev.langchain4j.agentic.declarative;
 
-import dev.langchain4j.agentic.Agent;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -63,7 +62,7 @@ public @interface LoopAgent {
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
-     * Array of sub-agents that will be invoked in parallel.
+     * Array of sub-agents that will be invoked in sequence at each loop iteration.
      *
      * @return array of sub-agents.
      */


### PR DESCRIPTION
## Issue
Closes #5474

## Change
`LoopAgent.subAgents()` Javadoc claimed sub-agents are "invoked in parallel", but `LoopPlanner` calls them one at a time per loop iteration (`LoopPlanner.nextAction()` increments `agentCursor` and calls `agents.get(agentCursor)`; there is no parallel path). The text was apparently copied from `@ParallelAgent` and also contradicts `LoopAgent`'s own class Javadoc ("in a loop"). Changed the one line to "invoked in sequence at each loop iteration", matching `SequenceAgent`'s wording. Javadoc-only; no API/behaviour change, no tests. The file also picks up Spotless `ratchetFrom` static-import reordering that editing it mandates for green CI — no functional effect.

```java
// before
Array of sub-agents that will be invoked in parallel.
// after
Array of sub-agents that will be invoked in sequence at each loop iteration.
```

## General checklist
<!-- new-module / embedding-store checklist sections are N/A for a docs-only change and were removed -->
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [X] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
