### PR TITLE
fix: Wrap the full last expression when fixing single-line JavaScript in Judge0

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/JavaScriptCodeFixer.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/src/main/java/dev/langchain4j/code/judge0/JavaScriptCodeFixer.java
@@ -10,9 +10,8 @@ class JavaScriptCodeFixer {
     static String fixIfNoLogToConsole(String code) {
         if (code.contains("\n")) {
             return fixIfNoLogToConsole(code, "\n");
-        } else {
-            return fixIfNoLogToConsole(code, " ");
         }
+        return fixSingleLineIfNoLogToConsole(code);
     }
 
     private static String fixIfNoLogToConsole(String code, String separator) {
@@ -24,6 +23,21 @@ class JavaScriptCodeFixer {
 
         parts[parts.length - 1] = "console.log(" + lastPart.replace(";", "") + ");";
         String fixedCode = String.join(separator, parts);
+        log.debug("The following code \"{}\" was fixed: \"{}\"", code, fixedCode);
+        return fixedCode;
+    }
+
+    private static String fixSingleLineIfNoLogToConsole(String code) {
+        int lastSemicolon = code.lastIndexOf(';');
+        String trailing = code.substring(lastSemicolon + 1);
+        String statement = trailing.trim();
+        if (statement.isEmpty() || statement.startsWith("console.log")) {
+            return code;
+        }
+
+        String prefix = code.substring(0, lastSemicolon + 1);
+        String leadingWhitespace = trailing.substring(0, trailing.indexOf(statement));
+        String fixedCode = prefix + leadingWhitespace + "console.log(" + statement + ");";
         log.debug("The following code \"{}\" was fixed: \"{}\"", code, fixedCode);
         return fixedCode;
     }

--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/src/test/java/dev/langchain4j/code/judge0/JavaScriptCodeFixerTest.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/src/test/java/dev/langchain4j/code/judge0/JavaScriptCodeFixerTest.java
@@ -1,14 +1,15 @@
 package dev.langchain4j.code.judge0;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 class JavaScriptCodeFixerTest {
 
     @Test
     void should_fix_multi_line_code_when_result_is_not_logged_to_console() {
-        String code = "const startDate = new Date('Feb 21, 1988 17:00:00');\nconst endDate = new Date('Apr 12, 2014 04:00:00');\nconst diff = endDate - startDate;\nconst result = diff / (1000*60*60);\n;const startDate = new Date('Feb 21, 1988 17:00:00');\nconst endDate = new Date('Apr 12, 2014 04:00:00');\nconst diff = endDate - startDate;\nconst result = diff / (1000*60*60);\n";
+        String code =
+                "const startDate = new Date('Feb 21, 1988 17:00:00');\nconst endDate = new Date('Apr 12, 2014 04:00:00');\nconst diff = endDate - startDate;\nconst result = diff / (1000*60*60);\n;const startDate = new Date('Feb 21, 1988 17:00:00');\nconst endDate = new Date('Apr 12, 2014 04:00:00');\nconst diff = endDate - startDate;\nconst result = diff / (1000*60*60);\n";
 
         String result = JavaScriptCodeFixer.fixIfNoLogToConsole(code + "result");
 
@@ -17,7 +18,8 @@ class JavaScriptCodeFixerTest {
 
     @Test
     void should_not_fix_multi_line_code_when_result_is_logged_to_console() {
-        String code = "const startDate = new Date('Feb 21, 1988 17:00:00');\nconst endDate = new Date('Apr 12, 2014 04:00:00');\nconst diff = endDate - startDate;\nconst result = diff / (1000*60*60);\nconsole.log(result);";
+        String code =
+                "const startDate = new Date('Feb 21, 1988 17:00:00');\nconst endDate = new Date('Apr 12, 2014 04:00:00');\nconst diff = endDate - startDate;\nconst result = diff / (1000*60*60);\nconsole.log(result);";
 
         String result = JavaScriptCodeFixer.fixIfNoLogToConsole(code);
 
@@ -26,7 +28,8 @@ class JavaScriptCodeFixerTest {
 
     @Test
     void should_fix_one_line_code_when_result_is_not_logged_to_console() {
-        String code = "const start = new Date('1988-02-21T17:00:00'); const end = new Date('2014-04-12T04:00:00'); const hours = (end - start) / (1000 * 60 * 60); ";
+        String code =
+                "const start = new Date('1988-02-21T17:00:00'); const end = new Date('2014-04-12T04:00:00'); const hours = (end - start) / (1000 * 60 * 60); ";
 
         String result = JavaScriptCodeFixer.fixIfNoLogToConsole(code + "hours");
 
@@ -35,7 +38,8 @@ class JavaScriptCodeFixerTest {
 
     @Test
     void should_not_fix_one_line_code_when_result_is_logged_to_console() {
-        String code = "const start = new Date('1988-02-21T17:00:00'); const end = new Date('2014-04-12T04:00:00'); const hours = (end - start) / (1000 * 60 * 60); console.log(hours);";
+        String code =
+                "const start = new Date('1988-02-21T17:00:00'); const end = new Date('2014-04-12T04:00:00'); const hours = (end - start) / (1000 * 60 * 60); console.log(hours);";
 
         String result = JavaScriptCodeFixer.fixIfNoLogToConsole(code);
 
@@ -58,5 +62,18 @@ class JavaScriptCodeFixerTest {
         String result = JavaScriptCodeFixer.fixIfNoLogToConsole(code);
 
         assertThat(result).isEqualTo(code);
+    }
+
+    @Test
+    void should_wrap_full_expression_for_single_line_code_with_spaces() {
+        assertThat(JavaScriptCodeFixer.fixIfNoLogToConsole("2 + 3")).isEqualTo("console.log(2 + 3);");
+        assertThat(JavaScriptCodeFixer.fixIfNoLogToConsole("Math.min(3, 7)")).isEqualTo("console.log(Math.min(3, 7));");
+    }
+
+    @Test
+    void should_wrap_full_last_expression_when_single_line_has_preceding_statements() {
+        String code = "const a = 2; const b = 3; a + b";
+        assertThat(JavaScriptCodeFixer.fixIfNoLogToConsole(code))
+                .isEqualTo("const a = 2; const b = 3; console.log(a + b);");
     }
 }


### PR DESCRIPTION
## Issue
Closes #5649

## Change
`JavaScriptCodeFixer.fixIfNoLogToConsole(code)` auto-wraps the last statement in `console.log(...)` so Judge0 prints the result.

The single-line path split on a single space and wrapped only the last space-separated token, so a final expression containing a space printed the wrong value: `2 + 3` became `2 + console.log(3);` and printed `3` instead of `5`.

The single-line branch now uses `fixSingleLineIfNoLogToConsole`, which treats the last `;` as the statement boundary, trims the trailing text, and wraps the whole final expression (`console.log(2 + 3);`), preserving leading whitespace. The multi-line path is untouched.

Two unit tests were added; the six existing tests still pass.

## Known limitations
- A bare final assignment with no result (e.g. single line `const x = 5`) becomes `console.log(const x = 5);`, which is invalid. This degenerate input has no result to print, outside this tool's contract (the result must be printable to console); the old code only handled it by accident.
- This is a string heuristic. A rare single line with an inner `;` (e.g. an inline `for` header) before a separate final expression may not be handled fully. Correct handling needs a JavaScript parser, out of scope here.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

<!-- 새 모듈/embedding store 추가가 아니므로 해당 체크리스트 섹션은 제외함. -->

## Pre-submission verification (사전 체크 / 정직성)
- Module build/tests run from a git worktree: `./mvnw -pl code-execution-engines/langchain4j-code-execution-engine-judge0 -am clean test` -> 8 tests pass (6 existing + 2 new).
- `Judge0JavaScriptEngineIT` was NOT run (requires `JUDGE0_API_KEY`, `@EnabledIfEnvironmentVariable`). Unit tests only.
- Spotless: `spotless:apply`/`check` cannot run inside the git worktree (jgit ratchet "Cannot find git repository"). Verified instead by applying the identical files in the main checkout (real `.git`): `spotless:check` passes after formatting. The committed files match `spotless:apply` output.

