### PR TITLE
fix: Map ContainsString filter to regex in MongoDB Atlas metadata filter mapper

### DIFF
--- a/langchain4j-mongodb-atlas/src/main/java/dev/langchain4j/store/embedding/mongodb/MongoDbMetadataFilterMapper.java
+++ b/langchain4j-mongodb-atlas/src/main/java/dev/langchain4j/store/embedding/mongodb/MongoDbMetadataFilterMapper.java
@@ -2,6 +2,7 @@ package dev.langchain4j.store.embedding.mongodb;
 
 import com.mongodb.client.model.Filters;
 import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.comparison.ContainsString;
 import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
 import dev.langchain4j.store.embedding.filter.comparison.IsGreaterThan;
 import dev.langchain4j.store.embedding.filter.comparison.IsGreaterThanOrEqualTo;
@@ -13,6 +14,7 @@ import dev.langchain4j.store.embedding.filter.comparison.IsNotIn;
 import dev.langchain4j.store.embedding.filter.logical.And;
 import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
+import java.util.regex.Pattern;
 import org.bson.conversions.Bson;
 
 class MongoDbMetadataFilterMapper {
@@ -40,8 +42,11 @@ class MongoDbMetadataFilterMapper {
             return mapOr((Or) filter);
         } else if (filter instanceof Not) {
             return mapNot((Not) filter);
+        } else if (filter instanceof ContainsString) {
+            return mapContains((ContainsString) filter);
         } else {
-            throw new UnsupportedOperationException("Unsupported filter type: " + filter.getClass().getName());
+            throw new UnsupportedOperationException(
+                    "Unsupported filter type: " + filter.getClass().getName());
         }
     }
 
@@ -50,7 +55,7 @@ class MongoDbMetadataFilterMapper {
     }
 
     private static Bson mapEqual(IsEqualTo filter) {
-        return Filters.eq(getFieldName(filter.key()), filter.comparisonValue() );
+        return Filters.eq(getFieldName(filter.key()), filter.comparisonValue());
     }
 
     private static Bson mapNotEqual(IsNotEqualTo filter) {
@@ -91,5 +96,9 @@ class MongoDbMetadataFilterMapper {
 
     private static Bson mapNot(Not filter) {
         return Filters.not(map(filter.expression()));
+    }
+
+    private static Bson mapContains(ContainsString filter) {
+        return Filters.regex(getFieldName(filter.key()), Pattern.quote(filter.comparisonValue()));
     }
 }

--- a/langchain4j-mongodb-atlas/src/test/java/dev/langchain4j/store/embedding/mongodb/MongoDbMetadataFilterMapperTest.java
+++ b/langchain4j-mongodb-atlas/src/test/java/dev/langchain4j/store/embedding/mongodb/MongoDbMetadataFilterMapperTest.java
@@ -1,0 +1,36 @@
+package dev.langchain4j.store.embedding.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mongodb.MongoClientSettings;
+import dev.langchain4j.store.embedding.filter.comparison.ContainsString;
+import java.util.regex.Pattern;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.Test;
+
+class MongoDbMetadataFilterMapperTest {
+
+    private static BsonDocument toBsonDocument(Bson bson) {
+        return bson.toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry());
+    }
+
+    @Test
+    void should_map_contains_string_to_regex() {
+        Bson bson = MongoDbMetadataFilterMapper.map(new ContainsString("name", "lang"));
+
+        BsonDocument document = toBsonDocument(bson);
+        assertThat(document.containsKey("metadata.name")).isTrue();
+        assertThat(document.getRegularExpression("metadata.name").getPattern()).isEqualTo(Pattern.quote("lang"));
+    }
+
+    @Test
+    void should_escape_regex_metacharacters_in_contains_string() {
+        Bson bson = MongoDbMetadataFilterMapper.map(new ContainsString("name", "a.b*c"));
+
+        BsonDocument document = toBsonDocument(bson);
+        assertThat(document.getRegularExpression("metadata.name").getPattern())
+                .isEqualTo(Pattern.quote("a.b*c"))
+                .isEqualTo("\\Qa.b*c\\E");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5552

## Change
`MongoDbMetadataFilterMapper.map()` had no branch for the core filter type `ContainsString`, so it fell through to the default branch and threw `UnsupportedOperationException`. Sibling stores (milvus, pgvector, azure-cosmos-nosql) already handle it; this closes that parity gap.

Added a `ContainsString` branch before the default `else`, plus a `mapContains` method that renders `Filters.regex(metadata.<key>, Pattern.quote(value))`.

`ContainsString.test()` uses `str.contains(value)`, a literal substring check. `Pattern.quote(...)` escapes the value so regex metacharacters (`.`, `*`, `(`) match literally, matching milvus's `LIKE %value%` semantics.

Where this runs: `ContainsString` is not a `$vectorSearch` pre-filter. It is applied in the post-search `$match` aggregation stage in `MongoDbEmbeddingStore.search()` and in `removeAll(Filter)`'s `deleteMany`. Both are ordinary query contexts that support `$regex` (per MongoDB docs), so the fix is valid at runtime.

Scope: the new branch, `mapContains`, and two imports, plus two spotless-ratchet reformats of pre-existing lines in the touched file (long `throw` wrap, a stray space) required for `spotless:check` to pass.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
