### PR TITLE
chore: update google-genai dependency to 1.59.0

### DIFF
--- a/langchain4j-google-genai/pom.xml
+++ b/langchain4j-google-genai/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.google.genai</groupId>
             <artifactId>google-genai</artifactId>
-            <version>1.58.0</version>
+            <version>1.59.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Updates the com.google.genai:google-genai dependency to the latest version 1.59.0.