### PR TITLE
fix: Preserve binary bytes in Azure dynamic sessions file download

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-azure-acads/src/main/java/dev/langchain4j/code/azure/acads/SessionsREPLTool.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-azure-acads/src/main/java/dev/langchain4j/code/azure/acads/SessionsREPLTool.java
@@ -423,9 +423,10 @@ public class SessionsREPLTool implements CodeExecutionEngine {
                     return "File not found: " + remoteFilePath;
                 }
 
-                // Convert response body to Base64
-                byte[] fileBytes = response.body().getBytes(StandardCharsets.UTF_8);
-                return Base64.getEncoder().encodeToString(fileBytes);
+                // Convert response body to Base64 from the canonical raw bytes.
+                // Using response.body() would round-trip through a decoded String and corrupt
+                // binary files (images, xlsx, etc.) whose bytes are not valid UTF-8.
+                return Base64.getEncoder().encodeToString(response.bodyBytes());
 
             } catch (Exception e) {
                 if (e.getMessage().contains("404")) {

--- a/code-execution-engines/langchain4j-code-execution-engine-azure-acads/src/test/java/dev/langchain4j/code/azure/acads/SessionsREPLToolTest.java
+++ b/code-execution-engines/langchain4j-code-execution-engine-azure-acads/src/test/java/dev/langchain4j/code/azure/acads/SessionsREPLToolTest.java
@@ -35,7 +35,9 @@ import dev.langchain4j.code.CodeExecutionEngine;
 import dev.langchain4j.http.client.HttpClient;
 import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -127,6 +129,45 @@ class SessionsREPLToolTest {
         assertThat(result).containsKey("result");
         assertThat(result).containsKey("stdout");
         assertThat(result).containsKey("stderr");
+    }
+
+    @Test
+    void testDownloadFilePreservesBinaryBytes() {
+        // A blob with bytes that are not valid UTF-8 (a fake PNG-ish header).
+        byte[] binaryBytes = new byte[] {(byte) 0xFF, (byte) 0xFE, (byte) 0x00, (byte) 0x01, (byte) 0xC0};
+
+        // Return a real SuccessfulHttpResponse so body()/bodyBytes() behave as in production.
+        SuccessfulHttpResponse response = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(binaryBytes)
+                .headers(Collections.emptyMap())
+                .build();
+        when(mockHttpClient.execute(any(HttpRequest.class))).thenReturn(response);
+
+        SessionsREPLTool.DefaultFileDownloader downloader = sessionsREPLTool.new DefaultFileDownloader();
+
+        String result = downloader.downloadFile("some/file.png");
+
+        // Base64 must be computed from the canonical raw bytes, not a lossy String round-trip.
+        assertThat(result).isEqualTo(Base64.getEncoder().encodeToString(binaryBytes));
+    }
+
+    @Test
+    void testDownloadFileRoundTripsValidUtf8Text() {
+        byte[] textBytes = "hello, world".getBytes(StandardCharsets.UTF_8);
+
+        SuccessfulHttpResponse response = SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(textBytes)
+                .headers(Collections.emptyMap())
+                .build();
+        when(mockHttpClient.execute(any(HttpRequest.class))).thenReturn(response);
+
+        SessionsREPLTool.DefaultFileDownloader downloader = sessionsREPLTool.new DefaultFileDownloader();
+
+        String result = downloader.downloadFile("notes.txt");
+
+        assertThat(result).isEqualTo(Base64.getEncoder().encodeToString(textBytes));
     }
 
     /**


### PR DESCRIPTION
# fix: Preserve binary bytes in Azure dynamic sessions file download

## Issue
Closes #5651

## Change
`SessionsREPLTool.DefaultFileDownloader.downloadFile()` built its Base64 result from `response.body().getBytes(StandardCharsets.UTF_8)`.

`SuccessfulHttpResponse.body()` returns `new String(body, charset())` — a decoded String view of the canonical `byte[]`. Re-encoding that String to UTF-8 is a lossy round-trip: any byte not valid in the response charset (UTF-8 by default) becomes U+FFFD. Downloading a sandbox's binary output (PNG, xlsx, etc. — the normal use of a file downloader) therefore produced silently corrupted Base64 that no longer decodes to the original file.

The fix encodes `response.bodyBytes()`, which returns the raw canonical `byte[]` losslessly. The `StandardCharsets` import is retained — it is still used when building request URLs and multipart upload bodies.

Added two unit tests in `SessionsREPLToolTest`: one feeds non-UTF-8 binary bytes (a fake PNG blob) through a real `SuccessfulHttpResponse` and asserts the Base64 matches the original bytes (fails before the fix); one confirms valid UTF-8 text still round-trips unchanged.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases <!-- binary blob (corrupted before fix) + valid UTF-8 text regression -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- unit tests green (5/5); no *IT in this module -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change isolated to langchain4j-code-execution-engine-azure-acads -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- after approval -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->

<!-- Checklist for adding new maven module — N/A (no new module) -->
<!-- Checklist for adding/changing embedding store integration — N/A (not an embedding store) -->

<!-- spotless: ran ./mvnw -Pspotless spotless:apply via the MAIN_ROOT bypass (worktree .git is a gitlink, ratchetFrom=origin/main can't resolve). Both changed files were already palantir-clean — no ratchet reformat, diff stays surgical. MAIN_ROOT restored pristine afterward. -->

---
<!-- 제출 전 실행 — 브랜치 stale 여부 확인 -->
