### PR TITLE
fix: advance the planner when an agent error handler returns a result

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentExecutor.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AgentExecutor.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.agentic.internal;
 
+import static dev.langchain4j.agentic.scope.DefaultAgenticScope.isSerializable;
+
 import dev.langchain4j.agentic.agent.AgentInvocationException;
 import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
 import dev.langchain4j.agentic.agent.MissingArgumentException;
@@ -11,13 +13,11 @@ import dev.langchain4j.agentic.planner.Planner;
 import dev.langchain4j.agentic.scope.AgentInvocation;
 import dev.langchain4j.agentic.scope.DefaultAgenticScope;
 import dev.langchain4j.service.TokenStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
-
-import static dev.langchain4j.agentic.scope.DefaultAgenticScope.isSerializable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements AgentInstance, InternalAgent {
 
@@ -40,23 +40,35 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
     }
 
     private Object handleAgentFailure(
-            AgentInvocationException e, DefaultAgenticScope agenticScope, Object invokedAgent, PlannerExecutor planner) {
+            AgentInvocationException e,
+            DefaultAgenticScope agenticScope,
+            Object invokedAgent,
+            PlannerExecutor planner,
+            AgentInvocationArguments args,
+            boolean plannerAlreadyNotified) {
         ErrorRecoveryResult recoveryResult = agenticScope.handleError(agentInvoker.name(), e);
         return switch (recoveryResult.type()) {
             case THROW_EXCEPTION -> throw e;
             case RETRY -> internalExecute(agenticScope, invokedAgent, planner, false);
-            case RETURN_RESULT -> recoveryResult.result();
+            case RETURN_RESULT ->
+                plannerAlreadyNotified
+                        ? recoveryResult.result()
+                        : completeAgentInvocation(recoveryResult.result(), agenticScope, invokedAgent, planner, args);
         };
     }
 
