### PR TITLE
fix: Guard against null content type in GcsSource metadata

### DIFF
--- a/document-loaders/langchain4j-document-loader-google-cloud-storage/src/main/java/dev/langchain4j/data/document/source/gcs/GcsSource.java
+++ b/document-loaders/langchain4j-document-loader-google-cloud-storage/src/main/java/dev/langchain4j/data/document/source/gcs/GcsSource.java
@@ -3,7 +3,6 @@ package dev.langchain4j.data.document.source.gcs;
 import com.google.cloud.storage.Blob;
 import dev.langchain4j.data.document.DocumentSource;
 import dev.langchain4j.data.document.Metadata;
-
 import java.io.InputStream;
 import java.nio.channels.Channels;
 
@@ -32,7 +31,9 @@ public class GcsSource implements DocumentSource {
         metadata.put("source", "gs://" + blob.getBucket() + "/" + blob.getName());
         metadata.put("bucket", blob.getBucket());
         metadata.put("name", blob.getName());
-        metadata.put("contentType", blob.getContentType());
+        if (blob.getContentType() != null) {
+            metadata.put("contentType", blob.getContentType());
+        }
         metadata.put("size", blob.getSize());
         metadata.put("createTime", blob.getCreateTimeOffsetDateTime().toString());
         metadata.put("updateTime", blob.getUpdateTimeOffsetDateTime().toString());

--- a/document-loaders/langchain4j-document-loader-google-cloud-storage/src/test/java/dev/langchain4j/data/document/source/gcs/GcsSourceTest.java
+++ b/document-loaders/langchain4j-document-loader-google-cloud-storage/src/test/java/dev/langchain4j/data/document/source/gcs/GcsSourceTest.java
@@ -1,0 +1,66 @@
+package dev.langchain4j.data.document.source.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.ReadChannel;
+import com.google.cloud.storage.Blob;
+import java.nio.ByteBuffer;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class GcsSourceTest {
+
+    private static Blob mockBlob(String contentType) {
+        Blob blob = mock(Blob.class);
+        // reader() must be non-null: GcsSource wraps it with Channels.newInputStream(...).
+        ReadChannel readChannel = mock(ReadChannel.class);
+        try {
+            // Simulate an empty (already exhausted) channel.
+            lenient()
+                    .when(readChannel.read(org.mockito.ArgumentMatchers.any(ByteBuffer.class)))
+                    .thenReturn(-1);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        when(blob.reader()).thenReturn(readChannel);
+        when(blob.getBucket()).thenReturn("my-bucket");
+        when(blob.getName()).thenReturn("my-object.txt");
+        when(blob.getSize()).thenReturn(123L);
+        when(blob.getCreateTimeOffsetDateTime()).thenReturn(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+        when(blob.getUpdateTimeOffsetDateTime()).thenReturn(OffsetDateTime.parse("2024-01-02T00:00:00Z"));
+        when(blob.getContentType()).thenReturn(contentType);
+        return blob;
+    }
+
+    @Test
+    void should_build_source_when_content_type_is_null() {
+        // given a valid object whose content type is not set (nullable per GCS Blob API)
+        Blob blob = mockBlob(null);
+
+        // when
+        GcsSource source = new GcsSource(blob);
+
+        // then no exception is thrown and the contentType key is simply absent
+        assertThat(source.metadata().getString("contentType")).isNull();
+        assertThat(source.metadata().containsKey("contentType")).isFalse();
+        // other metadata is still populated
+        assertThat(source.metadata().getString("source")).isEqualTo("gs://my-bucket/my-object.txt");
+        assertThat(source.metadata().getString("bucket")).isEqualTo("my-bucket");
+        assertThat(source.metadata().getString("name")).isEqualTo("my-object.txt");
+    }
+
+    @Test
+    void should_populate_content_type_when_present() {
+        // given
+        Blob blob = mockBlob("text/plain");
+
+        // when
+        GcsSource source = new GcsSource(blob);
+
+        // then
+        assertThat(source.metadata().getString("contentType")).isEqualTo("text/plain");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5672

## Change
`GcsSource` built its metadata by calling `metadata.put("contentType", blob.getContentType())`. `Blob.getContentType()` is nullable, and core `Metadata.put(String, String)` rejects null with an `IllegalArgumentException`. Loading a valid, non-empty object without a content type therefore failed: `loadDocument()` threw, and `loadDocuments()` caught the exception and silently skipped the object.

This change skips the `contentType` key when `getContentType()` returns null, so the key is absent rather than holding a meaningless `"null"` string. The sibling `AzureBlobStorageSource` already guards its metadata (via `String.valueOf`); this brings the GCS loader in line. Scope is limited to the `contentType` line.

Added `GcsSourceTest` with a Mockito-mocked `Blob`: a regression case (null content type builds successfully, key absent) and a positive case (`text/plain` preserved).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
