### PR TITLE
Validate pgvector metadata index type

### DIFF
--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandler.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandler.java
@@ -1,8 +1,10 @@
 package dev.langchain4j.store.embedding.pgvector;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.store.embedding.filter.Filter;
-
 import java.sql.*;
 import java.util.Collections;
 import java.util.HashMap;
@@ -10,9 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
 
 /**
  * Handle Metadata stored in independent columns
@@ -32,9 +31,10 @@ class ColumnsMetadataHandler implements MetadataHandler {
     public ColumnsMetadataHandler(MetadataStorageConfig config) {
         List<String> columnsDefinitionList = ensureNotEmpty(config.columnDefinitions(), "Metadata definition");
         this.columnsDefinition = columnsDefinitionList.stream()
-                .map(MetadataColumDefinition::from).collect(Collectors.toList());
-        this.columnsName = columnsDefinition.stream()
-                .map(MetadataColumDefinition::getName).collect(Collectors.toList());
+                .map(MetadataColumDefinition::from)
+                .collect(Collectors.toList());
+        this.columnsName =
+                columnsDefinition.stream().map(MetadataColumDefinition::getName).collect(Collectors.toList());
         this.filterMapper = new ColumnFilterMapper();
         this.indexes = getOrDefault(config.indexes(), Collections.emptyList());
         this.indexType = config.indexType();
@@ -43,7 +43,8 @@ class ColumnsMetadataHandler implements MetadataHandler {
     @Override
     public String columnDefinitionsString() {
         return this.columnsDefinition.stream()
-                .map(MetadataColumDefinition::getFullDefinition).collect(Collectors.joining(","));
+                .map(MetadataColumDefinition::getFullDefinition)
+                .collect(Collectors.joining(","));
     }
 
     @Override
@@ -53,22 +54,22 @@ class ColumnsMetadataHandler implements MetadataHandler {
 
     @Override
     public void createMetadataIndexes(Statement statement, String table) {
-        String indexTypeSql = indexType == null ? "" : "USING " + indexType;
-        this.indexes.stream().map(String::trim)
-                .forEach(index -> {
-                    String indexSql = String.format("create index if not exists %s_%s on %s %s ( %s )",
-                            table, index, table, indexTypeSql, index);
-                    try {
-                        statement.executeUpdate(indexSql);
-                    } catch (SQLException e) {
-                        throw new RuntimeException(String.format("Cannot create indexes %s: %s", index, e));
-                    }
-                });
+        String indexTypeSql = PgVectorMetadataIndexValidator.indexTypeSql(indexType);
+        this.indexes.stream().map(String::trim).forEach(index -> {
+            String indexSql = String.format(
+                    "create index if not exists %s_%s on %s %s ( %s )", table, index, table, indexTypeSql, index);
+            try {
+                statement.executeUpdate(indexSql);
+            } catch (SQLException e) {
+                throw new RuntimeException(String.format("Cannot create indexes %s: %s", index, e));
+            }
+        });
     }
 
     @Override
     public String insertClause() {
-        return this.columnsName.stream().map(c -> String.format("%s = EXCLUDED.%s", c, c))
+        return this.columnsName.stream()
+                .map(c -> String.format("%s = EXCLUDED.%s", c, c))
                 .collect(Collectors.joining(","));
     }
 
@@ -107,5 +108,4 @@ class ColumnsMetadataHandler implements MetadataHandler {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/JSONBMetadataHandler.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/JSONBMetadataHandler.java
@@ -24,13 +24,13 @@ class JSONBMetadataHandler extends JSONMetadataHandler {
 
     @Override
     public void createMetadataIndexes(Statement statement, String table) {
-        String indexTypeSql = indexType == null ? "" : "USING " + indexType;
+        String indexTypeSql = PgVectorMetadataIndexValidator.indexTypeSql(indexType);
         for (String str : this.indexes) {
             String index = str.trim();
             String indexName = formatIndex(index);
             try {
-                String indexSql = String.format("create index if not exists %s_%s on %s %s (%s)",
-                        table, indexName, table, indexTypeSql, index);
+                String indexSql = String.format(
+                        "create index if not exists %s_%s on %s %s (%s)", table, indexName, table, indexTypeSql, index);
                 statement.executeUpdate(indexSql);
             } catch (SQLException e) {
                 throw new RuntimeException(String.format("Cannot create index %s: %s", index, e));
@@ -39,11 +39,13 @@ class JSONBMetadataHandler extends JSONMetadataHandler {
     }
 
     String formatIndex(String index) {
-        // (metadata_b->'name')
         String indexName;
         if (index.contains("->")) {
-            indexName = columnName + "_" + index.substring(index.indexOf("->") + 2, index.length() - 1)
-                    .trim().replaceAll("'", "");
+            indexName = columnName
+                    + "_"
+                    + index.substring(index.indexOf("->") + 2, index.length() - 1)
+                            .trim()
+                            .replaceAll("'", "");
         } else {
             indexName = index.replaceAll(" ", "_");
         }

--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/MetadataStorageConfig.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/MetadataStorageConfig.java
@@ -28,11 +28,17 @@ public interface MetadataStorageConfig {
      */
     List<String> columnDefinitions();
     /**
-     * Metadata Indexes, list of fields to use as index.
+     * Metadata Indexes, list of fields to use as index. These values are trusted
+     * developer-provided SQL fragments used by automatic metadata index creation:
+     * <ul>
+     * <li>COMBINED_JSON: indexes are not supported
+     * <li>COMBINED_JSONB: column or expression fragments such as <code>metadata</code>,
+     * <code>metadata jsonb_path_ops</code>, or <code>(metadata-&gt;'key')</code>
+     * <li>COLUMN_PER_KEY: column fragments such as <code>key</code>, <code>name</code>, or
+     * <code>age</code>
+     * </ul>
      * Example:
      * <ul>
-     * <li>COMBINED_JSON: <code>Collections.singletonList("metadata")</code> or
-     * <code>Arrays.asList("(metadata-&gt;'key')", "(metadata-&gt;'name')", "(metadata-&gt;'age')")</code>
      * <li>COMBINED_JSONB: <code>Collections.singletonList("metadata")</code> or
      * <code>Arrays.asList("(metadata-&gt;'key')", "(metadata-&gt;'name')", "(metadata-&gt;'age')")</code>
      * <li>COLUMN_PER_KEY: <code>Arrays.asList("key", "name", "age")</code>
@@ -45,8 +51,14 @@ public interface MetadataStorageConfig {
      * <ul>
      * <li>BTREE (default)
      * <li>GIN
-     * <li>... postgres indexes
+     * <li>HASH
+     * <li>GIST
+     * <li>BRIN
+     * <li>SPGIST
      * </ul>
+     * For automatic metadata index creation, values are validated against this allow-list
+     * of PostgreSQL index access methods. Other metadata storage configuration values are
+     * trusted developer-provided SQL fragments.
      * @return Index Type
      */
     String indexType();

