### PR TITLE
fix: Include failing file URL in GitHubDocumentLoader load-failure exception message

### DIFF
--- a/document-loaders/langchain4j-document-loader-github/src/main/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-github/src/main/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoader.java
@@ -210,7 +210,7 @@ public class GitHubDocumentLoader {
                         "Content must be a file, and not a directory: " + content.getHtmlUrl());
             }
         } catch (IOException ioException) {
-            throw new RuntimeException("Failed to load document from GitHub: {}", ioException);
+            throw new RuntimeException("Failed to load document from GitHub: " + content.getHtmlUrl(), ioException);
         }
     }
 

--- a/document-loaders/langchain4j-document-loader-github/src/test/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoaderTest.java
+++ b/document-loaders/langchain4j-document-loader-github/src/test/java/dev/langchain4j/data/document/loader/github/GitHubDocumentLoaderTest.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.data.document.loader.github;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.document.DocumentParser;
+import dev.langchain4j.data.document.parser.TextDocumentParser;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+import org.mockito.Mockito;
+
+class GitHubDocumentLoaderTest {
+
+    @Test
+    void loadDocument_wraps_io_error_with_file_url_in_message() throws IOException {
+        String htmlUrl = "https://github.com/owner/repo/blob/main/README.md";
+
+        GHContent content = Mockito.mock(GHContent.class);
+        when(content.isFile()).thenReturn(true);
+        when(content.read()).thenThrow(new IOException("boom"));
+        when(content.getHtmlUrl()).thenReturn(htmlUrl);
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        when(repository.getFileContent("README.md", "main")).thenReturn(content);
+
+        GitHub gitHub = Mockito.mock(GitHub.class);
+        when(gitHub.getRepository("owner/repo")).thenReturn(repository);
+
+        GitHubDocumentLoader loader = new GitHubDocumentLoader(gitHub);
+        DocumentParser parser = new TextDocumentParser();
+
+        assertThatThrownBy(() -> loader.loadDocument("owner", "repo", "main", "README.md", parser))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining(htmlUrl)
+                .hasMessageNotContaining("{}");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5683

## Change

`GitHubDocumentLoader.fromGitHub()` wrapped an `IOException` using an SLF4J `{}` placeholder. `RuntimeException(String, Throwable)` never substitutes `{}`, so the message leaked a literal `{}` and dropped the failing file's URL. The fix concatenates `content.getHtmlUrl()`, matching the sibling message on line 210:

```java
throw new RuntimeException("Failed to load document from GitHub: " + content.getHtmlUrl(), ioException);
```

Control flow, return value, and exception type are unchanged; backward compatible.

Added `GitHubDocumentLoaderTest` (the module's first unit test): it injects a mock `GitHub` via the `GitHubDocumentLoader(GitHub)` constructor, forces `GHContent.read()` to throw, and asserts the message contains the URL and not `{}` (positive and negative).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green <!-- N/A: change isolated to github document-loader module -->
- [ ] I have added/updated the documentation <!-- N/A: no public API/behavior contract change -->
- [ ] I have added an example in the examples repo <!-- N/A: bug fix, not a feature -->
- [ ] I have added/updated Spring Boot starter(s) <!-- N/A: not applicable -->

## Build / test evidence
- `./mvnw -pl document-loaders/langchain4j-document-loader-github -am clean test` (JDK 17): GitHubDocumentLoaderTest 1 run, 0 failures. IT skipped (`@EnabledIfEnvironmentVariable` GITHUB_TOKEN absent).
- Spotless verified via MAIN_ROOT `spotless:apply` (jgit `ratchetFrom` cannot open a git worktree's file-based `.git`): no reformatting of either file.
