### PR TITLE
feat(google-genai): support context cache creation and management

### DIFF
--- a/docs/docs/integrations/language-models/google-genai.md
+++ b/docs/docs/integrations/language-models/google-genai.md
@@ -372,6 +372,40 @@ String response = gemini.chat("Summarize the cached document in 3 bullet points.
 
 This feature is available on `GoogleGenAiChatModel`, `GoogleGenAiStreamingChatModel`, and `GoogleGenAiBatchChatModel`.
 
+### Creating and managing caches
+
+Instead of creating the cache out-of-band, you can create and manage it directly from LangChain4j with `GoogleGenAiCaches`, which wraps the SDK's cache lifecycle (create / get / list / update TTL / delete). The messages are cached using the same `GoogleGenAiContentMapper` the chat models use, so you stay in the LangChain4j `ChatMessage` domain.
+
+```java
+GoogleGenAiCaches caches = GoogleGenAiCaches.builder()
+    .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
+    .build();
+
+// Cache a large, reusable context (a system instruction plus a long document)
+CachedContent cache = caches.createCache(
+    "gemini-2.5-flash",
+    List.of(
+        SystemMessage.from("You are a precise assistant answering questions about the attached document."),
+        UserMessage.from(longDocumentText)),
+    Duration.ofHours(1));
+
+// Reuse it across many requests via cachedContent
+ChatModel gemini = GoogleGenAiChatModel.builder()
+    .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
+    .modelName("gemini-2.5-flash")
+    .cachedContent(cache.name().orElseThrow())
+    .build();
+
+String answer = gemini.chat("Summarize the cached document in 3 bullet points.");
+
+// Manage the cache lifecycle
+caches.updateCacheTtl(cache.name().orElseThrow(), Duration.ofHours(2));
+caches.listCaches();
+caches.deleteCache(cache.name().orElseThrow());
+```
+
+> Note: explicit context caching requires a paid tier; it is not available on the free tier.
+
 ## Thinking Models (Gemini 3.0+)
 
 Gemini 3.0 models (like `gemini-3.0-pro` and `gemini-3.0-flash`) support advanced reasoning (thinking) capabilities. 

--- a/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiCaches.java
+++ b/langchain4j-google-genai/src/main/java/dev/langchain4j/model/google/genai/GoogleGenAiCaches.java
@@ -1,0 +1,139 @@
+package dev.langchain4j.model.google.genai;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+import com.google.genai.Client;
+import com.google.genai.types.CachedContent;
+import com.google.genai.types.Content;
+import com.google.genai.types.CreateCachedContentConfig;
+import com.google.genai.types.DeleteCachedContentConfig;
+import com.google.genai.types.GetCachedContentConfig;
+import com.google.genai.types.ListCachedContentsConfig;
+import com.google.genai.types.UpdateCachedContentConfig;
+import dev.langchain4j.data.message.ChatMessage;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service for creating and managing Gemini
+ * <a href="https://ai.google.dev/gemini-api/docs/caching">context caches</a> using the official
+ * com.google.genai SDK.
+ *
+ * <p>Context caching stores large, frequently reused context (a system instruction, long documents,
+ * PDFs) on Google's servers once, so subsequent requests can reference it by name instead of
+ * resending it, reducing input-token cost and latency.
+ *
+ * <p>The name of a created cache ({@link CachedContent#name()}) can be supplied as the
+ * {@code cachedContent} of a {@link GoogleGenAiChatModel} (or its streaming/batch counterparts) to
+ * consume the cached context.
+ */
+public final class GoogleGenAiCaches {
+
+    private final Client client;
+
+    private GoogleGenAiCaches(Builder builder) {
+        this.client = builder.client != null
+                ? builder.client
+                : GoogleGenAiClientFactory.createClient(
+                        builder.apiKey, null, null, null, null, builder.customHeaders, builder.apiEndpoint);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates a context cache for the given model from the supplied messages.
+     *
+     * @param modelName the model the cache is bound to (e.g. {@code "gemini-2.5-flash"})
+     * @param messages  the messages to cache; a {@code SystemMessage} becomes the cached system
+     *                  instruction, the rest become cached contents
+     * @param ttl       optional time-to-live for the cache (e.g. {@code Duration.ofHours(1)}); may be
+     *                  {@code null}, in which case the API default is used
+     * @return the created cache, whose {@link CachedContent#name()} is used to consume it
+     */
+    public CachedContent createCache(String modelName, List<ChatMessage> messages, Duration ttl) {
+        ensureNotBlank(modelName, "modelName");
+        ensureNotEmpty(messages, "messages");
+        return client.caches.create(modelName, toCreateConfig(messages, ttl));
+    }
+
+    /** Retrieves a cache by name (e.g. {@code "cachedContents/abc123"}). */
+    public CachedContent getCache(String name) {
+        ensureNotBlank(name, "name");
+        return client.caches.get(name, GetCachedContentConfig.builder().build());
+    }
+
+    /** Lists all context caches for the current project. */
+    public List<CachedContent> listCaches() {
+        List<CachedContent> caches = new ArrayList<>();
+        client.caches.list(ListCachedContentsConfig.builder().build()).forEach(caches::add);
+        return caches;
+    }
+
+    /** Updates a cache's time-to-live and returns the updated cache. */
+    public CachedContent updateCacheTtl(String name, Duration ttl) {
+        ensureNotBlank(name, "name");
+        ensureNotNull(ttl, "ttl");
+        return client.caches.update(
+                name, UpdateCachedContentConfig.builder().ttl(ttl).build());
+    }
+
+    /** Deletes a context cache by name. */
+    public void deleteCache(String name) {
+        ensureNotBlank(name, "name");
+        client.caches.delete(name, DeleteCachedContentConfig.builder().build());
+    }
+
+    static CreateCachedContentConfig toCreateConfig(List<ChatMessage> messages, Duration ttl) {
+        List<Content> contents = GoogleGenAiContentMapper.toContents(messages);
+        Content systemInstruction = GoogleGenAiContentMapper.toSystemInstruction(messages);
+
+        CreateCachedContentConfig.Builder config = CreateCachedContentConfig.builder();
+        if (!contents.isEmpty()) {
+            config.contents(contents);
+        }
+        if (systemInstruction != null) {
+            config.systemInstruction(systemInstruction);
+        }
+        if (ttl != null) {
+            config.ttl(ttl);
+        }
+        return config.build();
+    }
+
+    public static class Builder {
+        private String apiKey;
+        private String apiEndpoint;
+        private Map<String, String> customHeaders;
+        private Client client;
+
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public Builder apiEndpoint(String apiEndpoint) {
+            this.apiEndpoint = apiEndpoint;
+            return this;
+        }
+
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeaders = customHeaders;
+            return this;
+        }
+
+        public Builder client(Client client) {
+            this.client = client;
+            return this;
+        }
+
+        public GoogleGenAiCaches build() {
+            return new GoogleGenAiCaches(this);
+        }
+    }
+}

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiCachesIT.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiCachesIT.java
@@ -1,0 +1,55 @@
+package dev.langchain4j.model.google.genai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.abort;
+
+import com.google.genai.errors.ClientException;
+import com.google.genai.types.CachedContent;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "GOOGLE_AI_GEMINI_API_KEY", matches = ".+")
+class GoogleGenAiCachesIT {
+
+    private static final String GOOGLE_AI_GEMINI_API_KEY = System.getenv("GOOGLE_AI_GEMINI_API_KEY");
+
+    @Test
+    void should_create_get_list_update_and_delete_cache() {
+        GoogleGenAiCaches caches =
+                GoogleGenAiCaches.builder().apiKey(GOOGLE_AI_GEMINI_API_KEY).build();
+
+        // explicit caching requires a minimum number of input tokens; pad the content heavily to clear it
+        List<ChatMessage> messages = List.of(
+                SystemMessage.from("You are an expert technical writer."),
+                UserMessage.from("Large reusable document context. ".repeat(10_000)));
+
+        CachedContent created;
+        try {
+            created = caches.createCache("gemini-2.5-flash", messages, Duration.ofMinutes(5));
+        } catch (ClientException e) {
+            // explicit context caching is not offered on the free tier (storage limit = 0); skip there
+            if (e.getMessage() != null && e.getMessage().contains("FreeTier")) {
+                abort("Context caching requires a paid tier: " + e.getMessage());
+            }
+            throw e;
+        }
+
+        String name = created.name().orElseThrow();
+        assertThat(name).startsWith("cachedContents/");
+
+        try {
+            assertThat(caches.getCache(name).name()).contains(name);
+            assertThat(caches.listCaches())
+                    .anyMatch(cache -> cache.name().filter(name::equals).isPresent());
+            assertThat(caches.updateCacheTtl(name, Duration.ofMinutes(10)).name())
+                    .contains(name);
+        } finally {
+            caches.deleteCache(name);
+        }
+    }
+}

--- a/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiCachesTest.java
+++ b/langchain4j-google-genai/src/test/java/dev/langchain4j/model/google/genai/GoogleGenAiCachesTest.java
@@ -1,0 +1,37 @@
+package dev.langchain4j.model.google.genai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.genai.types.CreateCachedContentConfig;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GoogleGenAiCachesTest {
+
+    @Test
+    void should_map_system_instruction_contents_and_ttl_to_create_config() {
+        List<ChatMessage> messages = List.of(
+                SystemMessage.from("You are a helpful assistant."), UserMessage.from("Reusable document context."));
+
+        CreateCachedContentConfig config = GoogleGenAiCaches.toCreateConfig(messages, Duration.ofMinutes(5));
+
+        assertThat(config.systemInstruction()).isPresent();
+        assertThat(config.contents()).isPresent();
+        assertThat(config.contents().get()).isNotEmpty();
+        assertThat(config.ttl()).contains(Duration.ofMinutes(5));
+    }
+
+    @Test
+    void should_omit_ttl_when_null_and_system_instruction_when_absent() {
+        CreateCachedContentConfig config =
+                GoogleGenAiCaches.toCreateConfig(List.of(UserMessage.from("Reusable document context.")), null);
+
+        assertThat(config.ttl()).isEmpty();
+        assertThat(config.systemInstruction()).isEmpty();
+        assertThat(config.contents()).isPresent();
+    }
+}


### PR DESCRIPTION
GoogleGenAiChatModel` and its streaming/batch counterparts can already consume a context cache via `cachedContent(name)`, but the cache itself has to be created out-of-band because the module exposes no way to create or manage one. The current docs reflect this: they assume the cache was already created "using the official Google Gen AI SDK or API" and only cover passing its name in.

Context caching stores a large reused prefix (a long document, a big system instruction) on the server, so later requests can reference it instead of resending it each call, which reduces input-token cost and latency. This adds `GoogleGenAiCaches`, a standalone helper that wraps the `com.google.genai` SDK's `Caches` client, so that prefix can be created and managed from LangChain4j rather than out-of-band:

```java
GoogleGenAiCaches caches = GoogleGenAiCaches.builder()
    .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
    .build();

CachedContent cache = caches.createCache(
    "gemini-2.5-flash",
    List.of(
        SystemMessage.from("You answer questions about the attached document."),
        UserMessage.from(longDocumentText)),
    Duration.ofHours(1));

ChatModel gemini = GoogleGenAiChatModel.builder()
    .apiKey(System.getenv("GOOGLE_AI_GEMINI_API_KEY"))
    .modelName("gemini-2.5-flash")
    .cachedContent(cache.name().orElseThrow())
    .build();
```

It mirrors the existing `GoogleGenAiFiles` helper: same builder (`apiKey` / `apiEndpoint` / `customHeaders` / `client`), same client construction via `GoogleGenAiClientFactory`, and thin SDK-native return types. `createCache` takes LangChain4j `ChatMessage`s and builds the cached content through the module's `GoogleGenAiContentMapper`, so callers stay in the `ChatMessage` domain instead of assembling Google `Content` objects.

The Python counterpart exposes the creation side the same way: `langchain-google-genai` has a public `create_context_cache` helper that builds the cache from LangChain messages and returns the name to pass as `cached_content`.

Lifecycle covered: `createCache` / `getCache` / `listCaches` / `updateCacheTtl` / `deleteCache`. If you'd prefer a smaller surface, this trims naturally to just `createCache` (the `ChatMessage` mapping is where the integration value is), leaving the rest of the lifecycle to the SDK client.

Closes #5680.

Related: #5676 covers the consumption side on this module (a per-request `cachedContent` override); this PR covers creating the cache that parameter refers to. #5493 tracks the same creation/management need for the older `google-ai-gemini` module.

### Changes
- `GoogleGenAiCaches`: new standalone helper wrapping `client.caches` (create/get/list/updateCacheTtl/delete), mirroring `GoogleGenAiFiles`. Cache content is built from `ChatMessage`s via `GoogleGenAiContentMapper`.
- Docs: a "Creating and managing caches" subsection under "Cached Content Support" in `google-genai.md` (create -> reuse via `cachedContent` -> manage lifecycle).

### Testing
- `mvn -pl langchain4j-google-genai test` -> 121 passing, 0 failures. Includes a new offline unit test
  (`GoogleGenAiCachesTest`, 2 tests) covering the `ChatMessage` -> `CreateCachedContentConfig` mapping, including the
  null-ttl and no-system-message edge cases.
- Integration test `GoogleGenAiCachesIT` (gated on `GOOGLE_AI_GEMINI_API_KEY`, like the rest of the module) exercises
  the full create -> get -> list -> update -> delete lifecycle. **Run against the real API on `gemini-2.5-flash`
  (1/1 passing).** Explicit context caching requires a paid tier, so the IT skips cleanly on a free-tier key (its
  cache storage limit is 0); it cleans up the created cache in a `finally` block.
- `spotless:check` passes.

### Checklist
- [x] No breaking changes (purely additive; one new class + docs).
- [x] Offline unit tests + a key-gated integration test (run live against the real API).
- [x] Mirrors the existing `GoogleGenAiFiles` helper (builder, client construction, thin SDK-native types).
- [x] Ran the module build and tests locally (green) + spotless.
