### PR TITLE
Follow up on AgentsRegistry implementation

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/AgentsRegistry.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/planner/AgentsRegistry.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.agentic.planner;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +88,7 @@ public interface AgentsRegistry {
 
         @Override
         public Map<String, AgentInstance> allAgents() {
-            return mergedAgents;
+            return Collections.unmodifiableMap(mergedAgents);
         }
 
         @Override

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/AgentsRegistryIT.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/AgentsRegistryIT.java
@@ -71,11 +71,13 @@ class AgentsRegistryIT {
 
         originalClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(registryClassLoader);
+        AgentsRegistry.refresh();
     }
 
     @AfterAll
     static void tearDown() throws Exception {
         Thread.currentThread().setContextClassLoader(originalClassLoader);
+        AgentsRegistry.refresh();
         registryClassLoader.close();
         deleteRecursively(tempDir);
     }


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
<!-- Please specify the ID of the issue this PR is addressing. For example: "Closes #1234" or "Fixes #1234" -->
Follow-up to #5653 addressing review feedback on AgentsRegistry.

## Change

  CompositeAgentsRegistry.allAgents() returns an unmodifiable map
  The interface javadoc promises "an unmodifiable map of agent names to AgentInstances" and EmptyAgentsRegistry honors this with Map.of(), but CompositeAgentsRegistry was returning the internal HashMap directly. Callers could
  put()/clear() and silently corrupt the shared registry. Now wrapped with Collections.unmodifiableMap().

  AgentsRegistryIT calls refresh() after classloader swap
  The integration test was setting the context classloader but not calling AgentsRegistry.refresh(), so it only worked if no prior code in the JVM had triggered AgentsRegistry.get(). If any earlier test initialized the holder
  (e.g. AgentsRegistryTest leaving it as the empty registry), the IT would see a stale empty registry. Added refresh() in both @BeforeAll and @AfterAll.

  Evaluated but not changed

  Static initializer poisoning (LazyHolder.INSTANCE = discover())
  The reviewer noted that if discover() throws during the static field initializer (e.g. duplicate agent names), the holder class is permanently poisoned with ExceptionInInitializerError, and every subsequent get()/refresh()
  throws NoClassDefFoundError. Moving discovery out of the static initializer was considered, but the only alternatives either break thread safety (multiple threads calling discover() concurrently on first access) or require
  explicit synchronization (double-checked locking), which adds complexity disproportionate to the risk. The poisoning scenario only occurs with a misconfigured SPI provider, which is a deployment-time error rather than a
  runtime race. The holder idiom's thread safety guarantee via the JVM class loading mechanism was preserved as-is.

  Registry override via builder (.registry(myOwnRegistry))
  Allowing builders to accept an explicit registry instead of relying solely on SPI was acknowledged as a good idea but deferred to a follow-up PR to keep this change scoped.

  @RegistryAgent ignoring @V parameters / exception types / package placement
  These were flagged as minor/non-blocking in the review and are not addressed here.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
