### PR TITLE
fix: omit blank/null Content-Type part header in JDK multipart body

### DIFF
--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/MultipartBodyPublisher.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/MultipartBodyPublisher.java
@@ -1,13 +1,13 @@
 package dev.langchain4j.http.client.jdk;
 
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.http.client.FormDataFile;
-
 import java.net.http.HttpRequest;
 import java.util.ArrayList;
 import java.util.List;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 @Experimental
 class MultipartBodyPublisher {
@@ -30,9 +30,12 @@ class MultipartBodyPublisher {
     }
 
     void addFile(String name, FormDataFile file) {
-        String header = "--" + BOUNDARY + CRLF + "Content-Disposition: form-data; name=\""
-                + name + "\"; filename=\"" + file.fileName() + "\"" + CRLF + "Content-Type: "
-                + file.contentType() + CRLF + CRLF;
+        String header = "--" + BOUNDARY + CRLF + "Content-Disposition: form-data; name=\"" + name + "\"; filename=\""
+                + file.fileName() + "\"" + CRLF;
+        if (!isNullOrBlank(file.contentType())) {
+            header += "Content-Type: " + file.contentType() + CRLF;
+        }
+        header += CRLF;
 
         parts.add(header.getBytes(UTF_8));
         parts.add(file.content());

--- a/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/MultipartBodyPublisherTest.java
+++ b/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/MultipartBodyPublisherTest.java
@@ -1,13 +1,12 @@
 package dev.langchain4j.http.client.jdk;
 
-import dev.langchain4j.http.client.FormDataFile;
-import org.junit.jupiter.api.Test;
-
-import java.io.ByteArrayOutputStream;
-import java.util.List;
-
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.langchain4j.http.client.FormDataFile;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
 
 class MultipartBodyPublisherTest {
 
@@ -20,11 +19,10 @@ class MultipartBodyPublisherTest {
 
         String body = bodyAsString(publisher.parts());
 
-        String expected =
-                """
+        String expected = """
                         ------LangChain4j
                         Content-Disposition: form-data; name="field1"
-                        
+
                         value1
                         ------LangChain4j--
                         """;
@@ -43,12 +41,11 @@ class MultipartBodyPublisherTest {
 
         String body = bodyAsString(publisher.parts());
 
-        String expected =
-                """
+        String expected = """
                         ------LangChain4j
                         Content-Disposition: form-data; name="file"; filename="test.txt"
                         Content-Type: text/plain
-                        
+
                         hello
                         ------LangChain4j--
                         """;
@@ -68,16 +65,59 @@ class MultipartBodyPublisherTest {
 
         String body = bodyAsString(publisher.parts());
 
-        String expected =
-                """
+        String expected = """
                         ------LangChain4j
                         Content-Disposition: form-data; name="field1"
-                        
+
                         value1
                         ------LangChain4j
                         Content-Disposition: form-data; name="file"; filename="test.txt"
                         Content-Type: text/plain
-                        
+
+                        hello
+                        ------LangChain4j--
+                        """;
+
+        assertEquals(normalize(expected), body);
+    }
+
+    @Test
+    void should_omit_content_type_header_when_content_type_is_null() {
+        MultipartBodyPublisher publisher = new MultipartBodyPublisher();
+
+        FormDataFile file = new FormDataFile("audio.wav", null, "hello".getBytes(UTF_8));
+
+        publisher.addFile("file", file);
+        publisher.build();
+
+        String body = bodyAsString(publisher.parts());
+
+        String expected = """
+                        ------LangChain4j
+                        Content-Disposition: form-data; name="file"; filename="audio.wav"
+
+                        hello
+                        ------LangChain4j--
+                        """;
+
+        assertEquals(normalize(expected), body);
+    }
+
+    @Test
+    void should_omit_content_type_header_when_content_type_is_blank() {
+        MultipartBodyPublisher publisher = new MultipartBodyPublisher();
+
+        FormDataFile file = new FormDataFile("audio.wav", "  ", "hello".getBytes(UTF_8));
+
+        publisher.addFile("file", file);
+        publisher.build();
+
+        String body = bodyAsString(publisher.parts());
+
+        String expected = """
+                        ------LangChain4j
+                        Content-Disposition: form-data; name="file"; filename="audio.wav"
+
                         hello
                         ------LangChain4j--
                         """;


### PR DESCRIPTION
## Issue
Relates to #5466. That issue is fixed for the **Apache** client in #5467 and explicitly notes that *"The JDK client (`langchain4j-http-client-jdk`) has the identical bug"*. This PR fixes the **JDK** client half. No dedicated JDK issue exists, so this references #5466 rather than closing it — happy to track it under a separate issue if maintainers prefer.

## Change
`MultipartBodyPublisher.addFile` in `langchain4j-http-client-jdk` concatenated `"Content-Type: " + file.contentType()` into the part header unconditionally, so:

- a **null** content type emitted a literal `Content-Type: null` line, and
- a **blank** content type emitted an empty `Content-Type:` line,

both of which are malformed multipart. This is reachable on a normal path: `Audio.mimeType()` is null when unset and `DefaultOpenAiClient.audioTranscription()` forwards `file.mimeType()` unguarded — and the JDK client is the default HTTP client.

The fix guards the header with `Utils.isNullOrBlank(...)` so the per-part `Content-Type` line is omitted when the content type is null or blank, matching the OkHttp client and the accepted Apache fix (#5467). Behaviour is unchanged when a content type is present.

Added unit tests for the null and blank cases; the existing `should_build_body_with_file` test already covers the positive (content-type-present) case.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

> **Note on testing:** I ran the changed module's unit tests (`langchain4j-http-client-jdk`, `MultipartBodyPublisherTest`) — 5/5 green — and `spotless:check` passes. The module's `*IT` integration tests require live HTTP endpoints and were not run. The change is isolated to `langchain4j-http-client-jdk`, which the core/main modules do not depend on.
