### PR TITLE
fix: Decode Voyage AI base64 embeddings as little-endian

### DIFF
--- a/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiEmbeddingDeserializer.java
+++ b/langchain4j-voyage-ai/src/main/java/dev/langchain4j/model/voyageai/VoyageAiEmbeddingDeserializer.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -29,7 +29,8 @@ class VoyageAiEmbeddingDeserializer extends StdDeserializer<List<EmbeddingRespon
     }
 
     @Override
-    public List<EmbeddingResponse.EmbeddingData> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public List<EmbeddingResponse.EmbeddingData> deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
         JsonNode dataNode = p.getCodec().readTree(p);
 
         if (dataNode != null && dataNode.isArray()) {
@@ -50,7 +51,10 @@ class VoyageAiEmbeddingDeserializer extends StdDeserializer<List<EmbeddingRespon
                     throw new RuntimeException("Unexpected embedding " + embeddingNode);
                 }
 
-                embeddings.add(new EmbeddingResponse.EmbeddingData(data.get("object").asText(), embedding, data.get("index").asInt()));
+                embeddings.add(new EmbeddingResponse.EmbeddingData(
+                        data.get("object").asText(),
+                        embedding,
+                        data.get("index").asInt()));
             }
 
             return embeddings;
@@ -62,7 +66,7 @@ class VoyageAiEmbeddingDeserializer extends StdDeserializer<List<EmbeddingRespon
     private List<Float> decodeBase64ToFloatList(String base64String) {
         byte[] bytes = BASE64_DECODER.decode(base64String);
         List<Float> embedding = new ArrayList<>();
-        ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+        ByteBuffer byteBuffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
 
         while (byteBuffer.remaining() >= Float.BYTES) {
             embedding.add(byteBuffer.getFloat());

--- a/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiEmbeddingDeserializerTest.java
+++ b/langchain4j-voyage-ai/src/test/java/dev/langchain4j/model/voyageai/VoyageAiEmbeddingDeserializerTest.java
@@ -1,23 +1,23 @@
 package dev.langchain4j.model.voyageai;
 
+import static dev.langchain4j.model.voyageai.VoyageAiJsonUtils.getObjectMapper;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Base64;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Base64;
-import java.util.List;
-
-import static dev.langchain4j.model.voyageai.VoyageAiJsonUtils.getObjectMapper;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(MockitoExtension.class)
 class VoyageAiEmbeddingDeserializerTest {
@@ -26,8 +26,10 @@ class VoyageAiEmbeddingDeserializerTest {
 
     @Mock
     JsonParser jsonParser;
+
     @Mock
     DeserializationContext deserializationContext;
+
     @Mock
     ObjectCodec objectCodec;
 
@@ -35,13 +37,15 @@ class VoyageAiEmbeddingDeserializerTest {
     void should_deserialize_correctly() throws IOException {
 
         // given
-        JsonNode dataNode = OBJECT_MAPPER.readTree("[{\"object\":\"embedding\",\"embedding\":[1.1, 2.2, 3.3],\"index\":0},{\"object\":\"embedding\",\"embedding\":[4.4, 5.5, 6.6],\"index\":1}]");
+        JsonNode dataNode = OBJECT_MAPPER.readTree(
+                "[{\"object\":\"embedding\",\"embedding\":[1.1, 2.2, 3.3],\"index\":0},{\"object\":\"embedding\",\"embedding\":[4.4, 5.5, 6.6],\"index\":1}]");
         doReturn(objectCodec).when(jsonParser).getCodec();
         doReturn(dataNode).when(objectCodec).readTree(jsonParser);
         VoyageAiEmbeddingDeserializer deserializer = new VoyageAiEmbeddingDeserializer();
 
         // when
-        List<EmbeddingResponse.EmbeddingData> embeddingDataList = deserializer.deserialize(jsonParser, deserializationContext);
+        List<EmbeddingResponse.EmbeddingData> embeddingDataList =
+                deserializer.deserialize(jsonParser, deserializationContext);
 
         // then
         assertThat(embeddingDataList).hasSize(2);
@@ -53,16 +57,19 @@ class VoyageAiEmbeddingDeserializerTest {
     void should_deserialize_base64_correctly() throws IOException {
 
         // given
-        String base64_1 = encodeFloatArrayToBase64(new float[]{1.1f, 2.2f, 3.3f});
-        String base64_2 = encodeFloatArrayToBase64(new float[]{4.4f, 5.5f, 6.6f});
+        String base64_1 = encodeFloatArrayToBase64(new float[] {1.1f, 2.2f, 3.3f});
+        String base64_2 = encodeFloatArrayToBase64(new float[] {4.4f, 5.5f, 6.6f});
 
-        JsonNode dataNode = OBJECT_MAPPER.readTree(String.format("[{\"object\":\"embedding\",\"embedding\": \"%s\",\"index\":0},{\"object\":\"embedding\",\"embedding\":\"%s\",\"index\":1}]", base64_1, base64_2));
+        JsonNode dataNode = OBJECT_MAPPER.readTree(String.format(
+                "[{\"object\":\"embedding\",\"embedding\": \"%s\",\"index\":0},{\"object\":\"embedding\",\"embedding\":\"%s\",\"index\":1}]",
+                base64_1, base64_2));
         doReturn(objectCodec).when(jsonParser).getCodec();
         doReturn(dataNode).when(objectCodec).readTree(jsonParser);
         VoyageAiEmbeddingDeserializer deserializer = new VoyageAiEmbeddingDeserializer();
 
         // when
-        List<EmbeddingResponse.EmbeddingData> embeddingDataList = deserializer.deserialize(jsonParser, deserializationContext);
+        List<EmbeddingResponse.EmbeddingData> embeddingDataList =
+                deserializer.deserialize(jsonParser, deserializationContext);
 
         // then
         assertThat(embeddingDataList).hasSize(2);
@@ -71,7 +78,8 @@ class VoyageAiEmbeddingDeserializerTest {
     }
 
     String encodeFloatArrayToBase64(float[] floatArray) {
-        ByteBuffer byteBuffer = ByteBuffer.allocate(floatArray.length * Float.BYTES);
+        ByteBuffer byteBuffer =
+                ByteBuffer.allocate(floatArray.length * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
         for (float value : floatArray) {
             byteBuffer.putFloat(value);
         }


### PR DESCRIPTION
## Issue
Closes #5634

## Change
`VoyageAiEmbeddingDeserializer.decodeBase64ToFloatList()` wrapped the decoded bytes in a `ByteBuffer` without setting the byte order, so float32 values were read as the JDK default BIG_ENDIAN.

Voyage AI encodes base64 embeddings as little-endian float32 (the official Voyage Python SDK decodes with `np.frombuffer(..., np.float32)`, native order). The mismatch byte-swapped every float, so `encodingFormat("base64")` returned wrong embeddings.

Fix: set the buffer to `ByteOrder.LITTLE_ENDIAN`, matching the sibling `OpenAiEmbeddingDeserializer` which already does this for the same wire format.

```java
ByteBuffer byteBuffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
```

The existing `should_deserialize_base64_correctly` test passed only because its helper encoded the fixture as BIG_ENDIAN too — a self-consistent round-trip that hid the bug. The helper now encodes little-endian (the real wire format), so it fails before this fix and passes after.

The non-base64 (float array) path is unchanged. The touched files predate the current formatter, so `spotless:apply` reformatted them (import order, line wrapping); those incidental lines are formatter output, not manual edits.

⚠️  Breaking change (behavioral — for base64 users)

  This fix changes the embedding values returned for the same input when using .encodingFormat("base64"). Previously, Voyage's little-endian base64 was decoded as big-endian, so the returned float vectors were
  byte-swapped (incorrect). They are now decoded correctly.

  Who is affected: only users who explicitly configured VoyageAiEmbeddingModel with .encodingFormat("base64"). The default (float-array) path is unaffected — its output does not change.

  Impact: if you persisted embeddings generated with the previous version using base64, those stored vectors are incompatible with embeddings produced after this fix. Mixing them (e.g. old stored documents + new
  queries) will silently degrade or break similarity search.

  Required action after upgrading: re-embed and re-index any data that was embedded via encodingFormat("base64"). No action is needed if you did not use base64.

## General checklist
- [ ] There are no breaking changes (API, behaviour) — base64 was opt-in and previously broken; this corrects the output
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases <!-- N/A — a byte-order fix has no rejection/negative path; the test asserts correct decoding (positive case) -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

