### PR TITLE
fix: Include $defs in Vertex AI Anthropic tool input schema for tools using schema references

### DIFF
--- a/langchain4j-vertex-ai-anthropic/src/main/java/dev/langchain4j/model/vertexai/anthropic/internal/mapper/AnthropicRequestMapper.java
+++ b/langchain4j-vertex-ai-anthropic/src/main/java/dev/langchain4j/model/vertexai/anthropic/internal/mapper/AnthropicRequestMapper.java
@@ -21,6 +21,7 @@ import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.vertexai.anthropic.internal.Constants;
 import dev.langchain4j.model.vertexai.anthropic.internal.api.*;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -199,10 +200,15 @@ public class AnthropicRequestMapper {
 
         List<String> required = parameters != null ? parameters.required() : emptyList();
 
-        Map<String, Object> inputSchema = Map.of(
-                "type", "object",
-                "properties", properties,
-                "required", required);
+        Map<String, Object> inputSchema = new LinkedHashMap<>();
+        inputSchema.put("type", "object");
+        inputSchema.put("properties", properties);
+        inputSchema.put("required", required);
+        if (parameters != null
+                && parameters.definitions() != null
+                && !parameters.definitions().isEmpty()) {
+            inputSchema.put("$defs", toMap(parameters.definitions()));
+        }
 
         String description;
         if (isNotNullOrBlank(toolSpecification.description())) {

--- a/langchain4j-vertex-ai-anthropic/src/test/java/dev/langchain4j/model/vertexai/anthropic/internal/mapper/AnthropicRequestMapperTest.java
+++ b/langchain4j-vertex-ai-anthropic/src/test/java/dev/langchain4j/model/vertexai/anthropic/internal/mapper/AnthropicRequestMapperTest.java
@@ -1,0 +1,63 @@
+package dev.langchain4j.model.vertexai.anthropic.internal.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonReferenceSchema;
+import dev.langchain4j.model.vertexai.anthropic.internal.api.AnthropicTool;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AnthropicRequestMapperTest {
+
+    @Test
+    void should_include_defs_when_parameters_have_definitions() {
+        JsonObjectSchema address = JsonObjectSchema.builder()
+                .addStringProperty("street")
+                .addStringProperty("city")
+                .build();
+
+        JsonObjectSchema parameters = JsonObjectSchema.builder()
+                .addProperty(
+                        "address",
+                        JsonReferenceSchema.builder().reference("Address").build())
+                .definitions(Map.of("Address", address))
+                .build();
+
+        ToolSpecification toolSpecification = ToolSpecification.builder()
+                .name("register_address")
+                .description("Registers an address")
+                .parameters(parameters)
+                .build();
+
+        AnthropicTool tool = AnthropicRequestMapper.toAnthropicTool(toolSpecification);
+
+        assertThat(tool.inputSchema).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> inputSchema = (Map<String, Object>) tool.inputSchema;
+        assertThat(inputSchema).containsKey("$defs");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> defs = (Map<String, Object>) inputSchema.get("$defs");
+        assertThat(defs).containsKey("Address");
+    }
+
+    @Test
+    void should_not_include_defs_when_parameters_have_no_definitions() {
+        JsonObjectSchema parameters =
+                JsonObjectSchema.builder().addStringProperty("name").build();
+
+        ToolSpecification toolSpecification = ToolSpecification.builder()
+                .name("greet")
+                .description("Greets a person")
+                .parameters(parameters)
+                .build();
+
+        AnthropicTool tool = AnthropicRequestMapper.toAnthropicTool(toolSpecification);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> inputSchema = (Map<String, Object>) tool.inputSchema;
+        assertThat(inputSchema).doesNotContainKey("$defs");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5613

## Change
`AnthropicRequestMapper.toAnthropicTool()` built a tool `input_schema` from `properties` and `required` only, never reading `parameters.definitions()`. When a parameter references a definition, core `JsonSchemaElementUtils.toMap` emits `{"$ref":"#/$defs/Name"}`, but the matching top-level `$defs` was missing, so a dangling `$ref` schema was sent to the Vertex AI Anthropic API.

The fix adds `$defs` (via core `toMap(parameters.definitions())`) only when `definitions()` is non-empty. Tools without definitions are unchanged (backward compatible). This restores parity with the sibling `langchain4j-anthropic`, which serializes `$defs` in its `toAnthropicTool` (PR #5499).

New unit test `AnthropicRequestMapperTest` covers both cases: parameters referencing a definition yield `$defs` containing it; parameters without definitions have no `$defs` key.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- API 키가 필요한 *IT(@EnabledIfEnvironmentVariable)는 로컬에서 실행하지 않음. 추가/실행한 것은 API 키 불요 단위테스트뿐. -->
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- core/main 단위테스트는 -am 빌드로 함께 실행됨(1254 통과). -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- N/A — 새 maven 모듈 / embedding store 통합과 무관하여 해당 체크리스트 섹션 생략 -->

