### PR TITLE
fix: Anthropic honors cache_control on AiMessage and ToolExecutionResultMessage

### DIFF
--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -475,32 +475,36 @@ to see an example of specifying tool `metadata` in the low-level `ToolSpecificat
 
 ## Caching
 
-`AnthropicChatModel` and `AnthropicStreamingChatModel` support caching of system messages and tools.
-Caching is disabled by default.
-It can be enabled by setting the `cacheSystemMessages` and `cacheTools` parameters, respectively.
-
-When enabled,`cache_control` blocks will be added to the last system message and tool, respectively.
-
-`AnthropicChatModel` and `AnthropicStreamingChatModel` return `AnthropicTokenUsage` in response which
-contains `cacheCreationInputTokens` and `cacheReadInputTokens`.
+`AnthropicChatModel` and `AnthropicStreamingChatModel` return `AnthropicTokenUsage` in the response,
+which contains `cacheCreationInputTokens` and `cacheReadInputTokens`.
 
 More info on caching can be found [here](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching).
-### Caching User Messages
 
-To enable prompt caching for a `UserMessage`, you need to set the `cache_control` attribute to `ephemeral`. The cache control marker will be automatically applied to the last content block of the message.
+### Caching System Messages and Tools
+
+Caching of system messages and tools is disabled by default.
+It can be enabled by setting the `cacheSystemMessages` and `cacheTools` parameters, respectively.
+
+When enabled, `cache_control` blocks will be added to the last system message and tool, respectively.
+
+### Caching Individual Messages
+
+`UserMessage`, `AiMessage`, and `ToolExecutionResultMessage` can each be marked for caching by setting
+the `cache_control` attribute to `ephemeral`. The cache control marker is automatically applied to the
+last content block of the message (for `ToolExecutionResultMessage`, this is the `tool_result` block
+itself).
+
+`UserMessage` exposes a mutable attributes map:
 
 ```java
 UserMessage userMessage = UserMessage.from("Hello cached world");
 userMessage.attributes().put("cache_control", "ephemeral");
 ```
 
-### Caching AI and Tool Result Messages
-
-The same `cache_control` attribute is honored on `AiMessage` and `ToolExecutionResultMessage`.
-This is especially useful in an agentic tool-execution loop, where the conversation history grows
-on every turn: marking the last message of a turn as `ephemeral` lets subsequent, larger requests
-reuse the cached prefix instead of re-billing the whole growing history at full price. Since these
-messages carry an immutable attributes map, set it via `toBuilder()`:
+`AiMessage` and `ToolExecutionResultMessage` carry an immutable attributes map, so set it via
+`toBuilder()`. This is especially useful in an agentic tool-execution loop, where the conversation
+history grows on every turn: marking the last message of a turn as `ephemeral` lets subsequent, larger
+requests reuse the cached prefix instead of re-billing the whole growing history at full price.
 
 ```java
 AiMessage aiMessage = someAiMessage.toBuilder()
@@ -511,9 +515,6 @@ ToolExecutionResultMessage toolExecutionResultMessage = someToolExecutionResultM
         .attributes(Map.of("cache_control", "ephemeral"))
         .build();
 ```
-
-As with `UserMessage`, the cache control marker is automatically applied to the last content block
-of the message (for `ToolExecutionResultMessage`, this is the `tool_result` block itself).
 
 ### Cache Diagnostics
 

--- a/docs/docs/integrations/language-models/anthropic.md
+++ b/docs/docs/integrations/language-models/anthropic.md
@@ -494,6 +494,27 @@ UserMessage userMessage = UserMessage.from("Hello cached world");
 userMessage.attributes().put("cache_control", "ephemeral");
 ```
 
