### PR TITLE
fix: align IsIn/IsNotIn numeric comparison with IsEqualTo/IsNotEqualTo

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/NumberComparator.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/filter/comparison/NumberComparator.java
@@ -1,7 +1,6 @@
 package dev.langchain4j.store.embedding.filter.comparison;
 
 import dev.langchain4j.Internal;
-
 import java.math.BigDecimal;
 import java.util.Collection;
 
@@ -13,24 +12,10 @@ class NumberComparator {
     }
 
     static boolean containsAsBigDecimals(Object actualNumber, Collection<?> comparisonNumbers) {
-        BigDecimal actualNumberAsBigDecimal = toBigDecimal(actualNumber);
+        BigDecimal actualNumberAsBigDecimal = new BigDecimal(actualNumber.toString());
         return comparisonNumbers.stream()
-                .map(NumberComparator::toBigDecimal)
+                .map(comparisonNumber -> new BigDecimal(comparisonNumber.toString()))
                 .anyMatch(comparisonNumberAsBigDecimal ->
                         comparisonNumberAsBigDecimal.compareTo(actualNumberAsBigDecimal) == 0);
-    }
-
-    private static BigDecimal toBigDecimal(Object actualNumber) {
-        if (actualNumber instanceof Integer integer) {
-            return BigDecimal.valueOf(integer);
-        } else if (actualNumber instanceof Long long1) {
-            return BigDecimal.valueOf(long1);
-        } else if (actualNumber instanceof Float float1) {
-            return BigDecimal.valueOf(float1);
-        } else if (actualNumber instanceof Double double1) {
-            return BigDecimal.valueOf(double1);
-        }
-
-        throw new IllegalArgumentException("Unsupported type: " + actualNumber.getClass().getName());
     }
 }

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsInTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsInTest.java
@@ -1,0 +1,83 @@
+package dev.langchain4j.store.embedding.filter.comparison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import dev.langchain4j.data.document.Metadata;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class IsInTest {
+
+    @Test
+    void shouldReturnFalseWhenNotMetadata() {
+        IsIn isIn = new IsIn("key", List.of("value"));
+        assertThat(isIn.test("notMetadata")).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenKeyNotFound() {
+        IsIn isIn = new IsIn("key", List.of("value"));
+        Metadata metadata = new Metadata(Map.of());
+        assertThat(isIn.test(metadata)).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenValueIsInCollection() {
+        IsIn isIn = new IsIn("key", List.of("value1", "value2"));
+        Metadata metadata = new Metadata(Map.of("key", "value2"));
+        assertThat(isIn.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenValueIsNotInCollection() {
+        IsIn isIn = new IsIn("key", List.of("value1", "value2"));
+        Metadata metadata = new Metadata(Map.of("key", "value3"));
+        assertThat(isIn.test(metadata)).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenActualValueIsUUIDAsString() {
+        UUID uuid = UUID.randomUUID();
+        IsIn isIn = new IsIn("key", List.of(uuid));
+        Metadata metadata = new Metadata(Map.of("key", uuid.toString()));
+        assertThat(isIn.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenComparingDifferentNumberTypes() {
+        IsIn isIn = new IsIn("key", List.of(1L));
+        Metadata metadata = new Metadata(Map.of("key", 1));
+        assertThat(isIn.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldBeConsistentWithIsEqualToForFloatMetadata() {
+        // given: a Float metadata value and a Double comparison value that are numerically equal
+        IsEqualTo isEqualTo = new IsEqualTo("key", 1.1);
+        IsIn isIn = new IsIn("key", List.of(1.1));
+        Metadata metadata = new Metadata(Map.of("key", 1.1f));
+
+        // then: isIn(x) must match whenever isEqualTo(x) matches
+        assertThat(isEqualTo.test(metadata)).isTrue();
+        assertThat(isIn.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenTestingNullObject() {
+        IsIn isIn = new IsIn("key", List.of("value"));
+        assertThat(isIn.test(null)).isFalse();
+    }
+
+    @Test
+    void shouldThrowExceptionWhenComparisonValuesIsNull() {
+        assertThatThrownBy(() -> new IsIn("key", null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenComparisonValuesIsEmpty() {
+        assertThatThrownBy(() -> new IsIn("key", List.of())).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsNotInTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/store/embedding/filter/comparison/IsNotInTest.java
@@ -1,0 +1,65 @@
+package dev.langchain4j.store.embedding.filter.comparison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import dev.langchain4j.data.document.Metadata;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class IsNotInTest {
+
+    @Test
+    void shouldReturnFalseWhenNotMetadata() {
+        IsNotIn isNotIn = new IsNotIn("key", List.of("value"));
+        assertThat(isNotIn.test("notMetadata")).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenKeyNotFound() {
+        IsNotIn isNotIn = new IsNotIn("key", List.of("value"));
+        Metadata metadata = new Metadata(Map.of());
+        assertThat(isNotIn.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenValueIsInCollection() {
+        IsNotIn isNotIn = new IsNotIn("key", List.of("value1", "value2"));
+        Metadata metadata = new Metadata(Map.of("key", "value2"));
+        assertThat(isNotIn.test(metadata)).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenValueIsNotInCollection() {
+        IsNotIn isNotIn = new IsNotIn("key", List.of("value1", "value2"));
+        Metadata metadata = new Metadata(Map.of("key", "value3"));
+        assertThat(isNotIn.test(metadata)).isTrue();
+    }
+
+    @Test
+    void shouldBeConsistentWithIsNotEqualToForFloatMetadata() {
+        // given: a Float metadata value and a Double comparison value that are numerically equal
+        IsNotIn isNotIn = new IsNotIn("key", List.of(1.1));
+        Metadata metadata = new Metadata(Map.of("key", 1.1f));
+
+        // then: since isEqualTo(1.1) matches this metadata, isNotIn(1.1) must not match
+        assertThat(isNotIn.test(metadata)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenTestingNullObject() {
+        IsNotIn isNotIn = new IsNotIn("key", List.of("value"));
+        assertThat(isNotIn.test(null)).isFalse();
+    }
+
+    @Test
+    void shouldThrowExceptionWhenComparisonValuesIsNull() {
+        assertThatThrownBy(() -> new IsNotIn("key", null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenComparisonValuesIsEmpty() {
+        assertThatThrownBy(() -> new IsNotIn("key", List.of())).isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5716

## Change

`IsIn`/`IsNotIn` filters used a different numeric-conversion path than `IsEqualTo`/`IsNotEqualTo`, causing the same metadata value to be matched inconsistently between them:

- `IsEqualTo`/`IsNotEqualTo` → `NumberComparator.compareAsBigDecimals` → `new BigDecimal(value.toString())`.
- `IsIn`/`IsNotIn` → `NumberComparator.containsAsBigDecimals` → a private `toBigDecimal` helper using `BigDecimal.valueOf(floatValue)`, which implicitly widens `float` to `double` first, introducing floating-point representation error (e.g. `1.1f` becomes `1.100000023841858` instead of `1.1`).

So `isEqualTo(1.1)` could match a `Float` metadata value that `isIn(List.of(1.1))` did not match on the exact same data.

This PR makes `containsAsBigDecimals` use the same `new BigDecimal(value.toString())` conversion as `compareAsBigDecimals`, for both the actual value and every comparison value. This also removes the narrow `Integer`/`Long`/`Float`/`Double` type whitelist in `toBigDecimal` (which threw `IllegalArgumentException` for other `Number` subtypes), aligning `IsIn`/`IsNotIn` with `IsEqualTo`'s more permissive `Number`-based handling.

## General checklist
- [X] There are no breaking changes (API, behaviour) — this only fixes an inconsistency; the corrected result matches what `IsEqualTo`/`IsNotEqualTo` already produced
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Test plan
- Added `IsInTest` and `IsNotInTest` (previously no dedicated test classes existed for these filters), covering the existing documented behavior plus a `shouldBeConsistentWithIsEqualToForFloatMetadata` / `shouldBeConsistentWithIsNotEqualToForFloatMetadata` regression test each.
- Verified both consistency tests fail without the fix (`Expecting value to be true but was false` / `Expecting value to be false but was true`) and pass with it applied; all other pre-existing filter tests were unaffected.
- Ran the full `langchain4j-core` suite (1149 tests) — all green.
- Ran `./mvnw spotless:apply`/`spotless:check` — clean.