### PR TITLE
Add jsonSchema() to Byte/Short/BigInteger/BigDecimal output parsers

### DIFF
--- a/docs/docs/tutorials/structured-outputs.md
+++ b/docs/docs/tutorials/structured-outputs.md
@@ -810,10 +810,10 @@ If LLM and LLM provider supports the methods described above, it is better to us
 | `long`, `Long`                                             | ✅           | ✅         |
 | `float`, `Float`                                           | ✅           | ✅         |
 | `double`, `Double`                                         | ✅           | ✅         |
-| `byte`, `Byte`                                             | ❌           | ✅         |
-| `short`, `Short`                                           | ❌           | ✅         |
-| `BigInteger`                                               | ❌           | ✅         |
-| `BigDecimal`                                               | ❌           | ✅         |
+| `byte`, `Byte`                                             | ✅           | ✅         |
+| `short`, `Short`                                           | ✅           | ✅         |
+| `BigInteger`                                               | ✅           | ✅         |
+| `BigDecimal`                                               | ✅           | ✅         |
 | `Date`                                                     | ❌           | ✅         |
 | `LocalDate`                                                | ❌           | ✅         |
 | `LocalTime`                                                | ❌           | ✅         |

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/BigDecimalOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/BigDecimalOutputParser.java
@@ -3,7 +3,10 @@ package dev.langchain4j.service.output;
 import static dev.langchain4j.service.output.ParsingUtils.parseAsStringOrJson;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
 import java.math.BigDecimal;
