### PR TITLE
feat: Add prefix overload to AzureBlobStorageDocumentLoader.loadDocuments

### DIFF
--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/src/main/java/dev/langchain4j/data/document/loader/azure/storage/blob/AzureBlobStorageDocumentLoader.java
@@ -5,6 +5,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.specialized.BlobInputStream;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentLoader;
@@ -44,16 +45,37 @@ public class AzureBlobStorageDocumentLoader {
      * @return A list of documents.
      */
     public List<Document> loadDocuments(String containerName, DocumentParser parser) {
+        return loadDocuments(containerName, null, parser);
+    }
+
+    /**
+     * Loads all documents from an Azure Blob Storage container.
+     * Skips any documents that fail to load.
+     *
+     * @param containerName The name of the container to load from.
+     * @param prefix Only blobs whose names start with this prefix are loaded; {@code null} loads all blobs.
+     * @param parser The parser to be used for parsing text from the blob.
+     * @return A list of documents.
+     */
+    public List<Document> loadDocuments(String containerName, String prefix, DocumentParser parser) {
         List<Document> documents = new ArrayList<>();
 
-        blobServiceClient.getBlobContainerClient(containerName).listBlobs().forEach(blob -> {
-            try {
-                documents.add(loadDocument(containerName, blob.getName(), parser));
-            } catch (Exception e) {
-                log.warn(
-                        "Failed to load blob '{}' from container '{}', skipping it.", blob.getName(), containerName, e);
-            }
-        });
+        ListBlobsOptions options = new ListBlobsOptions().setPrefix(prefix);
+
+        blobServiceClient
+                .getBlobContainerClient(containerName)
+                .listBlobs(options, null)
+                .forEach(blob -> {
+                    try {
+                        documents.add(loadDocument(containerName, blob.getName(), parser));
+                    } catch (Exception e) {
+                        log.warn(
+                                "Failed to load blob '{}' from container '{}', skipping it.",
+                                blob.getName(),
+                                containerName,
+                                e);
+                    }
+                });
 
         return documents;
     }

--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/src/test/java/dev/langchain4j/data/document/loader/azure/storage/blob/LocalAzureBlobStorageDocumentLoaderIT.java
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/src/test/java/dev/langchain4j/data/document/loader/azure/storage/blob/LocalAzureBlobStorageDocumentLoaderIT.java
@@ -93,6 +93,25 @@ class LocalAzureBlobStorageDocumentLoaderIT {
                 .isEqualTo("https://" + TEST_ACCOUNT + ".blob.core.windows.net/" + TEST_CONTAINER + "/" + TEST_BLOB);
     }
 
+    @Test
+    void should_load_documents_with_prefix() {
+        AzureBlobStorageDocumentLoader loader = new AzureBlobStorageDocumentLoader(blobServiceClient);
+        List<Document> documents = loader.loadDocuments(TEST_CONTAINER, "test-directory/", parser);
+
+        assertThat(documents).hasSize(1);
+        assertThat(documents.get(0).text()).isEqualTo(TEST_CONTENT_2);
+        assertThat(documents.get(0).metadata().getString("source"))
+                .isEqualTo("https://" + TEST_ACCOUNT + ".blob.core.windows.net/" + TEST_CONTAINER + "/" + TEST_BLOB_2);
+    }
+
+    @Test
+    void should_return_empty_list_when_prefix_matches_no_blobs() {
+        AzureBlobStorageDocumentLoader loader = new AzureBlobStorageDocumentLoader(blobServiceClient);
+        List<Document> documents = loader.loadDocuments(TEST_CONTAINER, "no-such-prefix/", parser);
+
+        assertThat(documents).isEmpty();
+    }
+
     @AfterAll
     static void afterAll() {
         blobServiceClient.getBlobContainerClient(TEST_CONTAINER).delete();


### PR DESCRIPTION
## Issue
Closes #5667

## Change
Add `loadDocuments(String containerName, String prefix, DocumentParser parser)` to `AzureBlobStorageDocumentLoader`. It lists blobs with `new ListBlobsOptions().setPrefix(prefix)`, so only blobs whose names start with `prefix` are loaded.

The existing `loadDocuments(containerName, parser)` now delegates with `prefix = null`. The Azure SDK's no-arg `listBlobs()` already uses a default `ListBlobsOptions` with a null prefix, so `setPrefix(null)` lists all blobs exactly as before. No behavior change, no breaking change.

This brings the Azure loader in line with `AmazonS3DocumentLoader` and `TencentCosDocumentLoader`, which already offer a prefix overload.

```java
public List<Document> loadDocuments(String containerName, String prefix, DocumentParser parser) {
    ListBlobsOptions options = new ListBlobsOptions().setPrefix(prefix);
    blobServiceClient.getBlobContainerClient(containerName).listBlobs(options, null).forEach(...);
}
```

## Testing
Added two tests to `LocalAzureBlobStorageDocumentLoaderIT` (Azurite Testcontainers): `should_load_documents_with_prefix` asserts a matching prefix returns only the matching blob, and `should_return_empty_list_when_prefix_matches_no_blobs` asserts a non-matching prefix returns an empty list. The existing `should_load_multiple_documents` confirms the no-arg overload still returns all blobs.
`./mvnw -pl document-loaders/langchain4j-document-loader-azure-storage-blob -am clean test` passes (module tests are Testcontainers ITs run via failsafe; test sources compile). The Azurite IT was not executed locally because Docker was unavailable in this environment.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

<!-- Not adding a new maven module or embedding store integration: those checklist sections are omitted. -->

