### PR TITLE
Surface async agent failures as AgentInvocationException

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AsyncResponse.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/AsyncResponse.java
@@ -9,7 +9,8 @@ public class AsyncResponse<T> implements DelayedResponse<T> {
     private final CompletableFuture<T> futureResponse;
 
     public AsyncResponse(Supplier<T> responseSupplier) {
-        this.futureResponse = CompletableFuture.supplyAsync(responseSupplier, DefaultExecutorProvider.getDefaultExecutorService());
+        this.futureResponse =
+                CompletableFuture.supplyAsync(responseSupplier, DefaultExecutorProvider.getDefaultExecutorService());
     }
 
     @Override
@@ -19,7 +20,7 @@ public class AsyncResponse<T> implements DelayedResponse<T> {
 
     @Override
     public T blockingGet() {
-        return futureResponse.join();
+        return DelayedResponse.join(futureResponse);
     }
 
     @Override

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/DelayedResponse.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/DelayedResponse.java
@@ -1,5 +1,8 @@
 package dev.langchain4j.agentic.internal;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
 public interface DelayedResponse<T> {
 
     boolean isDone();
@@ -8,5 +11,28 @@ public interface DelayedResponse<T> {
 
     default Object result() {
         return isDone() ? blockingGet() : "<pending>";
+    }
+
+    /**
+     * Blocks on {@code future} and, on failure, rethrows the original cause instead of the
+     * {@link CompletionException} that {@link CompletableFuture#join()} wraps it in, so an
+     * asynchronous agent failure surfaces the same exception type as the synchronous path (an
+     * {@link dev.langchain4j.agentic.agent.AgentInvocationException}) instead of leaking the
+     * {@code CompletableFuture} plumbing. A checked-exception cause cannot be rethrown from here
+     * and is left wrapped.
+     */
+    static <R> R join(CompletableFuture<R> future) {
+        try {
+            return future.join();
+        } catch (CompletionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw e;
+        }
     }
 }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PendingResponse.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/PendingResponse.java
@@ -3,7 +3,6 @@ package dev.langchain4j.agentic.internal;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -69,7 +68,7 @@ public class PendingResponse<T> implements DelayedResponse<T> {
     @Override
     @JsonIgnore
     public T blockingGet() {
-        return futureResponse.join();
+        return DelayedResponse.join(futureResponse);
     }
 
     /**

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/StreamingResponse.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/internal/StreamingResponse.java
@@ -22,7 +22,7 @@ public class StreamingResponse implements DelayedResponse<String> {
 
     @Override
     public String blockingGet() {
-        return futureResponse.join().aiMessage().text();
+        return DelayedResponse.join(futureResponse).aiMessage().text();
     }
 
     @Override

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/AsyncAgentExceptionParityTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/AsyncAgentExceptionParityTest.java
@@ -1,0 +1,55 @@
+package dev.langchain4j.agentic;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agentic.agent.AgentInvocationException;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.Test;
+
+class AsyncAgentExceptionParityTest {
+
+    static final ChatModel FAILING_MODEL = new ChatModel() {
+        @Override
+        public ChatResponse chat(ChatRequest chatRequest) {
+            throw new RuntimeException("model failure");
+        }
+    };
+
+    public interface Writer {
+
+        @UserMessage("Write about {{topic}}")
+        @Agent(outputKey = "story")
+        String write(@V("topic") String topic);
+    }
+
+    private UntypedAgent workflowWith(boolean async) {
+        Writer writer = AgenticServices.agentBuilder(Writer.class)
+                .chatModel(FAILING_MODEL)
+                .async(async)
+                .outputKey("story")
+                .build();
+        return AgenticServices.sequenceBuilder()
+                .subAgents(writer)
+                .outputKey("story")
+                .build();
+    }
+
+    @Test
+    void sync_agent_failure_throws_agentInvocationException() {
+        assertThatThrownBy(() -> workflowWith(false).invoke(Map.of("topic", "dragons")))
+                .isInstanceOf(AgentInvocationException.class);
+    }
+
+    @Test
+    void async_agent_failure_throws_same_type_as_sync() {
+        assertThatThrownBy(() -> workflowWith(true).invoke(Map.of("topic", "dragons")))
+                .isInstanceOf(AgentInvocationException.class)
+                .isNotInstanceOf(CompletionException.class);
+    }
+}

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/DelayedResponseTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/internal/DelayedResponseTest.java
@@ -1,0 +1,87 @@
+package dev.langchain4j.agentic.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Answers.RETURNS_SELF;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import dev.langchain4j.agentic.agent.AgentInvocationException;
+import dev.langchain4j.service.TokenStream;
+import java.io.IOException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class DelayedResponseTest {
+
+    @Test
+    void asyncResponse_rethrows_original_runtime_exception_not_completionException() {
+        AgentInvocationException original = new AgentInvocationException("boom");
+        AsyncResponse<String> response = new AsyncResponse<>(() -> {
+            throw original;
+        });
+
+        assertThatThrownBy(response::blockingGet)
+                .isInstanceOf(AgentInvocationException.class)
+                .isSameAs(original);
+    }
+
+    @Test
+    void pendingResponse_rethrows_original_runtime_exception_not_completionException() {
+        AgentInvocationException original = new AgentInvocationException("boom");
+        PendingResponse<String> response = new PendingResponse<>("id");
+        response.completeExceptionally(original);
+
+        assertThatThrownBy(response::blockingGet)
+                .isInstanceOf(AgentInvocationException.class)
+                .isSameAs(original);
+    }
+
+    @Test
+    void streamingResponse_rethrows_original_runtime_exception_not_completionException() {
+        AgentInvocationException original = new AgentInvocationException("boom");
+        AtomicReference<Consumer<Throwable>> errorHandler = new AtomicReference<>();
+
+        TokenStream tokenStream = mock(TokenStream.class, RETURNS_SELF);
+        doAnswer(invocation -> {
+                    errorHandler.set(invocation.getArgument(0));
+                    return tokenStream;
+                })
+                .when(tokenStream)
+                .onError(any());
+        doAnswer(invocation -> {
+                    errorHandler.get().accept(original);
+                    return null;
+                })
+                .when(tokenStream)
+                .start();
+
+        StreamingResponse response = new StreamingResponse(tokenStream);
+
+        assertThatThrownBy(response::blockingGet)
+                .isInstanceOf(AgentInvocationException.class)
+                .isSameAs(original);
+    }
+
+    @Test
+    void checked_exception_cause_is_left_wrapped_in_completionException() {
+        IOException checked = new IOException("io");
+        PendingResponse<String> response = new PendingResponse<>("id");
+        response.completeExceptionally(checked);
+
+        assertThatThrownBy(response::blockingGet)
+                .isInstanceOf(CompletionException.class)
+                .hasCause(checked);
+    }
+
+    @Test
+    void successful_response_is_returned_unchanged() {
+        PendingResponse<String> response = new PendingResponse<>("id");
+        response.complete("ok");
+
+        assertThat(response.blockingGet()).isEqualTo("ok");
+    }
+}


### PR DESCRIPTION
## Issue
Closes #5745

## Change

`DelayedResponse.blockingGet()` resolves its future with `CompletableFuture.join()`, which wraps any failure in a `java.util.concurrent.CompletionException`. So when an async agent fails, the caller does not get the `AgentInvocationException` that the sync path throws; it gets a `CompletionException` (cause `AgentInvocationException`) once the result is resolved through `AgenticScope.readState(...)` or when the root call ends. A `catch (AgentInvocationException)` handles the sync case but misses the async one.

`AsyncResponse`, `StreamingResponse` and `PendingResponse` are the three `DelayedResponse` implementations, and all leak `CompletionException` from `blockingGet()` the same way. This adds a shared `DelayedResponse.join(CompletableFuture)` helper that rethrows the original cause instead of the `CompletionException` wrapper when the cause is unchecked (`RuntimeException`/`Error`), and routes all three through it. A checked-exception cause is left wrapped, so no checked exception is thrown from an unchecked method.

Behaviour change: `blockingGet()` no longer leaks `CompletionException`; it surfaces the underlying cause. An async agent failure now throws `AgentInvocationException`, matching the sync path; a streaming or pending failure surfaces its own cause (for streaming that is the model error, which was never an `AgentInvocationException`). Code that specifically caught `CompletionException` here would now catch that underlying type. This does not touch the parallel executor, which surfaces sub-agent failures through its own `ExecutionException` handling.

Tests:
- `DelayedResponseTest` (unit, per implementation): a failed `AsyncResponse` / `PendingResponse` / `StreamingResponse` rethrows the original `AgentInvocationException` (same instance), a checked cause stays wrapped in `CompletionException`, and a successful response is returned unchanged.
- `AsyncAgentExceptionParityTest` (end-to-end through `AgenticServices`): a failing agent throws `AgentInvocationException` on both the sync and async paths, and the two exceptions have the same type.

Both fail on current main (async throws `CompletionException`) and pass with the change.

```
mvn -pl langchain4j-agentic test
```

Module suite: 78 tests, 0 failures (7 new).

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
