### PR TITLE
fix: add langchain4j-document-parser-docling to BOM

### DIFF
--- a/langchain4j-bom/pom.xml
+++ b/langchain4j-bom/pom.xml
@@ -546,6 +546,12 @@
                 <version>${langchain4j.beta.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-document-parser-docling</artifactId>
+                <version>${langchain4j.beta.version}</version>
+            </dependency>
+
             <!-- document transformers -->
 
             <dependency>


### PR DESCRIPTION
## Issue
<!-- Update with the real issue number once the bug report is filed. -->
Closes #5504

## Change
Register `langchain4j-document-parser-docling` in `langchain4j-bom/pom.xml`.

The module was introduced in #4933 and added to the root `pom.xml`, but the corresponding BOM `dependencyManagement` entry was omitted. Its five sibling document parsers (apache-pdfbox, apache-poi, apache-tika, markdown, yaml) are already managed in the BOM.

The new entry is placed at the end of the `<!-- document parsers -->` block and uses `${langchain4j.beta.version}`, matching the siblings and the module's inherited parent version (1.17.0-beta27-SNAPSHOT).

This is the same fix pattern as #4675 (which added the missing spring-restclient entry for #4674).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change <!-- N/A — BOM has no source; verified via mvn validate/effective-pom -->
- [ ] The tests cover both positive and negative cases <!-- N/A -->
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- N/A — BOM has no tests -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is BOM-only -->

## Checklist for adding new maven module
- [X] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml` <!-- module already in root pom.xml via #4933; this PR adds the missing BOM entry -->

<!-- Embedding store checklist sections removed: not applicable to a BOM dependency-management change. -->