### PR TITLE
feat(a2a): make the A2A client transport configurable

### DIFF
--- a/docs/docs/tutorials/agents.md
+++ b/docs/docs/tutorials/agents.md
@@ -2804,6 +2804,51 @@ ResultWithAgenticScope<String> result = workflow.converse("hello");
 
 In this sequence, the first agent sends a message with no `contextId`/`taskId` (they are `null` in the scope). The server creates a new task and context. The response IDs are written to the scope. When the second agent runs, it reads the now-populated `contextId` and `taskId` from the scope and sends them on the message envelope, continuing the same conversation.
 
+### Configuring the A2A transport
+
+By default an A2A client agent communicates with the remote server over the JSON-RPC transport using its default configuration. It is possible to select and customize the transport, for instance to register call interceptors adding authentication, custom headers or OpenTelemetry context propagation, by passing an `A2AClientTransportConfigurer` to the builder:
+
+```java
+A2AClientTransportConfigurer transport = A2AClientTransportConfigurer.transport(
+        JSONRPCTransport.class,
+        new JSONRPCTransportConfigBuilder().addInterceptor(myOpenTelemetryInterceptor));
+
+A2ACreativeWriter creativeWriter = AgenticServices
+        .a2aBuilder(A2A_SERVER_URL, A2ACreativeWriter.class)
+        .clientTransport(transport)
+        .outputKey("story")
+        .build();
+```
+
+The `A2AClientTransportConfigurer.transport(...)` factory covers the common case of choosing a transport and its configuration builder, mirroring the A2A SDK `ClientBuilder.withTransport(...)` method. For full control, an `A2AClientTransportConfigurer` is a functional interface receiving the underlying A2A `ClientBuilder`, so any configuration supported by the SDK (transport selection, interceptors, custom HTTP client, client configuration, ...) can be applied:
+
+```java
+A2ACreativeWriter creativeWriter = AgenticServices
+        .a2aBuilder(A2A_SERVER_URL, A2ACreativeWriter.class)
+        .clientTransport((A2AClientTransportConfigurer) clientBuilder -> clientBuilder.withTransport(
+                JSONRPCTransport.class,
+                new JSONRPCTransportConfigBuilder().addInterceptor(myOpenTelemetryInterceptor)))
+        .outputKey("story")
+        .build();
+```
+
+When using the declarative API, the transport can be configured by adding a static method annotated with `@A2AClientTransportSupplier` that returns the `A2AClientTransportConfigurer` to the agent interface:
+
+```java
+public interface A2ACreativeWriter {
+
+    @A2AClientAgent(a2aServerUrl = "http://localhost:8080", outputKey = "story")
+    String generateStory(@V("topic") String topic);
+
+    @A2AClientTransportSupplier
+    static A2AClientTransportConfigurer transport() {
+        return A2AClientTransportConfigurer.transport(
+                JSONRPCTransport.class,
+                new JSONRPCTransportConfigBuilder().addInterceptor(myOpenTelemetryInterceptor));
+    }
+}
+```
+
 ## MCP-based Tool Agents
 
 The additional `langchain4j-agentic-mcp` module allows wrapping a single [MCP](https://modelcontextprotocol.io/) tool as a non-AI agent in the agentic system. Unlike regular agents that use an LLM, an MCP tool agent simply executes the MCP tool directly and returns its result. This makes it possible to compose MCP tools with other agents in larger agentic systems, without involving an LLM for the tool execution itself.

--- a/langchain4j-agentic-a2a/revapi.json
+++ b/langchain4j-agentic-a2a/revapi.json
@@ -16,6 +16,30 @@
           "old": "method io.a2a.spec.AgentCard dev.langchain4j.agentic.a2a.A2AClientInstance::agentCard()",
           "new": "method org.a2aproject.sdk.spec.AgentCard dev.langchain4j.agentic.a2a.A2AClientInstance::agentCard()",
           "justification": "Bump to A2A 1.0.0-CR1"
+        },
+        {
+          "ignore": true,
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class org.a2aproject.sdk.client.ClientBuilder",
+          "justification": "A2A SDK transport types are intentionally exposed by A2AClientTransportConfigurer to let users configure the A2A client transport."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class org.a2aproject.sdk.client.transport.spi.ClientTransport",
+          "justification": "A2A SDK transport types are intentionally exposed by A2AClientTransportConfigurer to let users configure the A2A client transport."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class org.a2aproject.sdk.client.transport.spi.ClientTransportConfig",
+          "justification": "A2A SDK transport types are intentionally exposed by A2AClientTransportConfigurer to let users configure the A2A client transport."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class org.a2aproject.sdk.client.transport.spi.ClientTransportConfigBuilder",
+          "justification": "A2A SDK transport types are intentionally exposed by A2AClientTransportConfigurer to let users configure the A2A client transport."
         }
       ]
     }

