### PR TITLE
fix: guard against null function in streamed OpenAI tool-call deltas

### DIFF
--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingChatModel.java
@@ -44,6 +44,7 @@ import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
 import dev.langchain4j.model.openai.internal.chat.Delta;
+import dev.langchain4j.model.openai.internal.chat.FunctionCall;
 import dev.langchain4j.model.openai.internal.chat.ToolCall;
 import dev.langchain4j.model.openai.internal.shared.StreamOptions;
 import dev.langchain4j.model.openai.spi.OpenAiStreamingChatModelBuilderFactory;
@@ -248,9 +249,10 @@ public class OpenAiStreamingChatModel implements StreamingChatModel {
                 }
 
                 String id = toolCallBuilder.updateId(toolCall.id());
-                String name = toolCallBuilder.updateName(toolCall.function().name());
+                FunctionCall functionCall = toolCall.function();
+                String name = toolCallBuilder.updateName(functionCall == null ? null : functionCall.name());
 
-                String partialArguments = toolCall.function().arguments();
+                String partialArguments = functionCall == null ? null : functionCall.arguments();
                 if (isNotNullOrEmpty(partialArguments)) {
                     toolCallBuilder.appendArguments(partialArguments);
 

--- a/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
+++ b/langchain4j-open-ai/src/main/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilder.java
@@ -203,11 +203,13 @@ public class OpenAiStreamingResponseBuilder {
                 }
 
                 FunctionCall functionCall = toolCall.function();
-                if (functionCall.name() != null) {
-                    builder.nameBuilder.append(functionCall.name());
-                }
-                if (functionCall.arguments() != null) {
-                    builder.argumentsBuilder.append(functionCall.arguments());
+                if (functionCall != null) {
+                    if (functionCall.name() != null) {
+                        builder.nameBuilder.append(functionCall.name());
+                    }
+                    if (functionCall.arguments() != null) {
+                        builder.argumentsBuilder.append(functionCall.arguments());
+                    }
                 }
             }
         }

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingChatModelRawEventTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingChatModelRawEventTest.java
@@ -69,4 +69,51 @@ class OpenAiStreamingChatModelRawEventTest {
         assertThat(partialResponses.toString()).isEqualTo("Hello");
         assertThat(rawEvents).containsExactly(roleEvent);
     }
+
+    @Test
+    void should_not_throw_npe_when_tool_call_delta_has_no_function_object() throws Exception {
+        // Given: an OpenAI-compatible gateway (e.g. LiteLLM, vLLM) emits a header chunk with an id
+        // but no "function" object at all, followed by a chunk carrying the function details.
+        ServerSentEvent headerChunk = new ServerSentEvent(
+                null,
+                "{\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":"
+                        + "[{\"index\":0,\"id\":\"call_x\",\"type\":\"function\"}]}}]}");
+        ServerSentEvent functionChunk = new ServerSentEvent(
+                null,
+                "{\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":"
+                        + "[{\"index\":0,\"function\":{\"name\":\"getWeather\",\"arguments\":\"{}\"}}]}}]}");
+        ServerSentEvent doneEvent = new ServerSentEvent(null, "[DONE]");
+        List<ServerSentEvent> events = List.of(headerChunk, functionChunk, doneEvent);
+        MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(events);
+
+        StreamingChatModel model = OpenAiStreamingChatModel.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                .apiKey("test-key")
+                .modelName("gpt-4o-mini")
+                .build();
+
+        CompletableFuture<ChatResponse> futureResponse = new CompletableFuture<>();
+
+        // When: streaming (should not throw NPE)
+        model.chat("What is the weather?", new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {}
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                futureResponse.complete(completeResponse);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                futureResponse.completeExceptionally(error);
+            }
+        });
+
+        // Then
+        ChatResponse response = futureResponse.get(5, TimeUnit.SECONDS);
+        assertThat(response.aiMessage().toolExecutionRequests()).hasSize(1);
+        assertThat(response.aiMessage().toolExecutionRequests().get(0).id()).isEqualTo("call_x");
+        assertThat(response.aiMessage().toolExecutionRequests().get(0).name()).isEqualTo("getWeather");
+    }
 }

