### PR TITLE
fix: Escape SQL LIKE single-character wildcard in Hibernate metadata contains filter

### DIFF
--- a/langchain4j-hibernate/src/main/java/dev/langchain4j/store/embedding/hibernate/HibernateEmbeddingStore.java
+++ b/langchain4j-hibernate/src/main/java/dev/langchain4j/store/embedding/hibernate/HibernateEmbeddingStore.java
@@ -834,7 +834,7 @@ public class HibernateEmbeddingStore<E> implements EmbeddingStore<TextSegment> {
                                         .comparisonValue()
                                         .replace("\\", "\\\\")
                                         .replace("%", "\\%")
-                                        .replace("?", "\\?")
+                                        .replace("_", "\\_")
                                 + "%",
                         '\\'));
     }

--- a/langchain4j-hibernate/src/test/java/dev/langchain4j/store/embedding/hibernate/HibernateEmbeddingStoreContainsFilterTest.java
+++ b/langchain4j-hibernate/src/test/java/dev/langchain4j/store/embedding/hibernate/HibernateEmbeddingStoreContainsFilterTest.java
@@ -1,0 +1,85 @@
+package dev.langchain4j.store.embedding.hibernate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.store.embedding.filter.comparison.ContainsString;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+import org.hibernate.metamodel.mapping.AttributeMapping;
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.hibernate.query.criteria.JpaExpression;
+import org.hibernate.query.criteria.JpaPath;
+import org.hibernate.query.criteria.JpaPredicate;
+import org.hibernate.query.criteria.JpaRoot;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for the SQL LIKE pattern produced by {@code HibernateEmbeddingStore.mapContains} when translating a
+ * {@link ContainsString} metadata filter. These tests run without a live database: the store instance is created via
+ * Mockito (bypassing the regular constructor) and {@code mapContains} is invoked through reflection so the real method
+ * body executes against mocked Hibernate criteria collaborators.
+ */
+class HibernateEmbeddingStoreContainsFilterTest {
+
+    @SuppressWarnings("unchecked")
+    private String capturePattern(String comparisonValue) throws Exception {
+        HibernateEmbeddingStore<?> store = mock(HibernateEmbeddingStore.class, CALLS_REAL_METHODS);
+
+        // Inject a mapped attribute for key "key" so mapContains takes the mapped branch (avoids the unmapped
+        // branch which dereferences the null unmappedMetadataAttributeMapping field).
+        Field mappingsField = HibernateEmbeddingStore.class.getDeclaredField("metadataAttributeMappings");
+        mappingsField.setAccessible(true);
+        mappingsField.set(store, Map.of("key", mock(AttributeMapping.class)));
+
+        JpaRoot<Object> root = mock(JpaRoot.class);
+        HibernateCriteriaBuilder cb = mock(HibernateCriteriaBuilder.class);
+        JpaPath<Object> path = mock(JpaPath.class);
+        JpaPredicate notNullPredicate = mock(JpaPredicate.class);
+        JpaPredicate likePredicate = mock(JpaPredicate.class);
+        JpaPredicate andPredicate = mock(JpaPredicate.class);
+
+        when(root.get("key")).thenReturn(path);
+        when(path.isNotNull()).thenReturn(notNullPredicate);
+
+        ArgumentCaptor<String> patternCaptor = ArgumentCaptor.forClass(String.class);
+        when(cb.like(eq((JpaExpression<String>) (JpaExpression<?>) path), patternCaptor.capture(), eq('\\')))
+                .thenReturn(likePredicate);
+        when(cb.and(notNullPredicate, likePredicate)).thenReturn(andPredicate);
+
+        ContainsString containsString = new ContainsString("key", comparisonValue);
+
+        Method mapContains = HibernateEmbeddingStore.class.getDeclaredMethod(
+                "mapContains", JpaRoot.class, HibernateCriteriaBuilder.class, ContainsString.class);
+        mapContains.setAccessible(true);
+        JpaPredicate result = (JpaPredicate) mapContains.invoke(store, root, cb, containsString);
+
+        assertThat(result).isSameAs(andPredicate);
+        return patternCaptor.getValue();
+    }
+
+    @Test
+    void escapes_single_character_wildcard_underscore() throws Exception {
+        assertThat(capturePattern("a_b")).isEqualTo("%a\\_b%");
+    }
+
+    @Test
+    void escapes_multi_character_wildcard_percent() throws Exception {
+        assertThat(capturePattern("a%b")).isEqualTo("%a\\%b%");
+    }
+
+    @Test
+    void does_not_escape_question_mark_which_is_not_a_like_wildcard() throws Exception {
+        assertThat(capturePattern("a?b")).isEqualTo("%a?b%");
+    }
+
+    @Test
+    void escapes_backslash() throws Exception {
+        assertThat(capturePattern("a\\b")).isEqualTo("%a\\\\b%");
+    }
+}


### PR DESCRIPTION
## Issue
<!-- 사람이 실제 이슈번호로 갱신할 것 (위 issue 초안을 제출한 뒤 번호 기입) -->
Closes #5521

## Change

`HibernateEmbeddingStore.mapContains` builds a SQL `LIKE` pattern from a `ContainsString` filter value, using `\` as the escape character.

The escaping was wrong: it escaped `?`, which is not a `LIKE` wildcard, and did not escape `_`, the single-character `LIKE` wildcard. So a value like `a_b` matched `axb` — a false positive that violates the core `ContainsString.test()` contract (`String.contains()`, a plain substring match).

Fix: replace `.replace("?", "\\?")` with `.replace("_", "\\_")`. Dropping the `?` escape is safe because `?` is a `LIKE` literal; escaping of `\` and `%` is unchanged.

Test: `HibernateEmbeddingStoreContainsFilterTest` (new) asserts the generated `LIKE` pattern for inputs containing `_`, `%`, `?`, and `\`. It needs no database: it creates the store via Mockito to bypass the constructor, injects a mapped attribute and invokes the private `mapContains` by reflection so the real method runs against mocked Hibernate criteria collaborators, then captures the pattern with an `ArgumentCaptor`. Removing the fix makes the `_` and `?` cases fail, confirming the test is not tautological.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- 단위테스트(`mvn -pl langchain4j-hibernate clean test`) 4건 green. 모듈의 *IT는 live DB(PgVector/Oracle/Db2/SQLServer/CockroachDB/MariaDB)·Testcontainers 의존이라 로컬 미실행. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- "Checklist for adding new maven module" 생략: 신규 모듈 없음. -->
<!-- "Checklist for adding/changing embedding store integration" 생략: 통합 추가·스키마 변경 없음, 기존 필터 동작 버그 수정만. -->

