### PR TITLE
Update Dev Container support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,12 @@
 {
-  "name": "Java",
+  "name": "LangChain4j",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers/features/java:1": {
-      "version": "21-oracle",
-      "jdkDistro": "oracle"
+      "version": "25",
+      "jdkDistro": "tem",
+      "installMaven": true,
+      "mavenVersion": "latest"
     },
     "ghcr.io/devcontainers/features/azure-cli:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
@@ -13,13 +15,20 @@
 
   "customizations": {
     "vscode": {
-      "settings": {},
+      "settings": {
+        "java.configuration.updateBuildConfiguration": "automatic",
+        "java.compile.nullAnalysis.mode": "automatic"
+      },
       "extensions": [
         "redhat.vscode-xml",
+        "redhat.vscode-yaml",
         "visualstudioexptteam.vscodeintellicode",
-        "vscjava.vscode-java-pack"
+        "vscjava.vscode-java-pack",
+        "editorconfig.editorconfig"
       ]
     }
   },
+
+  "postCreateCommand": "java -version && mvn -version",
   "remoteUser": "vscode"
 }


### PR DESCRIPTION
## Issue

The Dev Container had drifted from the project's CI setup: it pinned the Oracle JDK distribution at version 21, while CI builds use **Temurin** across JDK 17/21/25, with the release and docs builds running on **JDK 25**.

## Change

Modernize `.devcontainer/devcontainer.json` to align with CI and add sensible defaults:

- **JDK distribution**: `oracle` → `tem` (Temurin), matching CI.
- **JDK version**: `21-oracle` → `25`, matching the release/docs builds. (The project still keeps Java 17 source compatibility.)
- **Maven**: now installed via the Java feature (`installMaven: true`).
- **VS Code settings**: `java.configuration.updateBuildConfiguration: automatic` and `java.compile.nullAnalysis.mode: automatic` for a smoother experience on this large multi-module project.
- **Extensions**: added `redhat.vscode-yaml` (workflows) and `editorconfig.editorconfig` (the repo ships an `.editorconfig`).
- **postCreateCommand**: `java -version && mvn -version` to verify the toolchain on create.
- Renamed the container display name from "Java" to "LangChain4j".

The existing `azure-cli`, `docker-in-docker`, and `github-cli` features are kept unchanged.

## General checklist
- [x] There are no breaking changes
- [x] I have manually run all the unit and integration tests in the module I have added or changed, and they are all green

