### PR TITLE
fix: Populate logProbs in OpenAI streaming response metadata

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.openai;
 import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.finishReasonFrom;
+import static dev.langchain4j.model.openai.internal.OpenAiUtils.logProbsFrom;
 import static dev.langchain4j.model.openai.internal.OpenAiUtils.tokenUsageFrom;
 import static java.util.stream.Collectors.toList;
 
@@ -17,6 +18,8 @@ import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
 import dev.langchain4j.model.openai.internal.chat.Delta;
 import dev.langchain4j.model.openai.internal.chat.FunctionCall;
+import dev.langchain4j.model.openai.internal.chat.LogProb;
+import dev.langchain4j.model.openai.internal.chat.LogProbs;
 import dev.langchain4j.model.openai.internal.chat.ToolCall;
 import dev.langchain4j.model.openai.internal.completion.CompletionChoice;
 import dev.langchain4j.model.openai.internal.completion.CompletionResponse;
@@ -29,6 +32,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -59,6 +63,7 @@ public class OpenAiStreamingResponseBuilder {
     private final AtomicReference<FinishReason> finishReason = new AtomicReference<>();
     private final AtomicReference<SuccessfulHttpResponse> rawHttpResponse = new AtomicReference<>();
     private final Queue<ServerSentEvent> rawServerSentEvents = new ConcurrentLinkedQueue<>();
+    private final List<LogProb> logProbs = new CopyOnWriteArrayList<>();
 
     private final boolean returnThinking;
     private final boolean accumulateToolCallId;
@@ -133,6 +138,11 @@ public class OpenAiStreamingResponseBuilder {
         String finishReason = chatCompletionChoice.finishReason();
         if (finishReason != null) {
             this.finishReason.set(finishReasonFrom(finishReason));
+        }
+
+        LogProbs logProbs = chatCompletionChoice.logprobs();
+        if (logProbs != null && logProbs.content() != null) {
+            this.logProbs.addAll(logProbs.content());
         }
 
         Delta delta = chatCompletionChoice.delta();
@@ -294,6 +304,12 @@ public class OpenAiStreamingResponseBuilder {
                 .systemFingerprint(systemFingerprint.get())
                 .rawHttpResponse(rawHttpResponse.get())
                 .rawServerSentEvents(new ArrayList<>(rawServerSentEvents))
+                .logProbs(
+                        logProbs.isEmpty()
+                                ? null
+                                : logProbsFrom(LogProbs.builder()
+                                        .content(new ArrayList<>(logProbs))
+                                        .build()))
                 .build();
     }
 

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
@@ -227,6 +227,68 @@ class OpenAiStreamingResponseBuilderTest {
         assertThat(toolExecutionRequests).extracting(ToolExecutionRequest::id).containsExactly("call_1", "call_2");
     }
 
+    @Test
+    void should_accumulate_logprobs_across_streaming_chunks() {
+        // Given: streaming chunks, each carrying one token's logprobs.content (as OpenAI sends them)
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+
+        builder.append(chatCompletionResponseWithLogProb(dev.langchain4j.model.openai.internal.chat.LogProb.builder()
+                .token("Hello")
+                .logprob(-0.1)
+                .bytes(List.of(72, 101, 108, 108, 111))
+                .build()));
+        builder.append(chatCompletionResponseWithLogProb(dev.langchain4j.model.openai.internal.chat.LogProb.builder()
+                .token("!")
+                .logprob(-0.2)
+                .bytes(List.of(33))
+                .build()));
+
+        // When
+        ChatResponse chatResponse = builder.build();
+
+        // Then: metadata exposes the accumulated logprobs in order
+        OpenAiChatResponseMetadata metadata = (OpenAiChatResponseMetadata) chatResponse.metadata();
+        assertThat(metadata.logProbs()).hasSize(2);
+        assertThat(metadata.logProbs())
+                .extracting(dev.langchain4j.model.openai.LogProb::token)
+                .containsExactly("Hello", "!");
+        assertThat(metadata.logProbs().get(0).logprob()).isEqualTo(-0.1);
+    }
+
+    @Test
+    void should_keep_logprobs_null_when_not_requested() {
+        // Given: a response without logprobs (logprobs not requested)
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+        builder.append(ChatCompletionResponse.builder()
+                .id("resp_1")
+                .model("gpt-4o")
+                .choices(List.of(ChatCompletionChoice.builder()
+                        .index(0)
+                        .delta(Delta.builder().content("Hello").build())
+                        .build()))
+                .build());
+
+        // When
+        ChatResponse chatResponse = builder.build();
+
+        // Then: logProbs stays null (backward compatible)
+        OpenAiChatResponseMetadata metadata = (OpenAiChatResponseMetadata) chatResponse.metadata();
+        assertThat(metadata.logProbs()).isNull();
+    }
+
+    private static ChatCompletionResponse chatCompletionResponseWithLogProb(
+            dev.langchain4j.model.openai.internal.chat.LogProb logProb) {
+        return ChatCompletionResponse.builder()
+                .id("resp_1")
+                .model("gpt-4o")
+                .choices(List.of(ChatCompletionChoice.builder()
+                        .index(0)
+                        .delta(Delta.builder().content(logProb.token()).build())
+                        .logprobs(LogProbs.builder().content(List.of(logProb)).build())
+                        .build()))
+                .build();
+    }
+
     private static ChatCompletionResponse chatCompletionResponse(ToolCall toolCall) {
         return ChatCompletionResponse.builder()
                 .id("resp_1")


### PR DESCRIPTION
## Issue
Closes #5560

## Change
`OpenAiStreamingResponseBuilder` now accumulates logprobs from streamed choices and exposes them in the response metadata.

- `append(ChatCompletionResponse)` reads `choice.logprobs().content()` from each chunk and appends it, in order, to a thread-safe `CopyOnWriteArrayList` (this builder is called from streaming threads).
- `buildMetadata()` converts the accumulated content with the existing `OpenAiUtils.logProbsFrom(...)` helper and sets it via `.logProbs(...)`. When nothing was accumulated (logprobs not requested), it stays `null`.

This closes the parity gap with the non-streaming `OpenAiChatModel.doChat()`, which already populates logprobs. PR #4306 added logprobs only to the non-streaming path; this completes the streaming sibling.

No public signature changes; behavior is unchanged when logprobs are not requested (backward compatible).

Added two unit tests to `OpenAiStreamingResponseBuilderTest` (no API key or mock needed): one asserts logprobs accumulate in order across chunks, one asserts the field stays `null` when no logprobs are present.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- N/A — core/main modules not touched; change is confined to langchain4j-open-ai internal builder -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- N/A — documentation/examples are added after review per template guidance -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- "new maven module" / "new embedding store" / "changing embedding store" 섹션 삭제: 신규 모듈도 embedding store도 아닌 기존 통합 내부 버그픽스이므로 해당 없음 -->

