### PR TITLE
Anthropic: add cache diagnostics (beta) support

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -51,6 +51,7 @@ AnthropicChatModel model = AnthropicChatModel.builder()
     .toolMetadataKeysToSend(...)
     .cacheSystemMessages(...)
     .cacheTools(...)
+    .returnCacheDiagnostics(...)
     .thinkingType(...)
     .thinkingBudgetTokens(...)
     .thinkingDisplay(...)
@@ -72,9 +73,10 @@ See the description of some of the parameters above [here](https://docs.anthropi
 
 ### Per-Request Parameters
 
-The Anthropic-specific options shown above (`cacheSystemMessages`, `cacheTools`, `thinkingType`,
-`thinkingBudgetTokens`, `sendThinking`, `returnThinking`, `midConversationSystemMessages`, `toolChoiceName`,
-`disableParallelToolUse` and `userId`)
+The Anthropic-specific options shown above (`cacheSystemMessages`, `cacheTools`, `returnCacheDiagnostics`,
+`thinkingType`, `thinkingBudgetTokens`, `sendThinking`, `returnThinking`, `midConversationSystemMessages`,
+`toolChoiceName`, `disableParallelToolUse` and `userId`), as well as `previousMessageId` (request-only, see
+[Cache Diagnostics](#cache-diagnostics)),
 can also be set per request via `AnthropicChatRequestParameters`, overriding the values configured on the model
 builder. This lets a single shared model instance vary these options from one call to the next — for example,
 enabling prompt caching for a long-running agent loop while skipping it for a cheap one-shot completion, without
@@ -486,6 +488,48 @@ To enable prompt caching for a `UserMessage`, you need to set the `cache_control
 UserMessage userMessage = UserMessage.from("Hello cached world");
 userMessage.attributes().put("cache_control", "ephemeral");
 ```
+
+### Cache Diagnostics
+
+Anthropic's (beta) [cache diagnostics](https://docs.anthropic.com/en/docs/build-with-claude/cache-diagnostics)
+feature reports *why* a prompt-cache hit was missed (model, system prompt, tools or message history changed),
+instead of only showing `cacheReadInputTokens` drop to zero.
+
+It requires the `cache-diagnosis-2026-04-07` beta header and is enabled via `returnCacheDiagnostics`. Pass
+`previousMessageId` as `null` on the first turn of a conversation to opt in, and the `id` of the previous
+response on every subsequent turn:
+
+```java
+AnthropicChatModel model = AnthropicChatModel.builder()
+        .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+        .beta("cache-diagnosis-2026-04-07")
+        .returnCacheDiagnostics(true)
+        .build();
+
+ChatResponse response1 = model.chat(ChatRequest.builder()
+        .messages(UserMessage.from("Summarize section 1."))
+        .build());
+String previousMessageId = ((AnthropicChatResponseMetadata) response1.metadata()).id();
+
+ChatResponse response2 = model.chat(ChatRequest.builder()
+        .messages(UserMessage.from("Summarize section 1."), UserMessage.from("Now summarize section 2."))
+        .parameters(AnthropicChatRequestParameters.builder()
+                // returnCacheDiagnostics and previousMessageId must be set together on the same
+                // AnthropicChatRequestParameters — they are not merged independently with the model's defaults
+                .returnCacheDiagnostics(true)
+                .previousMessageId(previousMessageId)
+                .build())
+        .build());
+
+AnthropicCacheDiagnostics diagnostics = ((AnthropicChatResponseMetadata) response2.metadata()).cacheDiagnostics();
+if (diagnostics != null && diagnostics.cacheMissReasonType() != null) {
+    // e.g. "model_changed", "system_changed", "tools_changed", "messages_changed",
+    // "previous_message_not_found" or "unavailable"
+    System.out.println(diagnostics.cacheMissReasonType());
+}
+```
+
+`cacheDiagnostics()` is `null` when diagnostics weren't requested or no divergence was found.
 
 ## Thinking
 

--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -514,9 +514,8 @@ String previousMessageId = ((AnthropicChatResponseMetadata) response1.metadata()
 ChatResponse response2 = model.chat(ChatRequest.builder()
         .messages(UserMessage.from("Summarize section 1."), UserMessage.from("Now summarize section 2."))
         .parameters(AnthropicChatRequestParameters.builder()
-                // returnCacheDiagnostics and previousMessageId must be set together on the same
-                // AnthropicChatRequestParameters — they are not merged independently with the model's defaults
-                .returnCacheDiagnostics(true)
+                // returnCacheDiagnostics is already enabled on the model above, so on subsequent turns
+                // you only need to supply the previousMessageId (it changes every turn).
                 .previousMessageId(previousMessageId)
                 .build())
         .build());

--- a/langchain4j-anthropic/pom.xml
+++ b/langchain4j-anthropic/pom.xml
@@ -49,7 +49,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-
         <!-- test dependencies -->
 
         <dependency>

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicCacheDiagnostics.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicCacheDiagnostics.java
@@ -1,0 +1,97 @@
+package dev.langchain4j.model.anthropic;
+
+import dev.langchain4j.Experimental;
+import java.util.Objects;
+
+/**
+ * Result of Anthropic's (beta) cache diagnostics comparison for a single request, surfaced via
+ * {@link AnthropicChatResponseMetadata#cacheDiagnostics()}.
+ * <p>
+ * Cache diagnostics compares the current request against the one identified by
+ * {@code previousMessageId} (set via {@link AnthropicChatRequestParameters.Builder#previousMessageId(String)})
+ * and reports the first point where the two diverged, so that an unexpected prompt-cache miss
+ * (e.g. {@code usage.cacheReadInputTokens} dropping to zero) can be diagnosed instead of guessed at.
+ * Requires {@link AnthropicChatRequestParameters.Builder#returnCacheDiagnostics(Boolean)} to be enabled.
+ * <p>
+ * {@link AnthropicChatResponseMetadata#cacheDiagnostics()} itself is {@code null} when diagnostics
+ * were not requested, or when a comparison ran and found no divergence. When this object is present,
+ * {@link #cacheMissReasonType()} is {@code null} while the comparison is still running (treat this as
+ * inconclusive and check the next turn), otherwise it is one of: {@code "model_changed"},
+ * {@code "system_changed"}, {@code "tools_changed"}, {@code "messages_changed"},
+ * {@code "previous_message_not_found"}, or {@code "unavailable"}.
+ * <p>
+ * See the <a href="https://docs.anthropic.com/en/docs/build-with-claude/cache-diagnostics">cache diagnostics docs</a>.
+ *
+ * @since 1.10.0
+ */
+@Experimental
+public class AnthropicCacheDiagnostics {
+
+    private final String cacheMissReasonType;
+    private final Integer cacheMissedInputTokens;
+
+    private AnthropicCacheDiagnostics(Builder builder) {
+        this.cacheMissReasonType = builder.cacheMissReasonType;
+        this.cacheMissedInputTokens = builder.cacheMissedInputTokens;
+    }
+
+    /**
+     * The cache-miss reason discriminator, or {@code null} while the comparison is still running.
+     */
+    public String cacheMissReasonType() {
+        return cacheMissReasonType;
+    }
+
+    /**
+     * An estimate of how many input tokens fell after the divergence point. Only populated for the
+     * {@code "*_changed"} reason types; {@code null} otherwise.
+     */
+    public Integer cacheMissedInputTokens() {
+        return cacheMissedInputTokens;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AnthropicCacheDiagnostics)) return false;
+        AnthropicCacheDiagnostics that = (AnthropicCacheDiagnostics) o;
+        return Objects.equals(cacheMissReasonType, that.cacheMissReasonType)
+                && Objects.equals(cacheMissedInputTokens, that.cacheMissedInputTokens);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cacheMissReasonType, cacheMissedInputTokens);
+    }
+
+    @Override
+    public String toString() {
+        return "AnthropicCacheDiagnostics{" + "cacheMissReasonType='"
+                + cacheMissReasonType + '\'' + ", cacheMissedInputTokens="
+                + cacheMissedInputTokens + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String cacheMissReasonType;
+        private Integer cacheMissedInputTokens;
+
+        public Builder cacheMissReasonType(String cacheMissReasonType) {
+            this.cacheMissReasonType = cacheMissReasonType;
+            return this;
+        }
+
+        public Builder cacheMissedInputTokens(Integer cacheMissedInputTokens) {
+            this.cacheMissedInputTokens = cacheMissedInputTokens;
+            return this;
+        }
+
+        public AnthropicCacheDiagnostics build() {
+            return new AnthropicCacheDiagnostics(this);
+        }
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -146,10 +146,8 @@ public class AnthropicChatModel implements ChatModel {
                 .userId(getOrDefault(builder.userId, anthropicDefaults.userId()))
                 .returnCacheDiagnostics(
                         getOrDefault(builder.returnCacheDiagnostics, anthropicDefaults.returnCacheDiagnostics()))
-                .previousMessageId(
-                        anthropicDefaults.returnCacheDiagnostics() != null
-                                ? anthropicDefaults.previousMessageId()
-                                : null)
+                // previousMessageId is a per-request value (it changes every turn); it is never carried
+                // as a model-level default, only supplied via per-request AnthropicChatRequestParameters.
                 .build();
     }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -10,6 +10,7 @@ import static dev.langchain4j.model.anthropic.InternalAnthropicHelper.validate;
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType.EPHEMERAL;
 import static dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType.NO_CACHE;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAiMessage;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toCacheDiagnostics;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toFinishReason;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toTokenUsage;
 import static java.util.Arrays.asList;
@@ -143,6 +144,12 @@ public class AnthropicChatModel implements ChatModel {
                 .disableParallelToolUse(
                         getOrDefault(builder.disableParallelToolUse, anthropicDefaults.disableParallelToolUse()))
                 .userId(getOrDefault(builder.userId, anthropicDefaults.userId()))
+                .returnCacheDiagnostics(
+                        getOrDefault(builder.returnCacheDiagnostics, anthropicDefaults.returnCacheDiagnostics()))
+                .previousMessageId(
+                        anthropicDefaults.returnCacheDiagnostics() != null
+                                ? anthropicDefaults.previousMessageId()
+                                : null)
                 .build();
     }
 
@@ -192,6 +199,7 @@ public class AnthropicChatModel implements ChatModel {
         private Boolean strictTools;
         private Set<Capability> supportedCapabilities;
         private Supplier<Map<String, String>> customHeadersSupplier;
+        private Boolean returnCacheDiagnostics;
 
         /**
          * Sets a custom {@link HttpClientBuilder} for the underlying HTTP client.
@@ -735,6 +743,22 @@ public class AnthropicChatModel implements ChatModel {
         }
 
         /**
+         * Enables Anthropic's (beta) cache diagnostics for every request.
+         * <p>
+         * Requires the {@code cache-diagnosis-2026-04-07} beta header to also be set via {@link #beta(String)}.
+         * There is intentionally no model-level default for the {@code id} to compare against — it must be
+         * set per-request via {@link AnthropicChatRequestParameters.Builder#previousMessageId(String)}; see
+         * {@link AnthropicChatRequestParameters#previousMessageId()} for why.
+         *
+         * @see AnthropicChatRequestParameters.Builder#returnCacheDiagnostics(Boolean)
+         * @see AnthropicCacheDiagnostics
+         */
+        public AnthropicChatModelBuilder returnCacheDiagnostics(Boolean returnCacheDiagnostics) {
+            this.returnCacheDiagnostics = returnCacheDiagnostics;
+            return this;
+        }
+
+        /**
          * Sets arbitrary extra parameters to include in the Anthropic API request body.
          * Use this for experimental or provider-specific fields not yet covered by dedicated builder methods.
          *
@@ -829,7 +853,9 @@ public class AnthropicChatModel implements ChatModel {
                 parameters.userId(),
                 this.skills,
                 this.customParameters,
-                this.strictTools);
+                this.strictTools,
+                getOrDefault(parameters.returnCacheDiagnostics(), false),
+                parameters.previousMessageId());
 
         ParsedAndRawResponse response =
                 withRetryMappingExceptions(() -> client.createMessageWithRawResponse(anthropicRequest), maxRetries);
@@ -846,6 +872,7 @@ public class AnthropicChatModel implements ChatModel {
                 .tokenUsage(toTokenUsage(response.usage))
                 .finishReason(toFinishReason(response.stopReason))
                 .rawHttpResponse(parsedAndRawResponse.rawResponse())
+                .cacheDiagnostics(toCacheDiagnostics(response.diagnostics))
                 .build();
 
         return ChatResponse.builder()

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatModel.java
@@ -137,8 +137,8 @@ public class AnthropicChatModel implements ChatModel {
                 .thinkingBudgetTokens(
                         getOrDefault(builder.thinkingBudgetTokens, anthropicDefaults.thinkingBudgetTokens()))
                 .sendThinking(getOrDefault(builder.sendThinking, anthropicDefaults.sendThinking()))
-                .midConversationSystemMessages(
-                        getOrDefault(builder.midConversationSystemMessages, anthropicDefaults.midConversationSystemMessages()))
+                .midConversationSystemMessages(getOrDefault(
+                        builder.midConversationSystemMessages, anthropicDefaults.midConversationSystemMessages()))
                 .returnThinking(getOrDefault(builder.returnThinking, anthropicDefaults.returnThinking()))
                 .toolChoiceName(getOrDefault(builder.toolChoiceName, anthropicDefaults.toolChoiceName()))
                 .disableParallelToolUse(

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
@@ -25,6 +25,8 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
     private final String toolChoiceName;
     private final Boolean disableParallelToolUse;
     private final String userId;
+    private final Boolean returnCacheDiagnostics;
+    private final String previousMessageId;
 
     private AnthropicChatRequestParameters(Builder builder) {
         super(builder);
@@ -38,6 +40,8 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
         this.toolChoiceName = builder.toolChoiceName;
         this.disableParallelToolUse = builder.disableParallelToolUse;
         this.userId = builder.userId;
+        this.returnCacheDiagnostics = builder.returnCacheDiagnostics;
+        this.previousMessageId = builder.previousMessageId;
     }
 
     public Boolean cacheSystemMessages() {
@@ -80,6 +84,35 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
         return userId;
     }
 
+    /**
+     * Whether to request a (beta) cache-diagnostics comparison for this request.
+     *
+     * @see AnthropicCacheDiagnostics
+     */
+    public Boolean returnCacheDiagnostics() {
+        return returnCacheDiagnostics;
+    }
+
+    /**
+     * The {@code id} of the previous response to compare against when {@link #returnCacheDiagnostics()}
+     * is enabled. Pass {@code null} on the first turn of a conversation to opt in without a prior
+     * message to compare, and the {@code id} of the previous {@link AnthropicChatResponseMetadata} on
+     * every subsequent turn.
+     * <p>
+     * <b>This field and {@link #returnCacheDiagnostics()} are always merged as a unit, sourced from
+     * the same {@link ChatRequestParameters} object — set them together.</b> Unlike this class's other
+     * optional fields, {@code null} is a meaningful, required value here, so it can't be merged
+     * independently with {@code getOrDefault}-style "last non-null value wins" semantics (that could
+     * never override a previously-set non-null default back to {@code null}). Whenever a layer
+     * (a model-level default or a per-request override) specifies {@code returnCacheDiagnostics}
+     * explicitly, this field is taken verbatim from that same layer, {@code null} or not.
+     *
+     * @see AnthropicCacheDiagnostics
+     */
+    public String previousMessageId() {
+        return previousMessageId;
+    }
+
     @Override
     public AnthropicChatRequestParameters overrideWith(ChatRequestParameters that) {
         return AnthropicChatRequestParameters.builder()
@@ -111,7 +144,9 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 && Objects.equals(returnThinking, that.returnThinking)
                 && Objects.equals(toolChoiceName, that.toolChoiceName)
                 && Objects.equals(disableParallelToolUse, that.disableParallelToolUse)
-                && Objects.equals(userId, that.userId);
+                && Objects.equals(userId, that.userId)
+                && Objects.equals(returnCacheDiagnostics, that.returnCacheDiagnostics)
+                && Objects.equals(previousMessageId, that.previousMessageId);
     }
 
     @Override
@@ -127,7 +162,9 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 returnThinking,
                 toolChoiceName,
                 disableParallelToolUse,
-                userId);
+                userId,
+                returnCacheDiagnostics,
+                previousMessageId);
     }
 
     @Override
@@ -154,6 +191,8 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 + ", toolChoiceName=" + toolChoiceName
                 + ", disableParallelToolUse=" + disableParallelToolUse
                 + ", userId=" + userId
+                + ", returnCacheDiagnostics=" + returnCacheDiagnostics
+                + ", previousMessageId=" + previousMessageId
                 + '}';
     }
 
