### PR TITLE
Mask secrets in builder toString() to prevent leaking API keys and passwords

### DIFF
--- a/langchain4j-hibernate/src/main/java/dev/langchain4j/store/embedding/hibernate/HibernateEmbeddingStore.java
+++ b/langchain4j-hibernate/src/main/java/dev/langchain4j/store/embedding/hibernate/HibernateEmbeddingStore.java
@@ -434,9 +434,9 @@ public class HibernateEmbeddingStore<E> implements EmbeddingStore<TextSegment> {
             try {
                 sessionFactory
                         .getSchemaManager()
-                        .truncateTable(entityPersister.getIdentifierTableMapping().getTableName());
-            }
-            catch (UnsupportedOperationException ex) {
+                        .truncateTable(
+                                entityPersister.getIdentifierTableMapping().getTableName());
+            } catch (UnsupportedOperationException ex) {
                 // Workaround HHH-20500 since we can't reliably detect the Hibernate ORM version
                 sessionFactory.inStatelessTransaction(session -> {
                     session.createMutationQuery("delete from " + entityPersister.getEntityName())
@@ -1781,7 +1781,7 @@ public class HibernateEmbeddingStore<E> implements EmbeddingStore<TextSegment> {
             return "HibernateEmbeddingStore.DynamicBuilder(jdbcUrl=" + this.jdbcUrl
                     + ", databaseKind=" + this.databaseKind
                     + ", user=" + this.user
-                    + ", password=" + this.password
+                    + ", password=" + (this.password == null ? null : "********")
                     + ", table=" + this.table
                     + ", dimension=" + this.dimension
                     + ", createIndex=" + this.createIndex

--- a/langchain4j-nomic/src/main/java/dev/langchain4j/model/nomic/NomicClient.java
+++ b/langchain4j-nomic/src/main/java/dev/langchain4j/model/nomic/NomicClient.java
@@ -1,20 +1,19 @@
 package dev.langchain4j.model.nomic;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import dev.langchain4j.internal.Utils;
+import java.io.IOException;
+import java.time.Duration;
 import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
-
-import java.io.IOException;
-import java.time.Duration;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 
 class NomicClient {
 
@@ -27,7 +26,8 @@ class NomicClient {
     private final NomicApi nomicApi;
     private final String authorizationHeader;
 
-    NomicClient(String baseUrl, String apiKey, Duration timeout, Boolean logRequests, Boolean logResponses, Logger logger) {
+    NomicClient(
+            String baseUrl, String apiKey, Duration timeout, Boolean logRequests, Boolean logResponses, Logger logger) {
 
         OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
                 .callTimeout(timeout)
@@ -58,8 +58,8 @@ class NomicClient {
 
     public EmbeddingResponse embed(EmbeddingRequest request) {
         try {
-            retrofit2.Response<EmbeddingResponse> retrofitResponse
-                    = nomicApi.embed(request, authorizationHeader).execute();
+            retrofit2.Response<EmbeddingResponse> retrofitResponse =
+                    nomicApi.embed(request, authorizationHeader).execute();
 
             if (retrofitResponse.isSuccessful()) {
                 return retrofitResponse.body();
@@ -86,8 +86,7 @@ class NomicClient {
         private Boolean logResponses;
         private Logger logger;
 
-        NomicClientBuilder() {
-        }
+        NomicClientBuilder() {}
 
         public NomicClientBuilder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
@@ -120,11 +119,14 @@ class NomicClient {
         }
 
         public NomicClient build() {
-            return new NomicClient(this.baseUrl, this.apiKey, this.timeout, this.logRequests, this.logResponses, this.logger);
+            return new NomicClient(
+                    this.baseUrl, this.apiKey, this.timeout, this.logRequests, this.logResponses, this.logger);
         }
 
         public String toString() {
-            return "NomicClient.NomicClientBuilder(baseUrl=" + this.baseUrl + ", apiKey=" + this.apiKey + ", timeout=" + this.timeout + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
+            return "NomicClient.NomicClientBuilder(baseUrl=" + this.baseUrl + ", apiKey="
+                    + (this.apiKey == null ? null : "********") + ", timeout=" + this.timeout + ", logRequests="
+                    + this.logRequests + ", logResponses=" + this.logResponses + ")";
         }
     }
 }

--- a/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStore.java
+++ b/langchain4j-pgvector/src/main/java/dev/langchain4j/store/embedding/pgvector/PgVectorEmbeddingStore.java
@@ -897,7 +897,8 @@ public class PgVectorEmbeddingStore implements EmbeddingStore<TextSegment> {
 
         public String toString() {
             return "PgVectorEmbeddingStore.PgVectorEmbeddingStoreBuilder(host=" + this.host + ", port=" + this.port
-                    + ", user=" + this.user + ", password=" + this.password + ", database=" + this.database + ", table="
+                    + ", user=" + this.user + ", password=" + (this.password == null ? null : "********")
+                    + ", database=" + this.database + ", table="
                     + this.table + ", dimension=" + this.dimension + ", useIndex=" + this.useIndex + ", indexListSize="
                     + this.indexListSize + ", createTable=" + this.createTable + ", dropTableFirst="
                     + this.dropTableFirst + ", skipCreateVectorExtension=" + this.skipCreateVectorExtension

--- a/langchain4j-weaviate/src/main/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStore.java
+++ b/langchain4j-weaviate/src/main/java/dev/langchain4j/store/embedding/weaviate/WeaviateEmbeddingStore.java
@@ -543,7 +543,8 @@ public class WeaviateEmbeddingStore implements EmbeddingStore<TextSegment> {
         }
 
         public String toString() {
-            return "WeaviateEmbeddingStore.WeaviateEmbeddingStoreBuilder(apiKey=" + this.apiKey + ", scheme="
+            return "WeaviateEmbeddingStore.WeaviateEmbeddingStoreBuilder(apiKey="
+                    + (this.apiKey == null ? null : "********") + ", scheme="
                     + this.scheme + ", host=" + this.host + ", port=" + this.port + ", useGrpcForInserts="
                     + this.useGrpcForInserts + ", securedGrpc=" + this.securedGrpc + ", grpcPort=" + this.grpcPort
                     + ", objectClass=" + this.objectClass + ", avoidDups=" + this.avoidDups + ", consistencyLevel="

--- a/web-search-engines/langchain4j-web-search-engine-google-custom/src/main/java/dev/langchain4j/web/search/google/customsearch/GoogleCustomSearchApiClient.java
+++ b/web-search-engines/langchain4j-web-search-engine-google-custom/src/main/java/dev/langchain4j/web/search/google/customsearch/GoogleCustomSearchApiClient.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.web.search.google.customsearch;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestInitializer;
@@ -7,15 +10,11 @@ import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.customsearch.v1.CustomSearchAPI;
 import com.google.api.services.customsearch.v1.CustomSearchAPIRequest;
 import com.google.api.services.customsearch.v1.model.Search;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class GoogleCustomSearchApiClient {
 
@@ -25,50 +24,70 @@ class GoogleCustomSearchApiClient {
     private final CustomSearchAPIRequest<Search> customSearchRequest;
     private final boolean logResponses;
 
-    GoogleCustomSearchApiClient(String apiKey,
-                                String csi,
-                                Boolean siteRestrict,
-                                Duration timeout,
-                                Integer maxRetries,
-                                boolean logRequests,
-                                boolean logResponses) {
+    GoogleCustomSearchApiClient(
+            String apiKey,
+            String csi,
+            Boolean siteRestrict,
+            Duration timeout,
+            Integer maxRetries,
+            boolean logRequests,
+            boolean logResponses) {
 
         try {
-            ensureNotBlank(apiKey, "%s", "Google Custom Search API Key must be defined. " +
-                    "It can be generated here: https://console.developers.google.com/apis/credentials");
-            ensureNotBlank(csi, "%s", "Google Custom Search Engine ID must be defined. " +
-                    "It can be created here: https://cse.google.com/cse/create/new");
+            ensureNotBlank(
+                    apiKey,
+                    "%s",
+                    "Google Custom Search API Key must be defined. "
+                            + "It can be generated here: https://console.developers.google.com/apis/credentials");
+            ensureNotBlank(
+                    csi,
+                    "%s",
+                    "Google Custom Search Engine ID must be defined. "
+                            + "It can be created here: https://cse.google.com/cse/create/new");
 
             this.logResponses = logResponses;
 
-            CustomSearchAPI.Builder customSearchAPIBuilder = new CustomSearchAPI.Builder(GoogleNetHttpTransport.newTrustedTransport(), new GsonFactory(), new HttpRequestInitializer() {
-                @Override
-                public void initialize(HttpRequest httpRequest) {
-                    httpRequest.setConnectTimeout(Math.toIntExact(timeout.toMillis()));
-                    httpRequest.setReadTimeout(Math.toIntExact(timeout.toMillis()));
-                    httpRequest.setWriteTimeout(Math.toIntExact(timeout.toMillis()));
-                    httpRequest.setNumberOfRetries(maxRetries);
-                    if (logRequests) {
-                        httpRequest.setInterceptor(new GoogleSearchApiHttpRequestLoggingInterceptor());
-                    }
-                    if (logResponses) {
-                        httpRequest.setResponseInterceptor(new GoogleSearchApiHttpResponseLoggingInterceptor());
-                    }
-                }
-            }).setApplicationName("LangChain4j");
+            CustomSearchAPI.Builder customSearchAPIBuilder = new CustomSearchAPI.Builder(
+                            GoogleNetHttpTransport.newTrustedTransport(),
+                            new GsonFactory(),
+                            new HttpRequestInitializer() {
+                                @Override
+                                public void initialize(HttpRequest httpRequest) {
+                                    httpRequest.setConnectTimeout(Math.toIntExact(timeout.toMillis()));
+                                    httpRequest.setReadTimeout(Math.toIntExact(timeout.toMillis()));
+                                    httpRequest.setWriteTimeout(Math.toIntExact(timeout.toMillis()));
+                                    httpRequest.setNumberOfRetries(maxRetries);
+                                    if (logRequests) {
+                                        httpRequest.setInterceptor(new GoogleSearchApiHttpRequestLoggingInterceptor());
+                                    }
+                                    if (logResponses) {
+                                        httpRequest.setResponseInterceptor(
+                                                new GoogleSearchApiHttpResponseLoggingInterceptor());
+                                    }
+                                }
+                            })
+                    .setApplicationName("LangChain4j");
 
             CustomSearchAPI customSearchAPI = customSearchAPIBuilder.build();
 
             if (siteRestrict) {
-                customSearchRequest = customSearchAPI.cse().siterestrict().list().setKey(apiKey).setCx(csi);
+                customSearchRequest = customSearchAPI
+                        .cse()
+                        .siterestrict()
+                        .list()
+                        .setKey(apiKey)
+                        .setCx(csi);
             } else {
-                customSearchRequest = customSearchAPI.cse().list().setKey(apiKey).setCx(csi);
+                customSearchRequest =
+                        customSearchAPI.cse().list().setKey(apiKey).setCx(csi);
             }
         } catch (IOException e) {
             LOGGER.error("Error occurred while creating Google Custom Search API client", e);
             throw new RuntimeException(e);
         } catch (GeneralSecurityException e) {
-            LOGGER.error("Error occurred while creating Google Custom Search API client using GoogleNetHttpTransport.newTrustedTransport()", e);
+            LOGGER.error(
+                    "Error occurred while creating Google Custom Search API client using GoogleNetHttpTransport.newTrustedTransport()",
+                    e);
             throw new RuntimeException(e);
         }
     }
@@ -111,9 +130,9 @@ class GoogleCustomSearchApiClient {
                         .setCr(requestQuery.getCr())
                         .setGooglehost(requestQuery.getGoogleHost())
                         .setStart(calculateIndexStartPage(
-                                getDefaultNaturalNumber(requestQuery.getStartPage()),
-                                getDefaultNaturalNumber(requestQuery.getStartIndex())
-                        ).longValue())
+                                        getDefaultNaturalNumber(requestQuery.getStartPage()),
+                                        getDefaultNaturalNumber(requestQuery.getStartIndex()))
+                                .longValue())
                         .setFilter(requestQuery.getFilter())
                         .execute();
             } else if (customSearchRequest instanceof CustomSearchAPI.Cse.List) {
@@ -147,9 +166,9 @@ class GoogleCustomSearchApiClient {
                         .setCr(requestQuery.getCr())
                         .setGooglehost(requestQuery.getGoogleHost())
                         .setStart(calculateIndexStartPage(
-                                getDefaultNaturalNumber(requestQuery.getStartPage()),
-                                getDefaultNaturalNumber(requestQuery.getStartIndex())
-                        ).longValue())
+                                        getDefaultNaturalNumber(requestQuery.getStartPage()),
+                                        getDefaultNaturalNumber(requestQuery.getStartIndex()))
+                                .longValue())
                         .setFilter(requestQuery.getFilter())
                         .execute();
             } else {
@@ -195,8 +214,7 @@ class GoogleCustomSearchApiClient {
         private boolean logRequests;
         private boolean logResponses;
 
-        GoogleCustomSearchApiClientBuilder() {
-        }
+        GoogleCustomSearchApiClientBuilder() {}
 
         public GoogleCustomSearchApiClientBuilder apiKey(String apiKey) {
             this.apiKey = apiKey;
@@ -234,11 +252,21 @@ class GoogleCustomSearchApiClient {
         }
 
         public GoogleCustomSearchApiClient build() {
-            return new GoogleCustomSearchApiClient(this.apiKey, this.csi, this.siteRestrict, this.timeout, this.maxRetries, this.logRequests, this.logResponses);
+            return new GoogleCustomSearchApiClient(
+                    this.apiKey,
+                    this.csi,
+                    this.siteRestrict,
+                    this.timeout,
+                    this.maxRetries,
+                    this.logRequests,
+                    this.logResponses);
         }
 
         public String toString() {
-            return "GoogleCustomSearchApiClient.GoogleCustomSearchApiClientBuilder(apiKey=" + this.apiKey + ", csi=" + this.csi + ", siteRestrict=" + this.siteRestrict + ", timeout=" + this.timeout + ", maxRetries=" + this.maxRetries + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
+            return "GoogleCustomSearchApiClient.GoogleCustomSearchApiClientBuilder(apiKey="
+                    + (this.apiKey == null ? null : "********") + ", csi=" + this.csi + ", siteRestrict="
+                    + this.siteRestrict + ", timeout=" + this.timeout + ", maxRetries=" + this.maxRetries
+                    + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
         }
     }
 }

--- a/web-search-engines/langchain4j-web-search-engine-google-custom/src/main/java/dev/langchain4j/web/search/google/customsearch/GoogleCustomWebSearchEngine.java
+++ b/web-search-engines/langchain4j-web-search-engine-google-custom/src/main/java/dev/langchain4j/web/search/google/customsearch/GoogleCustomWebSearchEngine.java
@@ -385,7 +385,8 @@ public class GoogleCustomWebSearchEngine implements WebSearchEngine {
         }
 
         public String toString() {
-            return "GoogleCustomWebSearchEngine.GoogleCustomWebSearchEngineBuilder(apiKey=" + this.apiKey + ", csi="
+            return "GoogleCustomWebSearchEngine.GoogleCustomWebSearchEngineBuilder(apiKey="
+                    + (this.apiKey == null ? null : "********") + ", csi="
                     + this.csi + ", siteRestrict=" + this.siteRestrict + ", includeImages=" + this.includeImages
                     + ", timeout=" + this.timeout + ", maxRetries=" + this.maxRetries + ", logRequests="
                     + this.logRequests + ", logResponses=" + this.logResponses + ")";

--- a/web-search-engines/langchain4j-web-search-engine-searchapi/src/main/java/dev/langchain4j/web/search/searchapi/SearchApiWebSearchEngine.java
+++ b/web-search-engines/langchain4j-web-search-engine-searchapi/src/main/java/dev/langchain4j/web/search/searchapi/SearchApiWebSearchEngine.java
@@ -169,7 +169,8 @@ public class SearchApiWebSearchEngine implements WebSearchEngine {
         }
 
         public String toString() {
-            return "SearchApiWebSearchEngine.SearchApiWebSearchEngineBuilder(apiKey=" + this.apiKey + ", baseUrl="
+            return "SearchApiWebSearchEngine.SearchApiWebSearchEngineBuilder(apiKey="
+                    + (this.apiKey == null ? null : "********") + ", baseUrl="
                     + this.baseUrl + ", timeout=" + this.timeout + ", engine=" + this.engine + ", optionalParameters="
                     + this.optionalParameters + ")";
         }

--- a/web-search-engines/langchain4j-web-search-engine-searchapi/src/main/java/dev/langchain4j/web/search/searchapi/SearchApiWebSearchRequest.java
+++ b/web-search-engines/langchain4j-web-search-engine-searchapi/src/main/java/dev/langchain4j/web/search/searchapi/SearchApiWebSearchRequest.java
@@ -13,11 +13,12 @@ class SearchApiWebSearchRequest {
     /**
      * @param additionalRequestParameters overrides optionalParameters for matching keys
      */
-    SearchApiWebSearchRequest(String engine,
-                              String apiKey,
-                              String query,
-                              Map<String, Object> optionalParameters,
-                              Map<String, Object> additionalRequestParameters) {
+    SearchApiWebSearchRequest(
+            String engine,
+            String apiKey,
+            String query,
+            Map<String, Object> optionalParameters,
+            Map<String, Object> additionalRequestParameters) {
         this.engine = engine;
         this.apiKey = apiKey;
         this.query = query;
@@ -54,8 +55,7 @@ class SearchApiWebSearchRequest {
         private Map<String, Object> optionalParameters;
         private Map<String, Object> additionalRequestParameters;
 
-        SearchApiWebSearchRequestBuilder() {
-        }
+        SearchApiWebSearchRequestBuilder() {}
 
         public SearchApiWebSearchRequestBuilder engine(String engine) {
             this.engine = engine;
@@ -77,17 +77,22 @@ class SearchApiWebSearchRequest {
             return this;
         }
 
-        public SearchApiWebSearchRequestBuilder additionalRequestParameters(Map<String, Object> additionalRequestParameters) {
+        public SearchApiWebSearchRequestBuilder additionalRequestParameters(
+                Map<String, Object> additionalRequestParameters) {
             this.additionalRequestParameters = additionalRequestParameters;
             return this;
         }
 
         public SearchApiWebSearchRequest build() {
-            return new SearchApiWebSearchRequest(this.engine, this.apiKey, this.query, this.optionalParameters, this.additionalRequestParameters);
+            return new SearchApiWebSearchRequest(
+                    this.engine, this.apiKey, this.query, this.optionalParameters, this.additionalRequestParameters);
         }
 
         public String toString() {
-            return "SearchApiWebSearchRequest.SearchApiWebSearchRequestBuilder(engine=" + this.engine + ", apiKey=" + this.apiKey + ", query=" + this.query + ", optionalParameters=" + this.optionalParameters + ", additionalRequestParameters=" + this.additionalRequestParameters + ")";
+            return "SearchApiWebSearchRequest.SearchApiWebSearchRequestBuilder(engine=" + this.engine + ", apiKey="
+                    + (this.apiKey == null ? null : "********") + ", query=" + this.query + ", optionalParameters="
+                    + this.optionalParameters + ", additionalRequestParameters=" + this.additionalRequestParameters
+                    + ")";
         }
     }
 }

--- a/web-search-engines/langchain4j-web-search-engine-tavily/src/main/java/dev/langchain4j/web/search/tavily/TavilySearchRequest.java
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/src/main/java/dev/langchain4j/web/search/tavily/TavilySearchRequest.java
@@ -13,7 +13,15 @@ class TavilySearchRequest {
     private List<String> includeDomains;
     private List<String> excludeDomains;
 
-    TavilySearchRequest(String apiKey, String query, String searchDepth, Boolean includeAnswer, Boolean includeRawContent, Integer maxResults, List<String> includeDomains, List<String> excludeDomains) {
+    TavilySearchRequest(
+            String apiKey,
+            String query,
+            String searchDepth,
+            Boolean includeAnswer,
+            Boolean includeRawContent,
+            Integer maxResults,
+            List<String> includeDomains,
+            List<String> excludeDomains) {
         this.apiKey = apiKey;
         this.query = query;
         this.searchDepth = searchDepth;
@@ -70,8 +78,7 @@ class TavilySearchRequest {
         private List<String> includeDomains;
         private List<String> excludeDomains;
 
-        TavilySearchRequestBuilder() {
-        }
+        TavilySearchRequestBuilder() {}
 
         public TavilySearchRequestBuilder apiKey(String apiKey) {
             this.apiKey = apiKey;
@@ -114,11 +121,23 @@ class TavilySearchRequest {
         }
 
         public TavilySearchRequest build() {
-            return new TavilySearchRequest(this.apiKey, this.query, this.searchDepth, this.includeAnswer, this.includeRawContent, this.maxResults, this.includeDomains, this.excludeDomains);
+            return new TavilySearchRequest(
+                    this.apiKey,
+                    this.query,
+                    this.searchDepth,
+                    this.includeAnswer,
+                    this.includeRawContent,
+                    this.maxResults,
+                    this.includeDomains,
+                    this.excludeDomains);
         }
 
         public String toString() {
-            return "TavilySearchRequest.TavilySearchRequestBuilder(apiKey=" + this.apiKey + ", query=" + this.query + ", searchDepth=" + this.searchDepth + ", includeAnswer=" + this.includeAnswer + ", includeRawContent=" + this.includeRawContent + ", maxResults=" + this.maxResults + ", includeDomains=" + this.includeDomains + ", excludeDomains=" + this.excludeDomains + ")";
+            return "TavilySearchRequest.TavilySearchRequestBuilder(apiKey=" + (this.apiKey == null ? null : "********")
+                    + ", query=" + this.query + ", searchDepth=" + this.searchDepth + ", includeAnswer="
+                    + this.includeAnswer + ", includeRawContent=" + this.includeRawContent + ", maxResults="
+                    + this.maxResults + ", includeDomains=" + this.includeDomains + ", excludeDomains="
+                    + this.excludeDomains + ")";
         }
     }
 }


### PR DESCRIPTION
## Problem

Several builder `toString()` implementations render sensitive fields in plain text, so any log line, exception message, or debug output that includes one of these builders leaks the credential.

**API keys**
- `NomicClient`
- `WeaviateEmbeddingStore`
- `SearchApiWebSearchEngine`, `SearchApiWebSearchRequest`
- `TavilySearchRequest`
- `GoogleCustomWebSearchEngine`, `GoogleCustomSearchApiClient`

**Database passwords**
- `PgVectorEmbeddingStore`
- `HibernateEmbeddingStore`

Example:

```java
String s = WeaviateEmbeddingStore.builder().apiKey("my-secret-key").toString();
// -> "WeaviateEmbeddingStore.WeaviateEmbeddingStoreBuilder(apiKey=my-secret-key, scheme=...)"
```

This is the same class of issue reported for Cohere in #5702, and `JinaEmbeddingModel` already guards against it.

## Fix

Apply the masking pattern already used by `JinaEmbeddingModel`: render `********` instead of the raw value, while still showing `null` for debuggability.

```java
", apiKey=" + (this.apiKey == null ? null : "********")
```

Only `toString()` output changes — no public API or behavioral changes.