### PR TITLE
fix: defensively copy input list in ChatMemory.set(...) before eviction

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/MessageWindowChatMemory.java
@@ -106,6 +106,7 @@ public class MessageWindowChatMemory implements ChatMemory {
     private void set(List<ChatMessage> messages) {
         Integer maxMessages = this.maxMessagesProvider.apply(this.id);
         ensureGreaterThanZero(maxMessages, "maxMessages");
+        messages = new ArrayList<>(messages);
         ensureCapacity(messages, maxMessages);
         store.updateMessages(id, messages);
     }

--- a/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
+++ b/langchain4j/src/main/java/dev/langchain4j/memory/chat/TokenWindowChatMemory.java
@@ -110,6 +110,7 @@ public class TokenWindowChatMemory implements ChatMemory {
     private void set(List<ChatMessage> messages) {
         Integer maxTokens = maxTokensProvider.apply(id);
         ensureGreaterThanZero(maxTokens, "maxTokens");
+        messages = new ArrayList<>(messages);
         ensureCapacity(messages, maxTokens, tokenCountEstimator);
         store.updateMessages(id, messages);
     }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/MessageWindowChatMemoryTest.java
@@ -11,6 +11,9 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.HitCountChatMemoryStore.HitCounts;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
@@ -634,5 +637,37 @@ class MessageWindowChatMemoryTest implements WithAssertions {
             chatMemory.set(userMessage("world"), aiMessage("hi"));
         });
         assertThat(counts).isEqualTo(new HitCounts(0, 1, 0));
+    }
+
+    @Test
+    void set_with_varargs_should_not_throw_when_eviction_is_needed() {
+
+        // given
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(2);
+
+        // when-then: must not throw UnsupportedOperationException (Arrays.asList is fixed-size)
+        chatMemory.set(userMessage("m1"), userMessage("m2"), userMessage("m3"));
+
+        assertThat(chatMemory.messages()).containsExactly(userMessage("m2"), userMessage("m3"));
+    }
+
+    @Test
+    void set_with_list_should_not_mutate_or_alias_the_caller_provided_list() {
+
+        // given
+        ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(2);
+        List<dev.langchain4j.data.message.ChatMessage> callerList =
+                new ArrayList<>(Arrays.asList(userMessage("a1"), userMessage("a2"), userMessage("a3")));
+
+        // when
+        chatMemory.set(callerList);
+
+        // then: the caller's list must remain untouched
+        assertThat(callerList).containsExactly(userMessage("a1"), userMessage("a2"), userMessage("a3"));
+        assertThat(chatMemory.messages()).containsExactly(userMessage("a2"), userMessage("a3"));
+
+        // and further mutation of the caller's list must not affect stored memory
+        callerList.add(userMessage("a4-injected"));
+        assertThat(chatMemory.messages()).containsExactly(userMessage("a2"), userMessage("a3"));
     }
 }

--- a/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/memory/chat/TokenWindowChatMemoryTest.java
@@ -19,6 +19,9 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.model.openai.OpenAiChatModelName;
 import dev.langchain4j.model.openai.OpenAiTokenCountEstimator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
@@ -839,5 +842,42 @@ class TokenWindowChatMemoryTest implements WithAssertions {
             chatMemory.set(userMessage("world"), aiMessage("hi"));
         });
         assertThat(counts).isEqualTo(new HitCountChatMemoryStore.HitCounts(0, 1, 0));
+    }
+
+    @Test
+    void set_with_varargs_should_not_throw_when_eviction_is_needed() {
+
+        // given
+        ChatMemory chatMemory = TokenWindowChatMemory.withMaxTokens(25, TOKEN_COUNT_ESTIMATOR);
+        UserMessage m1 = userMessageWithTokens(10);
+        UserMessage m2 = userMessageWithTokens(10);
+        UserMessage m3 = userMessageWithTokens(10);
+
+        // when-then: must not throw UnsupportedOperationException (Arrays.asList is fixed-size)
+        chatMemory.set(m1, m2, m3);
+
+        assertThat(chatMemory.messages()).containsExactly(m2, m3);
+    }
+
+    @Test
+    void set_with_list_should_not_mutate_or_alias_the_caller_provided_list() {
+
+        // given
+        ChatMemory chatMemory = TokenWindowChatMemory.withMaxTokens(25, TOKEN_COUNT_ESTIMATOR);
+        UserMessage m1 = userMessageWithTokens(10);
+        UserMessage m2 = userMessageWithTokens(10);
+        UserMessage m3 = userMessageWithTokens(10);
+        List<ChatMessage> callerList = new ArrayList<>(Arrays.asList(m1, m2, m3));
+
+        // when
+        chatMemory.set(callerList);
+
+        // then: the caller's list must remain untouched
+        assertThat(callerList).containsExactly(m1, m2, m3);
+        assertThat(chatMemory.messages()).containsExactly(m2, m3);
+
+        // and further mutation of the caller's list must not affect stored memory
+        callerList.add(userMessageWithTokens(10));
+        assertThat(chatMemory.messages()).containsExactly(m2, m3);
     }
 }


### PR DESCRIPTION
## Issue
Closes #5713

## Change

`MessageWindowChatMemory.set(List<ChatMessage>)` and `TokenWindowChatMemory.set(List<ChatMessage>)` called `ensureCapacity(messages, ...)` directly on the caller-supplied list. When eviction is actually needed (the input has more messages/tokens than the configured max), `ensureCapacity` calls `messages.remove(...)` on that same list, causing two problems:

1. `ChatMemory.set(ChatMessage...)` (the varargs default in the `ChatMemory` interface) wraps the array with `Arrays.asList(...)`, a fixed-size list. `remove()` on it throws `UnsupportedOperationException`, so `memory.set(m1, m2, m3)` crashed whenever eviction was needed — exactly the case `set(...)` exists to handle.
2. `ChatMemory.set(List<ChatMessage>)` with an ordinary mutable list didn't throw, but mutated the caller's list in place and then stored it **by reference** (`SingleSlotChatMemoryStore`/`InMemoryChatMemoryStore` both store the list as-is, without copying). So the caller's list was silently mutated, and any further mutation the caller made to that same list object afterwards silently corrupted the stored chat memory.

This PR adds a defensive copy (`new ArrayList<>(messages)`) at the top of the private `set(List)` in both classes, before `ensureCapacity` is called.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Test plan
- Added `set_with_varargs_should_not_throw_when_eviction_is_needed` and `set_with_list_should_not_mutate_or_alias_the_caller_provided_list` to both `MessageWindowChatMemoryTest` and `TokenWindowChatMemoryTest`.
- Verified all four new tests fail without the fix: varargs cases throw `UnsupportedOperationException` at `ensureCapacity(...)`, list cases show the caller's list mutated/aliased.
- Verified all four pass with the fix applied.
- Ran the full `langchain4j` (1258 tests) and `langchain4j-core` (1131 tests) suites — all green.
- Ran `./mvnw spotless:check` on both modules — clean.