### PR TITLE
fix: Map model download exceptions for all Jlama models

### DIFF
--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaEmbeddingModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaEmbeddingModel.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.model.jlama;
 
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+
 import com.github.tjake.jlama.model.AbstractModel;
 import com.github.tjake.jlama.model.ModelSupport;
 import com.github.tjake.jlama.model.bert.BertModel;
@@ -10,43 +12,41 @@ import dev.langchain4j.internal.RetryUtils;
 import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
 import dev.langchain4j.model.jlama.spi.JlamaEmbeddingModelBuilderFactory;
 import dev.langchain4j.model.output.Response;
-
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
-import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 
 public class JlamaEmbeddingModel extends DimensionAwareEmbeddingModel {
     private final BertModel model;
     private final Generator.PoolingType poolingType;
     private final String modelName;
 
-    public JlamaEmbeddingModel(Path modelCachePath,
-                               String modelName,
-                               String authToken,
-                               Integer threadCount,
-                               Boolean quantizeModelAtRuntime,
-                               Generator.PoolingType poolingType,
-                               Path workingDirectory) {
+    public JlamaEmbeddingModel(
+            Path modelCachePath,
+            String modelName,
+            String authToken,
+            Integer threadCount,
+            Boolean quantizeModelAtRuntime,
+            Generator.PoolingType poolingType,
+            Path workingDirectory) {
 
         JlamaModelRegistry registry = JlamaModelRegistry.getOrCreate(modelCachePath);
-        JlamaModel jlamaModel = RetryUtils.withRetryMappingExceptions(() -> registry.downloadModel(modelName, Optional.ofNullable(authToken)), 2);
+        JlamaModel jlamaModel = RetryUtils.withRetryMappingExceptions(
+                () -> registry.downloadModel(modelName, Optional.ofNullable(authToken)),
+                2,
+                JlamaExceptionMapper.INSTANCE);
 
         if (jlamaModel.getModelType() != ModelSupport.ModelType.BERT) {
             throw new IllegalArgumentException("Model type must be BERT");
         }
 
         JlamaModel.Loader loader = jlamaModel.loader();
-        if (quantizeModelAtRuntime != null && quantizeModelAtRuntime)
-            loader = loader.quantized();
+        if (quantizeModelAtRuntime != null && quantizeModelAtRuntime) loader = loader.quantized();
 
-        if (threadCount != null)
-            loader = loader.threadCount(threadCount);
+        if (threadCount != null) loader = loader.threadCount(threadCount);
 
-        if (workingDirectory != null)
-            loader = loader.workingDirectory(workingDirectory);
+        if (workingDirectory != null) loader = loader.workingDirectory(workingDirectory);
 
         loader = loader.inferenceType(AbstractModel.InferenceType.FULL_EMBEDDING);
 
@@ -130,11 +130,21 @@ public class JlamaEmbeddingModel extends DimensionAwareEmbeddingModel {
         }
 
         public JlamaEmbeddingModel build() {
-            return new JlamaEmbeddingModel(this.modelCachePath, this.modelName, this.authToken, this.threadCount, this.quantizeModelAtRuntime, this.poolingType, this.workingDirectory);
+            return new JlamaEmbeddingModel(
+                    this.modelCachePath,
+                    this.modelName,
+                    this.authToken,
+                    this.threadCount,
+                    this.quantizeModelAtRuntime,
+                    this.poolingType,
+                    this.workingDirectory);
         }
 
         public String toString() {
-            return "JlamaEmbeddingModel.JlamaEmbeddingModelBuilder(modelCachePath=" + this.modelCachePath + ", modelName=" + this.modelName + ", authToken=" + this.authToken + ", threadCount=" + this.threadCount + ", quantizeModelAtRuntime=" + this.quantizeModelAtRuntime + ", poolingType=" + this.poolingType + ", workingDirectory=" + this.workingDirectory + ")";
+            return "JlamaEmbeddingModel.JlamaEmbeddingModelBuilder(modelCachePath=" + this.modelCachePath
+                    + ", modelName=" + this.modelName + ", authToken=" + this.authToken + ", threadCount="
+                    + this.threadCount + ", quantizeModelAtRuntime=" + this.quantizeModelAtRuntime + ", poolingType="
+                    + this.poolingType + ", workingDirectory=" + this.workingDirectory + ")";
         }
     }
 }

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaLanguageModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaLanguageModel.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.model.jlama;
 
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+
 import com.github.tjake.jlama.model.AbstractModel;
 import com.github.tjake.jlama.model.functions.Generator;
 import com.github.tjake.jlama.safetensors.DType;
@@ -10,12 +12,9 @@ import dev.langchain4j.model.language.LanguageModel;
 import dev.langchain4j.model.output.FinishReason;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
-
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.UUID;
-
-import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 
 public class JlamaLanguageModel implements LanguageModel {
     private final AbstractModel model;
@@ -23,30 +22,30 @@ public class JlamaLanguageModel implements LanguageModel {
     private final Integer maxTokens;
     private final UUID id = UUID.randomUUID();
 
-    public JlamaLanguageModel(Path modelCachePath,
-                              String modelName,
-                              String authToken,
-                              Integer threadCount,
-                              Boolean quantizeModelAtRuntime,
-                              Path workingDirectory,
-                              DType workingQuantizedType,
-                              Float temperature,
-                              Integer maxTokens) {
+    public JlamaLanguageModel(
+            Path modelCachePath,
+            String modelName,
+            String authToken,
+            Integer threadCount,
+            Boolean quantizeModelAtRuntime,
+            Path workingDirectory,
+            DType workingQuantizedType,
+            Float temperature,
+            Integer maxTokens) {
         JlamaModelRegistry registry = JlamaModelRegistry.getOrCreate(modelCachePath);
-        JlamaModel jlamaModel = RetryUtils.withRetryMappingExceptions(() -> registry.downloadModel(modelName, Optional.ofNullable(authToken)), 2);
+        JlamaModel jlamaModel = RetryUtils.withRetryMappingExceptions(
+                () -> registry.downloadModel(modelName, Optional.ofNullable(authToken)),
+                2,
+                JlamaExceptionMapper.INSTANCE);
 
         JlamaModel.Loader loader = jlamaModel.loader();
-        if (quantizeModelAtRuntime != null && quantizeModelAtRuntime)
-            loader = loader.quantized();
+        if (quantizeModelAtRuntime != null && quantizeModelAtRuntime) loader = loader.quantized();
 
-        if (workingQuantizedType != null)
-            loader = loader.workingQuantizationType(workingQuantizedType);
+        if (workingQuantizedType != null) loader = loader.workingQuantizationType(workingQuantizedType);
 
-        if (threadCount != null)
-            loader = loader.threadCount(threadCount);
+        if (threadCount != null) loader = loader.threadCount(threadCount);
 
-        if (workingDirectory != null)
-            loader = loader.workingDirectory(workingDirectory);
+        if (workingDirectory != null) loader = loader.workingDirectory(workingDirectory);
 
         this.model = loader.load();
         this.temperature = temperature == null ? 0.7f : temperature;
@@ -72,9 +71,10 @@ public class JlamaLanguageModel implements LanguageModel {
 
     @Override
     public Response<String> generate(String prompt) {
-        Generator.Response r = model.generate(id, PromptContext.of(prompt), temperature, maxTokens, (token, time) -> {
-        });
-        return Response.from(r.responseText, new TokenUsage(r.promptTokens, r.generatedTokens), toFinishReason(r.finishReason));
+        Generator.Response r =
+                model.generate(id, PromptContext.of(prompt), temperature, maxTokens, (token, time) -> {});
+        return Response.from(
+                r.responseText, new TokenUsage(r.promptTokens, r.generatedTokens), toFinishReason(r.finishReason));
     }
 
     public static class JlamaLanguageModelBuilder {
@@ -138,11 +138,24 @@ public class JlamaLanguageModel implements LanguageModel {
         }
 
         public JlamaLanguageModel build() {
-            return new JlamaLanguageModel(this.modelCachePath, this.modelName, this.authToken, this.threadCount, this.quantizeModelAtRuntime, this.workingDirectory, this.workingQuantizedType, this.temperature, this.maxTokens);
+            return new JlamaLanguageModel(
+                    this.modelCachePath,
+                    this.modelName,
+                    this.authToken,
+                    this.threadCount,
+                    this.quantizeModelAtRuntime,
+                    this.workingDirectory,
+                    this.workingQuantizedType,
+                    this.temperature,
+                    this.maxTokens);
         }
 
         public String toString() {
-            return "JlamaLanguageModel.JlamaLanguageModelBuilder(modelCachePath=" + this.modelCachePath + ", modelName=" + this.modelName + ", authToken=" + this.authToken + ", threadCount=" + this.threadCount + ", quantizeModelAtRuntime=" + this.quantizeModelAtRuntime + ", workingDirectory=" + this.workingDirectory + ", workingQuantizedType=" + this.workingQuantizedType + ", temperature=" + this.temperature + ", maxTokens=" + this.maxTokens + ")";
+            return "JlamaLanguageModel.JlamaLanguageModelBuilder(modelCachePath=" + this.modelCachePath + ", modelName="
+                    + this.modelName + ", authToken=" + this.authToken + ", threadCount=" + this.threadCount
+                    + ", quantizeModelAtRuntime=" + this.quantizeModelAtRuntime + ", workingDirectory="
+                    + this.workingDirectory + ", workingQuantizedType=" + this.workingQuantizedType + ", temperature="
+                    + this.temperature + ", maxTokens=" + this.maxTokens + ")";
         }
     }
 }

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingChatModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingChatModel.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.jlama;
 
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.model.jlama.JlamaLanguageModel.toFinishReason;
+import static dev.langchain4j.model.jlama.Json.fromJson;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+
 import com.github.tjake.jlama.model.AbstractModel;
 import com.github.tjake.jlama.model.functions.Generator;
 import com.github.tjake.jlama.safetensors.DType;
@@ -20,29 +25,23 @@ import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.exception.UnsupportedFeatureException;
+import dev.langchain4j.internal.ChatRequestValidationUtils;
 import dev.langchain4j.internal.RetryUtils;
 import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
-import dev.langchain4j.internal.ChatRequestValidationUtils;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.jlama.spi.JlamaStreamingChatModelBuilderFactory;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
-
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
-import static dev.langchain4j.model.jlama.JlamaLanguageModel.toFinishReason;
-import static dev.langchain4j.model.jlama.Json.fromJson;
-import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 
 public class JlamaStreamingChatModel implements StreamingChatModel {
     private final AbstractModel model;
@@ -50,30 +49,30 @@ public class JlamaStreamingChatModel implements StreamingChatModel {
     private final Integer maxTokens;
     private final UUID id = UUID.randomUUID();
 
-    public JlamaStreamingChatModel(Path modelCachePath,
-                                   String modelName,
-                                   String authToken,
-                                   Integer threadCount,
-                                   Boolean quantizeModelAtRuntime,
-                                   Path workingDirectory,
-                                   DType workingQuantizedType,
-                                   Float temperature,
-                                   Integer maxTokens) {
+    public JlamaStreamingChatModel(
+            Path modelCachePath,
+            String modelName,
+            String authToken,
+            Integer threadCount,
+            Boolean quantizeModelAtRuntime,
+            Path workingDirectory,
+            DType workingQuantizedType,
+            Float temperature,
+            Integer maxTokens) {
         JlamaModelRegistry registry = JlamaModelRegistry.getOrCreate(modelCachePath);
-        JlamaModel jlamaModel = RetryUtils.withRetryMappingExceptions(() -> registry.downloadModel(modelName, Optional.ofNullable(authToken)), 2);
+        JlamaModel jlamaModel = RetryUtils.withRetryMappingExceptions(
+                () -> registry.downloadModel(modelName, Optional.ofNullable(authToken)),
+                2,
+                JlamaExceptionMapper.INSTANCE);
 
         JlamaModel.Loader loader = jlamaModel.loader();
-        if (quantizeModelAtRuntime != null && quantizeModelAtRuntime)
-            loader = loader.quantized();
+        if (quantizeModelAtRuntime != null && quantizeModelAtRuntime) loader = loader.quantized();
 
-        if (workingQuantizedType != null)
-            loader = loader.workingQuantizationType(workingQuantizedType);
+        if (workingQuantizedType != null) loader = loader.workingQuantizationType(workingQuantizedType);
 
-        if (threadCount != null)
-            loader = loader.threadCount(threadCount);
+        if (threadCount != null) loader = loader.threadCount(threadCount);
 
-        if (workingDirectory != null)
-            loader = loader.workingDirectory(workingDirectory);
+        if (workingDirectory != null) loader = loader.workingDirectory(workingDirectory);
 
         this.model = loader.load();
         this.temperature = temperature == null ? 0.3f : temperature;
@@ -81,7 +80,8 @@ public class JlamaStreamingChatModel implements StreamingChatModel {
     }
 
     public static JlamaStreamingChatModelBuilder builder() {
-        for (JlamaStreamingChatModelBuilderFactory factory : loadFactories(JlamaStreamingChatModelBuilderFactory.class)) {
+        for (JlamaStreamingChatModelBuilderFactory factory :
+                loadFactories(JlamaStreamingChatModelBuilderFactory.class)) {
             return factory.get();
         }
         return new JlamaStreamingChatModelBuilder();
@@ -132,7 +132,10 @@ public class JlamaStreamingChatModel implements StreamingChatModel {
         generate(messages, List.of(), handler);
     }
 
-    private void generate(List<ChatMessage> messages, List<ToolSpecification> toolSpecifications, StreamingResponseHandler<AiMessage> handler) {
+    private void generate(
+            List<ChatMessage> messages,
+            List<ToolSpecification> toolSpecifications,
+            StreamingResponseHandler<AiMessage> handler) {
         if (model.promptSupport().isEmpty())
             throw new UnsupportedOperationException("This model does not support chat generation");
 
@@ -153,12 +156,14 @@ public class JlamaStreamingChatModel implements StreamingChatModel {
                 }
                 case AI -> {
                     AiMessage aiMessage = (AiMessage) message;
-                    if (aiMessage.text() != null)
-                        promptBuilder.addAssistantMessage(aiMessage.text());
+                    if (aiMessage.text() != null) promptBuilder.addAssistantMessage(aiMessage.text());
 
                     if (aiMessage.hasToolExecutionRequests())
                         for (ToolExecutionRequest toolExecutionRequest : aiMessage.toolExecutionRequests()) {
-                            ToolCall toolCall = new ToolCall(toolExecutionRequest.name(), toolExecutionRequest.id(), fromJson(toolExecutionRequest.arguments(), LinkedHashMap.class));
+                            ToolCall toolCall = new ToolCall(
+                                    toolExecutionRequest.name(),
+                                    toolExecutionRequest.id(),
+                                    fromJson(toolExecutionRequest.arguments(), LinkedHashMap.class));
                             promptBuilder.addToolCall(toolCall);
                         }
                 }
@@ -186,15 +191,23 @@ public class JlamaStreamingChatModel implements StreamingChatModel {
             });
 
             if (r.finishReason == Generator.FinishReason.TOOL_CALL) {
-                List<ToolExecutionRequest> toolCalls = r.toolCalls.stream().map(f -> ToolExecutionRequest.builder()
-                        .name(f.getName())
-                        .id(f.getId())
-                        .arguments(JsonSupport.toJson(f.getParameters()))
-                        .build()).toList();
+                List<ToolExecutionRequest> toolCalls = r.toolCalls.stream()
+                        .map(f -> ToolExecutionRequest.builder()
+                                .name(f.getName())
+                                .id(f.getId())
+                                .arguments(JsonSupport.toJson(f.getParameters()))
+                                .build())
+                        .toList();
 
-                handler.onComplete(Response.from(AiMessage.from(toolCalls), new TokenUsage(r.promptTokens, r.generatedTokens), toFinishReason(r.finishReason)));
+                handler.onComplete(Response.from(
+                        AiMessage.from(toolCalls),
+                        new TokenUsage(r.promptTokens, r.generatedTokens),
+                        toFinishReason(r.finishReason)));
             } else {
-                handler.onComplete(Response.from(AiMessage.from(r.responseText), new TokenUsage(r.promptTokens, r.generatedTokens), toFinishReason(r.finishReason)));
+                handler.onComplete(Response.from(
+                        AiMessage.from(r.responseText),
+                        new TokenUsage(r.promptTokens, r.generatedTokens),
+                        toFinishReason(r.finishReason)));
             }
         } catch (Throwable t) {
             handler.onError(t);
@@ -262,11 +275,25 @@ public class JlamaStreamingChatModel implements StreamingChatModel {
         }
 
         public JlamaStreamingChatModel build() {
-            return new JlamaStreamingChatModel(this.modelCachePath, this.modelName, this.authToken, this.threadCount, this.quantizeModelAtRuntime, this.workingDirectory, this.workingQuantizedType, this.temperature, this.maxTokens);
+            return new JlamaStreamingChatModel(
+                    this.modelCachePath,
+                    this.modelName,
+                    this.authToken,
+                    this.threadCount,
+                    this.quantizeModelAtRuntime,
+                    this.workingDirectory,
+                    this.workingQuantizedType,
+                    this.temperature,
+                    this.maxTokens);
         }
 
         public String toString() {
-            return "JlamaStreamingChatModel.JlamaStreamingChatModelBuilder(modelCachePath=" + this.modelCachePath + ", modelName=" + this.modelName + ", authToken=" + this.authToken + ", threadCount=" + this.threadCount + ", quantizeModelAtRuntime=" + this.quantizeModelAtRuntime + ", workingDirectory=" + this.workingDirectory + ", workingQuantizedType=" + this.workingQuantizedType + ", temperature=" + this.temperature + ", maxTokens=" + this.maxTokens + ")";
+            return "JlamaStreamingChatModel.JlamaStreamingChatModelBuilder(modelCachePath=" + this.modelCachePath
+                    + ", modelName=" + this.modelName + ", authToken=" + this.authToken + ", threadCount="
+                    + this.threadCount + ", quantizeModelAtRuntime=" + this.quantizeModelAtRuntime
+                    + ", workingDirectory=" + this.workingDirectory + ", workingQuantizedType="
+                    + this.workingQuantizedType + ", temperature=" + this.temperature + ", maxTokens=" + this.maxTokens
+                    + ")";
         }
     }
 }

--- a/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingLanguageModel.java
+++ b/langchain4j-jlama/src/main/java/dev/langchain4j/model/jlama/JlamaStreamingLanguageModel.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.model.jlama;
 
+import static dev.langchain4j.model.jlama.JlamaLanguageModel.toFinishReason;
+import static dev.langchain4j.spi.ServiceHelper.loadFactories;
+
 import com.github.tjake.jlama.model.AbstractModel;
 import com.github.tjake.jlama.model.functions.Generator;
 import com.github.tjake.jlama.safetensors.DType;
@@ -10,13 +13,9 @@ import dev.langchain4j.model.jlama.spi.JlamaStreamingLanguageModelBuilderFactory
 import dev.langchain4j.model.language.StreamingLanguageModel;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
-
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.UUID;
-
-import static dev.langchain4j.model.jlama.JlamaLanguageModel.toFinishReason;
-import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 
 public class JlamaStreamingLanguageModel implements StreamingLanguageModel {
     private final AbstractModel model;
@@ -24,30 +23,30 @@ public class JlamaStreamingLanguageModel implements StreamingLanguageModel {
     private final Integer maxTokens;
     private final UUID id = UUID.randomUUID();
 
-    public JlamaStreamingLanguageModel(Path modelCachePath,
-                                       String modelName,
-                                       String authToken,
-                                       Integer threadCount,
-                                       Boolean quantizeModelAtRuntime,
-                                       Path workingDirectory,
-                                       DType workingQuantizedType,
-                                       Float temperature,
-                                       Integer maxTokens) {
+    public JlamaStreamingLanguageModel(
+            Path modelCachePath,
+            String modelName,
+            String authToken,
+            Integer threadCount,
+            Boolean quantizeModelAtRuntime,
+            Path workingDirectory,
+            DType workingQuantizedType,
+            Float temperature,
+            Integer maxTokens) {
         JlamaModelRegistry registry = JlamaModelRegistry.getOrCreate(modelCachePath);
-        JlamaModel jlamaModel = RetryUtils.withRetryMappingExceptions(() -> registry.downloadModel(modelName, Optional.ofNullable(authToken)), 2);
+        JlamaModel jlamaModel = RetryUtils.withRetryMappingExceptions(
+                () -> registry.downloadModel(modelName, Optional.ofNullable(authToken)),
+                2,
+                JlamaExceptionMapper.INSTANCE);
 
         JlamaModel.Loader loader = jlamaModel.loader();
-        if (quantizeModelAtRuntime != null && quantizeModelAtRuntime)
-            loader = loader.quantized();
+        if (quantizeModelAtRuntime != null && quantizeModelAtRuntime) loader = loader.quantized();
 
-        if (workingQuantizedType != null)
-            loader = loader.workingQuantizationType(workingQuantizedType);
+        if (workingQuantizedType != null) loader = loader.workingQuantizationType(workingQuantizedType);
 
-        if (threadCount != null)
-            loader = loader.threadCount(threadCount);
+        if (threadCount != null) loader = loader.threadCount(threadCount);
 
-        if (workingDirectory != null)
-            loader = loader.workingDirectory(workingDirectory);
+        if (workingDirectory != null) loader = loader.workingDirectory(workingDirectory);
 
         this.model = loader.load();
         this.temperature = temperature == null ? 0.7f : temperature;
@@ -55,7 +54,8 @@ public class JlamaStreamingLanguageModel implements StreamingLanguageModel {
     }
 
     public static JlamaStreamingLanguageModelBuilder builder() {
-        for (JlamaStreamingLanguageModelBuilderFactory factory : loadFactories(JlamaStreamingLanguageModelBuilderFactory.class)) {
+        for (JlamaStreamingLanguageModelBuilderFactory factory :
+                loadFactories(JlamaStreamingLanguageModelBuilderFactory.class)) {
             return factory.get();
         }
         return new JlamaStreamingLanguageModelBuilder();
@@ -64,11 +64,13 @@ public class JlamaStreamingLanguageModel implements StreamingLanguageModel {
     @Override
     public void generate(String prompt, StreamingResponseHandler<String> handler) {
         try {
-            Generator.Response r = model.generate(id, PromptContext.of(prompt), temperature, maxTokens, (token, time) -> {
-                handler.onNext(token);
-            });
+            Generator.Response r =
+                    model.generate(id, PromptContext.of(prompt), temperature, maxTokens, (token, time) -> {
+                        handler.onNext(token);
+                    });
 
-            handler.onComplete(Response.from(r.responseText, new TokenUsage(r.promptTokens, r.generatedTokens), toFinishReason(r.finishReason)));
+            handler.onComplete(Response.from(
+                    r.responseText, new TokenUsage(r.promptTokens, r.generatedTokens), toFinishReason(r.finishReason)));
         } catch (Throwable t) {
             handler.onError(t);
         }
@@ -135,11 +137,25 @@ public class JlamaStreamingLanguageModel implements StreamingLanguageModel {
         }
 
         public JlamaStreamingLanguageModel build() {
-            return new JlamaStreamingLanguageModel(this.modelCachePath, this.modelName, this.authToken, this.threadCount, this.quantizeModelAtRuntime, this.workingDirectory, this.workingQuantizedType, this.temperature, this.maxTokens);
+            return new JlamaStreamingLanguageModel(
+                    this.modelCachePath,
+                    this.modelName,
+                    this.authToken,
+                    this.threadCount,
+                    this.quantizeModelAtRuntime,
+                    this.workingDirectory,
+                    this.workingQuantizedType,
+                    this.temperature,
+                    this.maxTokens);
         }
 
         public String toString() {
-            return "JlamaStreamingLanguageModel.JlamaStreamingLanguageModelBuilder(modelCachePath=" + this.modelCachePath + ", modelName=" + this.modelName + ", authToken=" + this.authToken + ", threadCount=" + this.threadCount + ", quantizeModelAtRuntime=" + this.quantizeModelAtRuntime + ", workingDirectory=" + this.workingDirectory + ", workingQuantizedType=" + this.workingQuantizedType + ", temperature=" + this.temperature + ", maxTokens=" + this.maxTokens + ")";
+            return "JlamaStreamingLanguageModel.JlamaStreamingLanguageModelBuilder(modelCachePath="
+                    + this.modelCachePath + ", modelName=" + this.modelName + ", authToken=" + this.authToken
+                    + ", threadCount=" + this.threadCount + ", quantizeModelAtRuntime=" + this.quantizeModelAtRuntime
+                    + ", workingDirectory=" + this.workingDirectory + ", workingQuantizedType="
+                    + this.workingQuantizedType + ", temperature=" + this.temperature + ", maxTokens=" + this.maxTokens
+                    + ")";
         }
     }
 }

--- a/langchain4j-jlama/src/test/java/dev/langchain4j/model/jlama/JlamaUnexistingModelIT.java
+++ b/langchain4j-jlama/src/test/java/dev/langchain4j/model/jlama/JlamaUnexistingModelIT.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.model.jlama;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.exception.AuthenticationException;
+import java.io.File;
+import org.junit.jupiter.api.Test;
+
+class JlamaUnexistingModelIT {
+
+    @Test
+    void streaming_chat_model_should_fail_trying_to_download_unexisting_model() {
+        File tmpDir = new File(System.getProperty("java.io.tmpdir") + File.separator + "jlama_tests");
+        tmpDir.mkdirs();
+
+        assertThatThrownBy(() -> JlamaStreamingChatModel.builder()
+                        .modelName("tjake/XYZ-JQ4")
+                        .modelCachePath(tmpDir.toPath())
+                        .temperature(0.0f)
+                        .maxTokens(64)
+                        .build())
+                .isExactlyInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void language_model_should_fail_trying_to_download_unexisting_model() {
+        File tmpDir = new File(System.getProperty("java.io.tmpdir") + File.separator + "jlama_tests");
+        tmpDir.mkdirs();
+
+        assertThatThrownBy(() -> JlamaLanguageModel.builder()
+                        .modelName("tjake/XYZ-JQ4")
+                        .modelCachePath(tmpDir.toPath())
+                        .temperature(0.0f)
+                        .maxTokens(64)
+                        .build())
+                .isExactlyInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void streaming_language_model_should_fail_trying_to_download_unexisting_model() {
+        File tmpDir = new File(System.getProperty("java.io.tmpdir") + File.separator + "jlama_tests");
+        tmpDir.mkdirs();
+
+        assertThatThrownBy(() -> JlamaStreamingLanguageModel.builder()
+                        .modelName("tjake/XYZ-JQ4")
+                        .modelCachePath(tmpDir.toPath())
+                        .temperature(0.0f)
+                        .maxTokens(64)
+                        .build())
+                .isExactlyInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void embedding_model_should_fail_trying_to_download_unexisting_model() {
+        File tmpDir = new File(System.getProperty("java.io.tmpdir") + File.separator + "jlama_tests");
+        tmpDir.mkdirs();
+
+        assertThatThrownBy(() -> JlamaEmbeddingModel.builder()
+                        .modelName("tjake/XYZ-JQ4")
+                        .modelCachePath(tmpDir.toPath())
+                        .build())
+                .isExactlyInstanceOf(AuthenticationException.class);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5535

## Change
PR #2607 added `JlamaExceptionMapper` but wired it into `JlamaChatModel` only. The four sibling models (`JlamaStreamingChatModel`, `JlamaLanguageModel`, `JlamaStreamingLanguageModel`, `JlamaEmbeddingModel`) used the 2-arg `RetryUtils.withRetryMappingExceptions(action, maxRetries)`, which falls back to `ExceptionMapper.DEFAULT`. DEFAULT cannot parse Jlama's `IOException("HTTP response code: NNN ...")`, so download failures (401/403/404) threw a generic `LangChain4jException` instead of the intended `AuthenticationException` / `ModelNotFoundException`.

This passes `JlamaExceptionMapper.INSTANCE` to the 3-arg overload in all four constructors, keeping the existing retry count of 2.

Compatibility: the error path stays a `RuntimeException`. The new types (`AuthenticationException`, `ModelNotFoundException`) are subtypes of the `LangChain4jException` that was thrown before, so existing broad `catch (LangChain4jException)` handlers are unaffected — the change only adds the specificity that `JlamaChatModel` already provides. The success path is unchanged.

Precedent: merged PR #2986 (commit c78a65de6) fixed the same class of sibling exception-mapping inconsistency in the OpenAI module.

Tests: new `JlamaUnexistingModelIT` with one `@Test` per sibling, mirroring the accepted `JlamaUnexistingChatModelIT` pattern, asserting `AuthenticationException`. These ITs are network-dependent and were NOT run locally (project IT policy); the module unit build is green and the IT compiles.

Diff size note: the functional change is four one-argument additions (`, JlamaExceptionMapper.INSTANCE`) plus the new test file. The remaining diff is Spotless auto-formatting: `langchain4j-jlama` is only built under the `jdk21` profile and its sources were not Palantir-formatted, so the Spotless `ratchetFrom origin/main` gate reformats each touched file in full. The formatting was produced by `spotless:apply`, not by hand.

Caveat: open PR #5442 reformats these same Jlama files and touches these `withRetryMappingExceptions` lines, so a rebase will likely be needed after either merges.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases <!-- N/A: existing positive-path coverage exists; this fix targets the negative download-failure path only -->
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- N/A: ITs are network-dependent, not run locally per project IT policy; module unit build is green and the new IT compiles -->
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green <!-- N/A: change is isolated to langchain4j-jlama -->
- [ ] I have added/updated the documentation <!-- N/A: behaviour-consistency bug fix, no doc change -->
- [ ] I have added an example in the examples repo (only for "big" features) <!-- N/A -->
- [ ] I have added/updated Spring Boot starter(s) (if applicable) <!-- N/A -->

<!-- Checklist for adding new maven module: skipped, no new module. -->
<!-- Checklist for new/existing embedding store integration: skipped, not an embedding store change. -->

