### PR TITLE
fix: strip only one leading space in SSE data/event fields per WHATWG spec (#5531)

### DIFF
--- a/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/DefaultServerSentEventParser.java
+++ b/langchain4j-http-client/src/main/java/dev/langchain4j/http/client/sse/DefaultServerSentEventParser.java
@@ -33,13 +33,13 @@ public class DefaultServerSentEventParser implements ServerSentEventParser {
                 }
 
                 if (line.startsWith("event:")) {
-                    event = line.substring("event:".length()).trim();
+                    event = stripSingleLeadingSpace(line.substring("event:".length()));
                 } else if (line.startsWith("data:")) {
-                    String content = line.substring("data:".length());
+                    String content = stripSingleLeadingSpace(line.substring("data:".length()));
                     if (!data.isEmpty()) {
                         data.append("\n");
                     }
-                    data.append(content.trim());
+                    data.append(content);
                 }
             }
 
@@ -50,5 +50,18 @@ public class DefaultServerSentEventParser implements ServerSentEventParser {
         } catch (IOException e) {
             ignoringExceptions(() -> listener.onError(e));
         }
+    }
+
+    /**
+     * Strips at most a single leading U+0020 SPACE from the given value, as required by the
+     * <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream">
+     * WHATWG HTML Living Standard</a> for server-sent events. All other whitespace (additional
+     * leading spaces, trailing spaces, tabs, etc.) is preserved.
+     *
+     * @param value the raw field value (text after the field name and colon)
+     * @return the value with at most one leading space removed
+     */
+    private static String stripSingleLeadingSpace(String value) {
+        return value.startsWith(" ") ? value.substring(1) : value;
     }
 }

--- a/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/sse/DefaultServerSentEventParserTest.java
+++ b/langchain4j-http-client/src/test/java/dev/langchain4j/http/client/sse/DefaultServerSentEventParserTest.java
@@ -131,6 +131,68 @@ class DefaultServerSentEventParserTest {
     }
 
     @Test
+    void shouldPreserveExtraLeadingSpacesInDataField() {
+        // Per WHATWG HTML Living Standard (Server-sent events), only a single
+        // leading U+0020 SPACE should be stripped from each data: value;
+        // all remaining leading whitespace must be preserved.
+
+        // given
+        String input = "data:   indented\n\n";
+        InputStream stream = new ByteArrayInputStream(input.getBytes(UTF_8));
+
+        // when
+        parser.parse(stream, listener);
+
+        // then - two leading spaces are preserved
+        verify(listener).onEvent(eq(new ServerSentEvent(null, "  indented")), any());
+    }
+
+    @Test
+    void shouldPreserveTrailingWhitespaceInDataField() {
+        // Trailing whitespace must be preserved per the WHATWG spec.
+
+        // given
+        String input = "data: trailing   \n\n";
+        InputStream stream = new ByteArrayInputStream(input.getBytes(UTF_8));
+
+        // when
+        parser.parse(stream, listener);
+
+        // then
+        verify(listener).onEvent(eq(new ServerSentEvent(null, "trailing   ")), any());
+    }
+
+    @Test
+    void shouldParseDataFieldWithoutLeadingSpace() {
+        // When there is no space after the colon, nothing is stripped.
+
+        // given
+        String input = "data:no-space\n\n";
+        InputStream stream = new ByteArrayInputStream(input.getBytes(UTF_8));
+
+        // when
+        parser.parse(stream, listener);
+
+        // then
+        verify(listener).onEvent(eq(new ServerSentEvent(null, "no-space")), any());
+    }
+
+    @Test
+    void shouldPreserveWhitespaceInMultiLineDataField() {
+        // Each data: line should have only one leading space removed.
+
+        // given
+        String input = "data:  first  \ndata:   second\n\n";
+        InputStream stream = new ByteArrayInputStream(input.getBytes(UTF_8));
+
+        // when
+        parser.parse(stream, listener);
+
+        // then
+        verify(listener).onEvent(eq(new ServerSentEvent(null, " first  \n  second")), any());
+    }
+
+    @Test
     void shouldHandleIOException() {
 
         // given


### PR DESCRIPTION
## Issue
Closes #5531

## Change

### Problem
`DefaultServerSentEventParser.parse()` called `String.trim()` on `data:` and `event:` field values, removing **all** leading and trailing whitespace. The [WHATWG HTML Living Standard](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream) specifies that only a single leading U+0020 SPACE should be removed from each field value; all other whitespace must be preserved.

This is particularly impactful for LLM token streaming, where whitespace can carry semantic meaning (e.g., code indentation, markdown formatting, Python code blocks).

### Root Cause
In `DefaultServerSentEventParser.java`:
- `event:` field: `line.substring("event:".length()).trim()` — over-trims
- `data:` field: `content.trim()` — over-trims

Both used `trim()` instead of the spec-compliant "strip one leading space" behavior.

### Fix
Introduced a `stripSingleLeadingSpace(String)` private helper that removes at most one leading U+0020 SPACE, applied to both `data:` and `event:` field values. All other whitespace (additional leading spaces, trailing spaces, tabs) is preserved per the WHATWG spec.

### Reproduction
Before the fix, feeding `data:   indented\n\n` to the parser produced `"indented"` (all leading spaces stripped). After the fix, it correctly produces `"  indented"` (one space removed, two preserved).

### Tests
Added 4 unit tests in `DefaultServerSentEventParserTest`:
1. `shouldPreserveExtraLeadingSpacesInDataField` — multiple leading spaces (only one removed)
2. `shouldPreserveTrailingWhitespaceInDataField` — trailing spaces preserved
3. `shouldParseDataFieldWithoutLeadingSpace` — no space after colon (nothing stripped)
4. `shouldPreserveWhitespaceInMultiLineDataField` — multi-line data with extra spaces

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) (N/A — bug fix, no API change)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Not applicable - this is a bug fix, not a new module -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Not applicable - this is a bug fix, not an embedding store integration -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Not applicable - this is a bug fix, not an embedding store integration -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j