+import java.util.Optional;
 
 @Internal
 class BigDecimalOutputParser implements OutputParser<BigDecimal> {
@@ -15,6 +18,18 @@ class BigDecimalOutputParser implements OutputParser<BigDecimal> {
 
     private static BigDecimal parseBigDecimal(String text) {
         return new BigDecimal(text.trim());
+    }
+
+    @Override
+    public Optional<JsonSchema> jsonSchema() {
+        JsonSchema jsonSchema = JsonSchema.builder()
+                .name("number")
+                .rootElement(JsonObjectSchema.builder()
+                        .addNumberProperty("value")
+                        .required("value")
+                        .build())
+                .build();
+        return Optional.of(jsonSchema);
     }
 
     @Override

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/BigIntegerOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/BigIntegerOutputParser.java
@@ -3,7 +3,10 @@ package dev.langchain4j.service.output;
 import static dev.langchain4j.service.output.ParsingUtils.parseAsStringOrJson;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
 import java.math.BigInteger;
+import java.util.Optional;
 
 @Internal
 class BigIntegerOutputParser implements OutputParser<BigInteger> {
@@ -15,6 +18,18 @@ class BigIntegerOutputParser implements OutputParser<BigInteger> {
 
     private static BigInteger parseBigInteger(String text) {
         return new BigInteger(text.trim());
+    }
+
+    @Override
+    public Optional<JsonSchema> jsonSchema() {
+        JsonSchema jsonSchema = JsonSchema.builder()
+                .name("integer")
+                .rootElement(JsonObjectSchema.builder()
+                        .addIntegerProperty("value")
+                        .required("value")
+                        .build())
+                .build();
+        return Optional.of(jsonSchema);
     }
 
     @Override

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/ByteOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/ByteOutputParser.java
@@ -4,6 +4,9 @@ import static dev.langchain4j.service.output.ParsingUtils.parseAsStringOrJson;
 import static dev.langchain4j.service.tool.DefaultToolExecutor.getBoundedLongValue;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import java.util.Optional;
 
 @Internal
 class ByteOutputParser implements OutputParser<Byte> {
@@ -19,6 +22,18 @@ class ByteOutputParser implements OutputParser<Byte> {
         } catch (NumberFormatException nfe) {
             return (byte) getBoundedLongValue(text, "byte", Byte.class, Byte.MIN_VALUE, Byte.MAX_VALUE);
         }
+    }
+
+    @Override
+    public Optional<JsonSchema> jsonSchema() {
+        JsonSchema jsonSchema = JsonSchema.builder()
+                .name("integer")
+                .rootElement(JsonObjectSchema.builder()
+                        .addIntegerProperty("value")
+                        .required("value")
+                        .build())
+                .build();
+        return Optional.of(jsonSchema);
     }
 
     @Override

--- a/langchain4j/src/main/java/dev/langchain4j/service/output/ShortOutputParser.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/output/ShortOutputParser.java
@@ -4,6 +4,9 @@ import static dev.langchain4j.service.output.ParsingUtils.parseAsStringOrJson;
 import static dev.langchain4j.service.tool.DefaultToolExecutor.getBoundedLongValue;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import java.util.Optional;
 
 @Internal
 class ShortOutputParser implements OutputParser<Short> {
@@ -19,6 +22,18 @@ class ShortOutputParser implements OutputParser<Short> {
         } catch (NumberFormatException nfe) {
             return (short) getBoundedLongValue(text, "short", Short.class, Short.MIN_VALUE, Short.MAX_VALUE);
         }
+    }
+
+    @Override
+    public Optional<JsonSchema> jsonSchema() {
+        JsonSchema jsonSchema = JsonSchema.builder()
+                .name("integer")
+                .rootElement(JsonObjectSchema.builder()
+                        .addIntegerProperty("value")
+                        .required("value")
+                        .build())
+                .build();
+        return Optional.of(jsonSchema);
     }
 
     @Override

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/BigDecimalOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/BigDecimalOutputParserTest.java
@@ -3,7 +3,10 @@ package dev.langchain4j.service.output;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
 import java.math.BigDecimal;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -70,5 +73,21 @@ class BigDecimalOutputParserTest {
 
         // then
         assertThat(instructions).isEqualTo("floating point number");
+    }
+
+    @Test
+    void json_schema() {
+        // when
+        Optional<JsonSchema> jsonSchema = parser.jsonSchema();
+
+        // then
+        assertThat(jsonSchema)
+                .hasValue(JsonSchema.builder()
+                        .name("number")
+                        .rootElement(JsonObjectSchema.builder()
+                                .addNumberProperty("value")
+                                .required("value")
+                                .build())
+                        .build());
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/BigIntegerOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/BigIntegerOutputParserTest.java
@@ -3,7 +3,10 @@ package dev.langchain4j.service.output;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
 import java.math.BigInteger;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -71,5 +74,21 @@ class BigIntegerOutputParserTest {
 
         // then
         assertThat(instructions).isEqualTo("integer number");
+    }
+
+    @Test
+    void json_schema() {
+        // when
+        Optional<JsonSchema> jsonSchema = parser.jsonSchema();
+
+        // then
+        assertThat(jsonSchema)
+                .hasValue(JsonSchema.builder()
+                        .name("integer")
+                        .rootElement(JsonObjectSchema.builder()
+                                .addIntegerProperty("value")
+                                .required("value")
+                                .build())
+                        .build());
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/ByteOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/ByteOutputParserTest.java
@@ -3,6 +3,9 @@ package dev.langchain4j.service.output;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -81,5 +84,21 @@ class ByteOutputParserTest {
 
         // then
         assertThat(instructions).isEqualTo("integer number in range [-128, 127]");
+    }
+
+    @Test
+    void json_schema() {
+        // when
+        Optional<JsonSchema> jsonSchema = parser.jsonSchema();
+
+        // then
+        assertThat(jsonSchema)
+                .hasValue(JsonSchema.builder()
+                        .name("integer")
+                        .rootElement(JsonObjectSchema.builder()
+                                .addIntegerProperty("value")
+                                .required("value")
+                                .build())
+                        .build());
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/ServiceOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/ServiceOutputParserTest.java
@@ -1,5 +1,11 @@
 package dev.langchain4j.service.output;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import dev.langchain4j.data.message.AiMessage;
@@ -9,11 +15,6 @@ import dev.langchain4j.model.output.structured.Description;
 import dev.langchain4j.service.IllegalConfigurationException;
 import dev.langchain4j.service.Result;
 import dev.langchain4j.service.TokenStream;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.stubbing.Answer;
-
 import java.io.Serializable;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -27,12 +28,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.stubbing.Answer;
 
 class ServiceOutputParserTest {
 
@@ -67,23 +66,19 @@ class ServiceOutputParserTest {
                 AiMessage.aiMessage("2024-07-02T11:38:00"), LocalDateTime.class, LocalDateTimeOutputParser.class);
         testWhetherProperOutputParserWasCalled(
                 AiMessage.aiMessage(Weather.SUNNY.name()), Weather.class, EnumOutputParser.class);
-        Type listOfWeatherEnumTypes = new TypeReference<List<Weather>>() {
-        }.getType();
+        Type listOfWeatherEnumTypes = new TypeReference<List<Weather>>() {}.getType();
         testWhetherProperOutputParserWasCalled(
                 AiMessage.aiMessage("SUNNY\nCLOUDY"), listOfWeatherEnumTypes, EnumListOutputParser.class);
 
-        Type setOfWeatherEnumTypes = new TypeReference<Set<Weather>>() {
-        }.getType();
+        Type setOfWeatherEnumTypes = new TypeReference<Set<Weather>>() {}.getType();
         testWhetherProperOutputParserWasCalled(
                 AiMessage.aiMessage("SUNNY\nCLOUDY"), setOfWeatherEnumTypes, EnumSetOutputParser.class);
 
-        Type listOfStringsType = new TypeReference<List<String>>() {
-        }.getType();
+        Type listOfStringsType = new TypeReference<List<String>>() {}.getType();
         testWhetherProperOutputParserWasCalled(
                 AiMessage.aiMessage("SUNNY\nCLOUDY"), listOfStringsType, StringListOutputParser.class);
 
-        Type setOfStringsType = new TypeReference<Set<String>>() {
-        }.getType();
+        Type setOfStringsType = new TypeReference<Set<String>>() {}.getType();
         testWhetherProperOutputParserWasCalled(
                 AiMessage.aiMessage("SUNNY\nCLOUDY"), setOfStringsType, StringSetOutputParser.class);
     }
@@ -94,7 +89,8 @@ class ServiceOutputParserTest {
         DefaultOutputParserFactory defaultOutputParserFactory = new DefaultOutputParserFactory();
         OutputParserFactory defaultOutputParserFactorySpy = spy(defaultOutputParserFactory);
 
-        ChatResponse chatResponseStub = ChatResponse.builder().aiMessage(aiMessage).build();
+        ChatResponse chatResponseStub =
+                ChatResponse.builder().aiMessage(aiMessage).build();
         sut = new ServiceOutputParser(defaultOutputParserFactorySpy);
 
         AtomicReference<OutputParser<?>> capturedParserReference = new AtomicReference<>();
@@ -129,70 +125,72 @@ class ServiceOutputParserTest {
         assertThat(sut.jsonSchema(Float.class)).isPresent();
         assertThat(sut.jsonSchema(double.class)).isPresent();
         assertThat(sut.jsonSchema(Double.class)).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Double>>() {
-        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Double>>() {}.getType()))
+                .isPresent();
+
+        // byte, short, BigInteger, BigDecimal (added jsonSchema() in follow-up to #5465)
+        assertThat(sut.jsonSchema(byte.class)).isPresent();
+        assertThat(sut.jsonSchema(Byte.class)).isPresent();
+        assertThat(sut.jsonSchema(short.class)).isPresent();
+        assertThat(sut.jsonSchema(Short.class)).isPresent();
+        assertThat(sut.jsonSchema(BigInteger.class)).isPresent();
+        assertThat(sut.jsonSchema(BigDecimal.class)).isPresent();
 
         // POJOs
         assertThat(sut.jsonSchema(Person.class)).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Person>>() {
-        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Person>>() {}.getType()))
+                .isPresent();
 
-        assertThat(sut.jsonSchema(new TypeReference<List<Person>>() {
-        }.getType())).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Set<Person>>() {
-        }.getType())).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Set<Person>>>() {
-        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<List<Person>>() {}.getType()))
+                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Set<Person>>() {}.getType()))
+                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Set<Person>>>() {}.getType()))
+                .isPresent();
 
         // Enums
         assertThat(sut.jsonSchema(Weather.class)).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Weather>>() {
-        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Weather>>() {}.getType()))
+                .isPresent();
 
