### PR TITLE
fix: wmv MIME type mapping key in CustomMimeTypesFileTypeDetector

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetector.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetector.java
@@ -89,7 +89,7 @@ public class CustomMimeTypesFileTypeDetector extends FileTypeDetector {
         defaultMappings.put("avi",    "video/avi");
         defaultMappings.put("flv",    "video/x-flv");
         defaultMappings.put("webm",   "video/webm");
-        defaultMappings.put("mmv",    "video/wmv");
+        defaultMappings.put("wmv", "video/wmv");
         defaultMappings.put("3gpp",   "video/3gpp");
     }
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetectorTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/CustomMimeTypesFileTypeDetectorTest.java
@@ -42,6 +42,18 @@ class CustomMimeTypesFileTypeDetectorTest {
     }
 
     @Test
+    void should_return_a_mime_type_for_wmv_from_default_mapping() {
+        // given
+        CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();
+
+        // when
+        String mimeType = detector.probeContentType("video.wmv");
+
+        // then
+        assertThat(mimeType).isEqualTo("video/wmv");
+    }
+
+    @Test
     void should_return_a_mime_type_from_default_mapping_from_string() {
         // given
         CustomMimeTypesFileTypeDetector detector = new CustomMimeTypesFileTypeDetector();


### PR DESCRIPTION
## Issue
Closes #5510

## Change
`CustomMimeTypesFileTypeDetector`'s default video mappings had a typo in the WMV entry key: `defaultMappings.put("mmv", "video/wmv")`. All sibling video entries key on the file extension (`mp4`, `mov`, `avi`, `webm`, …), and the value `video/wmv` makes the intended key `"wmv"` obvious. With the typo, real `.wmv` files never matched the default mapping and fell through to the JDK (`Files.probeContentType` → `video/x-ms-wmv`), while the `.mmv` key was dead (no such extension). This affects multimodal video MIME detection for the Gemini/Vertex AI providers.

This PR changes the key `"mmv"` → `"wmv"`, keeping the value `"video/wmv"` unchanged. One production line; no behaviour change for any other extension, no API change, no new dependency. Spotless (palantir) collapses the manual column alignment only on the changed line, as expected for `ratchetFrom origin/main`.

## Tests
Added a deterministic unit test mirroring the existing default-mapping String assertions:
`assertThat(new CustomMimeTypesFileTypeDetector().probeContentType("video.wmv")).isEqualTo("video/wmv");`
This is a positive fail-then-pass assertion: it fails on current `main` (returns the JDK fallback `video/x-ms-wmv`) and passes after the fix. A negative case is not meaningful for a mapping-key correction, so none was added.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases — positive-only; negative case not meaningful for a mapping-key fix
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation — not applicable (internal mapping fix)
- [ ] I have added an example in the examples repo — not applicable
- [ ] I have added/updated Spring Boot starter(s) — not applicable

<!-- "Checklist for adding new maven module" omitted: no new module. -->
<!-- "Checklist for adding/changing embedding store integration" omitted: not an embedding store change. -->
