### PR TITLE
fix: Map Vertex AI Gemini content-policy finish reasons to CONTENT_FILTER

### DIFF
--- a/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/FinishReasonMapper.java
+++ b/langchain4j-vertex-ai-gemini/src/main/java/dev/langchain4j/model/vertexai/gemini/FinishReasonMapper.java
@@ -12,6 +12,10 @@ class FinishReasonMapper {
             case MAX_TOKENS:
                 return FinishReason.LENGTH;
             case SAFETY:
+            case RECITATION:
+            case BLOCKLIST:
+            case PROHIBITED_CONTENT:
+            case SPII:
                 return FinishReason.CONTENT_FILTER;
         }
         return FinishReason.OTHER;

--- a/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/FinishReasonMapperTest.java
+++ b/langchain4j-vertex-ai-gemini/src/test/java/dev/langchain4j/model/vertexai/gemini/FinishReasonMapperTest.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.model.vertexai.gemini;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.vertexai.api.Candidate;
+import dev.langchain4j.model.output.FinishReason;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class FinishReasonMapperTest {
+
+    @ParameterizedTest
+    @EnumSource(
+            value = Candidate.FinishReason.class,
+            names = {"RECITATION", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII"})
+    void should_map_content_policy_reasons_to_content_filter(Candidate.FinishReason finishReason) {
+        assertThat(FinishReasonMapper.map(finishReason)).isEqualTo(FinishReason.CONTENT_FILTER);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "STOP, STOP",
+        "MAX_TOKENS, LENGTH",
+        "SAFETY, CONTENT_FILTER",
+        "MALFORMED_FUNCTION_CALL, OTHER",
+        "FINISH_REASON_UNSPECIFIED, OTHER"
+    })
+    void should_map_known_and_unmapped_reasons(Candidate.FinishReason finishReason, FinishReason expected) {
+        assertThat(FinishReasonMapper.map(finishReason)).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5614

## Change

`langchain4j-vertex-ai-gemini` `FinishReasonMapper.map` only mapped `STOP`, `MAX_TOKENS` and `SAFETY`. The Vertex SDK content-policy reasons `RECITATION`, `BLOCKLIST`, `PROHIBITED_CONTENT` and `SPII` fell through to the default and were returned as `FinishReason.OTHER`, hiding the fact that the response was blocked by a content policy.

This adds four `case` labels so those reasons return `FinishReason.CONTENT_FILTER`, matching `SAFETY` and the sibling `langchain4j-google-ai-gemini` mapper. The existing three cases and the default `OTHER` are unchanged; `MALFORMED_FUNCTION_CALL` and `FINISH_REASON_UNSPECIFIED` still map to `OTHER`.

```java
case SAFETY:
case RECITATION:
case BLOCKLIST:
case PROHIBITED_CONTENT:
case SPII:
    return FinishReason.CONTENT_FILTER;
```

Added `FinishReasonMapperTest` (new file) covering the four fixed reasons plus regression cases. The four positive assertions fail before this change and pass after.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is isolated to langchain4j-vertex-ai-gemini -->
<!-- Below items wait until the PR is reviewed and approved. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — no doc change for an internal mapper fix -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->

<!-- "new maven module" and "embedding store" checklist sections omitted — not applicable to this fix. -->

