### PR TITLE
fix: Escape double quotes and backslashes in Cosmos DB NoSQL filter values

### DIFF
--- a/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/rag/content/retriever/azure/cosmos/nosql/DefaultAzureCosmosDBNoSqlFilterMapper.java
+++ b/langchain4j-azure-cosmos-nosql/src/main/java/dev/langchain4j/rag/content/retriever/azure/cosmos/nosql/DefaultAzureCosmosDBNoSqlFilterMapper.java
@@ -152,7 +152,8 @@ public class DefaultAzureCosmosDBNoSqlFilterMapper implements AzureCosmosDBNoSql
 
     private String formatValue(Object value) {
         if (value instanceof String) {
-            return "\"" + value + "\"";
+            String escaped = ((String) value).replace("\\", "\\\\").replace("\"", "\\\"");
+            return "\"" + escaped + "\"";
         }
         return value.toString();
     }

--- a/langchain4j-azure-cosmos-nosql/src/test/java/dev/langchain4j/rag/content/retriever/azure/cosmos/nosql/DefaultAzureCosmosDBNoSqlFilterMapperTest.java
+++ b/langchain4j-azure-cosmos-nosql/src/test/java/dev/langchain4j/rag/content/retriever/azure/cosmos/nosql/DefaultAzureCosmosDBNoSqlFilterMapperTest.java
@@ -140,6 +140,27 @@ class DefaultAzureCosmosDBNoSqlFilterMapperTest {
     }
 
     @Test
+    void map_escapesDoubleQuotesInValue() {
+        IsEqualTo filter = new IsEqualTo("size", "12\"display");
+        String result = mapper.map(filter);
+        assertThat(result).isEqualTo("c.size = \"12\\\"display\"");
+    }
+
+    @Test
+    void map_escapesBackslashInValue() {
+        IsEqualTo filter = new IsEqualTo("path", "a\\b");
+        String result = mapper.map(filter);
+        assertThat(result).isEqualTo("c.path = \"a\\\\b\"");
+    }
+
+    @Test
+    void map_escapesDoubleQuotesInContainsString() {
+        ContainsString filter = new ContainsString("desc", "a\"b");
+        String result = mapper.map(filter);
+        assertThat(result).isEqualTo("CONTAINS(c.desc, \"a\\\"b\")");
+    }
+
+    @Test
     void map_throwsExceptionForUnsupportedFilter() {
         Filter unsupportedFilter = new Filter() {
             @Override


### PR DESCRIPTION
## Issue
<!-- Update # with the real issue number after the bug issue is filed. -->
Closes #5500

## Change
`DefaultAzureCosmosDBNoSqlFilterMapper.formatValue(Object)` wrapped String values in double quotes without escaping embedded `"` or `\`, producing broken Cosmos DB NoSQL SQL (e.g. `IsEqualTo("size","12\"display")` -> `c.size = "12"display"`).

`formatValue` is the single entry point for every String filter path (`mapIsEqualTo`, `mapContainsString`, `mapInValues`, `mapFullText*`), so the defect reaches all of them.

Fix: escape backslashes first, then double quotes:
```java
String escaped = ((String) value).replace("\\", "\\\\").replace("\"", "\\\"");
return "\"" + escaped + "\"";
```

Values without `"` or `\` are emitted unchanged, so existing tests stay green. Added 3 unit tests: a quote, a backslash, and a quote propagated through `ContainsString`.

The sibling `langchain4j-azure-ai-search` mapper shares the same gap; left for a follow-up.

## Pre-checks
- Unit tests: 21 run, 0 failures (18 existing + 3 new). The 3 new tests fail on the unpatched mapper and pass after the fix.
- Spotless: `spotless:check` cannot run in the worktree (JGit "Cannot find git repository"), so it ran in the main checkout — `apply` made no diff, `check` passed, and the checkout was restored to pristine.
- Integration tests (`*IT`, `@EnabledIfEnvironmentVariable`) not run (require Azure credentials); none added or modified.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases <!-- happy-path values stay unchanged; escaping cases added -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- unit tests green; Azure ITs require credentials and were not run -->
- [ ] I have manually run all the unit and integration tests in the core and main modules <!-- change is confined to langchain4j-azure-cosmos-nosql -->
- [ ] I have added/updated the documentation <!-- add after approval -->
- [ ] I have added an example in the examples repo <!-- not a big feature -->
- [ ] I have added/updated Spring Boot starter(s) <!-- not applicable -->

<!-- New maven module and embedding store checklists omitted: no new module and no embedding store integration added/changed. -->