--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorMetadataIndexValidator.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorMetadataIndexValidator.java
@@ -1,0 +1,29 @@
+package dev.langchain4j.store.embedding.pgvector;
+
+import static dev.langchain4j.internal.Utils.isNullOrBlank;
+
+import java.util.Locale;
+import java.util.Set;
+
+final class PgVectorMetadataIndexValidator {
+
+    private static final Set<String> INDEX_TYPES = Set.of("btree", "hash", "gin", "gist", "brin", "spgist");
+
+    private PgVectorMetadataIndexValidator() {}
+
+    static String indexTypeSql(String indexType) {
+        if (indexType == null) {
+            return "";
+        }
+
+        if (isNullOrBlank(indexType)) {
+            throw new IllegalArgumentException("Invalid metadata index type: '" + indexType + "'");
+        }
+
+        String trimmed = indexType.trim();
+        if (!INDEX_TYPES.contains(trimmed.toLowerCase(Locale.ROOT))) {
+            throw new IllegalArgumentException("Invalid metadata index type: '" + indexType + "'");
+        }
+        return "USING " + trimmed;
+    }
+}

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandlerTest.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/ColumnsMetadataHandlerTest.java
@@ -1,0 +1,86 @@
+package dev.langchain4j.store.embedding.pgvector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.AdditionalAnswers;
+
+class ColumnsMetadataHandlerTest {
+
+    @Test
+    void createMetadataIndexes() throws SQLException {
+        Statement statement = mock(Statement.class);
+        List<String> sqlStatementQueries = new ArrayList<>();
+        when(statement.executeUpdate(anyString()))
+                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String) q)));
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COLUMN_PER_KEY)
+                .columnDefinitions(Collections.singletonList("age integer"))
+                .indexes(Collections.singletonList("age"))
+                .indexType("BTREE")
+                .build();
+        ColumnsMetadataHandler columnsMetadataHandler = new ColumnsMetadataHandler(metadataStorageConfig);
+
+        columnsMetadataHandler.createMetadataIndexes(statement, "embeddings");
+
+        assertThat(sqlStatementQueries)
+                .containsExactly("create index if not exists embeddings_age on embeddings USING BTREE ( age )");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "btree", "hash", "gin", "gist", "brin", "spgist", "BTREE", "HASH", "GIN", "GIST", "BRIN", "SPGIST"
+            })
+    void createMetadataIndexes_allowsSupportedIndexTypes(String indexType) throws SQLException {
+        Statement statement = mock(Statement.class);
+        List<String> sqlStatementQueries = new ArrayList<>();
+        when(statement.executeUpdate(anyString()))
+                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String) q)));
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COLUMN_PER_KEY)
+                .columnDefinitions(Collections.singletonList("age integer"))
+                .indexes(Collections.singletonList("age"))
+                .indexType(indexType)
+                .build();
+        ColumnsMetadataHandler columnsMetadataHandler = new ColumnsMetadataHandler(metadataStorageConfig);
+
+        columnsMetadataHandler.createMetadataIndexes(statement, "embeddings");
+
+        assertThat(sqlStatementQueries).hasSize(1);
+        assertThat(sqlStatementQueries.get(0)).contains("USING " + indexType + " ");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"BTREE; drop table users;--", "unknown", "", " "})
+    void createMetadataIndexes_rejectsUnsupportedIndexType(String indexType) {
+        Statement statement = mock(Statement.class);
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COLUMN_PER_KEY)
+                .columnDefinitions(Collections.singletonList("age integer"))
+                .indexes(Collections.singletonList("age"))
+                .indexType(indexType)
+                .build();
+        ColumnsMetadataHandler columnsMetadataHandler = new ColumnsMetadataHandler(metadataStorageConfig);
+
+        assertThatThrownBy(() -> columnsMetadataHandler.createMetadataIndexes(statement, "embeddings"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("index type");
+        verifyNoInteractions(statement);
+    }
+}

