### PR TITLE
Forward enableEnhancedCivicAnswers to the Gemini generation config

### DIFF
--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
@@ -157,6 +157,7 @@ class BaseGeminiChatModel {
                         .presencePenalty(parameters.presencePenalty())
                         .frequencyPenalty(parameters.frequencyPenalty())
                         .responseLogprobs(responseLogprobs)
+                        .enableEnhancedCivicAnswers(enableEnhancedCivicAnswers)
                         .logprobs(logprobs)
                         .thinkingConfig(this.thinkingConfig)
                         .mediaResolution(this.mediaResolution)

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatModelTest.java
@@ -361,6 +361,7 @@ class GoogleAiGeminiChatModelTest {
                             .seed(42)
                             .candidateCount(1)
                             .responseLogprobs(false)
+                            .enableEnhancedCivicAnswers(false)
                             .build());
         }
 

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiEnhancedCivicAnswersTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiEnhancedCivicAnswersTest.java
@@ -1,0 +1,77 @@
+package dev.langchain4j.model.googleai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleAiGeminiEnhancedCivicAnswersTest {
+
+    private static final String TEST_MODEL_NAME = "gemini-1.5-pro";
+
+    @Mock
+    GeminiService mockGeminiService;
+
+    @Captor
+    ArgumentCaptor<GeminiGenerateContentRequest> requestCaptor;
+
+    @Test
+    void shouldForwardEnableEnhancedCivicAnswersWhenEnabled() {
+        var model = GoogleAiGeminiChatModel.builder()
+                .apiKey("test-key")
+                .modelName(TEST_MODEL_NAME)
+                .enableEnhancedCivicAnswers(true)
+                .build(mockGeminiService);
+
+        var chatRequest =
+                ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+        when(mockGeminiService.generateContent(any(), any())).thenReturn(createSimpleResponse("Hi"));
+
+        model.chat(chatRequest);
+
+        verify(mockGeminiService).generateContent(eq(TEST_MODEL_NAME), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().generationConfig().enableEnhancedCivicAnswers())
+                .isTrue();
+    }
+
+    @Test
+    void shouldDefaultEnableEnhancedCivicAnswersToFalse() {
+        var model = GoogleAiGeminiChatModel.builder()
+                .apiKey("test-key")
+                .modelName(TEST_MODEL_NAME)
+                .build(mockGeminiService);
+
+        var chatRequest =
+                ChatRequest.builder().messages(UserMessage.from("Hello")).build();
+        when(mockGeminiService.generateContent(any(), any())).thenReturn(createSimpleResponse("Hi"));
+
+        model.chat(chatRequest);
+
+        verify(mockGeminiService).generateContent(eq(TEST_MODEL_NAME), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().generationConfig().enableEnhancedCivicAnswers())
+                .isFalse();
+    }
+
+    private GeminiGenerateContentResponse createSimpleResponse(String text) {
+        var candidate = new GeminiGenerateContentResponse.GeminiCandidate(
+                new GeminiContent(
+                        List.of(GeminiContent.GeminiPart.builder().text(text).build()), "model"),
+                GeminiGenerateContentResponse.GeminiCandidate.GeminiFinishReason.STOP,
+                null,
+                null);
+        var usageMetadata = new GeminiGenerateContentResponse.GeminiUsageMetadata(0, 0, 0, null, null);
+        return new GeminiGenerateContentResponse("id", "model", List.of(candidate), usageMetadata, null);
+    }
+}

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
@@ -71,5 +71,28 @@ class GoogleAiGeminiStreamingChatModelTest {
             assertThat(result.cachedContent()).isNull();
             assertThatCharSequence(Json.toJson(result)).doesNotContain("\"cachedContent\"");
         }
+
+        @Test
+        void enableEnhancedCivicAnswersInContentRequest() {
+            GoogleAiGeminiStreamingChatModel chatModel = GoogleAiGeminiStreamingChatModel.builder()
+                    .apiKey("ApiKey")
+                    .modelName("ModelName")
+                    .enableEnhancedCivicAnswers(true)
+                    .build();
+            GeminiGenerateContentRequest result = chatModel.createGenerateContentRequest(DEFAULT_REQUEST);
+
+            assertThat(result.generationConfig().enableEnhancedCivicAnswers()).isTrue();
+        }
+
+        @Test
+        void defaultEnableEnhancedCivicAnswersInContentRequest() {
+            GoogleAiGeminiStreamingChatModel chatModel = GoogleAiGeminiStreamingChatModel.builder()
+                    .apiKey("ApiKey")
+                    .modelName("ModelName")
+                    .build();
+            GeminiGenerateContentRequest result = chatModel.createGenerateContentRequest(DEFAULT_REQUEST);
+
+            assertThat(result.generationConfig().enableEnhancedCivicAnswers()).isFalse();
+        }
     }
 }


### PR DESCRIPTION
`GoogleAiGeminiChatModel` and `GoogleAiGeminiStreamingChatModel` accept `enableEnhancedCivicAnswers(Boolean)`
on the builder, but the value was never sent to the API. `BaseGeminiChatModel#createGenerateContentRequest`
builds the `GeminiGenerationConfig` without it, so the option was silently ignored.

`GeminiGenerationConfig` already maps the field (`enableEnhancedCivicAnswers` with the matching
`@JsonProperty`); this just populates it from the existing field, next to `responseLogprobs`. The fix is shared
by the sync and streaming models, since both go through `createGenerateContentRequest`.

The builder option is documented as "Enables enhanced civic answers", and the field is a real Gemini
`generationConfig` parameter (it also exists in the official `google-genai` Java SDK's `GenerateContentConfig`),
so this is a missed wiring rather than an intentionally unsupported option. The sibling `responseLogprobs` is
forwarded the same way.

Closes #5546

### Changes
- `BaseGeminiChatModel`: pass `enableEnhancedCivicAnswers` into the `GeminiGenerationConfig` builder (shared by
  the sync and streaming models).
- `GoogleAiGeminiEnhancedCivicAnswersTest` (new): asserts the flag is forwarded when enabled and defaults to
  `false` otherwise, using the existing mocked-`GeminiService` request-capture pattern.
- `GoogleAiGeminiStreamingChatModelTest`: added enabled and default cases on the streaming path, following that
  test's existing `createGenerateContentRequest` style.
- `GoogleAiGeminiChatModelTest#shouldSendRequestWithAllParameters`: expected config updated to include the
  now-forwarded default, mirroring the existing `responseLogprobs(false)` assertion.

### Testing
`mvn -pl langchain4j-google-ai-gemini test` -> 334 passing, 0 failures. `spotless:check` passes.

### Checklist
- [x] No breaking changes (additive; default behavior unchanged, since `false` was already the effective default).
- [x] Unit tests added (positive: enabled is forwarded; default: false; both sync and streaming).
- [x] Ran the module build and tests locally (green) + spotless.
