### PR TITLE
fix: Include $defs in Anthropic tool input schema for tools using schema references

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolSchema.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolSchema.java
@@ -24,6 +24,9 @@ public class AnthropicToolSchema {
     public Map<String, Map<String, Object>> properties;
     public List<String> required;
 
+    @JsonProperty("$defs")
+    public Map<String, Map<String, Object>> defs;
+
     public AnthropicToolSchema() {}
 
     /**
@@ -41,6 +44,7 @@ public class AnthropicToolSchema {
         this.additionalProperties = builder.additionalProperties;
         this.properties = builder.properties;
         this.required = builder.required;
+        this.defs = builder.defs;
     }
 
     @Override
@@ -50,12 +54,13 @@ public class AnthropicToolSchema {
         return Objects.equals(type, that.type)
                 && Objects.equals(additionalProperties, that.additionalProperties)
                 && Objects.equals(properties, that.properties)
-                && Objects.equals(required, that.required);
+                && Objects.equals(required, that.required)
+                && Objects.equals(defs, that.defs);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, additionalProperties, properties, required);
+        return Objects.hash(type, additionalProperties, properties, required, defs);
     }
 
     @Override
@@ -65,6 +70,7 @@ public class AnthropicToolSchema {
                 + ", additionalProperties=" + additionalProperties
                 + ", properties=" + properties
                 + ", required=" + required
+                + ", defs=" + defs
                 + '}';
     }
 
@@ -78,6 +84,7 @@ public class AnthropicToolSchema {
         private Boolean additionalProperties;
         private Map<String, Map<String, Object>> properties;
         private List<String> required;
+        private Map<String, Map<String, Object>> defs;
 
         public Builder type(String type) {
             this.type = type;
@@ -96,6 +103,11 @@ public class AnthropicToolSchema {
 
         public Builder required(List<String> required) {
             this.required = required;
+            return this;
+        }
+
+        public Builder defs(Map<String, Map<String, Object>> defs) {
+            this.defs = defs;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -412,15 +412,19 @@ public class AnthropicMapper {
 
         boolean strict = isEffectivelyStrict(toolSpecification, Boolean.TRUE.equals(strictTools));
 
+        AnthropicToolSchema.Builder inputSchemaBuilder = AnthropicToolSchema.builder()
+                .properties(parameters != null ? toMap(parameters.properties(), strict) : emptyMap())
+                .required(parameters != null ? parameters.required() : emptyList())
+                .additionalProperties(strict ? Boolean.FALSE : null);
+        if (parameters != null && !parameters.definitions().isEmpty()) {
+            inputSchemaBuilder.defs(mapDefs(parameters.definitions()));
+        }
+
         AnthropicTool.Builder toolBuilder = AnthropicTool.builder()
                 .name(toolSpecification.name())
                 .description(toolSpecification.description())
                 .strict(strict ? Boolean.TRUE : null)
-                .inputSchema(AnthropicToolSchema.builder()
-                        .properties(parameters != null ? toMap(parameters.properties(), strict) : emptyMap())
-                        .required(parameters != null ? parameters.required() : emptyList())
-                        .additionalProperties(strict ? Boolean.FALSE : null)
-                        .build());
+                .inputSchema(inputSchemaBuilder.build());
 
         if (cacheToolsPrompt != AnthropicCacheType.NO_CACHE) {
             toolBuilder.cacheControl(cacheToolsPrompt.cacheControl());

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -331,6 +331,65 @@ class AnthropicMapperTest {
     }
 
     @Test
+    void test_toAnthropicTool_with_definitions() throws JsonProcessingException {
+
+        // given
+        String reference = "Foo";
+        JsonSchemaElement fooSchema = JsonObjectSchema.builder()
+                .addStringProperty("name")
+                .required("name")
+                .build();
+        ToolSpecification toolSpecification = ToolSpecification.builder()
+                .name("tool")
+                .description("description")
+                .parameters(JsonObjectSchema.builder()
+                        .addProperty(
+                                "foo",
+                                JsonReferenceSchema.builder()
+                                        .reference(reference)
+                                        .build())
+                        .required("foo")
+                        .definitions(Map.of(reference, fooSchema))
+                        .build())
+                .build();
+
+        // when
+        AnthropicTool anthropicTool = toAnthropicTool(toolSpecification, AnthropicCacheType.NO_CACHE, Set.of(), null);
+
+        // then
+        assertThat(anthropicTool.inputSchema.defs).isNotNull();
+        assertThat(anthropicTool.inputSchema.defs).containsKey(reference);
+
+        // and the $defs key is serialized as "$defs" (not snake_cased to "defs")
+        String json = new ObjectMapper().writeValueAsString(anthropicTool.inputSchema);
+        assertThat(json).contains("\"$defs\"");
+        assertThat(json).doesNotContain("\"defs\"");
+    }
+
+    @Test
+    void test_toAnthropicTool_without_definitions_omits_defs() throws JsonProcessingException {
+
+        // given
+        ToolSpecification toolSpecification = ToolSpecification.builder()
+                .name("tool")
+                .description("description")
+                .parameters(JsonObjectSchema.builder()
+                        .addStringProperty("parameter")
+                        .required("parameter")
+                        .build())
+                .build();
+
+        // when
+        AnthropicTool anthropicTool = toAnthropicTool(toolSpecification, AnthropicCacheType.NO_CACHE, Set.of(), null);
+
+        // then
+        assertThat(anthropicTool.inputSchema.defs).isNull();
+
+        String json = new ObjectMapper().writeValueAsString(anthropicTool.inputSchema);
+        assertThat(json).doesNotContain("$defs");
+    }
+
+    @Test
     void test_toAnthropicSchema_with_optional_fields() throws JsonProcessingException {
 
         // given


### PR DESCRIPTION
## Issue
<!-- Update with the real issue number once filed. -->
Closes #5498

## Change

`AnthropicMapper.toAnthropicTool()` did not serialize a tool parameter's top-level `$defs` into the tool `input_schema`. Because the referenced definitions in `JsonObjectSchema.definitions()` were dropped, a parameter using a `$ref` (`JsonReferenceSchema`) reached Anthropic as a dangling reference.

This is the missed sibling of PR #5131 (Closes #5133), which added `$defs` to the structured-output path (`toAnthropicSchema`) only. The OpenAI mapper already preserves `$defs` for the same input, so this also restores cross-provider parity.

Changes:
- `AnthropicToolSchema`: add a `defs` field mapped to `$defs` via `@JsonProperty("$defs")` (needed because the class uses `SnakeCaseStrategy`), with builder support and `equals`/`hashCode`/`toString`. The deprecated 3-arg constructor is untouched.
- `AnthropicMapper.toAnthropicTool()`: populate `defs` from `parameters.definitions()` when non-empty, reusing `mapDefs` and mirroring `toAnthropicSchema`.

Backward compatible: `@JsonInclude(NON_NULL)` applies, so tools without definitions produce identical output.

Tests (`AnthropicMapperTest`): a positive test asserts `$defs` is present, contains the referenced key, and serializes as `"$defs"` (regression guard for the `@JsonProperty`); a negative test asserts no `$defs` is emitted without definitions.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- core/main untouched -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A, add after approval -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->

<!-- "new maven module" and "embedding store" checklists omitted: not applicable, this is a bug fix in an existing module. -->