--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2AClientTransportConfigurer.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/A2AClientTransportConfigurer.java
@@ -1,0 +1,67 @@
+package dev.langchain4j.agentic.a2a;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import org.a2aproject.sdk.client.ClientBuilder;
+import org.a2aproject.sdk.client.transport.spi.ClientTransport;
+import org.a2aproject.sdk.client.transport.spi.ClientTransportConfig;
+import org.a2aproject.sdk.client.transport.spi.ClientTransportConfigBuilder;
+
+/**
+ * Customizes the transport of the A2A {@link org.a2aproject.sdk.client.Client} created for an A2A client agent.
+ * <p>
+ * By default an A2A client agent communicates over the JSON-RPC transport with its default configuration. Providing
+ * an {@code A2AClientTransportConfigurer} gives full control over the {@link ClientBuilder} used under the hood, so it
+ * is possible to:
+ * <ul>
+ *     <li>select a different transport implementation (JSON-RPC, gRPC, REST, ...);</li>
+ *     <li>register {@link org.a2aproject.sdk.client.transport.spi.interceptors.ClientCallInterceptor call interceptors}
+ *     to add authentication, OpenTelemetry context propagation, custom headers and so on;</li>
+ *     <li>plug in a custom HTTP client.</li>
+ * </ul>
+ * <p>
+ * A configurer can be passed programmatically through
+ * {@link dev.langchain4j.agentic.internal.A2AClientBuilder#clientTransport(Object)}:
+ * <pre>{@code
+ * A2AClientTransportConfigurer transport = A2AClientTransportConfigurer.transport(
+ *         JSONRPCTransport.class,
+ *         new JSONRPCTransportConfigBuilder().addInterceptor(myOpenTelemetryInterceptor));
+ *
+ * MyAgent agent = AgenticServices.a2aBuilder(a2aServerUrl, MyAgent.class)
+ *         .clientTransport(transport)
+ *         .build();
+ * }</pre>
+ * or declaratively by annotating a static supplier method with
+ * {@link dev.langchain4j.agentic.declarative.A2AClientTransportSupplier}.
+ *
+ * @see dev.langchain4j.agentic.declarative.A2AClientTransportSupplier
+ */
+@FunctionalInterface
+public interface A2AClientTransportConfigurer {
+
+    /**
+     * Configures the given {@link ClientBuilder}. Implementations are expected to at least set a transport via
+     * {@link ClientBuilder#withTransport(Class, ClientTransportConfigBuilder)} (or the config-based overload).
+     *
+     * @param clientBuilder the client builder to configure.
+     */
+    void configure(ClientBuilder clientBuilder);
+
+    /**
+     * Convenience factory building a configurer that simply sets the given transport and its configuration builder,
+     * mirroring {@link ClientBuilder#withTransport(Class, ClientTransportConfigBuilder)}. This covers the most common
+     * case of choosing a transport and configuring it, for example to register call interceptors.
+     *
+     * @param transportClass         the transport implementation class to use.
+     * @param transportConfigBuilder the configuration builder for the chosen transport.
+     * @param <T>                    the transport type.
+     * @return a configurer applying the given transport and configuration.
+     */
+    static <T extends ClientTransport> A2AClientTransportConfigurer transport(
+            Class<T> transportClass,
+            ClientTransportConfigBuilder<? extends ClientTransportConfig<T>, ?> transportConfigBuilder) {
+        ensureNotNull(transportClass, "transportClass");
+        ensureNotNull(transportConfigBuilder, "transportConfigBuilder");
+        return clientBuilder -> clientBuilder.withTransport(transportClass, transportConfigBuilder);
+    }
+}