-    private Object internalExecute(DefaultAgenticScope agenticScope, Object invokedAgent, PlannerExecutor planner, boolean async) {
+    private Object internalExecute(
+            DefaultAgenticScope agenticScope, Object invokedAgent, PlannerExecutor planner, boolean async) {
+        AgentInvocationArguments args = null;
         try {
-            AgentInvocationArguments args = null;
             try {
                 args = agentInvoker.toInvocationArguments(agenticScope);
             } catch (MissingArgumentException e) {
                 if (optional()) {
-                    LOG.info("Skipping optional agent '{}' because of missing argument '{}'", agentInvoker.name(), e.argumentName());
+                    LOG.info(
+                            "Skipping optional agent '{}' because of missing argument '{}'",
+                            agentInvoker.name(),
+                            e.argumentName());
                     Object response = agenticScope.readState(agentInvoker.outputKey());
                     if (planner != null) {
                         planner.onSubagentInvoked(new AgentInvocation(type(), name(), agentId(), Map.of(), response));
@@ -67,28 +79,44 @@ public record AgentExecutor(AgentInvoker agentInvoker, Object agent) implements 
             }
 
             Object response = agentResponse(agenticScope, invokedAgent, planner, args, async);
-            String outputKey = agentInvoker.outputKey();
-            if (outputKey != null && !outputKey.isBlank()) {
-                agenticScope.writeState(outputKey, response);
-            }
-            AgentInvocation agentInvocation = new AgentInvocation(type(), name(), agentId(), args.namedArgs(), isSerializable(response) ? response : "<unknown>");
-            agenticScope.registerAgentInvocation(agentInvocation, invokedAgent);
-            if (planner != null) {
-                planner.onSubagentInvoked(agentInvocation);
-            }
-            return response;
+            return completeAgentInvocation(response, agenticScope, invokedAgent, planner, args);
         } catch (AgentInvocationException e) {
-            return handleAgentFailure(e, agenticScope, invokedAgent, planner);
+            return handleAgentFailure(e, agenticScope, invokedAgent, planner, args, false);
         }
     }
 
-    private Object agentResponse(DefaultAgenticScope agenticScope, Object invokedAgent, PlannerExecutor planner, AgentInvocationArguments args, boolean async) {
+    private Object completeAgentInvocation(
+            Object response,
+            DefaultAgenticScope agenticScope,
+            Object invokedAgent,
+            PlannerExecutor planner,
+            AgentInvocationArguments args) {
+        String outputKey = agentInvoker.outputKey();
+        if (outputKey != null && !outputKey.isBlank()) {
+            agenticScope.writeState(outputKey, response);
+        }
+        Map<String, Object> namedArgs = args != null ? args.namedArgs() : Map.of();
+        AgentInvocation agentInvocation = new AgentInvocation(
+                type(), name(), agentId(), namedArgs, isSerializable(response) ? response : "<unknown>");
+        agenticScope.registerAgentInvocation(agentInvocation, invokedAgent);
+        if (planner != null) {
+            planner.onSubagentInvoked(agentInvocation);
+        }
+        return response;
+    }
+
+    private Object agentResponse(
+            DefaultAgenticScope agenticScope,
+            Object invokedAgent,
+            PlannerExecutor planner,
+            AgentInvocationArguments args,
+            boolean async) {
         if (async) {
             return new AsyncResponse<>(() -> {
                 try {
                     return agentInvoker.invoke(agenticScope, invokedAgent, args);
                 } catch (AgentInvocationException e) {
-                    return handleAgentFailure(e, agenticScope, invokedAgent, planner);
+                    return handleAgentFailure(e, agenticScope, invokedAgent, planner, args, true);
                 }
             });
         }

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ErrorRecoveryResultTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/ErrorRecoveryResultTest.java
@@ -1,0 +1,109 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class ErrorRecoveryResultTest {
+
+    static final ChatModel STUB_MODEL = new ChatModel() {
+        @Override
+        public ChatResponse chat(ChatRequest chatRequest) {
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("draft story"))
+                    .build();
+        }
+    };
+
+    public interface StoryWriter {
+
+        @UserMessage("Write a story about {{topic}}")
+        @Agent(outputKey = "story")
+        String write(@V("topic") String topic);
+    }
+
+    public interface StoryEditor {
+
+        @UserMessage("Rewrite {{story}} in the style {{style}}")
+        @Agent(outputKey = "story")
+        String edit(@V("story") String story, @V("style") String style);
+    }
+
+    public interface StoryPublisher {
+
+        @UserMessage("Publish {{story}}")
+        @Agent(outputKey = "published")
+        String publish(@V("story") String story);
+    }
+
+    @Test
+    void error_handler_returning_result_completes_sequence() {
+        StoryWriter writer = AgenticServices.agentBuilder(StoryWriter.class)
+                .chatModel(STUB_MODEL)
+                .build();
+        StoryEditor editor = AgenticServices.agentBuilder(StoryEditor.class)
+                .chatModel(STUB_MODEL)
+                .build();
+        StoryPublisher publisher = spy(AgenticServices.agentBuilder(StoryPublisher.class)
+                .chatModel(STUB_MODEL)
+                .build());
+
+        AtomicReference<String> failedAgent = new AtomicReference<>();
+
+        UntypedAgent workflow = AgenticServices.sequenceBuilder()
+                .subAgents(writer, editor, publisher)
+                .outputKey("published")
+                .errorHandler(errorContext -> {
+                    failedAgent.set(errorContext.agentName());
+                    return ErrorRecoveryResult.result("default story");
+                })
+                .build();
+
+        Object result =
+                assertTimeoutPreemptively(Duration.ofSeconds(5), () -> workflow.invoke(Map.of("topic", "dragons")));
+
+        assertThat(failedAgent.get()).isEqualTo("edit");
+        verify(publisher).publish("default story");
+        assertThat(result).isEqualTo("draft story");
+    }
+
+    @Test
+    void error_handler_returning_result_on_last_agent_returns_recovered_value() {
+        StoryWriter writer = AgenticServices.agentBuilder(StoryWriter.class)
+                .chatModel(STUB_MODEL)
+                .build();
+        StoryEditor editor = AgenticServices.agentBuilder(StoryEditor.class)
+                .chatModel(STUB_MODEL)
+                .build();
+
+        AtomicReference<String> failedAgent = new AtomicReference<>();
+
+        UntypedAgent workflow = AgenticServices.sequenceBuilder()
+                .subAgents(writer, editor)
+                .outputKey("story")
+                .errorHandler(errorContext -> {
+                    failedAgent.set(errorContext.agentName());
+                    return ErrorRecoveryResult.result("default story");
+                })
+                .build();
+
+        Object result =
+                assertTimeoutPreemptively(Duration.ofSeconds(5), () -> workflow.invoke(Map.of("topic", "dragons")));
+
+        assertThat(failedAgent.get()).isEqualTo("edit");
+        assertThat(result).isEqualTo("default story");
+    }
+}


### PR DESCRIPTION
# Issue

Fixes #5681

## Change

When an agent inside a workflow (e.g. a `sequenceBuilder()`) fails and the configured `errorHandler` returns `ErrorRecoveryResult.result(...)`, `invoke()` never returns. The calling thread spins at 100% CPU with no response.

Reproduction from the issue: a two-agent sequence where the second agent is invoked with a missing argument, and the handler returns a default value:

```java
.errorHandler(errorContext -> ErrorRecoveryResult.result("it is default value"))
```

The handler runs (its logging is printed), but the workflow then hangs.

### Root cause

In `AgentExecutor`, the normal completion path writes the output key, registers the invocation, and calls `planner.onSubagentInvoked(...)` so the planner can schedule the next action. The synchronous `RETURN_RESULT` recovery branch skipped all of this and just returned the recovered value.

As a result the planner was never advanced past the failed agent. In `PlannerBasedInvocationHandler.PlannerLoop.loop()` the `nextAction` stays `null` and the loop keeps running `Thread.yield(); continue;` forever.

`retry()` and `throwException()` were unaffected (retry re-enters the normal completion path, throw propagates out of the loop), which is why only `result()` hung, and it had no workflow-level test coverage.

### Fix

Route the returned recovery result through the same completion logic as a normal response (extracted into `completeAgentInvocation`): write the output key, register the invocation, and notify the planner.

The async path already notifies the planner with a placeholder before the task runs, so it keeps returning the raw recovered value to avoid a double notification.

### Test

Added `ErrorRecoveryResultTest`, a model-free regression test (stub `ChatModel`) covering both planner outcomes when a failed agent recovers via `result(...)`: one where the failing agent is in the middle of the sequence (the planner must advance to the next agent, which receives the recovered value) and one where it is the last agent (the planner must terminate and return the recovered value, matching the issue repro). `assertTimeoutPreemptively` makes a regression fail fast rather than hang CI.

```
mvn -pl langchain4j-agentic test
Tests run: 65, Failures: 0, Errors: 0, Skipped: 0
```

Verified the new test times out (fails) on unmodified main and passes with the fix. `mvn -pl langchain4j-agentic spotless:check` is clean.

Also ran the existing error-recovery and sequence integration tests in `WorkflowAgentsIT` against a live model (`sequential_agents_tests`, `sequential_agents_with_error_tests`, `sequential_declarative_agents_with_error_recovery_tests`, `sequential_programmatic_agents_with_error_recovery_tests`, `error_recovery_with_async_agent_tests`); all green, confirming the `retry()` / `throwException()` paths and the shared completion path are unaffected.

## General checklist

- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)