-        assertThat(sut.jsonSchema(new TypeReference<List<Weather>>() {
-        }.getType())).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Set<Weather>>() {
-        }.getType())).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Set<Weather>>>() {
-        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<List<Weather>>() {}.getType()))
+                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Set<Weather>>() {}.getType()))
+                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Set<Weather>>>() {}.getType()))
+                .isPresent();
 
         // Strings
-        assertThat(sut.jsonSchema(new TypeReference<Result<String>>() {
-        }.getType())).isEmpty();
+        assertThat(sut.jsonSchema(new TypeReference<Result<String>>() {}.getType()))
+                .isEmpty();
 
-        assertThat(sut.jsonSchema(new TypeReference<List<String>>() {
-        }.getType())).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Set<String>>() {
-        }.getType())).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Set<String>>>() {
-        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<List<String>>() {}.getType()))
+                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Set<String>>() {}.getType()))
+                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Set<String>>>() {}.getType()))
+                .isPresent();
 
         // JSON schema is not required
         assertThat(sut.jsonSchema(String.class)).isEmpty();
-        assertThat(sut.jsonSchema(new TypeReference<Result<String>>() {
-        }.getType())).isEmpty();
+        assertThat(sut.jsonSchema(new TypeReference<Result<String>>() {}.getType()))
+                .isEmpty();
 
         assertThat(sut.jsonSchema(AiMessage.class)).isEmpty();