+### Caching AI and Tool Result Messages
+
+The same `cache_control` attribute is honored on `AiMessage` and `ToolExecutionResultMessage`.
+This is especially useful in an agentic tool-execution loop, where the conversation history grows
+on every turn: marking the last message of a turn as `ephemeral` lets subsequent, larger requests
+reuse the cached prefix instead of re-billing the whole growing history at full price. Since these
+messages carry an immutable attributes map, set it via `toBuilder()`:
+
+```java
+AiMessage aiMessage = someAiMessage.toBuilder()
+        .attributes(Map.of("cache_control", "ephemeral"))
+        .build();
+
+ToolExecutionResultMessage toolExecutionResultMessage = someToolExecutionResultMessage.toBuilder()
+        .attributes(Map.of("cache_control", "ephemeral"))
+        .build();
+```
+
+As with `UserMessage`, the cache control marker is automatically applied to the last content block
+of the message (for `ToolExecutionResultMessage`, this is the `tool_result` block itself).
+
 ### Cache Diagnostics
 
 Anthropic's (beta) [cache diagnostics](https://docs.anthropic.com/en/docs/build-with-claude/cache-diagnostics)

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolResultContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolResultContent.java
@@ -32,8 +32,26 @@ public class AnthropicToolResultContent extends AnthropicMessageContent {
     }
 
     public AnthropicToolResultContent(
-            String toolUseId, List<AnthropicMessageContent> content, Boolean isError) {
+            String toolUseId, String content, Boolean isError, AnthropicCacheControl cacheControl) {
+        super("tool_result", cacheControl);
+        this.toolUseId = toolUseId;
+        this.content = content;
+        this.isError = isError;
+    }
+
+    public AnthropicToolResultContent(String toolUseId, List<AnthropicMessageContent> content, Boolean isError) {
         super("tool_result");
+        this.toolUseId = toolUseId;
+        this.content = content;
+        this.isError = isError;
+    }
+
+    public AnthropicToolResultContent(
+            String toolUseId,
+            List<AnthropicMessageContent> content,
+            Boolean isError,
+            AnthropicCacheControl cacheControl) {
+        super("tool_result", cacheControl);
         this.toolUseId = toolUseId;
         this.content = content;
         this.isError = isError;

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolUseContent.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/api/AnthropicToolUseContent.java
@@ -26,6 +26,13 @@ public class AnthropicToolUseContent extends AnthropicMessageContent {
         this.input = input;
     }
 
+    public AnthropicToolUseContent(String id, String name, String input, AnthropicCacheControl cacheControl) {
+        super("tool_use", cacheControl);
+        this.id = id;
+        this.name = name;
+        this.input = input;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
@@ -56,6 +63,7 @@ public class AnthropicToolUseContent extends AnthropicMessageContent {
         private String id;
         private String name;
         private String input;
+        private AnthropicCacheControl cacheControl;
 
         public Builder id(String id) {
             this.id = id;
@@ -72,8 +80,13 @@ public class AnthropicToolUseContent extends AnthropicMessageContent {
             return this;
         }
 
+        public Builder cacheControl(AnthropicCacheControl cacheControl) {
+            this.cacheControl = cacheControl;
+            return this;
+        }
+
         public AnthropicToolUseContent build() {
-            return new AnthropicToolUseContent(id, name, input);
+            return new AnthropicToolUseContent(id, name, input, cacheControl);
         }
     }
 }

--- a/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
+++ b/langchain4j-anthropic/src/main/java/dev/langchain4j/model/anthropic/internal/mapper/AnthropicMapper.java
@@ -37,6 +37,7 @@ import dev.langchain4j.model.anthropic.AnthropicCacheDiagnostics;
 import dev.langchain4j.model.anthropic.AnthropicServerTool;
 import dev.langchain4j.model.anthropic.AnthropicServerToolResult;
 import dev.langchain4j.model.anthropic.AnthropicTokenUsage;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheControl;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheMissReason;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCacheType;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicContent;
@@ -80,6 +81,10 @@ public class AnthropicMapper {
     public static final String SERVER_TOOL_RESULTS_KEY =
             "server_tool_results"; // do not change, will break backward compatibility!
     public static final String CACHE_CONTROL = "cache_control";
+
+    private static boolean isMarkedForCaching(Map<String, Object> attributes) {
+        return attributes != null && "ephemeral".equals(attributes.get(CACHE_CONTROL));
+    }
 
     public static List<AnthropicMessage> toAnthropicMessages(List<ChatMessage> messages) {
         return toAnthropicMessages(messages, false, false);
@@ -137,10 +142,14 @@ public class AnthropicMapper {
     }
 
     private static AnthropicToolResultContent toAnthropicToolResultContent(ToolExecutionResultMessage message) {
+        AnthropicCacheControl cacheControl =
+                isMarkedForCaching(message.attributes()) ? AnthropicCacheType.EPHEMERAL.cacheControl() : null;
+        Boolean isError = Boolean.TRUE.equals(message.isError()) ? true : null;
+
         if (message.hasSingleText()) {
-            return new AnthropicToolResultContent(
-                    message.id(), message.text(), Boolean.TRUE.equals(message.isError()) ? true : null);
+            return new AnthropicToolResultContent(message.id(), message.text(), isError, cacheControl);
         }
+
         List<AnthropicMessageContent> contentBlocks = new ArrayList<>();
         for (dev.langchain4j.data.message.Content content : message.contents()) {
             if (content instanceof TextContent textContent) {
@@ -158,13 +167,11 @@ public class AnthropicMapper {
                 throw illegalArgument("Unsupported content type in tool result: " + content.type());
             }
         }
-        return new AnthropicToolResultContent(
-                message.id(), contentBlocks, Boolean.TRUE.equals(message.isError()) ? true : null);
+        return new AnthropicToolResultContent(message.id(), contentBlocks, isError, cacheControl);
     }
 
     private static List<AnthropicMessageContent> toAnthropicMessageContents(UserMessage message) {
-        boolean shouldCache = message.attributes() != null
-                && "ephemeral".equals(message.attributes().get(CACHE_CONTROL));
+        boolean shouldCache = isMarkedForCaching(message.attributes());
 
         List<dev.langchain4j.data.message.Content> contents = message.contents();
         List<AnthropicMessageContent> anthropicContents = new ArrayList<>();
@@ -226,19 +233,32 @@ public class AnthropicMapper {
             }
         }
 
+        boolean shouldCache = isMarkedForCaching(message.attributes());
+        boolean hasToolExecutionRequests = message.hasToolExecutionRequests();
+
         if (isNotNullOrBlank(message.text())) {
-            contents.add(new AnthropicTextContent(message.text()));
+            // the tool_use blocks added below (if any) become the last content block instead of this text
+            boolean applyCache = shouldCache && !hasToolExecutionRequests;
+            contents.add(
+                    applyCache
+                            ? new AnthropicTextContent(message.text(), AnthropicCacheType.EPHEMERAL.cacheControl())
+                            : new AnthropicTextContent(message.text()));
         }
 
-        if (message.hasToolExecutionRequests()) {
-            List<AnthropicToolUseContent> toolUseContents = message.toolExecutionRequests().stream()
-                    .map(toolExecutionRequest -> AnthropicToolUseContent.builder()
-                            .id(toolExecutionRequest.id())
-                            .name(toolExecutionRequest.name())
-                            .input(toAnthropicInput(toolExecutionRequest))
-                            .build())
-                    .toList();
-            contents.addAll(toolUseContents);
+        if (hasToolExecutionRequests) {
+            List<ToolExecutionRequest> toolExecutionRequests = message.toolExecutionRequests();
+            for (int i = 0; i < toolExecutionRequests.size(); i++) {
+                ToolExecutionRequest toolExecutionRequest = toolExecutionRequests.get(i);
+                boolean isLastItem = i == toolExecutionRequests.size() - 1;
+                AnthropicToolUseContent.Builder toolUseContentBuilder = AnthropicToolUseContent.builder()
+                        .id(toolExecutionRequest.id())
+                        .name(toolExecutionRequest.name())
+                        .input(toAnthropicInput(toolExecutionRequest));
+                if (shouldCache && isLastItem) {
+                    toolUseContentBuilder.cacheControl(AnthropicCacheType.EPHEMERAL.cacheControl());
+                }
+                contents.add(toolUseContentBuilder.build());
+            }
         }
 
         return contents;

--- a/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
+++ b/langchain4j-anthropic/src/test/java/dev/langchain4j/model/anthropic/AnthropicMapperTest.java
@@ -633,6 +633,129 @@ class AnthropicMapperTest {
     }
 
     @Test
+    void should_map_ai_message_text_with_cache_control_metadata() {
+        // given
+        AiMessage aiMessage = AiMessage.builder()
+                .text("Hi")
+                .attributes(singletonMap("cache_control", "ephemeral"))
+                .build();
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(aiMessage));
+
+        // then
+        assertThat(anthropicMessages).hasSize(1);
+        AnthropicMessage message = anthropicMessages.get(0);
+        assertThat(message.content).hasSize(1);
+
+        AnthropicTextContent textContent = (AnthropicTextContent) message.content.get(0);
+        assertThat(textContent.text).isEqualTo("Hi");
+        assertThat(textContent.cacheControl).isNotNull();
+        assertThat(textContent.cacheControl).extracting("type").isEqualTo("ephemeral");
+    }
+
+    @Test
+    void should_apply_cache_control_to_last_content_block_of_ai_message_with_tool_execution_requests() {
+        // given
+        AiMessage aiMessage = AiMessage.builder()
+                .text("Let me check that")
+                .toolExecutionRequests(singletonList(ToolExecutionRequest.builder()
+                        .id("12345")
+                        .name("calculator")
+                        .arguments("{\"first\": 2, \"second\": 2}")
+                        .build()))
+                .attributes(singletonMap("cache_control", "ephemeral"))
+                .build();
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(aiMessage));
+
+        // then
+        AnthropicMessage message = anthropicMessages.get(0);
+        assertThat(message.content).hasSize(2);
+
+        AnthropicTextContent textContent = (AnthropicTextContent) message.content.get(0);
+        assertThat(textContent.cacheControl).isNull();
+
+        AnthropicToolUseContent toolUseContent = (AnthropicToolUseContent) message.content.get(1);
+        assertThat(toolUseContent.cacheControl).isNotNull();
+        assertThat(toolUseContent.cacheControl).extracting("type").isEqualTo("ephemeral");
+    }
+
+    @Test
+    void should_not_apply_cache_control_to_ai_message_without_cache_control_attribute() {
+        // given
+        AiMessage aiMessage = AiMessage.from("Hi");
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(aiMessage));
+
+        // then
+        AnthropicTextContent textContent =
+                (AnthropicTextContent) anthropicMessages.get(0).content.get(0);
+        assertThat(textContent.cacheControl).isNull();
+    }
+
+    @Test
+    void should_map_tool_execution_result_message_with_single_text_and_cache_control_metadata() {
+        // given
+        ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.builder()
+                .id("12345")
+                .toolName("calculator")
+                .text("4")
+                .attributes(singletonMap("cache_control", "ephemeral"))
+                .build();
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(toolExecutionResultMessage));
+
+        // then
+        assertThat(anthropicMessages).hasSize(1);
+        AnthropicToolResultContent content =
+                (AnthropicToolResultContent) anthropicMessages.get(0).content.get(0);
+        assertThat(content.content).isEqualTo("4");
+        assertThat(content.cacheControl).isNotNull();
+        assertThat(content.cacheControl).extracting("type").isEqualTo("ephemeral");
+    }
+
+    @Test
+    void should_map_tool_execution_result_message_with_multiple_content_blocks_and_cache_control_metadata() {
+        // given
+        ToolExecutionResultMessage toolExecutionResultMessage = ToolExecutionResultMessage.builder()
+                .id("12345")
+                .toolName("calculator")
+                .contents(TextContent.from("here is the chart"), ImageContent.from(DICE_IMAGE_URL))
+                .attributes(singletonMap("cache_control", "ephemeral"))
+                .build();
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(toolExecutionResultMessage));
+
+        // then
+        AnthropicToolResultContent content =
+                (AnthropicToolResultContent) anthropicMessages.get(0).content.get(0);
+        // cache control is applied to the outer tool_result block, not an inner content block
+        assertThat(content.cacheControl).isNotNull();
+        assertThat(content.cacheControl).extracting("type").isEqualTo("ephemeral");
+        assertThat(content.content).isInstanceOf(List.class);
+    }
+
+    @Test
+    void should_not_apply_cache_control_to_tool_execution_result_message_without_cache_control_attribute() {
+        // given
+        ToolExecutionResultMessage toolExecutionResultMessage =
+                ToolExecutionResultMessage.from("12345", "calculator", "4");
+
+        // when
+        List<AnthropicMessage> anthropicMessages = toAnthropicMessages(singletonList(toolExecutionResultMessage));
+
+        // then
+        AnthropicToolResultContent content =
+                (AnthropicToolResultContent) anthropicMessages.get(0).content.get(0);
+        assertThat(content.cacheControl).isNull();
+    }
+
+    @Test
     void mid_conversation_system_messages_disabled_sends_all_system_messages_via_top_level_system_prompt() {
         // given
         List<ChatMessage> messages = asList(


### PR DESCRIPTION
## Issue
Closes #5727

## Change
`AnthropicMapper` already honored a `cache_control: "ephemeral"` attribute on `UserMessage` (#4487). In an agentic tool loop, `AiServices` resends the growing conversation tail (`AiMessage` + `ToolExecutionResultMessage`) on every call, but neither of those message types could be marked for caching, so every accumulated tool result was rebilled at full price on each turn.

This extends the same `cache_control` handling to `AiMessage` and `ToolExecutionResultMessage`, mirroring the existing `UserMessage` behavior:
```java
AiMessage aiMessage = someAiMessage.toBuilder()
        .attributes(Map.of("cache_control", "ephemeral"))
        .build();
```
The cache marker is applied to the last content block of the message (for `ToolExecutionResultMessage`, the `tool_result` block itself). `AnthropicToolResultContent` and `AnthropicToolUseContent` gained `cacheControl`-aware constructor/builder overloads so the marker is set at construction time, consistent with how `AnthropicTextContent` already does it for `UserMessage`.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [X] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)