### PR TITLE
[FEATURE] Set User-Agent header to LangChain4j in Ollama and Anthropic modules

### DIFF
--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/client/DefaultAnthropicClient.java
@@ -674,6 +674,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
         HttpRequest httpRequest = HttpRequest.builder()
                 .method(GET)
                 .url(baseUrl, "models")
+                .addHeader("User-Agent", "LangChain4j")
                 .addHeader("x-api-key", apiKey)
                 .addHeader("anthropic-version", version)
                 .addHeaders(customHeadersSupplier.get())
@@ -702,6 +703,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
      * <p>Constructs a POST request with the following headers:</p>
      * <ul>
      *   <li>{@code Content-Type: application/json}</li>
+     *   <li>{@code User-Agent: LangChain4j}</li>
      *   <li>{@code x-api-key}: The configured API key</li>
      *   <li>{@code anthropic-version}: The configured API version</li>
      *   <li>{@code anthropic-beta}: The configured beta features (if set)</li>
@@ -716,6 +718,7 @@ public class DefaultAnthropicClient extends AnthropicClient {
                 .method(POST)
                 .url(baseUrl, path)
                 .addHeader("Content-Type", "application/json")
+                .addHeader("User-Agent", "LangChain4j")
                 .addHeader("x-api-key", apiKey)
                 .addHeader("anthropic-version", version)
                 .addHeaders(customHeadersSupplier.get())

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicCustomHeadersTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicCustomHeadersTest.java
@@ -113,6 +113,7 @@ class AnthropicCustomHeadersTest {
         assertThat(headers).containsEntry("x-custom-header", "custom-value");
         assertThat(headers).containsEntry("x-api-key", "my-real-key");
         assertThat(headers).containsKey("anthropic-version");
+        assertThat(headers).containsEntry("user-agent", "LangChain4j");
     }
 
     @Test

--- a/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
+++ b/langchain4j-ollama/src/main/java/dev/langchain4j/model/ollama/OllamaClient.java
@@ -44,6 +44,7 @@ import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.model.output.TokenUsage;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -79,11 +80,13 @@ class OllamaClient {
     }
 
     private Map<String, String> buildRequestHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("User-Agent", "LangChain4j");
         Map<String, String> dynamicHeaders = customHeadersSupplier.get();
-        if (isNullOrEmpty(dynamicHeaders)) {
-            return Map.of();
+        if (!isNullOrEmpty(dynamicHeaders)) {
+            headers.putAll(dynamicHeaders);
         }
-        return dynamicHeaders;
+        return headers;
     }
 
     static Builder builder() {

--- a/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaClientUserAgentTest.java
+++ b/langchain4j-ollama/src/test/java/dev/langchain4j/model/ollama/OllamaClientUserAgentTest.java
@@ -1,0 +1,57 @@
+package dev.langchain4j.model.ollama;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OllamaClientUserAgentTest {
+
+    private HttpServer server;
+    private AtomicReference<Map<String, String>> capturedHeaders;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        capturedHeaders = new AtomicReference<>();
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/api/tags", exchange -> {
+            Map<String, String> headers = new java.util.HashMap<>();
+            exchange.getRequestHeaders().forEach((name, values) -> headers.put(name.toLowerCase(), values.get(0)));
+            capturedHeaders.set(headers);
+
+            byte[] body = "{\"models\": []}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.getResponseBody().close();
+        });
+        server.start();
+        baseUrl = "http://localhost:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void should_set_user_agent_header() {
+        OllamaClient ollamaClient = OllamaClient.builder()
+                .baseUrl(baseUrl)
+                .timeout(Duration.ofSeconds(5))
+                .build();
+
+        ollamaClient.listModels();
+
+        Map<String, String> headers = capturedHeaders.get();
+        assertThat(headers).containsEntry("user-agent", "LangChain4j");
+    }
+}


### PR DESCRIPTION

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #967 (partial — first batch of providers)

## Change
<!-- Please describe the changes you made. -->
Added `User-Agent: LangChain4j` header to HTTP requests made by the **Ollama** and **Anthropic** provider modules.

**Ollama** (`OllamaClient.java`):
- Modified `buildRequestHeaders()` to always include `User-Agent: LangChain4j`
- Custom headers from the supplier are merged on top of the default

**Anthropic** (`DefaultAnthropicClient.java`):
- Added `User-Agent: LangChain4j` header to `listModels()` GET request
- Added `User-Agent: LangChain4j` header to `toHttpRequest()` POST requests
- Updated Javadoc to reflect the new header

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
