### PR TITLE
fix: skip recording token usage metric when token count is null

### DIFF
--- a/langchain4j-micrometer-metrics/src/main/java/dev/langchain4j/micrometer/metrics/listeners/MicrometerMetricsChatModelListener.java
+++ b/langchain4j-micrometer-metrics/src/main/java/dev/langchain4j/micrometer/metrics/listeners/MicrometerMetricsChatModelListener.java
@@ -75,7 +75,13 @@ public class MicrometerMetricsChatModelListener implements ChatModelListener {
     }
 
     private void addTokenMetric(
-            ChatModelResponseContext responseContext, OTelGenAiTokenType tokenType, int tokenCount) {
+            ChatModelResponseContext responseContext, OTelGenAiTokenType tokenType, Integer tokenCount) {
+
+        if (tokenCount == null) {
+            // Token counts are nullable (TokenUsage documents each component as "null if unknown").
+            // Skip recording a token type whose count is unknown instead of failing the whole response.
+            return;
+        }
 
         DistributionSummary.builder(OTelGenAiMetricName.TOKEN_USAGE.value())
                 .baseUnit("tokens")

--- a/langchain4j-micrometer-metrics/src/test/java/dev/langchain4j/micrometer/metrics/listeners/MicrometerMetricsChatModelListenerTest.java
+++ b/langchain4j-micrometer-metrics/src/test/java/dev/langchain4j/micrometer/metrics/listeners/MicrometerMetricsChatModelListenerTest.java
@@ -1,11 +1,13 @@
 package dev.langchain4j.micrometer.metrics.listeners;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.micrometer.metrics.conventions.OTelGenAiAttributes;
 import dev.langchain4j.micrometer.metrics.conventions.OTelGenAiMetricName;
+import dev.langchain4j.micrometer.metrics.conventions.OTelGenAiTokenType;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
 import dev.langchain4j.model.chat.request.ChatRequest;
@@ -68,8 +70,69 @@ class MicrometerMetricsChatModelListenerTest {
                 .isNotNull();
     }
 
+    @Test
+    void should_record_only_output_metric_when_input_token_count_is_null() {
+        ChatModelResponseContext responseContext = responseContextWithTokenUsage(new TokenUsage(null, 20));
+
+        listener.onResponse(responseContext);
+
+        assertThat(meterRegistry
+                        .find(OTelGenAiMetricName.TOKEN_USAGE.value())
+                        .tag(OTelGenAiAttributes.TOKEN_TYPE.value(), OTelGenAiTokenType.OUTPUT.value())
+                        .summary())
+                .isNotNull();
+        assertThat(meterRegistry
+                        .find(OTelGenAiMetricName.TOKEN_USAGE.value())
+                        .tag(OTelGenAiAttributes.TOKEN_TYPE.value(), OTelGenAiTokenType.INPUT.value())
+                        .meter())
+                .isNull();
+    }
+
+    @Test
+    void should_record_only_input_metric_when_output_token_count_is_null() {
+        ChatModelResponseContext responseContext = responseContextWithTokenUsage(new TokenUsage(10, null));
+
+        listener.onResponse(responseContext);
+
+        assertThat(meterRegistry
+                        .find(OTelGenAiMetricName.TOKEN_USAGE.value())
+                        .tag(OTelGenAiAttributes.TOKEN_TYPE.value(), OTelGenAiTokenType.INPUT.value())
+                        .summary())
+                .isNotNull();
+        assertThat(meterRegistry
+                        .find(OTelGenAiMetricName.TOKEN_USAGE.value())
+                        .tag(OTelGenAiAttributes.TOKEN_TYPE.value(), OTelGenAiTokenType.OUTPUT.value())
+                        .meter())
+                .isNull();
+    }
+
+    @Test
+    void should_record_no_token_metric_and_not_throw_when_all_token_counts_are_null() {
+        ChatModelResponseContext responseContext = responseContextWithTokenUsage(new TokenUsage());
+
+        assertThatCode(() -> listener.onResponse(responseContext)).doesNotThrowAnyException();
+
+        assertThat(meterRegistry.find(OTelGenAiMetricName.TOKEN_USAGE.value()).meter())
+                .isNull();
+    }
+
     private ChatModelResponseContext createResponseContext(ModelProvider modelProvider) {
         return createResponseContext(modelProvider, "gpt-4o", "gpt-4o");
+    }
+
+    private ChatModelResponseContext responseContextWithTokenUsage(TokenUsage tokenUsage) {
+        ChatResponse chatResponse = ChatResponse.builder()
+                .aiMessage(new AiMessage("Hello"))
+                .modelName("gpt-4o")
+                .tokenUsage(tokenUsage)
+                .build();
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(UserMessage.from("Hi"))
+                .modelName("gpt-4o")
+                .build();
+
+        return new ChatModelResponseContext(
+                chatResponse, chatRequest, ModelProvider.MICROSOFT_FOUNDRY, new HashMap<>());
     }
 
     private ChatModelResponseContext createResponseContext(


### PR DESCRIPTION
## Issue
Closes #5571

## Change

`MicrometerMetricsChatModelListener` threw a `NullPointerException` when a chat response had a `TokenUsage` with a `null` input or output count. `TokenUsage` documents each component as "null if unknown", but `addTokenMetric` took a primitive `int`, so the nullable `Integer` count auto-unboxed and threw. Because input was recorded first, the response lost both token metrics; `ChatModelListenerUtils.onResponse` caught and logged the exception, so token usage was silently dropped and a warning logged on every such response. Providers reach this on normal paths (e.g. Ollama `InternalOllamaHelper`, Google GenAI streaming `GoogleGenAiStreamingChatModel`).

Changed `addTokenMetric`'s count parameter to `Integer` and skip recording when it is `null`, so the known token type is recorded and the unknown one skipped. This matches OpenTelemetry `gen_ai.client.token.usage`, which records a data point per known token type. Tags, metric name and registration are unchanged, as is behaviour when both counts are present.

Added unit tests for null input, null output, and all-null counts (each reproduces the NPE before the fix). No new dependencies.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is isolated to langchain4j-micrometer-metrics; core/main not modified -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- wait until approved -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A — bug fix -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->
