### PR TITLE
fix: mask apiKey in NomicEmbeddingModel builder toString

### DIFF
--- a/langchain4j-nomic/src/main/java/dev/langchain4j/model/nomic/NomicEmbeddingModel.java
+++ b/langchain4j-nomic/src/main/java/dev/langchain4j/model/nomic/NomicEmbeddingModel.java
@@ -1,21 +1,20 @@
 package dev.langchain4j.model.nomic;
 
-import dev.langchain4j.data.embedding.Embedding;
-import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
-import dev.langchain4j.model.output.Response;
-import dev.langchain4j.model.output.TokenUsage;
-import org.slf4j.Logger;
-
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static java.time.Duration.ofSeconds;
 import static java.util.stream.Collectors.toList;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
 
 /**
  * An integration with Nomic Atlas's Text Embeddings API.
@@ -41,8 +40,7 @@ public class NomicEmbeddingModel extends DimensionAwareEmbeddingModel {
             Duration timeout,
             Integer maxRetries,
             Boolean logRequests,
-            Boolean logResponses
-    ) {
+            Boolean logResponses) {
         this.client = NomicClient.builder()
                 .baseUrl(getOrDefault(baseUrl, DEFAULT_BASE_URL))
                 .apiKey(ensureNotBlank(apiKey, "apiKey"))
@@ -77,9 +75,7 @@ public class NomicEmbeddingModel extends DimensionAwareEmbeddingModel {
     @Override
     public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
 
-        List<String> texts = textSegments.stream()
-                .map(TextSegment::text)
-                .collect(toList());
+        List<String> texts = textSegments.stream().map(TextSegment::text).collect(toList());
 
         return embedTexts(texts);
     }
@@ -113,9 +109,7 @@ public class NomicEmbeddingModel extends DimensionAwareEmbeddingModel {
     }
 
     private List<Embedding> getEmbeddings(EmbeddingResponse response) {
-        return response.getEmbeddings().stream()
-                .map(Embedding::from)
-                .collect(toList());
+        return response.getEmbeddings().stream().map(Embedding::from).collect(toList());
     }
 
     private Integer getTokenUsage(EmbeddingResponse response) {
@@ -137,8 +131,7 @@ public class NomicEmbeddingModel extends DimensionAwareEmbeddingModel {
         private Boolean logResponses;
         private Logger logger;
 
-        NomicEmbeddingModelBuilder() {
-        }
+        NomicEmbeddingModelBuilder() {}
 
         public NomicEmbeddingModelBuilder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
@@ -199,7 +192,11 @@ public class NomicEmbeddingModel extends DimensionAwareEmbeddingModel {
         }
 
         public String toString() {
-            return "NomicEmbeddingModel.NomicEmbeddingModelBuilder(baseUrl=" + this.baseUrl + ", apiKey=" + this.apiKey + ", modelName=" + this.modelName + ", taskType=" + this.taskType + ", maxSegmentsPerBatch=" + this.maxSegmentsPerBatch + ", timeout=" + this.timeout + ", maxRetries=" + this.maxRetries + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
+            return "NomicEmbeddingModel.NomicEmbeddingModelBuilder(baseUrl=" + this.baseUrl + ", apiKey="
+                    + (this.apiKey == null ? null : "********") + ", modelName=" + this.modelName + ", taskType="
+                    + this.taskType + ", maxSegmentsPerBatch=" + this.maxSegmentsPerBatch + ", timeout=" + this.timeout
+                    + ", maxRetries=" + this.maxRetries + ", logRequests=" + this.logRequests + ", logResponses="
+                    + this.logResponses + ")";
         }
     }
 }

--- a/langchain4j-nomic/src/test/java/dev/langchain4j/model/nomic/NomicEmbeddingModelBuilderTest.java
+++ b/langchain4j-nomic/src/test/java/dev/langchain4j/model/nomic/NomicEmbeddingModelBuilderTest.java
@@ -1,0 +1,25 @@
+package dev.langchain4j.model.nomic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class NomicEmbeddingModelBuilderTest {
+
+    @Test
+    void toString_should_mask_api_key() {
+        String toString = NomicEmbeddingModel.builder()
+                .apiKey("secret-api-key")
+                .modelName("nomic-embed-text-v1.5")
+                .toString();
+
+        assertThat(toString).doesNotContain("secret-api-key").contains("apiKey=********");
+    }
+
+    @Test
+    void toString_should_render_null_api_key_as_null() {
+        String toString = new NomicEmbeddingModel.NomicEmbeddingModelBuilder().toString();
+
+        assertThat(toString).contains("apiKey=null");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5558

## Change

`NomicEmbeddingModel.NomicEmbeddingModelBuilder.toString()` printed the `apiKey` in plaintext, leaking it into any log that includes the builder.

This masks it the same way the merged jina fix (PR #3680) does:

```java
", apiKey=" + (this.apiKey == null ? null : "********") + ", modelName=" + ...
```

The key now renders as `apiKey=********` when set and `apiKey=null` when unset.

Scope is the public `NomicEmbeddingModel` builder only. The package-private `NomicClientBuilder.toString()` has the same leak but is being rewritten by open PR #4973, so it is intentionally left out to avoid a conflict.

Note: `NomicEmbeddingModel.java` was not previously palantir-formatted, so the spotless ratchet reformatted unrelated lines (import order, lambda/empty-constructor style) in this file. These are spotless-required, not manual edits.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is isolated to langchain4j-nomic; core/main untouched -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — no doc-facing change -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A — not a feature -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A — not applicable -->

<!-- Checklist for adding new maven module: N/A — no new module. -->
<!-- Checklist for adding/changing embedding store integration: N/A — this is an embedding model, not a store. -->

