### PR TITLE
fix: Ensure custom HuggingFace base URL ends with a trailing slash

### DIFF
--- a/langchain4j-hugging-face/src/main/java/dev/langchain4j/model/huggingface/DefaultHuggingFaceClient.java
+++ b/langchain4j-hugging-face/src/main/java/dev/langchain4j/model/huggingface/DefaultHuggingFaceClient.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.model.huggingface;
 
+import static dev.langchain4j.internal.Utils.ensureTrailingForwardSlash;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 
 import dev.langchain4j.model.huggingface.client.EmbeddingRequest;
@@ -33,7 +34,7 @@ class DefaultHuggingFaceClient implements HuggingFaceClient {
                 .build();
 
         Retrofit retrofit = new Retrofit.Builder()
-                .baseUrl(Objects.isNull(baseUrl) ? BASE_URL : baseUrl)
+                .baseUrl(ensureTrailingForwardSlash(Objects.isNull(baseUrl) ? BASE_URL : baseUrl))
                 .client(okHttpClient)
                 .addConverterFactory(JacksonConverterFactory.create())
                 .build();

--- a/langchain4j-hugging-face/src/test/java/dev/langchain4j/model/huggingface/HuggingFaceEmbeddingModelTest.java
+++ b/langchain4j-hugging-face/src/test/java/dev/langchain4j/model/huggingface/HuggingFaceEmbeddingModelTest.java
@@ -1,0 +1,30 @@
+package dev.langchain4j.model.huggingface;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.junit.jupiter.api.Test;
+
+class HuggingFaceEmbeddingModelTest {
+
+    @Test
+    void should_build_with_custom_base_url_missing_trailing_slash() {
+        // A custom base URL with a path but no trailing slash (e.g. the inference router URL
+        // copied without the final '/') is rejected by Retrofit with "baseUrl must end in /",
+        // so the client must normalize it.
+        assertThatNoException()
+                .isThrownBy(() -> HuggingFaceEmbeddingModel.builder()
+                        .accessToken("hf_test_token")
+                        .modelId("sentence-transformers/all-MiniLM-L6-v2")
+                        .baseUrl("https://router.huggingface.co/hf-inference")
+                        .build());
+    }
+
+    @Test
+    void should_build_with_default_base_url() {
+        assertThatNoException()
+                .isThrownBy(() -> HuggingFaceEmbeddingModel.builder()
+                        .accessToken("hf_test_token")
+                        .modelId("sentence-transformers/all-MiniLM-L6-v2")
+                        .build());
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5533

## Change
`DefaultHuggingFaceClient` passed the user-supplied `baseUrl` straight to Retrofit, which rejects a base URL not ending in `/` (`IllegalArgumentException: baseUrl must end in /`). So a custom endpoint URL without a trailing slash failed at `build()` time, breaking the custom-`baseUrl` feature from #2282.

This wraps the base URL in `Utils.ensureTrailingForwardSlash`, matching every other Retrofit-based client (Jina, Nomic, Cohere, Voyage, OVH, Vespa, Chroma). It restores the protection added in #1519 and lost in the Jackson migration (#1728).

Non-breaking: the default `BASE_URL` already ends with `/`, and `ensureTrailingForwardSlash` is idempotent. Added `HuggingFaceEmbeddingModelTest` covering a custom URL without a trailing slash (fails without this fix) and the default URL.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases <!-- N/A — the fix normalizes the URL; both covered scenarios (custom URL without slash, default URL) are success paths -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- unit tests green; *IT require HF_API_KEY and were not run -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is isolated to langchain4j-hugging-face -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- after approval -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->

<!-- Checklist for adding new maven module — N/A (no new module) -->
<!-- Checklist for adding/changing embedding store integration — N/A (not an embedding store) -->
