### PR TITLE
fix: avoid IllegalArgumentException in RetryPolicy jitter when bound is 0

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/RetryUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/RetryUtils.java
@@ -156,7 +156,15 @@ public final class RetryUtils {
         public int jitterDelayMillis(int retry) {
             double delay = rawDelayMs(retry);
             double jitter = delay * jitterScale;
-            return (int) (delay + RANDOM.nextInt((int) jitter));
+            int jitterBound = (int) jitter;
+            // Random.nextInt(bound) requires a strictly positive bound.
+            // The bound is 0 when jitter is disabled (jitterScale == 0) or when the
+            // base delay is too small to produce at least 1ms of jitter; in those
+            // cases there is no jitter to add, so return the base delay as-is.
+            if (jitterBound <= 0) {
+                return (int) delay;
+            }
+            return (int) (delay + RANDOM.nextInt(jitterBound));
         }
 
         /**

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/RetryUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/RetryUtils.java
@@ -157,10 +157,6 @@ public final class RetryUtils {
             double delay = rawDelayMs(retry);
             double jitter = delay * jitterScale;
             int jitterBound = (int) jitter;
-            // Random.nextInt(bound) requires a strictly positive bound.
-            // The bound is 0 when jitter is disabled (jitterScale == 0) or when the
-            // base delay is too small to produce at least 1ms of jitter; in those
-            // cases there is no jitter to add, so return the base delay as-is.
             if (jitterBound <= 0) {
                 return (int) delay;
             }

--- a/langchain4j-core/src/test/java/dev/langchain4j/internal/RetryUtilsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/internal/RetryUtilsTest.java
@@ -27,6 +27,28 @@ class RetryUtilsTest {
     }
 
     @Test
+    void jitterDelayMillis_returns_base_delay_when_jitter_is_disabled() {
+        // jitterScale == 0 disables jitter; the jitter bound is 0, which must not
+        // be passed to Random.nextInt (it requires a strictly positive bound).
+        RetryUtils.RetryPolicy policy = RetryUtils.retryPolicyBuilder()
+                .delayMillis(500)
+                .jitterScale(0.0)
+                .build();
+
+        assertThat(policy.jitterDelayMillis(0)).isEqualTo(500);
+        assertThat(policy.jitterDelayMillis(2)).isEqualTo((int) policy.rawDelayMs(2));
+    }
+
+    @Test
+    void jitterDelayMillis_returns_base_delay_when_base_delay_too_small_for_jitter() {
+        // With a tiny base delay, delay * jitterScale rounds down to a 0 jitter bound.
+        RetryUtils.RetryPolicy policy =
+                RetryUtils.retryPolicyBuilder().delayMillis(1).jitterScale(0.2).build();
+
+        assertThat(policy.jitterDelayMillis(0)).isEqualTo(1);
+    }
+
+    @Test
     void with_retry_directly() throws Exception {
         @SuppressWarnings("unchecked")
         Callable<String> mockAction = mock(Callable.class);


### PR DESCRIPTION
## Issue
Closes #5721

## Change

`RetryPolicy.jitterDelayMillis(int)` passed `(int) jitter` straight to `Random.nextInt(bound)`, which requires a **strictly positive** bound. The bound rounds down to `0` in two realistic configurations:

1. **Jitter disabled** — `jitterScale == 0` (the natural way to turn jitter off; nothing validates against it).
2. **Small base delay** — when `rawDelayMs(retry) * jitterScale < 1` (e.g. `delayMillis(1)` with the default `jitterScale = 0.2`).

In both cases `Random.nextInt(0)` throws `IllegalArgumentException: bound must be positive`. Since `sleep(retry)` calls `jitterDelayMillis(retry)` on every retry, such a policy throws on the first retriable failure instead of retrying, masking the original error. The default policy (`jitterScale = 0.2`, `delayMillis = 500`) is unaffected, which is why the existing `jitter()` test didn't catch it.

**Fix:** when the jitter bound is `<= 0` there is nothing to add, so return the base delay unchanged.

Added two unit tests (disabled jitter, and base delay too small for jitter). Both fail on `main` with `IllegalArgumentException` and pass with this change; the existing `jitter()` test for the default policy is unchanged.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [ ] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)

<!-- Note: ran the affected `langchain4j-core` unit tests (`RetryUtilsTest`, 12/12 green) and `spotless:apply`/`check` on the changed files. Did not run the full core+main integration suites, which require provider credentials; this change is a self-contained internal utility fix with no documentation or API surface impact. -->