### PR TITLE
fix: prevent integer overflow in AwsDocumentConverter for long and BigInteger tool arguments

### DIFF
--- a/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AwsDocumentConverter.java
+++ b/langchain4j-bedrock/src/main/java/dev/langchain4j/model/bedrock/AwsDocumentConverter.java
@@ -90,7 +90,7 @@ class AwsDocumentConverter {
         } else if (value.isDouble() || value.isFloat() || value.isBigDecimal()) {
             doc = Document.fromNumber(value.asDouble());
         } else if (value.isInt() || value.isLong() || value.isShort() || value.isBigInteger()) {
-            doc = Document.fromNumber(value.asInt());
+            doc = Document.fromNumber(value.bigIntegerValue());
         } else if (value.isArray()) {
             List<Document> list = new ArrayList<>();
             for (JsonNode node : value) {

--- a/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/AwsDocumentConverterTest.java
+++ b/langchain4j-bedrock/src/test/java/dev/langchain4j/model/bedrock/AwsDocumentConverterTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -79,8 +80,7 @@ class AwsDocumentConverterTest {
     @Test
     void convert_json_to_primitive_types() {
         // Given
-        String json =
-                """
+        String json = """
                 {
                     "string": "test",
                     "integer": 42,
@@ -102,8 +102,7 @@ class AwsDocumentConverterTest {
     @Test
     void convert_json_to_list() {
         // Given
-        String json =
-                """
+        String json = """
                 {
                     "list": ["item1", 2, true]
                 }
@@ -122,8 +121,7 @@ class AwsDocumentConverterTest {
     @Test
     void convert_json_to_nested_object() {
         // Given
-        String json =
-                """
+        String json = """
                 {
                     "nested": {
                         "inner_key": "inner_value"
@@ -473,6 +471,44 @@ class AwsDocumentConverterTest {
         assertThat(json)
                 .containsIgnoringWhitespaces("\"longValue\": " + Long.MAX_VALUE)
                 .containsIgnoringWhitespaces("\"bigDecimal\": " + Double.MAX_VALUE);
+    }
+
+    @Test
+    void documentFromJson_preserves_long_value() {
+        // Given - a JSON integer larger than Integer.MAX_VALUE
+        String json = "{\"id\":9223372036854775807}";
+
+        // When
+        Document document = AwsDocumentConverter.documentFromJson(json);
+
+        // Then - the full long value must be preserved (no narrowing to int)
+        assertThat(document.asMap().get("id").asNumber().longValue()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    void documentFromJson_preserves_big_integer_value() {
+        // Given - a JSON integer larger than Long.MAX_VALUE
+        BigInteger huge = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        String json = "{\"id\":" + huge + "}";
+
+        // When
+        Document document = AwsDocumentConverter.documentFromJson(json);
+
+        // Then - the full BigInteger value must be preserved
+        assertThat(document.asMap().get("id").asNumber().bigDecimalValue().toBigIntegerExact())
+                .isEqualTo(huge);
+    }
+
+    @Test
+    void documentFromJson_preserves_int_value() {
+        // Given - a regular int value (regression: in-range values stay unchanged)
+        String json = "{\"id\":42}";
+
+        // When
+        Document document = AwsDocumentConverter.documentFromJson(json);
+
+        // Then
+        assertThat(document.asMap().get("id").asNumber().intValue()).isEqualTo(42);
     }
 
     @Test


### PR DESCRIPTION
## Issue
<!-- Update with the real issue number once the issue is filed -->
Closes #5502

## Change

`AwsDocumentConverter.getDocument(JsonNode)` matched the integer branch on `isInt() || isLong() || isShort() || isBigInteger()` but converted with `Document.fromNumber(value.asInt())`. Jackson `asInt()` narrows `long`/`BigInteger` to `(int)`, silently corrupting values outside the int range (`9223372036854775807` becomes `-1`).

This is reached on a normal path: `AbstractBedrockChatModel.convertToolRequests()` converts LLM tool-call argument JSON to a `Document` via `documentFromJson(...)`, so large integer tool arguments were mangled before being sent to Bedrock.

Fix: convert with `value.bigIntegerValue()`. A `Document.fromNumber(BigInteger)` overload exists in sdk-core, so no new import or dependency is needed. This is width-preserving and symmetric with the reverse `documentToObject()` (`asNumber()`) and the `double` branch (`asDouble()`). In-range `int` values are unchanged (backward compatible).

Tests: added `documentFromJson` round-trip tests for `Long.MAX_VALUE`, a value above `Long.MAX_VALUE`, and an in-range int regression. The first two fail on the old code and pass after the fix.

Note: spotless ratchet reformatted three pre-existing text blocks in the touched test file (required to pass CI `spotless:check`).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- "new maven module" and "embedding store" checklists omitted: not applicable to this bug fix. -->