--- a/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/JSONBMetadataHandlerTest.java
+++ b/langchain4j-pgvector/src/test/java/dev/langchain4j/store/embedding/pgvector/JSONBMetadataHandlerTest.java
@@ -1,7 +1,8 @@
 package dev.langchain4j.store.embedding.pgvector;
 
-import org.junit.jupiter.api.Test;
-import org.mockito.AdditionalAnswers;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -9,9 +10,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.AdditionalAnswers;
 
 class JSONBMetadataHandlerTest {
 
@@ -20,7 +22,7 @@ class JSONBMetadataHandlerTest {
         Statement statement = mock(Statement.class);
         List<String> sqlStatementQueries = new ArrayList<>();
         when(statement.executeUpdate(anyString()))
-                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String)q)));
+                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String) q)));
 
         MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
                 .storageMode(MetadataStorageMode.COMBINED_JSONB)
@@ -32,8 +34,8 @@ class JSONBMetadataHandlerTest {
         jsonbMetadataHandler.createMetadataIndexes(statement, "embeddings");
 
         assertThat(sqlStatementQueries).hasSize(1);
-        assertThat(sqlStatementQueries.get(0)).isEqualTo("create index if not exists embeddings_metadata on embeddings " +
-                "USING GIN (metadata)");
+        assertThat(sqlStatementQueries.get(0))
+                .isEqualTo("create index if not exists embeddings_metadata on embeddings " + "USING GIN (metadata)");
     }
 
     @Test
@@ -41,7 +43,7 @@ class JSONBMetadataHandlerTest {
         Statement statement = mock(Statement.class);
         List<String> sqlStatementQueries = new ArrayList<>();
         when(statement.executeUpdate(anyString()))
-                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String)q)));
+                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String) q)));
 
         MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
                 .storageMode(MetadataStorageMode.COMBINED_JSONB)
@@ -53,8 +55,9 @@ class JSONBMetadataHandlerTest {
         jsonbMetadataHandler.createMetadataIndexes(statement, "embeddings");
 
         assertThat(sqlStatementQueries).hasSize(1);
-        assertThat(sqlStatementQueries.get(0)).isEqualTo("create index if not exists embeddings_metadata_jsonb_path_ops on embeddings " +
-                "USING GIN (metadata jsonb_path_ops)");
+        assertThat(sqlStatementQueries.get(0))
+                .isEqualTo("create index if not exists embeddings_metadata_jsonb_path_ops on embeddings "
+                        + "USING GIN (metadata jsonb_path_ops)");
     }
 
     @Test
