### PR TITLE
fix: Paginate ListObjects in TencentCosDocumentLoader to load all obj…

### DIFF
--- a/document-loaders/langchain4j-document-loader-tencent-cos/src/main/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoader.java
+++ b/document-loaders/langchain4j-document-loader-tencent-cos/src/main/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoader.java
@@ -2,7 +2,6 @@ package dev.langchain4j.data.document.loader.tencent.cos;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static java.util.stream.Collectors.toList;
 
 import com.qcloud.cos.COSClient;
 import com.qcloud.cos.ClientConfig;
@@ -75,18 +74,23 @@ public class TencentCosDocumentLoader {
 
         ObjectListing objectListing = cosClient.listObjects(listObjectsRequest);
 
-        List<COSObjectSummary> filteredObjects = objectListing.getObjectSummaries().stream()
-                .filter(object -> !object.getKey().endsWith("/") && object.getSize() > 0)
-                .collect(toList());
-
-        for (COSObjectSummary object : filteredObjects) {
-            String key = object.getKey();
-            try {
-                Document document = loadDocument(bucket, key, parser);
-                documents.add(document);
-            } catch (Exception e) {
-                log.warn("Failed to load an object with key '{}' from bucket '{}', skipping it.", key, bucket, e);
+        while (true) {
+            for (COSObjectSummary object : objectListing.getObjectSummaries()) {
+                if (object.getKey().endsWith("/") || object.getSize() == 0) {
+                    continue;
+                }
+                String key = object.getKey();
+                try {
+                    Document document = loadDocument(bucket, key, parser);
+                    documents.add(document);
+                } catch (Exception e) {
+                    log.warn("Failed to load an object with key '{}' from bucket '{}', skipping it.", key, bucket, e);
+                }
             }
+            if (!objectListing.isTruncated()) {
+                break;
+            }
+            objectListing = cosClient.listNextBatchOfObjects(objectListing);
         }
 
         return documents;

--- a/document-loaders/langchain4j-document-loader-tencent-cos/src/test/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoaderTest.java
+++ b/document-loaders/langchain4j-document-loader-tencent-cos/src/test/java/dev/langchain4j/data/document/loader/tencent/cos/TencentCosDocumentLoaderTest.java
@@ -1,39 +1,176 @@
 package dev.langchain4j.data.document.loader.tencent.cos;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.qcloud.cos.COSClient;
+import com.qcloud.cos.model.COSObject;
+import com.qcloud.cos.model.COSObjectInputStream;
+import com.qcloud.cos.model.COSObjectSummary;
+import com.qcloud.cos.model.GetObjectRequest;
+import com.qcloud.cos.model.ListObjectsRequest;
+import com.qcloud.cos.model.ObjectListing;
+import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentParser;
+import dev.langchain4j.data.document.parser.TextDocumentParser;
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.junit.jupiter.api.Test;
 
 class TencentCosDocumentLoaderTest {
 
-    private final COSClient cosClient = mock(COSClient.class);
-    private final DocumentParser parser = mock(DocumentParser.class);
-    private final TencentCosDocumentLoader loader = new TencentCosDocumentLoader(cosClient);
+    private static final String BUCKET = "test-bucket";
+
+    private final DocumentParser parser = new TextDocumentParser();
 
     @Test
     void should_throw_when_bucket_is_null() {
+        TencentCosDocumentLoader loader = new TencentCosDocumentLoader(mock(COSClient.class));
         assertThatThrownBy(() -> loader.loadDocument(null, "some-key", parser))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void should_throw_when_bucket_is_blank() {
+        TencentCosDocumentLoader loader = new TencentCosDocumentLoader(mock(COSClient.class));
         assertThatThrownBy(() -> loader.loadDocument("   ", "some-key", parser))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void should_throw_when_key_is_null() {
+        TencentCosDocumentLoader loader = new TencentCosDocumentLoader(mock(COSClient.class));
         assertThatThrownBy(() -> loader.loadDocument("some-bucket", null, parser))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void should_throw_when_key_is_blank() {
+        TencentCosDocumentLoader loader = new TencentCosDocumentLoader(mock(COSClient.class));
         assertThatThrownBy(() -> loader.loadDocument("some-bucket", "   ", parser))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_load_all_documents_across_paginated_responses() {
+
+        ObjectListing page1 = mock(ObjectListing.class);
+        COSObjectSummary summaryA = new COSObjectSummary();
+        summaryA.setKey("a.txt");
+        summaryA.setSize(10);
+        when(page1.getObjectSummaries()).thenReturn(List.of(summaryA));
+        when(page1.isTruncated()).thenReturn(true);
+
+        ObjectListing page2 = mock(ObjectListing.class);
+        COSObjectSummary summaryB = new COSObjectSummary();
+        summaryB.setKey("b.txt");
+        summaryB.setSize(20);
+        when(page2.getObjectSummaries()).thenReturn(List.of(summaryB));
+        when(page2.isTruncated()).thenReturn(false);
+
+        List<String> loadedKeys = new ArrayList<>();
+        COSClient cosClient = stubCosClient(Map.of("a.txt", "content-a", "b.txt", "content-b"), loadedKeys);
+        when(cosClient.listObjects(any(ListObjectsRequest.class))).thenReturn(page1);
+        when(cosClient.listNextBatchOfObjects(page1)).thenReturn(page2);
+
+        TencentCosDocumentLoader loader = new TencentCosDocumentLoader(cosClient);
+
+        List<Document> documents = loader.loadDocuments(BUCKET, parser);
+
+        assertThat(documents).extracting(Document::text).containsExactly("content-a", "content-b");
+        assertThat(loadedKeys).containsExactly("a.txt", "b.txt");
+    }
+
+    @Test
+    void should_load_single_page_when_not_truncated() {
+
+        ObjectListing onlyPage = mock(ObjectListing.class);
+        COSObjectSummary summaryA = new COSObjectSummary();
+        summaryA.setKey("a.txt");
+        summaryA.setSize(10);
+        when(onlyPage.getObjectSummaries()).thenReturn(List.of(summaryA));
+        when(onlyPage.isTruncated()).thenReturn(false);
+
+        List<String> loadedKeys = new ArrayList<>();
+        COSClient cosClient = stubCosClient(Map.of("a.txt", "content-a"), loadedKeys);
+        when(cosClient.listObjects(any(ListObjectsRequest.class))).thenReturn(onlyPage);
+
+        TencentCosDocumentLoader loader = new TencentCosDocumentLoader(cosClient);
+
+        List<Document> documents = loader.loadDocuments(BUCKET, parser);
+
+        assertThat(documents).extracting(Document::text).containsExactly("content-a");
+    }
+
+    @Test
+    void should_return_empty_list_when_no_objects() {
+
+        ObjectListing emptyPage = mock(ObjectListing.class);
+        when(emptyPage.getObjectSummaries()).thenReturn(List.of());
+        when(emptyPage.isTruncated()).thenReturn(false);
+
+        COSClient cosClient = mock(COSClient.class);
+        when(cosClient.listObjects(any(ListObjectsRequest.class))).thenReturn(emptyPage);
+
+        TencentCosDocumentLoader loader = new TencentCosDocumentLoader(cosClient);
+
+        List<Document> documents = loader.loadDocuments(BUCKET, parser);
+
+        assertThat(documents).isEmpty();
+    }
+
+    @Test
+    void should_skip_directories_and_empty_files() {
+
+        ObjectListing page = mock(ObjectListing.class);
+        COSObjectSummary directoryMarker = new COSObjectSummary();
+        directoryMarker.setKey("dir/");
+        directoryMarker.setSize(0);
+        COSObjectSummary emptyFile = new COSObjectSummary();
+        emptyFile.setKey("empty.txt");
+        emptyFile.setSize(0);
+        COSObjectSummary realFile = new COSObjectSummary();
+        realFile.setKey("real.txt");
+        realFile.setSize(100);
+        when(page.getObjectSummaries()).thenReturn(List.of(directoryMarker, emptyFile, realFile));
+        when(page.isTruncated()).thenReturn(false);
+
+        List<String> loadedKeys = new ArrayList<>();
+        COSClient cosClient = stubCosClient(Map.of("real.txt", "real-content"), loadedKeys);
+        when(cosClient.listObjects(any(ListObjectsRequest.class))).thenReturn(page);
+
+        TencentCosDocumentLoader loader = new TencentCosDocumentLoader(cosClient);
+
+        List<Document> documents = loader.loadDocuments(BUCKET, parser);
+
+        assertThat(documents).hasSize(1);
+        assertThat(documents.get(0).text()).isEqualTo("real-content");
+    }
+
+    private static COSClient stubCosClient(Map<String, String> keyToContent, List<String> loadedKeys) {
+        COSClient cosClient = mock(COSClient.class);
+        for (var entry : keyToContent.entrySet()) {
+            when(cosClient.getObject(argThat((GetObjectRequest req) ->
+                            req != null && entry.getKey().equals(req.getKey()))))
+                    .thenAnswer(invocation -> {
+                        loadedKeys.add(entry.getKey());
+                        return objectWithContent(entry.getValue());
+                    });
+        }
+        return cosClient;
+    }
+
+    private static COSObject objectWithContent(String content) {
+        COSObject cosObject = new COSObject();
+        cosObject.setObjectContent(
+                new COSObjectInputStream(new ByteArrayInputStream(content.getBytes()), mock(HttpRequestBase.class)));
+        return cosObject;
     }
 }


### PR DESCRIPTION
…ects

The loadDocuments() method only fetched the first page of results (max 1000 objects) from Tencent COS. This is a follow-up to #5662 which fixed the same issue in AmazonS3DocumentLoader.

Use a while-loop with isTruncated() and listNextBatchOfObjects() to iterate through all pages, matching the pattern already used by AmazonS3DocumentLoader and GoogleCloudStorageDocumentLoader.

<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Closes #

## Change
<!-- Please describe the changes you made. -->


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] There are no breaking changes (API, behaviour)
- [ ] I have added unit and/or integration tests for my change
- [ ] The tests cover both positive and negative cases
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) 
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
