### PR TITLE
fix: support Float and Double values in Qdrant equality metadata filters

### DIFF
--- a/langchain4j-qdrant/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantFilterConverter.java
+++ b/langchain4j-qdrant/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantFilterConverter.java
@@ -84,10 +84,16 @@ class QdrantFilterConverter {
         } else if (value instanceof Integer || value instanceof Long) {
             long lValue = Long.parseLong(value.toString());
             return ConditionFactory.match(key, lValue);
+        } else if (value instanceof Float || value instanceof Double) {
+            // Qdrant's Match proto has no float/double field, so equality is expressed as a Range
+            // where gte == lte == value.
+            double dValue = Double.parseDouble(value.toString());
+            return ConditionFactory.range(
+                    key, Common.Range.newBuilder().setGte(dValue).setLte(dValue).build());
         }
 
         throw new IllegalArgumentException(
-                "Invalid value type for IsEqualTo. Can either be a String or Boolean or Integer or Long");
+                "Invalid value type for IsEqualTo. Can either be a String or Boolean or Integer or Long or Float or Double");
     }
 
     private static Condition buildNeCondition(IsNotEqualTo notEqual) {
@@ -106,10 +112,18 @@ class QdrantFilterConverter {
             Condition condition = ConditionFactory.match(key, lValue);
             return ConditionFactory.filter(
                     Common.Filter.newBuilder().addMustNot(condition).build());
+        } else if (value instanceof Float || value instanceof Double) {
+            // Qdrant's Match proto has no float/double field, so inequality is expressed as a
+            // must_not Range where gte == lte == value.
+            double dValue = Double.parseDouble(value.toString());
+            Condition condition = ConditionFactory.range(
+                    key, Common.Range.newBuilder().setGte(dValue).setLte(dValue).build());
+            return ConditionFactory.filter(
+                    Common.Filter.newBuilder().addMustNot(condition).build());
         }
 
         throw new IllegalArgumentException(
-                "Invalid value type for IsNotEqualto. Can either be a String or Boolean or Integer or Long");
+                "Invalid value type for IsNotEqualto. Can either be a String or Boolean or Integer or Long or Float or Double");
     }
 
     private static Condition buildGtCondition(IsGreaterThan greaterThan) {

--- a/langchain4j-qdrant/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantFilterConverter.java
+++ b/langchain4j-qdrant/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantFilterConverter.java
@@ -86,8 +86,9 @@ class QdrantFilterConverter {
             return ConditionFactory.match(key, lValue);
         } else if (value instanceof Float || value instanceof Double) {
             // Qdrant's Match proto has no float/double field, so equality is expressed as a Range
-            // where gte == lte == value.
-            double dValue = Double.parseDouble(value.toString());
+            // where gte == lte == value. Convert via doubleValue() (not the string form) so the bound
+            // matches how a Float is stored: ValueMapFactory widens it through ValueFactory.value(double).
+            double dValue = ((Number) value).doubleValue();
             return ConditionFactory.range(
                     key, Common.Range.newBuilder().setGte(dValue).setLte(dValue).build());
         }
@@ -114,8 +115,9 @@ class QdrantFilterConverter {
                     Common.Filter.newBuilder().addMustNot(condition).build());
         } else if (value instanceof Float || value instanceof Double) {
             // Qdrant's Match proto has no float/double field, so inequality is expressed as a
-            // must_not Range where gte == lte == value.
-            double dValue = Double.parseDouble(value.toString());
+            // must_not Range where gte == lte == value. Convert via doubleValue() (not the string form)
+            // so the bound matches how a Float is stored: widened through ValueFactory.value(double).
+            double dValue = ((Number) value).doubleValue();
             Condition condition = ConditionFactory.range(
                     key, Common.Range.newBuilder().setGte(dValue).setLte(dValue).build());
             return ConditionFactory.filter(

--- a/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantFilterConverterTest.java
+++ b/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantFilterConverterTest.java
@@ -6,6 +6,7 @@ import dev.langchain4j.store.embedding.filter.Filter;
 import dev.langchain4j.store.embedding.filter.comparison.*;
 import io.qdrant.client.grpc.Common;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class QdrantFilterConverterTest {
@@ -267,5 +268,22 @@ class QdrantFilterConverterTest {
                         .getExceptKeywords()
                         .getStringsCount())
                 .isEqualTo(4);
+    }
+
+    @Test
+    void isEqualToFilter_floatValue_rangeBoundMustEqualStoredValue() {
+        float value = 0.1f;
+
+        // What Qdrant actually persists for metadata.put("k", 0.1f):
+        double stored =
+                ValueMapFactory.valueMap(Collections.singletonMap("k", value)).get("k").getDoubleValue();
+
+        // What the IsEqualTo filter searches for:
+        Common.Filter convertedFilter = QdrantFilterConverter.convertExpression(new IsEqualTo("k", value));
+        double searchedGte = convertedFilter.getMust(0).getField().getRange().getGte();
+
+        assertThat(searchedGte)
+                .as("equality range bound must equal the stored representation, otherwise IsEqualTo(0.1f) never matches a row stored with put(\"k\", 0.1f)")
+                .isEqualTo(stored);
     }
 }

--- a/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantFilterConverterTest.java
+++ b/langchain4j-qdrant/src/test/java/dev/langchain4j/store/embedding/qdrant/QdrantFilterConverterTest.java
@@ -45,6 +45,22 @@ class QdrantFilterConverterTest {
         assertThat(convertedFilter.getMust(0).getField().getKey()).isEqualTo("bool-value");
         assertThat(convertedFilter.getMust(0).getField().getMatch().getBoolean())
                 .isEqualTo(true);
+
+        filter = new IsEqualTo("double-value", 9.99);
+        convertedFilter = QdrantFilterConverter.convertExpression(filter);
+        assertThat(convertedFilter).isNotNull();
+        assertThat(convertedFilter.getMustCount()).isEqualTo(1);
+        assertThat(convertedFilter.getMust(0).getField().getKey()).isEqualTo("double-value");
+        assertThat(convertedFilter.getMust(0).getField().getRange().getGte()).isEqualTo(9.99);
+        assertThat(convertedFilter.getMust(0).getField().getRange().getLte()).isEqualTo(9.99);
+
+        filter = new IsEqualTo("float-value", 1.5f);
+        convertedFilter = QdrantFilterConverter.convertExpression(filter);
+        assertThat(convertedFilter).isNotNull();
+        assertThat(convertedFilter.getMustCount()).isEqualTo(1);
+        assertThat(convertedFilter.getMust(0).getField().getKey()).isEqualTo("float-value");
+        assertThat(convertedFilter.getMust(0).getField().getRange().getGte()).isEqualTo(1.5);
+        assertThat(convertedFilter.getMust(0).getField().getRange().getLte()).isEqualTo(1.5);
     }
 
     @Test
@@ -108,6 +124,55 @@ class QdrantFilterConverterTest {
                         .getMatch()
                         .getBoolean())
                 .isEqualTo(true);
+
+        filter = new IsNotEqualTo("double-value", 9.99);
+        convertedFilter = QdrantFilterConverter.convertExpression(filter);
+        assertThat(convertedFilter).isNotNull();
+        assertThat(convertedFilter.getMustCount()).isEqualTo(1);
+        assertThat(convertedFilter
+                        .getMust(0)
+                        .getFilter()
+                        .getMustNot(0)
+                        .getField()
+                        .getKey())
+                .isEqualTo("double-value");
+        assertThat(convertedFilter
+                        .getMust(0)
+                        .getFilter()
+                        .getMustNot(0)
+                        .getField()
+                        .getRange()
+                        .getGte())
+                .isEqualTo(9.99);
+        assertThat(convertedFilter
+                        .getMust(0)
+                        .getFilter()
+                        .getMustNot(0)
+                        .getField()
+                        .getRange()
+                        .getLte())
+                .isEqualTo(9.99);
+
+        filter = new IsNotEqualTo("float-value", 1.5f);
+        convertedFilter = QdrantFilterConverter.convertExpression(filter);
+        assertThat(convertedFilter).isNotNull();
+        assertThat(convertedFilter.getMustCount()).isEqualTo(1);
+        assertThat(convertedFilter
+                        .getMust(0)
+                        .getFilter()
+                        .getMustNot(0)
+                        .getField()
+                        .getRange()
+                        .getGte())
+                .isEqualTo(1.5);
+        assertThat(convertedFilter
+                        .getMust(0)
+                        .getFilter()
+                        .getMustNot(0)
+                        .getField()
+                        .getRange()
+                        .getLte())
+                .isEqualTo(1.5);
     }
 
     @Test


### PR DESCRIPTION
## Issue
Closes #5597

## Change

`QdrantFilterConverter.buildEqCondition` and `buildNeCondition` rejected `Float`/`Double` comparison values with an `IllegalArgumentException`, even though `Metadata` declares `Float`/`Double` as supported types and offers `put(String, float)`/`put(String, double)`. A value stored as a double could be saved but never queried back with `IsEqualTo`/`IsNotEqualTo`.

Qdrant's `Match` proto has no float field, so this adds a `Float`/`Double` branch mapping equality to a `Range` with `gte == lte == value`, reusing the range pattern already used by `IsGreaterThan`/`IsLessThan` in the same class. `IsNotEqualTo` wraps that range in `must_not`. The integer, long, string, and boolean branches are unchanged.

This aligns Qdrant with sibling stores (Pinecone, Milvus) that already accept floating-point equality.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- N/A — change is isolated to langchain4j-qdrant; core/main untouched -->
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
<!-- N/A — docs added after review per CONTRIBUTING.md -->
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

<!-- N/A — no new maven module added -->
<!-- N/A — no new embedding store integration added -->
<!-- N/A — no change to embedding store persistence format -->

