### PR TITLE
fix: Preserve BigInteger values when converting MCP structured content

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolExecutionHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolExecutionHelper.java
@@ -100,7 +100,8 @@ class ToolExecutionHelper {
             case NUMBER ->
                 switch (content.numberType()) {
                     case INT -> content.asInt();
-                    case LONG, BIG_INTEGER -> content.asLong();
+                    case LONG -> content.asLong();
+                    case BIG_INTEGER -> content.bigIntegerValue();
                     case FLOAT, DOUBLE, BIG_DECIMAL -> content.asDouble();
                 };
             case STRING -> content.asText();

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/StructuredContentParsingTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/StructuredContentParsingTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.service.tool.ToolExecutionResult;
+import java.math.BigInteger;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -81,6 +82,59 @@ public class StructuredContentParsingTest {
         assertThat(map.get("items")).isEqualTo(java.util.List.of(1, 2, 3));
         assertThat(map.get("nested")).isInstanceOf(Map.class);
         assertThat(((Map<String, Object>) map.get("nested")).get("labels")).isEqualTo(java.util.List.of("a", "b"));
+        verifyNoInteractions(extractor);
+    }
+
+    @Test
+    public void should_preserve_integer_larger_than_long_max_value() throws JsonProcessingException {
+        // 9223372036854775808 = Long.MAX_VALUE + 1, parsed by Jackson as a BigIntegerNode.
+        // Converting it via asLong() silently truncates to Long.MIN_VALUE, so the value must be kept as BigInteger.
+        String response = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 5,
+                  "result": {
+                    "structuredContent": {
+                      "bigValue": 9223372036854775808
+                    }
+                  }
+                }
+                """;
+
+        JsonNode responseNode = objectMapper.readTree(response);
+        McpToolResultExtractor extractor = mock(McpToolResultExtractor.class);
+
+        ToolExecutionResult toolExecutionResult = ToolExecutionHelper.extractResult(responseNode, false, extractor);
+
+        assertThat(toolExecutionResult.result()).isInstanceOf(Map.class);
+        Map<String, Object> map = (Map<String, Object>) toolExecutionResult.result();
+        assertThat(map.get("bigValue")).isEqualTo(new BigInteger("9223372036854775808"));
+        verifyNoInteractions(extractor);
+    }
+
+    @Test
+    public void should_preserve_long_max_value_as_long() throws JsonProcessingException {
+        // Long.MAX_VALUE must still be parsed as a Long (no regression for INT/LONG number types).
+        String response = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 6,
+                  "result": {
+                    "structuredContent": {
+                      "longValue": 9223372036854775807
+                    }
+                  }
+                }
+                """;
+
+        JsonNode responseNode = objectMapper.readTree(response);
+        McpToolResultExtractor extractor = mock(McpToolResultExtractor.class);
+
+        ToolExecutionResult toolExecutionResult = ToolExecutionHelper.extractResult(responseNode, false, extractor);
+
+        assertThat(toolExecutionResult.result()).isInstanceOf(Map.class);
+        Map<String, Object> map = (Map<String, Object>) toolExecutionResult.result();
+        assertThat(map.get("longValue")).isEqualTo(Long.MAX_VALUE);
         verifyNoInteractions(extractor);
     }
 


### PR DESCRIPTION
## Issue
Closes #5570

## Change

`ToolExecutionHelper.toObject(JsonNode)` converted the Jackson `BIG_INTEGER` number type with `asLong()`. For a JSON integer larger than `Long.MAX_VALUE` (parsed by Jackson as a `BigIntegerNode`), this truncates to the lower 64 bits, silently yielding a wrong value. This path is reached from `extractResult` for tools that return `structuredContent` (tools with an `outputSchema`).

The fix splits `BIG_INTEGER` from `LONG` and converts it with `bigIntegerValue()`, preserving the full magnitude:
```java
case LONG -> content.asLong();
case BIG_INTEGER -> content.bigIntegerValue();
```
`INT`, `LONG`, and the floating-point branches are unchanged.

Added two unit tests to `StructuredContentParsingTest`: one asserting `Long.MAX_VALUE + 1` is preserved as `BigInteger`, and one regression test asserting `Long.MAX_VALUE` is still parsed as `Long`.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- Unit tests pass (84 green incl. new tests). The module's *IT require external credentials/Docker and were not run locally. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- Sections for new maven module and embedding store integration omitted: not applicable to this bug fix. -->
