### PR TITLE
docs: Fix "an COS" to "a COS" in TencentCosDocumentLoader Javadoc

### DIFF
--- a/document-loaders/langchain4j-document-loader-tencent-cos/src/main/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-tencent-cos/src/main/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoader.java
@@ -46,7 +46,7 @@ public class TencentCosDocumentLoader {
     }
 
     /**
-     * Loads all documents from an COS bucket.
+     * Loads all documents from a COS bucket.
      * Skips any documents that fail to load.
      *
      * @param bucket COS bucket to load from.
@@ -58,7 +58,7 @@ public class TencentCosDocumentLoader {
     }
 
     /**
-     * Loads all documents from an COS bucket.
+     * Loads all documents from a COS bucket.
      * Skips any documents that fail to load.
      *
      * @param bucket COS bucket to load from.


### PR DESCRIPTION
## Issue
Trivial Javadoc grammar fix; no separate issue filed.

## Change
Both `loadDocuments` overloads' Javadoc read "Loads all documents from an COS bucket". "COS" begins with a consonant sound, so the correct article is "a", not "an". This fixes both occurrences to "a COS bucket". Javadoc-only, no behavior change.

```java
- * Loads all documents from an COS bucket.
+ * Loads all documents from a COS bucket.
```

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change <!-- N/A — Javadoc-only typo fix, no behavior change → no test per config -->
- [ ] The tests cover both positive and negative cases <!-- N/A — no test added -->
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- N/A — Javadoc comment-only change cannot affect test outcomes; spotless:check green (JDK17) -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change isolated to tencent-cos document loader -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — the change is itself a Javadoc fix; no separate docs needed -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->

<!-- Omitted "new maven module" and "embedding store integration" checklists — not applicable to a Javadoc typo fix. -->

## Pre-submit checks
- `spotless:check` passes (JDK17). Javadoc-only change, so no tests are required and behavior is unchanged.

