### PR TITLE
fix: Paginate ListObjectsV2 in AmazonS3DocumentLoader to load all objects

### DIFF
--- a/document-loaders/langchain4j-document-loader-amazon-s3/src/main/java/dev/langchain4j/data/document/loader/amazon/s3/AmazonS3DocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-amazon-s3/src/main/java/dev/langchain4j/data/document/loader/amazon/s3/AmazonS3DocumentLoader.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
 
 public class AmazonS3DocumentLoader {
 
@@ -89,9 +90,9 @@ public class AmazonS3DocumentLoader {
                 .prefix(prefix)
                 .build();
 
-        ListObjectsV2Response listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request);
+        ListObjectsV2Iterable listObjectsV2Responses = s3Client.listObjectsV2Paginator(listObjectsV2Request);
 
-        List<S3Object> filteredS3Objects = listObjectsV2Response.contents().stream()
+        List<S3Object> filteredS3Objects = listObjectsV2Responses.contents().stream()
                 .filter(s3Object -> !s3Object.key().endsWith("/") && s3Object.size() > 0)
                 .collect(toList());
 

--- a/document-loaders/langchain4j-document-loader-amazon-s3/src/test/java/dev/langchain4j/data/document/loader/amazon/s3/AmazonS3DocumentLoaderTest.java
+++ b/document-loaders/langchain4j-document-loader-amazon-s3/src/test/java/dev/langchain4j/data/document/loader/amazon/s3/AmazonS3DocumentLoaderTest.java
@@ -1,0 +1,111 @@
+package dev.langchain4j.data.document.loader.amazon.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentParser;
+import dev.langchain4j.data.document.parser.TextDocumentParser;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
+
+class AmazonS3DocumentLoaderTest {
+
+    private static final String BUCKET = "test-bucket";
+
+    private final S3Client s3Client = mock(S3Client.class);
+    private final AmazonS3DocumentLoader loader = new AmazonS3DocumentLoader(s3Client);
+    private final DocumentParser parser = new TextDocumentParser();
+
+    @Test
+    void should_load_all_documents_across_paginated_responses() {
+
+        // given: a truncated first page followed by a second page,
+        // simulating a bucket whose objects span more than one ListObjectsV2 response (the >1000 keys case)
+        ListObjectsV2Response page1 = ListObjectsV2Response.builder()
+                .contents(S3Object.builder().key("a.txt").size(10L).build())
+                .isTruncated(true)
+                .nextContinuationToken("token")
+                .build();
+        ListObjectsV2Response page2 = ListObjectsV2Response.builder()
+                .contents(S3Object.builder().key("b.txt").size(10L).build())
+                .isTruncated(false)
+                .build();
+
+        // drive the real paginator so the actual continuation-token loop is exercised
+        when(s3Client.listObjectsV2Paginator(any(ListObjectsV2Request.class)))
+                .thenAnswer(invocation -> new ListObjectsV2Iterable(s3Client, invocation.getArgument(0)));
+        when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(page1, page2);
+
+        when(s3Client.getObject(
+                        argThat((GetObjectRequest request) -> request != null && "a.txt".equals(request.key()))))
+                .thenReturn(responseInputStream("content-a"));
+        when(s3Client.getObject(
+                        argThat((GetObjectRequest request) -> request != null && "b.txt".equals(request.key()))))
+                .thenReturn(responseInputStream("content-b"));
+
+        // when
+        List<Document> documents = loader.loadDocuments(BUCKET, parser);
+
+        // then: both pages are traversed and both objects are loaded
+        assertThat(documents).extracting(Document::text).containsExactly("content-a", "content-b");
+    }
+
+    @Test
+    void should_load_single_page_when_not_truncated() {
+
+        // given
+        ListObjectsV2Response onlyPage = ListObjectsV2Response.builder()
+                .contents(S3Object.builder().key("a.txt").size(10L).build())
+                .isTruncated(false)
+                .build();
+
+        when(s3Client.listObjectsV2Paginator(any(ListObjectsV2Request.class)))
+                .thenAnswer(invocation -> new ListObjectsV2Iterable(s3Client, invocation.getArgument(0)));
+        when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(onlyPage);
+        when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(responseInputStream("content-a"));
+
+        // when
+        List<Document> documents = loader.loadDocuments(BUCKET, parser);
+
+        // then
+        assertThat(documents).extracting(Document::text).containsExactly("content-a");
+    }
+
+    @Test
+    void should_return_empty_list_when_no_objects() {
+
+        // given
+        ListObjectsV2Response emptyPage =
+                ListObjectsV2Response.builder().isTruncated(false).build();
+
+        when(s3Client.listObjectsV2Paginator(any(ListObjectsV2Request.class)))
+                .thenAnswer(invocation -> new ListObjectsV2Iterable(s3Client, invocation.getArgument(0)));
+        when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(emptyPage);
+
+        // when
+        List<Document> documents = loader.loadDocuments(BUCKET, parser);
+
+        // then
+        assertThat(documents).isEmpty();
+    }
+
+    private static ResponseInputStream<GetObjectResponse> responseInputStream(String content) {
+        return new ResponseInputStream<>(
+                GetObjectResponse.builder().build(),
+                AbortableInputStream.create(new ByteArrayInputStream(content.getBytes())));
+    }
+}


### PR DESCRIPTION
## Issue
<!-- Update with the real issue number once the bug report above is filed. -->
Closes #5661

## Change
`AmazonS3DocumentLoader.loadDocuments` called `s3Client.listObjectsV2(request)` once, reading only the first response. S3 ListObjectsV2 returns at most 1000 keys per response, so buckets/prefixes with more than 1000 objects silently lost everything past the first page, despite the Javadoc promising to load all documents.

This replaces the single call with `s3Client.listObjectsV2Paginator(request)`. The returned `ListObjectsV2Iterable.contents()` transparently follows the continuation token and flattens every page, so the existing filter/load loop is unchanged. The change is scoped to this one method plus the new import.

Added a unit test class (`AmazonS3DocumentLoaderTest`, JUnit 5 + AssertJ + Mockito) that drives the real paginator: a truncated first page plus a second page asserts both objects load (the >1000-keys path); single-page and empty-bucket cases cover the boundaries. The existing LocalStack IT is untouched.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- unit tests green; LocalStack IT needs Docker — run before submitting, then check -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

