### PR TITLE
feat(gemini): support per-request cachedContentName override

### DIFF
--- a/langchain4j-google-ai-gemini/revapi.json
+++ b/langchain4j-google-ai-gemini/revapi.json
@@ -244,6 +244,18 @@
           "code": "java.field.removed",
           "old": "field dev.langchain4j.model.googleai.BaseGeminiChatModel.imageConfig @ dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel",
           "justification": "Image generation config (aspectRatio/imageSize) is now part of GoogleAiGeminiChatRequestParameters and resolved per-request, replacing the model-level imageConfig field"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.removed",
+          "old": "field dev.langchain4j.model.googleai.BaseGeminiChatModel.cachedContentName @ dev.langchain4j.model.googleai.GoogleAiGeminiChatModel",
+          "justification": "cachedContentName is now part of GoogleAiGeminiChatRequestParameters and resolved per-request, replacing the model-level cachedContentName field"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.removed",
+          "old": "field dev.langchain4j.model.googleai.BaseGeminiChatModel.cachedContentName @ dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel",
+          "justification": "cachedContentName is now part of GoogleAiGeminiChatRequestParameters and resolved per-request, replacing the model-level cachedContentName field"
         }
       ]
     }

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/BaseGeminiChatModel.java
@@ -55,7 +55,6 @@ class BaseGeminiChatModel {
     protected final Boolean enableEnhancedCivicAnswers;
     protected final GeminiMediaResolutionLevel mediaResolution;
     protected final boolean mediaResolutionPerPartEnabled;
-    protected final String cachedContentName;
 
     protected final GoogleAiGeminiChatRequestParameters defaultRequestParameters;
 
@@ -80,7 +79,6 @@ class BaseGeminiChatModel {
         this.logprobs = builder.logprobs;
         this.mediaResolution = builder.mediaResolution;
         this.mediaResolutionPerPartEnabled = getOrDefault(builder.mediaResolutionPerPartEnabled, false);
-        this.cachedContentName = builder.cachedContentName;
 
         ChatRequestParameters commonParameters;
         if (builder.defaultRequestParameters != null) {
@@ -110,6 +108,7 @@ class BaseGeminiChatModel {
                 // Gemini-specific parameters
                 .aspectRatio(getOrDefault(builder.aspectRatio, geminiParameters.aspectRatio()))
                 .imageSize(getOrDefault(builder.imageSize, geminiParameters.imageSize()))
+                .cachedContentName(getOrDefault(builder.cachedContentName, geminiParameters.cachedContentName()))
                 .build();
     }
 
@@ -127,8 +126,7 @@ class BaseGeminiChatModel {
     }
 
     protected GeminiGenerateContentRequest createGenerateContentRequest(ChatRequest chatRequest) {
-        GoogleAiGeminiChatRequestParameters parameters =
-                (GoogleAiGeminiChatRequestParameters) chatRequest.parameters();
+        GoogleAiGeminiChatRequestParameters parameters = (GoogleAiGeminiChatRequestParameters) chatRequest.parameters();
         GeminiGenerationConfig.GeminiImageConfig effectiveImageConfig =
                 buildImageConfig(parameters.aspectRatio(), parameters.imageSize());
 
@@ -182,7 +180,7 @@ class BaseGeminiChatModel {
                         this.allowGoogleMaps,
                         this.retrieveGoogleMapsWidgetToken))
                 .toolConfig(toToolConfig(parameters.toolChoice(), this.functionCallingConfig))
-                .cachedContent(this.cachedContentName)
+                .cachedContent(parameters.cachedContentName())
                 .build();
     }
 
@@ -779,6 +777,8 @@ class BaseGeminiChatModel {
          * to create the cache out of band via the
          * <a href="https://ai.google.dev/gemini-api/docs/caching">Gemini context caching API</a> and pass the
          * returned resource name here.</p>
+         *
+         * <p>Can be overridden per-request via {@link GoogleAiGeminiChatRequestParameters#cachedContentName()}.</p>
          */
         public B cachedContentName(String cachedContentName) {
             this.cachedContentName = cachedContentName;

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatRequestParameters.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GoogleAiGeminiChatRequestParameters.java
@@ -14,11 +14,13 @@ public class GoogleAiGeminiChatRequestParameters extends DefaultChatRequestParam
 
     private final String aspectRatio;
     private final String imageSize;
+    private final String cachedContentName;
 
     private GoogleAiGeminiChatRequestParameters(Builder builder) {
         super(builder);
         this.aspectRatio = builder.aspectRatio;
         this.imageSize = builder.imageSize;
+        this.cachedContentName = builder.cachedContentName;
     }
 
     public String aspectRatio() {
@@ -27,6 +29,15 @@ public class GoogleAiGeminiChatRequestParameters extends DefaultChatRequestParam
 
     public String imageSize() {
         return imageSize;
+    }
+
+    /**
+     * The resource name of a previously created cache (e.g. {@code "cachedContents/abc123"}) to attach
+     * to this specific request, overriding any global {@code cachedContentName} configured on the
+     * {@link GoogleAiGeminiChatModel}/{@link GoogleAiGeminiStreamingChatModel}.
+     */
+    public String cachedContentName() {
+        return cachedContentName;
     }
 
     @Override
@@ -51,12 +62,14 @@ public class GoogleAiGeminiChatRequestParameters extends DefaultChatRequestParam
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         GoogleAiGeminiChatRequestParameters that = (GoogleAiGeminiChatRequestParameters) o;
-        return Objects.equals(aspectRatio, that.aspectRatio) && Objects.equals(imageSize, that.imageSize);
+        return Objects.equals(aspectRatio, that.aspectRatio)
+                && Objects.equals(imageSize, that.imageSize)
+                && Objects.equals(cachedContentName, that.cachedContentName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), aspectRatio, imageSize);
+        return Objects.hash(super.hashCode(), aspectRatio, imageSize, cachedContentName);
     }
 
     @Override
@@ -74,7 +87,8 @@ public class GoogleAiGeminiChatRequestParameters extends DefaultChatRequestParam
                 + toolChoice() + ", responseFormat="
                 + responseFormat() + ", aspectRatio="
                 + quoted(aspectRatio) + ", imageSize="
-                + quoted(imageSize) + '}';
+                + quoted(imageSize) + ", cachedContentName="
+                + quoted(cachedContentName) + '}';
     }
 
     public static Builder builder() {
@@ -85,6 +99,7 @@ public class GoogleAiGeminiChatRequestParameters extends DefaultChatRequestParam
 
         private String aspectRatio;
         private String imageSize;
+        private String cachedContentName;
 
         @Override
         public Builder overrideWith(ChatRequestParameters parameters) {
@@ -92,6 +107,7 @@ public class GoogleAiGeminiChatRequestParameters extends DefaultChatRequestParam
             if (parameters instanceof GoogleAiGeminiChatRequestParameters geminiParameters) {
                 aspectRatio(getOrDefault(geminiParameters.aspectRatio(), aspectRatio));
                 imageSize(getOrDefault(geminiParameters.imageSize(), imageSize));
+                cachedContentName(getOrDefault(geminiParameters.cachedContentName(), cachedContentName));
             }
             return this;
         }
@@ -107,6 +123,11 @@ public class GoogleAiGeminiChatRequestParameters extends DefaultChatRequestParam
 
         public Builder imageSize(String imageSize) {
             this.imageSize = imageSize;
+            return this;
+        }
+
+        public Builder cachedContentName(String cachedContentName) {
+            this.cachedContentName = cachedContentName;
             return this;
         }
 

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GoogleAiGeminiStreamingChatModelTest.java
@@ -127,15 +127,21 @@ class GoogleAiGeminiStreamingChatModelTest {
 
         @Test
         void cachedContentNameInContentRequest() {
-            GoogleAiGeminiStreamingChatModel chatModel = GoogleAiGeminiStreamingChatModel.builder()
-                    .apiKey("ApiKey")
-                    .modelName("ModelName")
-                    .cachedContentName("cachedContents/abc123")
-                    .build();
-            GeminiGenerateContentRequest result = chatModel.createGenerateContentRequest(DEFAULT_REQUEST);
+            GoogleAiGeminiStreamingChatModel.GoogleAiGeminiStreamingChatModelBuilder builder =
+                    GoogleAiGeminiStreamingChatModel.builder()
+                            .apiKey("ApiKey")
+                            .modelName("ModelName")
+                            .cachedContentName("cachedContents/abc123");
+            GoogleAiGeminiStreamingChatModel chatModel = new GoogleAiGeminiStreamingChatModel(builder, geminiService);
 
-            assertThat(result.cachedContent()).isEqualTo("cachedContents/abc123");
-            assertThatCharSequence(Json.toJson(result)).contains("\"cachedContent\" : \"cachedContents/abc123\"");
+            chatModel.chat(ChatRequest.builder().messages(new UserMessage("Hi")).build(), handler);
+
+            verify(geminiService)
+                    .generateContentStream(eq("ModelName"), requestCaptor.capture(), eq(false), eq(null), any());
+
+            assertThat(requestCaptor.getValue().cachedContent()).isEqualTo("cachedContents/abc123");
+            assertThatCharSequence(Json.toJson(requestCaptor.getValue()))
+                    .contains("\"cachedContent\" : \"cachedContents/abc123\"");
         }
 
         @Test
@@ -148,6 +154,30 @@ class GoogleAiGeminiStreamingChatModelTest {
 
             assertThat(result.cachedContent()).isNull();
             assertThatCharSequence(Json.toJson(result)).doesNotContain("\"cachedContent\"");
+        }
+
+        @Test
+        void shouldUseRequestLevelCachedContentNameWhenProvided() {
+            GoogleAiGeminiStreamingChatModel.GoogleAiGeminiStreamingChatModelBuilder builder =
+                    GoogleAiGeminiStreamingChatModel.builder()
+                            .apiKey("ApiKey")
+                            .modelName("ModelName")
+                            .cachedContentName("cachedContents/global");
+            GoogleAiGeminiStreamingChatModel chatModel = new GoogleAiGeminiStreamingChatModel(builder, geminiService);
+
+            ChatRequest chatRequest = ChatRequest.builder()
+                    .messages(new UserMessage("Hi"))
+                    .parameters(GoogleAiGeminiChatRequestParameters.builder()
+                            .cachedContentName("cachedContents/per-request")
+                            .build())
+                    .build();
+
+            chatModel.chat(chatRequest, handler);
+
+            verify(geminiService)
+                    .generateContentStream(eq("ModelName"), requestCaptor.capture(), eq(false), eq(null), any());
+
+            assertThat(requestCaptor.getValue().cachedContent()).isEqualTo("cachedContents/per-request");
         }
 
         @Test


### PR DESCRIPTION
## Summary
Closes #5568.

`cachedContentName` could previously only be configured globally on the `GoogleAiGeminiChatModel`/`GoogleAiGeminiStreamingChatModel` builder, attached to every request. Since a `ChatRequest` encapsulates a full conversation and the Gemini `cachedContent` is the prefix for that conversation, it should be configurable per request too.

This follows the exact pattern #4913 established for `aspectRatio`/`imageSize`:
- `GoogleAiGeminiChatRequestParameters` gains a `cachedContentName` field (getter, builder setter, `overrideWith` merge, `equals`/`hashCode`/`toString`)
- `BaseGeminiChatModel` no longer keeps a separate `cachedContentName` instance field; it's folded into `defaultRequestParameters` at construction time and read off the resolved per-request `parameters` in `createGenerateContentRequest`
- A `cachedContentName` set via `ChatRequestParameters` on an individual request overrides the globally configured one (same override semantics as `aspectRatio`/`imageSize`)

```java
ChatModel model = GoogleAiGeminiChatModel.builder()
        .apiKey(System.getenv("GEMINI_AI_KEY"))
        .cachedContentName("cachedContents/abc123") // default
        .build();

ChatResponse response = model.chat(ChatRequest.builder()
        .messages(UserMessage.from("..."))
        .parameters(GoogleAiGeminiChatRequestParameters.builder()
                .cachedContentName("cachedContents/xyz789") // overrides the default for this request
                .build())
        .build());
```

## Test plan
- [x] Updated existing `cachedContentNameInContentRequest` / `defaultCachedContentNameInContentRequest` tests to exercise the full `chat()` merge path (they previously bypassed it by calling `createGenerateContentRequest` directly with an empty `ChatRequest`)
- [x] Added `shouldUseRequestLevelCachedContentNameWhenProvided`, mirroring `shouldUseRequestLevelImageConfigWhenProvided`
- [x] `mvn -pl langchain4j-google-ai-gemini test` passes
- [x] `mvn -pl langchain4j-google-ai-gemini spotless:check` passes