### PR TITLE
fix: Guard against null content in Mistral FIM streaming event listener

### DIFF
--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiFimServerSentEventListener.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiFimServerSentEventListener.java
@@ -63,15 +63,17 @@ class MistralAiFimServerSentEventListener implements ServerSentEventListener {
                     chatCompletionResponse.getChoices().get(0);
 
             List<MistralAiMessageContent> chunks = choice.getDelta().getContent();
-            for (var chunk : chunks) {
-                if (chunk instanceof MistralAiTextContent textContent) {
-                    String text = textContent.getText();
-                    if (isNotNullOrEmpty(text)) {
-                        contentBuilder.append(text);
-                        try {
-                            handler.onNext(text);
-                        } catch (Exception e) {
-                            withLoggingExceptions(() -> handler.onError(e));
+            if (isNotNullOrEmpty(chunks)) {
+                for (var chunk : chunks) {
+                    if (chunk instanceof MistralAiTextContent textContent) {
+                        String text = textContent.getText();
+                        if (isNotNullOrEmpty(text)) {
+                            contentBuilder.append(text);
+                            try {
+                                handler.onNext(text);
+                            } catch (Exception e) {
+                                withLoggingExceptions(() -> handler.onError(e));
+                            }
                         }
                     }
                 }

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiStreamingFimModelTest.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiStreamingFimModelTest.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.model.mistralai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.model.chat.TestStreamingResponseHandler;
+import dev.langchain4j.model.output.Response;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MistralAiStreamingFimModelTest {
+
+    private static final String MODEL = "codestral-latest";
+
+    @Test
+    void should_stream_text_and_complete() {
+        // given
+        List<ServerSentEvent> events =
+                List.of(textEvent("def add(a, b):"), textEvent(" return a + b"), finishEvent("stop"), doneEvent());
+
+        MistralAiStreamingFimModel model = createModel(events);
+
+        // when
+        Response<String> response = generate(model, "def add");
+
+        // then
+        assertThat(response.content()).isEqualTo("def add(a, b): return a + b");
+    }
+
+    @Test
+    void should_not_fail_on_delta_without_content() {
+        // given - a finish_reason-only chunk has an empty delta (no "content" field)
+        List<ServerSentEvent> events = List.of(textEvent("return 42"), finishEvent("stop"), doneEvent());
+
+        MistralAiStreamingFimModel model = createModel(events);
+
+        // when / then - must not throw NullPointerException on the content-less delta
+        assertThatCode(() -> {
+                    Response<String> response = generate(model, "def answer");
+                    assertThat(response.content()).isEqualTo("return 42");
+                })
+                .doesNotThrowAnyException();
+    }
+
+    // -- Helper methods --
+
+    private static MistralAiStreamingFimModel createModel(List<ServerSentEvent> events) {
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(events);
+        return MistralAiStreamingFimModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("test-api-key")
+                .modelName(MODEL)
+                .build();
+    }
+
+    private static Response<String> generate(MistralAiStreamingFimModel model, String prompt) {
+        var handler = new TestStreamingResponseHandler<String>();
+        model.generate(prompt, handler);
+        return handler.get();
+    }
+
+    private static ServerSentEvent textEvent(String text) {
+        String escaped = text.replace("\"", "\\\"");
+        return event("""
+                {"id":"abc123","model":"%s","choices":[{"index":0,"delta":{"content":[{"type":"text","text":"%s"}]}}]}""".formatted(MODEL, escaped));
+    }
+
+    private static ServerSentEvent finishEvent(String reason) {
+        return event("""
+                {"id":"abc123","model":"%s","choices":[{"index":0,"delta":{},"finish_reason":"%s"}],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}""".formatted(MODEL, reason));
+    }
+
+    private static ServerSentEvent doneEvent() {
+        return new ServerSentEvent(null, "[DONE]");
+    }
+
+    private static ServerSentEvent event(String data) {
+        return new ServerSentEvent(null, data);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5580

## Change
`MistralAiFimServerSentEventListener.onEvent()` iterated the content delta with an enhanced-for loop and no null check. Mistral streams normal SSE deltas with no `content` field (for example the `finish_reason` / metadata-only chunk), so `choice.getDelta().getContent()` is `null` and the loop throws `NullPointerException`.
This wraps the loop in `if (isNotNullOrEmpty(chunks))`, mirroring the existing guard in the chat streaming listener `MistralAiServerSentEventListener` (line 107). `isNotNullOrEmpty` was already statically imported, so there are no new imports or dependencies.
Added `MistralAiStreamingFimModelTest` using `MockHttpClient` to inject SSE without an API key: a negative case feeds a content-less `finish_reason` delta (NPE before the fix, passes after) and a positive case asserts text is streamed and concatenated.
This completes PR #5123, which fixed the chat paths but left the FIM streaming path unguarded.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

