### PR TITLE
fix: Override equals, hashCode and toString in WatsonxChatRequestParameters

### DIFF
--- a/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParameters.java
+++ b/langchain4j-watsonx/src/main/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParameters.java
@@ -10,6 +10,7 @@ import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
@@ -130,6 +131,80 @@ public class WatsonxChatRequestParameters extends DefaultChatRequestParameters {
                 .overrideWith(that)
                 .overrideWith(this)
                 .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        WatsonxChatRequestParameters that = (WatsonxChatRequestParameters) o;
+        return Objects.equals(projectId, that.projectId)
+                && Objects.equals(spaceId, that.spaceId)
+                && Objects.equals(thinking, that.thinking)
+                && Objects.equals(logitBias, that.logitBias)
+                && Objects.equals(logprobs, that.logprobs)
+                && Objects.equals(topLogprobs, that.topLogprobs)
+                && Objects.equals(seed, that.seed)
+                && Objects.equals(toolChoiceName, that.toolChoiceName)
+                && Objects.equals(guidedChoice, that.guidedChoice)
+                && Objects.equals(guidedRegex, that.guidedRegex)
+                && Objects.equals(guidedGrammar, that.guidedGrammar)
+                && Objects.equals(repetitionPenalty, that.repetitionPenalty)
+                && Objects.equals(lengthPenalty, that.lengthPenalty)
+                && Objects.equals(deploymentId, that.deploymentId)
+                && Objects.equals(timeout, that.timeout);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                super.hashCode(),
+                projectId,
+                spaceId,
+                thinking,
+                logitBias,
+                logprobs,
+                topLogprobs,
+                seed,
+                toolChoiceName,
+                guidedChoice,
+                guidedRegex,
+                guidedGrammar,
+                repetitionPenalty,
+                lengthPenalty,
+                deploymentId,
+                timeout);
+    }
+
+    @Override
+    public String toString() {
+        return "WatsonxChatRequestParameters{" + "modelName="
+                + modelName() + ", temperature="
+                + temperature() + ", topP="
+                + topP() + ", topK="
+                + topK() + ", frequencyPenalty="
+                + frequencyPenalty() + ", presencePenalty="
+                + presencePenalty() + ", maxOutputTokens="
+                + maxOutputTokens() + ", stopSequences="
+                + stopSequences() + ", toolSpecifications="
+                + toolSpecifications() + ", toolChoice="
+                + toolChoice() + ", responseFormat="
+                + responseFormat() + ", projectId="
+                + projectId + ", spaceId="
+                + spaceId + ", thinking="
+                + thinking + ", logitBias="
+                + logitBias + ", logprobs="
+                + logprobs + ", topLogprobs="
+                + topLogprobs + ", seed="
+                + seed + ", toolChoiceName="
+                + toolChoiceName + ", guidedChoice="
+                + guidedChoice + ", guidedRegex="
+                + guidedRegex + ", guidedGrammar="
+                + guidedGrammar + ", repetitionPenalty="
+                + repetitionPenalty + ", lengthPenalty="
+                + lengthPenalty + ", deploymentId="
+                + deploymentId + ", timeout="
+                + timeout + '}';
     }
 
     public static class Builder extends DefaultChatRequestParameters.Builder<Builder> {

--- a/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParametersTest.java
+++ b/langchain4j-watsonx/src/test/java/dev/langchain4j/model/watsonx/WatsonxChatRequestParametersTest.java
@@ -1,0 +1,84 @@
+package dev.langchain4j.model.watsonx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class WatsonxChatRequestParametersTest {
+
+    private static WatsonxChatRequestParameters.Builder fullyPopulated() {
+        return WatsonxChatRequestParameters.builder()
+                // common (parent) fields
+                .modelName("ibm/granite-3-8b-instruct")
+                .temperature(0.7)
+                .maxOutputTokens(100)
+                // watsonx-specific fields
+                .projectId("project-id")
+                .spaceId("space-id")
+                .logitBias(Map.of("token", 1))
+                .logprobs(true)
+                .topLogprobs(5)
+                .seed(42)
+                .toolChoiceName("tool")
+                .timeout(Duration.ofSeconds(10))
+                .guidedChoice(Set.of("a", "b"))
+                .guidedRegex("[0-9]+")
+                .guidedGrammar("grammar")
+                .repetitionPenalty(1.1)
+                .lengthPenalty(1.2)
+                .deploymentId("deployment-id");
+    }
+
+    @Test
+    void equals_and_hashCode_should_include_watsonx_fields() {
+        WatsonxChatRequestParameters params1 = fullyPopulated().build();
+        WatsonxChatRequestParameters params2 = fullyPopulated().build();
+
+        assertThat(params1).isEqualTo(params2);
+        assertThat(params1.hashCode()).isEqualTo(params2.hashCode());
+    }
+
+    @Test
+    void equals_should_distinguish_each_watsonx_field() {
+        WatsonxChatRequestParameters base = fullyPopulated().build();
+
+        assertThat(base).isNotEqualTo(fullyPopulated().projectId("other").build());
+        assertThat(base).isNotEqualTo(fullyPopulated().spaceId("other").build());
+        assertThat(base)
+                .isNotEqualTo(fullyPopulated().logitBias(Map.of("token", 2)).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().logprobs(false).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().topLogprobs(9).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().seed(7).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().toolChoiceName("other").build());
+        assertThat(base)
+                .isNotEqualTo(fullyPopulated().timeout(Duration.ofSeconds(20)).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().guidedChoice(Set.of("c")).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().guidedRegex("[a-z]+").build());
+        assertThat(base).isNotEqualTo(fullyPopulated().guidedGrammar("other").build());
+        assertThat(base).isNotEqualTo(fullyPopulated().repetitionPenalty(2.0).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().lengthPenalty(2.0).build());
+        assertThat(base).isNotEqualTo(fullyPopulated().deploymentId("other").build());
+    }
+
+    @Test
+    void equals_should_still_honor_inherited_fields() {
+        WatsonxChatRequestParameters base = fullyPopulated().build();
+
+        assertThat(base).isNotEqualTo(fullyPopulated().modelName("other").build());
+        assertThat(base).isNotEqualTo(fullyPopulated().temperature(0.1).build());
+    }
+
+    @Test
+    void toString_should_include_watsonx_fields() {
+        String text = fullyPopulated().build().toString();
+
+        assertThat(text)
+                .contains("projectId=project-id")
+                .contains("spaceId=space-id")
+                .contains("seed=42")
+                .contains("deploymentId=deployment-id");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5635

## Change

`WatsonxChatRequestParameters` adds 15 fields on top of `DefaultChatRequestParameters` but did not override `equals()`, `hashCode()` or `toString()`. The inherited implementations compare only the 11 common fields, so two instances differing only in a watsonx-specific field (e.g. `projectId`, `seed`, `deploymentId`) were wrongly equal and shared a hash code, and `toString()` hid those fields.

This adds the three overrides, following the existing pattern in the sibling provider parameter classes (`OpenAiChatRequestParameters`, `OllamaChatRequestParameters`, `AnthropicChatRequestParameters`): `equals()` delegates to `super.equals(o)` then compares the watsonx fields, `hashCode()` combines `super.hashCode()` with them, and `toString()` lists all fields. No existing field, signature or behaviour changes — the methods are only added.

`WatsonxChatRequestParametersTest` is added: equal instances are equal with matching hash codes, instances differing in each watsonx field are not equal, inherited-field differences are still honoured, and `toString()` includes the watsonx fields.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is isolated to langchain4j-watsonx; core/main untouched -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — wait until approved -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->


