### PR TITLE
fix: Throw typed exception for null-valued required skill tool argument

### DIFF
--- a/langchain4j-skills/src/main/java/dev/langchain4j/skills/AbstractSkillToolExecutor.java
+++ b/langchain4j-skills/src/main/java/dev/langchain4j/skills/AbstractSkillToolExecutor.java
@@ -1,15 +1,14 @@
 package dev.langchain4j.skills;
 
+import static dev.langchain4j.internal.Utils.isNullOrEmpty;
+import static dev.langchain4j.internal.Utils.toBase64;
+
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.internal.Json;
 import dev.langchain4j.service.tool.ToolExecutor;
-
 import java.util.Map;
-
-import static dev.langchain4j.internal.Utils.isNullOrEmpty;
-import static dev.langchain4j.internal.Utils.toBase64;
 
 abstract class AbstractSkillToolExecutor implements ToolExecutor {
 
@@ -30,10 +29,11 @@ abstract class AbstractSkillToolExecutor implements ToolExecutor {
     }
 
     protected String getRequiredArgument(String argumentName, Map<String, Object> arguments) {
-        if (isNullOrEmpty(arguments) || !arguments.containsKey(argumentName)) {
+        Object value = isNullOrEmpty(arguments) ? null : arguments.get(argumentName);
+        if (value == null) {
             throwException("Missing required tool argument '%s'".formatted(argumentName));
         }
-        return arguments.get(argumentName).toString();
+        return value.toString();
     }
 
     protected void throwException(String message) {
@@ -42,13 +42,9 @@ abstract class AbstractSkillToolExecutor implements ToolExecutor {
 
     protected void throwException(String message, Exception e) {
         if (throwToolArgumentsExceptions) {
-            throw e == null
-                    ? new ToolArgumentsException(message)
-                    : new ToolArgumentsException(message, e);
+            throw e == null ? new ToolArgumentsException(message) : new ToolArgumentsException(message, e);
         } else {
-            throw e == null
-                    ? new ToolExecutionException(message)
-                    : new ToolExecutionException(message, e);
+            throw e == null ? new ToolExecutionException(message) : new ToolExecutionException(message, e);
         }
     }
 

--- a/langchain4j-skills/src/test/java/dev/langchain4j/skills/ActivateSkillToolExecutorTest.java
+++ b/langchain4j-skills/src/test/java/dev/langchain4j/skills/ActivateSkillToolExecutorTest.java
@@ -1,0 +1,54 @@
+package dev.langchain4j.skills;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.exception.ToolArgumentsException;
+import dev.langchain4j.exception.ToolExecutionException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ActivateSkillToolExecutorTest {
+
+    @Test
+    void should_throw_ToolExecutionException_when_required_argument_value_is_null() {
+        ActivateSkillToolExecutor executor = executor(false);
+
+        assertThatThrownBy(() -> executor.executeWithContext(requestWithRawArguments("{\"skill_name\": null}"), null))
+                .isInstanceOf(ToolExecutionException.class)
+                .hasMessageContaining("Missing required tool argument");
+    }
+
+    @Test
+    void should_throw_ToolArgumentsException_when_required_argument_value_is_null() {
+        ActivateSkillToolExecutor executor = executor(true);
+
+        assertThatThrownBy(() -> executor.executeWithContext(requestWithRawArguments("{\"skill_name\": null}"), null))
+                .isInstanceOf(ToolArgumentsException.class)
+                .hasMessageContaining("Missing required tool argument");
+    }
+
+    @Test
+    void should_throw_ToolExecutionException_when_required_argument_is_missing() {
+        ActivateSkillToolExecutor executor = executor(false);
+
+        assertThatThrownBy(() -> executor.executeWithContext(requestWithRawArguments("{}"), null))
+                .isInstanceOf(ToolExecutionException.class)
+                .hasMessageContaining("Missing required tool argument");
+    }
+
+    private ActivateSkillToolExecutor executor(boolean throwToolArgumentsExceptions) {
+        ActivateSkillToolConfig config = ActivateSkillToolConfig.builder()
+                .throwToolArgumentsExceptions(throwToolArgumentsExceptions)
+                .build();
+        return new ActivateSkillToolExecutor(config, Map.of());
+    }
+
+    private ToolExecutionRequest requestWithRawArguments(String arguments) {
+        return ToolExecutionRequest.builder()
+                .id("1")
+                .name("activate_skill")
+                .arguments(arguments)
+                .build();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5609

## Change

`AbstractSkillToolExecutor.getRequiredArgument(...)` only checked whether the argument key was present (`containsKey`), not whether its value was `null`. A required argument supplied with an explicit `null` value (e.g. `{"skill_name": null}`) passed the check and hit `arguments.get(name).toString()`, throwing an unhandled `NullPointerException` instead of the tool's typed exception.

The value is now resolved once and a single null-check handles both the missing-key and null-value cases:

```java
Object value = isNullOrEmpty(arguments) ? null : arguments.get(argumentName);
if (value == null) {
    throwException("Missing required tool argument '%s'".formatted(argumentName));
}
return value.toString();
```

A null-valued required argument now throws `ToolExecutionException` (default) or `ToolArgumentsException` (when `throwToolArgumentsExceptions` is enabled), same as a missing argument. The public signature and the existing null-map / empty-map behaviour are unchanged (backward compatible). This mirrors the merged sibling fix #5456 for the shell executor.

Added `ActivateSkillToolExecutorTest` with positive/negative cases: null-valued argument raises the correct typed exception under both toggle states, and a missing argument still raises `ToolExecutionException`.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is confined to langchain4j-skills -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — no behaviour to document; bug fix -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->

