### PR TITLE
fix: Skip search results with unresolvable URIs in GoogleCustomWebSearchEngine

### DIFF
--- a/web-search-engines/langchain4j-web-search-engine-google-custom/src/main/java/dev/langchain4j/web/search/google/customsearch/GoogleCustomWebSearchEngine.java
+++ b/web-search-engines/langchain4j-web-search-engine-google-custom/src/main/java/dev/langchain4j/web/search/google/customsearch/GoogleCustomWebSearchEngine.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * An implementation of a {@link WebSearchEngine} that uses
@@ -126,16 +127,7 @@ public class GoogleCustomWebSearchEngine implements WebSearchEngine {
         if (Boolean.TRUE.equals(includeImages) && !searchTypeImage) {
             requestQuery.setSearchType("image");
             Search imagesSearch = googleCustomSearchApiClient.searchResults(requestQuery);
-            if (!isNullOrEmpty(imagesSearch.getItems())) {
-                List<ImageSearchResult> images = imagesSearch.getItems().stream()
-                        .map(result -> ImageSearchResult.from(
-                                result.getTitle(),
-                                createUriSafely(result.getLink()),
-                                createUriSafely(result.getImage().getContextLink()),
-                                createUriSafely(result.getImage().getThumbnailLink())))
-                        .collect(toList());
-                addImagesToSearchInformation(searchInformationMetadata, images);
-            }
+            addImagesToSearchInformation(searchInformationMetadata, toImageSearchResults(imagesSearch));
         }
 
         return WebSearchResults.from(
@@ -155,6 +147,28 @@ public class GoogleCustomWebSearchEngine implements WebSearchEngine {
         if (!isNullOrEmpty(images)) {
             searchInformationMetadata.put("images", images);
         }
+    }
+
+    static List<ImageSearchResult> toImageSearchResults(Search imagesSearch) {
+        if (isNullOrEmpty(imagesSearch.getItems())) {
+            return new ArrayList<>();
+        }
+        return imagesSearch.getItems().stream()
+                .map(result -> {
+                    // Skip results whose primary image link cannot be resolved into a URI,
+                    // so a single unresolvable link does not abort the whole search.
+                    URI imageLink = createUriSafely(result.getLink());
+                    if (imageLink == null) {
+                        return null;
+                    }
+                    return ImageSearchResult.from(
+                            result.getTitle(),
+                            imageLink,
+                            createUriSafely(result.getImage().getContextLink()),
+                            createUriSafely(result.getImage().getThumbnailLink()));
+                })
+                .filter(Objects::nonNull)
+                .collect(toList());
     }
 
     private static Map<String, Object> toSearchMetadata(Search search, boolean searchTypeImage) {
@@ -203,19 +217,27 @@ public class GoogleCustomWebSearchEngine implements WebSearchEngine {
         return Collections.emptyMap();
     }
 
-    private static List<WebSearchOrganicResult> toWebSearchOrganicResults(Search search, Boolean searchTypeImage) {
-        List<WebSearchOrganicResult> organicResults = new ArrayList<>();
-        if (!isNullOrEmpty(search.getItems())) {
-            organicResults = search.getItems().stream()
-                    .map(result -> WebSearchOrganicResult.from(
+    static List<WebSearchOrganicResult> toWebSearchOrganicResults(Search search, Boolean searchTypeImage) {
+        if (isNullOrEmpty(search.getItems())) {
+            return new ArrayList<>();
+        }
+        return search.getItems().stream()
+                .map(result -> {
+                    // Skip results whose link cannot be resolved into a URI,
+                    // so a single unresolvable link does not abort the whole search.
+                    URI url = createUriSafely(result.getLink());
+                    if (url == null) {
+                        return null;
+                    }
+                    return WebSearchOrganicResult.from(
                             result.getTitle(),
-                            createUriSafely(result.getLink()),
+                            url,
                             result.getSnippet(),
                             null, // by default google custom search api does not return content
-                            toResultMetadataMap(result, searchTypeImage)))
-                    .collect(toList());
-        }
-        return organicResults;
+                            toResultMetadataMap(result, searchTypeImage));
+                })
+                .filter(Objects::nonNull)
+                .collect(toList());
     }
 
     private static Integer calculatePageNumberFromQueries(GenericJson query) {

--- a/web-search-engines/langchain4j-web-search-engine-google-custom/src/test/java/dev/langchain4j/web/search/google/customsearch/GoogleCustomWebSearchEngineTest.java
+++ b/web-search-engines/langchain4j-web-search-engine-google-custom/src/test/java/dev/langchain4j/web/search/google/customsearch/GoogleCustomWebSearchEngineTest.java
@@ -1,0 +1,144 @@
+package dev.langchain4j.web.search.google.customsearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.google.api.services.customsearch.v1.model.Result;
+import com.google.api.services.customsearch.v1.model.Search;
+import dev.langchain4j.web.search.WebSearchOrganicResult;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GoogleCustomWebSearchEngineTest {
+
+    // createUriSafely returns null for this input even after percent-encoding,
+    // see GoogleCustomWebSearchUtilsTest#createUriSafely_withSeverelyInvalidUri_returnsNull
+    private static final String UNRESOLVABLE_LINK = "ht[tp://example.com with spaces and [brackets] and {braces}";
+
+    private static Result organicItem(String title, String link) {
+        return new Result().setTitle(title).setLink(link).setSnippet("snippet of " + title);
+    }
+
+    private static Result imageItem(String title, String link, String contextLink, String thumbnailLink) {
+        return new Result()
+                .setTitle(title)
+                .setLink(link)
+                .setImage(new Result.Image().setContextLink(contextLink).setThumbnailLink(thumbnailLink));
+    }
+
+    @Test
+    void toWebSearchOrganicResults_mapsAllValidResults() {
+        Search search = new Search()
+                .setItems(List.of(
+                        organicItem("First", "https://example.com/a"), organicItem("Second", "https://example.com/b")));
+
+        List<WebSearchOrganicResult> results = GoogleCustomWebSearchEngine.toWebSearchOrganicResults(search, false);
+
+        assertThat(results).hasSize(2);
+        assertThat(results)
+                .extracting(r -> r.url().toString())
+                .containsExactly("https://example.com/a", "https://example.com/b");
+    }
+
+    @Test
+    void toWebSearchOrganicResults_skipsResultWithUnresolvableUriAndKeepsTheRest() {
+        Search search = new Search()
+                .setItems(List.of(
+                        organicItem("Valid before", "https://example.com/a"),
+                        organicItem("Broken", UNRESOLVABLE_LINK),
+                        organicItem("Valid after", "https://example.com/b")));
+
+        List<WebSearchOrganicResult> results = GoogleCustomWebSearchEngine.toWebSearchOrganicResults(search, false);
+
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(WebSearchOrganicResult::title).containsExactly("Valid before", "Valid after");
+    }
+
+    @Test
+    void toWebSearchOrganicResults_withNullItems_returnsEmptyList() {
+        assertThat(GoogleCustomWebSearchEngine.toWebSearchOrganicResults(new Search(), false))
+                .isEmpty();
+    }
+
+    @Test
+    void toImageSearchResults_mapsAllValidResults() {
+        Search search = new Search()
+                .setItems(List.of(
+                        imageItem(
+                                "First",
+                                "https://example.com/a.png",
+                                "https://example.com/a",
+                                "https://example.com/a-thumb.png"),
+                        imageItem(
+                                "Second",
+                                "https://example.com/b.png",
+                                "https://example.com/b",
+                                "https://example.com/b-thumb.png")));
+
+        List<GoogleCustomWebSearchEngine.ImageSearchResult> results =
+                GoogleCustomWebSearchEngine.toImageSearchResults(search);
+
+        assertThat(results).hasSize(2);
+        assertThat(results)
+                .extracting(r -> r.imageLink().toString())
+                .containsExactly("https://example.com/a.png", "https://example.com/b.png");
+    }
+
+    @Test
+    void toImageSearchResults_skipsResultWithUnresolvableImageLinkAndKeepsTheRest() {
+        Search search = new Search()
+                .setItems(List.of(
+                        imageItem(
+                                "Valid",
+                                "https://example.com/a.png",
+                                "https://example.com/a",
+                                "https://example.com/a-thumb.png"),
+                        imageItem(
+                                "Broken",
+                                UNRESOLVABLE_LINK,
+                                "https://example.com/b",
+                                "https://example.com/b-thumb.png")));
+
+        List<GoogleCustomWebSearchEngine.ImageSearchResult> results =
+                GoogleCustomWebSearchEngine.toImageSearchResults(search);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).title()).isEqualTo("Valid");
+    }
+
+    @Test
+    void toImageSearchResults_keepsResultWhenOnlyContextAndThumbnailLinksAreUnresolvable() {
+        Search search = new Search()
+                .setItems(List.of(imageItem(
+                        "Valid main link", "https://example.com/a.png", UNRESOLVABLE_LINK, UNRESOLVABLE_LINK)));
+
+        List<GoogleCustomWebSearchEngine.ImageSearchResult> results =
+                GoogleCustomWebSearchEngine.toImageSearchResults(search);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).imageLink().toString()).isEqualTo("https://example.com/a.png");
+        assertThat(results.get(0).contextLink()).isNull();
+        assertThat(results.get(0).thumbnailLink()).isNull();
+    }
+
+    @Test
+    void toImageSearchResults_withNullItems_returnsEmptyList() {
+        assertThat(GoogleCustomWebSearchEngine.toImageSearchResults(new Search()))
+                .isEmpty();
+    }
+
+    @Test
+    void mappingDoesNotThrowWhenEveryLinkIsUnresolvable() {
+        Search organic = new Search().setItems(List.of(organicItem("Broken", UNRESOLVABLE_LINK)));
+        Search images = new Search()
+                .setItems(List.of(imageItem("Broken", UNRESOLVABLE_LINK, UNRESOLVABLE_LINK, UNRESOLVABLE_LINK)));
+
+        assertThatCode(() -> {
+                    assertThat(GoogleCustomWebSearchEngine.toWebSearchOrganicResults(organic, false))
+                            .isEmpty();
+                    assertThat(GoogleCustomWebSearchEngine.toImageSearchResults(images))
+                            .isEmpty();
+                })
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5627

## Change

`GoogleCustomWebSearchEngine` aborted the whole search when one result link could not be parsed into a URI.

`UriUtils.createUriSafely` returns `null` for links that percent-encoding cannot repair. That `null` reached `WebSearchOrganicResult.from(...)`, whose constructor calls `ensureNotNull(url, "url")` and threw `IllegalArgumentException`, which propagated out of the stream. The image branch had the same problem on the primary image link.

Both mapping paths now skip a result whose primary link resolves to `null` and keep the rest. For images, only the primary `imageLink` triggers a skip; `contextLink` and `thumbnailLink` stay nullable as before, so their absence does not drop a result.

To make the mapping unit-testable without an API key, `toWebSearchOrganicResults` is now package-private and the inline image-mapping lambda is extracted into a package-private `toImageSearchResults(Search)` helper. Valid links map exactly as before.

This completes the fix for #3588 (the encoding part was handled in #3589).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- "new maven module" and "embedding store" checklist sections omitted: not applicable (no new module, not an embedding store). -->
