### PR TITLE
Support input_image format for OpenAI-compatible images

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
@@ -61,6 +61,7 @@ public class OpenAiChatModel implements ChatModel {
     private final boolean returnThinking;
     private final boolean sendThinking;
     private final String thinkingFieldName;
+    private final boolean useInputImageFormat;
     private final List<ChatModelListener> listeners;
 
     public OpenAiChatModel(OpenAiChatModelBuilder builder) {
@@ -128,6 +129,7 @@ public class OpenAiChatModel implements ChatModel {
         this.returnThinking = getOrDefault(builder.returnThinking, false);
         this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.thinkingFieldName = getOrDefault(builder.thinkingFieldName, "reasoning_content");
+        this.useInputImageFormat = getOrDefault(builder.useInputImageFormat, false);
         this.listeners = copy(builder.listeners);
     }
 
@@ -152,7 +154,13 @@ public class OpenAiChatModel implements ChatModel {
         validate(parameters);
 
         ChatCompletionRequest openAiRequest = toOpenAiChatRequest(
-                        chatRequest, parameters, sendThinking, thinkingFieldName, strictTools, strictJsonSchema)
+                        chatRequest,
+                        parameters,
+                        sendThinking,
+                        thinkingFieldName,
+                        strictTools,
+                        strictJsonSchema,
+                        useInputImageFormat)
                 .build();
 
         ParsedAndRawResponse<ChatCompletionResponse> parsedAndRawResponse = withRetryMappingExceptions(
@@ -232,6 +240,7 @@ public class OpenAiChatModel implements ChatModel {
         private Boolean returnThinking;
         private Boolean sendThinking;
         private String thinkingFieldName;
+        private Boolean useInputImageFormat;
         private Boolean logprobs;
         private Integer topLogprobs;
         private Duration timeout;
@@ -457,6 +466,19 @@ public class OpenAiChatModel implements ChatModel {
         public OpenAiChatModelBuilder sendThinking(Boolean sendThinking) {
             this.sendThinking = sendThinking;
             this.thinkingFieldName = "reasoning_content";
+            return this;
+        }
+
+        /**
+         * Controls whether image content is sent using the {@code input_image} format.
+         * <p>
+         * Disabled by default, preserving the OpenAI Chat Completions {@code image_url} format.
+         *
+         * @param useInputImageFormat whether to send image content as {@code input_image}
+         * @return {@code this}
+         */
+        public OpenAiChatModelBuilder useInputImageFormat(Boolean useInputImageFormat) {
+            this.useInputImageFormat = useInputImageFormat;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -68,6 +68,7 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
     private final boolean sendThinking;
     private final String thinkingFieldName;
     private final boolean accumulateToolCallId;
+    private final boolean useInputImageFormat;
     private final List<ChatModelListener> listeners;
 
     public OpenAiStreamingChatModel(OpenAiStreamingChatModelBuilder builder) {
@@ -132,6 +133,7 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
         this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.thinkingFieldName = getOrDefault(builder.thinkingFieldName, "reasoning_content");
         this.accumulateToolCallId = getOrDefault(builder.accumulateToolCallId, true);
+        this.useInputImageFormat = getOrDefault(builder.useInputImageFormat, false);
         this.listeners = copy(builder.listeners);
     }
 
@@ -146,13 +148,17 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
         OpenAiChatRequestParameters parameters = (OpenAiChatRequestParameters) chatRequest.parameters();
         validate(parameters);
 
-        ChatCompletionRequest openAiRequest =
-                toOpenAiChatRequest(
-                                chatRequest, parameters, sendThinking, thinkingFieldName, strictTools, strictJsonSchema)
-                        .stream(true)
-                        .streamOptions(
-                                StreamOptions.builder().includeUsage(true).build())
-                        .build();
+        ChatCompletionRequest openAiRequest = toOpenAiChatRequest(
+                        chatRequest,
+                        parameters,
+                        sendThinking,
+                        thinkingFieldName,
+                        strictTools,
+                        strictJsonSchema,
+                        useInputImageFormat)
+                .stream(true)
+                .streamOptions(StreamOptions.builder().includeUsage(true).build())
+                .build();
 
         OpenAiStreamingResponseBuilder openAiResponseBuilder =
                 new OpenAiStreamingResponseBuilder(returnThinking, accumulateToolCallId);
@@ -310,6 +316,7 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
         private Boolean sendThinking;
         private String thinkingFieldName;
         private Boolean accumulateToolCallId;
+        private Boolean useInputImageFormat;
         private Duration timeout;
         private Boolean logRequests;
         private Boolean logResponses;
@@ -543,6 +550,19 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
          */
         public OpenAiStreamingChatModelBuilder accumulateToolCallId(Boolean accumulateToolCallId) {
             this.accumulateToolCallId = accumulateToolCallId;
+            return this;
+        }
+
+        /**
+         * Controls whether image content is sent using the {@code input_image} format.
+         * <p>
+         * Disabled by default, preserving the OpenAI Chat Completions {@code image_url} format.
+         *
+         * @param useInputImageFormat whether to send image content as {@code input_image}
+         * @return {@code this}
+         */
+        public OpenAiStreamingChatModelBuilder useInputImageFormat(Boolean useInputImageFormat) {
+            this.useInputImageFormat = useInputImageFormat;
             return this;
         }
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/OpenAiUtils.java
@@ -89,21 +89,31 @@ public class OpenAiUtils {
     public static final String DEFAULT_USER_AGENT = "langchain4j-openai";
 
     public static List<Message> toOpenAiMessages(List<ChatMessage> messages) {
-        return toOpenAiMessages(messages, false, null);
+        return toOpenAiMessages(messages, false, null, false);
     }
 
     public static List<Message> toOpenAiMessages(
             List<ChatMessage> messages, boolean sendThinking, String thinkingFieldName) {
+        return toOpenAiMessages(messages, sendThinking, thinkingFieldName, false);
+    }
+
+    public static List<Message> toOpenAiMessages(
+            List<ChatMessage> messages, boolean sendThinking, String thinkingFieldName, boolean useInputImageFormat) {
         return messages.stream()
-                .map(message -> toOpenAiMessage(message, sendThinking, thinkingFieldName))
+                .map(message -> toOpenAiMessage(message, sendThinking, thinkingFieldName, useInputImageFormat))
                 .collect(toList());
     }
 
     public static Message toOpenAiMessage(ChatMessage message) {
-        return toOpenAiMessage(message, false, null);
+        return toOpenAiMessage(message, false, null, false);
     }
 
     public static Message toOpenAiMessage(ChatMessage message, boolean sendThinking, String thinkingFieldName) {
+        return toOpenAiMessage(message, sendThinking, thinkingFieldName, false);
+    }
+
+    public static Message toOpenAiMessage(
+            ChatMessage message, boolean sendThinking, String thinkingFieldName, boolean useInputImageFormat) {
         if (message instanceof SystemMessage) {
             return dev.langchain4j.model.openai.internal.chat.SystemMessage.from(((SystemMessage) message).text());
         }
@@ -117,7 +127,7 @@ public class OpenAiUtils {
             } else {
                 return dev.langchain4j.model.openai.internal.chat.UserMessage.builder()
                         .content(userMessage.contents().stream()
-                                .map(OpenAiUtils::toOpenAiContent)
+                                .map(content -> toOpenAiContent(content, useInputImageFormat))
                                 .collect(toList()))
                         .name(userMessage.name())
                         .build();
@@ -190,11 +200,12 @@ public class OpenAiUtils {
         throw illegalArgument("Unknown message type: " + message.type());
     }
 
-    private static dev.langchain4j.model.openai.internal.chat.Content toOpenAiContent(Content content) {
+    private static dev.langchain4j.model.openai.internal.chat.Content toOpenAiContent(
+            Content content, boolean useInputImageFormat) {
         if (content instanceof TextContent) {
             return toOpenAiContent((TextContent) content);
         } else if (content instanceof ImageContent) {
-            return toOpenAiContent((ImageContent) content);
+            return toOpenAiContent((ImageContent) content, useInputImageFormat);
         } else if (content instanceof VideoContent videoContent) {
             return toOpenAiContent(videoContent);
         } else if (content instanceof AudioContent audioContent) {
@@ -213,7 +224,15 @@ public class OpenAiUtils {
                 .build();
     }
 
-    private static dev.langchain4j.model.openai.internal.chat.Content toOpenAiContent(ImageContent content) {
+    private static dev.langchain4j.model.openai.internal.chat.Content toOpenAiContent(
+            ImageContent content, boolean useInputImageFormat) {
+        if (useInputImageFormat) {
+            return dev.langchain4j.model.openai.internal.chat.Content.builder()
+                    .type(ContentType.INPUT_IMAGE)
+                    .inputImageUrl(toUrl(content.image()))
+                    .build();
+        }
+
         return dev.langchain4j.model.openai.internal.chat.Content.builder()
                 .type(ContentType.IMAGE_URL)
                 .imageUrl(ImageUrl.builder()
@@ -554,9 +573,22 @@ public class OpenAiUtils {
             String thinkingFieldName,
             Boolean strictTools,
             Boolean strictJsonSchema) {
+        return toOpenAiChatRequest(
+                chatRequest, parameters, sendThinking, thinkingFieldName, strictTools, strictJsonSchema, false);
+    }
+
+    public static ChatCompletionRequest.Builder toOpenAiChatRequest(
+            ChatRequest chatRequest,
+            OpenAiChatRequestParameters parameters,
+            boolean sendThinking,
+            String thinkingFieldName,
+            Boolean strictTools,
+            Boolean strictJsonSchema,
+            boolean useInputImageFormat) {
 
         return ChatCompletionRequest.builder()
-                .messages(toOpenAiMessages(chatRequest.messages(), sendThinking, thinkingFieldName))
+                .messages(
+                        toOpenAiMessages(chatRequest.messages(), sendThinking, thinkingFieldName, useInputImageFormat))
                 // common parameters
                 .model(parameters.modelName())
                 .temperature(parameters.temperature())

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Content.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/Content.java
@@ -3,12 +3,13 @@ package dev.langchain4j.model.openai.internal.chat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import dev.langchain4j.internal.JacocoIgnoreCoverageGenerated;
-
+import java.util.Locale;
 import java.util.Objects;
 
 @JsonDeserialize(builder = Content.Builder.class)
@@ -22,8 +23,9 @@ public final class Content {
     @JsonProperty
     private final String text;
 
-    @JsonProperty
     private final ImageUrl imageUrl;
+
+    private final String inputImageUrl;
 
     @JsonProperty
     private final VideoUrl videoUrl;
@@ -38,6 +40,7 @@ public final class Content {
         this.type = builder.type;
         this.text = builder.text;
         this.imageUrl = builder.imageUrl;
+        this.inputImageUrl = builder.inputImageUrl;
         this.videoUrl = builder.videoUrl;
         this.inputAudio = builder.inputAudio;
         this.file = builder.file;
@@ -53,6 +56,10 @@ public final class Content {
 
     public ImageUrl imageUrl() {
         return imageUrl;
+    }
+
+    public String inputImageUrl() {
+        return inputImageUrl;
     }
 
     public VideoUrl videoUrl() {
@@ -79,6 +86,7 @@ public final class Content {
         return Objects.equals(type, another.type)
                 && Objects.equals(text, another.text)
                 && Objects.equals(imageUrl, another.imageUrl)
+                && Objects.equals(inputImageUrl, another.inputImageUrl)
                 && Objects.equals(videoUrl, another.videoUrl)
                 && Objects.equals(inputAudio, another.inputAudio)
                 && Objects.equals(file, another.file);
@@ -91,6 +99,7 @@ public final class Content {
         h += (h << 5) + Objects.hashCode(type);
         h += (h << 5) + Objects.hashCode(text);
         h += (h << 5) + Objects.hashCode(imageUrl);
+        h += (h << 5) + Objects.hashCode(inputImageUrl);
         h += (h << 5) + Objects.hashCode(videoUrl);
         h += (h << 5) + Objects.hashCode(inputAudio);
         h += (h << 5) + Objects.hashCode(file);
@@ -103,7 +112,8 @@ public final class Content {
         return "Content{" + "type="
                 + type + ", text="
                 + text + ", imageUrl="
-                + imageUrl + ", videoUrl="
+                + imageUrl + ", inputImageUrl="
+                + inputImageUrl + ", videoUrl="
                 + videoUrl + ", inputAudio="
                 + inputAudio + ", file="
                 + file + "}";
@@ -111,6 +121,11 @@ public final class Content {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    @JsonProperty("image_url")
+    private Object imageUrlForSerialization() {
+        return imageUrl != null ? imageUrl : inputImageUrl;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -121,6 +136,7 @@ public final class Content {
         private ContentType type;
         private String text;
         private ImageUrl imageUrl;
+        private String inputImageUrl;
         private VideoUrl videoUrl;
         private InputAudio inputAudio;
         private PdfFile file;
@@ -137,6 +153,29 @@ public final class Content {
 
         public Builder imageUrl(ImageUrl imageUrl) {
             this.imageUrl = imageUrl;
+            this.inputImageUrl = null;
+            return this;
+        }
+
+        @JsonProperty("image_url")
+        Builder imageUrl(JsonNode imageUrl) {
+            if (imageUrl == null || imageUrl.isNull()) {
+                return this;
+            }
+
+            if (imageUrl.isTextual()) {
+                return inputImageUrl(imageUrl.asText());
+            }
+
+            return imageUrl(ImageUrl.builder()
+                    .url(textValue(imageUrl.get("url")))
+                    .detail(imageDetail(imageUrl.get("detail")))
+                    .build());
+        }
+
+        public Builder inputImageUrl(String inputImageUrl) {
+            this.inputImageUrl = inputImageUrl;
+            this.imageUrl = null;
             return this;
         }
 
@@ -157,6 +196,18 @@ public final class Content {
 
         public Content build() {
             return new Content(this);
+        }
+
+        private static String textValue(JsonNode node) {
+            return node == null || node.isNull() ? null : node.asText();
+        }
+
+        private static ImageDetail imageDetail(JsonNode node) {
+            if (node == null || node.isNull()) {
+                return null;
+            }
+
+            return ImageDetail.valueOf(node.asText().toUpperCase(Locale.ROOT));
         }
     }
 }

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/ContentType.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/internal/chat/ContentType.java
@@ -7,6 +7,8 @@ public enum ContentType {
     TEXT,
     @JsonProperty("image_url")
     IMAGE_URL,
+    @JsonProperty("input_image")
+    INPUT_IMAGE,
     @JsonProperty("video_url")
     VIDEO_URL,
     @JsonProperty("input_audio")

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/OpenAiImageContentFormatTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/internal/OpenAiImageContentFormatTest.java
@@ -1,0 +1,244 @@
+package dev.langchain4j.model.openai.internal;
+
+import static dev.langchain4j.model.openai.internal.OpenAiUtils.toOpenAiMessages;
+import static dev.langchain4j.model.openai.internal.chat.ContentType.IMAGE_URL;
+import static dev.langchain4j.model.openai.internal.chat.ContentType.INPUT_IMAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import dev.langchain4j.model.openai.internal.chat.Content;
+import dev.langchain4j.model.openai.internal.chat.UserMessage;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OpenAiImageContentFormatTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void should_use_chat_completions_image_url_format_by_default() throws Exception {
+        // given
+        ImageContent imageContent = new ImageContent("base64data", "image/jpeg", ImageContent.DetailLevel.LOW);
+        dev.langchain4j.data.message.UserMessage userMessage =
+                dev.langchain4j.data.message.UserMessage.from(imageContent);
+
+        // when
+        UserMessage openAiMessage =
+                (UserMessage) toOpenAiMessages(List.of(userMessage)).get(0);
+
+        // then
+        @SuppressWarnings("unchecked")
+        List<Content> contents = (List<Content>) openAiMessage.content();
+        Content content = contents.get(0);
+        assertThat(content.type()).isEqualTo(IMAGE_URL);
+        assertThat(content.imageUrl().getUrl()).isEqualTo("data:image/jpeg;base64,base64data");
+        assertThat(content.imageUrl().getDetail().name()).isEqualTo("LOW");
+        assertThat(content.inputImageUrl()).isNull();
+
+        String json = OBJECT_MAPPER.writeValueAsString(content);
+        assertThat(json)
+                .contains("\"type\":\"image_url\"")
+                .contains("\"image_url\":{\"url\":\"data:image/jpeg;base64,base64data\",\"detail\":\"low\"}");
+    }
+
+    @Test
+    void should_use_input_image_format_when_configured() throws Exception {
+        // given
+        ImageContent imageContent = new ImageContent("base64data", "image/jpeg", ImageContent.DetailLevel.LOW);
+        dev.langchain4j.data.message.UserMessage userMessage =
+                dev.langchain4j.data.message.UserMessage.from(imageContent);
+
+        // when
+        UserMessage openAiMessage = (UserMessage)
+                toOpenAiMessages(List.of(userMessage), false, null, true).get(0);
+
+        // then
+        @SuppressWarnings("unchecked")
+        List<Content> contents = (List<Content>) openAiMessage.content();
+        Content content = contents.get(0);
+        assertThat(content.type()).isEqualTo(INPUT_IMAGE);
+        assertThat(content.inputImageUrl()).isEqualTo("data:image/jpeg;base64,base64data");
+        assertThat(content.imageUrl()).isNull();
+
+        String json = OBJECT_MAPPER.writeValueAsString(content);
+        assertThat(json)
+                .contains("\"type\":\"input_image\"")
+                .contains("\"image_url\":\"data:image/jpeg;base64,base64data\"")
+                .doesNotContain("detail");
+    }
+
+    @Test
+    void chat_model_should_use_image_url_format_by_default() throws Exception {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(successfulChatCompletionResponse());
+        OpenAiChatModel model = OpenAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .build();
+
+        // when
+        model.chat(chatRequestWithImage());
+
+        // then
+        JsonNode content = firstRequestContent(mockHttpClient);
+        assertThat(content.get("type").asText()).isEqualTo("image_url");
+        assertThat(content.get("image_url").isObject()).isTrue();
+        assertThat(content.get("image_url").get("url").asText()).isEqualTo("data:image/jpeg;base64,base64data");
+        assertThat(content.get("image_url").get("detail").asText()).isEqualTo("low");
+    }
+
+    @Test
+    void chat_model_should_use_input_image_format_when_configured() throws Exception {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(successfulChatCompletionResponse());
+        OpenAiChatModel model = OpenAiChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .useInputImageFormat(true)
+                .build();
+
+        // when
+        model.chat(chatRequestWithImage());
+
+        // then
+        JsonNode content = firstRequestContent(mockHttpClient);
+        assertThat(content.get("type").asText()).isEqualTo("input_image");
+        assertThat(content.get("image_url").isTextual()).isTrue();
+        assertThat(content.get("image_url").asText()).isEqualTo("data:image/jpeg;base64,base64data");
+        assertThat(content.has("detail")).isFalse();
+    }
+
+    @Test
+    void streaming_chat_model_should_use_input_image_format_when_configured() throws Exception {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(successfulStreamingChatCompletionEvents());
+        OpenAiStreamingChatModel model = OpenAiStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .useInputImageFormat(true)
+                .build();
+
+        // when
+        TestStreamingChatResponseHandler handler = new TestStreamingChatResponseHandler();
+        model.chat(chatRequestWithImage(), handler);
+        handler.get();
+
+        // then
+        JsonNode content = firstRequestContent(mockHttpClient);
+        assertThat(content.get("type").asText()).isEqualTo("input_image");
+        assertThat(content.get("image_url").isTextual()).isTrue();
+        assertThat(content.get("image_url").asText()).isEqualTo("data:image/jpeg;base64,base64data");
+        assertThat(content.has("detail")).isFalse();
+    }
+
+    @Test
+    void should_deserialize_chat_completions_image_url_format() throws Exception {
+        // given
+        String json =
+                "{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/jpeg;base64,base64data\",\"detail\":\"low\"}}";
+
+        // when
+        Content content = OBJECT_MAPPER.readValue(json, Content.class);
+
+        // then
+        assertThat(content.type()).isEqualTo(IMAGE_URL);
+        assertThat(content.imageUrl()).isNotNull();
+        assertThat(content.imageUrl().getUrl()).isEqualTo("data:image/jpeg;base64,base64data");
+        assertThat(content.imageUrl().getDetail().name()).isEqualTo("LOW");
+        assertThat(content.inputImageUrl()).isNull();
+    }
+
+    @Test
+    void should_deserialize_input_image_format() throws Exception {
+        // given
+        String json = "{\"type\":\"input_image\",\"image_url\":\"data:image/jpeg;base64,base64data\"}";
+
+        // when
+        Content content = OBJECT_MAPPER.readValue(json, Content.class);
+
+        // then
+        assertThat(content.type()).isEqualTo(INPUT_IMAGE);
+        assertThat(content.inputImageUrl()).isEqualTo("data:image/jpeg;base64,base64data");
+        assertThat(content.imageUrl()).isNull();
+    }
+
+    private static ChatRequest chatRequestWithImage() {
+        ImageContent imageContent = new ImageContent("base64data", "image/jpeg", ImageContent.DetailLevel.LOW);
+        dev.langchain4j.data.message.UserMessage userMessage =
+                dev.langchain4j.data.message.UserMessage.from(imageContent);
+        return ChatRequest.builder().messages(userMessage).build();
+    }
+
+    private static JsonNode firstRequestContent(MockHttpClient mockHttpClient) throws Exception {
+        return OBJECT_MAPPER
+                .readTree(mockHttpClient.request().body())
+                .get("messages")
+                .get(0)
+                .get("content")
+                .get(0);
+    }
+
+    private static SuccessfulHttpResponse successfulChatCompletionResponse() {
+        return SuccessfulHttpResponse.builder().statusCode(200).body("""
+                        {
+                          "id": "chatcmpl-test",
+                          "object": "chat.completion",
+                          "created": 1,
+                          "model": "gpt-4o-mini",
+                          "choices": [
+                            {
+                              "index": 0,
+                              "message": {
+                                "role": "assistant",
+                                "content": "ok"
+                              },
+                              "finish_reason": "stop"
+                            }
+                          ]
+                        }
+                        """).build();
+    }
+
+    private static List<ServerSentEvent> successfulStreamingChatCompletionEvents() {
+        return List.of(
+                new ServerSentEvent(null, """
+                                {
+                                  "id": "chatcmpl-test",
+                                  "object": "chat.completion.chunk",
+                                  "created": 1,
+                                  "model": "gpt-4o-mini",
+                                  "choices": [
+                                    {
+                                      "index": 0,
+                                      "delta": {
+                                        "role": "assistant",
+                                        "content": "ok"
+                                      },
+                                      "finish_reason": null
+                                    }
+                                  ]
+                                }
+                                """), new ServerSentEvent(null, """
+                                {
+                                  "id": "chatcmpl-test",
+                                  "object": "chat.completion.chunk",
+                                  "created": 1,
+                                  "model": "gpt-4o-mini",
+                                  "choices": [
+                                    {
+                                      "index": 0,
+                                      "delta": {},
+                                      "finish_reason": "stop"
+                                    }
+                                  ]
+                                }
+                                """), new ServerSentEvent(null, "[DONE]"));
+    }
+}


### PR DESCRIPTION
## Summary
  - Add an opt-in `useInputImageFormat(boolean)` builder option to `OpenAiChatModel`
    and `OpenAiStreamingChatModel` for OpenAI-compatible servers that expect the
    `input_image` image payload.
  - When enabled, image content is serialized as
    `{"type":"input_image","image_url":"data:..."}` (string `image_url`, no `detail`)
    instead of the default Chat Completions
    `{"type":"image_url","image_url":{"url":"data:...","detail":"..."}}`.
  - Disabled by default — existing `image_url` object payload is unchanged.
  - `Content` now supports serialization **and** deserialization of both the
    object-shaped `image_url` and the string-shaped `input_image` form.

  Fixes #4551

  ## Usage
  ```java
  OpenAiChatModel model = OpenAiChatModel.builder()
          .baseUrl(...)
          .apiKey(...)
          .modelName(...)
          .useInputImageFormat(true) // opt in to the input_image payload
          .build();
  ```
  Testing

  - Added OpenAiImageContentFormatTest covering:
    - default image_url object format (serialization) for chat and streaming chat
    - input_image string format when useInputImageFormat(true) is set
    - deserialization of both the object-shaped image_url and string-shaped
  input_image forms
  - <fill in: ran mvn -pl langchain4j-open-ai test locally / relying on CI>

  Checklist

  - [x] No breaking changes (default behavior unchanged; new option defaults to false)
  - [ ] No new dependencies added
  - [ ] New code follows existing OpenAI builder conventions (boolean opt-in, mirrors sendThinking/returnThinking)
  - [ ] Tests added and passing