--- a/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilder.java
+++ b/langchain4j-agentic-a2a/src/main/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilder.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.a2aproject.sdk.A2A;
 import org.a2aproject.sdk.client.Client;
+import org.a2aproject.sdk.client.ClientBuilder;
 import org.a2aproject.sdk.client.ClientEvent;
 import org.a2aproject.sdk.client.MessageEvent;
 import org.a2aproject.sdk.client.TaskEvent;
@@ -60,7 +61,7 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
     private static final Logger LOG = LoggerFactory.getLogger(DefaultA2AClientBuilder.class);
 
     private final AgentCard agentCard;
-    private final Client a2aClient;
+    private Client a2aClient;
 
     private final String name;
     private String agentId;
@@ -71,18 +72,12 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
     private boolean async;
 
     private AgentListener agentListener;
+    private A2AClientTransportConfigurer transportConfigurer;
 
     DefaultA2AClientBuilder(String a2aServerUrl, Class<T> agentServiceClass) {
         this.agentCard = agentCard(a2aServerUrl);
         this.name = agentCard.name();
         this.agentId = this.name;
-        try {
-            this.a2aClient = Client.builder(agentCard)
-                    .withTransport(JSONRPCTransport.class, new JSONRPCTransportConfigBuilder())
-                    .build();
-        } catch (A2AClientException e) {
-            throw new RuntimeException(e);
-        }
         this.agentServiceClass = agentServiceClass;
     }
 
@@ -94,11 +89,31 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
         }
     }
 
