### PR TITLE
fix: moderate text content of multimodal user messages in MessageModeratorInputGuardrail

### DIFF
--- a/langchain4j-guardrails/src/main/java/dev/langchain4j/guardrails/MessageModeratorInputGuardrail.java
+++ b/langchain4j-guardrails/src/main/java/dev/langchain4j/guardrails/MessageModeratorInputGuardrail.java
@@ -2,6 +2,7 @@ package dev.langchain4j.guardrails;
 
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.guardrail.InputGuardrail;
 import dev.langchain4j.guardrail.InputGuardrailResult;
@@ -9,6 +10,7 @@ import dev.langchain4j.model.moderation.Moderation;
 import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.service.ModerationException;
+import java.util.stream.Collectors;
 
 /**
  * An {@link InputGuardrail} that validates user messages using a {@link ModerationModel} to detect
@@ -25,7 +27,6 @@ import dev.langchain4j.service.ModerationException;
  * </p>
  */
 public class MessageModeratorInputGuardrail implements InputGuardrail {
-
 
     private final ModerationModel moderationModel;
 
@@ -53,12 +54,29 @@ public class MessageModeratorInputGuardrail implements InputGuardrail {
      */
     @Override
     public InputGuardrailResult validate(UserMessage userMessage) {
-        Response<Moderation> response = moderationModel.moderate(userMessage);
+        // The user message can be multimodal (text plus an image) or contain several text parts.
+        // For such messages UserMessage.singleText() throws, so extract all text content and
+        // moderate it as a plain text message. Single-text messages are moderated as-is to keep
+        // the existing behaviour (ModerationModel moderates plain text anyway).
+        UserMessage messageToModerate =
+                userMessage.hasSingleText() ? userMessage : UserMessage.from(extractText(userMessage));
+
+        Response<Moderation> response = moderationModel.moderate(messageToModerate);
 
         if (response.content().flagged()) {
-            return fatal("User message has been flagged", new ModerationException("User message has been flagged", response.content()));
+            return fatal(
+                    "User message has been flagged",
+                    new ModerationException("User message has been flagged", response.content()));
         } else {
             return success();
         }
+    }
+
+    private static String extractText(UserMessage userMessage) {
+        return userMessage.contents().stream()
+                .filter(TextContent.class::isInstance)
+                .map(TextContent.class::cast)
+                .map(TextContent::text)
+                .collect(Collectors.joining());
     }
 }

--- a/langchain4j-guardrails/src/test/java/dev/langchain4j/guardrails/MessageModeratorInputGuardrailTest.java
+++ b/langchain4j-guardrails/src/test/java/dev/langchain4j/guardrails/MessageModeratorInputGuardrailTest.java
@@ -1,5 +1,14 @@
 package dev.langchain4j.guardrails;
 
+import static dev.langchain4j.test.guardrail.GuardrailAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.guardrail.GuardrailResult;
 import dev.langchain4j.guardrail.InputGuardrailResult;
@@ -8,13 +17,7 @@ import dev.langchain4j.model.moderation.ModerationModel;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.service.ModerationException;
 import org.junit.jupiter.api.Test;
-
-import static dev.langchain4j.test.guardrail.GuardrailAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
 
 class MessageModeratorInputGuardrailTest {
 
@@ -56,10 +59,7 @@ class MessageModeratorInputGuardrailTest {
         InputGuardrailResult result = moderatorInputGuardrail.validate(userMessage);
 
         // Then
-        assertThat(result)
-                .isNotNull()
-                .extracting(InputGuardrailResult::result)
-                .isEqualTo(GuardrailResult.Result.FATAL);
+        assertThat(result).isNotNull().extracting(InputGuardrailResult::result).isEqualTo(GuardrailResult.Result.FATAL);
 
         assertThat(result.getFirstFailureException())
                 .isNotNull()
@@ -99,5 +99,33 @@ class MessageModeratorInputGuardrailTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("moderationModel cannot be null");
     }
-}
 
+    @Test
+    void should_moderate_text_of_multimodal_user_message_without_throwing() {
+        // Given
+        ModerationModel moderationModel = mock(ModerationModel.class);
+        Response<Moderation> response = Response.from(Moderation.notFlagged());
+        when(moderationModel.moderate(any(UserMessage.class))).thenReturn(response);
+
+        MessageModeratorInputGuardrail moderatorInputGuardrail = new MessageModeratorInputGuardrail(moderationModel);
+        // a multimodal message (text plus an image): UserMessage.singleText() would throw on it,
+        // so the guardrail must moderate the extracted text instead of the original message
+        UserMessage multimodal = UserMessage.from(
+                TextContent.from("Please describe this picture"), ImageContent.from("https://example.com/image.png"));
+
+        // When
+        InputGuardrailResult result = moderatorInputGuardrail.validate(multimodal);
+
+        // Then
+        assertThat(result)
+                .isNotNull()
+                .extracting(InputGuardrailResult::result)
+                .isEqualTo(GuardrailResult.Result.SUCCESS);
+
+        ArgumentCaptor<UserMessage> captor = ArgumentCaptor.forClass(UserMessage.class);
+        verify(moderationModel).moderate(captor.capture());
+        // the moderation model receives a plain-text message built from the extracted text content,
+        // not the original multimodal message
+        assertThat(captor.getValue().singleText()).isEqualTo("Please describe this picture");
+    }
+}


### PR DESCRIPTION
## Context
Fixes #5523

`MessageModeratorInputGuardrail.validate()` called `moderationModel.moderate(userMessage)`. `ModerationModel` has no `moderate(UserMessage)` overload, so for a multimodal user message (text plus an image) or any message with more than one text part the call binds to `moderate(ChatMessage)` -> `moderate(List)` -> `UserMessage.singleText()`, which throws when the message does not contain exactly one `TextContent`. A supported, realistic input (e.g. `UserMessage.from(Content...)` with text + image) therefore failed instead of being moderated.

## Change
For a non-single-text message, extract all `TextContent`, concatenate them, and moderate that as a plain text `UserMessage`. Single-text messages keep being moderated as-is, so existing behaviour is unchanged.

## Verification
- Added `should_moderate_text_of_multimodal_user_message_without_throwing`: validates that a multimodal `UserMessage` (text + image) succeeds, and that the moderation model receives a plain-text message built from the extracted text content (captured with `ArgumentCaptor`), not the original multimodal message.
- All existing tests still pass (single-text messages are still moderated as-is).
- `./mvnw -pl langchain4j-guardrails -am test -Dtest=MessageModeratorInputGuardrailTest` → `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0`.
- `./mvnw -pl langchain4j-guardrails spotless:apply` applied.

Backward compatible: single-text messages are moderated exactly as before.