### PR TITLE
fix: honor root metadata mode in Weaviate removeAll(Filter)

### DIFF
--- a/langchain4j-weaviate/src/main/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStore.java
+++ b/langchain4j-weaviate/src/main/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStore.java
@@ -211,29 +211,52 @@ public class WeaviateEmbeddingStore implements EmbeddingStore<TextSegment> {
         // WhereFilter cannot reliably filter nested map fields.
         // Therefore we fallback to client-side filtering.
 
-        List<String> idsToDelete = client.data().objectsGetter().withClassName(objectClass).run().getResult().stream()
-                .filter(obj -> {
-                    if (obj.getProperties() == null) {
-                        return false;
-                    }
+        List<WeaviateObject> objects =
+                client.data().objectsGetter().withClassName(objectClass).run().getResult();
 
-                    Object metadataObj = obj.getProperties().get(metadataFieldName);
+        if (objects == null || objects.isEmpty()) {
+            return;
+        }
 
-                    if (!(metadataObj instanceof Map)) {
-                        return false;
-                    }
-
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> metadata = (Map<String, Object>) metadataObj;
-
-                    return filter.test(new Metadata(metadata));
-                })
+        List<String> idsToDelete = objects.stream()
+                .filter(obj -> obj.getProperties() != null
+                        && matchesFilter(obj.getProperties(), metadataFieldName, textFieldName, filter))
                 .map(WeaviateObject::getId)
                 .collect(Collectors.toList());
 
         if (!idsToDelete.isEmpty()) {
             removeAll(idsToDelete);
         }
+    }
+
+    /**
+     * Tests a stored object's properties against the given filter, mirroring the dual storage modes
+     * of {@link #toMetadata(Map)}. In nested mode the metadata is read from {@code metadataFieldName};
+     * in root mode ({@code metadataFieldName} is empty) the metadata is taken from the properties
+     * themselves, excluding the text field and Weaviate's internal index flags, which are not valid
+     * {@link Metadata} values.
+     */
+    static boolean matchesFilter(
+            Map<String, Object> properties, String metadataFieldName, String textFieldName, Filter filter) {
+        Map<String, Object> metadata;
+        if (metadataFieldName.isEmpty()) {
+            metadata = new HashMap<>(properties);
+            metadata.remove(textFieldName);
+            metadata.remove(ADDITIONALS);
+            metadata.remove("indexFilterable");
+            metadata.remove("indexSearchable");
+            metadata.values().removeIf(NULL_VALUE::equals);
+        } else {
+            Object metadataObj = properties.get(metadataFieldName);
+            if (!(metadataObj instanceof Map)) {
+                return false;
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> nested = (Map<String, Object>) metadataObj;
+            metadata = nested;
+        }
+
+        return filter.test(new Metadata(metadata));
     }
 
     /**

--- a/langchain4j-weaviate/src/test/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStoreTest.java
+++ b/langchain4j-weaviate/src/test/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStoreTest.java
@@ -1,0 +1,97 @@
+package dev.langchain4j.store.embedding.weaviate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WeaviateEmbeddingStoreTest {
+
+    private static final String TEXT_FIELD = "text";
+    private static final String METADATA_FIELD = "_metadata";
+
+    private static Map<String, Object> rootModeProperties() {
+        // Mirrors what buildObject() stores in root metadata mode: text, the Boolean index flags,
+        // and metadata entries flattened into the root of the object.
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(TEXT_FIELD, "hello");
+        properties.put("indexFilterable", true);
+        properties.put("indexSearchable", true);
+        properties.put("key", "value");
+        return properties;
+    }
+
+    private static Map<String, Object> nestedModeProperties() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("key", "value");
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(TEXT_FIELD, "hello");
+        properties.put("indexFilterable", true);
+        properties.put("indexSearchable", true);
+        properties.put(METADATA_FIELD, metadata);
+        return properties;
+    }
+
+    @Test
+    void should_match_root_mode_when_filter_matches() {
+        Filter filter = new IsEqualTo("key", "value");
+
+        boolean matched = WeaviateEmbeddingStore.matchesFilter(rootModeProperties(), "", TEXT_FIELD, filter);
+
+        assertThat(matched).isTrue();
+    }
+
+    @Test
+    void should_not_match_root_mode_when_filter_does_not_match() {
+        Filter filter = new IsEqualTo("key", "other");
+
+        boolean matched = WeaviateEmbeddingStore.matchesFilter(rootModeProperties(), "", TEXT_FIELD, filter);
+
+        assertThat(matched).isFalse();
+    }
+
+    @Test
+    void should_match_nested_mode_when_filter_matches() {
+        Filter filter = new IsEqualTo("key", "value");
+
+        boolean matched =
+                WeaviateEmbeddingStore.matchesFilter(nestedModeProperties(), METADATA_FIELD, TEXT_FIELD, filter);
+
+        assertThat(matched).isTrue();
+    }
+
+    @Test
+    void should_not_match_nested_mode_when_filter_does_not_match() {
+        Filter filter = new IsEqualTo("key", "other");
+
+        boolean matched =
+                WeaviateEmbeddingStore.matchesFilter(nestedModeProperties(), METADATA_FIELD, TEXT_FIELD, filter);
+
+        assertThat(matched).isFalse();
+    }
+
+    @Test
+    void should_not_match_nested_mode_when_metadata_field_is_missing() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(TEXT_FIELD, "hello");
+        Filter filter = new IsEqualTo("key", "value");
+
+        boolean matched = WeaviateEmbeddingStore.matchesFilter(properties, METADATA_FIELD, TEXT_FIELD, filter);
+
+        assertThat(matched).isFalse();
+    }
+
+    @Test
+    void should_not_throw_when_root_properties_contain_boolean_index_flags() {
+        Filter filter = new IsEqualTo("key", "value");
+
+        // Boolean index flags are not supported Metadata value types; matchesFilter must strip them
+        // before constructing Metadata, otherwise new Metadata(...) throws IllegalArgumentException.
+        assertThatCode(() -> WeaviateEmbeddingStore.matchesFilter(rootModeProperties(), "", TEXT_FIELD, filter))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5630

## Change

This PR fixes two things in `WeaviateEmbeddingStore.removeAll(Filter)`:

1. **Root metadata mode fix (main change).** In root metadata mode (`metadataFieldName("")`) metadata is flattened into the object root, but `removeAll(Filter)` looked it up via `properties.get(metadataFieldName)` (`get("")` → always `null`), so the `instanceof Map` check failed for every object and nothing was deleted. The predicate is now extracted into a package-private static helper `matchesFilter(...)` that branches on both storage modes, mirroring the existing `toMetadata` read path. In root mode it reads the metadata from the properties, removing the text field, Weaviate's internal `indexFilterable`/`indexSearchable` flags (Boolean values `Metadata` does not support), and `<null>` placeholders. Nested mode behaviour is unchanged.

2. **Null guard on the same call (minor, separable).** `objectsGetter()...getResult()` had no null guard, unlike the sibling `removeAll()`. Added `objects == null || objects.isEmpty()` to match. Reviewers who prefer can ask to split this out.

New unit tests cover root and nested modes (positive and negative) and confirm the Boolean index flags no longer trigger an exception.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
<!-- Unit tests run and green; the module's *IT require a live Weaviate / credentials and were not run locally. -->
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- N/A — change is confined to langchain4j-weaviate; core/main were not modified. -->
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
<!-- Docs/examples deferred until review, per template. -->
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

<!-- N/A — no new maven module added. -->
<!-- N/A — no new embedding store integration added. -->

## Checklist for changing existing embedding store integration
<!-- Requires a live Weaviate instance / credentials (*IT). Not run locally. -->
- [ ] I have manually verified that the `WeaviateEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

---

