### PR TITLE
fix: Support all date functions when extracting metadata key in SqlFilterParser

### DIFF
--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
@@ -324,7 +324,7 @@ public class SqlFilterParser implements FilterParser {
                             return currentHour();
                         case "MINUTE":
                             return currentMinute();
-                            // TODO add other
+                        // TODO add other
                     }
                 } else {
                     // TODO parse timestamp?

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/main/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParser.java
@@ -211,7 +211,12 @@ public class SqlFilterParser implements FilterParser {
             return column.getColumnName();
         } else if (expression instanceof Function function) {
             String name = function.getName();
-            if (name.equalsIgnoreCase("YEAR") || name.equalsIgnoreCase("MONTH")) {
+            if (name.equalsIgnoreCase("YEAR")
+                    || name.equalsIgnoreCase("MONTH")
+                    || name.equalsIgnoreCase("WEEKOFYEAR")
+                    || name.equalsIgnoreCase("DAYOFYEAR")
+                    || name.equalsIgnoreCase("DAYOFMONTH")
+                    || name.equalsIgnoreCase("DAYOFWEEK")) {
                 ExpressionList<?> parameters = function.getParameters();
                 if (parameters != null && parameters.size() == 1) {
                     Expression parameter = parameters.get(0);

--- a/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
+++ b/embedding-store-filter-parsers/langchain4j-embedding-store-filter-parser-sql/src/test/java/dev/langchain4j/store/embedding/filter/parser/sql/SqlFilterParserTest.java
@@ -1502,4 +1502,17 @@ class SqlFilterParserTest {
                         .isEqualTo(2024L)
                         .and(metadataKey("genre").isIn("comedy", "drama")));
     }
+
+    @Test
+    void should_support_date_functions_in_WHERE_clause() {
+
+        assertThat(parser.parse("SELECT * FROM movies WHERE WEEKOFYEAR(publish_date) = WEEKOFYEAR(CURDATE())"))
+                .isEqualTo(metadataKey("publish_date").isEqualTo(currentWeek()));
+        assertThat(parser.parse("SELECT * FROM movies WHERE DAYOFYEAR(publish_date) = DAYOFYEAR(CURDATE())"))
+                .isEqualTo(metadataKey("publish_date").isEqualTo(currentDayOfYear()));
+        assertThat(parser.parse("SELECT * FROM movies WHERE DAYOFMONTH(publish_date) = DAYOFMONTH(CURDATE())"))
+                .isEqualTo(metadataKey("publish_date").isEqualTo(currentDayOfMonth()));
+        assertThat(parser.parse("SELECT * FROM movies WHERE DAYOFWEEK(publish_date) = DAYOFWEEK(CURDATE())"))
+                .isEqualTo(metadataKey("publish_date").isEqualTo(currentDayOfWeek()));
+    }
 }


### PR DESCRIPTION
## Issue
Closes #5698

## Change
In `SqlFilterParser`, `getValue(Expression)` resolves six date functions (`YEAR`, `MONTH`, `WEEKOFYEAR`, `DAYOFYEAR`, `DAYOFMONTH`, `DAYOFWEEK`), but `getKey(Expression)` unwrapped a column only for `YEAR` and `MONTH`.
So a query like `WEEKOFYEAR(publish_date) = WEEKOFYEAR(CURDATE())` resolved the value on the right but threw `IllegalArgumentException` when extracting the key on the left.
This is an internal inconsistency between `getKey` and `getValue`. #4170 introduced left-side `YEAR`/`MONTH` unwrapping; #4269 later grew `getValue` and the Javadoc date-function set to six functions but did not update `getKey` (incomplete fix).

Fix: add the four missing `equalsIgnoreCase` checks to `getKey`'s function-name condition so it matches the six functions `getValue` supports. The single-column parameter check and column-name extraction are unchanged.

Added a positive test `should_support_date_functions_in_WHERE_clause` mirroring the existing `should_support_YEAR_function_in_WHERE_clause`, asserting the four functions on the WHERE left side parse to the correct `metadataKey`.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases <!-- positive only: 4 newly-supported functions now parse. The unsupported-function path (throws IllegalArgumentException) is unchanged and already covered by existing tests. -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


