### PR TITLE
fix: mask apiKey in Cohere builder toString

### DIFF
--- a/langchain4j-cohere/src/main/java/dev/langchain4j/model/cohere/CohereEmbeddingModel.java
+++ b/langchain4j-cohere/src/main/java/dev/langchain4j/model/cohere/CohereEmbeddingModel.java
@@ -1,22 +1,21 @@
 package dev.langchain4j.model.cohere;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static java.time.Duration.ofSeconds;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.DimensionAwareEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
-import org.slf4j.Logger;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import static java.time.Duration.ofSeconds;
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.toList;
+import org.slf4j.Logger;
 
 /**
  * An implementation of an {@link EmbeddingModel} that uses
@@ -33,14 +32,15 @@ public class CohereEmbeddingModel extends DimensionAwareEmbeddingModel {
     private final int maxSegmentsPerBatch;
 
     @Deprecated(forRemoval = true, since = "1.4.0")
-    public CohereEmbeddingModel(String baseUrl,
-                                String apiKey,
-                                String modelName,
-                                String inputType,
-                                Duration timeout,
-                                Boolean logRequests,
-                                Boolean logResponses,
-                                Integer maxSegmentsPerBatch) {
+    public CohereEmbeddingModel(
+            String baseUrl,
+            String apiKey,
+            String modelName,
+            String inputType,
+            Duration timeout,
+            Boolean logRequests,
+            Boolean logResponses,
+            Integer maxSegmentsPerBatch) {
         this.client = CohereClient.builder()
                 .baseUrl(getOrDefault(baseUrl, DEFAULT_BASE_URL))
                 .apiKey(ensureNotBlank(apiKey, "apiKey"))
@@ -83,9 +83,7 @@ public class CohereEmbeddingModel extends DimensionAwareEmbeddingModel {
     @Override
     public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
 
-        List<String> texts = textSegments.stream()
-                .map(TextSegment::text)
-                .collect(toList());
+        List<String> texts = textSegments.stream().map(TextSegment::text).collect(toList());
 
         return embedTexts(texts);
     }
@@ -116,17 +114,11 @@ public class CohereEmbeddingModel extends DimensionAwareEmbeddingModel {
             totalTokenUsage += getTokenUsage(response);
         }
 
-        return Response.from(
-                embeddings,
-                new TokenUsage(totalTokenUsage, 0)
-        );
-
+        return Response.from(embeddings, new TokenUsage(totalTokenUsage, 0));
     }
 
     private static List<Embedding> getEmbeddings(EmbedResponse response) {
-        return stream(response.getEmbeddings())
-                .map(Embedding::from)
-                .collect(toList());
+        return stream(response.getEmbeddings()).map(Embedding::from).collect(toList());
     }
 
     private static Integer getTokenUsage(EmbedResponse response) {
@@ -149,8 +141,7 @@ public class CohereEmbeddingModel extends DimensionAwareEmbeddingModel {
         private Logger logger;
         private Integer maxSegmentsPerBatch;
 
-        CohereEmbeddingModelBuilder() {
-        }
+        CohereEmbeddingModelBuilder() {}
 
         public CohereEmbeddingModelBuilder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
@@ -206,7 +197,11 @@ public class CohereEmbeddingModel extends DimensionAwareEmbeddingModel {
         }
 
         public String toString() {
-            return "CohereEmbeddingModel.CohereEmbeddingModelBuilder(baseUrl=" + this.baseUrl + ", apiKey=" + this.apiKey + ", modelName=" + this.modelName + ", inputType=" + this.inputType + ", timeout=" + this.timeout + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ", maxSegmentsPerBatch=" + this.maxSegmentsPerBatch + ")";
+            return "CohereEmbeddingModel.CohereEmbeddingModelBuilder(baseUrl=" + this.baseUrl + ", apiKey="
+                    + (this.apiKey == null ? null : "********") + ", modelName=" + this.modelName + ", inputType="
+                    + this.inputType + ", timeout=" + this.timeout + ", logRequests=" + this.logRequests
+                    + ", logResponses=" + this.logResponses + ", maxSegmentsPerBatch=" + this.maxSegmentsPerBatch
+                    + ")";
         }
     }
 }

--- a/langchain4j-cohere/src/main/java/dev/langchain4j/model/cohere/CohereScoringModel.java
+++ b/langchain4j-cohere/src/main/java/dev/langchain4j/model/cohere/CohereScoringModel.java
@@ -1,21 +1,20 @@
 package dev.langchain4j.model.cohere;
 
-import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.output.Response;
-import dev.langchain4j.model.output.TokenUsage;
-import dev.langchain4j.model.scoring.ScoringModel;
-import org.slf4j.Logger;
-
-import java.net.Proxy;
-import java.time.Duration;
-import java.util.List;
-
 import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
 import static dev.langchain4j.internal.Utils.getOrDefault;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static java.time.Duration.ofSeconds;
 import static java.util.Comparator.comparingInt;
 import static java.util.stream.Collectors.toList;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
+import dev.langchain4j.model.scoring.ScoringModel;
+import java.net.Proxy;
+import java.time.Duration;
+import java.util.List;
+import org.slf4j.Logger;
 
 /**
  * An implementation of a {@link ScoringModel} that uses
@@ -38,8 +37,7 @@ public class CohereScoringModel implements ScoringModel {
             Integer maxRetries,
             Proxy proxy,
             Boolean logRequests,
-            Boolean logResponses
-    ) {
+            Boolean logResponses) {
         this.client = CohereClient.builder()
                 .baseUrl(getOrDefault(baseUrl, DEFAULT_BASE_URL))
                 .apiKey(ensureNotBlank(apiKey, "apiKey"))
@@ -85,9 +83,7 @@ public class CohereScoringModel implements ScoringModel {
         RerankRequest request = RerankRequest.builder()
                 .model(modelName)
                 .query(query)
-                .documents(segments.stream()
-                        .map(TextSegment::text)
-                        .collect(toList()))
+                .documents(segments.stream().map(TextSegment::text).collect(toList()))
                 .build();
 
         RerankResponse response = withRetryMappingExceptions(() -> client.rerank(request), maxRetries);
@@ -97,7 +93,8 @@ public class CohereScoringModel implements ScoringModel {
                 .map(Result::getRelevanceScore)
                 .collect(toList());
 
-        return Response.from(scores, new TokenUsage(response.getMeta().getBilledUnits().getSearchUnits()));
+        return Response.from(
+                scores, new TokenUsage(response.getMeta().getBilledUnits().getSearchUnits()));
     }
 
     public static class CohereScoringModelBuilder {
@@ -111,8 +108,7 @@ public class CohereScoringModel implements ScoringModel {
         private Boolean logResponses;
         private Logger logger;
 
-        CohereScoringModelBuilder() {
-        }
+        CohereScoringModelBuilder() {}
 
         public CohereScoringModelBuilder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
@@ -168,7 +164,10 @@ public class CohereScoringModel implements ScoringModel {
         }
 
         public String toString() {
-            return "CohereScoringModel.CohereScoringModelBuilder(baseUrl=" + this.baseUrl + ", apiKey=" + this.apiKey + ", modelName=" + this.modelName + ", timeout=" + this.timeout + ", maxRetries=" + this.maxRetries + ", proxy=" + this.proxy + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
+            return "CohereScoringModel.CohereScoringModelBuilder(baseUrl=" + this.baseUrl + ", apiKey="
+                    + (this.apiKey == null ? null : "********") + ", modelName=" + this.modelName + ", timeout="
+                    + this.timeout + ", maxRetries=" + this.maxRetries + ", proxy=" + this.proxy + ", logRequests="
+                    + this.logRequests + ", logResponses=" + this.logResponses + ")";
         }
     }
 }

--- a/langchain4j-cohere/src/test/java/dev/langchain4j/model/cohere/CohereModelBuilderTest.java
+++ b/langchain4j-cohere/src/test/java/dev/langchain4j/model/cohere/CohereModelBuilderTest.java
@@ -1,0 +1,42 @@
+package dev.langchain4j.model.cohere;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CohereModelBuilderTest {
+
+    @Test
+    void embeddingModelBuilder_toString_should_mask_api_key() {
+        String toString = CohereEmbeddingModel.builder()
+                .apiKey("secret-api-key")
+                .modelName("embed-english-v3.0")
+                .toString();
+
+        assertThat(toString).doesNotContain("secret-api-key").contains("apiKey=********");
+    }
+
+    @Test
+    void embeddingModelBuilder_toString_should_render_null_api_key_as_null() {
+        String toString = new CohereEmbeddingModel.CohereEmbeddingModelBuilder().toString();
+
+        assertThat(toString).contains("apiKey=null");
+    }
+
+    @Test
+    void scoringModelBuilder_toString_should_mask_api_key() {
+        String toString = CohereScoringModel.builder()
+                .apiKey("secret-api-key")
+                .modelName("rerank-english-v3.0")
+                .toString();
+
+        assertThat(toString).doesNotContain("secret-api-key").contains("apiKey=********");
+    }
+
+    @Test
+    void scoringModelBuilder_toString_should_render_null_api_key_as_null() {
+        String toString = new CohereScoringModel.CohereScoringModelBuilder().toString();
+
+        assertThat(toString).contains("apiKey=null");
+    }
+}


### PR DESCRIPTION
Prevent apiKey from being logged in plain text when builder toString is called.

## Issue
Closes #5702

## Change
`CohereEmbeddingModel` and `CohereScoringModel` builder `toString()` printed the apiKey in plaintext.
Now masks it as `apiKey=********` (null remains `apiKey=null`), matching PR #5559 (Nomic) and PR #3680 (Jina).

Added `CohereModelBuilderTest` with positive/negative cases.

Note: spotless ratchet reformatted unrelated lines in the two model files (import order, line wrapping). Not manual refactoring.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo
- [ ] I have added/updated Spring Boot starter(s)