### PR TITLE
fix: Set required input_audio format from audio mime type in OpenAI official chat model

### DIFF
--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -161,6 +161,9 @@ class InternalOpenAiOfficialHelper {
                                 .inputAudio(ChatCompletionContentPartInputAudio.InputAudio.builder()
                                         .data(ensureNotBlank(
                                                 audioContent.audio().base64Data(), "audio.base64Data"))
+                                        .format(ChatCompletionContentPartInputAudio.InputAudio.Format.of(ensureNotBlank(
+                                                        audioContent.audio().mimeType(), "audio.mimeType")
+                                                .split("/")[1]))
                                         .build())
                                 .build()
                                 .inputAudio())

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.model.openaiofficial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openai.models.chat.completions.ChatCompletionContentPartInputAudio;
+import com.openai.models.chat.completions.ChatCompletionMessageParam;
+import dev.langchain4j.data.message.AudioContent;
+import dev.langchain4j.data.message.UserMessage;
+import org.junit.jupiter.api.Test;
+
+class InternalOpenAiOfficialHelperTest {
+
+    private static final String BASE64_AUDIO = "QUJD"; // any non-blank base64 payload
+
+    @Test
+    void should_set_input_audio_format_from_wav_mime_type() {
+        UserMessage message = UserMessage.from(AudioContent.from(BASE64_AUDIO, "audio/wav"));
+
+        ChatCompletionMessageParam param = InternalOpenAiOfficialHelper.toOpenAiMessage(message);
+
+        ChatCompletionContentPartInputAudio.InputAudio inputAudio = param.asUser()
+                .content()
+                .asArrayOfContentParts()
+                .get(0)
+                .asInputAudio()
+                .inputAudio();
+        assertThat(inputAudio.data()).isEqualTo(BASE64_AUDIO);
+        assertThat(inputAudio.format()).isEqualTo(ChatCompletionContentPartInputAudio.InputAudio.Format.WAV);
+    }
+
+    @Test
+    void should_set_input_audio_format_from_mp3_mime_type() {
+        UserMessage message = UserMessage.from(AudioContent.from(BASE64_AUDIO, "audio/mp3"));
+
+        ChatCompletionMessageParam param = InternalOpenAiOfficialHelper.toOpenAiMessage(message);
+
+        assertThat(param.asUser()
+                        .content()
+                        .asArrayOfContentParts()
+                        .get(0)
+                        .asInputAudio()
+                        .inputAudio()
+                        .format())
+                .isEqualTo(ChatCompletionContentPartInputAudio.InputAudio.Format.MP3);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5590

## Change
`InternalOpenAiOfficialHelper.toOpenAiMessage()` mapped `AudioContent` to the OpenAI SDK `InputAudio` setting only `data`, never the required `format` field. Building any audio message therefore threw `IllegalStateException: \`format\` is required, but was not set` before any API call.

This sets `format` from the audio mime type subtype (`audio/wav` → `wav`, `audio/mp3` → `mp3`), mirroring the sibling module `langchain4j-open-ai` (`OpenAiUtils.toOpenAiContent(AudioContent)`, which uses `extractSubtype(mimeType)`). The change is one added builder call; no other content types are affected.

Added `InternalOpenAiOfficialHelperTest` with two unit tests (wav, mp3) asserting the resulting `InputAudio.format()`. Without the fix both tests fail with the `format is required` error; with it they pass — no API key needed.

```java
.format(ChatCompletionContentPartInputAudio.InputAudio.Format.of(
        ensureNotBlank(audioContent.audio().mimeType(), "audio.mimeType").split("/")[1]))
```

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases <!-- two positive cases (wav, mp3); they regression-guard the previously-thrown IllegalStateException -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- unit tests green (JDK 17); the module *IT are @EnabledIfEnvironmentVariable (OpenAI/Azure/GitHub keys) and were not run locally -->
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green <!-- not run; change is isolated to langchain4j-open-ai-official -->
- [ ] I have added/updated the documentation <!-- N/A — internal mapping bug fix; docs added after approval -->
- [ ] I have added an example in the examples repo <!-- N/A — bug fix, not a feature -->
- [ ] I have added/updated Spring Boot starter(s) <!-- N/A -->

<!-- New maven module / embedding store checklists omitted — not applicable to this bug fix. -->
