### PR TITLE
fix: ClassCastException when an MCP tool inputSchema contains anyOf alongside type "object"

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/ToolSpecificationHelper.java
@@ -69,7 +69,11 @@ class ToolSpecificationHelper {
      * to a JsonSchemaElement object that describes the tool's arguments.
      */
     static JsonSchemaElement jsonNodeToJsonSchemaElement(JsonNode node) {
-        if (node.has("anyOf")) {
+        // MCP SEP-2106 allows composition keywords such as anyOf alongside type "object", and the tool
+        // inputSchema root is always type "object". JsonObjectSchema cannot represent a schema-level anyOf,
+        // so an object-typed node is parsed as an object (its anyOf constraint is not carried over) rather
+        // than as a JsonAnyOfSchema that the root would then fail to cast.
+        if (node.has("anyOf") && !isObjectType(node)) {
             JsonAnyOfSchema.Builder anyOf = JsonAnyOfSchema.builder();
             JsonSchemaElement[] types = StreamSupport.stream(node.get("anyOf").spliterator(), false)
                     .map(ToolSpecificationHelper::jsonNodeToJsonSchemaElement)
@@ -205,6 +209,13 @@ class ToolSpecificationHelper {
             anyOf.anyOf(types);
             return anyOf.build();
         }
+    }
+
+    private static boolean isObjectType(JsonNode node) {
+        JsonNode typeNode = node.get("type");
+        return typeNode != null
+                && typeNode.getNodeType() == JsonNodeType.STRING
+                && typeNode.asText().equals("object");
     }
 
     private static JsonSchemaElement toTypeElement(JsonNode node) {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/ToolSpecificationHelperTest.java
@@ -344,6 +344,82 @@ class ToolSpecificationHelperTest {
     }
 
     @Test
+    void toolWithAnyOfAlongsideObjectTypeAtRoot() throws JsonProcessingException {
+        String text =
+                // language=json
+                """
+                [{
+                    "name": "fetch_artifacts",
+                    "description": "Fetch build artifacts",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "version": {
+                          "type": "string",
+                          "description": "Version identifier. Provide this, run_url, or both."
+                        },
+                        "run_url": {
+                          "type": "string",
+                          "description": "Execution run URL. Provide this, version, or both."
+                        },
+                        "filter": {
+                          "type": "string",
+                          "description": "Comma-separated list of names to fetch."
+                        },
+                        "signed": {
+                          "type": "boolean",
+                          "description": "If true, returns signed URLs."
+                        }
+                      },
+                      "anyOf": [
+                        { "required": ["version"] },
+                        { "required": ["run_url"] }
+                      ]
+                    }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+
+        assertThat(toolSpecifications).hasSize(1);
+        ToolSpecification toolSpecification = toolSpecifications.get(0);
+        assertThat(toolSpecification.name()).isEqualTo("fetch_artifacts");
+        JsonObjectSchema parameters = toolSpecification.parameters();
+        assertThat(parameters.properties()).containsOnlyKeys("version", "run_url", "filter", "signed");
+        assertThat(parameters.properties().get("version")).isInstanceOf(JsonStringSchema.class);
+        assertThat(parameters.properties().get("signed")).isInstanceOf(JsonBooleanSchema.class);
+    }
+
+    @Test
+    void toolWithAnyOfAlongsideObjectTypeAndPropertiesInBranches() throws JsonProcessingException {
+        String text =
+                // language=json
+                """
+                [{
+                    "name": "fetch_by_key",
+                    "inputSchema": {
+                      "type": "object",
+                      "anyOf": [
+                        {
+                          "properties": { "version": { "type": "string" } },
+                          "required": ["version"]
+                        },
+                        {
+                          "properties": { "run_url": { "type": "string" } },
+                          "required": ["run_url"]
+                        }
+                      ]
+                    }
+                }]
+                """;
+        ArrayNode json = OBJECT_MAPPER.readValue(text, ArrayNode.class);
+        List<ToolSpecification> toolSpecifications = ToolSpecificationHelper.toolSpecificationListFromMcpResponse(json);
+
+        assertThat(toolSpecifications).hasSize(1);
+        assertThat(toolSpecifications.get(0).parameters()).isInstanceOf(JsonObjectSchema.class);
+    }
+
+    @Test
     void nullTypeName() throws JsonProcessingException {
         // the 'value' parameter has an empty definition, so it can be anything
         String text = """


### PR DESCRIPTION
## Issue
Fixes #5720

## Change

`ToolSpecificationHelper.jsonNodeToJsonSchemaElement` checks `anyOf` before `type`, so an MCP tool `inputSchema` that contains a root-level `anyOf` alongside `type: "object"` (allowed by MCP SEP-2106) parses as `JsonAnyOfSchema`, and the cast to `JsonObjectSchema` in `toolSpecificationListFromMcpResponse` throws a `ClassCastException`. `McpToolProvider` catches it and returns zero tools for the whole server, so a single tool with such a schema silently disables every tool on that server.

The fix: an object-typed node (`type: "object"`, which the MCP tool `inputSchema` root always is) is parsed as an object, so `properties` and `required` are preserved and the tools load again. The composition constraint itself is not carried over, since `JsonObjectSchema` has no representation for a schema-level `anyOf`. Nodes that carry `anyOf` without an object type keep the existing `JsonAnyOfSchema` behavior, so all existing schema shapes (unions of objects, arrays with mixed item types, etc.) parse as before.

Testing:
- Two new tests in `ToolSpecificationHelperTest`: the exact schema from the issue (properties at the root alongside `anyOf`), and a variant where the properties are declared inside the `anyOf` branches. Both fail with the reported `ClassCastException` without the fix and parse into a `JsonObjectSchema` with it.
- All 16 pre-existing schema tests unchanged and green.
- Full `langchain4j-mcp` unit suite: 86 tests green. Spotless clean.


## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`