-        assertThat(sut.jsonSchema(new TypeReference<Result<AiMessage>>() {
-        }.getType())).isEmpty();
+        assertThat(sut.jsonSchema(new TypeReference<Result<AiMessage>>() {}.getType()))
+                .isEmpty();
 
         assertThat(sut.jsonSchema(Response.class)).isEmpty(); // legacy
         assertThat(sut.jsonSchema(TokenStream.class)).isEmpty();
 
         // JSON schema is (currently) not supported
-        assertThat(sut.jsonSchema(byte.class)).isEmpty();
-        assertThat(sut.jsonSchema(Byte.class)).isEmpty();
-        assertThat(sut.jsonSchema(short.class)).isEmpty();
-        assertThat(sut.jsonSchema(Short.class)).isEmpty();
-        assertThat(sut.jsonSchema(BigInteger.class)).isEmpty();
-        assertThat(sut.jsonSchema(BigDecimal.class)).isEmpty();
         assertThat(sut.jsonSchema(Date.class)).isEmpty();
         assertThat(sut.jsonSchema(LocalDate.class)).isEmpty();
         assertThat(sut.jsonSchema(LocalTime.class)).isEmpty();
         assertThat(sut.jsonSchema(LocalDateTime.class)).isEmpty();
         assertThat(sut.jsonSchema(Map.class)).isEmpty();
