### PR TITLE
feat(anthropic): add midConversationSystemMessages option for mid-conversation system messages

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -56,6 +56,7 @@ AnthropicChatModel model = AnthropicChatModel.builder()
     .thinkingDisplay(...)
     .returnThinking(...)
     .sendThinking(...)
+    .midConversationSystemMessages(...)
     .timeout(...)
     .maxRetries(...)
     .logRequests(...)
@@ -72,7 +73,8 @@ See the description of some of the parameters above [here](https://docs.anthropi
 ### Per-Request Parameters
 
 The Anthropic-specific options shown above (`cacheSystemMessages`, `cacheTools`, `thinkingType`,
-`thinkingBudgetTokens`, `sendThinking`, `returnThinking`, `toolChoiceName`, `disableParallelToolUse` and `userId`)
+`thinkingBudgetTokens`, `sendThinking`, `returnThinking`, `midConversationSystemMessages`, `toolChoiceName`,
+`disableParallelToolUse` and `userId`)
 can also be set per request via `AnthropicChatRequestParameters`, overriding the values configured on the model
 builder. This lets a single shared model instance vary these options from one call to the next — for example,
 enabling prompt caching for a long-running agent loop while skipping it for a cheap one-shot completion, without
@@ -492,6 +494,52 @@ ChatModel model = AnthropicChatModel.builder()
         .sendThinking(true)
         .build();
 ```
+
+## Mid-Conversation System Messages
+
+By default, every `SystemMessage` is folded into the top-level `system` prompt regardless of where it appears
+in the message list. This matches how Anthropic has always worked and is unchanged.
+
+Claude Opus 4.8 additionally supports
+[mid-conversation system messages](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages):
+a `SystemMessage` that appears *after* the conversation has started can be sent inline as a `system` entry in the
+`messages` array, so it takes effect from that point in the conversation onward (for example, to change the
+assistant's instructions partway through a session). Enable this with `midConversationSystemMessages(true)`:
+
+```java
+AnthropicChatModel model = AnthropicChatModel.builder()
+    .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+    .modelName("claude-opus-4-8")
+    .midConversationSystemMessages(true)
+    .build();
+
+ChatResponse response = model.chat(ChatRequest.builder()
+    .messages(
+        SystemMessage.from("You are a helpful assistant."), // leading -> top-level "system" prompt
+        UserMessage.from("Hello"),
+        AiMessage.from("Hi! How can I help?"),
+        SystemMessage.from("From now on, answer only in French."), // mid-conversation -> inline
+        UserMessage.from("What is the capital of Spain?"))
+    .build());
+```
+
+When enabled, **leading** `SystemMessage`s (those before the first user/assistant message) still populate the
+top-level `system` prompt; only those appearing after the conversation has started are sent inline. This is not
+just a convention — Anthropic requires it: a `system` message cannot be the first entry in the `messages` array,
+and the base system prompt belongs in the stable, cacheable prefix anyway. With the option disabled (the
+default), behaviour is unchanged and all `SystemMessage`s go to the top-level `system` prompt.
+
+It can also be set per request via `AnthropicChatRequestParameters` (see [Per-Request Parameters](#per-request-parameters)).
+
+:::note
+Anthropic constrains where a mid-conversation system message may be placed: it must immediately follow a `user`
+turn (including a `user` turn carrying tool results), must precede an `assistant` turn or end the array, and must
+not sit between a `tool_use` block and its `tool_result`. Consecutive `system` messages are also not allowed.
+Note that, with the option disabled, langchain4j merges multiple `SystemMessage`s into the top-level `system`
+field; with it enabled, two adjacent mid-conversation `SystemMessage`s would be sent as consecutive inline
+`system` entries and rejected. langchain4j does not reorder or merge inline messages — it sends them at the
+position you provide — so an unsupported model or an invalid placement results in a `400` from the Anthropic API.
+:::
 
 ## PDF Support
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -133,8 +133,8 @@ public class AnthropicChatModel implements ChatModel {
                 .thinkingBudgetTokens(
                         getOrDefault(builder.thinkingBudgetTokens, anthropicDefaults.thinkingBudgetTokens()))
                 .sendThinking(getOrDefault(builder.sendThinking, anthropicDefaults.sendThinking()))
-                .inlineSystemMessages(
-                        getOrDefault(builder.inlineSystemMessages, anthropicDefaults.inlineSystemMessages()))
+                .midConversationSystemMessages(
+                        getOrDefault(builder.midConversationSystemMessages, anthropicDefaults.midConversationSystemMessages()))
                 .returnThinking(getOrDefault(builder.returnThinking, anthropicDefaults.returnThinking()))
                 .toolChoiceName(getOrDefault(builder.toolChoiceName, anthropicDefaults.toolChoiceName()))
                 .disableParallelToolUse(
@@ -175,7 +175,7 @@ public class AnthropicChatModel implements ChatModel {
         private String thinkingDisplay;
         private Boolean returnThinking;
         private Boolean sendThinking;
-        private Boolean inlineSystemMessages;
+        private Boolean midConversationSystemMessages;
         private Duration timeout;
         private Integer maxRetries;
         private Boolean logRequests;
@@ -569,25 +569,27 @@ public class AnthropicChatModel implements ChatModel {
         }
 
         /**
-         * Controls whether {@link SystemMessage}s that appear after the conversation has started are sent
-         * inline as {@code system} entries in the {@code messages} array, instead of being merged into the
-         * top-level {@code system} prompt.
+         * Controls whether a {@link SystemMessage} that appears after the conversation has started (a
+         * <em>mid-conversation</em> system message) is sent inline as a {@code system} entry in the
+         * {@code messages} array, instead of being merged into the top-level {@code system} prompt.
          * <p>
          * Disabled by default, in which case every {@link SystemMessage} is sent via the top-level
          * {@code system} prompt regardless of position (the existing behavior). When enabled, leading
          * {@link SystemMessage}s still populate the top-level {@code system} prompt, while later ones are
          * sent inline so they take effect from that point in the conversation onward.
          * <p>
-         * Supported only by Claude Opus 4.8. Anthropic also constrains placement: an inline system message
-         * must immediately follow a {@code user} turn (including a {@code user} turn carrying tool results)
-         * and must not sit between a {@code tool_use} block and its {@code tool_result}; an unsupported model
-         * or an invalid placement returns a 400.
+         * Supported only by Claude Opus 4.8. Anthropic also constrains placement: a mid-conversation system
+         * message must immediately follow a {@code user} turn (including a {@code user} turn carrying tool
+         * results) and must not sit between a {@code tool_use} block and its {@code tool_result}; an
+         * unsupported model or an invalid placement returns a 400. This library does not reorder messages;
+         * it sends them at the position the caller provided.
          *
-         * @param inlineSystemMessages whether to send mid-conversation system messages inline
+         * @param midConversationSystemMessages whether to send mid-conversation system messages inline
          * @return {@code this}
+         * @see <a href="https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages">Anthropic: mid-conversation system messages</a>
          */
-        public AnthropicChatModelBuilder inlineSystemMessages(Boolean inlineSystemMessages) {
-            this.inlineSystemMessages = inlineSystemMessages;
+        public AnthropicChatModelBuilder midConversationSystemMessages(Boolean midConversationSystemMessages) {
+            this.midConversationSystemMessages = midConversationSystemMessages;
             return this;
         }
 
@@ -778,7 +780,7 @@ public class AnthropicChatModel implements ChatModel {
                 chatRequest,
                 toThinking(parameters.thinkingType(), parameters.thinkingBudgetTokens(), this.thinkingDisplay),
                 getOrDefault(parameters.sendThinking(), true),
-                getOrDefault(parameters.inlineSystemMessages(), false),
+                getOrDefault(parameters.midConversationSystemMessages(), false),
                 getOrDefault(parameters.cacheSystemMessages(), false) ? EPHEMERAL : NO_CACHE,
                 getOrDefault(parameters.cacheTools(), false) ? EPHEMERAL : NO_CACHE,
                 false,

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -133,6 +133,8 @@ public class AnthropicChatModel implements ChatModel {
                 .thinkingBudgetTokens(
                         getOrDefault(builder.thinkingBudgetTokens, anthropicDefaults.thinkingBudgetTokens()))
                 .sendThinking(getOrDefault(builder.sendThinking, anthropicDefaults.sendThinking()))
+                .inlineSystemMessages(
+                        getOrDefault(builder.inlineSystemMessages, anthropicDefaults.inlineSystemMessages()))
                 .returnThinking(getOrDefault(builder.returnThinking, anthropicDefaults.returnThinking()))
                 .toolChoiceName(getOrDefault(builder.toolChoiceName, anthropicDefaults.toolChoiceName()))
                 .disableParallelToolUse(
@@ -173,6 +175,7 @@ public class AnthropicChatModel implements ChatModel {
         private String thinkingDisplay;
         private Boolean returnThinking;
         private Boolean sendThinking;
+        private Boolean inlineSystemMessages;
         private Duration timeout;
         private Integer maxRetries;
         private Boolean logRequests;
@@ -566,6 +569,29 @@ public class AnthropicChatModel implements ChatModel {
         }
 
         /**
+         * Controls whether {@link SystemMessage}s that appear after the conversation has started are sent
+         * inline as {@code system} entries in the {@code messages} array, instead of being merged into the
+         * top-level {@code system} prompt.
+         * <p>
+         * Disabled by default, in which case every {@link SystemMessage} is sent via the top-level
+         * {@code system} prompt regardless of position (the existing behavior). When enabled, leading
+         * {@link SystemMessage}s still populate the top-level {@code system} prompt, while later ones are
+         * sent inline so they take effect from that point in the conversation onward.
+         * <p>
+         * Supported only by Claude Opus 4.8. Anthropic also constrains placement: an inline system message
+         * must immediately follow a {@code user} turn (including a {@code user} turn carrying tool results)
+         * and must not sit between a {@code tool_use} block and its {@code tool_result}; an unsupported model
+         * or an invalid placement returns a 400.
+         *
+         * @param inlineSystemMessages whether to send mid-conversation system messages inline
+         * @return {@code this}
+         */
+        public AnthropicChatModelBuilder inlineSystemMessages(Boolean inlineSystemMessages) {
+            this.inlineSystemMessages = inlineSystemMessages;
+            return this;
+        }
+
+        /**
          * Sets the HTTP request timeout for calls to the Anthropic API.
          *
          * @param timeout the request timeout
@@ -752,6 +778,7 @@ public class AnthropicChatModel implements ChatModel {
                 chatRequest,
                 toThinking(parameters.thinkingType(), parameters.thinkingBudgetTokens(), this.thinkingDisplay),
                 getOrDefault(parameters.sendThinking(), true),
+                getOrDefault(parameters.inlineSystemMessages(), false),
                 getOrDefault(parameters.cacheSystemMessages(), false) ? EPHEMERAL : NO_CACHE,
                 getOrDefault(parameters.cacheTools(), false) ? EPHEMERAL : NO_CACHE,
                 false,

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
@@ -20,7 +20,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
     private final Boolean sendThinking;
-    private final Boolean inlineSystemMessages;
+    private final Boolean midConversationSystemMessages;
     private final Boolean returnThinking;
     private final String toolChoiceName;
     private final Boolean disableParallelToolUse;
@@ -33,7 +33,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
         this.sendThinking = builder.sendThinking;
-        this.inlineSystemMessages = builder.inlineSystemMessages;
+        this.midConversationSystemMessages = builder.midConversationSystemMessages;
         this.returnThinking = builder.returnThinking;
         this.toolChoiceName = builder.toolChoiceName;
         this.disableParallelToolUse = builder.disableParallelToolUse;
@@ -60,8 +60,8 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
         return sendThinking;
     }
 
-    public Boolean inlineSystemMessages() {
-        return inlineSystemMessages;
+    public Boolean midConversationSystemMessages() {
+        return midConversationSystemMessages;
     }
 
     public Boolean returnThinking() {
@@ -107,7 +107,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 && Objects.equals(thinkingType, that.thinkingType)
                 && Objects.equals(thinkingBudgetTokens, that.thinkingBudgetTokens)
                 && Objects.equals(sendThinking, that.sendThinking)
-                && Objects.equals(inlineSystemMessages, that.inlineSystemMessages)
+                && Objects.equals(midConversationSystemMessages, that.midConversationSystemMessages)
                 && Objects.equals(returnThinking, that.returnThinking)
                 && Objects.equals(toolChoiceName, that.toolChoiceName)
                 && Objects.equals(disableParallelToolUse, that.disableParallelToolUse)
@@ -123,7 +123,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 thinkingType,
                 thinkingBudgetTokens,
                 sendThinking,
-                inlineSystemMessages,
+                midConversationSystemMessages,
                 returnThinking,
                 toolChoiceName,
                 disableParallelToolUse,
@@ -149,7 +149,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 + ", thinkingType=" + thinkingType
                 + ", thinkingBudgetTokens=" + thinkingBudgetTokens
                 + ", sendThinking=" + sendThinking
-                + ", inlineSystemMessages=" + inlineSystemMessages
+                + ", midConversationSystemMessages=" + midConversationSystemMessages
                 + ", returnThinking=" + returnThinking
                 + ", toolChoiceName=" + toolChoiceName
                 + ", disableParallelToolUse=" + disableParallelToolUse
@@ -172,7 +172,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
         private String thinkingType;
         private Integer thinkingBudgetTokens;
         private Boolean sendThinking;
-        private Boolean inlineSystemMessages;
+        private Boolean midConversationSystemMessages;
         private Boolean returnThinking;
         private String toolChoiceName;
         private Boolean disableParallelToolUse;
@@ -187,7 +187,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 thinkingType(getOrDefault(anthropicParameters.thinkingType(), thinkingType));
                 thinkingBudgetTokens(getOrDefault(anthropicParameters.thinkingBudgetTokens(), thinkingBudgetTokens));
                 sendThinking(getOrDefault(anthropicParameters.sendThinking(), sendThinking));
-                inlineSystemMessages(getOrDefault(anthropicParameters.inlineSystemMessages(), inlineSystemMessages));
+                midConversationSystemMessages(getOrDefault(anthropicParameters.midConversationSystemMessages(), midConversationSystemMessages));
                 returnThinking(getOrDefault(anthropicParameters.returnThinking(), returnThinking));
                 toolChoiceName(getOrDefault(anthropicParameters.toolChoiceName(), toolChoiceName));
                 disableParallelToolUse(
@@ -226,8 +226,8 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
             return this;
         }
 
-        public Builder inlineSystemMessages(Boolean inlineSystemMessages) {
-            this.inlineSystemMessages = inlineSystemMessages;
+        public Builder midConversationSystemMessages(Boolean midConversationSystemMessages) {
+            this.midConversationSystemMessages = midConversationSystemMessages;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
@@ -20,6 +20,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
     private final String thinkingType;
     private final Integer thinkingBudgetTokens;
     private final Boolean sendThinking;
+    private final Boolean inlineSystemMessages;
     private final Boolean returnThinking;
     private final String toolChoiceName;
     private final Boolean disableParallelToolUse;
@@ -32,6 +33,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
         this.thinkingType = builder.thinkingType;
         this.thinkingBudgetTokens = builder.thinkingBudgetTokens;
         this.sendThinking = builder.sendThinking;
+        this.inlineSystemMessages = builder.inlineSystemMessages;
         this.returnThinking = builder.returnThinking;
         this.toolChoiceName = builder.toolChoiceName;
         this.disableParallelToolUse = builder.disableParallelToolUse;
@@ -56,6 +58,10 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
 
     public Boolean sendThinking() {
         return sendThinking;
+    }
+
+    public Boolean inlineSystemMessages() {
+        return inlineSystemMessages;
     }
 
     public Boolean returnThinking() {
@@ -101,6 +107,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 && Objects.equals(thinkingType, that.thinkingType)
                 && Objects.equals(thinkingBudgetTokens, that.thinkingBudgetTokens)
                 && Objects.equals(sendThinking, that.sendThinking)
+                && Objects.equals(inlineSystemMessages, that.inlineSystemMessages)
                 && Objects.equals(returnThinking, that.returnThinking)
                 && Objects.equals(toolChoiceName, that.toolChoiceName)
                 && Objects.equals(disableParallelToolUse, that.disableParallelToolUse)
@@ -116,6 +123,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 thinkingType,
                 thinkingBudgetTokens,
                 sendThinking,
+                inlineSystemMessages,
                 returnThinking,
                 toolChoiceName,
                 disableParallelToolUse,
@@ -141,6 +149,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 + ", thinkingType=" + thinkingType
                 + ", thinkingBudgetTokens=" + thinkingBudgetTokens
                 + ", sendThinking=" + sendThinking
+                + ", inlineSystemMessages=" + inlineSystemMessages
                 + ", returnThinking=" + returnThinking
                 + ", toolChoiceName=" + toolChoiceName
                 + ", disableParallelToolUse=" + disableParallelToolUse
@@ -163,6 +172,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
         private String thinkingType;
         private Integer thinkingBudgetTokens;
         private Boolean sendThinking;
+        private Boolean inlineSystemMessages;
         private Boolean returnThinking;
         private String toolChoiceName;
         private Boolean disableParallelToolUse;
@@ -177,6 +187,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 thinkingType(getOrDefault(anthropicParameters.thinkingType(), thinkingType));
                 thinkingBudgetTokens(getOrDefault(anthropicParameters.thinkingBudgetTokens(), thinkingBudgetTokens));
                 sendThinking(getOrDefault(anthropicParameters.sendThinking(), sendThinking));
+                inlineSystemMessages(getOrDefault(anthropicParameters.inlineSystemMessages(), inlineSystemMessages));
                 returnThinking(getOrDefault(anthropicParameters.returnThinking(), returnThinking));
                 toolChoiceName(getOrDefault(anthropicParameters.toolChoiceName(), toolChoiceName));
                 disableParallelToolUse(
@@ -212,6 +223,11 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
 
         public Builder sendThinking(Boolean sendThinking) {
             this.sendThinking = sendThinking;
+            return this;
+        }
+
+        public Builder inlineSystemMessages(Boolean inlineSystemMessages) {
+            this.inlineSystemMessages = inlineSystemMessages;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -129,6 +129,8 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 .thinkingBudgetTokens(
                         getOrDefault(builder.thinkingBudgetTokens, anthropicDefaults.thinkingBudgetTokens()))
                 .sendThinking(getOrDefault(builder.sendThinking, anthropicDefaults.sendThinking()))
+                .inlineSystemMessages(
+                        getOrDefault(builder.inlineSystemMessages, anthropicDefaults.inlineSystemMessages()))
                 .returnThinking(getOrDefault(builder.returnThinking, anthropicDefaults.returnThinking()))
                 .toolChoiceName(getOrDefault(builder.toolChoiceName, anthropicDefaults.toolChoiceName()))
                 .disableParallelToolUse(
@@ -163,6 +165,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         private String thinkingDisplay;
         private Boolean returnThinking;
         private Boolean sendThinking;
+        private Boolean inlineSystemMessages;
         private Duration timeout;
         private Boolean logRequests;
         private Boolean logResponses;
@@ -464,6 +467,29 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         }
 
         /**
+         * Controls whether {@link SystemMessage}s that appear after the conversation has started are sent
+         * inline as {@code system} entries in the {@code messages} array, instead of being merged into the
+         * top-level {@code system} prompt.
+         * <p>
+         * Disabled by default, in which case every {@link SystemMessage} is sent via the top-level
+         * {@code system} prompt regardless of position (the existing behavior). When enabled, leading
+         * {@link SystemMessage}s still populate the top-level {@code system} prompt, while later ones are
+         * sent inline so they take effect from that point in the conversation onward.
+         * <p>
+         * Supported only by Claude Opus 4.8. Anthropic also constrains placement: an inline system message
+         * must immediately follow a {@code user} turn (including a {@code user} turn carrying tool results)
+         * and must not sit between a {@code tool_use} block and its {@code tool_result}; an unsupported model
+         * or an invalid placement returns a 400.
+         *
+         * @param inlineSystemMessages whether to send mid-conversation system messages inline
+         * @return {@code this}
+         */
+        public AnthropicStreamingChatModelBuilder inlineSystemMessages(Boolean inlineSystemMessages) {
+            this.inlineSystemMessages = inlineSystemMessages;
+            return this;
+        }
+
+        /**
          * Sets the HTTP request timeout for calls to the Anthropic streaming API.
          *
          * @param timeout the request timeout
@@ -736,6 +762,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 chatRequest,
                 toThinking(parameters.thinkingType(), parameters.thinkingBudgetTokens(), this.thinkingDisplay),
                 getOrDefault(parameters.sendThinking(), true),
+                getOrDefault(parameters.inlineSystemMessages(), false),
                 getOrDefault(parameters.cacheSystemMessages(), false) ? EPHEMERAL : NO_CACHE,
                 getOrDefault(parameters.cacheTools(), false) ? EPHEMERAL : NO_CACHE,
                 true,

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -129,8 +129,8 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 .thinkingBudgetTokens(
                         getOrDefault(builder.thinkingBudgetTokens, anthropicDefaults.thinkingBudgetTokens()))
                 .sendThinking(getOrDefault(builder.sendThinking, anthropicDefaults.sendThinking()))
-                .inlineSystemMessages(
-                        getOrDefault(builder.inlineSystemMessages, anthropicDefaults.inlineSystemMessages()))
+                .midConversationSystemMessages(
+                        getOrDefault(builder.midConversationSystemMessages, anthropicDefaults.midConversationSystemMessages()))
                 .returnThinking(getOrDefault(builder.returnThinking, anthropicDefaults.returnThinking()))
                 .toolChoiceName(getOrDefault(builder.toolChoiceName, anthropicDefaults.toolChoiceName()))
                 .disableParallelToolUse(
@@ -165,7 +165,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         private String thinkingDisplay;
         private Boolean returnThinking;
         private Boolean sendThinking;
-        private Boolean inlineSystemMessages;
+        private Boolean midConversationSystemMessages;
         private Duration timeout;
         private Boolean logRequests;
         private Boolean logResponses;
@@ -467,25 +467,27 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         }
 
         /**
-         * Controls whether {@link SystemMessage}s that appear after the conversation has started are sent
-         * inline as {@code system} entries in the {@code messages} array, instead of being merged into the
-         * top-level {@code system} prompt.
+         * Controls whether a {@link SystemMessage} that appears after the conversation has started (a
+         * <em>mid-conversation</em> system message) is sent inline as a {@code system} entry in the
+         * {@code messages} array, instead of being merged into the top-level {@code system} prompt.
          * <p>
          * Disabled by default, in which case every {@link SystemMessage} is sent via the top-level
          * {@code system} prompt regardless of position (the existing behavior). When enabled, leading
          * {@link SystemMessage}s still populate the top-level {@code system} prompt, while later ones are
          * sent inline so they take effect from that point in the conversation onward.
          * <p>
-         * Supported only by Claude Opus 4.8. Anthropic also constrains placement: an inline system message
-         * must immediately follow a {@code user} turn (including a {@code user} turn carrying tool results)
-         * and must not sit between a {@code tool_use} block and its {@code tool_result}; an unsupported model
-         * or an invalid placement returns a 400.
+         * Supported only by Claude Opus 4.8. Anthropic also constrains placement: a mid-conversation system
+         * message must immediately follow a {@code user} turn (including a {@code user} turn carrying tool
+         * results) and must not sit between a {@code tool_use} block and its {@code tool_result}; an
+         * unsupported model or an invalid placement returns a 400. This library does not reorder messages;
+         * it sends them at the position the caller provided.
          *
-         * @param inlineSystemMessages whether to send mid-conversation system messages inline
+         * @param midConversationSystemMessages whether to send mid-conversation system messages inline
          * @return {@code this}
+         * @see <a href="https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages">Anthropic: mid-conversation system messages</a>
          */
-        public AnthropicStreamingChatModelBuilder inlineSystemMessages(Boolean inlineSystemMessages) {
-            this.inlineSystemMessages = inlineSystemMessages;
+        public AnthropicStreamingChatModelBuilder midConversationSystemMessages(Boolean midConversationSystemMessages) {
+            this.midConversationSystemMessages = midConversationSystemMessages;
             return this;
         }
 
@@ -762,7 +764,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 chatRequest,
                 toThinking(parameters.thinkingType(), parameters.thinkingBudgetTokens(), this.thinkingDisplay),
                 getOrDefault(parameters.sendThinking(), true),
-                getOrDefault(parameters.inlineSystemMessages(), false),
+                getOrDefault(parameters.midConversationSystemMessages(), false),
                 getOrDefault(parameters.cacheSystemMessages(), false) ? EPHEMERAL : NO_CACHE,
                 getOrDefault(parameters.cacheTools(), false) ? EPHEMERAL : NO_CACHE,
                 true,

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
@@ -57,7 +57,7 @@ class InternalAnthropicHelper {
             ChatRequest chatRequest,
             AnthropicThinking thinking,
             boolean sendThinking,
-            boolean inlineSystemMessages,
+            boolean midConversationSystemMessages,
             AnthropicCacheType cacheType,
             AnthropicCacheType toolsCacheType,
             boolean stream,
@@ -71,8 +71,8 @@ class InternalAnthropicHelper {
 
         AnthropicCreateMessageRequest.Builder requestBuilder = AnthropicCreateMessageRequest.builder().stream(stream)
                 .model(chatRequest.modelName())
-                .messages(toAnthropicMessages(chatRequest.messages(), sendThinking, inlineSystemMessages))
-                .system(toAnthropicSystemPrompt(chatRequest.messages(), cacheType, inlineSystemMessages))
+                .messages(toAnthropicMessages(chatRequest.messages(), sendThinking, midConversationSystemMessages))
+                .system(toAnthropicSystemPrompt(chatRequest.messages(), cacheType, midConversationSystemMessages))
                 .maxTokens(chatRequest.maxOutputTokens())
                 .stopSequences(chatRequest.stopSequences())
                 .temperature(chatRequest.temperature())

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
@@ -38,7 +38,8 @@ class InternalAnthropicHelper {
         if (parameters.presencePenalty() != null) {
             unsupportedFeatures.add("Presence Penalty");
         }
-        if (parameters.responseFormat() != null && parameters.responseFormat().type() == JSON
+        if (parameters.responseFormat() != null
+                && parameters.responseFormat().type() == JSON
                 && parameters.responseFormat().jsonSchema() == null) {
             unsupportedFeatures.add("Schemaless JSON response format");
         }
@@ -56,6 +57,7 @@ class InternalAnthropicHelper {
             ChatRequest chatRequest,
             AnthropicThinking thinking,
             boolean sendThinking,
+            boolean inlineSystemMessages,
             AnthropicCacheType cacheType,
             AnthropicCacheType toolsCacheType,
             boolean stream,
@@ -69,8 +71,8 @@ class InternalAnthropicHelper {
 
         AnthropicCreateMessageRequest.Builder requestBuilder = AnthropicCreateMessageRequest.builder().stream(stream)
                 .model(chatRequest.modelName())
-                .messages(toAnthropicMessages(chatRequest.messages(), sendThinking))
-                .system(toAnthropicSystemPrompt(chatRequest.messages(), cacheType))
+                .messages(toAnthropicMessages(chatRequest.messages(), sendThinking, inlineSystemMessages))
+                .system(toAnthropicSystemPrompt(chatRequest.messages(), cacheType, inlineSystemMessages))
                 .maxTokens(chatRequest.maxOutputTokens())
                 .stopSequences(chatRequest.stopSequences())
                 .temperature(chatRequest.temperature())
@@ -85,7 +87,8 @@ class InternalAnthropicHelper {
             tools.addAll(toAnthropicTools(serverTools));
         }
         if (!isNullOrEmpty(chatRequest.toolSpecifications())) {
-            tools.addAll(toAnthropicTools(chatRequest.toolSpecifications(), toolsCacheType, toolMetadataKeysToSend, strictTools));
+            tools.addAll(toAnthropicTools(
+                    chatRequest.toolSpecifications(), toolsCacheType, toolMetadataKeysToSend, strictTools));
         }
         if (!tools.isEmpty()) {
             requestBuilder.tools(tools);

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicRole.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicRole.java
@@ -1,13 +1,12 @@
 package dev.langchain4j.model.anthropic.internal.api;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-
 import java.util.Locale;
 
 public enum AnthropicRole {
-
     USER,
-    ASSISTANT;
+    ASSISTANT,
+    SYSTEM;
 
     @JsonValue
     public String serialize() {

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -87,7 +87,7 @@ public class AnthropicMapper {
     }
 
     public static List<AnthropicMessage> toAnthropicMessages(
-            List<ChatMessage> messages, boolean sendThinking, boolean inlineSystemMessages) {
+            List<ChatMessage> messages, boolean sendThinking, boolean midConversationSystemMessages) {
 
         List<AnthropicMessage> anthropicMessages = new ArrayList<>();
         List<AnthropicMessageContent> toolContents = new ArrayList<>();
@@ -100,8 +100,8 @@ public class AnthropicMapper {
                 toolContents.add(toAnthropicToolResultContent(toolExecutionResultMessage));
             } else if (message instanceof SystemMessage systemMessage) {
                 // a leading system message is handled in "toAnthropicSystemPrompt"; a mid-conversation one
-                // is emitted inline as a role:"system" message only when inlineSystemMessages is enabled
-                if (inlineSystemMessages && conversationStarted) {
+                // is emitted inline as a role:"system" message only when midConversationSystemMessages is enabled
+                if (midConversationSystemMessages && conversationStarted) {
                     if (!toolContents.isEmpty()) {
                         anthropicMessages.add(new AnthropicMessage(USER, toolContents));
                         toolContents = new ArrayList<>();
@@ -256,14 +256,14 @@ public class AnthropicMapper {
     }
 
     public static List<AnthropicTextContent> toAnthropicSystemPrompt(
-            List<ChatMessage> messages, AnthropicCacheType cacheType, boolean inlineSystemMessages) {
+            List<ChatMessage> messages, AnthropicCacheType cacheType, boolean midConversationSystemMessages) {
         List<SystemMessage> systemMessages = new ArrayList<>();
         boolean conversationStarted = false;
         for (ChatMessage message : messages) {
             if (message instanceof SystemMessage systemMessage) {
-                // when inlineSystemMessages is enabled, only leading system messages go to the top-level
+                // when midConversationSystemMessages is enabled, only leading system messages go to the top-level
                 // "system" field; mid-conversation ones are emitted inline by "toAnthropicMessages"
-                if (!inlineSystemMessages || !conversationStarted) {
+                if (!midConversationSystemMessages || !conversationStarted) {
                     systemMessages.add(systemMessage);
                 }
             } else {

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -9,8 +9,8 @@ import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.ASSISTANT;
+import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.SYSTEM;
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.USER;
-import static dev.langchain4j.model.anthropic.internal.client.Json.fromJson;
 import static dev.langchain4j.model.anthropic.internal.client.Json.toJson;
 import static dev.langchain4j.model.output.FinishReason.LENGTH;
 import static dev.langchain4j.model.output.FinishReason.OTHER;
@@ -79,21 +79,38 @@ public class AnthropicMapper {
     public static final String CACHE_CONTROL = "cache_control";
 
     public static List<AnthropicMessage> toAnthropicMessages(List<ChatMessage> messages) {
-        return toAnthropicMessages(messages, false);
+        return toAnthropicMessages(messages, false, false);
     }
 
     public static List<AnthropicMessage> toAnthropicMessages(List<ChatMessage> messages, boolean sendThinking) {
+        return toAnthropicMessages(messages, sendThinking, false);
+    }
+
+    public static List<AnthropicMessage> toAnthropicMessages(
+            List<ChatMessage> messages, boolean sendThinking, boolean inlineSystemMessages) {
 
         List<AnthropicMessage> anthropicMessages = new ArrayList<>();
         List<AnthropicMessageContent> toolContents = new ArrayList<>();
+        boolean conversationStarted = false;
 
         for (ChatMessage message : messages) {
 
             if (message instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+                conversationStarted = true;
                 toolContents.add(toAnthropicToolResultContent(toolExecutionResultMessage));
-            } else if (message instanceof SystemMessage) {
-                // ignore, it is handled in the "toAnthropicSystemPrompt" method
+            } else if (message instanceof SystemMessage systemMessage) {
+                // a leading system message is handled in "toAnthropicSystemPrompt"; a mid-conversation one
+                // is emitted inline as a role:"system" message only when inlineSystemMessages is enabled
+                if (inlineSystemMessages && conversationStarted) {
+                    if (!toolContents.isEmpty()) {
+                        anthropicMessages.add(new AnthropicMessage(USER, toolContents));
+                        toolContents = new ArrayList<>();
+                    }
+                    anthropicMessages.add(
+                            new AnthropicMessage(SYSTEM, List.of(new AnthropicTextContent(systemMessage.text()))));
+                }
             } else {
+                conversationStarted = true;
                 if (!toolContents.isEmpty()) {
                     anthropicMessages.add(new AnthropicMessage(USER, toolContents));
                     toolContents = new ArrayList<>();
@@ -235,10 +252,24 @@ public class AnthropicMapper {
 
     public static List<AnthropicTextContent> toAnthropicSystemPrompt(
             List<ChatMessage> messages, AnthropicCacheType cacheType) {
-        List<SystemMessage> systemMessages = messages.stream()
-                .filter(SystemMessage.class::isInstance)
-                .map(SystemMessage.class::cast)
-                .toList();
+        return toAnthropicSystemPrompt(messages, cacheType, false);
+    }
+
+    public static List<AnthropicTextContent> toAnthropicSystemPrompt(
+            List<ChatMessage> messages, AnthropicCacheType cacheType, boolean inlineSystemMessages) {
+        List<SystemMessage> systemMessages = new ArrayList<>();
+        boolean conversationStarted = false;
+        for (ChatMessage message : messages) {
+            if (message instanceof SystemMessage systemMessage) {
+                // when inlineSystemMessages is enabled, only leading system messages go to the top-level
+                // "system" field; mid-conversation ones are emitted inline by "toAnthropicMessages"
+                if (!inlineSystemMessages || !conversationStarted) {
+                    systemMessages.add(systemMessage);
+                }
+            } else {
+                conversationStarted = true;
+            }
+        }
 
         SystemMessage lastSystemMessage =
                 systemMessages.isEmpty() ? null : systemMessages.get(systemMessages.size() - 1);

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatModelIT.java
@@ -4,6 +4,7 @@ import static dev.langchain4j.data.message.UserMessage.userMessage;
 import static dev.langchain4j.internal.Utils.randomString;
 import static dev.langchain4j.internal.Utils.readBytes;
 import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_HAIKU_4_5_20251001;
+import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_OPUS_4_8;
 import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_SONNET_4_5_20250929;
 import static dev.langchain4j.model.output.FinishReason.STOP;
 import static java.util.Arrays.asList;
@@ -819,5 +820,40 @@ class AnthropicChatModelIT {
         assertThat(result.type()).isEqualTo("web_search_tool_result");
         assertThat(result.toolUseId()).isNotBlank();
         assertThat(result.content()).isNotNull();
+    }
+
+    @Test
+    void should_apply_mid_conversation_system_message() {
+
+        // given - mid-conversation system messages are supported by Claude Opus 4.8 only
+        boolean midConversationSystemMessages = true;
+        AnthropicChatModelName modelName = CLAUDE_OPUS_4_8;
+
+        ChatModel model = AnthropicChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .modelName(modelName)
+                .midConversationSystemMessages(midConversationSystemMessages)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        // a leading system message (goes to the top-level "system" field) followed by a mid-conversation
+        // system message (sent inline) that adds an instruction partway through the conversation. Anthropic
+        // requires an inline system message to immediately follow a "user" turn, so it is placed right after
+        // the last user message, as the final entry, where the model's next reply must honor it.
+        ChatRequest chatRequest = ChatRequest.builder()
+                .messages(
+                        SystemMessage.from("You are a helpful assistant."),
+                        UserMessage.from("Hello"),
+                        AiMessage.from("Hi! How can I help you today?"),
+                        UserMessage.from("What is the capital of France?"),
+                        SystemMessage.from("Include the exact word BANANA somewhere in your ryeply."))
+                .build();
+
+        // when - the request is accepted (no 400 for an invalid placement) ...
+        ChatResponse response = model.chat(chatRequest);
+
+        // then - ... and the inline system instruction takes effect on the reply
+        assertThat(response.aiMessage().text()).containsIgnoringCase("banana");
     }
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParametersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParametersTest.java
@@ -248,4 +248,52 @@ class AnthropicChatRequestParametersTest {
         assertThat(copy.disableParallelToolUse()).isTrue();
         assertThat(copy.userId()).isEqualTo("test-user-123");
     }
+
+    @Test
+    void inline_system_messages_is_plumbed_through_builder_override_defaultedBy_and_copy() {
+        // build + getter
+        assertThat(AnthropicChatRequestParameters.builder()
+                        .inlineSystemMessages(true)
+                        .build()
+                        .inlineSystemMessages())
+                .isTrue();
+
+        // defaults to null
+        assertThat(AnthropicChatRequestParameters.EMPTY.inlineSystemMessages()).isNull();
+
+        // overrideWith takes the other value when set
+        AnthropicChatRequestParameters overridden = AnthropicChatRequestParameters.builder()
+                .inlineSystemMessages(true)
+                .build()
+                .overrideWith(AnthropicChatRequestParameters.builder()
+                        .inlineSystemMessages(false)
+                        .build());
+        assertThat(overridden.inlineSystemMessages()).isFalse();
+
+        // defaultedBy keeps the original value
+        AnthropicChatRequestParameters defaulted = AnthropicChatRequestParameters.builder()
+                .inlineSystemMessages(true)
+                .build()
+                .defaultedBy(AnthropicChatRequestParameters.builder()
+                        .inlineSystemMessages(false)
+                        .build());
+        assertThat(defaulted.inlineSystemMessages()).isTrue();
+
+        // equals/hashCode distinguish the field
+        AnthropicChatRequestParameters on = AnthropicChatRequestParameters.builder()
+                .inlineSystemMessages(true)
+                .build();
+        AnthropicChatRequestParameters onCopy = AnthropicChatRequestParameters.builder()
+                .inlineSystemMessages(true)
+                .build();
+        AnthropicChatRequestParameters off = AnthropicChatRequestParameters.builder()
+                .inlineSystemMessages(false)
+                .build();
+        assertThat(on).isEqualTo(onCopy).hasSameHashCodeAs(onCopy);
+        assertThat(on).isNotEqualTo(off);
+
+        // toBuilder round-trips the field
+        assertThat(on.toBuilder().build()).isEqualTo(on);
+        assertThat(on.toBuilder().build().inlineSystemMessages()).isTrue();
+    }
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParametersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParametersTest.java
@@ -250,50 +250,50 @@ class AnthropicChatRequestParametersTest {
     }
 
     @Test
-    void inline_system_messages_is_plumbed_through_builder_override_defaultedBy_and_copy() {
+    void mid_conversation_system_messages_is_plumbed_through_builder_override_defaultedBy_and_copy() {
         // build + getter
         assertThat(AnthropicChatRequestParameters.builder()
-                        .inlineSystemMessages(true)
+                        .midConversationSystemMessages(true)
                         .build()
-                        .inlineSystemMessages())
+                        .midConversationSystemMessages())
                 .isTrue();
 
         // defaults to null
-        assertThat(AnthropicChatRequestParameters.EMPTY.inlineSystemMessages()).isNull();
+        assertThat(AnthropicChatRequestParameters.EMPTY.midConversationSystemMessages()).isNull();
 
         // overrideWith takes the other value when set
         AnthropicChatRequestParameters overridden = AnthropicChatRequestParameters.builder()
-                .inlineSystemMessages(true)
+                .midConversationSystemMessages(true)
                 .build()
                 .overrideWith(AnthropicChatRequestParameters.builder()
-                        .inlineSystemMessages(false)
+                        .midConversationSystemMessages(false)
                         .build());
-        assertThat(overridden.inlineSystemMessages()).isFalse();
+        assertThat(overridden.midConversationSystemMessages()).isFalse();
 
         // defaultedBy keeps the original value
         AnthropicChatRequestParameters defaulted = AnthropicChatRequestParameters.builder()
-                .inlineSystemMessages(true)
+                .midConversationSystemMessages(true)
                 .build()
                 .defaultedBy(AnthropicChatRequestParameters.builder()
-                        .inlineSystemMessages(false)
+                        .midConversationSystemMessages(false)
                         .build());
-        assertThat(defaulted.inlineSystemMessages()).isTrue();
+        assertThat(defaulted.midConversationSystemMessages()).isTrue();
 
         // equals/hashCode distinguish the field
         AnthropicChatRequestParameters on = AnthropicChatRequestParameters.builder()
-                .inlineSystemMessages(true)
+                .midConversationSystemMessages(true)
                 .build();
         AnthropicChatRequestParameters onCopy = AnthropicChatRequestParameters.builder()
-                .inlineSystemMessages(true)
+                .midConversationSystemMessages(true)
                 .build();
         AnthropicChatRequestParameters off = AnthropicChatRequestParameters.builder()
-                .inlineSystemMessages(false)
+                .midConversationSystemMessages(false)
                 .build();
         assertThat(on).isEqualTo(onCopy).hasSameHashCodeAs(onCopy);
         assertThat(on).isNotEqualTo(off);
 
         // toBuilder round-trips the field
         assertThat(on.toBuilder().build()).isEqualTo(on);
-        assertThat(on.toBuilder().build().inlineSystemMessages()).isTrue();
+        assertThat(on.toBuilder().build().midConversationSystemMessages()).isTrue();
     }
 }

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicInlineSystemMessagesTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicInlineSystemMessagesTest.java
@@ -1,0 +1,117 @@
+package dev.langchain4j.model.anthropic;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnthropicInlineSystemMessagesTest {
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(0);
+        wireMockServer.start();
+        wireMockServer.stubFor(post(anyUrl())
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "id": "msg_123",
+                                  "type": "message",
+                                  "role": "assistant",
+                                  "model": "claude-opus-4-8",
+                                  "content": [{"type": "text", "text": "Hello!"}],
+                                  "stop_reason": "end_turn",
+                                  "usage": {"input_tokens": 10, "output_tokens": 5}
+                                }
+                                """)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void should_send_mid_conversation_system_message_inline_when_enabled() {
+        AnthropicChatModel model = modelBuilder().inlineSystemMessages(true).build();
+
+        model.chat(ChatRequest.builder()
+                .messages(
+                        SystemMessage.from("Leading instruction."),
+                        UserMessage.from("Hi"),
+                        SystemMessage.from("From now on, be concise."))
+                .build());
+
+        String body = lastRequestBody();
+        // the mid-conversation system message is emitted as a role:"system" entry inside the messages array
+        // (whitespace is stripped because the client pretty-prints the request body)
+        assertThat(body.replaceAll("\\s+", "")).contains("\"role\":\"system\"");
+        assertThat(body).contains("From now on, be concise.");
+        // the leading system message still populates the top-level system field
+        assertThat(body).contains("Leading instruction.");
+    }
+
+    @Test
+    void should_not_inline_system_messages_by_default() {
+        AnthropicChatModel model = modelBuilder().build();
+
+        model.chat(ChatRequest.builder()
+                .messages(
+                        SystemMessage.from("Leading instruction."),
+                        UserMessage.from("Hi"),
+                        SystemMessage.from("From now on, be concise."))
+                .build());
+
+        String body = lastRequestBody();
+        // both system messages go to the top-level system field; none are inlined as role:"system"
+        assertThat(body.replaceAll("\\s+", "")).doesNotContain("\"role\":\"system\"");
+        assertThat(body).contains("Leading instruction.").contains("From now on, be concise.");
+    }
+
+    @Test
+    void should_inline_system_messages_per_request_when_model_default_is_disabled() {
+        AnthropicChatModel model = modelBuilder().build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Hi"), SystemMessage.from("From now on, be concise."))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .inlineSystemMessages(true)
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        String body = lastRequestBody();
+        assertThat(body.replaceAll("\\s+", "")).contains("\"role\":\"system\"");
+        assertThat(body).contains("From now on, be concise.");
+    }
+
+    private AnthropicChatModel.AnthropicChatModelBuilder modelBuilder() {
+        return AnthropicChatModel.builder()
+                .baseUrl("http://localhost:" + wireMockServer.port() + "/v1")
+                .apiKey("test-key")
+                .modelName("claude-opus-4-8");
+    }
+
+    private String lastRequestBody() {
+        List<LoggedRequest> requests = wireMockServer.findAll(postRequestedFor(urlPathEqualTo("/v1/messages")));
+        assertThat(requests).hasSize(1);
+        return requests.get(0).getBodyAsString();
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -1,12 +1,14 @@
 package dev.langchain4j.model.anthropic;
 
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.ASSISTANT;
+import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.SYSTEM;
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.USER;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.SERVER_TOOL_RESULTS_KEY;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.retainKeys;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAiMessage;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicMessages;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicSchema;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicSystemPrompt;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicTool;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -625,6 +627,91 @@ class AnthropicMapperTest {
         // FIX: Use extracting("type") to access the internal class field safely
         assertThat(second.cacheControl).isNotNull();
         assertThat(second.cacheControl).extracting("type").isEqualTo("ephemeral");
+    }
+
+    @Test
+    void inline_system_messages_disabled_sends_all_system_messages_via_top_level_system_prompt() {
+        // given
+        List<ChatMessage> messages = asList(
+                SystemMessage.from("leading"),
+                UserMessage.from("hi"),
+                SystemMessage.from("mid-conversation"),
+                UserMessage.from("bye"));
+
+        // when
+        List<AnthropicTextContent> systemPrompt = toAnthropicSystemPrompt(messages, AnthropicCacheType.NO_CACHE, false);
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(messages, false, false);
+
+        // then - both system messages go to the top-level system prompt, none are inlined
+        assertThat(systemPrompt)
+                .containsExactly(new AnthropicTextContent("leading"), new AnthropicTextContent("mid-conversation"));
+        assertThat(anthropicMessages)
+                .containsExactly(
+                        new AnthropicMessage(USER, singletonList(new AnthropicTextContent("hi"))),
+                        new AnthropicMessage(USER, singletonList(new AnthropicTextContent("bye"))));
+    }
+
+    @Test
+    void inline_system_messages_enabled_keeps_only_leading_system_messages_in_top_level_system_prompt() {
+        // given
+        List<ChatMessage> messages = asList(
+                SystemMessage.from("leading-1"),
+                SystemMessage.from("leading-2"),
+                UserMessage.from("hi"),
+                SystemMessage.from("mid-conversation"),
+                UserMessage.from("bye"));
+
+        // when
+        List<AnthropicTextContent> systemPrompt = toAnthropicSystemPrompt(messages, AnthropicCacheType.NO_CACHE, true);
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(messages, false, true);
+
+        // then - only the leading (pre-conversation) system messages populate the top-level system prompt
+        assertThat(systemPrompt)
+                .containsExactly(new AnthropicTextContent("leading-1"), new AnthropicTextContent("leading-2"));
+
+        // and the mid-conversation system message is emitted inline, in order, as a system-role message
+        assertThat(anthropicMessages)
+                .containsExactly(
+                        new AnthropicMessage(USER, singletonList(new AnthropicTextContent("hi"))),
+                        new AnthropicMessage(SYSTEM, singletonList(new AnthropicTextContent("mid-conversation"))),
+                        new AnthropicMessage(USER, singletonList(new AnthropicTextContent("bye"))));
+    }
+
+    @Test
+    void inline_system_messages_enabled_inlines_system_message_after_pending_tool_result() {
+        // given a system message that appears mid-conversation, right after a tool result
+        List<ChatMessage> messages = asList(
+                UserMessage.from("calc 2+2"),
+                AiMessage.from(ToolExecutionRequest.builder()
+                        .id("1")
+                        .name("calculator")
+                        .arguments("{}")
+                        .build()),
+                ToolExecutionResultMessage.from("1", "calculator", "4"),
+                SystemMessage.from("be concise"),
+                UserMessage.from("thanks"));
+
+        // when
+        List<AnthropicTextContent> systemPrompt = toAnthropicSystemPrompt(messages, AnthropicCacheType.NO_CACHE, true);
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(messages, false, true);
+
+        // then - no leading system message, so the top-level system prompt is empty
+        assertThat(systemPrompt).isEmpty();
+
+        // and the pending tool result is flushed before the inline system message, which precedes the next user message
+        assertThat(anthropicMessages)
+                .containsExactly(
+                        new AnthropicMessage(USER, singletonList(new AnthropicTextContent("calc 2+2"))),
+                        new AnthropicMessage(
+                                ASSISTANT,
+                                singletonList(AnthropicToolUseContent.builder()
+                                        .id("1")
+                                        .name("calculator")
+                                        .input("{}")
+                                        .build())),
+                        new AnthropicMessage(USER, singletonList(new AnthropicToolResultContent("1", "4", null))),
+                        new AnthropicMessage(SYSTEM, singletonList(new AnthropicTextContent("be concise"))),
+                        new AnthropicMessage(USER, singletonList(new AnthropicTextContent("thanks"))));
     }
 
     @SafeVarargs

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -630,7 +630,7 @@ class AnthropicMapperTest {
     }
 
     @Test
-    void inline_system_messages_disabled_sends_all_system_messages_via_top_level_system_prompt() {
+    void mid_conversation_system_messages_disabled_sends_all_system_messages_via_top_level_system_prompt() {
         // given
         List<ChatMessage> messages = asList(
                 SystemMessage.from("leading"),
@@ -652,7 +652,7 @@ class AnthropicMapperTest {
     }
 
     @Test
-    void inline_system_messages_enabled_keeps_only_leading_system_messages_in_top_level_system_prompt() {
+    void mid_conversation_system_messages_enabled_keeps_only_leading_system_messages_in_top_level_system_prompt() {
         // given
         List<ChatMessage> messages = asList(
                 SystemMessage.from("leading-1"),
@@ -678,7 +678,7 @@ class AnthropicMapperTest {
     }
 
     @Test
-    void inline_system_messages_enabled_inlines_system_message_after_pending_tool_result() {
+    void mid_conversation_system_messages_enabled_inlines_system_message_after_pending_tool_result() {
         // given a system message that appears mid-conversation, right after a tool result
         List<ChatMessage> messages = asList(
                 UserMessage.from("calc 2+2"),

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMidConversationSystemMessagesTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMidConversationSystemMessagesTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class AnthropicInlineSystemMessagesTest {
+class AnthropicMidConversationSystemMessagesTest {
 
     private WireMockServer wireMockServer;
 
@@ -49,7 +49,7 @@ class AnthropicInlineSystemMessagesTest {
 
     @Test
     void should_send_mid_conversation_system_message_inline_when_enabled() {
-        AnthropicChatModel model = modelBuilder().inlineSystemMessages(true).build();
+        AnthropicChatModel model = modelBuilder().midConversationSystemMessages(true).build();
 
         model.chat(ChatRequest.builder()
                 .messages(
@@ -68,7 +68,7 @@ class AnthropicInlineSystemMessagesTest {
     }
 
     @Test
-    void should_not_inline_system_messages_by_default() {
+    void should_not_mid_conversation_system_messages_by_default() {
         AnthropicChatModel model = modelBuilder().build();
 
         model.chat(ChatRequest.builder()
@@ -85,13 +85,13 @@ class AnthropicInlineSystemMessagesTest {
     }
 
     @Test
-    void should_inline_system_messages_per_request_when_model_default_is_disabled() {
+    void should_mid_conversation_system_messages_per_request_when_model_default_is_disabled() {
         AnthropicChatModel model = modelBuilder().build();
 
         ChatRequest request = ChatRequest.builder()
                 .messages(UserMessage.from("Hi"), SystemMessage.from("From now on, be concise."))
                 .parameters(AnthropicChatRequestParameters.builder()
-                        .inlineSystemMessages(true)
+                        .midConversationSystemMessages(true)
                         .build())
                 .build();
 


### PR DESCRIPTION
## Issue

Closes #5603

## Change

Right now the Anthropic integration folds every `SystemMessage` into the top-level `system` field, so there's no way to use Claude Opus 4.8's [mid-conversation system messages](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages). This adds an opt-in `midConversationSystemMessages` option (default off) that sends a `SystemMessage` appearing after the conversation has started as a `role:"system"` entry in the `messages` array. Leading system messages still go to the top-level `system` field, and with the option off behaviour is unchanged.

The library doesn't enforce or reorder placement: it sends the `SystemMessage` at whatever position the caller put it in, and Anthropic rejects invalid placements with a 400 (an inline system message has to follow a user turn, can't be first, and can't sit between a `tool_use` and its `tool_result`). Those rules are noted on the option's Javadoc.

I've opened this as a draft to get a read on the approach. I don't mind changing how it's exposed if you'd rather it worked differently.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
