### PR TITLE
Propagate image detail level in OpenAI official chat completions

### DIFF
--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -141,6 +141,7 @@ class InternalOpenAiOfficialHelper {
                         ChatCompletionContentPartImage.ImageUrl.builder();
                 if (imageContent.image().url() != null) {
                     imageUrlBuilder.url(imageContent.image().url().toString());
+                    imageUrlBuilder.detail(toImageDetail(imageContent.detailLevel()));
                     parts.add(ChatCompletionContentPart.ofImageUrl(ChatCompletionContentPartImage.builder()
                             .imageUrl(imageUrlBuilder.build())
                             .build()));
@@ -149,6 +150,7 @@ class InternalOpenAiOfficialHelper {
                     // https://github.com/openai/openai-java/blob/e5b8e55762ecde475fa2de081b770d28537c9cd3/openai-java-core/src/main/kotlin/com/openai/models/ChatCompletionContentPartImage.kt#L130
                     imageUrlBuilder.url("data:" + imageContent.image().mimeType() + ";base64,"
                             + imageContent.image().base64Data());
+                    imageUrlBuilder.detail(toImageDetail(imageContent.detailLevel()));
                     parts.add(ChatCompletionContentPart.ofImageUrl(ChatCompletionContentPartImage.builder()
                             .imageUrl(imageUrlBuilder.build())
                             .build()));
@@ -191,6 +193,17 @@ class InternalOpenAiOfficialHelper {
             }
         }
         return parts;
+    }
+
+    private static ChatCompletionContentPartImage.ImageUrl.Detail toImageDetail(ImageContent.DetailLevel detailLevel) {
+        return switch (detailLevel) {
+            case LOW -> ChatCompletionContentPartImage.ImageUrl.Detail.LOW;
+            case HIGH -> ChatCompletionContentPartImage.ImageUrl.Detail.HIGH;
+            case AUTO -> ChatCompletionContentPartImage.ImageUrl.Detail.AUTO;
+            case MEDIUM, ULTRA_HIGH -> throw new UnsupportedFeatureException(
+                    "DetailLevel " + detailLevel
+                            + " is not supported by OpenAI Chat Completions API. Supported values: LOW, HIGH, AUTO");
+        };
     }
 
     static List<ChatCompletionTool> toTools(Collection<ToolSpecification> toolSpecifications, boolean strict) {

--- a/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
+++ b/langchain4j-open-ai-official/src/main/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelper.java
@@ -200,9 +200,9 @@ class InternalOpenAiOfficialHelper {
             case LOW -> ChatCompletionContentPartImage.ImageUrl.Detail.LOW;
             case HIGH -> ChatCompletionContentPartImage.ImageUrl.Detail.HIGH;
             case AUTO -> ChatCompletionContentPartImage.ImageUrl.Detail.AUTO;
-            case MEDIUM, ULTRA_HIGH -> throw new UnsupportedFeatureException(
-                    "DetailLevel " + detailLevel
-                            + " is not supported by OpenAI Chat Completions API. Supported values: LOW, HIGH, AUTO");
+            case MEDIUM, ULTRA_HIGH ->
+                throw new UnsupportedFeatureException("DetailLevel " + detailLevel
+                        + " is not supported by OpenAI Chat Completions API. Supported values: LOW, HIGH, AUTO");
         };
     }
 

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
@@ -50,8 +50,8 @@ class InternalOpenAiOfficialHelperTest {
 
     @Test
     void should_set_image_detail_for_url_image() {
-        UserMessage message = UserMessage.from(ImageContent.from(
-                "https://example.com/image.png", ImageContent.DetailLevel.HIGH));
+        UserMessage message =
+                UserMessage.from(ImageContent.from("https://example.com/image.png", ImageContent.DetailLevel.HIGH));
 
         ChatCompletionMessageParam param = InternalOpenAiOfficialHelper.toOpenAiMessage(message);
 
@@ -83,8 +83,8 @@ class InternalOpenAiOfficialHelperTest {
 
     @Test
     void should_throw_when_image_detail_is_not_supported_by_openai_chat_completions() {
-        UserMessage message = UserMessage.from(ImageContent.from(
-                "https://example.com/image.png", ImageContent.DetailLevel.ULTRA_HIGH));
+        UserMessage message = UserMessage.from(
+                ImageContent.from("https://example.com/image.png", ImageContent.DetailLevel.ULTRA_HIGH));
 
         assertThatThrownBy(() -> InternalOpenAiOfficialHelper.toOpenAiMessage(message))
                 .isInstanceOf(UnsupportedFeatureException.class)

--- a/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
+++ b/langchain4j-open-ai-official/src/test/java/dev/langchain4j/model/openaiofficial/InternalOpenAiOfficialHelperTest.java
@@ -1,11 +1,15 @@
 package dev.langchain4j.model.openaiofficial;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.openai.models.chat.completions.ChatCompletionContentPartImage;
 import com.openai.models.chat.completions.ChatCompletionContentPartInputAudio;
 import com.openai.models.chat.completions.ChatCompletionMessageParam;
 import dev.langchain4j.data.message.AudioContent;
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.UnsupportedFeatureException;
 import org.junit.jupiter.api.Test;
 
 class InternalOpenAiOfficialHelperTest {
@@ -42,5 +46,49 @@ class InternalOpenAiOfficialHelperTest {
                         .inputAudio()
                         .format())
                 .isEqualTo(ChatCompletionContentPartInputAudio.InputAudio.Format.MP3);
+    }
+
+    @Test
+    void should_set_image_detail_for_url_image() {
+        UserMessage message = UserMessage.from(ImageContent.from(
+                "https://example.com/image.png", ImageContent.DetailLevel.HIGH));
+
+        ChatCompletionMessageParam param = InternalOpenAiOfficialHelper.toOpenAiMessage(message);
+
+        ChatCompletionContentPartImage.ImageUrl imageUrl = param.asUser()
+                .content()
+                .asArrayOfContentParts()
+                .get(0)
+                .asImageUrl()
+                .imageUrl();
+        assertThat(imageUrl.url()).isEqualTo("https://example.com/image.png");
+        assertThat(imageUrl.detail()).contains(ChatCompletionContentPartImage.ImageUrl.Detail.HIGH);
+    }
+
+    @Test
+    void should_set_image_detail_for_base64_image() {
+        UserMessage message = UserMessage.from(ImageContent.from("QUJD", "image/png", ImageContent.DetailLevel.LOW));
+
+        ChatCompletionMessageParam param = InternalOpenAiOfficialHelper.toOpenAiMessage(message);
+
+        ChatCompletionContentPartImage.ImageUrl imageUrl = param.asUser()
+                .content()
+                .asArrayOfContentParts()
+                .get(0)
+                .asImageUrl()
+                .imageUrl();
+        assertThat(imageUrl.url()).isEqualTo("data:image/png;base64,QUJD");
+        assertThat(imageUrl.detail()).contains(ChatCompletionContentPartImage.ImageUrl.Detail.LOW);
+    }
+
+    @Test
+    void should_throw_when_image_detail_is_not_supported_by_openai_chat_completions() {
+        UserMessage message = UserMessage.from(ImageContent.from(
+                "https://example.com/image.png", ImageContent.DetailLevel.ULTRA_HIGH));
+
+        assertThatThrownBy(() -> InternalOpenAiOfficialHelper.toOpenAiMessage(message))
+                .isInstanceOf(UnsupportedFeatureException.class)
+                .hasMessageContaining("ULTRA_HIGH")
+                .hasMessageContaining("LOW, HIGH, AUTO");
     }
 }


### PR DESCRIPTION
## Summary
- Propagate `ImageContent.detailLevel()` to the OpenAI official Java SDK chat completions image URL payload.
- Fail fast for `MEDIUM` and `ULTRA_HIGH`, which are not supported by OpenAI Chat Completions image detail.
- Add unit coverage for URL images, base64 images, and unsupported detail levels.

## Test Plan
- `./mvnw.cmd -s .codex-maven-settings.xml -B -U -pl langchain4j-open-ai-official -am "-Dtest=InternalOpenAiOfficialHelperTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`
- Temporarily removed the production detail mapping and confirmed the new tests fail with 3 failures, then restored the fix and confirmed the same test command passes.