-        assertThat(sut.jsonSchema(new TypeReference<Map<String, String>>() {
-        }.getType())).isEmpty();
+        assertThat(sut.jsonSchema(new TypeReference<Map<String, String>>() {}.getType()))
+                .isEmpty();
     }
 
     /********************************************************************************************
@@ -209,7 +207,8 @@ class ServiceOutputParserTest {
     void makeSureJsonBlockIsExtractedBeforeParse(String json) {
         // Given
         AiMessage aiMessage = AiMessage.aiMessage(json);
-        ChatResponse chatResponseStub = ChatResponse.builder().aiMessage(aiMessage).build();
+        ChatResponse chatResponseStub =
+                ChatResponse.builder().aiMessage(aiMessage).build();
         sut = new ServiceOutputParser();
 
         // When
@@ -233,7 +232,8 @@ class ServiceOutputParserTest {
     void makeSureNestedJsonBlockIsExtractedBeforeParse(String json) {
         // Given
         AiMessage aiMessage = AiMessage.aiMessage(json);
-        ChatResponse chatResponseStub = ChatResponse.builder().aiMessage(aiMessage).build();
+        ChatResponse chatResponseStub =
+                ChatResponse.builder().aiMessage(aiMessage).build();
         sut = new ServiceOutputParser();
 
         // When
@@ -251,7 +251,8 @@ class ServiceOutputParserTest {
     void illegalJsonBlockNotExtractedAndFailsParse(String json) {
         // Given
         AiMessage aiMessage = AiMessage.aiMessage(json);
-        ChatResponse chatResponseStub = ChatResponse.builder().aiMessage(aiMessage).build();
+        ChatResponse chatResponseStub =
+                ChatResponse.builder().aiMessage(aiMessage).build();
         sut = new ServiceOutputParser();
 
         // When / Then

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/ServiceOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/ServiceOutputParserTest.java
@@ -1,11 +1,5 @@
 package dev.langchain4j.service.output;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import dev.langchain4j.data.message.AiMessage;
@@ -15,6 +9,11 @@ import dev.langchain4j.model.output.structured.Description;
 import dev.langchain4j.service.IllegalConfigurationException;
 import dev.langchain4j.service.Result;
 import dev.langchain4j.service.TokenStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.stubbing.Answer;
+
 import java.io.Serializable;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -28,10 +27,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.stubbing.Answer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 class ServiceOutputParserTest {
 
@@ -66,19 +67,23 @@ class ServiceOutputParserTest {
                 AiMessage.aiMessage("2024-07-02T11:38:00"), LocalDateTime.class, LocalDateTimeOutputParser.class);
         testWhetherProperOutputParserWasCalled(
                 AiMessage.aiMessage(Weather.SUNNY.name()), Weather.class, EnumOutputParser.class);
-        Type listOfWeatherEnumTypes = new TypeReference<List<Weather>>() {}.getType();
+        Type listOfWeatherEnumTypes = new TypeReference<List<Weather>>() {
+        }.getType();
         testWhetherProperOutputParserWasCalled(
                 AiMessage.aiMessage("SUNNY\nCLOUDY"), listOfWeatherEnumTypes, EnumListOutputParser.class);
 
-        Type setOfWeatherEnumTypes = new TypeReference<Set<Weather>>() {}.getType();
+        Type setOfWeatherEnumTypes = new TypeReference<Set<Weather>>() {
+        }.getType();
         testWhetherProperOutputParserWasCalled(
                 AiMessage.aiMessage("SUNNY\nCLOUDY"), setOfWeatherEnumTypes, EnumSetOutputParser.class);
 
-        Type listOfStringsType = new TypeReference<List<String>>() {}.getType();
+        Type listOfStringsType = new TypeReference<List<String>>() {
+        }.getType();
         testWhetherProperOutputParserWasCalled(
                 AiMessage.aiMessage("SUNNY\nCLOUDY"), listOfStringsType, StringListOutputParser.class);
 
-        Type setOfStringsType = new TypeReference<Set<String>>() {}.getType();
+        Type setOfStringsType = new TypeReference<Set<String>>() {
+        }.getType();
         testWhetherProperOutputParserWasCalled(
                 AiMessage.aiMessage("SUNNY\nCLOUDY"), setOfStringsType, StringSetOutputParser.class);
     }
@@ -89,8 +94,7 @@ class ServiceOutputParserTest {
         DefaultOutputParserFactory defaultOutputParserFactory = new DefaultOutputParserFactory();
         OutputParserFactory defaultOutputParserFactorySpy = spy(defaultOutputParserFactory);
 
-        ChatResponse chatResponseStub =
-                ChatResponse.builder().aiMessage(aiMessage).build();
+        ChatResponse chatResponseStub = ChatResponse.builder().aiMessage(aiMessage).build();
         sut = new ServiceOutputParser(defaultOutputParserFactorySpy);
 
         AtomicReference<OutputParser<?>> capturedParserReference = new AtomicReference<>();
@@ -125,8 +129,8 @@ class ServiceOutputParserTest {
         assertThat(sut.jsonSchema(Float.class)).isPresent();
         assertThat(sut.jsonSchema(double.class)).isPresent();
         assertThat(sut.jsonSchema(Double.class)).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Double>>() {}.getType()))
-                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Double>>() {
+        }.getType())).isPresent();
 
         // byte, short, BigInteger, BigDecimal (added jsonSchema() in follow-up to #5465)
         assertThat(sut.jsonSchema(byte.class)).isPresent();
@@ -138,47 +142,47 @@ class ServiceOutputParserTest {
 
         // POJOs
         assertThat(sut.jsonSchema(Person.class)).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Person>>() {}.getType()))
-                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Person>>() {
+        }.getType())).isPresent();
 
-        assertThat(sut.jsonSchema(new TypeReference<List<Person>>() {}.getType()))
-                .isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Set<Person>>() {}.getType()))
-                .isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Set<Person>>>() {}.getType()))
-                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<List<Person>>() {
+        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Set<Person>>() {
+        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Set<Person>>>() {
+        }.getType())).isPresent();
 
         // Enums
         assertThat(sut.jsonSchema(Weather.class)).isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Weather>>() {}.getType()))
-                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Weather>>() {
+        }.getType())).isPresent();
 
-        assertThat(sut.jsonSchema(new TypeReference<List<Weather>>() {}.getType()))
-                .isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Set<Weather>>() {}.getType()))
-                .isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Set<Weather>>>() {}.getType()))
-                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<List<Weather>>() {
+        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Set<Weather>>() {
+        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Set<Weather>>>() {
+        }.getType())).isPresent();
 
         // Strings
-        assertThat(sut.jsonSchema(new TypeReference<Result<String>>() {}.getType()))
-                .isEmpty();
+        assertThat(sut.jsonSchema(new TypeReference<Result<String>>() {
+        }.getType())).isEmpty();
 
-        assertThat(sut.jsonSchema(new TypeReference<List<String>>() {}.getType()))
-                .isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Set<String>>() {}.getType()))
-                .isPresent();
-        assertThat(sut.jsonSchema(new TypeReference<Result<Set<String>>>() {}.getType()))
-                .isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<List<String>>() {
+        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Set<String>>() {
+        }.getType())).isPresent();
+        assertThat(sut.jsonSchema(new TypeReference<Result<Set<String>>>() {
+        }.getType())).isPresent();
 
         // JSON schema is not required
         assertThat(sut.jsonSchema(String.class)).isEmpty();
-        assertThat(sut.jsonSchema(new TypeReference<Result<String>>() {}.getType()))
-                .isEmpty();
+        assertThat(sut.jsonSchema(new TypeReference<Result<String>>() {
+        }.getType())).isEmpty();
 
         assertThat(sut.jsonSchema(AiMessage.class)).isEmpty();
-        assertThat(sut.jsonSchema(new TypeReference<Result<AiMessage>>() {}.getType()))
-                .isEmpty();
+        assertThat(sut.jsonSchema(new TypeReference<Result<AiMessage>>() {
+        }.getType())).isEmpty();
 
         assertThat(sut.jsonSchema(Response.class)).isEmpty(); // legacy
         assertThat(sut.jsonSchema(TokenStream.class)).isEmpty();
@@ -189,8 +193,8 @@ class ServiceOutputParserTest {
         assertThat(sut.jsonSchema(LocalTime.class)).isEmpty();
         assertThat(sut.jsonSchema(LocalDateTime.class)).isEmpty();
         assertThat(sut.jsonSchema(Map.class)).isEmpty();
-        assertThat(sut.jsonSchema(new TypeReference<Map<String, String>>() {}.getType()))
-                .isEmpty();
+        assertThat(sut.jsonSchema(new TypeReference<Map<String, String>>() {
+        }.getType())).isEmpty();
     }
 
     /********************************************************************************************
@@ -207,8 +211,7 @@ class ServiceOutputParserTest {
     void makeSureJsonBlockIsExtractedBeforeParse(String json) {
         // Given
         AiMessage aiMessage = AiMessage.aiMessage(json);
-        ChatResponse chatResponseStub =
-                ChatResponse.builder().aiMessage(aiMessage).build();
+        ChatResponse chatResponseStub = ChatResponse.builder().aiMessage(aiMessage).build();
         sut = new ServiceOutputParser();
 
         // When
@@ -232,8 +235,7 @@ class ServiceOutputParserTest {
     void makeSureNestedJsonBlockIsExtractedBeforeParse(String json) {
         // Given
         AiMessage aiMessage = AiMessage.aiMessage(json);
-        ChatResponse chatResponseStub =
-                ChatResponse.builder().aiMessage(aiMessage).build();
+        ChatResponse chatResponseStub = ChatResponse.builder().aiMessage(aiMessage).build();
         sut = new ServiceOutputParser();
 
         // When
@@ -251,8 +253,7 @@ class ServiceOutputParserTest {
     void illegalJsonBlockNotExtractedAndFailsParse(String json) {
         // Given
         AiMessage aiMessage = AiMessage.aiMessage(json);
-        ChatResponse chatResponseStub =
-                ChatResponse.builder().aiMessage(aiMessage).build();
+        ChatResponse chatResponseStub = ChatResponse.builder().aiMessage(aiMessage).build();
         sut = new ServiceOutputParser();
 
         // When / Then

--- a/langchain4j/src/test/java/dev/langchain4j/service/output/ShortOutputParserTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/output/ShortOutputParserTest.java
@@ -3,6 +3,9 @@ package dev.langchain4j.service.output;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchema;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -81,5 +84,21 @@ class ShortOutputParserTest {
 
         // then
         assertThat(instructions).isEqualTo("integer number in range [-32768, 32767]");
+    }
+
+    @Test
+    void json_schema() {
+        // when
+        Optional<JsonSchema> jsonSchema = parser.jsonSchema();
+
+        // then
+        assertThat(jsonSchema)
+                .hasValue(JsonSchema.builder()
+                        .name("integer")
+                        .rootElement(JsonObjectSchema.builder()
+                                .addIntegerProperty("value")
+                                .required("value")
+                                .build())
+                        .build());
     }
 }


### PR DESCRIPTION
## Issue
No dedicated issue. This implements the optional follow-up explicitly suggested by the author of #5465 in the merged commit message:

> "For full parity, these four types could also gain a `jsonSchema()` (as `Integer`/`Long`/`Float`/`Double` have) to support structured outputs. I left that out to keep this PR focused on the parsing-consistency bug ..."

## Change

`IntegerOutputParser`, `LongOutputParser`, `FloatOutputParser` and `DoubleOutputParser` implement `jsonSchema()`, which lets them participate in structured outputs (`RESPONSE_FORMAT_JSON_SCHEMA`). Their sibling numeric parsers `ByteOutputParser`, `ShortOutputParser`, `BigIntegerOutputParser` and `BigDecimalOutputParser` did not, so they fell back to the default `Optional.empty()`.

This PR adds `jsonSchema()` to the four remaining numeric parsers, mirroring the existing implementations:

- `Byte`, `Short`, `BigInteger` → `"integer"` schema with an integer `value` property (same as `Integer`/`Long`)
- `BigDecimal` → `"number"` schema with a number `value` property (same as `Float`/`Double`)

New unit tests (`json_schema()`) were added to each of the four parser tests, following the existing test style. Also updated `ServiceOutputParserTest.jsonSchema()` to reflect the new support (moved the four types from "not supported" assertions to "present" assertions).

## General checklist
- [ ] There are no breaking changes (API, behaviour) — purely additive; the default was `Optional.empty()`, now returns a schema
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the core and main modules — ran the full `service/output` test suite (including `ServiceOutputParserTest`) + `spotless:check` passes
- [x] I have added/updated the documentation — not applicable (internal parser behaviour)
- [ ] I have added an example in the examples repo — not applicable
- [ ] I have added/updated Spring Boot starter(s) — not applicable

## Verification
```
mvn -pl langchain4j test -Dtest='ByteOutputParserTest,ShortOutputParserTest,BigIntegerOutputParserTest,BigDecimalOutputParserTest,ServiceOutputParserTest'
# all tests pass
mvn -pl langchain4j spotless:check
# BUILD SUCCESS
```