@@ -177,6 +216,8 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
         private String toolChoiceName;
         private Boolean disableParallelToolUse;
         private String userId;
+        private Boolean returnCacheDiagnostics;
+        private String previousMessageId;
 
         @Override
         public Builder overrideWith(ChatRequestParameters parameters) {
@@ -193,6 +234,11 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 disableParallelToolUse(
                         getOrDefault(anthropicParameters.disableParallelToolUse(), disableParallelToolUse));
                 userId(getOrDefault(anthropicParameters.userId(), userId));
+                // returnCacheDiagnostics + previousMessageId are merged as a unit; see previousMessageId() javadoc.
+                if (anthropicParameters.returnCacheDiagnostics() != null) {
+                    returnCacheDiagnostics(anthropicParameters.returnCacheDiagnostics());
+                    previousMessageId(anthropicParameters.previousMessageId());
+                }
             }
             return this;
         }
@@ -248,6 +294,35 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
 
         public Builder userId(String userId) {
             this.userId = userId;
+            return this;
+        }
+
+        /**
+         * Enables Anthropic's (beta) cache diagnostics for this request, requesting a comparison
+         * against the request identified by {@link #previousMessageId(String)} — set both together;
+         * see {@link AnthropicChatRequestParameters#previousMessageId()} for why.
+         * Requires the {@code cache-diagnosis-2026-04-07} beta header to be set on the model
+         * (see {@code beta(String)} on {@link AnthropicChatModel.AnthropicChatModelBuilder} /
+         * {@link AnthropicStreamingChatModel.AnthropicStreamingChatModelBuilder}).
+         *
+         * @see AnthropicCacheDiagnostics
+         */
+        public Builder returnCacheDiagnostics(Boolean returnCacheDiagnostics) {
+            this.returnCacheDiagnostics = returnCacheDiagnostics;
+            return this;
+        }
+
+        /**
+         * The {@code id} of the previous response to compare against; see
+         * {@link AnthropicChatRequestParameters#previousMessageId()} for the full contract. Pass
+         * {@code null} (the default) on the first turn of a conversation to opt in without a prior
+         * message to compare, and the {@code id} of the previous {@link AnthropicChatResponseMetadata}
+         * on every subsequent turn.
+         *
+         * @see AnthropicCacheDiagnostics
+         */
+        public Builder previousMessageId(String previousMessageId) {
+            this.previousMessageId = previousMessageId;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
@@ -99,13 +99,10 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
      * message to compare, and the {@code id} of the previous {@link AnthropicChatResponseMetadata} on
      * every subsequent turn.
      * <p>
-     * <b>This field and {@link #returnCacheDiagnostics()} are always merged as a unit, sourced from
-     * the same {@link ChatRequestParameters} object — set them together.</b> Unlike this class's other
-     * optional fields, {@code null} is a meaningful, required value here, so it can't be merged
-     * independently with {@code getOrDefault}-style "last non-null value wins" semantics (that could
-     * never override a previously-set non-null default back to {@code null}). Whenever a layer
-     * (a model-level default or a per-request override) specifies {@code returnCacheDiagnostics}
-     * explicitly, this field is taken verbatim from that same layer, {@code null} or not.
+     * This is a per-request value: it changes on every turn and there is intentionally no model-level
+     * setter for it. It can therefore be varied per request on its own, while
+     * {@link #returnCacheDiagnostics()} is enabled once on the model builder — the per-request
+     * {@code previousMessageId} is not paired with, or gated on, {@code returnCacheDiagnostics}.
      *
      * @see AnthropicCacheDiagnostics
      */
@@ -235,11 +232,9 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 disableParallelToolUse(
                         getOrDefault(anthropicParameters.disableParallelToolUse(), disableParallelToolUse));
                 userId(getOrDefault(anthropicParameters.userId(), userId));
-                // returnCacheDiagnostics + previousMessageId are merged as a unit; see previousMessageId() javadoc.
-                if (anthropicParameters.returnCacheDiagnostics() != null) {
-                    returnCacheDiagnostics(anthropicParameters.returnCacheDiagnostics());
-                    previousMessageId(anthropicParameters.previousMessageId());
-                }
+                returnCacheDiagnostics(
+                        getOrDefault(anthropicParameters.returnCacheDiagnostics(), returnCacheDiagnostics));
+                previousMessageId(getOrDefault(anthropicParameters.previousMessageId(), previousMessageId));
             }
             return this;
         }
@@ -300,8 +295,7 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
 
         /**
          * Enables Anthropic's (beta) cache diagnostics for this request, requesting a comparison
-         * against the request identified by {@link #previousMessageId(String)} — set both together;
-         * see {@link AnthropicChatRequestParameters#previousMessageId()} for why.
+         * against the request identified by {@link #previousMessageId(String)}.
          * Requires the {@code cache-diagnosis-2026-04-07} beta header to be set on the model
          * (see {@code beta(String)} on {@link AnthropicChatModel.AnthropicChatModelBuilder} /
          * {@link AnthropicStreamingChatModel.AnthropicStreamingChatModelBuilder}).

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParameters.java
@@ -228,7 +228,8 @@ public class AnthropicChatRequestParameters extends DefaultChatRequestParameters
                 thinkingType(getOrDefault(anthropicParameters.thinkingType(), thinkingType));
                 thinkingBudgetTokens(getOrDefault(anthropicParameters.thinkingBudgetTokens(), thinkingBudgetTokens));
                 sendThinking(getOrDefault(anthropicParameters.sendThinking(), sendThinking));
-                midConversationSystemMessages(getOrDefault(anthropicParameters.midConversationSystemMessages(), midConversationSystemMessages));
+                midConversationSystemMessages(getOrDefault(
+                        anthropicParameters.midConversationSystemMessages(), midConversationSystemMessages));
                 returnThinking(getOrDefault(anthropicParameters.returnThinking(), returnThinking));
                 toolChoiceName(getOrDefault(anthropicParameters.toolChoiceName(), toolChoiceName));
                 disableParallelToolUse(

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatResponseMetadata.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicChatResponseMetadata.java
@@ -1,13 +1,12 @@
 package dev.langchain4j.model.anthropic;
 
+import static dev.langchain4j.internal.Utils.copy;
+
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEvent;
 import dev.langchain4j.model.chat.response.ChatResponseMetadata;
-
 import java.util.List;
 import java.util.Objects;
-
-import static dev.langchain4j.internal.Utils.copy;
 
 /**
  * @since 1.10.0
@@ -16,11 +15,13 @@ public class AnthropicChatResponseMetadata extends ChatResponseMetadata {
 
     private final SuccessfulHttpResponse rawHttpResponse;
     private final List<ServerSentEvent> rawServerSentEvents;
+    private final AnthropicCacheDiagnostics cacheDiagnostics;
 
     private AnthropicChatResponseMetadata(Builder builder) {
         super(builder);
         this.rawHttpResponse = builder.rawHttpResponse;
         this.rawServerSentEvents = copy(builder.rawServerSentEvents);
+        this.cacheDiagnostics = builder.cacheDiagnostics;
     }
 
     @Override
@@ -36,11 +37,21 @@ public class AnthropicChatResponseMetadata extends ChatResponseMetadata {
         return rawServerSentEvents;
     }
 
+    /**
+     * Result of Anthropic's (beta) cache diagnostics comparison, or {@code null} when it was not
+     * requested (see {@code returnCacheDiagnostics} on {@link AnthropicChatRequestParameters}) or
+     * no divergence was found.
+     */
+    public AnthropicCacheDiagnostics cacheDiagnostics() {
+        return cacheDiagnostics;
+    }
+
     @Override
     public Builder toBuilder() {
         return ((Builder) super.toBuilder(builder()))
                 .rawHttpResponse(rawHttpResponse)
-                .rawServerSentEvents(rawServerSentEvents);
+                .rawServerSentEvents(rawServerSentEvents)
+                .cacheDiagnostics(cacheDiagnostics);
     }
 
     @Override
@@ -50,12 +61,13 @@ public class AnthropicChatResponseMetadata extends ChatResponseMetadata {
         if (!super.equals(o)) return false;
         AnthropicChatResponseMetadata that = (AnthropicChatResponseMetadata) o;
         return Objects.equals(rawHttpResponse, that.rawHttpResponse)
-                && Objects.equals(rawServerSentEvents, that.rawServerSentEvents);
+                && Objects.equals(rawServerSentEvents, that.rawServerSentEvents)
+                && Objects.equals(cacheDiagnostics, that.cacheDiagnostics);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), rawHttpResponse, rawServerSentEvents);
+        return Objects.hash(super.hashCode(), rawHttpResponse, rawServerSentEvents, cacheDiagnostics);
     }
 
     @Override
