### PR TITLE
Report total token count from Google GenAI usage metadata

### DIFF
--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapper.java
@@ -284,13 +284,18 @@ class GoogleGenAiContentMapper {
         AiMessage aiMessage = aiMessageBuilder.build();
 
         TokenUsage usage = response.usageMetadata()
-                .map(meta -> new TokenUsage(
-                        meta.promptTokenCount().isPresent()
-                                ? meta.promptTokenCount().get()
-                                : 0,
-                        meta.candidatesTokenCount().isPresent()
-                                ? meta.candidatesTokenCount().get()
-                                : 0))
+                .map(meta -> {
+                    int promptTokenCount = meta.promptTokenCount().isPresent()
+                            ? meta.promptTokenCount().get()
+                            : 0;
+                    int candidatesTokenCount = meta.candidatesTokenCount().isPresent()
+                            ? meta.candidatesTokenCount().get()
+                            : 0;
+                    int totalTokenCount = meta.totalTokenCount().isPresent()
+                            ? meta.totalTokenCount().get()
+                            : promptTokenCount + candidatesTokenCount;
+                    return new TokenUsage(promptTokenCount, candidatesTokenCount, totalTokenCount);
+                })
                 .orElse(new TokenUsage(0, 0));
 
         FinishReason finishReason = candidate

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiContentMapperTest.java
@@ -266,6 +266,52 @@ class GoogleGenAiContentMapperTest {
     }
 
     @Test
+    void should_use_total_token_count_from_usage_metadata() {
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(Part.builder().text("Hello!").build())
+                                .build())
+                        .build()))
+                .usageMetadata(GenerateContentResponseUsageMetadata.builder()
+                        .promptTokenCount(10)
+                        .candidatesTokenCount(5)
+                        .thoughtsTokenCount(7)
+                        .totalTokenCount(22)
+                        .build())
+                .build();
+
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(response, "test-model");
+
+        assertThat(result.tokenUsage().inputTokenCount()).isEqualTo(10);
+        assertThat(result.tokenUsage().outputTokenCount()).isEqualTo(5);
+        assertThat(result.tokenUsage().totalTokenCount()).isEqualTo(22);
+    }
+
+    @Test
+    void should_fall_back_to_prompt_plus_candidates_when_total_token_count_absent() {
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(Part.builder().text("Hello!").build())
+                                .build())
+                        .build()))
+                .usageMetadata(GenerateContentResponseUsageMetadata.builder()
+                        .promptTokenCount(10)
+                        .candidatesTokenCount(5)
+                        .build())
+                .build();
+
+        ChatResponse result = GoogleGenAiContentMapper.toChatResponse(response, "test-model");
+
+        assertThat(result.tokenUsage().inputTokenCount()).isEqualTo(10);
+        assertThat(result.tokenUsage().outputTokenCount()).isEqualTo(5);
+        assertThat(result.tokenUsage().totalTokenCount()).isEqualTo(15);
+    }
+
+    @Test
     void should_return_google_gen_ai_metadata_with_raw_response() {
         GenerateContentResponse response = GenerateContentResponse.builder()
                 .candidates(List.of(Candidate.builder()


### PR DESCRIPTION
## Issue
Closes #5518

## Change

`GoogleGenAiContentMapper.toChatResponse()` built `TokenUsage` from only `promptTokenCount` and `candidatesTokenCount` via the 2-arg `TokenUsage(input, output)` constructor, which derives the total as `input + output`. The SDK's `usageMetadata.totalTokenCount()` was ignored.

For thinking-enabled Gemini models (2.5/3.x), `totalTokenCount` also covers thoughts, cached, and tool-use tokens, so `prompt + candidates` is smaller than the billed total and `tokenUsage().totalTokenCount()` was under-reported. The chat, streaming, and batch paths all route through `toChatResponse()`, so all three were affected.

This switches to the 3-arg `TokenUsage` constructor, passing `meta.totalTokenCount()` when present and falling back to `prompt + candidates` when absent. The sibling module `langchain4j-vertex-ai-gemini` (`TokenUsageMapper`) already uses this 3-arg pattern.

```java
int totalTokenCount = meta.totalTokenCount().isPresent()
        ? meta.totalTokenCount().get()
        : promptTokenCount + candidatesTokenCount;
return new TokenUsage(promptTokenCount, candidatesTokenCount, totalTokenCount);
```

Tested with google-genai SDK 1.59.0.

Behaviour note: for thinking models the reported total now grows to the correct, larger value. No API or signature change.

## General checklist
<!-- behaviour change: thinking-model total now larger (=more accurate); so the "no breaking changes" box reflects API-only safety honestly -->
- [ ] There are no breaking changes (API, behaviour) <!-- API/signature unchanged, but observable behaviour change: tokenUsage().totalTokenCount() for thinking models now reports the larger, correct SDK total (was prompt+candidates). Box left unchecked to flag the value change honestly. -->
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

<!-- "new maven module" / "new embedding store integration" / "changing existing embedding store" 섹션 생략: 신규 모듈도 embedding store도 아닌 provider 내부 버그픽스. -->

### Pre-checks
- Unit tests: `GoogleGenAiContentMapperTest` 37 passing (2 new), module total 119 passing. JDK 17, `./mvnw -pl langchain4j-google-genai clean test`.
- *IT는 surefire `clean test`에서 미실행(API 키 게이트) — 변경하지 않음.
- spotless: JDK 17 `spotless:apply`/`spotless:check` BUILD SUCCESS (worktree `.git`가 gitdir 포인터라 ratchet이 실패하므로 MAIN_ROOT 비-worktree 체크아웃에서 실행해 검증; 내 변경 라인만 포맷됨, 무관 라인 reformat 없음).
