### PR TITLE
Azure OpenAI: propagate image detail level

### DIFF
--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiChatModel.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiChatModel.java
@@ -87,6 +87,7 @@ public class AzureOpenAiChatModel implements ChatModel {
     private final Boolean strictJsonSchema;
     private final Integer maxCompletionTokens;
     private final ReasoningEffortValue reasoningEffort;
+    private final boolean honorImageDetailLevel;
 
     private final List<ChatModelListener> listeners;
     private final Set<Capability> supportedCapabilities;
@@ -167,6 +168,7 @@ public class AzureOpenAiChatModel implements ChatModel {
         this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
         this.maxCompletionTokens = builder.maxCompletionTokens;
         this.reasoningEffort = builder.reasoningEffort;
+        this.honorImageDetailLevel = getOrDefault(builder.honorImageDetailLevel, false);
 
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
@@ -187,7 +189,8 @@ public class AzureOpenAiChatModel implements ChatModel {
         ChatRequestParameters parameters = request.parameters();
         validate(parameters);
 
-        ChatCompletionsOptions options = new ChatCompletionsOptions(toOpenAiMessages(request.messages()))
+        ChatCompletionsOptions options = new ChatCompletionsOptions(
+                        toOpenAiMessages(request.messages(), honorImageDetailLevel))
                 .setModel(parameters.modelName())
                 .setTemperature(parameters.temperature())
                 .setTopP(parameters.topP())
@@ -290,6 +293,7 @@ public class AzureOpenAiChatModel implements ChatModel {
         private Map<String, String> customHeaders;
         private Set<Capability> supportedCapabilities;
         private ReasoningEffortValue reasoningEffort;
+        private Boolean honorImageDetailLevel;
 
         public Builder defaultRequestParameters(ChatRequestParameters parameters) {
             this.defaultRequestParameters = parameters;
@@ -507,6 +511,17 @@ public class AzureOpenAiChatModel implements ChatModel {
 
         public Builder reasoningEffort(ReasoningEffortValue reasoningEffort) {
             this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
+        /**
+         * Whether to pass image detail levels to Azure OpenAI. Disabled by default to preserve existing behavior.
+         *
+         * @param honorImageDetailLevel whether to honor image detail levels
+         * @return builder
+         */
+        public Builder honorImageDetailLevel(Boolean honorImageDetailLevel) {
+            this.honorImageDetailLevel = honorImageDetailLevel;
             return this;
         }
 

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModel.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/AzureOpenAiStreamingChatModel.java
@@ -105,6 +105,7 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
     private final boolean strictJsonSchema;
     private final Integer maxCompletionTokens;
     private final ReasoningEffortValue reasoningEffort;
+    private final boolean honorImageDetailLevel;
 
     private final List<ChatModelListener> listeners;
     private final Set<Capability> supportedCapabilities;
@@ -184,6 +185,7 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
         this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
         this.maxCompletionTokens = builder.maxCompletionTokens;
         this.reasoningEffort = builder.reasoningEffort;
+        this.honorImageDetailLevel = getOrDefault(builder.honorImageDetailLevel, false);
 
         this.listeners = copy(builder.listeners);
         this.supportedCapabilities = copy(builder.supportedCapabilities);
@@ -204,7 +206,8 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
         ChatRequestParameters parameters = request.parameters();
         validate(parameters);
 
-        ChatCompletionsOptions options = new ChatCompletionsOptions(toOpenAiMessages(request.messages()))
+        ChatCompletionsOptions options = new ChatCompletionsOptions(
+                        toOpenAiMessages(request.messages(), honorImageDetailLevel))
                 .setModel(parameters.modelName())
                 .setTemperature(parameters.temperature())
                 .setTopP(parameters.topP())
@@ -392,6 +395,7 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
         private Map<String, String> customHeaders;
         private Set<Capability> supportedCapabilities;
         private ReasoningEffortValue reasoningEffort;
+        private Boolean honorImageDetailLevel;
 
         public Builder defaultRequestParameters(ChatRequestParameters parameters) {
             this.defaultRequestParameters = parameters;
@@ -609,6 +613,17 @@ public class AzureOpenAiStreamingChatModel implements StreamingChatModel {
 
         public Builder reasoningEffort(ReasoningEffortValue reasoningEffort) {
             this.reasoningEffort = reasoningEffort;
+            return this;
+        }
+
+        /**
+         * Whether to pass image detail levels to Azure OpenAI. Disabled by default to preserve existing behavior.
+         *
+         * @param honorImageDetailLevel whether to honor image detail levels
+         * @return builder
+         */
+        public Builder honorImageDetailLevel(Boolean honorImageDetailLevel) {
+            this.honorImageDetailLevel = honorImageDetailLevel;
             return this;
         }
 

--- a/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
+++ b/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java
@@ -30,6 +30,7 @@ import com.azure.ai.openai.models.ChatCompletionsToolDefinition;
 import com.azure.ai.openai.models.ChatCompletionsToolSelection;
 import com.azure.ai.openai.models.ChatCompletionsToolSelectionPreset;
 import com.azure.ai.openai.models.ChatMessageImageContentItem;
+import com.azure.ai.openai.models.ChatMessageImageDetailLevel;
 import com.azure.ai.openai.models.ChatMessageImageUrl;
 import com.azure.ai.openai.models.ChatMessageTextContentItem;
 import com.azure.ai.openai.models.ChatRequestAssistantMessage;
@@ -251,11 +252,20 @@ class InternalAzureOpenAiHelper {
     }
 
     static List<ChatRequestMessage> toOpenAiMessages(List<ChatMessage> messages) {
+        return toOpenAiMessages(messages, false);
+    }
 
-        return messages.stream().map(InternalAzureOpenAiHelper::toOpenAiMessage).collect(toList());
+    static List<ChatRequestMessage> toOpenAiMessages(List<ChatMessage> messages, boolean honorImageDetailLevel) {
+        return messages.stream()
+                .map(message -> toOpenAiMessage(message, honorImageDetailLevel))
+                .collect(toList());
     }
 
     static ChatRequestMessage toOpenAiMessage(ChatMessage message) {
+        return toOpenAiMessage(message, false);
+    }
+
+    static ChatRequestMessage toOpenAiMessage(ChatMessage message, boolean honorImageDetailLevel) {
         if (message instanceof AiMessage aiMessage) {
             ChatRequestAssistantMessage chatRequestAssistantMessage =
                     new ChatRequestAssistantMessage(getOrDefault(aiMessage.text(), ""));
@@ -283,6 +293,9 @@ class InternalAzureOpenAiHelper {
                             } else if (content instanceof ImageContent imageContent) {
                                 String imageUrlString = toImageUrl(imageContent.image());
                                 ChatMessageImageUrl imageUrl = new ChatMessageImageUrl(imageUrlString);
+                                if (honorImageDetailLevel) {
+                                    imageUrl.setDetail(toDetail(imageContent.detailLevel()));
+                                }
                                 return new ChatMessageImageContentItem(imageUrl);
                             } else {
                                 throw new IllegalArgumentException("Unsupported content type: " + content.type());
@@ -314,6 +327,19 @@ class InternalAzureOpenAiHelper {
             return image.url().toString();
         }
         return String.format("data:%s;base64,%s", image.mimeType(), image.base64Data());
+    }
+
+    private static ChatMessageImageDetailLevel toDetail(ImageContent.DetailLevel detailLevel) {
+        if (detailLevel == null) {
+            return null;
+        }
+
+        return switch (detailLevel) {
+            case LOW -> ChatMessageImageDetailLevel.LOW;
+            case HIGH -> ChatMessageImageDetailLevel.HIGH;
+            case AUTO -> ChatMessageImageDetailLevel.AUTO;
+            default -> throw new UnsupportedFeatureException("Unsupported detail level: " + detailLevel);
+        };
     }
 
     private static List<ChatCompletionsToolCall> toolExecutionRequestsFrom(ChatMessage message) {

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelTest.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/AzureOpenAiChatModelTest.java
@@ -1,0 +1,91 @@
+package dev.langchain4j.model.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.models.ChatChoice;
+import com.azure.ai.openai.models.ChatCompletions;
+import com.azure.ai.openai.models.ChatCompletionsOptions;
+import com.azure.ai.openai.models.ChatRequestUserMessage;
+import com.azure.ai.openai.models.ChatResponseMessage;
+import com.azure.ai.openai.models.CompletionsFinishReason;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.UserMessage;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AzureOpenAiChatModelTest {
+
+    @Test
+    void should_not_honor_image_detail_level_by_default() {
+        // given
+        OpenAIClient client = mockClient();
+        AzureOpenAiChatModel model = AzureOpenAiChatModel.builder()
+                .openAIClient(client)
+                .deploymentName("test-deployment")
+                .build();
+
+        // when
+        model.chat(UserMessage.from(
+                "Describe this image",
+                ImageContent.from("https://example.com/image.png", ImageContent.DetailLevel.HIGH)));
+
+        // then
+        String contentJson = capturedUserMessageContent(client).toString();
+        assertThat(contentJson).contains("https://example.com/image.png").doesNotContain("\"detail\"");
+    }
+
+    @Test
+    void should_honor_image_detail_level_when_enabled() {
+        // given
+        OpenAIClient client = mockClient();
+        AzureOpenAiChatModel model = AzureOpenAiChatModel.builder()
+                .openAIClient(client)
+                .deploymentName("test-deployment")
+                .honorImageDetailLevel(true)
+                .build();
+
+        // when
+        model.chat(UserMessage.from(
+                "Describe this image",
+                ImageContent.from("https://example.com/image.png", ImageContent.DetailLevel.HIGH)));
+
+        // then
+        String contentJson = capturedUserMessageContent(client).toString();
+        assertThat(contentJson).contains("https://example.com/image.png").contains("\"detail\":\"high\"");
+    }
+
+    private static OpenAIClient mockClient() {
+        OpenAIClient client = mock(OpenAIClient.class);
+
+        ChatResponseMessage responseMessage = mock(ChatResponseMessage.class);
+        when(responseMessage.getContent()).thenReturn("ok");
+
+        ChatChoice choice = mock(ChatChoice.class);
+        when(choice.getMessage()).thenReturn(responseMessage);
+        when(choice.getFinishReason()).thenReturn(CompletionsFinishReason.STOPPED);
+
+        ChatCompletions chatCompletions = mock(ChatCompletions.class);
+        when(chatCompletions.getChoices()).thenReturn(List.of(choice));
+        when(chatCompletions.getModel()).thenReturn("test-deployment");
+
+        when(client.getChatCompletions(eq("test-deployment"), any(ChatCompletionsOptions.class)))
+                .thenReturn(chatCompletions);
+
+        return client;
+    }
+
+    private static Object capturedUserMessageContent(OpenAIClient client) {
+        ArgumentCaptor<ChatCompletionsOptions> optionsCaptor = ArgumentCaptor.forClass(ChatCompletionsOptions.class);
+        verify(client).getChatCompletions(eq("test-deployment"), optionsCaptor.capture());
+        ChatRequestUserMessage userMessage =
+                (ChatRequestUserMessage) optionsCaptor.getValue().getMessages().get(0);
+        return userMessage.getContent();
+    }
+}

--- a/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
+++ b/langchain4j-azure-open-ai/src/test/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelperTest.java
@@ -31,6 +31,7 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import dev.langchain4j.model.output.FinishReason;
 import java.io.IOException;
 import java.time.Duration;
@@ -297,6 +298,74 @@ class InternalAzureOpenAiHelperTest {
                 .contains("url")
                 .doesNotContain("data:image")
                 .doesNotContain("base64");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldNotIncludeImageDetailLevelByDefault() {
+        // Given
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.HIGH);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        String contentJson = requestMessage.getContent().toString();
+
+        assertThat(contentJson).contains(imageUrl).doesNotContain("\"detail\"");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldIgnoreUnsupportedImageDetailLevelByDefault() {
+        // Given
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.MEDIUM);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages);
+
+        // Then
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        String contentJson = requestMessage.getContent().toString();
+
+        assertThat(contentJson).contains(imageUrl).doesNotContain("\"detail\"");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldIncludeImageDetailLevelWhenEnabled() {
+        // Given
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.HIGH);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When
+        List<ChatRequestMessage> openAiMessages = InternalAzureOpenAiHelper.toOpenAiMessages(messages, true);
+
+        // Then
+        ChatRequestUserMessage requestMessage = (ChatRequestUserMessage) openAiMessages.get(0);
+        String contentJson = requestMessage.getContent().toString();
+
+        assertThat(contentJson).contains(imageUrl).contains("\"detail\":\"high\"");
+    }
+
+    @Test
+    void toOpenAiMessages_shouldThrowForUnsupportedImageDetailLevelWhenEnabled() {
+        // Given
+        String imageUrl = "https://example.com/image.png";
+        ImageContent imageContent = ImageContent.from(imageUrl, ImageContent.DetailLevel.MEDIUM);
+        UserMessage userMessage = UserMessage.from("Describe this image", imageContent);
+        List<ChatMessage> messages = List.of(userMessage);
+
+        // When/Then
+        assertThatThrownBy(() -> InternalAzureOpenAiHelper.toOpenAiMessages(messages, true))
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessageContaining("Unsupported detail level: MEDIUM");
     }
 
     @Test


### PR DESCRIPTION
## Issue
Closes #5508

## Change
The Azure OpenAI chat and streaming chat models now expose an opt-in `honorImageDetailLevel(Boolean)` builder option.

By default this option is `false`, so Azure OpenAI preserves the existing behavior and does not send the image `detail` field, including LangChain4j's default `ImageContent.DetailLevel.LOW`.

When `honorImageDetailLevel(true)` is enabled, Azure OpenAI maps supported LangChain4j image detail levels to Azure's request payload:
- `LOW` -> `low`
- `HIGH` -> `high`
- `AUTO` -> `auto`

Unsupported detail levels fail fast with `UnsupportedFeatureException` only when the opt-in flag is enabled. When the flag is disabled, unsupported detail levels are ignored together with all other image detail levels to preserve backward-compatible behavior.

Added regression coverage for:
- default behavior not serializing `detail`
- default behavior ignoring unsupported detail levels
- opt-in behavior preserving `HIGH` in the serialized Azure request content
- opt-in behavior rejecting unsupported `MEDIUM`

Validation:
- `./mvnw -pl langchain4j-azure-open-ai test`
- `./mvnw -pl langchain4j-azure-open-ai verify` (Azure ITs are invoked and skipped by the existing environment conditions when credentials are unavailable)
- `git diff --check`
- GitHub CI: `spotless`, `compliance`, `compile_and_unit_test`, `integration_test`, and `check-split-packages` passed

Local `./mvnw -pl langchain4j-azure-open-ai -Pspotless spotless:check` could not run in this linked worktree because Spotless failed before checking files with `Cannot find git repository in any parent directory`; the equivalent GitHub CI `spotless` check passed.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`

## Checklist for adding new embedding store integration
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j