### PR TITLE
Preserve Ollama tool response name

### DIFF
--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/InternalOllamaHelper.java
@@ -259,10 +259,18 @@ class InternalOllamaHelper {
                             .collect(Collectors.toList()))
                     .orElse(null);
         }
+
+        Map<String, Object> additionalFields = null;
+        if (chatMessage instanceof ToolExecutionResultMessage toolExecutionResultMessage
+                && !isNullOrEmpty(toolExecutionResultMessage.toolName())) {
+            additionalFields = Map.of("tool_name", toolExecutionResultMessage.toolName());
+        }
+
         return Message.builder()
                 .role(toOllamaRole(chatMessage.type()))
                 .content(toText(chatMessage))
                 .toolCalls(toolCalls)
+                .additionalFields(additionalFields)
                 .build();
     }
 

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/InternalOllamaHelperTest.java
@@ -1,11 +1,13 @@
 package dev.langchain4j.model.ollama;
 
+import static dev.langchain4j.model.ollama.OllamaJsonUtils.toJsonWithoutIdent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +50,29 @@ class InternalOllamaHelperTest {
         assertThat(messages).hasSize(1);
         assertThat(messages.get(0).getContent()).isEmpty();
         assertThat(messages.get(0).getImages()).containsExactly("aW1hZ2U=");
+    }
+
+    @Test
+    void toOllamaMessages_preservesToolNameInToolExecutionResultMessage() {
+        ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.builder()
+                .id("call-1")
+                .toolName("makeCoffee")
+                .text("Out of coffee beans.")
+                .isError(true)
+                .attributes(Map.of("local", "metadata"))
+                .build();
+
+        List<Message> messages =
+                InternalOllamaHelper.toOllamaMessages(List.<ChatMessage>of(toolExecutionResultMessage));
+
+        assertThat(messages).hasSize(1);
+        Message message = messages.get(0);
+        assertThat(message.getRole()).isEqualTo(Role.TOOL);
+        assertThat(message.getContent()).isEqualTo("Out of coffee beans.");
+        assertThat(message.getAdditionalFields()).containsExactly(Map.entry("tool_name", "makeCoffee"));
+        assertThat(toJsonWithoutIdent(message))
+                .contains("\"role\":\"tool\"", "\"content\":\"Out of coffee beans.\"", "\"tool_name\":\"makeCoffee\"")
+                .doesNotContain("is_error", "call-1", "local");
     }
 
     @Test


### PR DESCRIPTION
Fixes #4742

Summary:
- Preserve `ToolExecutionResultMessage.toolName()` in Ollama tool response messages as `tool_name`.
- Keep the existing role/content mapping unchanged.
- Do not serialize unsupported `id`, `isError`, or `attributes` fields to Ollama.

Validation:
- `./mvnw.cmd -pl langchain4j-ollama -Dtest=InternalOllamaHelperTest -DforkCount=0 test`
- 6 tests passed.

Local caveat: the normal forked Surefire run without `-DforkCount=0` fails before executing tests in this Windows/non-ASCII path environment with `processing of -javaagent failed`, so the focused validation used in-process Surefire.