### PR TITLE
http-client-jdk: set Content-Type for multipart/form-data requests

### DIFF
--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
@@ -6,9 +6,9 @@ import static java.util.stream.Collectors.joining;
 
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.TimeoutException;
+import dev.langchain4j.http.client.FormDataFile;
 import dev.langchain4j.http.client.HttpClient;
 import dev.langchain4j.http.client.HttpRequest;
-import dev.langchain4j.http.client.FormDataFile;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
@@ -58,7 +58,7 @@ public class JdkHttpClient implements HttpClient {
         } catch (HttpTimeoutException e) {
             throw new TimeoutException(e);
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();  
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -116,6 +116,9 @@ public class JdkHttpClient implements HttpClient {
             }
         } else {
             bodyPublisher = ofMultipartData(request.formDataFields(), request.formDataFiles());
+            // The multipart body is delimited by a boundary that the server needs in the Content-Type header to
+            // parse it; the OkHttp and Apache clients do the same.
+            builder.setHeader("Content-Type", MultipartBodyPublisher.contentType());
         }
         builder.method(request.method().name(), bodyPublisher);
 

--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/JdkHttpClient.java
@@ -116,8 +116,6 @@ public class JdkHttpClient implements HttpClient {
             }
         } else {
             bodyPublisher = ofMultipartData(request.formDataFields(), request.formDataFiles());
-            // The multipart body is delimited by a boundary that the server needs in the Content-Type header to
-            // parse it; the OkHttp and Apache clients do the same.
             builder.setHeader("Content-Type", MultipartBodyPublisher.contentType());
         }
         builder.method(request.method().name(), bodyPublisher);

--- a/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/MultipartBodyPublisher.java
+++ b/http-clients/langchain4j-http-client-jdk/src/main/java/dev/langchain4j/http/client/jdk/MultipartBodyPublisher.java
@@ -21,6 +21,14 @@ class MultipartBodyPublisher {
         return parts;
     }
 
+    /**
+     * The {@code Content-Type} header value (including the boundary) that must accompany the body produced by
+     * {@link #build()}. Without this header the server cannot parse the multipart payload.
+     */
+    static String contentType() {
+        return "multipart/form-data; boundary=" + BOUNDARY;
+    }
+
     void addField(String name, String value) {
         String part = "--" + BOUNDARY + CRLF + "Content-Disposition: form-data; name=\""
                 + name + "\"" + CRLF + CRLF

--- a/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/MultipartBodyPublisherTest.java
+++ b/http-clients/langchain4j-http-client-jdk/src/test/java/dev/langchain4j/http/client/jdk/MultipartBodyPublisherTest.java
@@ -125,6 +125,19 @@ class MultipartBodyPublisherTest {
         assertEquals(normalize(expected), body);
     }
 
+    @Test
+    void content_type_should_carry_the_boundary_used_in_the_body() {
+        MultipartBodyPublisher publisher = new MultipartBodyPublisher();
+        publisher.addField("field1", "value1");
+        publisher.build();
+
+        // The Content-Type header must advertise the same boundary the body is delimited with, otherwise the
+        // server cannot parse the payload.
+        assertEquals("multipart/form-data; boundary=----LangChain4j", MultipartBodyPublisher.contentType());
+        org.junit.jupiter.api.Assertions.assertTrue(
+                bodyAsString(publisher.parts()).contains("------LangChain4j"));
+    }
+
     private static String bodyAsString(List<byte[]> parts) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         for (byte[] part : parts) {


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## Issue
N/A — small standalone fix.

## Change
This PR has been **trimmed down** to a single, self-contained core fix, following @glaforge's feedback that the TwelveLabs integration itself belongs in `langchain4j-community`. The integration has moved to langchain4j/langchain4j-community#706; this PR now contains only the core bug fix that I found underneath it.

**The fix:** the JDK `HttpClient` built `multipart/form-data` request bodies but never set the `Content-Type` header (with the boundary), so servers that parse multipart requests rejected them (e.g. `content_type_invalid`). The OkHttp and Apache clients already set this header — this brings the JDK client in line.

- `JdkHttpClient` now sets `Content-Type: multipart/form-data; boundary=...` whenever the request carries form-data fields or files.
- `MultipartBodyPublisher.contentType()` exposes the boundary-bearing header value so the body and header always agree.
- Added a regression test asserting the advertised boundary matches the one used to delimit the body.

This is **non-breaking and additive** — it only adds a header that was previously missing on multipart requests; no existing behaviour changes.

### How it was tested
- `MultipartBodyPublisherTest` — added a regression test for the `Content-Type`/boundary fix; all JDK http-client unit tests are green.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
