### PR TITLE
docs: Update Apache Tika formats link to bundled version 3.2.3

### DIFF
--- a/document-parsers/langchain4j-document-parser-apache-tika/src/main/java/dev/langchain4j/data/document/parser/apache/tika/ApacheTikaDocumentParser.java
+++ b/document-parsers/langchain4j-document-parser-apache-tika/src/main/java/dev/langchain4j/data/document/parser/apache/tika/ApacheTikaDocumentParser.java
@@ -27,7 +27,7 @@ import org.xml.sax.ContentHandler;
  * </p>
  * <p>
  * For a full list of supported formats, refer to the
- * <a href="https://tika.apache.org/3.0.0/formats.html">Apache Tika documentation</a>.
+ * <a href="https://tika.apache.org/3.2.3/formats.html">Apache Tika documentation</a>.
  * </p>
  */
 public class ApacheTikaDocumentParser implements DocumentParser {


### PR DESCRIPTION
## Issue
Docs-only link version sync — no issue required (typo-fix).

## Change
The class Javadoc of `ApacheTikaDocumentParser` links to the Apache Tika formats page at `tika.apache.org/3.0.0/formats.html`, but the module bundles Tika 3.2.3 (`pom.xml` `apache-tika.version`). This updates the version segment `3.0.0` → `3.2.3` to match the bundled runtime.
PR #3387 established that this link tracks the bundled version (moving `2.9.1` → `3.0.0`); PR #3885 then bumped the pom to 3.2.3 but touched only pom files, leaving the Javadoc behind. This completes that fix.
The version-less URL returns 404, so the version segment is required; `3.2.3/formats.html` returns 200.

```java
 * <a href="https://tika.apache.org/3.2.3/formats.html">Apache Tika documentation</a>.
```

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change <!-- N/A — non-behavioral Javadoc link fix, no test -->
- [ ] The tests cover both positive and negative cases <!-- N/A — non-behavioral Javadoc link fix, no test -->
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- N/A — no behavior change; ran spotless:check on the module (green) -->
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green <!-- N/A — Javadoc-comment-only change -->
- [ ] I have added/updated the documentation <!-- N/A — this is the documentation fix itself -->
- [ ] I have added an example in the examples repo (only for "big" features) <!-- N/A -->
- [ ] I have added/updated Spring Boot starter(s) (if applicable) <!-- N/A -->

<!-- Omitted: "new maven module" and "new/existing embedding store" checklists — not applicable to a docs link fix. -->

