### PR TITLE
fix: forward image detail level to Azure OpenAI chat requests

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
@@ -30,6 +30,7 @@ import com.azure.ai.openai.models.ChatCompletionsToolDefinition;
 import com.azure.ai.openai.models.ChatCompletionsToolSelection;
 import com.azure.ai.openai.models.ChatCompletionsToolSelectionPreset;
 import com.azure.ai.openai.models.ChatMessageImageContentItem;
+import com.azure.ai.openai.models.ChatMessageImageDetailLevel;
 import com.azure.ai.openai.models.ChatMessageImageUrl;
 import com.azure.ai.openai.models.ChatMessageTextContentItem;
 import com.azure.ai.openai.models.ChatRequestAssistantMessage;
@@ -215,9 +216,11 @@ class InternalAzureOpenAiHelper {
             // configuration (e.g. AZURE_HTTP_CLIENT_IMPLEMENTATION) when multiple providers are on the classpath.
             return HttpClient.createDefault(clientOptions);
         } catch (IllegalStateException e) {
-            throw new IllegalStateException("No HttpClientProvider implementation found on the classpath. "
-                    + "Add 'com.azure:azure-core-http-netty' as a dependency, "
-                    + "or provide a custom HttpClientProvider via .httpClientProvider() on the builder.", e);
+            throw new IllegalStateException(
+                    "No HttpClientProvider implementation found on the classpath. "
+                            + "Add 'com.azure:azure-core-http-netty' as a dependency, "
+                            + "or provide a custom HttpClientProvider via .httpClientProvider() on the builder.",
+                    e);
         }
     }
 
@@ -257,9 +260,8 @@ class InternalAzureOpenAiHelper {
             return chatRequestAssistantMessage;
         } else if (message instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
             if (!toolExecutionResultMessage.hasSingleText()) {
-                throw new UnsupportedFeatureException(
-                        "Azure OpenAI does not support non-text content in tool results. "
-                                + "Only text content is supported.");
+                throw new UnsupportedFeatureException("Azure OpenAI does not support non-text content in tool results. "
+                        + "Only text content is supported.");
             }
             return new ChatRequestToolMessage(toolExecutionResultMessage.text(), toolExecutionResultMessage.id());
         } else if (message instanceof SystemMessage systemMessage) {
@@ -278,6 +280,7 @@ class InternalAzureOpenAiHelper {
                             } else if (content instanceof ImageContent imageContent) {
                                 String imageUrlString = toImageUrl(imageContent.image());
                                 ChatMessageImageUrl imageUrl = new ChatMessageImageUrl(imageUrlString);
+                                imageUrl.setDetail(toDetail(imageContent.detailLevel()));
                                 return new ChatMessageImageContentItem(imageUrl);
                             } else {
                                 throw new IllegalArgumentException("Unsupported content type: " + content.type());
@@ -309,6 +312,19 @@ class InternalAzureOpenAiHelper {
             return image.url().toString();
         }
         return String.format("data:%s;base64,%s", image.mimeType(), image.base64Data());
+    }
+
+    private static ChatMessageImageDetailLevel toDetail(ImageContent.DetailLevel detailLevel) {
+        if (detailLevel == null) {
+            return null;
+        }
+        // The Azure OpenAI SDK's ChatMessageImageDetailLevel only supports AUTO, LOW and HIGH.
+        return switch (detailLevel) {
+            case LOW -> ChatMessageImageDetailLevel.LOW;
+            case HIGH -> ChatMessageImageDetailLevel.HIGH;
+            case AUTO -> ChatMessageImageDetailLevel.AUTO;
+            default -> throw new UnsupportedFeatureException("Unsupported image detail level: " + detailLevel);
+        };
     }
 
     private static List<ChatCompletionsToolCall> toolExecutionRequestsFrom(ChatMessage message) {

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
@@ -2,6 +2,7 @@ package dev.langchain4j.model.azure;
 
 import static dev.langchain4j.model.azure.InternalAzureOpenAiHelper.aiMessageFrom;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.output.FinishReason;
 import java.io.IOException;
 import java.time.Duration;
@@ -155,8 +157,7 @@ class InternalAzureOpenAiHelperTest {
         String functionName = "current_time";
         String functionArguments = "{}";
         // language=json
-        String responseJson =
-                """
+        String responseJson = """
                 {
                         "role": "ASSISTANT",
                         "content": "Hello",
@@ -271,6 +272,53 @@ class InternalAzureOpenAiHelperTest {
                 .contains("url")
                 .doesNotContain("data:image")
                 .doesNotContain("base64");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldForwardLowImageDetailLevel() {
+        // Given
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.LOW);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        String contentJson = requestMessage.getContent().toString();
+        assertThat(contentJson).contains("\"detail\":\"low\"");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldForwardHighImageDetailLevel() {
+        // Given
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.HIGH);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        String contentJson = requestMessage.getContent().toString();
+        assertThat(contentJson).contains("\"detail\":\"high\"").doesNotContain("\"detail\":\"low\"");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldThrowForUnsupportedImageDetailLevel() {
+        // Given - Azure OpenAI SDK only supports AUTO, LOW and HIGH
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.ULTRA_HIGH);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When / Then
+        assertThatThrownBy(() -> InternalAzureOpenAiHelper.toOpenAiMessages(messages))
+                .isInstanceOf(UnsupportedFeatureException.class);
     }
 
     @Test


### PR DESCRIPTION
## Issue
<!-- Human: set the issue number after creating the bug-report issue. -->
Closes #5508

## Change
`InternalAzureOpenAiHelper.toOpenAiMessage()` did not forward `ImageContent.detailLevel()` to Azure, so the user-specified image detail was dropped and Azure used its server default.

This PR maps the detail level onto `ChatMessageImageUrl.setDetail(...)`, mirroring `OpenAiUtils.toDetail()` in the sibling `langchain4j-open-ai` module. A private `toDetail(ImageContent.DetailLevel)` maps LOW/HIGH/AUTO to `ChatMessageImageDetailLevel`; MEDIUM/ULTRA_HIGH throw `UnsupportedFeatureException` because the Azure SDK `ChatMessageImageDetailLevel` only supports AUTO/LOW/HIGH.

This aligns the request with the detail-aware `AzureOpenAiTokenCountEstimator` (PR #5388), removing the estimate/send mismatch.

Behaviour change: `ImageContent`'s default detail level is `LOW` (non-null), so callers that never set a detail now send `low` instead of relying on Azure's default. This matches the OpenAI module and the estimator above.

Note: the spotless ratchet (`ratchetFrom=origin/main`) reformatted a few pre-existing lines in the two touched files; no unrelated logic was changed.

Tests: positive LOW/HIGH assertions on the serialized JSON (`"detail":"low"` / `"high"`), and an `UnsupportedFeatureException` assertion for ULTRA_HIGH. Verified fail-then-pass against the unfixed code.

<!-- Conditional sections for new maven module / embedding store omitted: not applicable (single-file fix in existing module). -->

## General checklist
- [ ] There are no breaking changes (API, behaviour) <!-- behaviour: default-LOW now forwarded; parity with OpenAI module, see Change -->
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
