### PR TITLE
fix: Honor strictJsonSchema option in MistralAiStreamingChatModel

### DIFF
--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModel.java
@@ -46,6 +46,7 @@ public class MistralAiStreamingChatModel implements StreamingChatModel {
     private final boolean sendThinking;
     private final List<ChatModelListener> listeners;
     private final Set<Capability> supportedCapabilities;
+    private final boolean strictJsonSchema;
     private final ChatRequestParameters defaultRequestParameters;
 
     @SuppressWarnings({"unchecked"})
@@ -66,6 +67,7 @@ public class MistralAiStreamingChatModel implements StreamingChatModel {
         this.sendThinking = getOrDefault(builder.sendThinking, false);
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
+        this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
         this.defaultRequestParameters = initDefaultRequestParameters(builder);
     }
 
@@ -98,7 +100,7 @@ public class MistralAiStreamingChatModel implements StreamingChatModel {
         validate(chatRequest.parameters());
 
         MistralAiChatCompletionRequest request =
-                createMistralAiRequest(chatRequest, safePrompt, randomSeed, true, sendThinking, false);
+                createMistralAiRequest(chatRequest, safePrompt, randomSeed, true, sendThinking, strictJsonSchema);
         client.streamingChatCompletion(request, handler, returnThinking);
     }
 
@@ -153,6 +155,7 @@ public class MistralAiStreamingChatModel implements StreamingChatModel {
         private Logger logger;
         private List<ChatModelListener> listeners;
         private Set<Capability> supportedCapabilities;
+        private Boolean strictJsonSchema;
         private ChatRequestParameters defaultRequestParameters;
         private Supplier<Map<String, String>> customHeadersSupplier;
 
@@ -325,6 +328,11 @@ public class MistralAiStreamingChatModel implements StreamingChatModel {
 
         public MistralAiStreamingChatModelBuilder supportedCapabilities(Set<Capability> supportedCapabilities) {
             this.supportedCapabilities = Set.copyOf(supportedCapabilities);
+            return this;
+        }
+
+        public MistralAiStreamingChatModelBuilder strictJsonSchema(Boolean strictJsonSchema) {
+            this.strictJsonSchema = strictJsonSchema;
             return this;
         }
 

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModelStrictJsonSchemaTest.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiStreamingChatModelStrictJsonSchemaTest.java
@@ -1,0 +1,85 @@
+package dev.langchain4j.model.mistralai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.request.ResponseFormatType;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MistralAiStreamingChatModelStrictJsonSchemaTest {
+
+    private static final String MODEL = "mistral-small-latest";
+
+    @Test
+    void should_send_strict_true_when_strictJsonSchema_is_enabled() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(responseEvents());
+
+        StreamingChatModel model = MistralAiStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("test-api-key")
+                .modelName(MODEL)
+                .strictJsonSchema(true)
+                .build();
+
+        // when
+        chat(model);
+
+        // then
+        assertThat(mockHttpClient.request().body().replaceAll("\\s", "")).contains("\"strict\":true");
+    }
+
+    @Test
+    void should_NOT_send_strict_true_when_strictJsonSchema_is_not_set() {
+        // given
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(responseEvents());
+
+        StreamingChatModel model = MistralAiStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("test-api-key")
+                .modelName(MODEL)
+                .build();
+
+        // when
+        chat(model);
+
+        // then
+        assertThat(mockHttpClient.request().body().replaceAll("\\s", "")).contains("\"strict\":false");
+    }
+
+    private static void chat(StreamingChatModel model) {
+        ChatRequest request = ChatRequest.builder()
+                .messages(dev.langchain4j.data.message.UserMessage.from("What is the answer?"))
+                .responseFormat(ResponseFormat.builder()
+                        .type(ResponseFormatType.JSON)
+                        .jsonSchema(JsonSchema.builder()
+                                .name("Answer")
+                                .rootElement(JsonObjectSchema.builder()
+                                        .addStringProperty("answer")
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+        var handler = new TestStreamingChatResponseHandler();
+        model.chat(request, handler);
+        handler.get();
+    }
+
+    private static List<ServerSentEvent> responseEvents() {
+        return List.of(
+                new ServerSentEvent(null, """
+                        {"id":"abc123","model":"%s","choices":[{"index":0,"delta":{"content":[{"type":"text","text":"{\\"answer\\":\\"42\\"}"}]}}]}""".formatted(MODEL)),
+                new ServerSentEvent(null, """
+                        {"id":"abc123","model":"%s","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30,"num_cached_tokens":0}}""".formatted(MODEL)),
+                new ServerSentEvent(null, "[DONE]"));
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5582

## Change
`MistralAiStreamingChatModel.doChat()` passed the literal `false` for the `strict` flag and the builder had no setter, so strict JSON schema was always disabled for the streaming model, unlike the synchronous `MistralAiChatModel`. This is an incomplete fix from PR #4603, which wired the option into the synchronous model only.

This mirrors the synchronous model: a `strictJsonSchema` field initialized via `getOrDefault(builder.strictJsonSchema, false)`, a builder field and setter, and the field passed to `createMistralAiRequest` instead of the hardcoded `false`.

```java
MistralAiChatCompletionRequest request =
        createMistralAiRequest(chatRequest, safePrompt, randomSeed, true, sendThinking, strictJsonSchema);
```

The default stays `false`, so existing callers are unaffected.

Added `MistralAiStreamingChatModelStrictJsonSchemaTest` (`MockHttpClient`, no API key): a positive test asserts the request body contains `"strict":true` when `strictJsonSchema(true)` is set, and a regression test asserts `"strict":false` when it is not.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

Spotless: jgit ratchet fails inside the worktree ("Cannot find git repository"), so the two changed files were copied to the main checkout and `spotless:check -pl langchain4j-mistral-ai` was run there (0 files needed changes, both already clean); the temporary copies were then reverted.

