### PR TITLE
feat(google-ai-gemini): support context cache creation and management

### DIFF
--- a/docs/docs/integrations/language-models/google-ai-gemini.md
+++ b/docs/docs/integrations/language-models/google-ai-gemini.md
@@ -25,6 +25,7 @@ https://ai.google.dev/gemini-api/docs
     - [Uploading Files](#uploading-files)
     - [Managing Files](#managing-files)
     - [File States](#file-states)
+- [Context Caching](#context-caching)
 - [Batch Processing](#batch-processing)
     - [GoogleAiBatchChatModel](#googleaibatchchatmodel)
     - [Creating Batch Jobs](#creating-batch-jobs)
@@ -809,6 +810,42 @@ if (file.isActive()) {
     System.out.println("File processing failed");
 }
 ```
+
+## Context Caching
+
+The [context caching API](https://ai.google.dev/gemini-api/docs/caching) stores large, frequently reused context (a system instruction, long documents) on Google's servers once, so subsequent requests reference it by name instead of resending it, reducing input-token cost and latency.
+
+`GeminiCaches` manages the cache lifecycle (create / get / list / delete). The messages are cached using the same message mapping the chat models use, so you stay in the LangChain4j `ChatMessage` domain:
+
+```java
+GeminiCaches caches = GeminiCaches.builder()
+    .apiKey(System.getenv("GEMINI_AI_KEY"))
+    .build();
+
+// Cache a large, reusable context (a system instruction plus a long document)
+GeminiCachedContent cache = caches.createCache(
+    "gemini-2.5-flash",
+    List.of(
+        SystemMessage.from("You are a precise assistant answering questions about the attached document."),
+        UserMessage.from(longDocumentText)),
+    Duration.ofHours(1));
+
+// Reuse it across many requests via cachedContentName
+ChatModel gemini = GoogleAiGeminiChatModel.builder()
+    .apiKey(System.getenv("GEMINI_AI_KEY"))
+    .modelName("gemini-2.5-flash")
+    .cachedContentName(cache.name())
+    .build();
+
+String answer = gemini.chat("Summarize the cached document in 3 bullet points.");
+
+// Manage the cache lifecycle
+caches.getCache(cache.name());
+caches.listCaches();
+caches.deleteCache(cache.name());
+```
+
+> Note: explicit context caching requires a paid tier; it is not available on the free tier.
 
 ## Batch Processing
 

--- a/docs/docs/integrations/language-models/google-ai-gemini.md
+++ b/docs/docs/integrations/language-models/google-ai-gemini.md
@@ -813,7 +813,7 @@ if (file.isActive()) {
 
 ## Context Caching
 
-The [context caching API](https://ai.google.dev/gemini-api/docs/caching) stores large, frequently reused context (a system instruction, long documents) on Google's servers once, so subsequent requests reference it by name instead of resending it, reducing input-token cost and latency.
+The [context caching API](https://ai.google.dev/gemini-api/docs/generate-content/caching) stores large, frequently reused context (a system instruction, long documents) on Google's servers once, so subsequent requests reference it by name instead of resending it, reducing input-token cost and latency.
 
 `GeminiCaches` manages the cache lifecycle (create / get / list / delete). The messages are cached using the same message mapping the chat models use, so you stay in the LangChain4j `ChatMessage` domain:
 
@@ -844,6 +844,8 @@ caches.getCache(cache.name());
 caches.listCaches();
 caches.deleteCache(cache.name());
 ```
+
+`createCache` has three forms for expiration: with no expiration argument it uses the API default (currently 1 hour); with a `Duration` it sets a relative time-to-live; and with an `Instant` it sets an absolute expiry time.
 
 > Note: explicit context caching requires a paid tier; it is not available on the free tier.
 

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCaches.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCaches.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.googleai;
 import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
 import static dev.langchain4j.model.googleai.PartsAndContentsMapper.fromMessageToGContent;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -13,6 +14,8 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 /**
@@ -41,7 +44,7 @@ public final class GeminiCaches {
                 builder.logResponses,
                 builder.logger,
                 builder.timeout,
-                null);
+                builder.customHeadersSupplier);
     }
 
     public static Builder builder() {
@@ -61,6 +64,9 @@ public final class GeminiCaches {
     public GeminiCachedContent createCache(String modelName, List<ChatMessage> messages, Duration ttl) {
         ensureNotBlank(modelName, "modelName");
         ensureNotEmpty(messages, "messages");
+        if (ttl != null) {
+            ensureTrue(!ttl.isNegative(), "ttl cannot be negative");
+        }
         return geminiService.createCachedContent(toCreateRequest(modelName, messages, ttl));
     }
 
@@ -165,6 +171,7 @@ public final class GeminiCaches {
         private boolean logResponses;
         private Logger logger;
         private Duration timeout;
+        private Supplier<Map<String, String>> customHeadersSupplier;
 
         public Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
             this.httpClientBuilder = httpClientBuilder;
@@ -203,6 +210,16 @@ public final class GeminiCaches {
 
         public Builder timeout(Duration timeout) {
             this.timeout = timeout;
+            return this;
+        }
+
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        public Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
             return this;
         }
 

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCaches.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCaches.java
@@ -1,0 +1,213 @@
+package dev.langchain4j.model.googleai;
+
+import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.model.googleai.PartsAndContentsMapper.fromMessageToGContent;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+
+/**
+ * Service for creating and managing Gemini
+ * <a href="https://ai.google.dev/gemini-api/docs/caching">context caches</a>.
+ *
+ * <p>Context caching stores large, frequently reused context (a system instruction, long documents,
+ * PDFs) on Google's servers once, so subsequent requests can reference it by name instead of
+ * resending it, reducing input-token cost and latency.
+ *
+ * <p>The name of a created cache ({@link GeminiCachedContent#name()}) can be supplied as the
+ * {@code cachedContentName} of a {@link GoogleAiGeminiChatModel} (or its streaming counterpart) to
+ * consume the cached context.
+ */
+public final class GeminiCaches {
+
+    private final GeminiService geminiService;
+
+    private GeminiCaches(Builder builder) {
+        this.geminiService = new GeminiService(
+                builder.httpClientBuilder,
+                builder.apiKey,
+                builder.baseUrl,
+                builder.logRequestsAndResponses,
+                builder.logRequests,
+                builder.logResponses,
+                builder.logger,
+                builder.timeout,
+                null);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates a context cache for the given model from the supplied messages.
+     *
+     * @param modelName the model the cache is bound to (e.g. {@code "gemini-2.5-flash"})
+     * @param messages  the messages to cache; a {@code SystemMessage} becomes the cached system
+     *                  instruction, the rest become cached contents
+     * @param ttl       optional time-to-live for the cache (e.g. {@code Duration.ofHours(1)}); may be
+     *                  {@code null}, in which case the API default is used
+     * @return the created cache, whose {@link GeminiCachedContent#name()} is used to consume it
+     */
+    public GeminiCachedContent createCache(String modelName, List<ChatMessage> messages, Duration ttl) {
+        ensureNotBlank(modelName, "modelName");
+        ensureNotEmpty(messages, "messages");
+        return geminiService.createCachedContent(toCreateRequest(modelName, messages, ttl));
+    }
+
+    /**
+     * Retrieves a cache by name (e.g. {@code "cachedContents/abc123"}).
+     */
+    public GeminiCachedContent getCache(String name) {
+        ensureNotBlank(name, "name");
+        return geminiService.getCachedContent(name);
+    }
+
+    /**
+     * Lists all context caches for the current project.
+     */
+    public List<GeminiCachedContent> listCaches() {
+        List<GeminiCachedContent> allCaches = new ArrayList<>();
+        String pageToken = null;
+        do {
+            GeminiCachedContentsListResponse response = geminiService.listCachedContents(null, pageToken);
+            if (response.cachedContents() != null) {
+                allCaches.addAll(response.cachedContents());
+            }
+            pageToken = response.nextPageToken();
+        } while (isNotNullOrEmpty(pageToken));
+        return allCaches;
+    }
+
+    /**
+     * Deletes a context cache by name.
+     */
+    public void deleteCache(String name) {
+        ensureNotBlank(name, "name");
+        geminiService.deleteCachedContent(name);
+    }
+
+    static GeminiCreateCachedContentRequest toCreateRequest(
+            String modelName, List<ChatMessage> messages, Duration ttl) {
+        GeminiContent systemInstruction = new GeminiContent(List.of(), GeminiRole.MODEL.toString());
+        List<GeminiContent> contents = fromMessageToGContent(messages, systemInstruction, false);
+        return new GeminiCreateCachedContentRequest(
+                modelName.startsWith("models/") ? modelName : "models/" + modelName,
+                contents.isEmpty() ? null : contents,
+                !systemInstruction.parts().isEmpty() ? systemInstruction : null,
+                ttl != null ? toTtlString(ttl) : null);
+    }
+
+    static String toTtlString(Duration ttl) {
+        if (ttl.getNano() == 0) {
+            return ttl.getSeconds() + "s";
+        }
+        return BigDecimal.valueOf(ttl.getSeconds())
+                        .add(BigDecimal.valueOf(ttl.getNano(), 9))
+                        .stripTrailingZeros()
+                        .toPlainString()
+                + "s";
+    }
+
+    /**
+     * Represents a Gemini context cache,
+     * <a href="https://ai.google.dev/api/caching">documentation</a>
+     *
+     * @param name          the resource name of the cache (e.g., "cachedContents/abc123")
+     * @param model         the fully qualified name of the model the cache is bound to (e.g., "models/gemini-2.5-flash")
+     * @param displayName   an optional display name for the cache
+     * @param createTime    the timestamp indicating when the cache was created, formatted as an ISO-8601 string
+     * @param updateTime    the timestamp indicating when the cache was last updated, formatted as an ISO-8601 string
+     * @param expireTime    the timestamp indicating when the cache expires, formatted as an ISO-8601 string
+     * @param usageMetadata the token usage of the cached content
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GeminiCachedContent(
+            @JsonProperty("name") String name,
+            @JsonProperty("model") String model,
+            @JsonProperty("displayName") String displayName,
+            @JsonProperty("createTime") String createTime,
+            @JsonProperty("updateTime") String updateTime,
+            @JsonProperty("expireTime") String expireTime,
+            @JsonProperty("usageMetadata") UsageMetadata usageMetadata) {
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public record UsageMetadata(
+                @JsonProperty("totalTokenCount") Integer totalTokenCount) {}
+    }
+
+    record GeminiCreateCachedContentRequest(
+            @JsonProperty("model") String model,
+            @JsonProperty("contents") List<GeminiContent> contents,
+            @JsonProperty("systemInstruction") GeminiContent systemInstruction,
+            @JsonProperty("ttl") String ttl) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record GeminiCachedContentsListResponse(
+            @JsonProperty("cachedContents") List<GeminiCachedContent> cachedContents,
+            @JsonProperty("nextPageToken") String nextPageToken) {}
+
+    public static class Builder {
+        private HttpClientBuilder httpClientBuilder;
+        private String baseUrl;
+        private String apiKey;
+        private boolean logRequestsAndResponses;
+        private boolean logRequests;
+        private boolean logResponses;
+        private Logger logger;
+        private Duration timeout;
+
+        public Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public Builder logRequestsAndResponses(boolean logRequestsAndResponses) {
+            this.logRequestsAndResponses = logRequestsAndResponses;
+            return this;
+        }
+
+        public Builder logRequests(boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        public Builder logResponses(boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        public Builder logger(Logger logger) {
+            this.logger = logger;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public GeminiCaches build() {
+            return new GeminiCaches(this);
+        }
+    }
+}

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCaches.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCaches.java
@@ -3,6 +3,7 @@ package dev.langchain4j.model.googleai;
 import static dev.langchain4j.internal.Utils.isNotNullOrEmpty;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotEmpty;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.internal.ValidationUtils.ensureTrue;
 import static dev.langchain4j.model.googleai.PartsAndContentsMapper.fromMessageToGContent;
 
@@ -12,10 +13,12 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 /**
@@ -52,22 +55,54 @@ public final class GeminiCaches {
     }
 
     /**
-     * Creates a context cache for the given model from the supplied messages.
+     * Creates a context cache for the given model from the supplied messages, using the API's default
+     * expiration.
      *
      * @param modelName the model the cache is bound to (e.g. {@code "gemini-2.5-flash"})
      * @param messages  the messages to cache; a {@code SystemMessage} becomes the cached system
      *                  instruction, the rest become cached contents
-     * @param ttl       optional time-to-live for the cache (e.g. {@code Duration.ofHours(1)}); may be
-     *                  {@code null}, in which case the API default is used
      * @return the created cache, whose {@link GeminiCachedContent#name()} is used to consume it
      */
-    public GeminiCachedContent createCache(String modelName, List<ChatMessage> messages, Duration ttl) {
+    public GeminiCachedContent createCache(String modelName, List<ChatMessage> messages) {
+        return createCache(modelName, messages, (Duration) null);
+    }
+
+    /**
+     * Creates a context cache for the given model from the supplied messages, expiring after the given
+     * time-to-live.
+     *
+     * @param modelName the model the cache is bound to (e.g. {@code "gemini-2.5-flash"})
+     * @param messages  the messages to cache; a {@code SystemMessage} becomes the cached system
+     *                  instruction, the rest become cached contents
+     * @param ttl       the time-to-live for the cache (e.g. {@code Duration.ofHours(1)}); if
+     *                  {@code null}, the API default is used
+     * @return the created cache, whose {@link GeminiCachedContent#name()} is used to consume it
+     */
+    public GeminiCachedContent createCache(String modelName, List<ChatMessage> messages, @Nullable Duration ttl) {
         ensureNotBlank(modelName, "modelName");
         ensureNotEmpty(messages, "messages");
         if (ttl != null) {
             ensureTrue(!ttl.isNegative(), "ttl cannot be negative");
         }
-        return geminiService.createCachedContent(toCreateRequest(modelName, messages, ttl));
+        return geminiService.createCachedContent(
+                toCreateRequest(modelName, messages, ttl != null ? toTtlString(ttl) : null, null));
+    }
+
+    /**
+     * Creates a context cache for the given model from the supplied messages, expiring at the given
+     * instant.
+     *
+     * @param modelName  the model the cache is bound to (e.g. {@code "gemini-2.5-flash"})
+     * @param messages   the messages to cache; a {@code SystemMessage} becomes the cached system
+     *                   instruction, the rest become cached contents
+     * @param expireTime the instant at which the cache expires
+     * @return the created cache, whose {@link GeminiCachedContent#name()} is used to consume it
+     */
+    public GeminiCachedContent createCache(String modelName, List<ChatMessage> messages, Instant expireTime) {
+        ensureNotBlank(modelName, "modelName");
+        ensureNotEmpty(messages, "messages");
+        ensureNotNull(expireTime, "expireTime");
+        return geminiService.createCachedContent(toCreateRequest(modelName, messages, null, expireTime.toString()));
     }
 
     /**
@@ -102,18 +137,19 @@ public final class GeminiCaches {
         geminiService.deleteCachedContent(name);
     }
 
-    static GeminiCreateCachedContentRequest toCreateRequest(
-            String modelName, List<ChatMessage> messages, Duration ttl) {
+    private static GeminiCreateCachedContentRequest toCreateRequest(
+            String modelName, List<ChatMessage> messages, @Nullable String ttl, @Nullable String expireTime) {
         GeminiContent systemInstruction = new GeminiContent(List.of(), GeminiRole.MODEL.toString());
         List<GeminiContent> contents = fromMessageToGContent(messages, systemInstruction, false);
         return new GeminiCreateCachedContentRequest(
                 modelName.startsWith("models/") ? modelName : "models/" + modelName,
                 contents.isEmpty() ? null : contents,
                 !systemInstruction.parts().isEmpty() ? systemInstruction : null,
-                ttl != null ? toTtlString(ttl) : null);
+                ttl,
+                expireTime);
     }
 
-    static String toTtlString(Duration ttl) {
+    private static String toTtlString(Duration ttl) {
         if (ttl.getNano() == 0) {
             return ttl.getSeconds() + "s";
         }
@@ -155,7 +191,8 @@ public final class GeminiCaches {
             @JsonProperty("model") String model,
             @JsonProperty("contents") List<GeminiContent> contents,
             @JsonProperty("systemInstruction") GeminiContent systemInstruction,
-            @JsonProperty("ttl") String ttl) {}
+            @JsonProperty("ttl") String ttl,
+            @JsonProperty("expireTime") String expireTime) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     record GeminiCachedContentsListResponse(

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCaches.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiCaches.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 
 /**
  * Service for creating and managing Gemini
- * <a href="https://ai.google.dev/gemini-api/docs/caching">context caches</a>.
+ * <a href="https://ai.google.dev/gemini-api/docs/generate-content/caching">context caches</a>.
  *
  * <p>Context caching stores large, frequently reused context (a system instruction, long documents,
  * PDFs) on Google's servers once, so subsequent requests can reference it by name instead of
@@ -56,7 +56,7 @@ public final class GeminiCaches {
 
     /**
      * Creates a context cache for the given model from the supplied messages, using the API's default
-     * expiration.
+     * expiration (currently 1 hour).
      *
      * @param modelName the model the cache is bound to (e.g. {@code "gemini-2.5-flash"})
      * @param messages  the messages to cache; a {@code SystemMessage} becomes the cached system
@@ -64,7 +64,9 @@ public final class GeminiCaches {
      * @return the created cache, whose {@link GeminiCachedContent#name()} is used to consume it
      */
     public GeminiCachedContent createCache(String modelName, List<ChatMessage> messages) {
-        return createCache(modelName, messages, (Duration) null);
+        ensureNotBlank(modelName, "modelName");
+        ensureNotEmpty(messages, "messages");
+        return geminiService.createCachedContent(toCreateRequest(modelName, messages, null, null));
     }
 
     /**
@@ -74,18 +76,15 @@ public final class GeminiCaches {
      * @param modelName the model the cache is bound to (e.g. {@code "gemini-2.5-flash"})
      * @param messages  the messages to cache; a {@code SystemMessage} becomes the cached system
      *                  instruction, the rest become cached contents
-     * @param ttl       the time-to-live for the cache (e.g. {@code Duration.ofHours(1)}); if
-     *                  {@code null}, the API default is used
+     * @param ttl       the relative time-to-live for the cache (e.g. {@code Duration.ofHours(1)})
      * @return the created cache, whose {@link GeminiCachedContent#name()} is used to consume it
      */
-    public GeminiCachedContent createCache(String modelName, List<ChatMessage> messages, @Nullable Duration ttl) {
+    public GeminiCachedContent createCache(String modelName, List<ChatMessage> messages, Duration ttl) {
         ensureNotBlank(modelName, "modelName");
         ensureNotEmpty(messages, "messages");
-        if (ttl != null) {
-            ensureTrue(!ttl.isNegative(), "ttl cannot be negative");
-        }
-        return geminiService.createCachedContent(
-                toCreateRequest(modelName, messages, ttl != null ? toTtlString(ttl) : null, null));
+        ensureNotNull(ttl, "ttl");
+        ensureTrue(!ttl.isNegative(), "ttl cannot be negative");
+        return geminiService.createCachedContent(toCreateRequest(modelName, messages, toTtlString(ttl), null));
     }
 
     /**

--- a/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiService.java
+++ b/langchain4j-google-ai-gemini/src/main/java/dev/langchain4j/model/googleai/GeminiService.java
@@ -33,6 +33,9 @@ import dev.langchain4j.model.chat.response.CompleteToolCall;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.chat.response.StreamingHandle;
 import dev.langchain4j.model.googleai.BatchRequestResponse.ListOperationsResponse;
+import dev.langchain4j.model.googleai.GeminiCaches.GeminiCachedContent;
+import dev.langchain4j.model.googleai.GeminiCaches.GeminiCachedContentsListResponse;
+import dev.langchain4j.model.googleai.GeminiCaches.GeminiCreateCachedContentRequest;
 import dev.langchain4j.model.googleai.GeminiEmbeddingRequestResponse.GeminiBatchEmbeddingRequest;
 import dev.langchain4j.model.googleai.GeminiEmbeddingRequestResponse.GeminiBatchEmbeddingResponse;
 import dev.langchain4j.model.googleai.GeminiEmbeddingRequestResponse.GeminiEmbeddingRequest;
@@ -179,6 +182,29 @@ class GeminiService {
                 new StringPair("pageSize", pageSize != null ? String.valueOf(pageSize) : null),
                 new StringPair("pageToken", pageToken));
         return sendRequest(url, apiKey, null, GeminiModelsListResponse.class, GET);
+    }
+
+    GeminiCachedContent createCachedContent(GeminiCreateCachedContentRequest request) {
+        String url = String.format("%s/cachedContents", baseUrl);
+        return sendRequest(url, apiKey, request, GeminiCachedContent.class);
+    }
+
+    GeminiCachedContent getCachedContent(String name) {
+        String url = String.format("%s/%s", baseUrl, name);
+        return sendRequest(url, apiKey, null, GeminiCachedContent.class, GET);
+    }
+
+    GeminiCachedContentsListResponse listCachedContents(@Nullable Integer pageSize, @Nullable String pageToken) {
+        String url = buildUrl(
+                baseUrl + "/cachedContents",
+                new StringPair("pageSize", pageSize != null ? String.valueOf(pageSize) : null),
+                new StringPair("pageToken", pageToken));
+        return sendRequest(url, apiKey, null, GeminiCachedContentsListResponse.class, GET);
+    }
+
+    Void deleteCachedContent(String name) {
+        String url = String.format("%s/%s", baseUrl, name);
+        return sendRequest(url, apiKey, null, Void.class, DELETE);
     }
 
     void generateContentStream(

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiCachesIT.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiCachesIT.java
@@ -1,0 +1,61 @@
+package dev.langchain4j.model.googleai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.abort;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.model.googleai.GeminiCaches.GeminiCachedContent;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "GOOGLE_AI_GEMINI_API_KEY", matches = ".+")
+class GeminiCachesIT {
+
+    private static final String GOOGLE_AI_GEMINI_API_KEY = System.getenv("GOOGLE_AI_GEMINI_API_KEY");
+
+    @Test
+    void should_create_get_list_attach_and_delete_cache() {
+        GeminiCaches caches =
+                GeminiCaches.builder().apiKey(GOOGLE_AI_GEMINI_API_KEY).build();
+
+        // explicit caching requires a minimum number of input tokens; pad the content heavily to clear it
+        List<ChatMessage> messages = List.of(
+                SystemMessage.from("You are an expert technical writer."),
+                UserMessage.from("Large reusable document context. ".repeat(10_000)));
+
+        GeminiCachedContent created;
+        try {
+            created = caches.createCache("gemini-2.5-flash", messages, Duration.ofMinutes(5));
+        } catch (HttpException e) {
+            // explicit context caching is not offered on the free tier (storage limit = 0); skip there
+            if (e.getMessage() != null && e.getMessage().contains("FreeTier")) {
+                abort("Context caching requires a paid tier: " + e.getMessage());
+            }
+            throw e;
+        }
+
+        String name = created.name();
+        assertThat(name).startsWith("cachedContents/");
+        assertThat(created.usageMetadata().totalTokenCount()).isPositive();
+
+        try {
+            assertThat(caches.getCache(name).name()).isEqualTo(name);
+            assertThat(caches.listCaches()).anyMatch(cache -> name.equals(cache.name()));
+
+            GoogleAiGeminiChatModel model = GoogleAiGeminiChatModel.builder()
+                    .apiKey(GOOGLE_AI_GEMINI_API_KEY)
+                    .modelName("gemini-2.5-flash")
+                    .cachedContentName(name)
+                    .build();
+            assertThat(model.chat("Summarize the cached document in one sentence."))
+                    .isNotBlank();
+        } finally {
+            caches.deleteCache(name);
+        }
+    }
+}

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiCachesTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiCachesTest.java
@@ -1,0 +1,321 @@
+package dev.langchain4j.model.googleai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.MockHttpClient;
+import dev.langchain4j.http.client.MockHttpClientBuilder;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import dev.langchain4j.model.googleai.GeminiCaches.GeminiCachedContent;
+import dev.langchain4j.model.googleai.GeminiCaches.GeminiCachedContentsListResponse;
+import dev.langchain4j.model.googleai.GeminiCaches.GeminiCreateCachedContentRequest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class GeminiCachesTest {
+    private static final String TEST_API_KEY = "test-api-key";
+    private static final String TEST_BASE_URL = "https://test.googleapis.com/v1beta";
+
+    @Nested
+    class CreateCacheTest {
+
+        @Test
+        void shouldSendCorrectCreateCacheHttpRequest() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            subject.createCache(
+                    "gemini-2.5-flash",
+                    List.of(
+                            SystemMessage.from("You are an expert technical writer."),
+                            UserMessage.from("Reusable document context.")),
+                    Duration.ofMinutes(5));
+
+            HttpRequest sentRequest = mockHttpClient.request();
+            assertThat(sentRequest.method()).isEqualTo(HttpMethod.POST);
+            assertThat(sentRequest.url()).isEqualTo(TEST_BASE_URL + "/cachedContents");
+            assertThat(sentRequest.headers().get("Content-Type")).containsExactly("application/json");
+            assertThat(sentRequest.headers().get("User-Agent")).containsExactly("LangChain4j");
+            assertThat(sentRequest.headers().get("x-goog-api-key")).containsExactly(TEST_API_KEY);
+
+            GeminiCreateCachedContentRequest sentBody =
+                    Json.fromJson(sentRequest.body(), GeminiCreateCachedContentRequest.class);
+            assertThat(sentBody.model()).isEqualTo("models/gemini-2.5-flash");
+            assertThat(sentBody.systemInstruction().parts()).hasSize(1);
+            assertThat(sentBody.systemInstruction().parts().get(0).text())
+                    .isEqualTo("You are an expert technical writer.");
+            assertThat(sentBody.contents()).hasSize(1);
+            assertThat(sentBody.contents().get(0).role()).isEqualTo("user");
+            assertThat(sentBody.contents().get(0).parts().get(0).text()).isEqualTo("Reusable document context.");
+            assertThat(sentBody.ttl()).isEqualTo("300s");
+        }
+
+        @Test
+        void shouldOmitTtlWhenNullAndSystemInstructionWhenAbsent() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            subject.createCache("gemini-2.5-flash", List.of(UserMessage.from("Reusable document context.")), null);
+
+            String sentBody = mockHttpClient.request().body();
+            assertThat(sentBody).doesNotContain("\"ttl\"");
+            assertThat(sentBody).doesNotContain("\"systemInstruction\"");
+        }
+
+        @Test
+        void shouldReturnCreatedCache() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            GeminiCachedContent created = subject.createCache(
+                    "gemini-2.5-flash", List.of(UserMessage.from("Reusable document context.")), Duration.ofMinutes(5));
+
+            assertThat(created).isEqualTo(sampleCachedContent());
+        }
+
+        @Test
+        void shouldNotDoublePrefixAnAlreadyQualifiedModelName() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            subject.createCache(
+                    "models/gemini-2.5-flash",
+                    List.of(UserMessage.from("Reusable document context.")),
+                    Duration.ofMinutes(5));
+
+            GeminiCreateCachedContentRequest sentBody =
+                    Json.fromJson(mockHttpClient.request().body(), GeminiCreateCachedContentRequest.class);
+            assertThat(sentBody.model()).isEqualTo("models/gemini-2.5-flash");
+        }
+
+        @Test
+        void shouldPreserveSubSecondTtlPrecision() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            subject.createCache(
+                    "gemini-2.5-flash",
+                    List.of(UserMessage.from("Reusable document context.")),
+                    Duration.ofSeconds(90).plusMillis(500));
+
+            GeminiCreateCachedContentRequest sentBody =
+                    Json.fromJson(mockHttpClient.request().body(), GeminiCreateCachedContentRequest.class);
+            assertThat(sentBody.ttl()).isEqualTo("90.5s");
+        }
+
+        @Test
+        void shouldThrowWhenModelNameIsBlank() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            assertThatThrownBy(() -> subject.createCache(
+                            " ", List.of(UserMessage.from("Reusable document context.")), Duration.ofMinutes(5)))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThat(mockHttpClient.requests()).isEmpty();
+        }
+
+        @Test
+        void shouldThrowWhenMessagesAreEmpty() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            assertThatThrownBy(() -> subject.createCache("gemini-2.5-flash", List.of(), Duration.ofMinutes(5)))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThat(mockHttpClient.requests()).isEmpty();
+        }
+    }
+
+    @Nested
+    class GetCacheTest {
+
+        @Test
+        void shouldSendCorrectGetCacheHttpRequest() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            subject.getCache("cachedContents/abc123");
+
+            HttpRequest sentRequest = mockHttpClient.request();
+            assertThat(sentRequest.method()).isEqualTo(HttpMethod.GET);
+            assertThat(sentRequest.url()).isEqualTo(TEST_BASE_URL + "/cachedContents/abc123");
+            assertThat(sentRequest.headers().get("x-goog-api-key")).containsExactly(TEST_API_KEY);
+        }
+
+        @Test
+        void shouldReturnCache() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            GeminiCachedContent cache = subject.getCache("cachedContents/abc123");
+
+            assertThat(cache).isEqualTo(sampleCachedContent());
+        }
+
+        @Test
+        void shouldThrowWhenNameIsBlank() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            assertThatThrownBy(() -> subject.getCache(" ")).isInstanceOf(IllegalArgumentException.class);
+            assertThat(mockHttpClient.requests()).isEmpty();
+        }
+    }
+
+    @Nested
+    class ListCachesTest {
+
+        @Test
+        void shouldSendCorrectListCachesHttpRequest() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                    jsonResponse(new GeminiCachedContentsListResponse(List.of(sampleCachedContent()), null)));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            subject.listCaches();
+
+            HttpRequest sentRequest = mockHttpClient.request();
+            assertThat(sentRequest.method()).isEqualTo(HttpMethod.GET);
+            assertThat(sentRequest.url()).isEqualTo(TEST_BASE_URL + "/cachedContents");
+            assertThat(sentRequest.headers().get("x-goog-api-key")).containsExactly(TEST_API_KEY);
+        }
+
+        @Test
+        void shouldReturnAllCaches() {
+            GeminiCachedContent otherCachedContent = new GeminiCachedContent(
+                    "cachedContents/def456", "models/gemini-2.5-pro", null, null, null, null, null);
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(
+                    new GeminiCachedContentsListResponse(List.of(sampleCachedContent(), otherCachedContent), null)));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            List<GeminiCachedContent> caches = subject.listCaches();
+
+            assertThat(caches).containsExactly(sampleCachedContent(), otherCachedContent);
+        }
+
+        @Test
+        void shouldFollowNextPageTokenAcrossPages() {
+            GeminiCachedContent otherCachedContent = new GeminiCachedContent(
+                    "cachedContents/def456", "models/gemini-2.5-pro", null, null, null, null, null);
+            SequencedHttpClient httpClient = new SequencedHttpClient(
+                    jsonResponse(new GeminiCachedContentsListResponse(List.of(sampleCachedContent()), "page-2-token")),
+                    jsonResponse(new GeminiCachedContentsListResponse(List.of(otherCachedContent), null)));
+            GeminiCaches subject = createCaches(httpClient);
+
+            List<GeminiCachedContent> caches = subject.listCaches();
+
+            assertThat(caches).containsExactly(sampleCachedContent(), otherCachedContent);
+            assertThat(httpClient.requests).hasSize(2);
+            assertThat(httpClient.requests.get(0).url()).isEqualTo(TEST_BASE_URL + "/cachedContents");
+            assertThat(httpClient.requests.get(1).url())
+                    .isEqualTo(TEST_BASE_URL + "/cachedContents?pageToken=page-2-token");
+        }
+
+        @Test
+        void shouldStopPagingWhenNextPageTokenIsEmpty() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                    jsonResponse(new GeminiCachedContentsListResponse(List.of(sampleCachedContent()), "")));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            List<GeminiCachedContent> caches = subject.listCaches();
+
+            assertThat(caches).containsExactly(sampleCachedContent());
+            assertThat(mockHttpClient.requests()).hasSize(1);
+        }
+
+        @Test
+        void shouldReturnEmptyListWhenThereAreNoCaches() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                    SuccessfulHttpResponse.builder().statusCode(200).body("{}").build());
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            List<GeminiCachedContent> caches = subject.listCaches();
+
+            assertThat(caches).isEmpty();
+        }
+    }
+
+    @Nested
+    class DeleteCacheTest {
+
+        @Test
+        void shouldSendCorrectDeleteCacheHttpRequest() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                    SuccessfulHttpResponse.builder().statusCode(200).body("{}").build());
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            subject.deleteCache("cachedContents/abc123");
+
+            HttpRequest sentRequest = mockHttpClient.request();
+            assertThat(sentRequest.method()).isEqualTo(HttpMethod.DELETE);
+            assertThat(sentRequest.url()).isEqualTo(TEST_BASE_URL + "/cachedContents/abc123");
+            assertThat(sentRequest.headers().get("x-goog-api-key")).containsExactly(TEST_API_KEY);
+        }
+
+        @Test
+        void shouldThrowWhenNameIsBlank() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(
+                    SuccessfulHttpResponse.builder().statusCode(200).body("{}").build());
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            assertThatThrownBy(() -> subject.deleteCache(" ")).isInstanceOf(IllegalArgumentException.class);
+            assertThat(mockHttpClient.requests()).isEmpty();
+        }
+    }
+
+    private static GeminiCaches createCaches(HttpClient httpClient) {
+        return GeminiCaches.builder()
+                .httpClientBuilder(new MockHttpClientBuilder(httpClient))
+                .apiKey(TEST_API_KEY)
+                .baseUrl(TEST_BASE_URL)
+                .build();
+    }
+
+    private static final class SequencedHttpClient implements HttpClient {
+
+        private final List<HttpRequest> requests = new ArrayList<>();
+        private final Iterator<SuccessfulHttpResponse> responses;
+
+        private SequencedHttpClient(SuccessfulHttpResponse... responses) {
+            this.responses = List.of(responses).iterator();
+        }
+
+        @Override
+        public SuccessfulHttpResponse execute(HttpRequest request) {
+            requests.add(request);
+            return responses.next();
+        }
+
+        @Override
+        public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static SuccessfulHttpResponse jsonResponse(Object body) {
+        return SuccessfulHttpResponse.builder()
+                .statusCode(200)
+                .body(Json.toJson(body))
+                .build();
+    }
+
+    private static GeminiCachedContent sampleCachedContent() {
+        return new GeminiCachedContent(
+                "cachedContents/abc123",
+                "models/gemini-2.5-flash",
+                null,
+                "2026-07-06T10:00:00Z",
+                "2026-07-06T10:15:00Z",
+                "2026-07-06T11:00:00Z",
+                new GeminiCachedContent.UsageMetadata(2048));
+    }
+}

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiCachesTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiCachesTest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -112,6 +113,34 @@ class GeminiCachesTest {
             GeminiCreateCachedContentRequest sentBody =
                     Json.fromJson(mockHttpClient.request().body(), GeminiCreateCachedContentRequest.class);
             assertThat(sentBody.ttl()).isEqualTo("90.5s");
+        }
+
+        @Test
+        void shouldThrowWhenTtlIsNegative() {
+            GeminiCaches subject = createCaches(MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent())));
+
+            assertThatThrownBy(() -> subject.createCache(
+                            "gemini-2.5-flash",
+                            List.of(UserMessage.from("Reusable document context.")),
+                            Duration.ofMinutes(-5)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("ttl cannot be negative");
+        }
+
+        @Test
+        void shouldSendCustomHeaders() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = GeminiCaches.builder()
+                    .httpClientBuilder(new MockHttpClientBuilder(mockHttpClient))
+                    .apiKey(TEST_API_KEY)
+                    .baseUrl(TEST_BASE_URL)
+                    .customHeaders(Map.of("x-custom-header", "custom-value"))
+                    .build();
+
+            subject.createCache("gemini-2.5-flash", List.of(UserMessage.from("Reusable document context.")), null);
+
+            HttpRequest sentRequest = mockHttpClient.request();
+            assertThat(sentRequest.headers().get("x-custom-header")).containsExactly("custom-value");
         }
 
         @Test

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiCachesTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiCachesTest.java
@@ -61,6 +61,7 @@ class GeminiCachesTest {
             assertThat(sentBody.contents().get(0).role()).isEqualTo("user");
             assertThat(sentBody.contents().get(0).parts().get(0).text()).isEqualTo("Reusable document context.");
             assertThat(sentBody.ttl()).isEqualTo("300s");
+            assertThat(sentRequest.body()).doesNotContain("\"expireTime\"");
         }
 
         @Test
@@ -139,10 +140,12 @@ class GeminiCachesTest {
                     List.of(UserMessage.from("Reusable document context.")),
                     Instant.parse("2026-07-06T11:00:00Z"));
 
+            String requestBody = mockHttpClient.request().body();
+            assertThat(requestBody).contains("\"expireTime\"").doesNotContain("\"ttl\"");
+
             GeminiCreateCachedContentRequest sentBody =
-                    Json.fromJson(mockHttpClient.request().body(), GeminiCreateCachedContentRequest.class);
+                    Json.fromJson(requestBody, GeminiCreateCachedContentRequest.class);
             assertThat(sentBody.expireTime()).isEqualTo("2026-07-06T11:00:00Z");
-            assertThat(sentBody.ttl()).isNull();
         }
 
         @Test
@@ -154,6 +157,17 @@ class GeminiCachesTest {
                             "gemini-2.5-flash", List.of(UserMessage.from("Reusable document context.")), expireTime))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("expireTime");
+        }
+
+        @Test
+        void shouldThrowWhenTtlIsNull() {
+            GeminiCaches subject = createCaches(MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent())));
+            Duration ttl = null;
+
+            assertThatThrownBy(() -> subject.createCache(
+                            "gemini-2.5-flash", List.of(UserMessage.from("Reusable document context.")), ttl))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("ttl");
         }
 
         @Test

--- a/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiCachesTest.java
+++ b/langchain4j-google-ai-gemini/src/test/java/dev/langchain4j/model/googleai/GeminiCachesTest.java
@@ -17,6 +17,7 @@ import dev.langchain4j.model.googleai.GeminiCaches.GeminiCachedContent;
 import dev.langchain4j.model.googleai.GeminiCaches.GeminiCachedContentsListResponse;
 import dev.langchain4j.model.googleai.GeminiCaches.GeminiCreateCachedContentRequest;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -63,14 +64,15 @@ class GeminiCachesTest {
         }
 
         @Test
-        void shouldOmitTtlWhenNullAndSystemInstructionWhenAbsent() {
+        void shouldOmitExpirationAndSystemInstructionWhenUsingDefaultOverload() {
             MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
             GeminiCaches subject = createCaches(mockHttpClient);
 
-            subject.createCache("gemini-2.5-flash", List.of(UserMessage.from("Reusable document context.")), null);
+            subject.createCache("gemini-2.5-flash", List.of(UserMessage.from("Reusable document context.")));
 
             String sentBody = mockHttpClient.request().body();
             assertThat(sentBody).doesNotContain("\"ttl\"");
+            assertThat(sentBody).doesNotContain("\"expireTime\"");
             assertThat(sentBody).doesNotContain("\"systemInstruction\"");
         }
 
@@ -128,6 +130,33 @@ class GeminiCachesTest {
         }
 
         @Test
+        void shouldSendExpireTimeInRequest() {
+            MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
+            GeminiCaches subject = createCaches(mockHttpClient);
+
+            subject.createCache(
+                    "gemini-2.5-flash",
+                    List.of(UserMessage.from("Reusable document context.")),
+                    Instant.parse("2026-07-06T11:00:00Z"));
+
+            GeminiCreateCachedContentRequest sentBody =
+                    Json.fromJson(mockHttpClient.request().body(), GeminiCreateCachedContentRequest.class);
+            assertThat(sentBody.expireTime()).isEqualTo("2026-07-06T11:00:00Z");
+            assertThat(sentBody.ttl()).isNull();
+        }
+
+        @Test
+        void shouldThrowWhenExpireTimeIsNull() {
+            GeminiCaches subject = createCaches(MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent())));
+            Instant expireTime = null;
+
+            assertThatThrownBy(() -> subject.createCache(
+                            "gemini-2.5-flash", List.of(UserMessage.from("Reusable document context.")), expireTime))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("expireTime");
+        }
+
+        @Test
         void shouldSendCustomHeaders() {
             MockHttpClient mockHttpClient = MockHttpClient.thatAlwaysResponds(jsonResponse(sampleCachedContent()));
             GeminiCaches subject = GeminiCaches.builder()
@@ -137,7 +166,7 @@ class GeminiCachesTest {
                     .customHeaders(Map.of("x-custom-header", "custom-value"))
                     .build();
 
-            subject.createCache("gemini-2.5-flash", List.of(UserMessage.from("Reusable document context.")), null);
+            subject.createCache("gemini-2.5-flash", List.of(UserMessage.from("Reusable document context.")));
 
             HttpRequest sentRequest = mockHttpClient.request();
             assertThat(sentRequest.headers().get("x-custom-header")).containsExactly("custom-value");


### PR DESCRIPTION
## Issue
Closes #5493

## Change

Adds `GeminiCaches`, a helper for creating and managing Gemini [context caches](https://ai.google.dev/gemini-api/docs/caching) in `langchain4j-google-ai-gemini`: `createCache` / `getCache` / `listCaches` / `deleteCache` on the REST `cachedContents` resource.

The module can already consume a cache by name (global `cachedContentName` from #5300, per-request override from #5645), but the cache itself can only be created out-of-band (curl or an SDK), so the attach feature cannot be used end-to-end from LangChain4j. This adds the missing creation half. It is the `google-ai-gemini` counterpart of #5694, which added cache creation and management to the `google-genai` module.

Design notes:
- `GeminiCaches` is a standalone helper named to mirror `GeminiFiles`, the same relationship `GoogleGenAiCaches` has to `GoogleGenAiFiles` in `google-genai`, and it uses the same method naming as #5694 (`createCache`/`getCache`/`listCaches`/`deleteCache`).
- HTTP goes through `GeminiService`, constructed the same way `GoogleAiGeminiModelCatalog` does it, so the helper gets the module's standard auth header, logging, timeout and custom `HttpClientBuilder` support, and HTTP failures surface through LangChain4j's exception hierarchy rather than checked `IOException`s.
- `createCache(modelName, messages, ttl)` maps `List<ChatMessage>` with the same `PartsAndContentsMapper` the chat models use: a `SystemMessage` becomes the cached `systemInstruction`, the remaining messages become `contents`, so callers stay in the LangChain4j message domain. The Python counterpart exposes the creation side the same way: `langchain-google-genai` has a public `create_context_cache` helper that takes framework messages and returns the cache name to pass as `cached_content`.
- `listCaches()` follows `nextPageToken` internally, like `GoogleAiGeminiModelCatalog.listModels()`.
 - The builder exposes `customHeaders` (the same `Map`/`Supplier` overloads as `GoogleAiGeminiChatModel`), so proxy or auth headers configured for the chat models can also be used when creating caches.
- No `update`/TTL refresh in this PR: `dev.langchain4j.http.client.HttpMethod` has no `PATCH`. The TTL is set at creation; update can follow as a small addition once the http client supports PATCH (I can do that as a follow-up).
- Docs: new "Context Caching" section in `google-ai-gemini.md` (create, attach via `cachedContentName`, manage).

If you'd prefer a smaller surface, this trims naturally to just `createCache` (the `ChatMessage` mapping is where the integration value is), leaving the rest of the lifecycle to direct REST calls.

Testing:
- `GeminiCachesTest` (19 unit tests on the module's existing `MockHttpClient` harness): the exact HTTP method, URL and headers per operation, the wire body mapping (`systemInstruction`/`contents` split, model-name qualification, TTL formatting, omission of absent fields), response parsing, pagination (`nextPageToken` following across pages, termination on an absent or empty token), empty-list handling, and the validation guards (blank names, empty messages).
- `GeminiCachesIT` (gated on `GOOGLE_AI_GEMINI_API_KEY`): create, get, list, attach the created cache to a `GoogleAiGeminiChatModel` via `cachedContentName` and run a real chat request against it, then delete. Run on a paid-tier key: 1/1 green. On the free tier the test skips, since explicit caching is not available there.
- Full module unit suite: 365 tests green. Spotless clean.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