@@ -66,7 +78,8 @@ public class AnthropicChatResponseMetadata extends ChatResponseMetadata {
                 + tokenUsage() + ", finishReason="
                 + finishReason() + ", created="
                 + rawHttpResponse + ", rawServerSentEvents="
-                + rawServerSentEvents + '}';
+                + rawServerSentEvents + ", cacheDiagnostics="
+                + cacheDiagnostics + '}';
     }
 
     public static Builder builder() {
@@ -77,6 +90,7 @@ public class AnthropicChatResponseMetadata extends ChatResponseMetadata {
 
         private SuccessfulHttpResponse rawHttpResponse;
         private List<ServerSentEvent> rawServerSentEvents;
+        private AnthropicCacheDiagnostics cacheDiagnostics;
 
         public Builder rawHttpResponse(SuccessfulHttpResponse rawHttpResponse) {
             this.rawHttpResponse = rawHttpResponse;
@@ -85,6 +99,11 @@ public class AnthropicChatResponseMetadata extends ChatResponseMetadata {
 
         public Builder rawServerSentEvents(List<ServerSentEvent> rawServerSentEvents) {
             this.rawServerSentEvents = rawServerSentEvents;
+            return this;
+        }
+
+        public Builder cacheDiagnostics(AnthropicCacheDiagnostics cacheDiagnostics) {
+            this.cacheDiagnostics = cacheDiagnostics;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -132,8 +132,8 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 .thinkingBudgetTokens(
                         getOrDefault(builder.thinkingBudgetTokens, anthropicDefaults.thinkingBudgetTokens()))
                 .sendThinking(getOrDefault(builder.sendThinking, anthropicDefaults.sendThinking()))
-                .midConversationSystemMessages(
-                        getOrDefault(builder.midConversationSystemMessages, anthropicDefaults.midConversationSystemMessages()))
+                .midConversationSystemMessages(getOrDefault(
+                        builder.midConversationSystemMessages, anthropicDefaults.midConversationSystemMessages()))
                 .returnThinking(getOrDefault(builder.returnThinking, anthropicDefaults.returnThinking()))
                 .toolChoiceName(getOrDefault(builder.toolChoiceName, anthropicDefaults.toolChoiceName()))
                 .disableParallelToolUse(

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -141,10 +141,8 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 .userId(getOrDefault(builder.userId, anthropicDefaults.userId()))
                 .returnCacheDiagnostics(
                         getOrDefault(builder.returnCacheDiagnostics, anthropicDefaults.returnCacheDiagnostics()))
-                .previousMessageId(
-                        anthropicDefaults.returnCacheDiagnostics() != null
-                                ? anthropicDefaults.previousMessageId()
-                                : null)
+                // previousMessageId is a per-request value (it changes every turn); it is never carried
+                // as a model-level default, only supplied via per-request AnthropicChatRequestParameters.
                 .build();
     }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModel.java
@@ -139,6 +139,12 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 .disableParallelToolUse(
                         getOrDefault(builder.disableParallelToolUse, anthropicDefaults.disableParallelToolUse()))
                 .userId(getOrDefault(builder.userId, anthropicDefaults.userId()))
+                .returnCacheDiagnostics(
+                        getOrDefault(builder.returnCacheDiagnostics, anthropicDefaults.returnCacheDiagnostics()))
+                .previousMessageId(
+                        anthropicDefaults.returnCacheDiagnostics() != null
+                                ? anthropicDefaults.previousMessageId()
+                                : null)
                 .build();
     }
 
@@ -187,6 +193,7 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         private Boolean strictTools;
         private Set<Capability> supportedCapabilities;
         private Supplier<Map<String, String>> customHeadersSupplier;
+        private Boolean returnCacheDiagnostics;
 
         /**
          * Sets a custom {@link HttpClientBuilder} for the underlying HTTP client.
@@ -710,6 +717,22 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
         }
 
         /**
+         * Enables Anthropic's (beta) cache diagnostics for every request.
+         * <p>
+         * Requires the {@code cache-diagnosis-2026-04-07} beta header to also be set via {@link #beta(String)}.
+         * There is intentionally no model-level default for the {@code id} to compare against — it must be
+         * set per-request via {@link AnthropicChatRequestParameters.Builder#previousMessageId(String)}; see
+         * {@link AnthropicChatRequestParameters#previousMessageId()} for why.
+         *
+         * @see AnthropicChatRequestParameters.Builder#returnCacheDiagnostics(Boolean)
+         * @see AnthropicCacheDiagnostics
+         */
+        public AnthropicStreamingChatModelBuilder returnCacheDiagnostics(Boolean returnCacheDiagnostics) {
+            this.returnCacheDiagnostics = returnCacheDiagnostics;
+            return this;
+        }
+
+        /**
          * Sets arbitrary extra parameters to include in the Anthropic API request body.
          * Use this for experimental or provider-specific fields not yet covered by dedicated builder methods.
          *
@@ -805,7 +828,9 @@ public class AnthropicStreamingChatModel implements StreamingChatModel {
                 parameters.userId(),
                 this.skills,
                 this.customParameters,
-                this.strictTools);
+                this.strictTools,
+                getOrDefault(parameters.returnCacheDiagnostics(), false),
+                parameters.previousMessageId());
 
         boolean returnThinking = getOrDefault(parameters.returnThinking(), false);
         client.createMessage(

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/InternalAnthropicHelper.java
@@ -14,6 +14,7 @@ import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicContainer;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicContainer.AnthropicContainerSkill;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicDiagnosticsParameters;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicFormat;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicMetadata;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicOutputConfig;
@@ -148,7 +149,9 @@ class InternalAnthropicHelper {
             String userId,
             List<AnthropicSkill> skills,
             Map<String, Object> customParameters,
-            Boolean strictTools) {
+            Boolean strictTools,
+            boolean returnCacheDiagnostics,
+            String previousMessageId) {
 
         AnthropicCreateMessageRequest.Builder requestBuilder = AnthropicCreateMessageRequest.builder().stream(stream)
                 .model(chatRequest.modelName())
@@ -191,6 +194,10 @@ class InternalAnthropicHelper {
 
         if (!isNullOrEmpty(userId)) {
             requestBuilder.metadata(AnthropicMetadata.builder().userId(userId).build());
+        }
+
+        if (returnCacheDiagnostics) {
+            requestBuilder.diagnostics(new AnthropicDiagnosticsParameters(previousMessageId));
         }
 
         return requestBuilder.build();

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCacheMissReason.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCacheMissReason.java
@@ -1,0 +1,66 @@
+package dev.langchain4j.model.anthropic.internal.api;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Objects;
+
+/**
+ * The reason a cache-diagnostics comparison found a divergence, or why no comparison was produced.
+ * <p>
+ * {@code type} is a discriminator (e.g. {@code "model_changed"}, {@code "system_changed"},
+ * {@code "tools_changed"}, {@code "messages_changed"}, {@code "previous_message_not_found"},
+ * {@code "unavailable"}). {@code cacheMissedInputTokens} is only present for the {@code "*_changed"} types.
+ * <p>
+ * Kept as a flat, loosely-typed POJO (rather than a discriminated union of subclasses) since this
+ * is a beta feature whose field names and semantics may change before general availability.
+ */
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class AnthropicCacheMissReason {
+
+    public String type;
+    public Integer cacheMissedInputTokens;
+
+    public AnthropicCacheMissReason() {}
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Integer getCacheMissedInputTokens() {
+        return cacheMissedInputTokens;
+    }
+
+    public void setCacheMissedInputTokens(Integer cacheMissedInputTokens) {
+        this.cacheMissedInputTokens = cacheMissedInputTokens;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AnthropicCacheMissReason)) return false;
+        AnthropicCacheMissReason that = (AnthropicCacheMissReason) o;
+        return Objects.equals(type, that.type) && Objects.equals(cacheMissedInputTokens, that.cacheMissedInputTokens);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, cacheMissedInputTokens);
+    }
+
+    @Override
+    public String toString() {
+        return "AnthropicCacheMissReason{" + "type='"
+                + type + '\'' + ", cacheMissedInputTokens="
+                + cacheMissedInputTokens + '}';
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCreateMessageRequest.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCreateMessageRequest.java
@@ -31,6 +31,7 @@ public class AnthropicCreateMessageRequest {
     public AnthropicThinking thinking;
     public AnthropicMetadata metadata;
     public AnthropicContainer container;
+    public AnthropicDiagnosticsParameters diagnostics;
 
     @JsonIgnore
     public Map<String, Object> customParameters;
@@ -53,6 +54,7 @@ public class AnthropicCreateMessageRequest {
         this.thinking = builder.thinking;
         this.metadata = builder.metadata;
         this.container = builder.container;
+        this.diagnostics = builder.diagnostics;
         this.customParameters = builder.customParameters;
     }
 
@@ -206,6 +208,14 @@ public class AnthropicCreateMessageRequest {
         this.container = container;
     }
 
+    public AnthropicDiagnosticsParameters getDiagnostics() {
+        return diagnostics;
+    }
+
+    public void setDiagnostics(AnthropicDiagnosticsParameters diagnostics) {
+        this.diagnostics = diagnostics;
+    }
+
     @JsonAnyGetter
     public Map<String, Object> getCustomParameters() {
         return customParameters;
@@ -236,6 +246,7 @@ public class AnthropicCreateMessageRequest {
                         .thinking(this.thinking)
                         .metadata(this.metadata)
                         .container(this.container)
+                        .diagnostics(this.diagnostics)
                         .customParameters(this.customParameters);
     }
 
@@ -256,6 +267,7 @@ public class AnthropicCreateMessageRequest {
         private AnthropicThinking thinking;
         private AnthropicMetadata metadata;
         private AnthropicContainer container;
+        private AnthropicDiagnosticsParameters diagnostics;
         private Map<String, Object> customParameters;
 
         public Builder model(String model) {
@@ -330,6 +342,11 @@ public class AnthropicCreateMessageRequest {
 
         public Builder container(AnthropicContainer container) {
             this.container = container;
+            return this;
+        }
+
+        public Builder diagnostics(AnthropicDiagnosticsParameters diagnostics) {
+            this.diagnostics = diagnostics;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCreateMessageResponse.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicCreateMessageResponse.java
@@ -61,6 +61,12 @@ public class AnthropicCreateMessageResponse {
     public AnthropicUsage usage;
 
     /**
+     * Result of a (beta) cache-diagnostics comparison; {@code null} when not requested,
+     * not yet available, or no divergence was found. See {@link AnthropicDiagnostics}.
+     */
+    public AnthropicDiagnostics diagnostics;
+
+    /**
      * Default constructor.
      */
     public AnthropicCreateMessageResponse() {}
@@ -74,11 +80,12 @@ public class AnthropicCreateMessageResponse {
         this.stopReason = builder.stopReason;
         this.stopSequence = builder.stopSequence;
         this.usage = builder.usage;
+        this.diagnostics = builder.diagnostics;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, type, role, content, model, stopReason, stopSequence, usage);
+        return Objects.hash(id, type, role, content, model, stopReason, stopSequence, usage, diagnostics);
     }
 
     @Override
@@ -93,7 +100,8 @@ public class AnthropicCreateMessageResponse {
                 && Objects.equals(model, that.model)
                 && Objects.equals(stopReason, that.stopReason)
                 && Objects.equals(stopSequence, that.stopSequence)
-                && Objects.equals(usage, that.usage);
+                && Objects.equals(usage, that.usage)
+                && Objects.equals(diagnostics, that.diagnostics);
     }
 
     @Override
@@ -106,7 +114,8 @@ public class AnthropicCreateMessageResponse {
                 + model + '\'' + ", stopReason='"
                 + stopReason + '\'' + ", stopSequence='"
                 + stopSequence + '\'' + ", usage="
-                + usage + '}';
+                + usage + ", diagnostics="
+                + diagnostics + '}';
     }
 
     /**
@@ -130,6 +139,7 @@ public class AnthropicCreateMessageResponse {
         private String stopReason;
         private String stopSequence;
         private AnthropicUsage usage;
+        private AnthropicDiagnostics diagnostics;
 
         /**
          * Sets the unique identifier.
@@ -216,6 +226,17 @@ public class AnthropicCreateMessageResponse {
          */
         public Builder usage(AnthropicUsage usage) {
             this.usage = usage;
+            return this;
+        }
+
+        /**
+         * Sets the cache-diagnostics result.
+         *
+         * @param diagnostics the cache-diagnostics result
+         * @return this builder for chaining
+         */
+        public Builder diagnostics(AnthropicDiagnostics diagnostics) {
+            this.diagnostics = diagnostics;
             return this;
         }
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicDiagnostics.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicDiagnostics.java
@@ -1,0 +1,56 @@
+package dev.langchain4j.model.anthropic.internal.api;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Objects;
+
+/**
+ * Result of an Anthropic (beta) cache-diagnostics comparison, returned on
+ * {@code AnthropicCreateMessageResponse#diagnostics} (and, for streaming, on the {@code message_start} event)
+ * when the {@code cache-diagnosis-2026-04-07} beta header and {@code diagnostics.previous_message_id}
+ * request parameter were used.
+ */
+@JsonInclude(NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class AnthropicDiagnostics {
+
+    /**
+     * {@code null} when either {@code previous_message_id} was {@code null} (first turn) or the comparison
+     * found no divergence, and also {@code null} (with this object itself present) while the comparison
+     * was still running when the response was serialized.
+     */
+    public AnthropicCacheMissReason cacheMissReason;
+
+    public AnthropicDiagnostics() {}
+
+    public AnthropicCacheMissReason getCacheMissReason() {
+        return cacheMissReason;
+    }
+
+    public void setCacheMissReason(AnthropicCacheMissReason cacheMissReason) {
+        this.cacheMissReason = cacheMissReason;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AnthropicDiagnostics)) return false;
+        AnthropicDiagnostics that = (AnthropicDiagnostics) o;
+        return Objects.equals(cacheMissReason, that.cacheMissReason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cacheMissReason);
+    }
+
+    @Override
+    public String toString() {
+        return "AnthropicDiagnostics{" + "cacheMissReason=" + cacheMissReason + '}';
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicDiagnosticsParameters.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicDiagnosticsParameters.java
@@ -1,0 +1,56 @@
+package dev.langchain4j.model.anthropic.internal.api;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Objects;
+
+/**
+ * Request parameters enabling Anthropic's (beta) cache diagnostics feature.
+ * <p>
+ * {@code previousMessageId} must be serialized even when {@code null}, since sending
+ * {@code "diagnostics": {"previous_message_id": null}} is how a caller opts in on the first
+ * turn of a conversation. Requires the {@code cache-diagnosis-2026-04-07} beta header.
+ */
+@JsonInclude(ALWAYS)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class AnthropicDiagnosticsParameters {
+
+    public String previousMessageId;
+
+    public AnthropicDiagnosticsParameters() {}
+
+    public AnthropicDiagnosticsParameters(String previousMessageId) {
+        this.previousMessageId = previousMessageId;
+    }
+
+    public String getPreviousMessageId() {
+        return previousMessageId;
+    }
+
+    public void setPreviousMessageId(String previousMessageId) {
+        this.previousMessageId = previousMessageId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AnthropicDiagnosticsParameters)) return false;
+        AnthropicDiagnosticsParameters that = (AnthropicDiagnosticsParameters) o;
+        return Objects.equals(previousMessageId, that.previousMessageId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(previousMessageId);
+    }
+
+    @Override
+    public String toString() {
+        return "AnthropicDiagnosticsParameters{" + "previousMessageId='" + previousMessageId + '\'' + '}';
+    }
+}

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicResponseMessage.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicResponseMessage.java
@@ -1,13 +1,12 @@
 package dev.langchain4j.model.anthropic.internal.api;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.util.List;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonInclude(NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -22,4 +21,5 @@ public class AnthropicResponseMessage {
     public String stopReason;
     public String stopSequence;
     public AnthropicUsage usage;
+    public AnthropicDiagnostics diagnostics;
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolUseContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolUseContent.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import java.util.Map;
 import java.util.Objects;
 
 @JsonInclude(NON_NULL)
@@ -16,6 +15,7 @@ public class AnthropicToolUseContent extends AnthropicMessageContent {
 
     public String id;
     public String name;
+
     @com.fasterxml.jackson.annotation.JsonRawValue
     public String input;
 

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
@@ -20,6 +20,7 @@ import static dev.langchain4j.model.anthropic.internal.client.Json.toJson;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.REDACTED_THINKING_KEY;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.SERVER_TOOL_RESULTS_KEY;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.THINKING_SIGNATURE_KEY;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toCacheDiagnostics;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toFinishReason;
 import static java.util.Collections.synchronizedList;
 import static java.util.stream.Collectors.joining;
@@ -47,6 +48,7 @@ import dev.langchain4j.model.anthropic.internal.api.AnthropicCountTokensRequest;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageResponse;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicDelta;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicDiagnostics;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicModelsListResponse;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicResponseMessage;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicStreamingData;
@@ -299,6 +301,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
 
             final AtomicReference<String> responseId = new AtomicReference<>();
             final AtomicReference<String> responseModel = new AtomicReference<>();
+            final AtomicReference<AnthropicDiagnostics> responseDiagnostics = new AtomicReference<>();
 
             volatile String stopReason;
             volatile StreamingHandle streamingHandle;
@@ -388,6 +391,9 @@ public class DefaultAnthropicClient extends AnthropicClient {
                     }
                     if (message.model != null) {
                         responseModel.set(message.model);
+                    }
+                    if (message.diagnostics != null) {
+                        responseDiagnostics.set(message.diagnostics);
                     }
                 }
             }
@@ -613,6 +619,9 @@ public class DefaultAnthropicClient extends AnthropicClient {
                 }
                 if (!rawServerSentEvents.isEmpty()) {
                     metadataBuilder.rawServerSentEvents(new ArrayList<>(rawServerSentEvents));
+                }
+                if (responseDiagnostics.get() != null) {
+                    metadataBuilder.cacheDiagnostics(toCacheDiagnostics(responseDiagnostics.get()));
                 }
                 return metadataBuilder.build();
             }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -33,11 +33,14 @@ import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.pdf.PdfFile;
+import dev.langchain4j.model.anthropic.AnthropicCacheDiagnostics;
 import dev.langchain4j.model.anthropic.AnthropicServerTool;
 import dev.langchain4j.model.anthropic.AnthropicServerToolResult;
 import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheMissReason;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicContent;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicDiagnostics;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicImageContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicMessage;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicMessageContent;
@@ -369,6 +372,17 @@ public class AnthropicMapper {
                 .outputTokenCount(anthropicUsage.outputTokens)
                 .cacheCreationInputTokens(anthropicUsage.cacheCreationInputTokens)
                 .cacheReadInputTokens(anthropicUsage.cacheReadInputTokens)
+                .build();
+    }
+
+    public static AnthropicCacheDiagnostics toCacheDiagnostics(AnthropicDiagnostics anthropicDiagnostics) {
+        if (anthropicDiagnostics == null) {
+            return null;
+        }
+        AnthropicCacheMissReason cacheMissReason = anthropicDiagnostics.cacheMissReason;
+        return AnthropicCacheDiagnostics.builder()
+                .cacheMissReasonType(cacheMissReason == null ? null : cacheMissReason.type)
+                .cacheMissedInputTokens(cacheMissReason == null ? null : cacheMissReason.cacheMissedInputTokens)
                 .build();
     }
 

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicCacheDiagnosticsIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicCacheDiagnosticsIT.java
@@ -48,10 +48,8 @@ class AnthropicCacheDiagnosticsIT {
                 .messages(UserMessage.from(prompt))
                 .parameters(AnthropicChatRequestParameters.builder()
                         .modelName(CLAUDE_SONNET_4_5_20250929)
-                        // returnCacheDiagnostics must be re-stated here alongside previousMessageId --
-                        // the two are merged as a unit, sourced from the same parameters object (see
-                        // AnthropicChatRequestParameters#previousMessageId() javadoc).
-                        .returnCacheDiagnostics(true)
+                        // returnCacheDiagnostics is already enabled on the model, so only previousMessageId
+                        // needs to be supplied per request (see AnthropicChatRequestParameters#previousMessageId()).
                         .previousMessageId(metadata1.id())
                         .build())
                 .build());

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicCacheDiagnosticsIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicCacheDiagnosticsIT.java
@@ -1,0 +1,73 @@
+package dev.langchain4j.model.anthropic;
+
+import static dev.langchain4j.internal.Utils.randomString;
+import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_HAIKU_4_5_20251001;
+import static dev.langchain4j.model.anthropic.AnthropicChatModelName.CLAUDE_SONNET_4_5_20250929;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+class AnthropicCacheDiagnosticsIT {
+
+    private static final String BETA = "cache-diagnosis-2026-04-07";
+
+    @Test
+    void should_return_null_diagnostics_on_first_turn_and_model_changed_on_second_turn() {
+        // given
+        AnthropicChatModel model = AnthropicChatModel.builder()
+                .apiKey(System.getenv("ANTHROPIC_API_KEY"))
+                .beta(BETA)
+                .returnCacheDiagnostics(true)
+                .maxTokens(10)
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        String prompt = randomString(10);
+
+        // when: first turn, opting in with previousMessageId == null (the model default)
+        ChatResponse response1 = model.chat(ChatRequest.builder()
+                .messages(UserMessage.from(prompt))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .modelName(CLAUDE_HAIKU_4_5_20251001)
+                        .build())
+                .build());
+
+        // then: first turn always reports null diagnostics (nothing to compare against yet)
+        AnthropicChatResponseMetadata metadata1 = (AnthropicChatResponseMetadata) response1.metadata();
+        assertThat(metadata1.id()).isNotBlank();
+        assertThat(metadata1.cacheDiagnostics()).isNull();
+
+        // when: second turn, deliberately switching models to force a deterministic "model_changed" divergence
+        ChatResponse response2 = model.chat(ChatRequest.builder()
+                .messages(UserMessage.from(prompt))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .modelName(CLAUDE_SONNET_4_5_20250929)
+                        // returnCacheDiagnostics must be re-stated here alongside previousMessageId --
+                        // the two are merged as a unit, sourced from the same parameters object (see
+                        // AnthropicChatRequestParameters#previousMessageId() javadoc).
+                        .returnCacheDiagnostics(true)
+                        .previousMessageId(metadata1.id())
+                        .build())
+                .build());
+
+        // then
+        AnthropicChatResponseMetadata metadata2 = (AnthropicChatResponseMetadata) response2.metadata();
+        assertThat(metadata2.id()).isNotBlank();
+
+        AnthropicCacheDiagnostics diagnostics = metadata2.cacheDiagnostics();
+        if (diagnostics != null && diagnostics.cacheMissReasonType() != null) {
+            // comparison resolved in time for this response (the common case)
+            assertThat(diagnostics.cacheMissReasonType()).isEqualTo("model_changed");
+            assertThat(diagnostics.cacheMissedInputTokens()).isNotNull();
+        }
+        // else: either no comparison was returned, or it was still pending
+        // ("treat as inconclusive and check the next turn" per the Anthropic docs) -- both are
+        // legitimate, documented states for a single live call and not a wiring failure on their own.
+    }
+}

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestCacheParametersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestCacheParametersTest.java
@@ -195,6 +195,98 @@ class AnthropicChatRequestCacheParametersTest {
         assertThat(body).contains("request-user");
     }
 
+    @Test
+    void should_not_send_diagnostics_when_not_requested() {
+        AnthropicChatModel model = modelBuilder().build();
+
+        model.chat(ChatRequest.builder().messages(UserMessage.from("Hi")).build());
+
+        assertThat(lastRequestBody()).doesNotContain("\"diagnostics\"");
+    }
+
+    @Test
+    void should_opt_in_to_cache_diagnostics_with_null_previous_message_id_on_first_turn() {
+        AnthropicChatModel model = modelBuilder().build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Hi"))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .returnCacheDiagnostics(true)
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        String body = lastRequestBody();
+        assertThat(body).contains("\"diagnostics\"");
+        assertThat(body).contains("\"previous_message_id\" : null");
+    }
+
+    @Test
+    void should_send_previous_message_id_on_subsequent_turn() {
+        AnthropicChatModel model = modelBuilder().build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Hi"))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .returnCacheDiagnostics(true)
+                        .previousMessageId("msg_previous")
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        assertThat(lastRequestBody()).contains("\"previous_message_id\" : \"msg_previous\"");
+    }
+
+    @Test
+    void should_clear_previous_message_id_per_request_even_when_model_default_is_set() {
+        // Regression test: overrideWith() must not silently fall back to a stale model-level
+        // default when a request explicitly opts in to diagnostics fresh (previousMessageId == null),
+        // since null is a meaningful, required value here (see AnthropicDiagnosticsParameters).
+        AnthropicChatModel model = modelBuilder()
+                .defaultRequestParameters(AnthropicChatRequestParameters.builder()
+                        .previousMessageId("msg_stale_default")
+                        .build())
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Hi"))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .returnCacheDiagnostics(true)
+                        .previousMessageId(null)
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        String body = lastRequestBody();
+        assertThat(body).contains("\"previous_message_id\" : null");
+        assertThat(body).doesNotContain("msg_stale_default");
+    }
+
+    @Test
+    void should_not_pair_unrelated_default_previous_message_id_with_model_level_diagnostics_toggle() {
+        // Regression test: the model's own baseline defaultRequestParameters must apply the same
+        // "merge as a unit" rule as overrideWith() does. Without it, a previousMessageId carried on an
+        // unrelated defaultRequestParameters() object (with no returnCacheDiagnostics of its own) could
+        // get paired with an unrelated model-level returnCacheDiagnostics(true) toggle, sending a stale
+        // id the caller never associated with diagnostics.
+        AnthropicChatModel model = modelBuilder()
+                .returnCacheDiagnostics(true)
+                .defaultRequestParameters(AnthropicChatRequestParameters.builder()
+                        .previousMessageId("msg_unrelated")
+                        .build())
+                .build();
+
+        model.chat(ChatRequest.builder().messages(UserMessage.from("Hi")).build());
+
+        String body = lastRequestBody();
+        assertThat(body).contains("\"diagnostics\"");
+        assertThat(body).contains("\"previous_message_id\" : null");
+        assertThat(body).doesNotContain("msg_unrelated");
+    }
+
     private static ToolSpecification weatherTool() {
         return ToolSpecification.builder()
                 .name("get_weather")

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestCacheParametersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestCacheParametersTest.java
@@ -241,9 +241,9 @@ class AnthropicChatRequestCacheParametersTest {
 
     @Test
     void should_clear_previous_message_id_per_request_even_when_model_default_is_set() {
-        // Regression test: overrideWith() must not silently fall back to a stale model-level
-        // default when a request explicitly opts in to diagnostics fresh (previousMessageId == null),
-        // since null is a meaningful, required value here (see AnthropicDiagnosticsParameters).
+        // Regression test: previousMessageId is a per-request value and is never carried as a
+        // model-level default, so a stale id placed on defaultRequestParameters must not leak into a
+        // request that opts in fresh with previousMessageId == null (a meaningful first-turn value).
         AnthropicChatModel model = modelBuilder()
                 .defaultRequestParameters(AnthropicChatRequestParameters.builder()
                         .previousMessageId("msg_stale_default")
@@ -267,11 +267,9 @@ class AnthropicChatRequestCacheParametersTest {
 
     @Test
     void should_not_pair_unrelated_default_previous_message_id_with_model_level_diagnostics_toggle() {
-        // Regression test: the model's own baseline defaultRequestParameters must apply the same
-        // "merge as a unit" rule as overrideWith() does. Without it, a previousMessageId carried on an
-        // unrelated defaultRequestParameters() object (with no returnCacheDiagnostics of its own) could
-        // get paired with an unrelated model-level returnCacheDiagnostics(true) toggle, sending a stale
-        // id the caller never associated with diagnostics.
+        // Regression test: a previousMessageId carried on an unrelated defaultRequestParameters() object
+        // must not leak onto the wire just because returnCacheDiagnostics(true) is toggled on at the model
+        // level -- previousMessageId is per-request only and is never sourced from a model-level default.
         AnthropicChatModel model = modelBuilder()
                 .returnCacheDiagnostics(true)
                 .defaultRequestParameters(AnthropicChatRequestParameters.builder()
@@ -285,6 +283,27 @@ class AnthropicChatRequestCacheParametersTest {
         assertThat(body).contains("\"diagnostics\"");
         assertThat(body).contains("\"previous_message_id\" : null");
         assertThat(body).doesNotContain("msg_unrelated");
+    }
+
+    @Test
+    void should_send_per_request_previous_message_id_when_diagnostics_enabled_at_model_level() {
+        // The ergonomic path: enable diagnostics once on the model, then only vary previousMessageId
+        // per request (without re-stating returnCacheDiagnostics every turn). The per-request id must
+        // reach the wire instead of being silently dropped in favour of a null previous_message_id.
+        AnthropicChatModel model = modelBuilder().returnCacheDiagnostics(true).build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Hi"))
+                .parameters(AnthropicChatRequestParameters.builder()
+                        .previousMessageId("msg_previous")
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        String body = lastRequestBody();
+        assertThat(body).contains("\"diagnostics\"");
+        assertThat(body).contains("\"previous_message_id\" : \"msg_previous\"");
     }
 
     private static ToolSpecification weatherTool() {

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParametersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicChatRequestParametersTest.java
@@ -259,7 +259,8 @@ class AnthropicChatRequestParametersTest {
                 .isTrue();
 
         // defaults to null
-        assertThat(AnthropicChatRequestParameters.EMPTY.midConversationSystemMessages()).isNull();
+        assertThat(AnthropicChatRequestParameters.EMPTY.midConversationSystemMessages())
+                .isNull();
 
         // overrideWith takes the other value when set
         AnthropicChatRequestParameters overridden = AnthropicChatRequestParameters.builder()

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -10,6 +10,7 @@ import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.to
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicSchema;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicSystemPrompt;
 import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toAnthropicTool;
+import static dev.langchain4j.model.anthropic.internal.mapper.AnthropicMapper.toCacheDiagnostics;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -31,8 +32,10 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheMissReason;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicContent;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicDiagnostics;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicImageContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicMessage;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicMessageContent;
@@ -712,6 +715,43 @@ class AnthropicMapperTest {
                         new AnthropicMessage(USER, singletonList(new AnthropicToolResultContent("1", "4", null))),
                         new AnthropicMessage(SYSTEM, singletonList(new AnthropicTextContent("be concise"))),
                         new AnthropicMessage(USER, singletonList(new AnthropicTextContent("thanks"))));
+    }
+
+    @Test
+    void should_map_null_diagnostics_to_null() {
+        assertThat(toCacheDiagnostics(null)).isNull();
+    }
+
+    @Test
+    void should_map_diagnostics_with_no_cache_miss_reason_to_null_reason_type() {
+        // Given
+        AnthropicDiagnostics anthropicDiagnostics = new AnthropicDiagnostics();
+        anthropicDiagnostics.cacheMissReason = null;
+
+        // When
+        AnthropicCacheDiagnostics cacheDiagnostics = toCacheDiagnostics(anthropicDiagnostics);
+
+        // Then
+        assertThat(cacheDiagnostics).isNotNull();
+        assertThat(cacheDiagnostics.cacheMissReasonType()).isNull();
+        assertThat(cacheDiagnostics.cacheMissedInputTokens()).isNull();
+    }
+
+    @Test
+    void should_map_diagnostics_with_cache_miss_reason() {
+        // Given
+        AnthropicCacheMissReason reason = new AnthropicCacheMissReason();
+        reason.type = "system_changed";
+        reason.cacheMissedInputTokens = 41850;
+        AnthropicDiagnostics anthropicDiagnostics = new AnthropicDiagnostics();
+        anthropicDiagnostics.cacheMissReason = reason;
+
+        // When
+        AnthropicCacheDiagnostics cacheDiagnostics = toCacheDiagnostics(anthropicDiagnostics);
+
+        // Then
+        assertThat(cacheDiagnostics.cacheMissReasonType()).isEqualTo("system_changed");
+        assertThat(cacheDiagnostics.cacheMissedInputTokens()).isEqualTo(41850);
     }
 
     @SafeVarargs

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMidConversationSystemMessagesTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMidConversationSystemMessagesTest.java
@@ -49,7 +49,8 @@ class AnthropicMidConversationSystemMessagesTest {
 
     @Test
     void should_send_mid_conversation_system_message_inline_when_enabled() {
-        AnthropicChatModel model = modelBuilder().midConversationSystemMessages(true).build();
+        AnthropicChatModel model =
+                modelBuilder().midConversationSystemMessages(true).build();
 
         model.chat(ChatRequest.builder()
                 .messages(

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicSkillsTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicSkillsTest.java
@@ -33,7 +33,23 @@ class AnthropicSkillsTest {
 
     private static AnthropicCreateMessageRequest requestWithSkills(List<AnthropicSkill> skills) {
         return createAnthropicRequest(
-                chatRequest(), null, true, false, NO_CACHE, NO_CACHE, false, null, null, null, null, null, skills, null, null);
+                chatRequest(),
+                null,
+                true,
+                false,
+                NO_CACHE,
+                NO_CACHE,
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                skills,
+                null,
+                null,
+                false,
+                null);
     }
 
     @Test
@@ -79,6 +95,8 @@ class AnthropicSkillsTest {
                 null,
                 List.of(AnthropicSkill.PDF),
                 null,
+                null,
+                false,
                 null);
 
         assertThat(request.tools).extracting(tool -> tool.name).containsExactly("code_execution");
@@ -113,6 +131,8 @@ class AnthropicSkillsTest {
                 null,
                 List.of(AnthropicSkill.XLSX),
                 null,
+                null,
+                false,
                 null);
 
         // the regular tool name must not suppress the required code_execution server tool

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelThinkingIT.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicStreamingChatModelThinkingIT.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import java.util.List;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
@@ -26,6 +25,7 @@ import dev.langchain4j.http.client.jdk.JdkHttpClient;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.TestStreamingChatResponseHandler;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -39,26 +39,28 @@ class AnthropicStreamingChatModelThinkingIT {
     private static final int THINKING_BUDGET_TOKENS = 1024;
 
     @ParameterizedTest
-    @EnumSource(value = AnthropicChatModelName.class, mode = EXCLUDE, names = {"CLAUDE_OPUS_4_7"})
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = EXCLUDE,
+            names = {"CLAUDE_OPUS_4_7"})
     void should_return_and_send_thinking(AnthropicChatModelName modelName) {
 
         // given
         boolean returnThinking = true;
         // sendThinking = true by default
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         StreamingChatModel model = AnthropicStreamingChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
                 .baseUrl(System.getenv("ANTHROPIC_CACHING_BASE_URL"))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(modelName)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -72,9 +74,7 @@ class AnthropicStreamingChatModelThinkingIT {
         // then
         AiMessage aiMessage1 = spyHandler1.get().aiMessage();
         assertThat(aiMessage1.text()).containsIgnoringCase("Berlin");
-        assertThat(aiMessage1.thinking())
-                .containsIgnoringCase("Berlin")
-                .isEqualTo(spyHandler1.getThinking());
+        assertThat(aiMessage1.thinking()).containsIgnoringCase("Berlin").isEqualTo(spyHandler1.getThinking());
         String signature1 = aiMessage1.attribute("thinking_signature", String.class);
         assertThat(signature1).isNotBlank();
 
@@ -119,29 +119,30 @@ class AnthropicStreamingChatModelThinkingIT {
                 .contains(jsonify(signature1));
     }
 
-
     @ParameterizedTest
-    @EnumSource(value = AnthropicChatModelName.class, mode = EXCLUDE, names = {"CLAUDE_OPUS_4_7"})
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = EXCLUDE,
+            names = {"CLAUDE_OPUS_4_7"})
     void should_return_and_NOT_send_thinking(AnthropicChatModelName modelName) {
 
         // given
         boolean returnThinking = true;
         boolean sendThinking = false;
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         StreamingChatModel model = AnthropicStreamingChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
                 .baseUrl(System.getenv("ANTHROPIC_CACHING_BASE_URL"))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(modelName)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
                 .sendThinking(sendThinking)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -200,7 +201,10 @@ class AnthropicStreamingChatModelThinkingIT {
     }
 
     @ParameterizedTest
-    @EnumSource(value = AnthropicChatModelName.class, mode = EXCLUDE, names = {"CLAUDE_OPUS_4_7"})
+    @EnumSource(
+            value = AnthropicChatModelName.class,
+            mode = EXCLUDE,
+            names = {"CLAUDE_OPUS_4_7"})
     void should_return_and_send_thinking_with_tools(AnthropicChatModelName modelName) {
 
         // given
@@ -215,20 +219,19 @@ class AnthropicStreamingChatModelThinkingIT {
                         .build())
                 .build();
 
-        SpyingHttpClient spyingHttpClient = new SpyingHttpClient(JdkHttpClient.builder().build());
+        SpyingHttpClient spyingHttpClient =
+                new SpyingHttpClient(JdkHttpClient.builder().build());
 
         StreamingChatModel model = AnthropicStreamingChatModel.builder()
                 .httpClientBuilder(new MockHttpClientBuilder(spyingHttpClient))
                 .baseUrl(System.getenv("ANTHROPIC_CACHING_BASE_URL"))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(modelName)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
                 .toolSpecifications(toolSpecification)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();
@@ -246,18 +249,21 @@ class AnthropicStreamingChatModelThinkingIT {
         String signature1 = aiMessage1.attribute("thinking_signature", String.class);
         assertThat(signature1).isNotBlank();
         assertThat(aiMessage1.toolExecutionRequests()).hasSize(1);
-        ToolExecutionRequest toolExecutionRequest1 = aiMessage1.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest1 =
+                aiMessage1.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest1.name()).isEqualTo(toolSpecification.name());
         assertThat(toolExecutionRequest1.arguments()).contains("Munich");
 
         InOrder inOrder1 = inOrder(spyHandler1);
         inOrder1.verify(spyHandler1).get();
         inOrder1.verify(spyHandler1, atLeastOnce()).onPartialThinking(any(), any());
-        inOrder1.verify(spyHandler1, atLeast(0)).onPartialResponse(any(), any()); // do not care if onPartialResponse was called
-        inOrder1.verify(spyHandler1, atLeastOnce()).onPartialToolCall(argThat(toolCall ->
-                toolCall.name().equals(toolExecutionRequest1.name())), any());
-        inOrder1.verify(spyHandler1).onCompleteToolCall(argThat(toolCall ->
-                toolCall.toolExecutionRequest().equals(toolExecutionRequest1)));
+        inOrder1.verify(spyHandler1, atLeast(0))
+                .onPartialResponse(any(), any()); // do not care if onPartialResponse was called
+        inOrder1.verify(spyHandler1, atLeastOnce())
+                .onPartialToolCall(argThat(toolCall -> toolCall.name().equals(toolExecutionRequest1.name())), any());
+        inOrder1.verify(spyHandler1)
+                .onCompleteToolCall(
+                        argThat(toolCall -> toolCall.toolExecutionRequest().equals(toolExecutionRequest1)));
         inOrder1.verify(spyHandler1).onCompleteResponse(any());
         ignoreInteractions(spyHandler1).onUnmappedRawEvent(any());
         inOrder1.verifyNoMoreInteractions();
@@ -299,18 +305,21 @@ class AnthropicStreamingChatModelThinkingIT {
         String signature2 = aiMessage3.attribute("thinking_signature", String.class);
         assertThat(signature2).isNotBlank();
         assertThat(aiMessage3.toolExecutionRequests()).hasSize(1);
-        ToolExecutionRequest toolExecutionRequest2 = aiMessage3.toolExecutionRequests().get(0);
+        ToolExecutionRequest toolExecutionRequest2 =
+                aiMessage3.toolExecutionRequests().get(0);
         assertThat(toolExecutionRequest2.name()).isEqualTo(toolSpecification.name());
         assertThat(toolExecutionRequest2.arguments()).contains("Paris");
 
         InOrder inOrder3 = inOrder(spyHandler3);
         inOrder3.verify(spyHandler3).get();
         inOrder3.verify(spyHandler3, atLeastOnce()).onPartialThinking(any(), any());
-        inOrder3.verify(spyHandler3, atLeast(0)).onPartialResponse(any(), any()); // do not care if onPartialResponse was called
-        inOrder3.verify(spyHandler3, atLeastOnce()).onPartialToolCall(argThat(toolCall ->
-                toolCall.name().equals(toolExecutionRequest2.name())), any());
-        inOrder3.verify(spyHandler3).onCompleteToolCall(argThat(toolCall ->
-                toolCall.toolExecutionRequest().equals(toolExecutionRequest2)));
+        inOrder3.verify(spyHandler3, atLeast(0))
+                .onPartialResponse(any(), any()); // do not care if onPartialResponse was called
+        inOrder3.verify(spyHandler3, atLeastOnce())
+                .onPartialToolCall(argThat(toolCall -> toolCall.name().equals(toolExecutionRequest2.name())), any());
+        inOrder3.verify(spyHandler3)
+                .onCompleteToolCall(
+                        argThat(toolCall -> toolCall.toolExecutionRequest().equals(toolExecutionRequest2)));
         inOrder3.verify(spyHandler3).onCompleteResponse(any());
         ignoreInteractions(spyHandler3).onUnmappedRawEvent(any());
         inOrder3.verifyNoMoreInteractions();
@@ -321,7 +330,16 @@ class AnthropicStreamingChatModelThinkingIT {
 
         // when
         TestStreamingChatResponseHandler spyHandler4 = spy(new TestStreamingChatResponseHandler());
-        model.chat(List.of(userMessage1, aiMessage1, toolResultMessage1, aiMessage2, userMessage2, aiMessage3, toolResultMessage2), spyHandler4);
+        model.chat(
+                List.of(
+                        userMessage1,
+                        aiMessage1,
+                        toolResultMessage1,
+                        aiMessage2,
+                        userMessage2,
+                        aiMessage3,
+                        toolResultMessage2),
+                spyHandler4);
 
         // then
         AiMessage aiMessage4 = spyHandler4.get().aiMessage();
@@ -341,12 +359,8 @@ class AnthropicStreamingChatModelThinkingIT {
         // should send thinking in the follow-up requests
         List<HttpRequest> httpRequests = spyingHttpClient.requests();
         assertThat(httpRequests).hasSize(4);
-        assertThat(httpRequests.get(1).body())
-                .contains(jsonify(thinking1))
-                .contains(jsonify(signature1));
-        assertThat(httpRequests.get(3).body())
-                .contains(jsonify(thinking2))
-                .contains(jsonify(signature2));
+        assertThat(httpRequests.get(1).body()).contains(jsonify(thinking1)).contains(jsonify(signature1));
+        assertThat(httpRequests.get(3).body()).contains(jsonify(thinking2)).contains(jsonify(signature2));
     }
 
     @ParameterizedTest
@@ -359,12 +373,10 @@ class AnthropicStreamingChatModelThinkingIT {
                 .baseUrl(System.getenv("ANTHROPIC_CACHING_BASE_URL"))
                 .apiKey(System.getenv("ANTHROPIC_API_KEY"))
                 .modelName(CLAUDE_SONNET_4_5_20250929)
-
                 .thinkingType("enabled")
                 .thinkingBudgetTokens(THINKING_BUDGET_TOKENS)
                 .maxTokens(THINKING_BUDGET_TOKENS + 100)
                 .returnThinking(returnThinking)
-
                 .logRequests(true)
                 .logResponses(true)
                 .build();

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClientTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClientTest.java
@@ -4,23 +4,27 @@ import static dev.langchain4j.model.anthropic.internal.api.AnthropicRole.USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.http.client.HttpMethod;
 import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.MockHttpClient;
 import dev.langchain4j.http.client.MockHttpClientBuilder;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.model.anthropic.AnthropicChatResponseMetadata;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheMissReason;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCountTokensRequest;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageResponse;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicDiagnostics;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicDiagnosticsParameters;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicMessage;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicModelsListResponse;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicStreamingException;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicTextContent;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicUsage;
 import dev.langchain4j.model.anthropic.internal.api.MessageTokenCountResponse;
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.PartialToolCall;
@@ -166,6 +170,99 @@ class DefaultAnthropicClientTest {
             // Then
             HttpRequest sentRequest = mockHttpClient.request();
             assertThat(sentRequest.headers().get("anthropic-beta")).containsExactly(beta);
+        }
+
+        @Test
+        void shouldOmitDiagnosticsFieldWhenNotSet() {
+            // Given
+            AnthropicCreateMessageResponse expectedResponse = createMessageResponse("Test");
+            SuccessfulHttpResponse httpResponse = SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .body(Json.toJson(expectedResponse))
+                    .build();
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(httpResponse);
+            DefaultAnthropicClient subject = createClient(mockHttpClient);
+
+            AnthropicCreateMessageRequest request = createMessageRequest();
+
+            // When
+            subject.createMessage(request);
+
+            // Then
+            assertThat(mockHttpClient.request().body()).doesNotContain("\"diagnostics\"");
+        }
+
+        @Test
+        void shouldSendDiagnosticsWithNullPreviousMessageIdOnFirstTurn() {
+            // Given
+            AnthropicCreateMessageResponse expectedResponse = createMessageResponse("Test");
+            SuccessfulHttpResponse httpResponse = SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .body(Json.toJson(expectedResponse))
+                    .build();
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(httpResponse);
+            DefaultAnthropicClient subject = createClient(mockHttpClient);
+
+            AnthropicCreateMessageRequest request = createMessageRequest().toBuilder()
+                    .diagnostics(new AnthropicDiagnosticsParameters(null))
+                    .build();
+
+            // When
+            subject.createMessage(request);
+
+            // Then
+            String body = mockHttpClient.request().body();
+            assertThat(body).contains("\"diagnostics\"");
+            assertThat(body).contains("\"previous_message_id\" : null");
+        }
+
+        @Test
+        void shouldSendDiagnosticsWithPreviousMessageIdOnSubsequentTurn() {
+            // Given
+            AnthropicCreateMessageResponse expectedResponse = createMessageResponse("Test");
+            SuccessfulHttpResponse httpResponse = SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .body(Json.toJson(expectedResponse))
+                    .build();
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(httpResponse);
+            DefaultAnthropicClient subject = createClient(mockHttpClient);
+
+            AnthropicCreateMessageRequest request = createMessageRequest().toBuilder()
+                    .diagnostics(new AnthropicDiagnosticsParameters("msg_123"))
+                    .build();
+
+            // When
+            subject.createMessage(request);
+
+            // Then
+            assertThat(mockHttpClient.request().body()).contains("\"previous_message_id\" : \"msg_123\"");
+        }
+
+        @Test
+        void shouldParseCacheMissReasonFromResponse() {
+            // Given
+            AnthropicCacheMissReason reason = new AnthropicCacheMissReason();
+            reason.type = "system_changed";
+            reason.cacheMissedInputTokens = 41850;
+            AnthropicDiagnostics diagnostics = new AnthropicDiagnostics();
+            diagnostics.cacheMissReason = reason;
+            AnthropicCreateMessageResponse expectedResponse = createMessageResponse("Test");
+            expectedResponse.diagnostics = diagnostics;
+            SuccessfulHttpResponse httpResponse = SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .body(Json.toJson(expectedResponse))
+                    .build();
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(httpResponse);
+            DefaultAnthropicClient subject = createClient(mockHttpClient);
+
+            // When
+            AnthropicCreateMessageResponse actualResponse = subject.createMessage(createMessageRequest());
+
+            // Then
+            assertThat(actualResponse.diagnostics).isNotNull();
+            assertThat(actualResponse.diagnostics.cacheMissReason.type).isEqualTo("system_changed");
+            assertThat(actualResponse.diagnostics.cacheMissReason.cacheMissedInputTokens)
+                    .isEqualTo(41850);
         }
 
         @Test
@@ -394,6 +491,45 @@ class DefaultAnthropicClientTest {
         }
 
         @Test
+        void shouldIncludeCacheDiagnosticsFromMessageStartEvent() throws Exception {
+            // Given
+            List<ServerSentEvent> events = List.of(createMessageStartEventWithDiagnostics(), createMessageStopEvent());
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(events);
+
+            DefaultAnthropicClient subject = createClient(mockHttpClient);
+
+            AnthropicCreateMessageRequest request = createMessageRequest().toBuilder()
+                    .diagnostics(new AnthropicDiagnosticsParameters("msg_122"))
+                    .build();
+
+            CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
+
+            // When
+            subject.createMessage(request, new StreamingChatResponseHandler() {
+                @Override
+                public void onPartialResponse(String partialResponse) {}
+
+                @Override
+                public void onCompleteResponse(ChatResponse completeResponse) {
+                    futureResponse.complete(completeResponse);
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    futureResponse.completeExceptionally(error);
+                }
+            });
+
+            ChatResponse response = futureResponse.get(5, TimeUnit.SECONDS);
+
+            // Then
+            var metadata = (AnthropicChatResponseMetadata) response.metadata();
+            assertThat(metadata.cacheDiagnostics()).isNotNull();
+            assertThat(metadata.cacheDiagnostics().cacheMissReasonType()).isEqualTo("system_changed");
+            assertThat(metadata.cacheDiagnostics().cacheMissedInputTokens()).isEqualTo(41850);
+        }
+
+        @Test
         void shouldSendCorrectStreamingHttpRequest() throws Exception {
             // Given
             List<ServerSentEvent> events = List.of(createMessageStartEvent(), createMessageStopEvent());
@@ -521,26 +657,30 @@ class DefaultAnthropicClientTest {
             List<ServerSentEvent> events = List.of(
                     createMessageStartEvent(),
                     // Tool call 1 starts (content block index=1)
-                    new ServerSentEvent("content_block_start",
+                    new ServerSentEvent(
+                            "content_block_start",
                             "{\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tool_1\",\"name\":\"get_weather\"}}"),
-                    new ServerSentEvent("content_block_delta",
+                    new ServerSentEvent(
+                            "content_block_delta",
                             "{\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\"\"}}"),
                     // Tool call 2 starts BEFORE tool call 1 stops (content block index=2)
-                    new ServerSentEvent("content_block_start",
+                    new ServerSentEvent(
+                            "content_block_start",
                             "{\"type\":\"content_block_start\",\"index\":2,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tool_2\",\"name\":\"get_time\"}}"),
-                    new ServerSentEvent("content_block_delta",
+                    new ServerSentEvent(
+                            "content_block_delta",
                             "{\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"zone\\\"\"}}"),
                     // More deltas for both
-                    new ServerSentEvent("content_block_delta",
+                    new ServerSentEvent(
+                            "content_block_delta",
                             "{\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\": \\\"Paris\\\"}\"}}"),
-                    new ServerSentEvent("content_block_delta",
+                    new ServerSentEvent(
+                            "content_block_delta",
                             "{\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\": \\\"UTC\\\"}\"}}"),
                     // Tool call 1 stops
-                    new ServerSentEvent("content_block_stop",
-                            "{\"type\":\"content_block_stop\",\"index\":1}"),
+                    new ServerSentEvent("content_block_stop", "{\"type\":\"content_block_stop\",\"index\":1}"),
                     // Tool call 2 stops
-                    new ServerSentEvent("content_block_stop",
-                            "{\"type\":\"content_block_stop\",\"index\":2}"),
+                    new ServerSentEvent("content_block_stop", "{\"type\":\"content_block_stop\",\"index\":2}"),
                     createMessageDeltaWithToolUse(),
                     createMessageStopEvent());
             MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(events);
@@ -592,8 +732,7 @@ class DefaultAnthropicClientTest {
             assertThat(secondComplete.toolExecutionRequest().arguments()).isEqualTo("{\"zone\": \"UTC\"}");
 
             // Verify the final response also contains both tool execution requests
-            List<ToolExecutionRequest> toolRequests =
-                    response.aiMessage().toolExecutionRequests();
+            List<ToolExecutionRequest> toolRequests = response.aiMessage().toolExecutionRequests();
             assertThat(toolRequests).hasSize(2);
             assertThat(toolRequests.get(0).name()).isEqualTo("get_weather");
             assertThat(toolRequests.get(1).name()).isEqualTo("get_time");
@@ -681,6 +820,14 @@ class DefaultAnthropicClientTest {
         return new ServerSentEvent("message_start", data);
     }
 
+    private static ServerSentEvent createMessageStartEventWithDiagnostics() {
+        String data = String.format(
+                "{\"type\":\"message_start\",\"message\":{\"id\":\"%s\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"%s\",\"usage\":{\"input_tokens\":10,\"output_tokens\":0},"
+                        + "\"diagnostics\":{\"cache_miss_reason\":{\"type\":\"system_changed\",\"cache_missed_input_tokens\":41850}}}}",
+                "msg_123", DefaultAnthropicClientTest.TEST_MODEL_NAME);
+        return new ServerSentEvent("message_start", data);
+    }
+
     private static ServerSentEvent createContentBlockStartEvent() {
         String data = String.format(
                 "{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"%s\",\"text\":\"%s\"}}",
@@ -707,7 +854,8 @@ class DefaultAnthropicClientTest {
     }
 
     private static ServerSentEvent createMessageDeltaWithToolUse() {
-        return new ServerSentEvent("message_delta",
+        return new ServerSentEvent(
+                "message_delta",
                 "{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":50}}");
     }
 


### PR DESCRIPTION
## Issue
Closes #5658

## Change
Adds opt-in support for Anthropic's `cache-diagnosis-2026-04-07` beta feature, which reports why a prompt-cache hit was missed instead of only showing `usage.cacheReadInputTokens` drop to zero.

- `AnthropicChatRequestParameters`: new `returnCacheDiagnostics` + `previousMessageId` (per-request, mirrors `userId`)
- `AnthropicChatResponseMetadata#cacheDiagnostics()` exposes the result (sync and streaming) as a new `AnthropicCacheDiagnostics` type
- Request/response shape wired through new internal API POJOs (`AnthropicDiagnosticsParameters`, `AnthropicDiagnostics`, `AnthropicCacheMissReason`) and the mapper
- No behavior change when the feature isn't enabled (no extra request field, no allocation)

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
