### PR TITLE
fix: forward image detail level to Azure OpenAI chat requests (#5508)

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
@@ -30,6 +30,7 @@ import com.azure.ai.openai.models.ChatCompletionsToolDefinition;
 import com.azure.ai.openai.models.ChatCompletionsToolSelection;
 import com.azure.ai.openai.models.ChatCompletionsToolSelectionPreset;
 import com.azure.ai.openai.models.ChatMessageImageContentItem;
+import com.azure.ai.openai.models.ChatMessageImageDetailLevel;
 import com.azure.ai.openai.models.ChatMessageImageUrl;
 import com.azure.ai.openai.models.ChatMessageTextContentItem;
 import com.azure.ai.openai.models.ChatRequestAssistantMessage;
@@ -215,9 +216,11 @@ class InternalAzureOpenAiHelper {
             // configuration (e.g. AZURE_HTTP_CLIENT_IMPLEMENTATION) when multiple providers are on the classpath.
             return HttpClient.createDefault(clientOptions);
         } catch (IllegalStateException e) {
-            throw new IllegalStateException("No HttpClientProvider implementation found on the classpath. "
-                    + "Add 'com.azure:azure-core-http-netty' as a dependency, "
-                    + "or provide a custom HttpClientProvider via .httpClientProvider() on the builder.", e);
+            throw new IllegalStateException(
+                    "No HttpClientProvider implementation found on the classpath. "
+                            + "Add 'com.azure:azure-core-http-netty' as a dependency, "
+                            + "or provide a custom HttpClientProvider via .httpClientProvider() on the builder.",
+                    e);
         }
     }
 
@@ -257,9 +260,8 @@ class InternalAzureOpenAiHelper {
             return chatRequestAssistantMessage;
         } else if (message instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
             if (!toolExecutionResultMessage.hasSingleText()) {
-                throw new UnsupportedFeatureException(
-                        "Azure OpenAI does not support non-text content in tool results. "
-                                + "Only text content is supported.");
+                throw new UnsupportedFeatureException("Azure OpenAI does not support non-text content in tool results. "
+                        + "Only text content is supported.");
             }
             return new ChatRequestToolMessage(toolExecutionResultMessage.text(), toolExecutionResultMessage.id());
         } else if (message instanceof SystemMessage systemMessage) {
@@ -278,6 +280,10 @@ class InternalAzureOpenAiHelper {
                             } else if (content instanceof ImageContent imageContent) {
                                 String imageUrlString = toImageUrl(imageContent.image());
                                 ChatMessageImageUrl imageUrl = new ChatMessageImageUrl(imageUrlString);
+                                ChatMessageImageDetailLevel detail = toAzureDetail(imageContent.detailLevel());
+                                if (detail != null) {
+                                    imageUrl.setDetail(detail);
+                                }
                                 return new ChatMessageImageContentItem(imageUrl);
                             } else {
                                 throw new IllegalArgumentException("Unsupported content type: " + content.type());
@@ -302,6 +308,19 @@ class InternalAzureOpenAiHelper {
         }
 
         return null;
+    }
+
+    private static ChatMessageImageDetailLevel toAzureDetail(ImageContent.DetailLevel detailLevel) {
+        if (detailLevel == null) {
+            return null;
+        }
+        return switch (detailLevel) {
+            case LOW -> ChatMessageImageDetailLevel.LOW;
+            case HIGH -> ChatMessageImageDetailLevel.HIGH;
+            case AUTO -> ChatMessageImageDetailLevel.AUTO;
+            case MEDIUM -> ChatMessageImageDetailLevel.LOW;
+            case ULTRA_HIGH -> ChatMessageImageDetailLevel.HIGH;
+        };
     }
 
     private static String toImageUrl(Image image) {

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
@@ -155,8 +155,7 @@ class InternalAzureOpenAiHelperTest {
         String functionName = "current_time";
         String functionArguments = "{}";
         // language=json
-        String responseJson =
-                """
+        String responseJson = """
                 {
                         "role": "ASSISTANT",
                         "content": "Hello",
@@ -240,6 +239,91 @@ class InternalAzureOpenAiHelperTest {
 
         // The JSON should contain the image URL in data URI format
         assertThat(contentJson).contains(expectedDataUri).contains("image_url").contains("url");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldForwardLowDetailLevel() {
+        // Given
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.LOW);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        String contentJson = requestMessage.getContent().toString();
+        assertThat(contentJson).contains("\"detail\":\"low\"");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldForwardHighDetailLevel() {
+        // Given
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.HIGH);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        String contentJson = requestMessage.getContent().toString();
+        assertThat(contentJson).contains("\"detail\":\"high\"");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldForwardAutoDetailLevel() {
+        // Given
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.AUTO);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        String contentJson = requestMessage.getContent().toString();
+        assertThat(contentJson).contains("\"detail\":\"auto\"");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldMapMediumDetailLevelToLow() {
+        // Given
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.MEDIUM);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        String contentJson = requestMessage.getContent().toString();
+        assertThat(contentJson).contains("\"detail\":\"low\"");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldMapUltraHighDetailLevelToHigh() {
+        // Given
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.ULTRA_HIGH);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        String contentJson = requestMessage.getContent().toString();
+        assertThat(contentJson).contains("\"detail\":\"high\"");
     }
 
     @Test


### PR DESCRIPTION
PR Description
Image detail levels specified via ImageContent.detailLevel() were overlooked when building Azure OpenAI chat requests. This fix forwards the detail level to the Azure SDK's ChatMessageImageDetailLevel, supporting all LOW/HIGH/AUTO values with non-breaking fallbacks for MEDIUM and ULTRA_HIGH.

## Issue
Closes #5508

## Change
Forwarded ImageContent.detailLevel() to Azure OpenAI via ChatMessageImageUrl.setDetail().

Previously, InternalAzureOpenAiHelper.toOpenAiMessage() created ChatMessageImageUrl with only the URL string, silently dropping the user-specified image detail level. Now it maps the detail level onto the Azure SDK's ChatMessageImageDetailLevel and calls setDetail():

- LOW → ChatMessageImageDetailLevel.LOW
- HIGH → ChatMessageImageDetailLevel.HIGH  
- AUTO → ChatMessageImageDetailLevel.AUTO
- MEDIUM → `ChatMessageImageDetailLevel.LOW` (non-breaking fallback)
- ULTRA_HIGH → `ChatMessageImageDetailLevel.HIGH` (non-breaking fallback)
- null → detail field omitted (Azure server default)

This is brings  it update to date with langchain4j-open-ai module and the existing AzureOpenAiTokenCountEstimator (PR #5388).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)