--- a/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
+++ b/langchain4j-open-ai/src/test/java/dev/langchain4j/model/openai/OpenAiStreamingResponseBuilderTest.java
@@ -187,6 +187,42 @@ class OpenAiStreamingResponseBuilderTest {
     }
 
     @Test
+    void should_not_throw_npe_when_tool_call_has_no_function() {
+        // Given: an OpenAI-compatible gateway (e.g. LiteLLM, vLLM) emits a header chunk that carries
+        // an id but no "function" object at all: {"index":0,"id":"call_x","type":"function"}
+        OpenAiStreamingResponseBuilder builder = new OpenAiStreamingResponseBuilder();
+
+        ToolCall headerChunk = ToolCall.builder()
+                .id("call_x")
+                .index(0)
+                .type(ToolType.FUNCTION)
+                .function(null)
+                .build();
+
+        // When: appending the response (should not throw NPE)
+        builder.append(chatCompletionResponse(headerChunk));
+
+        // Then: a subsequent chunk carrying the function (and no id, as real gateways stream it once)
+        // completes the tool call normally
+        ToolCall functionChunk = ToolCall.builder()
+                .index(0)
+                .type(ToolType.FUNCTION)
+                .function(FunctionCall.builder()
+                        .name("getWeather")
+                        .arguments("{\"city\": \"Berlin\"}")
+                        .build())
+                .build();
+        builder.append(chatCompletionResponse(functionChunk));
+
+        ChatResponse chatResponse = builder.build();
+        List<ToolExecutionRequest> requests = chatResponse.aiMessage().toolExecutionRequests();
+        assertThat(requests).hasSize(1);
+        assertThat(requests.get(0).id()).isEqualTo("call_x");
+        assertThat(requests.get(0).name()).isEqualTo("getWeather");
+        assertThat(requests.get(0).arguments()).isEqualTo("{\"city\": \"Berlin\"}");
+    }
+
+    @Test
     void should_keep_all_tool_calls_from_same_delta() {
 
         // given


### PR DESCRIPTION
## Issue
Closes #5711

## Change

Some OpenAI-compatible gateways (LiteLLM, vLLM) emit a header chunk for a streamed tool call that carries an `id` but no `function` object at all, e.g. `{"index":0,"id":"call_x","type":"function"}`, with the `function` details arriving in a later chunk.

Both `OpenAiStreamingChatModel.handle(...)` and `OpenAiStreamingResponseBuilder.append(...)` dereferenced `toolCall.function()` without a null check, causing an NPE that aborted the entire stream. Note that `OpenAiStreamingResponseBuilder`'s `isSentinel(...)` helper already null-checks `function()` correctly, but the accumulation code right after it did not apply the same guard.

This PR adds the missing null guards in both places, so an id-only chunk is accumulated (id recorded, name/arguments skipped) instead of crashing the stream.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Test plan
- Added `should_not_throw_npe_when_tool_call_has_no_function` in `OpenAiStreamingResponseBuilderTest` (unit-level, reproduces the exact NPE at `OpenAiStreamingResponseBuilder.java:206` without the fix).
- Added `should_not_throw_npe_when_tool_call_delta_has_no_function_object` in `OpenAiStreamingChatModelRawEventTest` (end-to-end via `MockHttpClient`, reproduces the NPE at `OpenAiStreamingChatModel.java:251` without the fix).
- Verified both new tests fail with the original NPE stack trace when the fix is reverted, and pass with it applied.
- Ran the full `langchain4j-open-ai` (171 tests), `langchain4j-core` (1131 tests), and `langchain4j` (1423 tests) suites — all green.
- Ran `./mvnw spotless:apply`/`spotless:check` — clean.