### PR TITLE
fix(core): include inherited fields in tool schemas

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -260,11 +260,8 @@ public class JsonSchemaElementUtils {
 
         Map<String, JsonSchemaElement> properties = new LinkedHashMap<>();
         List<String> required = new ArrayList<>();
-        for (Field field : type.getDeclaredFields()) {
+        for (Field field : instanceFieldsIn(type)) {
             String fieldName = field.getName();
-            if (isStatic(field.getModifiers()) || fieldName.equals("__$hits$__") || fieldName.startsWith("this$")) {
-                continue;
-            }
             if (isRequired(field, areSubFieldsRequiredByDefault)) {
                 required.add(fieldName);
             }
@@ -294,6 +291,28 @@ public class JsonSchemaElementUtils {
         }
 
         return builder.build();
+    }
+
+    private static List<Field> instanceFieldsIn(Class<?> type) {
+        Map<String, Field> fieldsByName = new LinkedHashMap<>();
+        addInstanceFields(type, fieldsByName);
+        return new ArrayList<>(fieldsByName.values());
+    }
+
+    private static void addInstanceFields(Class<?> type, Map<String, Field> fieldsByName) {
+        Class<?> superclass = type.getSuperclass();
+        if (superclass != null && superclass != Object.class) {
+            addInstanceFields(superclass, fieldsByName);
+        }
+
+        for (Field field : type.getDeclaredFields()) {
+            String fieldName = field.getName();
+            if (isStatic(field.getModifiers()) || fieldName.equals("__$hits$__") || fieldName.startsWith("this$")) {
+                continue;
+            }
+            fieldsByName.remove(fieldName);
+            fieldsByName.put(fieldName, field);
+        }
     }
 
     private static boolean isRequired(Field field, boolean defaultValue) {

--- a/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/internal/JsonSchemaElementUtils.java
@@ -301,7 +301,7 @@ public class JsonSchemaElementUtils {
 
     private static void addInstanceFields(Class<?> type, Map<String, Field> fieldsByName) {
         Class<?> superclass = type.getSuperclass();
-        if (superclass != null && superclass != Object.class) {
+        if (superclass != null && superclass != Object.class && isCustomClass(superclass)) {
             addInstanceFields(superclass, fieldsByName);
         }
 

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
@@ -120,6 +120,19 @@ class ToolSpecificationsTest implements WithAssertions {
         public void toolMethod(@P("first person") Person p0, @P("second person") Person p1) {}
     }
 
+    public static class BaseRequest {
+        String id;
+    }
+
+    public static class CreatePersonRequest extends BaseRequest {
+        String name;
+    }
+
+    public static class ToolWithInheritedRequest {
+        @Tool
+        public void createPerson(CreatePersonRequest request) {}
+    }
+
     private static Method getF() throws NoSuchMethodException {
         return Wrapper.class.getMethod(
                 "f",
@@ -344,6 +357,25 @@ class ToolSpecificationsTest implements WithAssertions {
                                                         .required("street", "city")
                                                         .build())
                                         .required("name", "billingAddress", "shippingAddress")
+                                        .build())
+                        .required("arg0")
+                        .build());
+    }
+
+    @Test
+    void tool_specification_includes_inherited_request_fields() throws NoSuchMethodException {
+        Method method = ToolWithInheritedRequest.class.getMethod("createPerson", CreatePersonRequest.class);
+
+        ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);
+
+        assertThat(ts.parameters())
+                .isEqualTo(JsonObjectSchema.builder()
+                        .addProperty(
+                                "arg0",
+                                JsonObjectSchema.builder()
+                                        .addStringProperty("id")
+                                        .addStringProperty("name")
+                                        .required("id", "name")
                                         .build())
                         .required("arg0")
                         .build());

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
@@ -133,6 +133,15 @@ class ToolSpecificationsTest implements WithAssertions {
         public void createPerson(CreatePersonRequest request) {}
     }
 
+    public static class ErrorRequest extends RuntimeException {
+        String code;
+    }
+
+    public static class ToolWithJdkSuperclassRequest {
+        @Tool
+        public void report(ErrorRequest request) {}
+    }
+
     private static Method getF() throws NoSuchMethodException {
         return Wrapper.class.getMethod(
                 "f",
@@ -376,6 +385,24 @@ class ToolSpecificationsTest implements WithAssertions {
                                         .addStringProperty("id")
                                         .addStringProperty("name")
                                         .required("id", "name")
+                                        .build())
+                        .required("arg0")
+                        .build());
+    }
+
+    @Test
+    void tool_specification_ignores_non_custom_superclass_fields() throws NoSuchMethodException {
+        Method method = ToolWithJdkSuperclassRequest.class.getMethod("report", ErrorRequest.class);
+
+        ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);
+
+        assertThat(ts.parameters())
+                .isEqualTo(JsonObjectSchema.builder()
+                        .addProperty(
+                                "arg0",
+                                JsonObjectSchema.builder()
+                                        .addStringProperty("code")
+                                        .required("code")
                                         .build())
                         .required("arg0")
                         .build());

--- a/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
+++ b/langchain4j-core/src/test/java/dev/langchain4j/agent/tool/ToolSpecificationsTest.java
@@ -546,7 +546,10 @@ class ToolSpecificationsTest implements WithAssertions {
         ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);
 
         JsonSchemaElement element = ts.parameters().properties().get("arg0");
-        assertThat(element).isEqualTo(JsonStringSchema.builder().description("desc via description").build());
+        assertThat(element)
+                .isEqualTo(JsonStringSchema.builder()
+                        .description("desc via description")
+                        .build());
     }
 
     @Test
@@ -559,7 +562,9 @@ class ToolSpecificationsTest implements WithAssertions {
         ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);
 
         JsonSchemaElement element = ts.parameters().properties().get("arg0");
-        assertThat(element).isEqualTo(JsonStringSchema.builder().description("desc via value").build());
+        assertThat(element)
+                .isEqualTo(
+                        JsonStringSchema.builder().description("desc via value").build());
     }
 
     @Test
@@ -572,7 +577,8 @@ class ToolSpecificationsTest implements WithAssertions {
         ToolSpecification ts = ToolSpecifications.toolSpecificationFrom(method);
 
         assertThat(ts.parameters().properties()).containsKey("myParam");
-        JsonStringSchema element = (JsonStringSchema) ts.parameters().properties().get("myParam");
+        JsonStringSchema element =
+                (JsonStringSchema) ts.parameters().properties().get("myParam");
         assertThat(element.description()).isNull();
     }
 
@@ -599,9 +605,9 @@ class ToolSpecificationsTest implements WithAssertions {
         List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ChildTool());
 
         assertThat(specs).hasSize(2);
-        assertThat(specs).extracting(ToolSpecification::name)
-                .containsExactlyInAnyOrder("childMethod", "parentMethod");
-        assertThat(specs).extracting(ToolSpecification::description)
+        assertThat(specs).extracting(ToolSpecification::name).containsExactlyInAnyOrder("childMethod", "parentMethod");
+        assertThat(specs)
+                .extracting(ToolSpecification::description)
                 .containsExactlyInAnyOrder("child tool", "parent tool");
     }
 
@@ -665,7 +671,8 @@ class ToolSpecificationsTest implements WithAssertions {
 
     @Test
     void should_use_updated_tool_annotation_from_overriding_child() {
-        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ChildOverridingToolWithNewAnnotation());
+        List<ToolSpecification> specs =
+                ToolSpecifications.toolSpecificationsFrom(new ChildOverridingToolWithNewAnnotation());
 
         assertThat(specs).hasSize(1);
         assertThat(specs.get(0).name()).isEqualTo("renamed_compute");
@@ -728,12 +735,13 @@ class ToolSpecificationsTest implements WithAssertions {
 
     @Test
     void should_discover_both_when_overloaded_methods_in_parent_and_child_have_different_tool_names() {
-        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ChildWithOverloadedDifferentToolNames());
+        List<ToolSpecification> specs =
+                ToolSpecifications.toolSpecificationsFrom(new ChildWithOverloadedDifferentToolNames());
 
         assertThat(specs).hasSize(2);
-        assertThat(specs).extracting(ToolSpecification::name)
-                .containsExactlyInAnyOrder("process", "process_int");
-        assertThat(specs).extracting(ToolSpecification::description)
+        assertThat(specs).extracting(ToolSpecification::name).containsExactlyInAnyOrder("process", "process_int");
+        assertThat(specs)
+                .extracting(ToolSpecification::description)
                 .containsExactlyInAnyOrder("process a string", "process an int");
     }
 
@@ -747,8 +755,7 @@ class ToolSpecificationsTest implements WithAssertions {
     }
 
     @SuppressWarnings("unused")
-    public static class ImplementsToolInterface implements ToolInterface {
-    }
+    public static class ImplementsToolInterface implements ToolInterface {}
 
     @Test
     void should_discover_tool_from_interface_default_method() {
@@ -772,9 +779,11 @@ class ToolSpecificationsTest implements WithAssertions {
         List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ClassWithOwnToolAndInterface());
 
         assertThat(specs).hasSize(2);
-        assertThat(specs).extracting(ToolSpecification::name)
+        assertThat(specs)
+                .extracting(ToolSpecification::name)
                 .containsExactlyInAnyOrder("classMethod", "interfaceMethod");
-        assertThat(specs).extracting(ToolSpecification::description)
+        assertThat(specs)
+                .extracting(ToolSpecification::description)
                 .containsExactlyInAnyOrder("class tool", "interface tool");
     }
 
@@ -789,7 +798,8 @@ class ToolSpecificationsTest implements WithAssertions {
 
     @Test
     void should_use_class_method_when_overriding_interface_default() {
-        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ClassOverridingInterfaceDefault());
+        List<ToolSpecification> specs =
+                ToolSpecifications.toolSpecificationsFrom(new ClassOverridingInterfaceDefault());
 
         assertThat(specs).hasSize(1);
         assertThat(specs.get(0).name()).isEqualTo("interfaceMethod");
@@ -833,12 +843,15 @@ class ToolSpecificationsTest implements WithAssertions {
 
     @Test
     void should_discover_static_tool_from_interface() {
-        List<ToolSpecification> specs = ToolSpecifications.toolSpecificationsFrom(new ImplementsInterfaceWithStaticTool());
+        List<ToolSpecification> specs =
+                ToolSpecifications.toolSpecificationsFrom(new ImplementsInterfaceWithStaticTool());
 
         assertThat(specs).hasSize(2);
-        assertThat(specs).extracting(ToolSpecification::name)
+        assertThat(specs)
+                .extracting(ToolSpecification::name)
                 .containsExactlyInAnyOrder("staticMethod", "instanceMethod");
-        assertThat(specs).extracting(ToolSpecification::description)
+        assertThat(specs)
+                .extracting(ToolSpecification::description)
                 .containsExactlyInAnyOrder("static tool", "instance tool");
     }
 }


### PR DESCRIPTION
## Summary
- Include inherited fields from custom superclasses when generating JSON schemas for tool parameters
- Stop inherited-field traversal at non-custom/JDK superclasses to avoid internal fields and recursion
- Add regression coverage for inherited DTO fields and JDK-superclass edge cases

Fixes #2249

## Validation
- `.\mvnw.cmd -pl langchain4j-core "-Djacoco.skip=true" "-Dtest=ToolSpecificationsTest#tool_specification_ignores_non_custom_superclass_fields" test` (failed before the fix with `StackOverflowError`, passes after the fix)
- `.\mvnw.cmd -pl langchain4j-core "-Djacoco.skip=true" "-Dtest=ToolSpecificationsTest,JsonSchemaElementUtilsTest" test` (60 tests passed)
- `git diff --check HEAD~2..HEAD`

Local caveats: JaCoCo was skipped because its javaagent fails to start in this non-ASCII workspace path, and `spotless:check` could not run in this linked worktree because Spotless could not locate the Git repository. CI should run the default checks in a normal environment.