### PR TITLE
fix: unanimousLastWord convergence to normalize verdict token

### DIFF
--- a/langchain4j-agentic-patterns/src/main/java/dev/langchain4j/agentic/patterns/debate/ConvergenceStrategy.java
+++ b/langchain4j-agentic-patterns/src/main/java/dev/langchain4j/agentic/patterns/debate/ConvergenceStrategy.java
@@ -23,7 +23,10 @@ public interface ConvergenceStrategy {
             String firstVerdict = null;
             for (Object p : positions) {
                 String text = p.toString().trim();
-                String lastWord = text.substring(text.lastIndexOf(' ') + 1).trim().toUpperCase();
+                String[] tokens = text.split("\\s+");
+                String lastWord = tokens[tokens.length - 1]
+                        .replaceAll("^[^\\p{Alnum}]+|[^\\p{Alnum}]+$", "")
+                        .toUpperCase();
                 if (firstVerdict == null) {
                     firstVerdict = lastWord;
                 } else if (!firstVerdict.equals(lastWord)) {

--- a/langchain4j-agentic-patterns/src/test/java/dev/langchain4j/agentic/patterns/debate/ConvergenceStrategyTest.java
+++ b/langchain4j-agentic-patterns/src/test/java/dev/langchain4j/agentic/patterns/debate/ConvergenceStrategyTest.java
@@ -1,21 +1,22 @@
 package dev.langchain4j.agentic.patterns.debate;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class ConvergenceStrategyTest {
 
     @Test
     void unanimous_converges_when_all_equal() {
-        assertThat(ConvergenceStrategy.unanimous().hasConverged(List.of("A", "A", "A"))).isTrue();
+        assertThat(ConvergenceStrategy.unanimous().hasConverged(List.of("A", "A", "A")))
+                .isTrue();
     }
 
     @Test
     void unanimous_does_not_converge_when_different() {
-        assertThat(ConvergenceStrategy.unanimous().hasConverged(List.of("A", "B", "A"))).isFalse();
+        assertThat(ConvergenceStrategy.unanimous().hasConverged(List.of("A", "B", "A")))
+                .isFalse();
     }
 
     @Test
@@ -29,9 +30,35 @@ class ConvergenceStrategyTest {
     }
 
     @Test
+    void unanimousLastWord_converges_with_trailing_punctuation() {
+        assertThat(ConvergenceStrategy.unanimousLastWord()
+                        .hasConverged(List.of("I think AGREE.", "Definitely AGREE", "So AGREE!")))
+                .isTrue();
+    }
+
+    @Test
+    void unanimousLastWord_converges_across_multiline_verdicts() {
+        assertThat(ConvergenceStrategy.unanimousLastWord()
+                        .hasConverged(List.of("Reasoning here.\nAPPROVE", "Verdict: APPROVE.")))
+                .isTrue();
+    }
+
+    @Test
+    void unanimousLastWord_converges_on_single_word_verdicts() {
+        assertThat(ConvergenceStrategy.unanimousLastWord().hasConverged(List.of("AGREE", "AGREE")))
+                .isTrue();
+    }
+
+    @Test
+    void unanimousLastWord_does_not_converge_on_conflicting_verdicts() {
+        assertThat(ConvergenceStrategy.unanimousLastWord().hasConverged(List.of("I think AGREE", "Honestly DISAGREE")))
+                .isFalse();
+    }
+
+    @Test
     void custom_strategy_via_lambda() {
-        ConvergenceStrategy atLeastTwo = positions ->
-                positions.stream().distinct().count() <= 2;
+        ConvergenceStrategy atLeastTwo =
+                positions -> positions.stream().distinct().count() <= 2;
 
         assertThat(atLeastTwo.hasConverged(List.of("A", "B", "A"))).isTrue();
         assertThat(atLeastTwo.hasConverged(List.of("A", "B", "C"))).isFalse();


### PR DESCRIPTION
## Issue
<!-- Update with the real issue number once the bug issue is filed. -->
Closes #5478

## Change

Fixes `ConvergenceStrategy.unanimousLastWord()` in langchain4j-agentic-patterns.

The old extraction `text.substring(text.lastIndexOf(' ') + 1)` splits only on a literal space, so two realistic debater outputs broke convergence:
- Trailing punctuation: `"...AGREE."` -> `"AGREE."` != `"AGREE"`.
- Multiline replies: `"Reasoning here.\nAPPROVE"` -> `"here.\nAPPROVE"`.

Both cases misjudge a unanimous debate as non-converged, causing extra debate rounds (LLM cost and latency).

The fix splits on `\\s+` (covering newlines and tabs) and strips leading/trailing non-alphanumerics from the final token:

```java
String[] tokens = text.split("\\s+");
String lastWord = tokens[tokens.length - 1]
        .replaceAll("^[^\\p{Alnum}]+|[^\\p{Alnum}]+$", "")
        .toUpperCase();
```

`\\p{Alnum}` is used instead of `\\W` so non-ASCII verdict letters are preserved. The change stays within the single method; empty input still yields an empty token, matching prior behavior.

This aligns `unanimousLastWord()` with its sibling `unanimous()`, which compares whole positions via `Objects.equals`. The strategy (introduced in #5382) is registered by `DebateExampleIT` and `CodeReviewDebateIT`, whose prompts end with a one-word verdict.

Added four unit tests to `ConvergenceStrategyTest` (which previously had no coverage for this method): punctuated, multiline, single-word, and a negative conflicting-verdict case.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