@@ -62,7 +65,7 @@ class JSONBMetadataHandlerTest {
         Statement statement = mock(Statement.class);
         List<String> sqlStatementQueries = new ArrayList<>();
         when(statement.executeUpdate(anyString()))
-                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String)q)));
+                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String) q)));
 
         MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
                 .storageMode(MetadataStorageMode.COMBINED_JSONB)
@@ -74,9 +77,55 @@ class JSONBMetadataHandlerTest {
         jsonbMetadataHandler.createMetadataIndexes(statement, "embeddings");
 
         assertThat(sqlStatementQueries).hasSize(2);
-        assertThat(sqlStatementQueries.get(0)).isEqualTo("create index if not exists embeddings_metadata_key1 on embeddings " +
-                "USING GIN ((metadata->key1))");
-        assertThat(sqlStatementQueries.get(1)).isEqualTo("create index if not exists embeddings_metadata_key2 on embeddings " +
-                "USING GIN ((metadata->key2))");
+        assertThat(sqlStatementQueries.get(0))
+                .isEqualTo("create index if not exists embeddings_metadata_key1 on embeddings "
+                        + "USING GIN ((metadata->key1))");
+        assertThat(sqlStatementQueries.get(1))
+                .isEqualTo("create index if not exists embeddings_metadata_key2 on embeddings "
+                        + "USING GIN ((metadata->key2))");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "btree", "hash", "gin", "gist", "brin", "spgist", "BTREE", "HASH", "GIN", "GIST", "BRIN", "SPGIST"
+            })
+    void createMetadataIndexes_allowsSupportedIndexTypes(String indexType) throws SQLException {
+        Statement statement = mock(Statement.class);
+        List<String> sqlStatementQueries = new ArrayList<>();
+        when(statement.executeUpdate(anyString()))
+                .thenAnswer(AdditionalAnswers.answerVoid(q -> sqlStatementQueries.add((String) q)));
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COMBINED_JSONB)
+                .columnDefinitions(Collections.singletonList("metadata JSONB"))
+                .indexes(Collections.singletonList("metadata"))
+                .indexType(indexType)
+                .build();
+        JSONBMetadataHandler jsonbMetadataHandler = new JSONBMetadataHandler(metadataStorageConfig);
+
+        jsonbMetadataHandler.createMetadataIndexes(statement, "embeddings");
+
+        assertThat(sqlStatementQueries).hasSize(1);
+        assertThat(sqlStatementQueries.get(0)).contains("USING " + indexType + " ");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"GIN; drop table users;--", "unknown", "", " "})
+    void createMetadataIndexes_rejectsUnsupportedIndexType(String indexType) {
+        Statement statement = mock(Statement.class);
+
+        MetadataStorageConfig metadataStorageConfig = DefaultMetadataStorageConfig.builder()
+                .storageMode(MetadataStorageMode.COMBINED_JSONB)
+                .columnDefinitions(Collections.singletonList("metadata JSONB"))
+                .indexes(Collections.singletonList("metadata"))
+                .indexType(indexType)
+                .build();
+        JSONBMetadataHandler jsonbMetadataHandler = new JSONBMetadataHandler(metadataStorageConfig);
+
+        assertThatThrownBy(() -> jsonbMetadataHandler.createMetadataIndexes(statement, "embeddings"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("index type");
+        verifyNoInteractions(statement);
     }
 }


### PR DESCRIPTION
Fixes #5565.

Summary:
- Validate `MetadataStorageConfig.indexType` for PGVector metadata index DDL against PostgreSQL access methods: `btree`, `hash`, `gin`, `gist`, `brin`, and `spgist`.
- Apply the check in both JSONB and column-per-key metadata index creation paths.
- Leave table names and metadata index expressions as trusted developer-provided SQL fragments, matching pgvector's existing free-form design.

Validation:
- `./mvnw.cmd -pl langchain4j-pgvector spotless:apply`
- `./mvnw.cmd -pl langchain4j-pgvector "-Dtest=JSONBMetadataHandlerTest,ColumnsMetadataHandlerTest" "-DforkCount=0" test` (36 tests passing)
- `./mvnw.cmd -pl langchain4j-pgvector spotless:check`
- `git diff --check HEAD^ HEAD`
- Diff-only marker scan