### PR TITLE
test: Add should_embed_multiple_segments test coverage to BgeSmallEnV15EmbeddingModelIT

### DIFF
--- a/embeddings/langchain4j-embeddings-bge-small-en-v15/src/test/java/dev/langchain4j/model/embedding/onnx/bgesmallenv15/BgeSmallEnV15EmbeddingModelIT.java
+++ b/embeddings/langchain4j-embeddings-bge-small-en-v15/src/test/java/dev/langchain4j/model/embedding/onnx/bgesmallenv15/BgeSmallEnV15EmbeddingModelIT.java
@@ -2,13 +2,18 @@ package dev.langchain4j.model.embedding.onnx.bgesmallenv15;
 
 import static dev.langchain4j.internal.Utils.repeat;
 import static dev.langchain4j.model.embedding.onnx.internal.VectorUtils.magnitudeOf;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Percentage.withPercentage;
 
 import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.store.embedding.CosineSimilarity;
 import dev.langchain4j.store.embedding.RelevanceScore;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class BgeSmallEnV15EmbeddingModelIT {
@@ -26,6 +31,29 @@ class BgeSmallEnV15EmbeddingModelIT {
 
         double cosineSimilarity = CosineSimilarity.between(first, second);
         assertThat(RelevanceScore.fromCosineSimilarity(cosineSimilarity)).isGreaterThan(0.96);
+    }
+
+    @Test
+    void should_embed_multiple_segments() {
+
+        EmbeddingModel model = new BgeSmallEnV15EmbeddingModel();
+        TextSegment first = TextSegment.from("hi");
+        TextSegment second = TextSegment.from("hello");
+
+        Response<List<Embedding>> response = model.embedAll(asList(first, second));
+
+        List<Embedding> embeddings = response.content();
+        assertThat(embeddings).hasSize(2);
+
+        assertThat(embeddings.get(0)).isEqualTo(model.embed(first).content());
+        assertThat(embeddings.get(1)).isEqualTo(model.embed(second).content());
+
+        TokenUsage tokenUsage = response.tokenUsage();
+        assertThat(tokenUsage.inputTokenCount()).isEqualTo(2);
+        assertThat(tokenUsage.outputTokenCount()).isNull();
+        assertThat(tokenUsage.totalTokenCount()).isEqualTo(2);
+
+        assertThat(response.finishReason()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Issue
Closes #

## Change
`BgeSmallEnV15EmbeddingModelIT` had no test covering `EmbeddingModel.embedAll(List<TextSegment>)` and its `TokenUsage` result. Among the 10 sibling `langchain4j-embeddings-*` wrapper modules, 8 already have a `should_embed_multiple_segments()` test (`bge-small-en`, `bge-small-en-q`, `bge-small-zh-v15`, `bge-small-zh-v15-q`, `all-minilm-l6-v2`, `all-minilm-l6-v2-q`, `e5-small-v2`, `e5-small-v2-q`); only `bge-small-en-v15` and `bge-small-en-v15-q` are missing it. This gap has existed since the migration commit `c3a491e0b` (#4179) that first introduced this test file.

This PR adds `should_embed_multiple_segments()` to `BgeSmallEnV15EmbeddingModelIT`, mirroring the existing pattern from `BgeSmallEnEmbeddingModelIT` (same BGE/CLS-pooling model family): embeds two segments (`"hi"`, `"hello"`), asserts the returned embeddings match individual `embed()` calls, and asserts `TokenUsage.inputTokenCount() == 2` (verified against this module's tokenizer: both words map to a single vocab entry each, so `tokenCount - 2` for CLS/SEP yields 1 token each).

No production code, dependencies, or existing tests changed — only one new `@Test` method and its imports, placed between `should_embed()` and the sentence-transformers comparison test to match the sibling file's method order.

## General checklist
- [ ] There are no breaking changes (API, behaviour) — N/A, no production code changed, test-only addition
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases — assertions cover embedding equality, token count, null output/finish-reason fields
- [ ] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green — compiled successfully; `*IT` tests are bound to failsafe (integration-test phase) and were not executed locally (they require the ONNX model download)
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green — not run; change is scoped to a single leaf module with no core/main impact
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) — N/A, docs added after approval per convention
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) — N/A, not a feature
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable) — N/A
