### PR TITLE
feat(google-genai): support per-request cachedContent override

### DIFF
--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
@@ -50,7 +50,6 @@ public class GoogleGenAiChatModel implements ChatModel {
     private final List<String> allowedFunctionNames;
     private final String vertexSearchDatastore;
     private final Map<String, String> labels;
-    private final String cachedContent;
 
     private GoogleGenAiChatModel(Builder builder) {
         this.maxRetries = getOrDefault(builder.maxRetries, 2);
@@ -67,7 +66,6 @@ public class GoogleGenAiChatModel implements ChatModel {
         this.safetySettings = copy(builder.safetySettings);
         this.vertexSearchDatastore = builder.vertexSearchDatastore;
         this.labels = builder.labels != null ? new HashMap<>(builder.labels) : null;
-        this.cachedContent = builder.cachedContent;
 
         this.client = builder.client != null
                 ? builder.client
@@ -83,6 +81,11 @@ public class GoogleGenAiChatModel implements ChatModel {
         ChatRequestParameters commonParameters =
                 getOrDefault(builder.defaultRequestParameters, DefaultChatRequestParameters.EMPTY);
 
+        GoogleGenAiChatRequestParameters genAiParameters =
+                builder.defaultRequestParameters instanceof GoogleGenAiChatRequestParameters googleGenAiParameters
+                        ? googleGenAiParameters
+                        : GoogleGenAiChatRequestParameters.EMPTY;
+
         this.defaultRequestParameters = GoogleGenAiChatRequestParameters.builder()
                 .modelName(getOrDefault(builder.modelName, commonParameters.modelName()))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
@@ -95,6 +98,7 @@ public class GoogleGenAiChatModel implements ChatModel {
                 .toolSpecifications(commonParameters.toolSpecifications())
                 .toolChoice(commonParameters.toolChoice())
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
+                .cachedContent(getOrDefault(builder.cachedContent, genAiParameters.cachedContent()))
                 .build();
     }
 
@@ -103,12 +107,10 @@ public class GoogleGenAiChatModel implements ChatModel {
         Content systemInstruction = GoogleGenAiContentMapper.toSystemInstruction(chatRequest.messages());
         List<Content> contents = GoogleGenAiContentMapper.toContents(chatRequest.messages());
 
-        String requestCachedContent =
-                chatRequest.parameters() instanceof GoogleGenAiChatRequestParameters p ? p.cachedContent() : null;
-        String finalCachedContent = getOrDefault(requestCachedContent, cachedContent);
+        GoogleGenAiChatRequestParameters parameters = (GoogleGenAiChatRequestParameters) chatRequest.parameters();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                chatRequest.parameters(),
+                parameters,
                 systemInstruction,
                 safetySettings,
                 thinkingBudget,
@@ -120,7 +122,7 @@ public class GoogleGenAiChatModel implements ChatModel {
                 allowedFunctionNames,
                 vertexSearchDatastore,
                 labels,
-                finalCachedContent);
+                parameters.cachedContent());
 
         if (logRequests) {
             log.info(

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
@@ -83,7 +83,7 @@ public class GoogleGenAiChatModel implements ChatModel {
         ChatRequestParameters commonParameters =
                 getOrDefault(builder.defaultRequestParameters, DefaultChatRequestParameters.EMPTY);
 
-        this.defaultRequestParameters = DefaultChatRequestParameters.builder()
+        this.defaultRequestParameters = GoogleGenAiChatRequestParameters.builder()
                 .modelName(getOrDefault(builder.modelName, commonParameters.modelName()))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -103,6 +103,11 @@ public class GoogleGenAiChatModel implements ChatModel {
         Content systemInstruction = GoogleGenAiContentMapper.toSystemInstruction(chatRequest.messages());
         List<Content> contents = GoogleGenAiContentMapper.toContents(chatRequest.messages());
 
+        String requestCachedContent = chatRequest.parameters() instanceof GoogleGenAiChatRequestParameters p
+                ? p.cachedContent()
+                : null;
+        String finalCachedContent = getOrDefault(requestCachedContent, cachedContent);
+
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
                 chatRequest.parameters(),
                 systemInstruction,
@@ -116,7 +121,7 @@ public class GoogleGenAiChatModel implements ChatModel {
                 allowedFunctionNames,
                 vertexSearchDatastore,
                 labels,
-                cachedContent);
+                finalCachedContent);
 
         if (logRequests) {
             log.info(

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModel.java
@@ -103,9 +103,8 @@ public class GoogleGenAiChatModel implements ChatModel {
         Content systemInstruction = GoogleGenAiContentMapper.toSystemInstruction(chatRequest.messages());
         List<Content> contents = GoogleGenAiContentMapper.toContents(chatRequest.messages());
 
-        String requestCachedContent = chatRequest.parameters() instanceof GoogleGenAiChatRequestParameters p
-                ? p.cachedContent()
-                : null;
+        String requestCachedContent =
+                chatRequest.parameters() instanceof GoogleGenAiChatRequestParameters p ? p.cachedContent() : null;
         String finalCachedContent = getOrDefault(requestCachedContent, cachedContent);
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatRequestParameters.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatRequestParameters.java
@@ -1,12 +1,11 @@
 package dev.langchain4j.model.google.genai;
 
-import dev.langchain4j.model.chat.request.ChatRequestParameters;
-import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
-
-import java.util.Objects;
-
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.Utils.quoted;
+
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import java.util.Objects;
 
 public class GoogleGenAiChatRequestParameters extends DefaultChatRequestParameters {
 
@@ -50,20 +49,19 @@ public class GoogleGenAiChatRequestParameters extends DefaultChatRequestParamete
 
     @Override
     public String toString() {
-        return "GoogleGenAiChatRequestParameters{" +
-                "modelName=" + quoted(modelName()) +
-                ", temperature=" + temperature() +
-                ", topP=" + topP() +
-                ", topK=" + topK() +
-                ", frequencyPenalty=" + frequencyPenalty() +
-                ", presencePenalty=" + presencePenalty() +
-                ", maxOutputTokens=" + maxOutputTokens() +
-                ", stopSequences=" + stopSequences() +
-                ", toolSpecifications=" + toolSpecifications() +
-                ", toolChoice=" + toolChoice() +
-                ", responseFormat=" + responseFormat() +
-                ", cachedContent=" + quoted(cachedContent) +
-                '}';
+        return "GoogleGenAiChatRequestParameters{" + "modelName="
+                + quoted(modelName()) + ", temperature="
+                + temperature() + ", topP="
+                + topP() + ", topK="
+                + topK() + ", frequencyPenalty="
+                + frequencyPenalty() + ", presencePenalty="
+                + presencePenalty() + ", maxOutputTokens="
+                + maxOutputTokens() + ", stopSequences="
+                + stopSequences() + ", toolSpecifications="
+                + toolSpecifications() + ", toolChoice="
+                + toolChoice() + ", responseFormat="
+                + responseFormat() + ", cachedContent="
+                + quoted(cachedContent) + '}';
     }
 
     public static Builder builder() {

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatRequestParameters.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatRequestParameters.java
@@ -1,0 +1,96 @@
+package dev.langchain4j.model.google.genai;
+
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+
+import java.util.Objects;
+
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.Utils.quoted;
+
+public class GoogleGenAiChatRequestParameters extends DefaultChatRequestParameters {
+
+    private final String cachedContent;
+
+    private GoogleGenAiChatRequestParameters(Builder builder) {
+        super(builder);
+        this.cachedContent = builder.cachedContent;
+    }
+
+    /**
+     * The resource name of a previously created cache (e.g. {@code "cachedContents/abc123"}) to attach
+     * to this specific request, overriding any global {@code cachedContent} configured on the
+     * {@link GoogleGenAiChatModel}/{@link GoogleGenAiStreamingChatModel}.
+     */
+    public String cachedContent() {
+        return cachedContent;
+    }
+
+    @Override
+    public GoogleGenAiChatRequestParameters overrideWith(ChatRequestParameters that) {
+        return GoogleGenAiChatRequestParameters.builder()
+                .overrideWith(this)
+                .overrideWith(that)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        GoogleGenAiChatRequestParameters that = (GoogleGenAiChatRequestParameters) o;
+        return Objects.equals(cachedContent, that.cachedContent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), cachedContent);
+    }
+
+    @Override
+    public String toString() {
+        return "GoogleGenAiChatRequestParameters{" +
+                "modelName=" + quoted(modelName()) +
+                ", temperature=" + temperature() +
+                ", topP=" + topP() +
+                ", topK=" + topK() +
+                ", frequencyPenalty=" + frequencyPenalty() +
+                ", presencePenalty=" + presencePenalty() +
+                ", maxOutputTokens=" + maxOutputTokens() +
+                ", stopSequences=" + stopSequences() +
+                ", toolSpecifications=" + toolSpecifications() +
+                ", toolChoice=" + toolChoice() +
+                ", responseFormat=" + responseFormat() +
+                ", cachedContent=" + quoted(cachedContent) +
+                '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends DefaultChatRequestParameters.Builder<Builder> {
+
+        private String cachedContent;
+
+        @Override
+        public Builder overrideWith(ChatRequestParameters parameters) {
+            super.overrideWith(parameters);
+            if (parameters instanceof GoogleGenAiChatRequestParameters googleGenAiParameters) {
+                cachedContent(getOrDefault(googleGenAiParameters.cachedContent(), cachedContent));
+            }
+            return this;
+        }
+
+        public Builder cachedContent(String cachedContent) {
+            this.cachedContent = cachedContent;
+            return this;
+        }
+
+        @Override
+        public GoogleGenAiChatRequestParameters build() {
+            return new GoogleGenAiChatRequestParameters(this);
+        }
+    }
+}

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatRequestParameters.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiChatRequestParameters.java
@@ -9,6 +9,9 @@ import java.util.Objects;
 
 public class GoogleGenAiChatRequestParameters extends DefaultChatRequestParameters {
 
+    public static final GoogleGenAiChatRequestParameters EMPTY =
+            GoogleGenAiChatRequestParameters.builder().build();
+
     private final String cachedContent;
 
     private GoogleGenAiChatRequestParameters(Builder builder) {
@@ -30,6 +33,14 @@ public class GoogleGenAiChatRequestParameters extends DefaultChatRequestParamete
         return GoogleGenAiChatRequestParameters.builder()
                 .overrideWith(this)
                 .overrideWith(that)
+                .build();
+    }
+
+    @Override
+    public GoogleGenAiChatRequestParameters defaultedBy(ChatRequestParameters that) {
+        return GoogleGenAiChatRequestParameters.builder()
+                .overrideWith(that)
+                .overrideWith(this)
                 .build();
     }
 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
@@ -95,7 +95,7 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
         ChatRequestParameters commonParameters =
                 getOrDefault(builder.defaultRequestParameters, DefaultChatRequestParameters.EMPTY);
 
-        this.defaultRequestParameters = DefaultChatRequestParameters.builder()
+        this.defaultRequestParameters = GoogleGenAiChatRequestParameters.builder()
                 .modelName(getOrDefault(builder.modelName, commonParameters.modelName()))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
                 .topP(getOrDefault(builder.topP, commonParameters.topP()))
@@ -119,6 +119,11 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
         Content systemInstruction = GoogleGenAiContentMapper.toSystemInstruction(chatRequest.messages());
         List<Content> contents = GoogleGenAiContentMapper.toContents(chatRequest.messages());
 
+        String requestCachedContent = chatRequest.parameters() instanceof GoogleGenAiChatRequestParameters p
+                ? p.cachedContent()
+                : null;
+        String finalCachedContent = getOrDefault(requestCachedContent, cachedContent);
+
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
                 chatRequest.parameters(),
                 systemInstruction,
@@ -132,7 +137,7 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
                 allowedFunctionNames,
                 vertexSearchDatastore,
                 labels,
-                cachedContent);
+                finalCachedContent);
 
         if (logRequests) {
             log.info(

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
@@ -61,7 +61,6 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
     private final List<String> allowedFunctionNames;
     private final String vertexSearchDatastore;
     private final Map<String, String> labels;
-    private final String cachedContent;
 
     private final ExecutorService executor;
 
@@ -79,7 +78,6 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
         this.safetySettings = copy(builder.safetySettings);
         this.vertexSearchDatastore = builder.vertexSearchDatastore;
         this.labels = builder.labels != null ? new HashMap<>(builder.labels) : null;
-        this.cachedContent = builder.cachedContent;
 
         this.client = builder.client != null
                 ? builder.client
@@ -95,6 +93,11 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
         ChatRequestParameters commonParameters =
                 getOrDefault(builder.defaultRequestParameters, DefaultChatRequestParameters.EMPTY);
 
+        GoogleGenAiChatRequestParameters genAiParameters =
+                builder.defaultRequestParameters instanceof GoogleGenAiChatRequestParameters googleGenAiParameters
+                        ? googleGenAiParameters
+                        : GoogleGenAiChatRequestParameters.EMPTY;
+
         this.defaultRequestParameters = GoogleGenAiChatRequestParameters.builder()
                 .modelName(getOrDefault(builder.modelName, commonParameters.modelName()))
                 .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
@@ -107,6 +110,7 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
                 .toolSpecifications(commonParameters.toolSpecifications())
                 .toolChoice(commonParameters.toolChoice())
                 .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
+                .cachedContent(getOrDefault(builder.cachedContent, genAiParameters.cachedContent()))
                 .build();
 
         this.executor = getOrDefault(builder.executor, DefaultExecutorProvider::getDefaultExecutorService);
@@ -119,12 +123,10 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
         Content systemInstruction = GoogleGenAiContentMapper.toSystemInstruction(chatRequest.messages());
         List<Content> contents = GoogleGenAiContentMapper.toContents(chatRequest.messages());
 
-        String requestCachedContent =
-                chatRequest.parameters() instanceof GoogleGenAiChatRequestParameters p ? p.cachedContent() : null;
-        String finalCachedContent = getOrDefault(requestCachedContent, cachedContent);
+        GoogleGenAiChatRequestParameters parameters = (GoogleGenAiChatRequestParameters) chatRequest.parameters();
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(
-                chatRequest.parameters(),
+                parameters,
                 systemInstruction,
                 safetySettings,
                 thinkingBudget,
@@ -136,7 +138,7 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
                 allowedFunctionNames,
                 vertexSearchDatastore,
                 labels,
-                finalCachedContent);
+                parameters.cachedContent());
 
         if (logRequests) {
             log.info(

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModel.java
@@ -119,9 +119,8 @@ public class GoogleGenAiStreamingChatModel implements StreamingChatModel {
         Content systemInstruction = GoogleGenAiContentMapper.toSystemInstruction(chatRequest.messages());
         List<Content> contents = GoogleGenAiContentMapper.toContents(chatRequest.messages());
 
-        String requestCachedContent = chatRequest.parameters() instanceof GoogleGenAiChatRequestParameters p
-                ? p.cachedContent()
-                : null;
+        String requestCachedContent =
+                chatRequest.parameters() instanceof GoogleGenAiChatRequestParameters p ? p.cachedContent() : null;
         String finalCachedContent = getOrDefault(requestCachedContent, cachedContent);
 
         GenerateContentConfig config = GoogleGenAiConfigBuilder.buildConfig(

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelTest.java
@@ -19,6 +19,7 @@ import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import java.lang.reflect.Field;
 import java.time.Duration;
@@ -182,6 +183,7 @@ class GoogleGenAiChatModelTest {
         GoogleGenAiChatModel.Builder builder = GoogleGenAiChatModel.builder();
 
         assertThat(builder.googleCredentials(null)).isSameAs(builder);
+        assertThat(builder.projectId("project")).isSameAs(builder);
         assertThat(builder.location("us-central1")).isSameAs(builder);
     }
 
@@ -225,5 +227,34 @@ class GoogleGenAiChatModelTest {
         assertThat(configCaptor.getValue().cachedContent().isPresent()).isTrue();
         assertThat(configCaptor.getValue().cachedContent().get())
                 .isEqualTo("projects/123/locations/us-central1/cachedContents/per-request");
+    }
+
+    @Test
+    void global_cached_content_should_be_reflected_in_default_request_parameters() {
+        GoogleGenAiChatModel model = GoogleGenAiChatModel.builder()
+                .client(mock(Client.class))
+                .modelName("gemini-3.1-flash-lite")
+                .cachedContent("projects/123/locations/us-central1/cachedContents/global")
+                .build();
+
+        assertThat(model.defaultRequestParameters()).isInstanceOf(GoogleGenAiChatRequestParameters.class);
+        assertThat(((GoogleGenAiChatRequestParameters) model.defaultRequestParameters()).cachedContent())
+                .isEqualTo("projects/123/locations/us-central1/cachedContents/global");
+    }
+
+    @Test
+    void defaulted_by_should_preserve_cached_content() {
+        GoogleGenAiChatRequestParameters requestParameters = GoogleGenAiChatRequestParameters.builder()
+                .cachedContent("projects/123/locations/us-central1/cachedContents/per-request")
+                .build();
+
+        // Mirrors how AiServiceParamsUtil merges request parameters with defaults.
+        ChatRequestParameters merged = requestParameters.defaultedBy(
+                GoogleGenAiChatRequestParameters.builder().temperature(0.5).build());
+
+        assertThat(merged).isInstanceOf(GoogleGenAiChatRequestParameters.class);
+        assertThat(((GoogleGenAiChatRequestParameters) merged).cachedContent())
+                .isEqualTo("projects/123/locations/us-central1/cachedContents/per-request");
+        assertThat(merged.temperature()).isEqualTo(0.5);
     }
 }

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiChatModelTest.java
@@ -1,17 +1,30 @@
 package dev.langchain4j.model.google.genai;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.genai.Client;
+import com.google.genai.Models;
+import com.google.genai.types.Candidate;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
 import com.google.genai.types.SafetySetting;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ResponseFormat;
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class GoogleGenAiChatModelTest {
 
@@ -169,7 +182,48 @@ class GoogleGenAiChatModelTest {
         GoogleGenAiChatModel.Builder builder = GoogleGenAiChatModel.builder();
 
         assertThat(builder.googleCredentials(null)).isSameAs(builder);
-        assertThat(builder.projectId("project")).isSameAs(builder);
         assertThat(builder.location("us-central1")).isSameAs(builder);
+    }
+
+    @Test
+    void should_use_request_level_cached_content() throws Exception {
+        Client client = mock(Client.class);
+        Models models = mock(Models.class);
+        Field modelsField = Client.class.getDeclaredField("models");
+        modelsField.setAccessible(true);
+        modelsField.set(client, models);
+
+        GenerateContentResponse mockResponse = GenerateContentResponse.builder()
+                .candidates(List.of(Candidate.builder()
+                        .content(Content.builder()
+                                .role("model")
+                                .parts(List.of(Part.builder().text("response").build()))
+                                .build())
+                        .build()))
+                .build();
+
+        ArgumentCaptor<GenerateContentConfig> configCaptor = ArgumentCaptor.forClass(GenerateContentConfig.class);
+
+        when(models.generateContent(any(String.class), anyList(), configCaptor.capture()))
+                .thenReturn(mockResponse);
+
+        GoogleGenAiChatModel model = GoogleGenAiChatModel.builder()
+                .client(client)
+                .modelName("gemini-3.1-flash-lite")
+                .cachedContent("projects/123/locations/us-central1/cachedContents/global")
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Hello"))
+                .parameters(GoogleGenAiChatRequestParameters.builder()
+                        .cachedContent("projects/123/locations/us-central1/cachedContents/per-request")
+                        .build())
+                .build();
+
+        model.chat(request);
+
+        assertThat(configCaptor.getValue().cachedContent().isPresent()).isTrue();
+        assertThat(configCaptor.getValue().cachedContent().get())
+                .isEqualTo("projects/123/locations/us-central1/cachedContents/per-request");
     }
 }

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelTest.java
@@ -24,6 +24,9 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.FinishReason;
 import java.lang.reflect.Field;
+import org.mockito.ArgumentCaptor;
+import com.google.genai.types.GenerateContentConfig;
+import dev.langchain4j.model.chat.request.ChatRequest;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.HashMap;
@@ -330,5 +333,54 @@ class GoogleGenAiStreamingChatModelTest {
         ChatResponse response = future.get(5, TimeUnit.SECONDS);
 
         assertThat(response.metadata().finishReason()).isEqualTo(FinishReason.LENGTH);
+    }
+
+    @Test
+    void should_use_request_level_cached_content() throws Exception {
+        Client client = mock(Client.class);
+        Models models = mock(Models.class);
+        Field modelsField = Client.class.getDeclaredField("models");
+        modelsField.setAccessible(true);
+        modelsField.set(client, models);
+
+        @SuppressWarnings("unchecked")
+        ResponseStream<GenerateContentResponse> stream = mock(ResponseStream.class);
+
+        ArgumentCaptor<GenerateContentConfig> configCaptor = 
+                ArgumentCaptor.forClass(GenerateContentConfig.class);
+
+        when(models.generateContentStream(any(String.class), any(List.class), configCaptor.capture()))
+                .thenReturn(stream);
+
+        when(stream.iterator()).thenReturn(List.<GenerateContentResponse>of().iterator());
+
+        GoogleGenAiStreamingChatModel model = GoogleGenAiStreamingChatModel.builder()
+                .client(client)
+                .modelName("gemini-3.1-flash-lite")
+                .cachedContent("projects/123/locations/us-central1/cachedContents/global")
+                .build();
+
+        ChatRequest request = ChatRequest.builder()
+                .messages(UserMessage.from("Hello"))
+                .parameters(GoogleGenAiChatRequestParameters.builder()
+                        .cachedContent("projects/123/locations/us-central1/cachedContents/per-request")
+                        .build())
+                .build();
+
+        model.chat(request, new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {}
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {}
+            @Override
+            public void onError(Throwable error) {}
+        });
+
+        // Wait a little bit for the executor to run
+        Thread.sleep(100);
+
+        assertThat(configCaptor.getValue().cachedContent().isPresent()).isTrue();
+        assertThat(configCaptor.getValue().cachedContent().get())
+                .isEqualTo("projects/123/locations/us-central1/cachedContents/per-request");
     }
 }

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiStreamingChatModelTest.java
@@ -11,6 +11,7 @@ import com.google.genai.ResponseStream;
 import com.google.genai.types.Candidate;
 import com.google.genai.types.Content;
 import com.google.genai.types.FunctionCall;
+import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.Part;
 import com.google.genai.types.SafetySetting;
@@ -19,14 +20,12 @@ import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.ModelProvider;
 import dev.langchain4j.model.chat.Capability;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.FinishReason;
 import java.lang.reflect.Field;
-import org.mockito.ArgumentCaptor;
-import com.google.genai.types.GenerateContentConfig;
-import dev.langchain4j.model.chat.request.ChatRequest;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.HashMap;
@@ -36,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class GoogleGenAiStreamingChatModelTest {
 
@@ -346,8 +346,7 @@ class GoogleGenAiStreamingChatModelTest {
         @SuppressWarnings("unchecked")
         ResponseStream<GenerateContentResponse> stream = mock(ResponseStream.class);
 
-        ArgumentCaptor<GenerateContentConfig> configCaptor = 
-                ArgumentCaptor.forClass(GenerateContentConfig.class);
+        ArgumentCaptor<GenerateContentConfig> configCaptor = ArgumentCaptor.forClass(GenerateContentConfig.class);
 
         when(models.generateContentStream(any(String.class), any(List.class), configCaptor.capture()))
                 .thenReturn(stream);
@@ -370,8 +369,10 @@ class GoogleGenAiStreamingChatModelTest {
         model.chat(request, new StreamingChatResponseHandler() {
             @Override
             public void onPartialResponse(String partialResponse) {}
+
             @Override
             public void onCompleteResponse(ChatResponse completeResponse) {}
+
             @Override
             public void onError(Throwable error) {}
         });


### PR DESCRIPTION
Resolves #5675

This PR adds support for passing a `cachedContent` configuration parameter on a per-request basis for `GoogleGenAiChatModel` and `GoogleGenAiStreamingChatModel`. It includes unit tests verifying that the parameter overrides the globally configured model parameter correctly.

Mirroring the same behavior added in PR #5645 for `google-ai-gemini`.