### PR TITLE
fix: Add dockerTlsVerify builder method and deprecate misspelled dockerTslVerify

### DIFF
--- a/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransport.java
+++ b/langchain4j-mcp-docker/src/main/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransport.java
@@ -313,9 +313,17 @@ public class DockerMcpTransport implements McpTransport {
             return this;
         }
 
-        public DockerMcpTransport.Builder dockerTslVerify(Boolean dockerTlsVerify) {
+        public DockerMcpTransport.Builder dockerTlsVerify(Boolean dockerTlsVerify) {
             this.dockerTlsVerify = dockerTlsVerify;
             return this;
+        }
+
+        /**
+         * @deprecated misspelled method name, use {@link #dockerTlsVerify(Boolean)} instead.
+         */
+        @Deprecated
+        public DockerMcpTransport.Builder dockerTslVerify(Boolean dockerTlsVerify) {
+            return dockerTlsVerify(dockerTlsVerify);
         }
 
         public DockerMcpTransport.Builder registryEmail(String registryEmail) {

--- a/langchain4j-mcp-docker/src/test/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransportTest.java
+++ b/langchain4j-mcp-docker/src/test/java/dev/langchain4j/mcp/client/transport/docker/DockerMcpTransportTest.java
@@ -40,9 +40,38 @@ class DockerMcpTransportTest {
         assertThat(extractHost(client).getSchemeName()).isEqualTo("http");
     }
 
+    @Test
+    void shouldSetTlsVerifyFromCorrectlySpelledBuilderMethod() throws Exception {
+        DockerMcpTransport transport = DockerMcpTransport.builder()
+                .dockerHost("tcp://localhost:2375")
+                .image("alpine")
+                .dockerTlsVerify(true)
+                .build();
+
+        assertThat(extractDockerTlsVerify(transport)).isTrue();
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void shouldSetTlsVerifyFromDeprecatedMisspelledBuilderMethod() throws Exception {
+        DockerMcpTransport transport = DockerMcpTransport.builder()
+                .dockerHost("tcp://localhost:2375")
+                .image("alpine")
+                .dockerTslVerify(true)
+                .build();
+
+        assertThat(extractDockerTlsVerify(transport)).isTrue();
+    }
+
     private static HttpHost extractHost(DockerHttpClient client) throws Exception {
         Field field = client.getClass().getSuperclass().getDeclaredField("host");
         field.setAccessible(true);
         return (HttpHost) field.get(client);
+    }
+
+    private static Boolean extractDockerTlsVerify(DockerMcpTransport transport) throws Exception {
+        Field field = DockerMcpTransport.class.getDeclaredField("dockerTlsVerify");
+        field.setAccessible(true);
+        return (Boolean) field.get(transport);
     }
 }


### PR DESCRIPTION
## Issue
Closes #5573

## Change
`DockerMcpTransport.Builder` exposed the TLS-verify setter only as the misspelled `dockerTslVerify(Boolean)` (`Tsl` instead of `Tls`). The backing field and parameter already use the correct `dockerTlsVerify`.

This adds the correctly spelled `dockerTlsVerify(Boolean)` builder method and keeps the old `dockerTslVerify(Boolean)` as a `@Deprecated` alias that delegates to it, so existing callers keep compiling — no breaking change.

```java
public DockerMcpTransport.Builder dockerTlsVerify(Boolean dockerTlsVerify) {
    this.dockerTlsVerify = dockerTlsVerify;
    return this;
}

/** @deprecated misspelled method name, use {@link #dockerTlsVerify(Boolean)} instead. */
@Deprecated
public DockerMcpTransport.Builder dockerTslVerify(Boolean dockerTlsVerify) {
    return dockerTlsVerify(dockerTlsVerify);
}
```

Added two unit tests in `DockerMcpTransportTest` that build a transport through each method and verify the `dockerTlsVerify` field is set.

## General checklist
- [X] There are no breaking changes (API, behaviour) <!-- old method kept as deprecated alias -->
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases <!-- N/A — a builder setter has no invalid-input branch to assert; both tests are positive -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- langchain4j-mcp-docker unit tests: 5 green (DockerMcpTransportTest 4, DockerResultCallbackTest 1); DockerMcpTransportIT requires Docker, not run -->
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green <!-- N/A — change is isolated to langchain4j-mcp-docker -->
- [ ] I have added/updated the documentation <!-- wait until approved -->
- [ ] I have added an example in the examples repo <!-- N/A — not a big feature -->
- [ ] I have added/updated Spring Boot starter(s) <!-- N/A -->

<!-- Checklist for new maven module — N/A, omitted. -->
<!-- Checklist for new/changed embedding store — N/A, omitted. -->

