### PR TITLE
fix: match ContainsString as a literal substring in PgVector filter

### DIFF
--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorFilterMapper.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorFilterMapper.java
@@ -62,7 +62,8 @@ abstract class PgVectorFilterMapper {
     private String mapContains(ContainsString containsString) {
         String key =
                 formatKey(containsString.key(), containsString.comparisonValue().getClass());
-        return format("%s is not null and %s ~ %s", key, key, formatValue(containsString.comparisonValue()));
+        return format(
+                "%s is not null and position(%s in %s) > 0", key, formatValue(containsString.comparisonValue()), key);
     }
 
     private String mapEqual(IsEqualTo isEqualTo) {

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorFilterMapperTest.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/PgVectorFilterMapperTest.java
@@ -75,8 +75,7 @@ class PgVectorFilterMapperTest {
     @Test
     void sqlInjectionViaKey_shouldBeEscaped_jsonMapper() {
         // A crafted key that tries to break out of the ->>'...' string literal and inject "OR 1=1".
-        Filter filter =
-                metadataKey("x') IS NOT NULL OR 1=1 OR (metadata->>'y").isEqualTo("no-such-value");
+        Filter filter = metadataKey("x') IS NOT NULL OR 1=1 OR (metadata->>'y").isEqualTo("no-such-value");
 
         String sql = jsonMapper.map(filter);
 
@@ -110,5 +109,38 @@ class PgVectorFilterMapperTest {
         Filter filter = metadataKey("id) OR (1=1").isIn("a", "b");
 
         assertThatThrownBy(() -> columnMapper.map(filter)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void mapContains_shouldUseLiteralSubstringNotRegex_jsonMapper() {
+        // A value with regex metacharacters must be matched literally (ContainsString is str.contains),
+        // not interpreted as a POSIX regular expression by the "~" operator.
+        Filter filter = metadataKey("path").containsString("a.b");
+
+        String sql = jsonMapper.map(filter);
+
+        assertThat(sql)
+                .isEqualTo("(metadata->>'path')::text is not null"
+                        + " and position('a.b' in (metadata->>'path')::text) > 0");
+    }
+
+    @Test
+    void mapContains_shouldUseLiteralSubstringNotRegex_columnMapper() {
+        Filter filter = metadataKey("path").containsString("a.b");
+
+        String sql = columnMapper.map(filter);
+
+        assertThat(sql).isEqualTo("path::text is not null and position('a.b' in path::text) > 0");
+    }
+
+    @Test
+    void mapContains_shouldEscapeSingleQuoteInValue_jsonMapper() {
+        Filter filter = metadataKey("name").containsString("O'Brien");
+
+        String sql = jsonMapper.map(filter);
+
+        assertThat(sql)
+                .isEqualTo("(metadata->>'name')::text is not null"
+                        + " and position('O''Brien' in (metadata->>'name')::text) > 0");
     }
 }


### PR DESCRIPTION
## Issue
Closes #5594

## Change

`PgVectorFilterMapper.mapContains()` mapped the `ContainsString` filter to the PostgreSQL `~` operator, which is POSIX regular-expression matching. The core `ContainsString` contract is literal substring containment (`str.contains`), so values with regex metacharacters were misinterpreted: `"a.b"` also matched `axb`, `"C++"` matched `CC` but not `C++`, and an unbalanced `"["` raised `invalid regular expression` at query time.

This replaces `~` with the native literal-substring function `position(value in column) > 0`. It matches the core contract and the sibling MongoDB (`Pattern.quote`) and Milvus (`LIKE`) mappers. The existing single-quote escaping in `formatValue` still covers SQL-literal safety, so no metacharacter escaping table is needed.

Added three unit tests in `PgVectorFilterMapperTest` (JSON and column mappers, plus single-quote escaping). Each fails on the old `~` mapping and passes after the fix.

## General checklist
- [ ] There are no breaking changes (API, behaviour)
<!-- API unchanged. Behaviour changes only for values containing regex metacharacters — that misinterpretation is exactly the bug being fixed; correct literal-substring usage is unaffected. -->
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
<!-- This corrects the generated SQL for a filter mapping, so the tests assert the correct literal-substring output; there is no reject/negative path to cover. -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- PgVectorFilterMapperTest: 13 tests green (JDK 17). *IT require a live PostgreSQL/Testcontainers and were not run locally. -->
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

<!-- 신규 maven 모듈/신규 embedding store 체크리스트: 해당 없음(기존 모듈 버그픽스). -->

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `PgVectorEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
<!-- This changes only the WHERE-clause generation for the ContainsString filter; stored data format is unchanged. -->

---

