### PR TITLE
docs: fix grammar in MarkdownDocumentParser class Javadoc

### DIFF
--- a/document-parsers/langchain4j-document-parser-markdown/src/main/java/dev/langchain4j/data/document/parser/markdown/MarkdownDocumentParser.java
+++ b/document-parsers/langchain4j-document-parser-markdown/src/main/java/dev/langchain4j/data/document/parser/markdown/MarkdownDocumentParser.java
@@ -14,8 +14,8 @@ import org.commonmark.parser.Parser;
 import org.commonmark.renderer.text.TextContentRenderer;
 
 /**
- * Parses Markdown file into a {@link Document}.
- * please refer to the <a href="https://www.markdownguide.org/">official Markdown website</a>.
+ * Parses a Markdown file into a {@link Document}.
+ * Please refer to the <a href="https://www.markdownguide.org/">official Markdown website</a>.
  */
 public class MarkdownDocumentParser implements DocumentParser {
 


### PR DESCRIPTION
## Issue
No issue — trivial Javadoc grammar fix.

## Change
Fixes two grammar errors in the `MarkdownDocumentParser` class Javadoc:
- `Parses Markdown file` → `Parses a Markdown file` (missing article).
- `please refer to ...` → `Please refer to ...` (new sentence after a period must be capitalized).

Javadoc only — no behaviour, API, or bytecode change.

```java
/**
 * Parses a Markdown file into a {@link Document}.
 * Please refer to the <a href="https://www.markdownguide.org/">official Markdown website</a>.
 */
```

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
<!-- Documentation-only grammar fix: there is no behaviour to test. -->
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
<!-- Ran `spotless:check` on the module (JDK 17): passes. No compilation/behaviour change. -->
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

<!-- Checklist for adding new maven module / embedding store integration: N/A (docs-only change to an existing module). -->

