### PR TITLE
fix: mask apiKey in JinaScoringModel and JinaClient builder toString

### DIFF
--- a/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaScoringModel.java
+++ b/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/JinaScoringModel.java
@@ -1,5 +1,12 @@
 package dev.langchain4j.model.jina;
 
+import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static java.time.Duration.ofSeconds;
+import static java.util.Comparator.comparingInt;
+import static java.util.stream.Collectors.toList;
+
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.jina.internal.api.JinaRerankingRequest;
 import dev.langchain4j.model.jina.internal.api.JinaRerankingResponse;
@@ -7,17 +14,9 @@ import dev.langchain4j.model.jina.internal.client.JinaClient;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.model.scoring.ScoringModel;
-import org.slf4j.Logger;
-
 import java.time.Duration;
 import java.util.List;
-
-import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static java.time.Duration.ofSeconds;
-import static java.util.Comparator.comparingInt;
-import static java.util.stream.Collectors.toList;
+import org.slf4j.Logger;
 
 /**
  * An implementation of a {@link ScoringModel} that uses
@@ -32,13 +31,14 @@ public class JinaScoringModel implements ScoringModel {
     private final Integer maxRetries;
 
     @Deprecated(forRemoval = true, since = "1.4.0")
-    public JinaScoringModel(String baseUrl,
-                            String apiKey,
-                            String modelName,
-                            Duration timeout,
-                            Integer maxRetries,
-                            Boolean logRequests,
-                            Boolean logResponses) {
+    public JinaScoringModel(
+            String baseUrl,
+            String apiKey,
+            String modelName,
+            Duration timeout,
+            Integer maxRetries,
+            Boolean logRequests,
+            Boolean logResponses) {
         this.client = JinaClient.builder()
                 .baseUrl(getOrDefault(baseUrl, DEFAULT_BASE_URL))
                 .apiKey(ensureNotBlank(apiKey, "apiKey"))
@@ -73,10 +73,8 @@ public class JinaScoringModel implements ScoringModel {
         JinaRerankingRequest request = JinaRerankingRequest.builder()
                 .model(modelName)
                 .query(query)
-                .documents(segments.stream()
-                        .map(TextSegment::text)
-                        .collect(toList()))
-                .returnDocuments(false)  // decreasing response size, do not include text in response
+                .documents(segments.stream().map(TextSegment::text).collect(toList()))
+                .returnDocuments(false) // decreasing response size, do not include text in response
                 .build();
 
         JinaRerankingResponse response = withRetryMappingExceptions(() -> client.rerank(request), maxRetries);
@@ -86,11 +84,7 @@ public class JinaScoringModel implements ScoringModel {
                 .map(result -> result.relevanceScore)
                 .collect(toList());
 
-        TokenUsage tokenUsage = new TokenUsage(
-                response.usage.promptTokens,
-                0,
-                response.usage.totalTokens
-        );
+        TokenUsage tokenUsage = new TokenUsage(response.usage.promptTokens, 0, response.usage.totalTokens);
         return Response.from(scores, tokenUsage);
     }
 
@@ -104,8 +98,7 @@ public class JinaScoringModel implements ScoringModel {
         private Boolean logResponses;
         private Logger logger;
 
-        JinaScoringModelBuilder() {
-        }
+        JinaScoringModelBuilder() {}
 
         public JinaScoringModelBuilder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
@@ -156,7 +149,10 @@ public class JinaScoringModel implements ScoringModel {
         }
 
         public String toString() {
-            return "JinaScoringModel.JinaScoringModelBuilder(baseUrl=" + this.baseUrl + ", apiKey=" + this.apiKey + ", modelName=" + this.modelName + ", timeout=" + this.timeout + ", maxRetries=" + this.maxRetries + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
+            return "JinaScoringModel.JinaScoringModelBuilder(baseUrl=" + this.baseUrl + ", apiKey="
+                    + (this.apiKey == null ? null : "********") + ", modelName=" + this.modelName + ", timeout="
+                    + this.timeout + ", maxRetries=" + this.maxRetries + ", logRequests=" + this.logRequests
+                    + ", logResponses=" + this.logResponses + ")";
         }
     }
 }

--- a/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/internal/client/JinaClient.java
+++ b/langchain4j-jina/src/main/java/dev/langchain4j/model/jina/internal/client/JinaClient.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.model.jina.internal.client;
 
+import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.internal.Utils;
 import dev.langchain4j.model.jina.internal.api.JinaApi;
@@ -7,16 +10,12 @@ import dev.langchain4j.model.jina.internal.api.JinaEmbeddingRequest;
 import dev.langchain4j.model.jina.internal.api.JinaEmbeddingResponse;
 import dev.langchain4j.model.jina.internal.api.JinaRerankingRequest;
 import dev.langchain4j.model.jina.internal.api.JinaRerankingResponse;
+import java.io.IOException;
+import java.time.Duration;
 import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
-
-import java.io.IOException;
-import java.time.Duration;
-
-import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 
 public class JinaClient {
 
@@ -25,7 +24,8 @@ public class JinaClient {
     private final JinaApi jinaApi;
     private final String authorizationHeader;
 
-    JinaClient(String baseUrl, String apiKey, Duration timeout, boolean logRequests, boolean logResponses, Logger logger) {
+    JinaClient(
+            String baseUrl, String apiKey, Duration timeout, boolean logRequests, boolean logResponses, Logger logger) {
 
         OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
                 .callTimeout(timeout)
@@ -98,8 +98,7 @@ public class JinaClient {
         private boolean logResponses;
         private Logger logger;
 
-        JinaClientBuilder() {
-        }
+        JinaClientBuilder() {}
 
         public JinaClientBuilder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
@@ -132,11 +131,14 @@ public class JinaClient {
         }
 
         public JinaClient build() {
-            return new JinaClient(this.baseUrl, this.apiKey, this.timeout, this.logRequests, this.logResponses, this.logger);
+            return new JinaClient(
+                    this.baseUrl, this.apiKey, this.timeout, this.logRequests, this.logResponses, this.logger);
         }
 
         public String toString() {
-            return "JinaClient.JinaClientBuilder(baseUrl=" + this.baseUrl + ", apiKey=" + this.apiKey + ", timeout=" + this.timeout + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
+            return "JinaClient.JinaClientBuilder(baseUrl=" + this.baseUrl + ", apiKey="
+                    + (this.apiKey == null ? null : "********") + ", timeout=" + this.timeout + ", logRequests="
+                    + this.logRequests + ", logResponses=" + this.logResponses + ")";
         }
     }
 }

--- a/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/JinaScoringModelBuilderTest.java
+++ b/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/JinaScoringModelBuilderTest.java
@@ -1,0 +1,25 @@
+package dev.langchain4j.model.jina;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class JinaScoringModelBuilderTest {
+
+    @Test
+    void toString_should_mask_api_key() {
+        String toString = JinaScoringModel.builder()
+                .apiKey("secret-api-key")
+                .modelName("jina-reranker-v2-base-multilingual")
+                .toString();
+
+        assertThat(toString).doesNotContain("secret-api-key").contains("apiKey=********");
+    }
+
+    @Test
+    void toString_should_render_null_api_key_as_null() {
+        String toString = new JinaScoringModel.JinaScoringModelBuilder().toString();
+
+        assertThat(toString).contains("apiKey=null");
+    }
+}

--- a/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/internal/client/JinaClientBuilderTest.java
+++ b/langchain4j-jina/src/test/java/dev/langchain4j/model/jina/internal/client/JinaClientBuilderTest.java
@@ -1,0 +1,22 @@
+package dev.langchain4j.model.jina.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class JinaClientBuilderTest {
+
+    @Test
+    void toString_should_mask_api_key() {
+        String toString = JinaClient.builder().apiKey("secret-api-key").toString();
+
+        assertThat(toString).doesNotContain("secret-api-key").contains("apiKey=********");
+    }
+
+    @Test
+    void toString_should_render_null_api_key_as_null() {
+        String toString = JinaClient.builder().toString();
+
+        assertThat(toString).contains("apiKey=null");
+    }
+}


### PR DESCRIPTION

## Issue
Closes #5537

## Change
`JinaScoringModel.JinaScoringModelBuilder.toString()` and `JinaClient.JinaClientBuilder.toString()` printed `apiKey` in plaintext, leaking the Jina API key into any log, debug, or exception output that renders the builder.

PR #3680 fixed this leak for `JinaEmbeddingModel.JinaEmbeddingModelBuilder.toString()` but left the two sibling builders untouched. This completes it with the same masking expression:

```java
", apiKey=" + (this.apiKey == null ? null : "********")
```

Added pure unit tests for both builders asserting `toString()` omits the secret and renders `apiKey=********` (and `apiKey=null` when unset); no API key needed.

Note: both touched files are pre-palantir-format, so spotless `ratchetFrom=origin/main` reformats them fully (imports, line wrapping). This churn is required by the spotless check, not a functional change.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is isolated to langchain4j-jina; no core/main code touched -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — no public API or behaviour change to document -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->

<!-- "new maven module" / "embedding store" checklists removed — not applicable to this fix. -->
