### PR TITLE
fix: Throw MissingArgumentException for missing required input in McpClientAgentInvoker

### DIFF
--- a/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/McpClientAgentInvoker.java
+++ b/langchain4j-agentic-mcp/src/main/java/dev/langchain4j/agentic/mcp/McpClientAgentInvoker.java
@@ -1,9 +1,10 @@
 package dev.langchain4j.agentic.mcp;
 
 import dev.langchain4j.agentic.UntypedAgent;
-import dev.langchain4j.agentic.internal.InternalAgent;
+import dev.langchain4j.agentic.agent.MissingArgumentException;
 import dev.langchain4j.agentic.internal.AgentInvocationArguments;
 import dev.langchain4j.agentic.internal.AgentInvoker;
+import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
@@ -94,7 +95,9 @@ public class McpClientAgentInvoker implements AgentInvoker {
 
     @Override
     public List<AgentArgument> arguments() {
-        return Stream.of(inputKeys).map(input -> new AgentArgument(Object.class, input)).toList();
+        return Stream.of(inputKeys)
+                .map(input -> new AgentArgument(Object.class, input))
+                .toList();
     }
 
     @Override
@@ -116,6 +119,9 @@ public class McpClientAgentInvoker implements AgentInvoker {
         int i = 0;
         for (String argName : inputKeys) {
             Object argValue = agenticScope.readState(argName);
+            if (argValue == null) {
+                throw new MissingArgumentException(argName);
+            }
             positionalArgs[i++] = argValue;
             namedArgs.put(argName, argValue);
         }

--- a/langchain4j-agentic-mcp/src/test/java/dev/langchain4j/agentic/mcp/McpAgentTest.java
+++ b/langchain4j-agentic-mcp/src/test/java/dev/langchain4j/agentic/mcp/McpAgentTest.java
@@ -7,15 +7,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.AgenticServices;
 import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.agent.MissingArgumentException;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.observability.AgentRequest;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
-import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
@@ -67,9 +68,8 @@ class McpAgentTest {
         McpClient mcpClient = mockMcpClient("translate", "Translate text to a target language", "text", "language");
         mockToolResult(mcpClient, "Bonjour le monde");
 
-        UntypedAgent translator = McpAgent.builder(mcpClient)
-                .outputKey("translation")
-                .build();
+        UntypedAgent translator =
+                McpAgent.builder(mcpClient).outputKey("translation").build();
 
         Object result = translator.invoke(Map.of("text", "Hello world", "language", "French"));
 
@@ -137,9 +137,8 @@ class McpAgentTest {
                 .build();
         when(mcpClient.listTools()).thenReturn(List.of(otherTool));
 
-        assertThatThrownBy(() -> McpAgent.builder(mcpClient)
-                .toolName("nonexistent_tool")
-                .build())
+        assertThatThrownBy(() ->
+                        McpAgent.builder(mcpClient).toolName("nonexistent_tool").build())
                 .isInstanceOf(dev.langchain4j.agentic.planner.AgenticSystemConfigurationException.class)
                 .hasMessageContaining("nonexistent_tool")
                 .hasMessageContaining("not found");
@@ -150,9 +149,7 @@ class McpAgentTest {
         McpClient mcpClient = mockMcpClient("fail_tool", "A tool that fails", "input");
         mockToolError(mcpClient, "Something went wrong");
 
-        UntypedAgent agent = McpAgent.builder(mcpClient)
-                .outputKey("result")
-                .build();
+        UntypedAgent agent = McpAgent.builder(mcpClient).outputKey("result").build();
 
         assertThatThrownBy(() -> agent.invoke(Map.of("input", "test")))
                 .isInstanceOf(RuntimeException.class)
@@ -227,14 +224,12 @@ class McpAgentTest {
     void mcp_agent_topology_is_non_ai_agent() {
         McpClient mcpClient = mockMcpClient("tool", "A tool", "input");
 
-        UntypedAgent agent = McpAgent.builder(mcpClient)
-                .outputKey("result")
-                .build();
+        UntypedAgent agent = McpAgent.builder(mcpClient).outputKey("result").build();
 
         assertThat(agent).isInstanceOf(McpClientInstance.class);
         McpClientInstance mcpInstance = (McpClientInstance) agent;
-        assertThat(mcpInstance.topology()).isEqualTo(
-                dev.langchain4j.agentic.planner.AgenticSystemTopology.NON_AI_AGENT);
+        assertThat(mcpInstance.topology())
+                .isEqualTo(dev.langchain4j.agentic.planner.AgenticSystemTopology.NON_AI_AGENT);
     }
 
     @Test
@@ -279,9 +274,7 @@ class McpAgentTest {
         when(mcpClient.listTools()).thenReturn(List.of(toolSpec));
         mockToolResult(mcpClient, "2024-01-01T00:00:00Z");
 
-        UntypedAgent agent = McpAgent.builder(mcpClient)
-                .outputKey("time")
-                .build();
+        UntypedAgent agent = McpAgent.builder(mcpClient).outputKey("time").build();
 
         Object result = agent.invoke(Map.of());
         assertThat(result).isEqualTo("2024-01-01T00:00:00Z");
@@ -304,5 +297,24 @@ class McpAgentTest {
 
         double result = calculator.calculate("21 * 2 + 0.5");
         assertThat(result).isEqualTo(42.5);
+    }
+
+    @Test
+    void typed_mcp_agent_in_workflow_throws_on_missing_required_input() {
+        McpClient mcpClient = mockMcpClient("translate", "Translate text to a target language", "text", "language");
+
+        TypedTranslator translator = McpAgent.builder(mcpClient, TypedTranslator.class)
+                .outputKey("translation")
+                .build();
+
+        UntypedAgent pipeline = AgenticServices.sequenceBuilder()
+                .subAgents(translator)
+                .outputKey("translation")
+                .build();
+
+        // "language" is a required input of the typed agent but is absent from the AgenticScope state.
+        assertThatThrownBy(() -> pipeline.invoke(Map.of("text", "Hello world")))
+                .isInstanceOf(MissingArgumentException.class)
+                .hasMessageContaining("language");
     }
 }


### PR DESCRIPTION
## Issue
<!-- human updates with real issue number before submit -->
Closes #5476

## Change
The typed path of `McpClientAgentInvoker` did not honor the `AgentInvoker.toInvocationArguments(AgenticScope)` contract, which declares `throws MissingArgumentException`. `agentInvocationArguments(AgenticScope)` forwarded each `agenticScope.readState(argName)` without a null check, silently passing a missing required input to the MCP tool as `null`. Sibling invokers fail fast:

- `UntypedAgentInvoker.toInvocationArguments()` — `throw new MissingArgumentException(arg.name());`
- `AgentUtil.argumentFromAgenticScope()` — same throw, after its null → defaultValue → optional checks.

The fix adds the same null check on the typed path:

```java
if (argValue == null) {
    throw new MissingArgumentException(argName);
}
```

Typed path only. Typed `AgentArgument`s are hardwired `defaultValue=null, isOptional=false`, so the sibling's 3-tier check collapses to this throw. The untyped path is left untouched: its keys come from the tool's full JSON-Schema `properties()`, which includes optional MCP params a blanket throw would break (out-of-scope follow-up).

Test: added `typed_mcp_agent_in_workflow_throws_on_missing_required_input` in `McpAgentTest` (mockito `McpClient`, no API key) — a typed MCP agent in a `sequenceBuilder` workflow invoked with a required input absent. It fails on unmodified code and passes after the fix; positive cases stay covered by existing tests.

Spotless `apply`/`check` green on JDK 17. The ratchet (`ratchetFrom=origin/main`) reformatted unrelated lines in the two touched pre-palantir files; CI-required.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- N/A — change is isolated to langchain4j-agentic-mcp; core/main not touched. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- Below items wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- Conditional sections (new maven module / embedding store) omitted: not applicable to a bug fix in an existing module. -->
