### PR TITLE
fix: Avoid StringIndexOutOfBoundsException when cleaning unclosed code fence in SqlDatabaseContentRetriever

### DIFF
--- a/experimental/langchain4j-experimental-sql/src/main/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetriever.java
+++ b/experimental/langchain4j-experimental-sql/src/main/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetriever.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.experimental.rag.content.retriever.sql;
 
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 import dev.langchain4j.Experimental;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
@@ -11,11 +16,6 @@ import dev.langchain4j.model.input.PromptTemplate;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.query.Query;
-import net.sf.jsqlparser.JSQLParserException;
-import net.sf.jsqlparser.parser.CCJSqlParserUtil;
-import net.sf.jsqlparser.statement.select.Select;
-
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -25,11 +25,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static dev.langchain4j.internal.Utils.getOrDefault;
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
+import javax.sql.DataSource;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.select.Select;
 
 /**
  * <b>
@@ -53,13 +52,12 @@ import static java.util.Collections.singletonList;
 @Experimental
 public class SqlDatabaseContentRetriever implements ContentRetriever {
 
-    private static final PromptTemplate DEFAULT_PROMPT_TEMPLATE = PromptTemplate.from(
-            "You are an expert in writing SQL queries.\n" +
-                    "You have access to a {{sqlDialect}} database with the following structure:\n" +
-                    "{{databaseStructure}}\n" +
-                    "If a user asks a question that can be answered by querying this database, generate an SQL SELECT query.\n" +
-                    "Do not output anything else aside from a valid SQL statement!"
-    );
+    private static final PromptTemplate DEFAULT_PROMPT_TEMPLATE =
+            PromptTemplate.from("You are an expert in writing SQL queries.\n"
+                    + "You have access to a {{sqlDialect}} database with the following structure:\n"
+                    + "{{databaseStructure}}\n"
+                    + "If a user asks a question that can be answered by querying this database, generate an SQL SELECT query.\n"
+                    + "Do not output anything else aside from a valid SQL statement!");
 
     private final DataSource dataSource;
     private final String sqlDialect;
@@ -95,12 +93,13 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
      *                          This is an optional parameter. Default: 0.
      */
     @Experimental
