### PR TITLE
fix: support 3D logit output in OnnxScoringBertCrossEncoder

### DIFF
--- a/langchain4j-onnx-scoring/src/main/java/dev/langchain4j/model/scoring/onnx/OnnxScoringBertCrossEncoder.java
+++ b/langchain4j-onnx-scoring/src/main/java/dev/langchain4j/model/scoring/onnx/OnnxScoringBertCrossEncoder.java
@@ -138,16 +138,49 @@ class OnnxScoringBertCrossEncoder implements AutoCloseable {
     }
 
     private List<Double> toScore(OrtSession.Result result) throws OrtException {
-        float[][] output = (float[][]) result.get(0).getValue();
+        float[] logits = extractLogits(result.get(0).getValue());
         List<Double> scores = new ArrayList<>();
-        for (float[] floats : output) {
+        for (float logit : logits) {
             if (normalize) {
-                scores.add(sigmoid(floats[0]));
+                scores.add(sigmoid(logit));
             } else {
-                scores.add((double) floats[0]);
+                scores.add((double) logit);
             }
         }
         return scores;
+    }
+
+    /**
+     * Extracts a single logit per scored item from the raw ONNX output.
+     *
+     * <p>Cross-encoder rerankers expose their logits with a leading batch dimension. Depending on how
+     * the model was exported to ONNX (e.g. via Optimum, with or without an extra squeeze), the value
+     * returned by {@link ai.onnxruntime.OnnxTensor#getValue()} can be a 2D array
+     * ({@code float[][]}, shape {@code [batch, k]}) or a 3D array ({@code float[][][]}, shape
+     * {@code [batch, 1, 1]}, as produced for example by {@code BAAI/bge-reranker-base}). Both shapes
+     * are accepted: the first scalar of each item is used as its logit, preserving the historical
+     * behaviour for 2D outputs while avoiding a {@link ClassCastException} for 3D outputs.
+     *
+     * @param value the raw value returned by {@link ai.onnxruntime.OnnxTensor#getValue()}
+     * @return one logit per scored item, preserving the batch order
+     */
+    static float[] extractLogits(Object value) {
+        if (value instanceof float[][] matrix) {
+            float[] logits = new float[matrix.length];
+            for (int i = 0; i < matrix.length; i++) {
+                logits[i] = matrix[i][0];
+            }
+            return logits;
+        }
+        if (value instanceof float[][][] matrix) {
+            float[] logits = new float[matrix.length];
+            for (int i = 0; i < matrix.length; i++) {
+                logits[i] = matrix[i][0][0];
+            }
+            return logits;
+        }
+        throw new IllegalStateException(
+                "Unsupported ONNX scoring output shape: " + value.getClass().getName());
     }
 
     private double sigmoid(float x) {

--- a/langchain4j-onnx-scoring/src/test/java/dev/langchain4j/model/scoring/onnx/OnnxScoringBertCrossEncoderTest.java
+++ b/langchain4j-onnx-scoring/src/test/java/dev/langchain4j/model/scoring/onnx/OnnxScoringBertCrossEncoderTest.java
@@ -1,0 +1,49 @@
+package dev.langchain4j.model.scoring.onnx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class OnnxScoringBertCrossEncoderTest {
+
+    @Test
+    void extractLogits_should_handle_2d_output() {
+        float[][] output = {{0.1f}, {0.2f}, {0.3f}};
+
+        float[] logits = OnnxScoringBertCrossEncoder.extractLogits(output);
+
+        assertThat(logits).containsExactly(0.1f, 0.2f, 0.3f);
+    }
+
+    @Test
+    void extractLogits_should_handle_3d_output_from_bge_reranker() {
+        // BAAI/bge-reranker-base exported to ONNX (e.g. via Optimum) produces logits with shape
+        // [batch, 1, 1] (float[][][] / "[[[F"), which previously triggered:
+        //   ClassCastException: class [[[F cannot be cast to class [[F
+        float[][][] output = {{{0.5f}}, {{-0.2f}}, {{0.9f}}};
+
+        float[] logits = OnnxScoringBertCrossEncoder.extractLogits(output);
+
+        assertThat(logits).containsExactly(0.5f, -0.2f, 0.9f);
+    }
+
+    @Test
+    void extractLogits_should_take_first_value_when_multiple_logits_per_item() {
+        // historical behaviour: only the first logit per item is used
+        float[][] output = {{0.4f, 0.5f, 0.6f}};
+
+        float[] logits = OnnxScoringBertCrossEncoder.extractLogits(output);
+
+        assertThat(logits).containsExactly(0.4f);
+    }
+
+    @Test
+    void extractLogits_should_throw_on_unsupported_shape() {
+        float[] unsupported = {0.1f};
+
+        assertThatThrownBy(() -> OnnxScoringBertCrossEncoder.extractLogits(unsupported))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Unsupported ONNX scoring output shape");
+    }
+}


### PR DESCRIPTION
## Context
Fixes #3112

`OnnxScoringBertCrossEncoder.toScore()` casts the raw ONNX output to `float[][]`. Some cross-encoder rerankers exported to ONNX (e.g. `BAAI/bge-reranker-base` via Optimum) expose logits with shape `[batch, 1, 1]` (`float[][][]` / `[[[F`), so the cast throws:

```
java.lang.ClassCastException: class [[[F cannot be cast to class [[F
  at OnnxScoringBertCrossEncoder.toScore(...)
```

## Change
Extract one logit per scored item in a shape-agnostic way via a new package-private `extractLogits(Object value)` helper, handling both:
- **2D output** `[batch, k]` (`float[][]`) — historical behaviour, the first logit of each item is used
- **3D output** `[batch, 1, 1]` (`float[][][]`) — as produced by bge-reranker-base

Any other shape now raises a clear `IllegalStateException` instead of an obscure `ClassCastException`.

## Verification
- Added `OnnxScoringBertCrossEncoderTest` (4 unit tests): 2D output, 3D output (bge-reranker shape), multi-logit-per-item (historical behaviour preserved), and unsupported shape.
- `./mvnw -pl langchain4j-onnx-scoring -am test -Dtest=OnnxScoringBertCrossEncoderTest` → `Tests run: 4, Failures: 0, Errors: 0, Skipped: 0`.
- `./mvnw spotless:apply` applied.

The change is backward compatible: 2D outputs produce identical scores, it only additionally supports the 3D shape that previously crashed.