### PR TITLE
docs: Fix pooling mode and model path wording in OnnxEmbeddingModel Javadoc

### DIFF
--- a/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxEmbeddingModel.java
+++ b/embeddings/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxEmbeddingModel.java
@@ -23,9 +23,9 @@ public class OnnxEmbeddingModel extends AbstractInProcessEmbeddingModel {
     private final OnnxBertBiEncoder onnxBertBiEncoder;
 
     /**
-     * @param pathToModel     The path to the modelPath file (e.g., "/path/to/model.onnx")
+     * @param pathToModel     The path to the model file (e.g., "/path/to/model.onnx")
      * @param pathToTokenizer The path to the tokenizer file (e.g., "/path/to/tokenizer.json")
-     * @param poolingMode     The pooling model to use. Can be found in the ".../1_Pooling/config.json" file on HuggingFace.
+     * @param poolingMode     The pooling mode to use. Can be found in the ".../1_Pooling/config.json" file on HuggingFace.
      *                        Here is an <a href="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/blob/main/1_Pooling/config.json">example</a>.
      *                        {@code "pooling_mode_mean_tokens": true} means that {@link PoolingMode#MEAN} should be used.
      */
@@ -35,9 +35,9 @@ public class OnnxEmbeddingModel extends AbstractInProcessEmbeddingModel {
     }
 
     /**
-     * @param pathToModel     The path to the modelPath file (e.g., "/path/to/model.onnx")
+     * @param pathToModel     The path to the model file (e.g., "/path/to/model.onnx")
      * @param pathToTokenizer The path to the tokenizer file (e.g., "/path/to/tokenizer.json")
-     * @param poolingMode     The pooling model to use. Can be found in the ".../1_Pooling/config.json" file on HuggingFace.
+     * @param poolingMode     The pooling mode to use. Can be found in the ".../1_Pooling/config.json" file on HuggingFace.
      *                        Here is an <a href="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/blob/main/1_Pooling/config.json">example</a>.
      *                        {@code "pooling_mode_mean_tokens": true} means that {@link PoolingMode#MEAN} should be used.
      * @param executor        The executor to use to parallelize the embedding process.
@@ -50,7 +50,7 @@ public class OnnxEmbeddingModel extends AbstractInProcessEmbeddingModel {
     /**
      * @param pathToModel     The path to the model file (e.g., "/home/me/model.onnx")
      * @param pathToTokenizer The path to the tokenizer file (e.g., "/path/to/tokenizer.json")
-     * @param poolingMode     The pooling model to use. Can be found in the ".../1_Pooling/config.json" file on HuggingFace.
+     * @param poolingMode     The pooling mode to use. Can be found in the ".../1_Pooling/config.json" file on HuggingFace.
      *                        Here is an <a href="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/blob/main/1_Pooling/config.json">example</a>.
      *                        {@code "pooling_mode_mean_tokens": true} means that {@link PoolingMode#MEAN} should be used.
      */
@@ -61,7 +61,7 @@ public class OnnxEmbeddingModel extends AbstractInProcessEmbeddingModel {
     /**
      * @param pathToModel     The path to the model file (e.g., "/home/me/model.onnx")
      * @param pathToTokenizer The path to the tokenizer file (e.g., "/path/to/tokenizer.json")
-     * @param poolingMode     The pooling model to use. Can be found in the ".../1_Pooling/config.json" file on HuggingFace.
+     * @param poolingMode     The pooling mode to use. Can be found in the ".../1_Pooling/config.json" file on HuggingFace.
      *                        Here is an <a href="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/blob/main/1_Pooling/config.json">example</a>.
      *                        {@code "pooling_mode_mean_tokens": true} means that {@link PoolingMode#MEAN} should be used.
      * @param executor        The executor to use to parallelize the embedding process.


### PR DESCRIPTION
# docs: Fix pooling mode and model path wording in OnnxEmbeddingModel Javadoc

## Issue
Javadoc wording fix — no issue required (typo-fix, no runtime behavior change).

## Change
- `@param poolingMode` said "The pooling **model** to use" in all four constructors. The parameter type is the `PoolingMode` enum, and the same Javadoc references `{@link PoolingMode#MEAN}`, so the intended word is "mode". Fixed to "The pooling mode to use" (4 occurrences).
- `@param pathToModel` said "The path to the **modelPath** file" in the two `Path`-based constructors. The other two constructors already use the correct "The path to the model file". Fixed to match (2 occurrences).

Comment text only — no code, imports, or formatting changed.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change <!-- N/A — Javadoc wording fix, no behavior to test -->
- [ ] The tests cover both positive and negative cases <!-- N/A — no tests -->
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green <!-- unit tests (9/9) green; OnnxEmbeddingModelIT not run (downloads real ONNX models, skipped per repo policy for local runs) -->
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change confined to embeddings module -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — Javadoc is the documentation being fixed -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) <!-- N/A -->

<!-- "new maven module" and "embedding store integration" checklists omitted — not applicable to a Javadoc wording fix. -->

<!-- Pre-check note: module-scoped `spotless:apply`/`spotless:check` and `clean compile` verified green. Spotless was run from MAIN_ROOT because the pom pins `<ratchetFrom>origin/main</ratchetFrom>` and jgit cannot resolve the repo inside a linked git worktree ("Cannot find git repository"). The exact committed file content was validated there: spotless:apply produced no further changes, spotless:check BUILD SUCCESS, compile BUILD SUCCESS. -->
