### PR TITLE
fix: Encode page content as UTF-8 in SeleniumDocumentLoader

### DIFF
--- a/document-loaders/langchain4j-document-loader-selenium/src/main/java/dev/langchain4j/data/document/loader/selenium/SeleniumDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-selenium/src/main/java/dev/langchain4j/data/document/loader/selenium/SeleniumDocumentLoader.java
@@ -6,6 +6,7 @@ import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentParser;
 import dev.langchain4j.data.document.Metadata;
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Objects;
 import org.openqa.selenium.JavascriptExecutor;
@@ -68,7 +69,8 @@ public class SeleniumDocumentLoader implements AutoCloseable {
         requireNonNull(documentParser, "documentParser must not be null");
         logger.info("Loading document from URL: {}", url);
         String pageContent = pageContent(url);
-        Document parsedDocument = documentParser.parse(new ByteArrayInputStream(pageContent.getBytes()));
+        Document parsedDocument =
+                documentParser.parse(new ByteArrayInputStream(pageContent.getBytes(StandardCharsets.UTF_8)));
         parsedDocument.metadata().put(Document.URL, url);
         return parsedDocument;
     }

--- a/document-loaders/langchain4j-document-loader-selenium/src/test/java/dev/langchain4j/data/document/loader/selenium/SeleniumDocumentLoaderTest.java
+++ b/document-loaders/langchain4j-document-loader-selenium/src/test/java/dev/langchain4j/data/document/loader/selenium/SeleniumDocumentLoaderTest.java
@@ -1,0 +1,53 @@
+package dev.langchain4j.data.document.loader.selenium;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentParser;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+
+class SeleniumDocumentLoaderTest {
+
+    private static final String NON_ASCII_CONTENT = "café ☕ 日本語 €";
+    private static final String URL = "https://example.com";
+
+    @Test
+    void load_should_encode_page_content_as_utf8_before_parsing() {
+        WebDriver webDriver = mock(WebDriver.class);
+        when(webDriver.getPageSource()).thenReturn(NON_ASCII_CONTENT);
+
+        SeleniumDocumentLoader loader = SeleniumDocumentLoader.builder()
+                .webDriver(webDriver)
+                .timeout(Duration.ofSeconds(1))
+                .build()
+                .pageReadyCondition(wd -> true); // skip the JavascriptExecutor readyState wait
+
+        // Capture the exact bytes the parser receives from the loader.
+        AtomicReference<byte[]> capturedBytes = new AtomicReference<>();
+        DocumentParser capturingParser = inputStream -> {
+            capturedBytes.set(readAllBytes(inputStream));
+            return Document.from("parsed");
+        };
+
+        Document document = loader.load(URL, capturingParser);
+
+        // The handed-off bytes must be the UTF-8 encoding of the page content, not the platform default.
+        assertThat(capturedBytes.get()).isEqualTo(NON_ASCII_CONTENT.getBytes(StandardCharsets.UTF_8));
+        assertThat(document.metadata().getString(Document.URL)).isEqualTo(URL);
+    }
+
+    private static byte[] readAllBytes(InputStream inputStream) {
+        try {
+            return inputStream.readAllBytes();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5670

## Change
`SeleniumDocumentLoader.load(String url, DocumentParser)` encoded the fetched page content with `pageContent.getBytes()`, using the platform-default charset. `TextDocumentParser` decodes those bytes as UTF-8 by default, so on a JVM whose default charset is not UTF-8 (Java 17 target, before JEP 400) non-ASCII page content was corrupted after parsing.

This encodes explicitly with UTF-8, matching the parser's default decoding and the repo convention (`Utils.java`, `UriUtils.java` already use `getBytes(StandardCharsets.UTF_8)`):

```java
documentParser.parse(new ByteArrayInputStream(pageContent.getBytes(StandardCharsets.UTF_8)));
```

The change is limited to that one line plus the `StandardCharsets` import. `load(String url)` is untouched: it wraps the raw string via `Document.from(String, Metadata)` and never round-trips through bytes.

Added a credential-free unit test that mocks `WebDriver`, feeds non-ASCII page content, captures the bytes the parser receives, and asserts they equal the UTF-8 encoding — locking the contract deterministically on any default charset.

Series probe: the sibling `PlaywrightDocumentLoader` has the identical `getBytes()` pattern and is intentionally left for a follow-up PR once this one merges.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
<!-- The added unit test asserts UTF-8 bytes (positive path) and the metadata contract; the platform-default path was the bug being fixed. -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- New unit test passes. The pre-existing SeleniumDocumentLoaderIT is Testcontainers/browser-gated and was not run locally. -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
<!-- N/A — change is isolated to the selenium document-loader module. -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
<!-- N/A — bug fix, no doc change; per CONTRIBUTING, docs added after review. -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
<!-- N/A — not a big feature. -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
<!-- N/A — no Spring Boot starter for this module. -->

<!-- Checklist for adding new maven module: omitted — no new module. -->
<!-- Checklist for new/changed embedding store integration: omitted — not an embedding store. -->
