### PR TITLE
fix: Use UTF-8 when encoding Playwright page content for the document parser

### DIFF
--- a/document-loaders/langchain4j-document-loader-playwright/src/main/java/dev/langchain4j/data/document/loader/playwright/PlaywrightDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-playwright/src/main/java/dev/langchain4j/data/document/loader/playwright/PlaywrightDocumentLoader.java
@@ -9,6 +9,7 @@ import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentParser;
 import dev.langchain4j.data.document.Metadata;
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +64,8 @@ public class PlaywrightDocumentLoader implements AutoCloseable {
 
         String pageContent = pageContent(url);
 
-        Document parsedDocument = documentParser.parse(new ByteArrayInputStream(pageContent.getBytes()));
+        Document parsedDocument =
+                documentParser.parse(new ByteArrayInputStream(pageContent.getBytes(StandardCharsets.UTF_8)));
 
         parsedDocument.metadata().put(Document.URL, url);
         return parsedDocument;

--- a/document-loaders/langchain4j-document-loader-playwright/src/test/java/dev/langchain4j/data/document/loader/playwright/PlaywrightDocumentLoaderTest.java
+++ b/document-loaders/langchain4j-document-loader-playwright/src/test/java/dev/langchain4j/data/document/loader/playwright/PlaywrightDocumentLoaderTest.java
@@ -1,0 +1,47 @@
+package dev.langchain4j.data.document.loader.playwright;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.Page;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentParser;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class PlaywrightDocumentLoaderTest {
+
+    // Pins the UTF-8 encoding contract for load(url, parser): the page content must be handed to the
+    // DocumentParser as UTF-8 bytes, independent of the JVM's default charset. This is byte-identical
+    // to String.getBytes() on a UTF-8-default JVM, so on such CI it is a contract-pin, not a fail-on-bug guard.
+    @Test
+    void load_should_encode_page_content_as_utf8_for_the_parser() throws Exception {
+        String html = "<html><body>café © 日本語</body></html>";
+
+        Page page = mock(Page.class);
+        when(page.content()).thenReturn(html);
+
+        Browser browser = mock(Browser.class);
+        when(browser.newPage()).thenReturn(page);
+
+        DocumentParser parser = mock(DocumentParser.class);
+        when(parser.parse(any(InputStream.class))).thenReturn(Document.from("parsed"));
+
+        PlaywrightDocumentLoader loader =
+                PlaywrightDocumentLoader.builder().browser(browser).build();
+
+        loader.load("https://example.com", parser);
+
+        ArgumentCaptor<InputStream> captor = ArgumentCaptor.forClass(InputStream.class);
+        verify(parser).parse(captor.capture());
+
+        byte[] actualBytes = captor.getValue().readAllBytes();
+        assertThat(actualBytes).isEqualTo(html.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
# fix: Use UTF-8 when encoding Playwright page content for the document parser

## Issue
Closes #5685

## Change
`PlaywrightDocumentLoader.load(String url, DocumentParser documentParser)` encoded the fetched HTML with `pageContent.getBytes()`, which uses the JVM's default charset. `TextDocumentParser` decodes those bytes as UTF-8, so on any JVM whose default charset is not UTF-8 (the Java 17 target is platform-dependent) non-ASCII content (accents, CJK, ©, emoji) was silently corrupted.

This changes the encoding to `getBytes(StandardCharsets.UTF_8)`, matching the langchain4j-core convention. It is byte-identical on UTF-8-default JVMs (backward compatible) and correct on all others. Only the parser overload is touched; `load(String url)` has no such round trip.

```java
documentParser.parse(new ByteArrayInputStream(pageContent.getBytes(StandardCharsets.UTF_8)));
```

Also adds the module's first unit test (`PlaywrightDocumentLoaderTest`, Mockito inherited from parent, no new dependency): it mocks `Browser`/`Page`, captures the `InputStream` passed to a mocked `DocumentParser`, and asserts the bytes equal the page content's UTF-8 encoding. This pins the encoding contract on every platform. On a UTF-8-default CI it is byte-identical to the previous behaviour, so it is a contract-pin, not a fail-on-bug guard.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases <!-- N/A — single encoding-contract assertion; no meaningful negative case -->
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- Unit test passes (1/1). The existing *IT needs a Playwright Testcontainer/Docker and was not run in the unit phase. -->
- [ ] I have manually run all the unit and integration tests in the core and main modules <!-- N/A — change is isolated to this module; core/main untouched -->
- [ ] I have added/updated the documentation <!-- N/A — behaviour fix, no doc change -->
- [ ] I have added an example in the examples repo <!-- N/A — not a feature -->
- [ ] I have added/updated Spring Boot starter(s) <!-- N/A — not applicable -->

<!-- Conditional sections (new maven module / new or changed embedding store integration) omitted — not applicable to this fix. -->

## Pre-submission notes (honest)
- Unit test: `PlaywrightDocumentLoaderTest` passed (1/1, 0 failures) via `./mvnw -pl document-loaders/langchain4j-document-loader-playwright -am clean test` on JDK 25.
- `PlaywrightDocumentLoaderIT` (Testcontainers) was not run — Surefire runs `*Test`, not `*IT`; it needs Docker. Not affected by this change.
- Spotless: `./mvnw -T12C -Pspotless spotless:check -pl document-loaders/langchain4j-document-loader-playwright` passes (BUILD SUCCESS, JDK 17), run from a normal checkout after `spotless:apply` wrapped one long assignment in the test. It cannot run inside the isolated git worktree (spotless 2.44.4 JGit cannot resolve a worktree whose `.git` is a file: "Cannot find git repository in any parent directory").

## Staleness check (run before submitting)
