### PR TITLE
fix: Add space separator in chat model observation span contextual name

### DIFF
--- a/langchain4j-observation/src/main/java/dev/langchain4j/observation/convention/DefaultChatModelConvention.java
+++ b/langchain4j-observation/src/main/java/dev/langchain4j/observation/convention/DefaultChatModelConvention.java
@@ -50,6 +50,7 @@ public class DefaultChatModelConvention implements ChatModelConvention {
     @Override
     public @Nullable String getContextualName(final ChatModelObservationContext context) {
         return OPERATION_VALUE_CHAT
+                + " "
                 + ofNullable(context.getRequestContext())
                         .map(ChatModelRequestContext::chatRequest)
                         .map(ChatRequest::parameters)

--- a/langchain4j-observation/src/test/java/dev/langchain4j/observation/convention/DefaultChatModelConventionTest.java
+++ b/langchain4j-observation/src/test/java/dev/langchain4j/observation/convention/DefaultChatModelConventionTest.java
@@ -1,0 +1,42 @@
+package dev.langchain4j.observation.convention;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.ModelProvider;
+import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.observation.context.ChatModelObservationContext;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+
+class DefaultChatModelConventionTest {
+
+    private final DefaultChatModelConvention convention = new DefaultChatModelConvention();
+
+    @Test
+    void getContextualName_should_separate_operation_and_model_with_a_space() {
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("hello"))
+                .modelName("gpt-4o-mini")
+                .build();
+        ChatModelObservationContext context = observationContext(chatRequest);
+
+        assertThat(convention.getContextualName(context)).isEqualTo("chat gpt-4o-mini");
+    }
+
+    @Test
+    void getContextualName_should_fall_back_to_unknown_when_model_name_is_missing() {
+        ChatRequest chatRequest =
+                ChatRequest.builder().messages(UserMessage.from("hello")).build();
+        ChatModelObservationContext context = observationContext(chatRequest);
+
+        assertThat(convention.getContextualName(context)).isEqualTo("chat unknown");
+    }
+
+    private static ChatModelObservationContext observationContext(ChatRequest chatRequest) {
+        ChatModelRequestContext requestContext =
+                new ChatModelRequestContext(chatRequest, ModelProvider.OPEN_AI, new HashMap<>());
+        return new ChatModelObservationContext(requestContext, null, null);
+    }
+}


### PR DESCRIPTION
## Issue
<!-- Update with the real issue number after creating the issue. -->
Closes #5556

## Change
`DefaultChatModelConvention.getContextualName()` concatenated the operation name `"chat"` and the model name with no separator, producing span contextual names like `"chatgpt-4o-mini"`.

The method's Javadoc references the OpenTelemetry gen-ai span name convention `{gen_ai.operation.name} {gen_ai.request.model}` (space-separated). The same class already exposes the two values as separate `KeyValue`s, so the joined name was also internally inconsistent. The Micrometer Tracing bridge uses the contextual name as the span name, so every span from a normal request violated the referenced spec.

This adds a single space between the operation and the model name:
```java
return OPERATION_VALUE_CHAT
        + " "
        + ofNullable(context.getRequestContext())
                ...
                .orElse(UNKNOWN);
```
Now `getContextualName()` returns `"chat gpt-4o-mini"`, and `"chat unknown"` when the model name is absent.

A new unit test `DefaultChatModelConventionTest` covers both cases; both fail against the old code and pass after the fix.

<!-- Verified locally with JDK 17: ./mvnw -pl langchain4j-observation -am clean test → BUILD SUCCESS, 2 tests in the new class green. spotless:apply reported both files already clean (run from main checkout; jgit cannot read the worktree .git file). -->

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- N/A — change is confined to langchain4j-observation. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
<!-- N/A — docs added after review per CONTRIBUTING. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
<!-- N/A — small bug fix. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
<!-- N/A — no Spring Boot starter affected. -->

<!-- Conditional sections (new maven module / embedding store) omitted: not applicable to this fix. -->