-    public SqlDatabaseContentRetriever(DataSource dataSource,
-                                       String sqlDialect,
-                                       String databaseStructure,
-                                       PromptTemplate promptTemplate,
-                                       ChatModel chatModel,
-                                       Integer maxRetries) {
+    public SqlDatabaseContentRetriever(
+            DataSource dataSource,
+            String sqlDialect,
+            String databaseStructure,
+            PromptTemplate promptTemplate,
+            ChatModel chatModel,
+            Integer maxRetries) {
         this.dataSource = ensureNotNull(dataSource, "dataSource");
         this.sqlDialect = getOrDefault(sqlDialect, () -> getSqlDialect(dataSource));
         this.databaseStructure = getOrDefault(databaseStructure, () -> generateDDL(dataSource));
@@ -128,7 +127,7 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
         try (Connection connection = dataSource.getConnection()) {
             DatabaseMetaData metaData = connection.getMetaData();
 
-            ResultSet tables = metaData.getTables(null, null, "%", new String[]{"TABLE"});
+            ResultSet tables = metaData.getTables(null, null, "%", new String[] {"TABLE"});
 
             while (tables.next()) {
                 String tableName = tables.getString("TABLE_NAME");
@@ -155,17 +154,15 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
                 primaryKeyColumn = pk.getString("COLUMN_NAME");
             }
 
-            createTableStatement
-                    .append("CREATE TABLE ")
-                    .append(tableName)
-                    .append(" (\n");
+            createTableStatement.append("CREATE TABLE ").append(tableName).append(" (\n");
 
             while (columns.next()) {
                 String columnName = columns.getString("COLUMN_NAME");
                 String columnType = columns.getString("TYPE_NAME");
                 int size = columns.getInt("COLUMN_SIZE");
                 String nullable = columns.getString("IS_NULLABLE").equals("YES") ? " NULL" : " NOT NULL";
-                String columnDef = columns.getString("COLUMN_DEF") != null ? " DEFAULT " + columns.getString("COLUMN_DEF") : "";
+                String columnDef =
+                        columns.getString("COLUMN_DEF") != null ? " DEFAULT " + columns.getString("COLUMN_DEF") : "";
                 String comment = columns.getString("REMARKS");
 
                 createTableStatement
@@ -262,7 +259,7 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
                 validate(sqlQuery);
 
                 try (Connection connection = dataSource.getConnection();
-                     Statement statement = connection.createStatement()) {
+                        Statement statement = connection.createStatement()) {
 
                     String result = execute(sqlQuery, statement);
                     Content content = format(result, sqlQuery);
@@ -276,7 +273,8 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
         return emptyList();
     }
 
-    protected String generateSqlQuery(Query naturalLanguageQuery, String previousSqlQuery, String previousErrorMessage) {
+    protected String generateSqlQuery(
+            Query naturalLanguageQuery, String previousSqlQuery, String previousErrorMessage) {
 
         List<ChatMessage> messages = new ArrayList<>();
         messages.add(createSystemPrompt().toSystemMessage());
@@ -313,9 +311,7 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
                 : sqlQuery.substring(contentStart);
     }
 
-    protected void validate(String sqlQuery) {
-
-    }
+    protected void validate(String sqlQuery) {}
 
     protected boolean isSelect(String sqlQuery) {
         try {
@@ -344,7 +340,9 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
                 List<String> columnValues = new ArrayList<>();
                 for (int i = 1; i <= columnCount; i++) {
 
-                    String columnValue = resultSet.getObject(i) == null ? "" : resultSet.getObject(i).toString();
+                    String columnValue = resultSet.getObject(i) == null
+                            ? ""
+                            : resultSet.getObject(i).toString();
 
                     if (columnValue.contains(",")) {
                         columnValue = "\"" + columnValue + "\"";
@@ -370,8 +368,7 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
         private ChatModel chatModel;
         private Integer maxRetries;
 
-        SqlDatabaseContentRetrieverBuilder() {
-        }
+        SqlDatabaseContentRetrieverBuilder() {}
 
         public SqlDatabaseContentRetrieverBuilder dataSource(DataSource dataSource) {
             this.dataSource = dataSource;
@@ -404,11 +401,20 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
         }
 
         public SqlDatabaseContentRetriever build() {
-            return new SqlDatabaseContentRetriever(this.dataSource, this.sqlDialect, this.databaseStructure, this.promptTemplate, this.chatModel, this.maxRetries);
+            return new SqlDatabaseContentRetriever(
+                    this.dataSource,
+                    this.sqlDialect,
+                    this.databaseStructure,
+                    this.promptTemplate,
+                    this.chatModel,
+                    this.maxRetries);
         }
 
         public String toString() {
-            return "SqlDatabaseContentRetriever.SqlDatabaseContentRetrieverBuilder(dataSource=" + this.dataSource + ", sqlDialect=" + this.sqlDialect + ", databaseStructure=" + this.databaseStructure + ", promptTemplate=" + this.promptTemplate + ", chatModel=" + this.chatModel + ", maxRetries=" + this.maxRetries + ")";
+            return "SqlDatabaseContentRetriever.SqlDatabaseContentRetrieverBuilder(dataSource=" + this.dataSource
+                    + ", sqlDialect=" + this.sqlDialect + ", databaseStructure=" + this.databaseStructure
+                    + ", promptTemplate=" + this.promptTemplate + ", chatModel=" + this.chatModel + ", maxRetries="
+                    + this.maxRetries + ")";
         }
     }
 }

--- a/experimental/langchain4j-experimental-sql/src/main/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetriever.java
+++ b/experimental/langchain4j-experimental-sql/src/main/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetriever.java
@@ -299,11 +299,18 @@ public class SqlDatabaseContentRetriever implements ContentRetriever {
 
     protected String clean(String sqlQuery) {
         if (sqlQuery.contains("```sql")) {
-            return sqlQuery.substring(sqlQuery.indexOf("```sql") + 6, sqlQuery.lastIndexOf("```"));
+            return stripCodeFence(sqlQuery, sqlQuery.indexOf("```sql") + 6);
         } else if (sqlQuery.contains("```")) {
-            return sqlQuery.substring(sqlQuery.indexOf("```") + 3, sqlQuery.lastIndexOf("```"));
+            return stripCodeFence(sqlQuery, sqlQuery.indexOf("```") + 3);
         }
         return sqlQuery;
+    }
+
+    private static String stripCodeFence(String sqlQuery, int contentStart) {
+        int closingFence = sqlQuery.lastIndexOf("```");
+        return closingFence > contentStart
+                ? sqlQuery.substring(contentStart, closingFence)
+                : sqlQuery.substring(contentStart);
     }
 
     protected void validate(String sqlQuery) {

--- a/experimental/langchain4j-experimental-sql/src/test/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetrieverTest.java
+++ b/experimental/langchain4j-experimental-sql/src/test/java/dev/langchain4j/experimental/rag/content/retriever/sql/SqlDatabaseContentRetrieverTest.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.experimental.rag.content.retriever.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+
+import dev.langchain4j.model.chat.ChatModel;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+
+class SqlDatabaseContentRetrieverTest {
+
+    private final SqlDatabaseContentRetriever retriever = SqlDatabaseContentRetriever.builder()
+            .dataSource(mock(DataSource.class))
+            .sqlDialect("PostgreSQL")
+            .databaseStructure("test")
+            .chatModel(mock(ChatModel.class))
+            .build();
+
+    @Test
+    void clean_should_strip_content_from_closed_sql_fence() {
+        assertThat(retriever.clean("```sql\nSELECT * FROM customer\n```")).isEqualTo("\nSELECT * FROM customer\n");
+    }
+
+    @Test
+    void clean_should_strip_content_from_closed_plain_fence() {
+        assertThat(retriever.clean("```\nSELECT * FROM customer\n```")).isEqualTo("\nSELECT * FROM customer\n");
+    }
+
+    @Test
+    void clean_should_not_throw_when_sql_fence_is_not_closed() {
+        assertThatCode(() -> retriever.clean("```sql\nSELECT * FROM customer")).doesNotThrowAnyException();
+        assertThat(retriever.clean("```sql\nSELECT * FROM customer")).isEqualTo("\nSELECT * FROM customer");
+    }
+
+    @Test
+    void clean_should_not_throw_when_plain_fence_is_not_closed() {
+        assertThatCode(() -> retriever.clean("```\nSELECT * FROM customer")).doesNotThrowAnyException();
+        assertThat(retriever.clean("```\nSELECT * FROM customer")).isEqualTo("\nSELECT * FROM customer");
+    }
+
+    @Test
+    void clean_should_return_plain_text_unchanged() {
+        assertThat(retriever.clean("SELECT * FROM customer")).isEqualTo("SELECT * FROM customer");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5736

## Change

`SqlDatabaseContentRetriever.clean()` strips a markdown code fence from the generated SQL before executing it. When the response has an opening fence (```sql```/``````) but no closing fence, `substring(start, lastIndexOf("```"))` gets `end < start` (`lastIndexOf` matches the opening fence's own backticks) and throws `StringIndexOutOfBoundsException`. `clean()` runs outside `retrieve()`'s `try/catch`, so the exception escapes the retry / `emptyList()` fallback the method is designed around.

This extracts the shared boundary logic into a `stripCodeFence` helper: it slices to the closing fence only when one follows the opening tag, otherwise returns the text after the opening tag. Behaviour for correctly closed fences is unchanged.

Same underlying bug as #5731, fixed for `HibernateContentRetriever` in #5732 (both classes independently implement the same fence-stripping logic; `SqlDatabaseContentRetriever` was missed in that fix).

Added `SqlDatabaseContentRetrieverTest` (the module's first unit test — `clean()` is `protected` and pure, so no live database is needed) covering closed fences (regression), unclosed fences for both fence types, and plain text.

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green