+    /**
+     * Builds the underlying A2A {@link Client}, applying the given {@link A2AClientTransportConfigurer} when provided
+     * and falling back to the default JSON-RPC transport otherwise.
+     */
+    static Client buildClient(AgentCard agentCard, A2AClientTransportConfigurer transportConfigurer) {
+        ClientBuilder clientBuilder = Client.builder(agentCard);
+        if (transportConfigurer != null) {
+            transportConfigurer.configure(clientBuilder);
+        } else {
+            clientBuilder.withTransport(JSONRPCTransport.class, new JSONRPCTransportConfigBuilder());
+        }
+        try {
+            return clientBuilder.build();
+        } catch (A2AClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public T build() {
         if (agentServiceClass == UntypedAgent.class && inputKeys == null) {
             throw new IllegalArgumentException("Input names must be provided for UntypedAgent.");
         }
+
+        this.a2aClient = buildClient(agentCard, transportConfigurer);
 
         Object agent = Proxy.newProxyInstance(
                 agentServiceClass.getClassLoader(), new Class<?>[] {agentServiceClass, A2AClientInstance.class}, this);
@@ -312,6 +327,17 @@ public class DefaultA2AClientBuilder<T> implements A2AClientBuilder<T>, Internal
     @Override
     public DefaultA2AClientBuilder<T> listener(AgentListener agentListener) {
         this.agentListener = agentListener;
+        return this;
+    }
+
+    @Override
+    public DefaultA2AClientBuilder<T> clientTransport(Object transportConfigurer) {
+        if (transportConfigurer != null && !(transportConfigurer instanceof A2AClientTransportConfigurer)) {
+            throw new IllegalArgumentException("clientTransport() expects an instance of "
+                    + A2AClientTransportConfigurer.class.getName() + " but got "
+                    + transportConfigurer.getClass().getName());
+        }
+        this.transportConfigurer = (A2AClientTransportConfigurer) transportConfigurer;
         return this;
     }
 

--- a/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
+++ b/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
@@ -2,9 +2,25 @@ package dev.langchain4j.agentic.a2a;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import dev.langchain4j.agentic.UntypedAgent;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.a2aproject.sdk.A2A;
+import org.a2aproject.sdk.client.Client;
+import org.a2aproject.sdk.client.ClientBuilder;
+import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransport;
+import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransportConfigBuilder;
+import org.a2aproject.sdk.spec.AgentCard;
 import org.a2aproject.sdk.spec.Artifact;
 import org.a2aproject.sdk.spec.Message;
 import org.a2aproject.sdk.spec.Part;
@@ -13,6 +29,7 @@ import org.a2aproject.sdk.spec.TaskState;
 import org.a2aproject.sdk.spec.TaskStatus;
 import org.a2aproject.sdk.spec.TextPart;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 class DefaultA2AClientBuilderTest {
 
@@ -90,5 +107,87 @@ class DefaultA2AClientBuilderTest {
 
         assertThat(future).isCompleted();
         assertThat(future.get()).isEmpty();
+    }
+
+    @Test
+    void transportConfigurer_factory_appliesTransportAndConfigBuilderToClientBuilder() {
+        ClientBuilder clientBuilder = mock(ClientBuilder.class);
+        JSONRPCTransportConfigBuilder transportConfigBuilder = new JSONRPCTransportConfigBuilder();
+
+        A2AClientTransportConfigurer configurer =
+                A2AClientTransportConfigurer.transport(JSONRPCTransport.class, transportConfigBuilder);
+        configurer.configure(clientBuilder);
+
+        verify(clientBuilder).withTransport(JSONRPCTransport.class, transportConfigBuilder);
+    }
+
+    @Test
+    void transportConfigurer_factory_rejectsNullArguments() {
+        assertThatThrownBy(() -> A2AClientTransportConfigurer.transport(null, new JSONRPCTransportConfigBuilder()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("transportClass");
+
+        assertThatThrownBy(() -> A2AClientTransportConfigurer.transport(JSONRPCTransport.class, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("transportConfigBuilder");
+    }
+
+    @Test
+    void buildClient_withoutConfigurer_usesDefaultJsonRpcTransport() {
+        try (MockedStatic<Client> clientStatic = mockStatic(Client.class)) {
+            ClientBuilder clientBuilder = mock(ClientBuilder.class);
+            Client client = mock(Client.class);
+            clientStatic.when(() -> Client.builder(any())).thenReturn(clientBuilder);
+            when(clientBuilder.build()).thenReturn(client);
+
+            Client result = DefaultA2AClientBuilder.buildClient(null, null);
+
+            assertThat(result).isSameAs(client);
+            verify(clientBuilder).withTransport(eq(JSONRPCTransport.class), any(JSONRPCTransportConfigBuilder.class));
+            verify(clientBuilder).build();
+        }
+    }
+
+    @Test
+    void buildClient_withConfigurer_appliesConfigurerInsteadOfDefault() {
+        try (MockedStatic<Client> clientStatic = mockStatic(Client.class)) {
+            ClientBuilder clientBuilder = mock(ClientBuilder.class);
+            Client client = mock(Client.class);
+            clientStatic.when(() -> Client.builder(any())).thenReturn(clientBuilder);
+            when(clientBuilder.build()).thenReturn(client);
+
+            AtomicBoolean configured = new AtomicBoolean(false);
+            A2AClientTransportConfigurer configurer = builder -> {
+                assertThat(builder).isSameAs(clientBuilder);
+                configured.set(true);
+            };
+
+            Client result = DefaultA2AClientBuilder.buildClient(null, configurer);
+
+            assertThat(result).isSameAs(client);
+            assertThat(configured).isTrue();
+            // the default JSON-RPC transport must not be applied when a configurer is supplied
+            verify(clientBuilder, never())
+                    .withTransport(eq(JSONRPCTransport.class), any(JSONRPCTransportConfigBuilder.class));
+            verify(clientBuilder).build();
+        }
+    }
+
+    @Test
+    void clientTransport_rejectsUnexpectedTypeAndAcceptsNull() {
+        try (MockedStatic<A2A> a2aStatic = mockStatic(A2A.class)) {
+            AgentCard agentCard = mock(AgentCard.class);
+            when(agentCard.name()).thenReturn("test-agent");
+            a2aStatic.when(() -> A2A.getAgentCard(anyString())).thenReturn(agentCard);
+
+            DefaultA2AClientBuilder<UntypedAgent> builder =
+                    new DefaultA2AClientBuilder<>("http://localhost:1234", UntypedAgent.class);
+
+            assertThatThrownBy(() -> builder.clientTransport("not a configurer"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("A2AClientTransportConfigurer");
+
+            assertThat(builder.clientTransport(null)).isSameAs(builder);
+        }
     }
 }

--- a/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
+++ b/langchain4j-agentic-a2a/src/test/java/dev/langchain4j/agentic/a2a/DefaultA2AClientBuilderTest.java
@@ -11,16 +11,23 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import dev.langchain4j.agentic.AgenticServices;
 import dev.langchain4j.agentic.UntypedAgent;
+import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.agentic.declarative.A2AClientTransportSupplier;
+import dev.langchain4j.service.V;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.a2aproject.sdk.A2A;
 import org.a2aproject.sdk.client.Client;
 import org.a2aproject.sdk.client.ClientBuilder;
 import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransport;
 import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransportConfigBuilder;
+import org.a2aproject.sdk.spec.AgentCapabilities;
 import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentInterface;
 import org.a2aproject.sdk.spec.Artifact;
 import org.a2aproject.sdk.spec.Message;
 import org.a2aproject.sdk.spec.Part;
@@ -173,11 +180,23 @@ class DefaultA2AClientBuilderTest {
         }
     }
 
+    private static AgentCard minimalAgentCard(String name) {
+        return AgentCard.builder()
+                .name(name)
+                .description("test agent")
+                .version("1.0")
+                .capabilities(new AgentCapabilities(false, false, false, List.of()))
+                .defaultInputModes(List.of("text"))
+                .defaultOutputModes(List.of("text"))
+                .skills(List.of())
+                .supportedInterfaces(List.of(new AgentInterface("JSONRPC", "http://localhost:1234")))
+                .build();
+    }
+
     @Test
     void clientTransport_rejectsUnexpectedTypeAndAcceptsNull() {
         try (MockedStatic<A2A> a2aStatic = mockStatic(A2A.class)) {
-            AgentCard agentCard = mock(AgentCard.class);
-            when(agentCard.name()).thenReturn("test-agent");
+            AgentCard agentCard = minimalAgentCard("test-agent");
             a2aStatic.when(() -> A2A.getAgentCard(anyString())).thenReturn(agentCard);
 
             DefaultA2AClientBuilder<UntypedAgent> builder =
@@ -188,6 +207,40 @@ class DefaultA2AClientBuilderTest {
                     .hasMessageContaining("A2AClientTransportConfigurer");
 
             assertThat(builder.clientTransport(null)).isSameAs(builder);
+        }
+    }
+
+    static final AtomicReference<ClientBuilder> DECLARATIVE_CONFIGURED_BUILDER = new AtomicReference<>();
+
+    public interface TransportConfiguredAgent {
+
+        @A2AClientAgent(a2aServerUrl = "http://localhost:1234", outputKey = "response")
+        String ask(@V("question") String question);
+
+        @A2AClientTransportSupplier
+        static A2AClientTransportConfigurer transport() {
+            return DECLARATIVE_CONFIGURED_BUILDER::set;
+        }
+    }
+
+    @Test
+    void declarativeAgent_appliesTransportConfigurerFromSupplier() {
+        DECLARATIVE_CONFIGURED_BUILDER.set(null);
+        try (MockedStatic<A2A> a2aStatic = mockStatic(A2A.class);
+                MockedStatic<Client> clientStatic = mockStatic(Client.class)) {
+            AgentCard agentCard = minimalAgentCard("declarative-agent");
+            a2aStatic.when(() -> A2A.getAgentCard(anyString())).thenReturn(agentCard);
+            ClientBuilder clientBuilder = mock(ClientBuilder.class);
+            clientStatic.when(() -> Client.builder(any())).thenReturn(clientBuilder);
+            when(clientBuilder.build()).thenReturn(mock(Client.class));
+
+            AgenticServices.createAgenticSystem(TransportConfiguredAgent.class);
+
+            // the configurer returned by the @A2AClientTransportSupplier method must be applied to the client builder
+            assertThat(DECLARATIVE_CONFIGURED_BUILDER.get()).isSameAs(clientBuilder);
+            // and the default JSON-RPC transport must not be applied when a supplier is present
+            verify(clientBuilder, never())
+                    .withTransport(eq(JSONRPCTransport.class), any(JSONRPCTransportConfigBuilder.class));
         }
     }
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
@@ -712,7 +712,14 @@ public class AgenticServices {
                 .async(a2aClient.async());
 
         getAnnotatedMethodOnClass(agentServiceClass, A2AClientTransportSupplier.class)
-                .ifPresent(method -> a2aClientBuilder.clientTransport(invokeStatic(method)));
+                .ifPresent(method -> {
+                    if (!Modifier.isStatic(method.getModifiers()) || method.getParameterCount() != 0) {
+                        throw new IllegalArgumentException(
+                                "A method annotated with @A2AClientTransportSupplier must be "
+                                        + "static and take no arguments: " + method);
+                    }
+                    a2aClientBuilder.clientTransport(invokeStatic(method));
+                });
 
         getAnnotatedMethodOnClass(agentServiceClass, AgentListenerSupplier.class)
                 .ifPresent(method -> {

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/AgenticServices.java
@@ -17,6 +17,7 @@ import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import dev.langchain4j.agentic.agent.AgentBuilder;
 import dev.langchain4j.agentic.agent.UntypedAgentBuilder;
 import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.agentic.declarative.A2AClientTransportSupplier;
 import dev.langchain4j.agentic.declarative.ActivationCondition;
 import dev.langchain4j.agentic.declarative.AgentListenerSupplier;
 import dev.langchain4j.agentic.declarative.ChatModelSupplier;
@@ -28,16 +29,16 @@ import dev.langchain4j.agentic.declarative.ParallelAgent;
 import dev.langchain4j.agentic.declarative.ParallelMapperAgent;
 import dev.langchain4j.agentic.declarative.PlannerAgent;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
-import dev.langchain4j.agentic.internal.AbstractServiceBuilder;
 import dev.langchain4j.agentic.internal.A2AClientBuilder;
 import dev.langchain4j.agentic.internal.A2AService;
+import dev.langchain4j.agentic.internal.AbstractServiceBuilder;
 import dev.langchain4j.agentic.internal.AgentExecutor;
 import dev.langchain4j.agentic.internal.AgentInvoker;
 import dev.langchain4j.agentic.internal.AgentUtil;
-import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.internal.McpService;
 import dev.langchain4j.agentic.observability.AgentListener;
+import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgenticService;
 import dev.langchain4j.agentic.planner.PlannerBasedService;
 import dev.langchain4j.agentic.planner.PlannerBasedServiceImpl;
@@ -709,6 +710,9 @@ public class AgenticServices {
                         .toArray(String[]::new))
                 .outputKey(AgentUtil.outputKey(a2aClient.outputKey(), a2aClient.typedOutputKey()))
                 .async(a2aClient.async());
+
+        getAnnotatedMethodOnClass(agentServiceClass, A2AClientTransportSupplier.class)
+                .ifPresent(method -> a2aClientBuilder.clientTransport(invokeStatic(method)));
 
         getAnnotatedMethodOnClass(agentServiceClass, AgentListenerSupplier.class)
                 .ifPresent(method -> {

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2AClientTransportSupplier.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/declarative/A2AClientTransportSupplier.java
@@ -1,0 +1,33 @@
+package dev.langchain4j.agentic.declarative;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a static method that supplies the transport configuration for a declarative {@link A2AClientAgent}.
+ * <p>
+ * The annotated method must be static, take no arguments and return an instance of
+ * {@code dev.langchain4j.agentic.a2a.A2AClientTransportConfigurer} (provided by the {@code langchain4j-agentic-a2a}
+ * module). It allows the underlying A2A client transport to be selected and customized, for example to register call
+ * interceptors adding authentication or OpenTelemetry context propagation.
+ * <pre>{@code
+ * public interface MyA2AAgent {
+ *
+ *     @A2AClientAgent(a2aServerUrl = "http://localhost:8080", outputKey = "response")
+ *     String ask(@V("question") String question);
+ *
+ *     @A2AClientTransportSupplier
+ *     static A2AClientTransportConfigurer transport() {
+ *         return A2AClientTransportConfigurer.transport(
+ *                 JSONRPCTransport.class,
+ *                 new JSONRPCTransportConfigBuilder().addInterceptor(myOpenTelemetryInterceptor));
+ *     }
+ * }
+ * }</pre>
+ */
+@Retention(RUNTIME)
+@Target({METHOD})
+public @interface A2AClientTransportSupplier {}

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/A2AClientBuilder.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/A2AClientBuilder.java
@@ -12,5 +12,20 @@ public interface A2AClientBuilder<T> {
 
     A2AClientBuilder<T> listener(AgentListener agentListener);
 
+    /**
+     * Configures the transport used by the underlying A2A client, allowing for instance to select a specific
+     * transport implementation (JSON-RPC, gRPC, REST, ...) or to customize it with call interceptors enabling
+     * authentication, OpenTelemetry context propagation and so on.
+     * <p>
+     * The {@code transportConfigurer} argument is expected to be an instance of
+     * {@code dev.langchain4j.agentic.a2a.A2AClientTransportConfigurer}, provided by the
+     * {@code langchain4j-agentic-a2a} module. It is typed as {@link Object} here because this module does not
+     * depend on the A2A SDK, keeping the transport specific types confined to the A2A integration module.
+     *
+     * @param transportConfigurer the transport configurer to apply, or {@code null} to use the default transport.
+     * @return this builder.
+     */
+    A2AClientBuilder<T> clientTransport(Object transportConfigurer);
+
     T build();
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/A2AClientBuilder.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/A2AClientBuilder.java
@@ -25,7 +25,11 @@ public interface A2AClientBuilder<T> {
      * @param transportConfigurer the transport configurer to apply, or {@code null} to use the default transport.
      * @return this builder.
      */
-    A2AClientBuilder<T> clientTransport(Object transportConfigurer);
+    default A2AClientBuilder<T> clientTransport(Object transportConfigurer) {
+        // Default no-op so that pre-existing third-party implementations keep working unchanged; implementations
+        // supporting transport configuration (such as the one in langchain4j-agentic-a2a) override this method.
+        return this;
+    }
 
     T build();
 }


### PR DESCRIPTION
## Issue
Closes #5674

## Change
Currently the A2A client transport is hard-coded to JSON-RPC with its default configuration in `DefaultA2AClientBuilder`, so there is no way to choose a different transport or to customize it (for example to register call interceptors enabling authentication or OpenTelemetry context propagation, as requested in the issue).

This PR makes the transport configurable, both programmatically and declaratively, without leaking the A2A SDK types into the core `langchain4j-agentic` module.

**New public API (`langchain4j-agentic-a2a`)**
- `A2AClientTransportConfigurer` — a `@FunctionalInterface` receiving the underlying A2A SDK `ClientBuilder`, so any SDK configuration (transport selection, call interceptors, custom HTTP client, client configuration, ...) can be applied.
- `A2AClientTransportConfigurer.transport(transportClass, transportConfigBuilder)` — a convenience factory for the common case, mirroring `ClientBuilder.withTransport(...)`.

**Programmatic usage**
```java
A2AClientTransportConfigurer transport = A2AClientTransportConfigurer.transport(
        JSONRPCTransport.class,
        new JSONRPCTransportConfigBuilder().addInterceptor(myOpenTelemetryInterceptor));

MyAgent agent = AgenticServices.a2aBuilder(a2aServerUrl, MyAgent.class)
        .clientTransport(transport)
        .build();
```

**Declarative usage** — a static method annotated with the new `@A2AClientTransportSupplier` (mirroring the existing `@McpClientSupplier` / `@AgentListenerSupplier` pattern):
```java
public interface MyAgent {

    @A2AClientAgent(a2aServerUrl = "http://localhost:8080", outputKey = "response")
    String ask(@V("question") String question);

    @A2AClientTransportSupplier
    static A2AClientTransportConfigurer transport() {
        return A2AClientTransportConfigurer.transport(
                JSONRPCTransport.class,
                new JSONRPCTransportConfigBuilder().addInterceptor(myOpenTelemetryInterceptor));
    }
}
```

**Design notes**
- The core `langchain4j-agentic` module stays free of any A2A SDK dependency: the transport configurer is threaded through the internal `A2AClientBuilder` SPI as an `Object` (the same convention already used for `McpService.mcpBuilder(Object mcpClient, ...)`), and the SDK-typed API lives entirely in `langchain4j-agentic-a2a`.
- The underlying `Client` is now built lazily in `build()` so a configurer set via the fluent API is taken into account.
- **Fully backward compatible:** when no configurer is supplied the client still defaults to the JSON-RPC transport, exactly as before.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)