### PR TITLE
Suspend/resume the tool-calling loop, and async `@Tool` via CompletableFuture

### DIFF
--- a/docs/docs/tutorials/tools.md
+++ b/docs/docs/tutorials/tools.md
@@ -178,8 +178,8 @@ You can find more information on `JsonObjectSchema` [here](/tutorials/structured
 - `ToolSpecifications.toolSpecificationFrom(Method)`
 
 ```java
-class WeatherTools { 
-  
+class WeatherTools {
+
     @Tool("Returns the weather forecast for a given city")
     String getWeather(
             @P("The city for which the weather forecast should be returned") String city,
@@ -723,12 +723,12 @@ Any Java method annotated with `@Tool`
 and _explicitly_ specified during the build of an AI Service can be executed by the LLM:
 ```java
 interface MathGenius {
-    
+
     String ask(String question);
 }
 
 class Calculator {
-    
+
     @Tool
     double add(int a, int b) {
         return a + b;
@@ -909,10 +909,10 @@ enum Priority {
 
     @Description("Critical issues such as payment gateway failures or security breaches.") // this is ignored
     CRITICAL,
-    
+
     @Description("High-priority issues like major feature malfunctions or widespread outages.") // this is ignored
     HIGH,
-    
+
     @Description("Low-priority issues such as minor bugs or cosmetic problems.") // this is ignored
     LOW
 }
@@ -1384,7 +1384,7 @@ reprocessing by the LLM. This can be done by configuring the `returnBehavior` fi
 
 ```java
 class CalculatorWithImmediateReturn {
-    
+
     @Tool(returnBehavior = ReturnBehavior.IMMEDIATE)
     double add(int a, int b) {
         return a + b;
@@ -1498,6 +1498,159 @@ a response made up only of `IMMEDIATE` and/or `IMMEDIATE_IF_LAST` tools returns 
 regardless of which one is last (still subject to the no-errors rule).
 
 Like `IMMEDIATE`, `IMMEDIATE_IF_LAST` is only allowed on AI services with a `Result<T>` return type.
+
+#### `SUSPEND` for human-in-the-loop and async workflows
+
+`ReturnBehavior.SUSPEND` pauses the AI Service execution loop after the tool runs, leaving
+the tool call **pending** in chat memory without producing a `ToolExecutionResultMessage`.
+The tool method itself is still executed (e.g. to kick off a long-running job or persist a
+request), but its return value is discarded — the real result will be supplied later.
+
+This enables two common patterns:
+
+- **Human-in-the-loop** — the tool records a request that needs external input; the caller
+  fulfills the pending tool call once the user responds and resumes the conversation.
+- **Async / long-running jobs** — the tool starts a background process; the caller resumes
+  when the process completes and the real result is available.
+
+```java
+class OrderService {
+
+    @Tool(returnBehavior = ReturnBehavior.SUSPEND)
+    String placeOrder(String item, int quantity) {
+        String orderId = persistOrder(item, quantity);
+        externalService.processAsync(orderId); // kicks off async work
+        return orderId; // value is discarded — not sent to the LLM
+    }
+}
+```
+
+The AI Service must return `Result<T>` so the caller can detect the suspension:
+
+```java
+interface Assistant {
+    Result<String> chat(String userMessage);
+    Result<String> chat(@MemoryId String memoryId, String userMessage);
+}
+```
+
+When the LLM returns a response containing a `SUSPEND` tool (and no tool errored), the loop
+suspends: results of any non-`SUSPEND` tools in the same response are still recorded in chat
+memory, while the `SUSPEND` tool call(s) stay pending. The `Result` is returned with
+`finishReason == TOOL_EXECUTION` and `content == null`. A tool error anywhere in the response
+cancels the suspension so the LLM can react to the error on the next turn.
+
+When the same `AiMessage` contains both `SUSPEND` and `TO_LLM` (or `IMMEDIATE`) tools,
+only the non-suspend tools are recorded — the `SUSPEND` tool call stays pending. This partial
+state is valid and does not break the chat memory.
+
+:::note
+`SUSPEND` is only allowed on AI services returning `Result<T>`. Using it on a service with
+a different return type causes an `IllegalConfigurationException`.
+:::
+
+##### Resuming a suspended conversation
+
+To resume, the AI Service must implement the `ToolExecutionResumer` interface
+(or `StreamingToolExecutionResumer` for streaming). These are marker interfaces — no method
+body is needed; the framework dispatches `resume(...)` calls via the AI Service proxy.
+
+```java
+interface Assistant extends ToolExecutionResumer {
+    Result<String> chat(String userMessage);
+}
+```
+
+Once the external process completes (or the user provides input), build a
+`ToolExecutionResultMessage` and call `resume`:
+
+```java
+ToolExecutionResultMessage toolResult = ToolExecutionResultMessage.builder()
+        .id(toolExecutionRequest.id())
+        .toolName(toolExecutionRequest.name())
+        .text(orderService.getOrderStatus(orderId)) // the real result
+        .build();
+
+Result<String> result = assistant.resume(memoryId, toolResult);
+```
+
+`resume` appends the real result to chat memory and re-enters the execution loop — the LLM
+continues from where it left off. If the result triggers another `SUSPEND` tool, the loop
+suspends again and the caller can resume later.
+
+For streaming, use `StreamingToolExecutionResumer`:
+
+```java
+interface StreamingAssistant extends StreamingToolExecutionResumer {
+    TokenStream chat(String userMessage);
+}
+```
+
+```java
+TokenStream stream = streamingAssistant.resume(memoryId, toolResult);
+```
+
+:::note
+`resume` / `resumeStream` require a persistent `ChatMemory` (e.g. backed by a database).
+Without persistence, suspend/resume only works within the same process.
+:::
+
+### Async Tool Execution
+
+`@Tool` methods can return `CompletableFuture<T>` (or any `CompletionStage<T>`), which lets the
+tool body kick off or compose non-blocking work (e.g. an async HTTP call) instead of blocking
+inside the method. The framework then joins the future to obtain the result before passing it to
+the LLM.
+
+```java
+class ExternalApiService {
+
+    @Tool
+    CompletableFuture<String> fetchOrderStatus(String orderId) {
+        return httpClient.sendAsync(orderRequest, handler)
+                .thenApply(response -> parseStatus(response));
+    }
+
+    @Tool
+    CompletableFuture<Pojo> fetchOrderDetails(String orderId) {
+        return httpClient.sendAsync(orderRequest, handler)
+                .thenApply(response -> parseDetails(response));
+    }
+}
+```
+
+Type resolution follows the same rules as synchronous tools:
+- `CompletableFuture<String>` produces a text result.
+- `CompletableFuture<Pojo>` produces a JSON result (the generic type argument is inspected).
+
+If the future completes exceptionally, the exception is unwrapped and treated the same way as
+a synchronous tool error — the error message is sent back to the LLM for reprocessing.
+
+:::note
+Joining the future is a **blocking** operation, so the AI Service call stays synchronous — it does
+not return until the future completes. Returning a `CompletableFuture` lets a tool *compose* async
+work (`thenApply`, `thenCompose`, ...) and plug in async clients without you calling `.get()` or
+`.block()`; it does **not** make the surrounding invocation non-blocking, and it is not a
+parallelism mechanism. By default, tools — async or not — run one after another on the calling
+thread (each future is joined before the next tool is invoked). Running tools in parallel is a
+separate, opt-in feature, `executeToolsConcurrently(Executor)`, that applies to synchronous tools
+just as well.
+:::
+
+#### Reactor / Project Reactor integration
+
+Native `Mono`/`Flux` return types are **not** supported directly in the core module.
+Use a `Mono`-to-`CompletableFuture` adapter in your tool method, or configure a Reactor-aware
+adapter in the `langchain4j-reactor` module (see the module's README for details).
+
+```java
+@Tool
+CompletableFuture<String> fetchWithReactor(String orderId) {
+    return monoService.fetch(orderId)
+            .map(this::parseStatus)
+            .toFuture(); // Mono → CompletableFuture
+}
+```
 
 ### Error Handling
 

--- a/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ReturnBehavior.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/agent/tool/ReturnBehavior.java
@@ -109,5 +109,28 @@ public enum ReturnBehavior {
      * <p>
      * Only allowed on AI services returning {@code dev.langchain4j.service.Result}.
      */
-    IMMEDIATE_IF_LAST;
+    IMMEDIATE_IF_LAST,
+
+    /**
+     * <b>Suspends</b> the AI Service execution loop after this tool runs, instead of sending the
+     * tool result back to the LLM. The tool method is still executed (e.g. to kick off a long-running
+     * job or to persist the request for later), but its return value is <b>not</b> turned into a
+     * {@link dev.langchain4j.data.message.ToolExecutionResultMessage} — the corresponding tool call
+     * is left <em>pending</em> in the chat memory.
+     * <p>
+     * This enables human-in-the-loop and asynchronous workflows: the caller can fulfill the pending
+     * tool call later (once the external process completes or the user provides input) and resume the
+     * conversation by supplying the real {@link dev.langchain4j.data.message.ToolExecutionResultMessage}
+     * (see {@code dev.langchain4j.service.tool.ToolExecutionResumer}).
+     * <p>
+     * When a response contains a {@code SUSPEND} tool (and no tool errored), the loop suspends:
+     * results of any non-{@code SUSPEND} tools in the same response are still recorded in the chat
+     * memory, while the {@code SUSPEND} tool call(s) stay pending. A tool error anywhere in the
+     * response cancels the suspension so the LLM can react to the error on the next turn.
+     * <p>
+     * Only allowed on AI services returning {@code dev.langchain4j.service.Result}, so that the caller
+     * can detect the suspension (via {@link dev.langchain4j.model.output.FinishReason#TOOL_EXECUTION}
+     * and the pending tool calls in {@code Result.finalResponse()}).
+     */
+    SUSPEND;
 }

--- a/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/AiServiceStreamingResponseHandler.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.service;
 
+import static dev.langchain4j.agent.tool.ReturnBehavior.SUSPEND;
 import static dev.langchain4j.internal.Exceptions.runtime;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 import static dev.langchain4j.service.AiServiceParamsUtil.chatRequestParameters;
@@ -306,6 +307,7 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
             List<ToolExecutionResult> toolResults = new ArrayList<>();
             boolean anyToolErrored = false;
             List<ReturnBehavior> returnBehaviors = new ArrayList<>();
+            List<ToolExecutionResultMessage> suspendedResults = new ArrayList<>();
 
             if (toolExecutor != null) {
                 for (Future<ToolRequestResult> toolExecutionFuture : toolExecutionFutures) {
@@ -317,9 +319,14 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                         toolResults.add(toolResult);
                         ToolExecutionResultMessage toolExecutionResultMessage =
                                 toResultMessage(toolRequest, toolResult);
-                        addToMemory(toolExecutionResultMessage);
+                        ReturnBehavior returnBehavior = toolServiceContext.returnBehavior(toolRequest.name());
+                        if (returnBehavior == SUSPEND) {
+                            suspendedResults.add(toolExecutionResultMessage);
+                        } else {
+                            addToMemory(toolExecutionResultMessage);
+                        }
                         anyToolErrored = anyToolErrored || toolResult.isError();
-                        returnBehaviors.add(toolServiceContext.returnBehavior(toolRequest.name()));
+                        returnBehaviors.add(returnBehavior);
                     } catch (ExecutionException e) {
                         if (e.getCause() instanceof RuntimeException re) {
                             throw re;
@@ -338,11 +345,29 @@ class AiServiceStreamingResponseHandler implements StreamingChatResponseHandler 
                     ToolRequestResult toolRequestResult = new ToolRequestResult(toolRequest, toolResult);
                     fireToolExecutedEvent(toolRequestResult);
                     ToolExecutionResultMessage toolExecutionResultMessage = toResultMessage(toolRequest, toolResult);
-                    addToMemory(toolExecutionResultMessage);
+                    ReturnBehavior returnBehavior = toolServiceContext.returnBehavior(toolRequest.name());
+                    if (returnBehavior == SUSPEND) {
+                        suspendedResults.add(toolExecutionResultMessage);
+                    } else {
+                        addToMemory(toolExecutionResultMessage);
+                    }
                     anyToolErrored = anyToolErrored || toolResult.isError();
-                    returnBehaviors.add(toolServiceContext.returnBehavior(toolRequest.name()));
+                    returnBehaviors.add(returnBehavior);
                 }
             }
+
+            boolean suspended = !anyToolErrored && !suspendedResults.isEmpty();
+            if (suspended) {
+                ChatResponse finalChatResponse = finalResponse(chatResponse, aiMessage);
+                fireInvocationComplete(finalChatResponse);
+
+                if (completeResponseHandler != null) {
+                    completeResponseHandler.accept(finalChatResponse);
+                }
+                return;
+            }
+            // suspension cancelled by a tool error: record the deferred results so memory stays consistent
+            suspendedResults.forEach(this::addToMemory);
 
             if (ToolService.shouldReturnImmediately(anyToolErrored, returnBehaviors)) {
                 ChatResponse finalChatResponse = finalResponse(chatResponse, aiMessage);

--- a/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/DefaultAiServices.java
@@ -2,6 +2,7 @@ package dev.langchain4j.service;
 
 import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE;
 import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE_IF_LAST;
+import static dev.langchain4j.agent.tool.ReturnBehavior.SUSPEND;
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.Utils.isNullOrEmpty;
 import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
@@ -25,6 +26,7 @@ import dev.langchain4j.data.message.Content;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.guardrail.ChatExecutor;
 import dev.langchain4j.guardrail.GuardrailRequestParams;
@@ -55,7 +57,9 @@ import dev.langchain4j.service.guardrail.GuardrailService;
 import dev.langchain4j.service.memory.ChatMemoryAccess;
 import dev.langchain4j.service.memory.ChatMemoryService;
 import dev.langchain4j.service.output.ServiceOutputParser;
+import dev.langchain4j.service.tool.StreamingToolExecutionResumer;
 import dev.langchain4j.service.tool.ToolExecution;
+import dev.langchain4j.service.tool.ToolExecutionResumer;
 import dev.langchain4j.service.tool.ToolServiceContext;
 import dev.langchain4j.service.tool.ToolServiceResult;
 import dev.langchain4j.spi.services.TokenStreamAdapter;
@@ -137,6 +141,14 @@ class DefaultAiServices<T> extends AiServices<T> {
 
                         if (method.getDeclaringClass() == ChatMemoryAccess.class) {
                             return handleChatMemoryAccess(method, args);
+                        }
+
+                        if (method.getDeclaringClass() == ToolExecutionResumer.class) {
+                            return resume(args[0], (ToolExecutionResultMessage) args[1]);
+                        }
+
+                        if (method.getDeclaringClass() == StreamingToolExecutionResumer.class) {
+                            return resumeStream(args[0], (ToolExecutionResultMessage) args[1]);
                         }
 
                         // TODO do it once, when creating AI Service?
@@ -353,6 +365,25 @@ class DefaultAiServices<T> extends AiServices<T> {
                                 toolServiceContext,
                                 context.chatModel::chat);
 
+                        if (toolServiceResult.suspended()) {
+                            if (!isReturnTypeResult) {
+                                throw illegalConfiguration(
+                                        "AI Service method '%s' uses a tool with ReturnBehavior.%s but does not return %s. "
+                                                + "Use %s as the return type to detect the suspension and access the pending tool calls.",
+                                        method.getName(), SUSPEND, Result.class.getName(), Result.class.getName());
+                            }
+                            var result = Result.builder()
+                                    .content(null)
+                                    .tokenUsage(toolServiceResult.aggregateTokenUsage())
+                                    .sources(augmentationResult == null ? null : augmentationResult.contents())
+                                    .finishReason(TOOL_EXECUTION)
+                                    .toolExecutions(toolServiceResult.toolExecutions())
+                                    .intermediateResponses(toolServiceResult.intermediateResponses())
+                                    .finalResponse(toolServiceResult.finalResponse())
+                                    .build();
+                            return fireEventAndReturn(invocationContext, result);
+                        }
+
                         if (toolServiceResult.immediateToolReturn()) {
                             if (isReturnTypeResult) {
                                 var result = Result.builder()
@@ -447,6 +478,162 @@ class DefaultAiServices<T> extends AiServices<T> {
                                 : parsedResponse;
 
                         return fireEventAndReturn(invocationContext, actualResponse);
+                    }
+
+                    private Result<String> resume(Object memoryId, ToolExecutionResultMessage toolResult) {
+                        if (!context.hasChatMemory()) {
+                            throw illegalConfiguration(
+                                    "Cannot resume a conversation: AI Service '%s' is not configured with a ChatMemory. "
+                                            + "Suspended conversation state is stored in the ChatMemory identified by memoryId.",
+                                    context.aiServiceClass.getName());
+                        }
+                        if (context.chatModel == null) {
+                            throw illegalConfiguration(
+                                    "Cannot resume a conversation: AI Service '%s' is not configured with a (synchronous) ChatModel.",
+                                    context.aiServiceClass.getName());
+                        }
+
+                        ChatMemory chatMemory = context.chatMemoryService.getOrCreateChatMemory(memoryId);
+                        // fulfill the tool call left pending by the SUSPEND tool
+                        chatMemory.add(toolResult);
+
+                        InvocationContext invocationContext = InvocationContext.builder()
+                                .invocationId(UUID.randomUUID())
+                                .interfaceName(context.aiServiceClass.getName())
+                                .methodName("resume")
+                                .methodArguments(Arrays.asList(memoryId, toolResult))
+                                .chatMemoryId(memoryId)
+                                .defaultRequestParameters(determineChatRequestParameters(context))
+                                .modelProvider(determineModelProvider(context))
+                                .invocationParameters(new InvocationParameters())
+                                .managedParameters(LangChain4jManaged.current())
+                                .timestampNow()
+                                .build();
+
+                        List<ChatMessage> messages = chatMemory.messages();
+                        UserMessage lastUserMessage =
+                                UserMessage.findLast(messages).orElse(null);
+
+                        context.eventListenerRegistrar.fireEvent(AiServiceStartedEvent.builder()
+                                .invocationContext(invocationContext)
+                                .systemMessage(Optional.empty())
+                                .userMessage(lastUserMessage)
+                                .build());
+
+                        ToolServiceContext toolServiceContext =
+                                context.toolService.createContext(invocationContext, lastUserMessage, messages);
+
+                        ChatRequestParameters defaultParameters = determineChatRequestParameters(context);
+                        ChatRequestParameters parameters = (defaultParameters != null
+                                        ? defaultParameters
+                                        : ChatRequestParameters.builder().build())
+                                .overrideWith(ChatRequestParameters.builder()
+                                        .toolSpecifications(toolServiceContext.effectiveTools())
+                                        .build());
+
+                        ChatRequest chatRequest = context.chatRequestTransformer.apply(
+                                ChatRequest.builder()
+                                        .messages(messages)
+                                        .parameters(parameters)
+                                        .build(),
+                                memoryId);
+
+                        ChatExecutor chatExecutor = ChatExecutor.builder(context.chatModel)
+                                .chatRequest(chatRequest)
+                                .invocationContext(invocationContext)
+                                .eventListenerRegistrar(context.eventListenerRegistrar)
+                                .build();
+
+                        ChatResponse chatResponse = chatExecutor.execute();
+
+                        context.eventListenerRegistrar.fireEvent(AiServiceResponseReceivedEvent.builder()
+                                .invocationContext(invocationContext)
+                                .response(chatResponse)
+                                .request(chatRequest)
+                                .build());
+
+                        ToolServiceResult toolServiceResult = context.toolService.executeInferenceAndToolsLoop(
+                                context,
+                                memoryId,
+                                chatResponse,
+                                parameters,
+                                messages,
+                                chatMemory,
+                                invocationContext,
+                                toolServiceContext,
+                                context.chatModel::chat);
+
+                        ChatResponse finalResponse = toolServiceResult.finalResponse();
+                        boolean toolBoundary = toolServiceResult.suspended() || toolServiceResult.immediateToolReturn();
+                        Result<String> result = Result.<String>builder()
+                                .content(
+                                        toolBoundary
+                                                ? null
+                                                : finalResponse.aiMessage().text())
+                                .tokenUsage(toolServiceResult.aggregateTokenUsage())
+                                .finishReason(toolBoundary ? TOOL_EXECUTION : finalResponse.finishReason())
+                                .toolExecutions(toolServiceResult.toolExecutions())
+                                .intermediateResponses(toolServiceResult.intermediateResponses())
+                                .finalResponse(finalResponse)
+                                .build();
+                        fireEventAndReturn(invocationContext, result);
+                        return result;
+                    }
+
+                    private TokenStream resumeStream(Object memoryId, ToolExecutionResultMessage toolResult) {
+                        if (!context.hasChatMemory()) {
+                            throw illegalConfiguration(
+                                    "Cannot resume a conversation: AI Service '%s' is not configured with a ChatMemory. "
+                                            + "Suspended conversation state is stored in the ChatMemory identified by memoryId.",
+                                    context.aiServiceClass.getName());
+                        }
+                        if (context.streamingChatModel == null) {
+                            throw illegalConfiguration(
+                                    "Cannot resume a streaming conversation: AI Service '%s' is not configured with a StreamingChatModel.",
+                                    context.aiServiceClass.getName());
+                        }
+
+                        ChatMemory chatMemory = context.chatMemoryService.getOrCreateChatMemory(memoryId);
+                        // fulfill the tool call left pending by the SUSPEND tool
+                        chatMemory.add(toolResult);
+
+                        InvocationContext invocationContext = InvocationContext.builder()
+                                .invocationId(UUID.randomUUID())
+                                .interfaceName(context.aiServiceClass.getName())
+                                .methodName("resume")
+                                .methodArguments(Arrays.asList(memoryId, toolResult))
+                                .chatMemoryId(memoryId)
+                                .defaultRequestParameters(determineChatRequestParameters(context))
+                                .modelProvider(determineModelProvider(context))
+                                .invocationParameters(new InvocationParameters())
+                                .managedParameters(LangChain4jManaged.current())
+                                .timestampNow()
+                                .build();
+
+                        List<ChatMessage> messages = chatMemory.messages();
+                        UserMessage lastUserMessage =
+                                UserMessage.findLast(messages).orElse(null);
+
+                        context.eventListenerRegistrar.fireEvent(AiServiceStartedEvent.builder()
+                                .invocationContext(invocationContext)
+                                .systemMessage(Optional.empty())
+                                .userMessage(lastUserMessage)
+                                .build());
+
+                        ToolServiceContext toolServiceContext =
+                                context.toolService.createContext(invocationContext, lastUserMessage, messages);
+
+                        var tokenStreamParameters = AiServiceTokenStreamParameters.builder()
+                                .messages(messages)
+                                .toolServiceContext(toolServiceContext)
+                                .toolArgumentsErrorHandler(context.toolService.argumentsErrorHandler())
+                                .toolExecutionErrorHandler(context.toolService.executionErrorHandler())
+                                .toolExecutor(context.toolService.executor())
+                                .context(context)
+                                .invocationContext(invocationContext)
+                                .build();
+
+                        return new AiServiceTokenStream(tokenStreamParameters);
                     }
 
                     private Object fireEventAndReturn(InvocationContext invocationContext, Object result) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -32,6 +32,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 
 public class DefaultToolExecutor implements ToolExecutor {
 
@@ -161,6 +164,12 @@ public class DefaultToolExecutor implements ToolExecutor {
     private ToolExecutionResult execute(Object[] arguments) throws IllegalAccessException, InvocationTargetException {
         Object result = methodToInvoke.invoke(object, arguments);
 
+        Class<?> returnType = methodToInvoke.getReturnType();
+        if (result instanceof CompletionStage<?> stage) {
+            result = unwrapAsyncResult(stage);
+            returnType = asyncResultClass();
+        }
+
         List<Content> resultContents = toContents(result);
         if (resultContents != null) {
             return ToolExecutionResult.builder()
@@ -169,10 +178,37 @@ public class DefaultToolExecutor implements ToolExecutor {
                     .build();
         }
 
+        Object resolvedResult = result;
+        Class<?> resolvedReturnType = returnType;
         return ToolExecutionResult.builder()
                 .result(result)
-                .resultTextSupplier(() -> toText(result))
+                .resultTextSupplier(() -> toText(resolvedResult, resolvedReturnType))
                 .build();
+    }
+
+    private static Object unwrapAsyncResult(CompletionStage<?> stage) throws InvocationTargetException {
+        try {
+            return stage.toCompletableFuture().join();
+        } catch (CompletionException e) {
+            throw new InvocationTargetException(e.getCause() != null ? e.getCause() : e);
+        } catch (CancellationException e) {
+            throw new InvocationTargetException(e);
+        }
+    }
+
+    private Class<?> asyncResultClass() {
+        Type genericReturnType = methodToInvoke.getGenericReturnType();
+        if (genericReturnType instanceof ParameterizedType parameterizedType) {
+            Type actualType = parameterizedType.getActualTypeArguments()[0];
+            if (actualType instanceof Class<?> actualClass) {
+                return actualClass;
+            }
+            if (actualType instanceof ParameterizedType actualParameterizedType
+                    && actualParameterizedType.getRawType() instanceof Class<?> rawClass) {
+                return rawClass;
+            }
+        }
+        return Object.class;
     }
 
     private List<Content> toContents(Object result) {
@@ -193,8 +229,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         return null;
     }
 
-    private String toText(Object result) {
-        Class<?> returnType = methodToInvoke.getReturnType();
+    private String toText(Object result, Class<?> returnType) {
         if (returnType == void.class) {
             return "Success";
         } else if (returnType == String.class) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/StreamingToolExecutionResumer.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/StreamingToolExecutionResumer.java
@@ -1,0 +1,27 @@
+package dev.langchain4j.service.tool;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.agent.tool.ReturnBehavior;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.service.TokenStream;
+
+/**
+ * Streaming counterpart of {@link ToolExecutionResumer} for AI Services backed by a
+ * {@code StreamingChatModel}. Resumes a conversation suspended by a {@link ReturnBehavior#SUSPEND}
+ * tool; requires the AI Service to be configured with a {@code ChatMemory}.
+ *
+ * @since 1.18.0
+ */
+@Experimental
+public interface StreamingToolExecutionResumer {
+
+    /**
+     * Fulfills the pending tool call with its real result and streams another turn of the AI Service
+     * execution loop.
+     *
+     * @param memoryId   the id of the chat memory holding the suspended conversation.
+     * @param toolResult the result of the previously suspended tool call.
+     * @return the {@link TokenStream} of the resumed conversation.
+     */
+    TokenStream resume(Object memoryId, ToolExecutionResultMessage toolResult);
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionResumer.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolExecutionResumer.java
@@ -1,0 +1,27 @@
+package dev.langchain4j.service.tool;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.agent.tool.ReturnBehavior;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.service.Result;
+
+/**
+ * Lets an AI Service resume a conversation suspended by a tool declaring {@link ReturnBehavior#SUSPEND}.
+ * Requires the AI Service to be configured with a {@code ChatMemory}, where the suspended state is kept.
+ *
+ * @since 1.18.0
+ */
+@Experimental
+public interface ToolExecutionResumer {
+
+    /**
+     * Fulfills the pending tool call with its real result and runs another turn of the AI Service
+     * execution loop.
+     *
+     * @param memoryId   the id of the chat memory holding the suspended conversation.
+     * @param toolResult the result of the previously suspended tool call.
+     * @return the result of resuming the conversation, possibly suspended again by another
+     *         {@link ReturnBehavior#SUSPEND} tool.
+     */
+    Result<String> resume(Object memoryId, ToolExecutionResultMessage toolResult);
+}

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolService.java
@@ -2,6 +2,7 @@ package dev.langchain4j.service.tool;
 
 import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE;
 import static dev.langchain4j.agent.tool.ReturnBehavior.IMMEDIATE_IF_LAST;
+import static dev.langchain4j.agent.tool.ReturnBehavior.SUSPEND;
 import static dev.langchain4j.agent.tool.ToolSpecifications.toolSpecificationFrom;
 import static dev.langchain4j.internal.Exceptions.runtime;
 import static dev.langchain4j.internal.Utils.allConcreteMethods;
@@ -12,9 +13,9 @@ import static dev.langchain4j.internal.Utils.isNullOrBlank;
 import static dev.langchain4j.service.IllegalConfigurationException.illegalConfiguration;
 
 import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.CompensateFor;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.ReturnBehavior;
-import dev.langchain4j.agent.tool.CompensateFor;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolMemoryId;
@@ -43,12 +44,10 @@ import dev.langchain4j.service.IllegalConfigurationException;
 import dev.langchain4j.service.tool.search.ToolSearchService;
 import dev.langchain4j.service.tool.search.ToolSearchStrategy;
 import java.lang.reflect.Method;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.lang.reflect.Parameter;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -63,6 +62,8 @@ import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Internal
 public class ToolService {
@@ -267,8 +268,7 @@ public class ToolService {
         }
     }
 
-    private Map<String, BiConsumer<ToolExecution, InvocationContext>> findCompensatingActions(
-            Object objectWithTools) {
+    private Map<String, BiConsumer<ToolExecution, InvocationContext>> findCompensatingActions(Object objectWithTools) {
         Map<String, BiConsumer<ToolExecution, InvocationContext>> compensatingActions = new HashMap<>();
         if (compensatingToolMisconfiguration != null) {
             return compensatingActions;
@@ -300,15 +300,17 @@ public class ToolService {
                 }
                 Method toolMethod = ((DefaultToolExecutor) toolExecutor).originalMethod();
                 Class<?>[] compensatingParams = method.getParameterTypes();
-                boolean acceptsToolExecution = compensatingParams.length == 1
-                        && compensatingParams[0] == ToolExecution.class;
-                if (!acceptsToolExecution
-                        && !Arrays.equals(toolMethod.getParameterTypes(), compensatingParams)) {
+                boolean acceptsToolExecution =
+                        compensatingParams.length == 1 && compensatingParams[0] == ToolExecution.class;
+                if (!acceptsToolExecution && !Arrays.equals(toolMethod.getParameterTypes(), compensatingParams)) {
                     compensatingToolMisconfiguration = illegalConfiguration(
                             "@CompensateFor(\"%s\") on method '%s.%s' must have the same parameter types as tool '%s'"
                                     + " or a single %s parameter",
-                            toolName, objectWithTools.getClass().getName(), method.getName(),
-                            toolName, ToolExecution.class.getSimpleName());
+                            toolName,
+                            objectWithTools.getClass().getName(),
+                            method.getName(),
+                            toolName,
+                            ToolExecution.class.getSimpleName());
                     if (compensateOnToolErrors) {
                         throw compensatingToolMisconfiguration;
                     }
@@ -331,8 +333,9 @@ public class ToolService {
                             .methodToInvoke(method)
                             .propagateToolExecutionExceptions(true)
                             .build();
-                    compensatingActions.put(toolName, (toolExecution, ctx) ->
-                            executor.executeWithContext(toolExecution.request(), ctx));
+                    compensatingActions.put(
+                            toolName,
+                            (toolExecution, ctx) -> executor.executeWithContext(toolExecution.request(), ctx));
                 }
             }
         }
@@ -611,12 +614,37 @@ public class ToolService {
                 rewriteCurrentResults(toolExecutionRequests, toolResults, resultMessages, failedToolName);
             }
 
-            for (ToolExecutionResultMessage resultMessage : resultMessages) {
+            boolean suspended = !anyToolErrored && returnBehaviors.stream().anyMatch(rb -> rb == SUSPEND);
+
+            for (int i = 0; i < resultMessages.size(); i++) {
+                if (suspended && returnBehaviors.get(i) == SUSPEND) {
+                    // leave the tool call pending; it is fulfilled when the conversation is resumed
+                    continue;
+                }
+                ToolExecutionResultMessage resultMessage = resultMessages.get(i);
                 if (chatMemory != null) {
                     chatMemory.add(resultMessage);
                 } else {
                     messages.add(resultMessage);
                 }
+            }
+
+            if (suspended) {
+                ChatResponse finalResponse = intermediateResponses.remove(intermediateResponses.size() - 1);
+                List<ToolExecutionRequest> pendingRequests = new ArrayList<>();
+                for (int i = 0; i < toolExecutionRequests.size(); i++) {
+                    if (returnBehaviors.get(i) == SUSPEND) {
+                        pendingRequests.add(toolExecutionRequests.get(i));
+                    }
+                }
+                return ToolServiceResult.builder()
+                        .intermediateResponses(intermediateResponses)
+                        .finalResponse(finalResponse)
+                        .toolExecutions(toolExecutions)
+                        .aggregateTokenUsage(aggregateTokenUsage)
+                        .suspended(true)
+                        .pendingToolExecutionRequests(pendingRequests)
+                        .build();
             }
 
             if (shouldReturnImmediately(anyToolErrored, returnBehaviors)) {
@@ -667,23 +695,24 @@ public class ToolService {
                 .build();
     }
 
-    private void rewriteCurrentResults(List<ToolExecutionRequest> toolExecutionRequests,
-                                       Map<ToolExecutionRequest, ToolExecutionResult> toolResults,
-                                       List<ToolExecutionResultMessage> resultMessages,
-                                       String failedToolName) {
+    private void rewriteCurrentResults(
+            List<ToolExecutionRequest> toolExecutionRequests,
+            Map<ToolExecutionRequest, ToolExecutionResult> toolResults,
+            List<ToolExecutionResultMessage> resultMessages,
+            String failedToolName) {
         for (int i = 0; i < toolExecutionRequests.size(); i++) {
             ToolExecutionRequest request = toolExecutionRequests.get(i);
-            if (!toolResults.get(request).isError()
-                    && compensatingExecutors.containsKey(request.name())) {
+            if (!toolResults.get(request).isError() && compensatingExecutors.containsKey(request.name())) {
                 resultMessages.set(i, rolledBackResultMessage(resultMessages.get(i), failedToolName));
             }
         }
     }
 
-    private static void rewriteChatMemoryForCompensatedTools(List<ChatMessage> messages,
-                                                             ChatMemory chatMemory,
-                                                             List<CompensableToolExecution> compensableExecutions,
-                                                             String failedToolName) {
+    private static void rewriteChatMemoryForCompensatedTools(
+            List<ChatMessage> messages,
+            ChatMemory chatMemory,
+            List<CompensableToolExecution> compensableExecutions,
+            String failedToolName) {
         List<ChatMessage> memoryMessages = chatMemory != null ? new ArrayList<>(chatMemory.messages()) : messages;
         for (CompensableToolExecution entry : compensableExecutions) {
             ToolExecutionResultMessage originalMsg = entry.resultMessage();
@@ -713,7 +742,8 @@ public class ToolService {
 
     private record CompensableToolExecution(ToolExecution toolExecution, ToolExecutionResultMessage resultMessage) {}
 
-    private void compensateToolsActions(List<CompensableToolExecution> compensableExecutions, InvocationContext invocationContext) {
+    private void compensateToolsActions(
+            List<CompensableToolExecution> compensableExecutions, InvocationContext invocationContext) {
         for (int i = compensableExecutions.size() - 1; i >= 0; i--) {
             ToolExecution toolExecution = compensableExecutions.get(i).toolExecution();
             String toolName = toolExecution.request().name();

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolServiceResult.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/ToolServiceResult.java
@@ -3,11 +3,12 @@ package dev.langchain4j.service.tool;
 import static dev.langchain4j.internal.Utils.copy;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
 
-import java.util.List;
-import java.util.Objects;
 import dev.langchain4j.Internal;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.TokenUsage;
+import java.util.List;
+import java.util.Objects;
 
 @Internal
 public class ToolServiceResult {
@@ -17,6 +18,8 @@ public class ToolServiceResult {
     private final List<ToolExecution> toolExecutions;
     private final TokenUsage aggregateTokenUsage;
     private final boolean immediateToolReturn;
+    private final boolean suspended;
+    private final List<ToolExecutionRequest> pendingToolExecutionRequests;
 
     /**
      * @since 1.2.0
@@ -27,19 +30,22 @@ public class ToolServiceResult {
         this.toolExecutions = ensureNotNull(builder.toolExecutions, "toolExecutions");
         this.aggregateTokenUsage = builder.aggregateTokenUsage;
         this.immediateToolReturn = builder.immediateToolReturn;
+        this.suspended = builder.suspended;
+        this.pendingToolExecutionRequests = copy(builder.pendingToolExecutionRequests);
     }
 
     /**
      * @deprecated Please use {@link #ToolServiceResult(Builder)} instead
      */
     @Deprecated(since = "1.2.0")
-    public ToolServiceResult(ChatResponse chatResponse,
-                             List<ToolExecution> toolExecutions) {
+    public ToolServiceResult(ChatResponse chatResponse, List<ToolExecution> toolExecutions) {
         this.intermediateResponses = List.of();
         this.finalResponse = ensureNotNull(chatResponse, "chatResponse");
         this.toolExecutions = ensureNotNull(toolExecutions, "toolExecutions");
         this.aggregateTokenUsage = chatResponse.tokenUsage();
         this.immediateToolReturn = false;
+        this.suspended = false;
+        this.pendingToolExecutionRequests = List.of();
     }
 
     /**
@@ -94,6 +100,24 @@ public class ToolServiceResult {
         return immediateToolReturn;
     }
 
+    /**
+     * Whether the loop was suspended by a {@link dev.langchain4j.agent.tool.ReturnBehavior#SUSPEND} tool.
+     *
+     * @since 1.18.0
+     */
+    public boolean suspended() {
+        return suspended;
+    }
+
+    /**
+     * The tool calls left pending when the loop {@linkplain #suspended() suspended}; empty otherwise.
+     *
+     * @since 1.18.0
+     */
+    public List<ToolExecutionRequest> pendingToolExecutionRequests() {
+        return pendingToolExecutionRequests;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
@@ -103,23 +127,33 @@ public class ToolServiceResult {
                 && Objects.equals(this.finalResponse, that.finalResponse)
                 && Objects.equals(this.toolExecutions, that.toolExecutions)
                 && Objects.equals(this.aggregateTokenUsage, that.aggregateTokenUsage)
-                && Objects.equals(this.immediateToolReturn, that.immediateToolReturn);
+                && Objects.equals(this.immediateToolReturn, that.immediateToolReturn)
+                && Objects.equals(this.suspended, that.suspended)
+                && Objects.equals(this.pendingToolExecutionRequests, that.pendingToolExecutionRequests);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(intermediateResponses, finalResponse, toolExecutions, aggregateTokenUsage, immediateToolReturn);
+        return Objects.hash(
+                intermediateResponses,
+                finalResponse,
+                toolExecutions,
+                aggregateTokenUsage,
+                immediateToolReturn,
+                suspended,
+                pendingToolExecutionRequests);
     }
 
     @Override
     public String toString() {
-        return "ToolServiceResult{" +
-                "intermediateResponses=" + intermediateResponses +
-                ", finalResponse=" + finalResponse +
-                ", toolExecutions=" + toolExecutions +
-                ", aggregateTokenUsage=" + aggregateTokenUsage +
-                ", immediateToolReturn=" + immediateToolReturn +
-                '}';
+        return "ToolServiceResult{" + "intermediateResponses="
+                + intermediateResponses + ", finalResponse="
+                + finalResponse + ", toolExecutions="
+                + toolExecutions + ", aggregateTokenUsage="
+                + aggregateTokenUsage + ", immediateToolReturn="
+                + immediateToolReturn + ", suspended="
+                + suspended + ", pendingToolExecutionRequests="
+                + pendingToolExecutionRequests + '}';
     }
 
     public static Builder builder() {
@@ -133,6 +167,8 @@ public class ToolServiceResult {
         private List<ToolExecution> toolExecutions;
         private TokenUsage aggregateTokenUsage;
         private boolean immediateToolReturn;
+        private boolean suspended;
+        private List<ToolExecutionRequest> pendingToolExecutionRequests;
 
         public Builder intermediateResponses(List<ChatResponse> intermediateResponses) {
             this.intermediateResponses = intermediateResponses;
@@ -156,6 +192,22 @@ public class ToolServiceResult {
 
         public Builder immediateToolReturn(boolean immediateToolReturn) {
             this.immediateToolReturn = immediateToolReturn;
+            return this;
+        }
+
+        /**
+         * @since 1.18.0
+         */
+        public Builder suspended(boolean suspended) {
+            this.suspended = suspended;
+            return this;
+        }
+
+        /**
+         * @since 1.18.0
+         */
+        public Builder pendingToolExecutionRequests(List<ToolExecutionRequest> pendingToolExecutionRequests) {
+            this.pendingToolExecutionRequests = pendingToolExecutionRequests;
             return this;
         }
 

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/AsyncToolExecutionTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/AsyncToolExecutionTest.java
@@ -1,0 +1,205 @@
+package dev.langchain4j.service.tool;
+
+import static dev.langchain4j.agent.tool.ReturnBehavior.TO_LLM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.agent.tool.P;
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.Result;
+import dev.langchain4j.service.UserMessage;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+
+class AsyncToolExecutionTest {
+
+    interface Assistant {
+        Result<String> chat(@MemoryId String conversationId, @UserMessage String message);
+    }
+
+    static class Coordinates {
+        double latitude;
+        double longitude;
+
+        Coordinates(double latitude, double longitude) {
+            this.latitude = latitude;
+            this.longitude = longitude;
+        }
+    }
+
+    static class Tools {
+
+        String executingThread;
+
+        @Tool(returnBehavior = TO_LLM)
+        public CompletableFuture<String> lookup(@P(name = "key") String key) {
+            return CompletableFuture.supplyAsync(
+                    () -> {
+                        executingThread = Thread.currentThread().getName();
+                        return "looked-up:" + key;
+                    },
+                    Executors.newSingleThreadExecutor());
+        }
+
+        @Tool(returnBehavior = TO_LLM)
+        public CompletableFuture<Coordinates> geocode(@P(name = "city") String city) {
+            return CompletableFuture.completedFuture(new Coordinates(48.8566, 2.3522));
+        }
+
+        @Tool(returnBehavior = TO_LLM)
+        public CompletableFuture<String> fail(@P(name = "key") String key) {
+            return CompletableFuture.failedFuture(new RuntimeException("boom"));
+        }
+    }
+
+    static class GatedTools {
+
+        final CompletableFuture<String> gate = new CompletableFuture<>();
+
+        @Tool(returnBehavior = TO_LLM)
+        public CompletableFuture<String> awaitGate(@P(name = "key") String key) {
+            return gate;
+        }
+    }
+
+    @Test
+    void should_unwrap_completable_future_string_result() throws Exception {
+
+        DefaultToolExecutor executor =
+                new DefaultToolExecutor(new Tools(), Tools.class.getDeclaredMethod("lookup", String.class));
+
+        ToolExecutionResult result = executor.executeWithContext(
+                ToolExecutionRequest.builder()
+                        .name("lookup")
+                        .arguments("{\"key\": \"price\"}")
+                        .build(),
+                null);
+
+        assertThat(result.isError()).isFalse();
+        assertThat(result.resultText()).isEqualTo("looked-up:price");
+    }
+
+    @Test
+    void should_unwrap_completable_future_pojo_result_as_json() throws Exception {
+
+        DefaultToolExecutor executor =
+                new DefaultToolExecutor(new Tools(), Tools.class.getDeclaredMethod("geocode", String.class));
+
+        ToolExecutionResult result = executor.executeWithContext(
+                ToolExecutionRequest.builder()
+                        .name("geocode")
+                        .arguments("{\"city\": \"Paris\"}")
+                        .build(),
+                null);
+
+        assertThat(result.resultText()).contains("48.8566").contains("2.3522");
+    }
+
+    @Test
+    void should_route_async_tool_failure_through_error_handling() throws Exception {
+
+        DefaultToolExecutor executor =
+                new DefaultToolExecutor(new Tools(), Tools.class.getDeclaredMethod("fail", String.class));
+
+        ToolExecutionResult result = executor.executeWithContext(
+                ToolExecutionRequest.builder()
+                        .name("fail")
+                        .arguments("{\"key\": \"x\"}")
+                        .build(),
+                null);
+
+        assertThat(result.isError()).isTrue();
+        assertThat(result.resultText()).isEqualTo("boom");
+    }
+
+    @Test
+    void should_run_async_tool_body_on_its_own_executor() throws Exception {
+
+        Tools tools = new Tools();
+        DefaultToolExecutor executor =
+                new DefaultToolExecutor(tools, Tools.class.getDeclaredMethod("lookup", String.class));
+
+        executor.executeWithContext(
+                ToolExecutionRequest.builder()
+                        .name("lookup")
+                        .arguments("{\"key\": \"price\"}")
+                        .build(),
+                null);
+
+        assertThat(tools.executingThread)
+                .as("the async tool body runs on its own executor, not the thread that unwraps the future")
+                .isNotEqualTo(Thread.currentThread().getName());
+    }
+
+    @Test
+    void should_block_until_the_async_tool_future_completes() throws Exception {
+
+        GatedTools tools = new GatedTools();
+        DefaultToolExecutor executor =
+                new DefaultToolExecutor(tools, GatedTools.class.getDeclaredMethod("awaitGate", String.class));
+
+        Thread completer = new Thread(() -> {
+            try {
+                Thread.sleep(150);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            tools.gate.complete("resolved");
+        });
+        completer.start();
+
+        ToolExecutionResult result = executor.executeWithContext(
+                ToolExecutionRequest.builder()
+                        .name("awaitGate")
+                        .arguments("{\"key\": \"x\"}")
+                        .build(),
+                null);
+
+        assertThat(result.resultText())
+                .as("the future is still pending when the tool is invoked, so returning its "
+                        + "value proves the executor joined it synchronously (blocking) before returning")
+                .isEqualTo("resolved");
+
+        completer.join();
+    }
+
+    @Test
+    void should_feed_resolved_async_tool_result_to_the_model() {
+
+        ToolExecutionRequest lookupCall = ToolExecutionRequest.builder()
+                .id("call-1")
+                .name("lookup")
+                .arguments("{\"key\": \"price\"}")
+                .build();
+
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(AiMessage.from(lookupCall), AiMessage.from("done"));
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemoryProvider(id -> MessageWindowChatMemory.withMaxMessages(20))
+                .tools(new Tools())
+                .build();
+
+        Result<String> result = assistant.chat("conv-async", "what is the price");
+
+        assertThat(result.content()).isEqualTo("done");
+
+        List<ChatMessage> secondRequest = model.requests().get(1).messages();
+        ToolExecutionResultMessage toolResult = secondRequest.stream()
+                .filter(ToolExecutionResultMessage.class::isInstance)
+                .map(ToolExecutionResultMessage.class::cast)
+                .findFirst()
+                .orElseThrow();
+        assertThat(toolResult.text()).isEqualTo("looked-up:price");
+    }
+}

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ReturnBehaviorCombinationsTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ReturnBehaviorCombinationsTest.java
@@ -354,6 +354,7 @@ class ReturnBehaviorCombinationsTest {
                     case TO_LLM -> "to_llm";
                     case IMMEDIATE -> "immediate";
                     case IMMEDIATE_IF_LAST -> "immediate_if_last";
+                    case SUSPEND -> "suspend";
                 };
         return prefix + (step.errors() ? "_err" : "_ok");
     }

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/SuspendResumeToolTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/SuspendResumeToolTest.java
@@ -1,0 +1,262 @@
+package dev.langchain4j.service.tool;
+
+import static dev.langchain4j.agent.tool.ReturnBehavior.SUSPEND;
+import static dev.langchain4j.agent.tool.ReturnBehavior.TO_LLM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.mock.ChatModelMock;
+import dev.langchain4j.model.chat.mock.StreamingChatModelMock;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.IllegalConfigurationException;
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.Result;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.memory.ChatMemoryAccess;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class SuspendResumeToolTest {
+
+    interface Assistant extends ToolExecutionResumer, ChatMemoryAccess {
+        Result<String> chat(@MemoryId String conversationId, @UserMessage String message);
+    }
+
+    interface AssistantWithoutResult extends ToolExecutionResumer {
+        String chat(@MemoryId String conversationId, @UserMessage String message);
+    }
+
+    interface StreamingAssistant extends StreamingToolExecutionResumer, ChatMemoryAccess {
+        TokenStream chat(@MemoryId String conversationId, @UserMessage String message);
+    }
+
+    static class Tools {
+
+        boolean askHumanExecuted;
+        boolean lookupExecuted;
+
+        @Tool(returnBehavior = SUSPEND)
+        public String askHuman(String question) {
+            askHumanExecuted = true;
+            return "awaiting human input";
+        }
+
+        @Tool(returnBehavior = TO_LLM)
+        public String lookup(String key) {
+            lookupExecuted = true;
+            return "looked-up:" + key;
+        }
+    }
+
+    @Test
+    void should_suspend_loop_and_resume_with_real_tool_result() {
+
+        ToolExecutionRequest suspendCall = ToolExecutionRequest.builder()
+                .id("call-1")
+                .name("askHuman")
+                .arguments("{\"question\": \"pick a seat\"}")
+                .build();
+
+        ChatModelMock model =
+                ChatModelMock.thatAlwaysResponds(AiMessage.from(suspendCall), AiMessage.from("seat booked"));
+
+        Tools tools = new Tools();
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemoryProvider(id -> MessageWindowChatMemory.withMaxMessages(20))
+                .tools(tools)
+                .build();
+
+        Result<String> suspended = assistant.chat("conv-1", "book me a seat");
+
+        assertThat(model.requests()).hasSize(1);
+        assertThat(tools.askHumanExecuted).isTrue();
+        assertThat(suspended.content()).isNull();
+        assertThat(suspended.finishReason()).isEqualTo(FinishReason.TOOL_EXECUTION);
+        assertThat(suspended.finalResponse().aiMessage().hasToolExecutionRequests())
+                .isTrue();
+
+        List<ToolExecutionRequest> pending =
+                suspended.finalResponse().aiMessage().toolExecutionRequests();
+        assertThat(pending).hasSize(1);
+        assertThat(pending.get(0).name()).isEqualTo("askHuman");
+
+        ToolExecutionResultMessage toolResult = ToolExecutionResultMessage.from(pending.get(0), "seat 12A");
+        Result<String> resumed = assistant.resume("conv-1", toolResult);
+
+        assertThat(model.requests()).hasSize(2);
+        assertThat(resumed.content()).isEqualTo("seat booked");
+
+        assertThat(assistant.getChatMemory("conv-1").messages())
+                .anySatisfy(message -> assertThat(message).isInstanceOf(ToolExecutionResultMessage.class));
+    }
+
+    @Test
+    void should_record_non_suspended_tool_results_when_suspending() {
+
+        ToolExecutionRequest lookupCall = ToolExecutionRequest.builder()
+                .id("call-1")
+                .name("lookup")
+                .arguments("{\"key\": \"price\"}")
+                .build();
+        ToolExecutionRequest suspendCall = ToolExecutionRequest.builder()
+                .id("call-2")
+                .name("askHuman")
+                .arguments("{\"question\": \"confirm?\"}")
+                .build();
+
+        ChatModelMock model =
+                ChatModelMock.thatAlwaysResponds(AiMessage.from(lookupCall, suspendCall), AiMessage.from("confirmed"));
+
+        Tools tools = new Tools();
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(model)
+                .chatMemoryProvider(id -> MessageWindowChatMemory.withMaxMessages(20))
+                .tools(tools)
+                .build();
+
+        Result<String> suspended = assistant.chat("conv-2", "buy if cheap");
+
+        assertThat(tools.lookupExecuted).isTrue();
+        assertThat(tools.askHumanExecuted).isTrue();
+        assertThat(suspended.content()).isNull();
+        assertThat(suspended.finishReason()).isEqualTo(FinishReason.TOOL_EXECUTION);
+
+        List<ToolExecutionResultMessage> recordedResults = assistant.getChatMemory("conv-2").messages().stream()
+                .filter(ToolExecutionResultMessage.class::isInstance)
+                .map(ToolExecutionResultMessage.class::cast)
+                .toList();
+        assertThat(recordedResults)
+                .as("only the non-suspended tool result is recorded; the SUSPEND tool call stays pending")
+                .hasSize(1);
+        assertThat(recordedResults.get(0).toolName()).isEqualTo("lookup");
+
+        ToolExecutionResultMessage toolResult = ToolExecutionResultMessage.from(suspendCall, "yes");
+        Result<String> resumed = assistant.resume("conv-2", toolResult);
+
+        assertThat(resumed.content()).isEqualTo("confirmed");
+    }
+
+    @Test
+    void should_throw_when_suspend_tool_used_without_Result_return_type() {
+
+        ToolExecutionRequest suspendCall = ToolExecutionRequest.builder()
+                .id("call-1")
+                .name("askHuman")
+                .arguments("{\"question\": \"pick a seat\"}")
+                .build();
+
+        ChatModelMock model = ChatModelMock.thatAlwaysResponds(AiMessage.from(suspendCall));
+
+        AssistantWithoutResult assistant = AiServices.builder(AssistantWithoutResult.class)
+                .chatModel(model)
+                .chatMemoryProvider(id -> MessageWindowChatMemory.withMaxMessages(20))
+                .tools(new Tools())
+                .build();
+
+        assertThatThrownBy(() -> assistant.chat("conv-3", "book me a seat"))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("SUSPEND")
+                .hasMessageContaining("Result");
+    }
+
+    @Test
+    void should_suspend_streaming_loop() throws Exception {
+
+        ToolExecutionRequest suspendCall = ToolExecutionRequest.builder()
+                .id("call-1")
+                .name("askHuman")
+                .arguments("{\"question\": \"pick a seat\"}")
+                .build();
+
+        StreamingChatModelMock model =
+                StreamingChatModelMock.thatAlwaysStreams(AiMessage.from(suspendCall), AiMessage.from("seat booked"));
+
+        Tools tools = new Tools();
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemoryProvider(id -> MessageWindowChatMemory.withMaxMessages(20))
+                .tools(tools)
+                .build();
+
+        CompletableFuture<ChatResponse> future = new CompletableFuture<>();
+        assistant
+                .chat("conv-stream", "book me a seat")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .start();
+
+        ChatResponse finalResponse = future.get(10, TimeUnit.SECONDS);
+
+        assertThat(model.requests())
+                .as("suspend stops the loop after a single LLM call, with no reprocessing round trip")
+                .hasSize(1);
+        assertThat(tools.askHumanExecuted).isTrue();
+        assertThat(finalResponse.aiMessage().hasToolExecutionRequests())
+                .as("the suspended tool call is carried in the final response, left pending in memory")
+                .isTrue();
+        assertThat(finalResponse.aiMessage().toolExecutionRequests().get(0).name())
+                .isEqualTo("askHuman");
+    }
+
+    @Test
+    void should_resume_streaming_loop_with_real_tool_result() throws Exception {
+
+        ToolExecutionRequest suspendCall = ToolExecutionRequest.builder()
+                .id("call-1")
+                .name("askHuman")
+                .arguments("{\"question\": \"pick a seat\"}")
+                .build();
+
+        StreamingChatModelMock model =
+                StreamingChatModelMock.thatAlwaysStreams(AiMessage.from(suspendCall), AiMessage.from("seat booked"));
+
+        Tools tools = new Tools();
+        StreamingAssistant assistant = AiServices.builder(StreamingAssistant.class)
+                .streamingChatModel(model)
+                .chatMemoryProvider(id -> MessageWindowChatMemory.withMaxMessages(20))
+                .tools(tools)
+                .build();
+
+        CompletableFuture<ChatResponse> suspendedFuture = new CompletableFuture<>();
+        assistant
+                .chat("conv-sr", "book me a seat")
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(suspendedFuture::complete)
+                .onError(suspendedFuture::completeExceptionally)
+                .start();
+
+        ChatResponse suspended = suspendedFuture.get(10, TimeUnit.SECONDS);
+        ToolExecutionRequest pending =
+                suspended.aiMessage().toolExecutionRequests().get(0);
+
+        ToolExecutionResultMessage toolResult = ToolExecutionResultMessage.from(pending, "seat 12A");
+
+        CompletableFuture<ChatResponse> resumedFuture = new CompletableFuture<>();
+        assistant
+                .resume("conv-sr", toolResult)
+                .onPartialResponse(ignored -> {})
+                .onCompleteResponse(resumedFuture::complete)
+                .onError(resumedFuture::completeExceptionally)
+                .start();
+
+        ChatResponse resumed = resumedFuture.get(10, TimeUnit.SECONDS);
+
+        assertThat(model.requests()).hasSize(2);
+        assertThat(resumed.aiMessage().text()).isEqualTo("seat booked");
+
+        assertThat(assistant.getChatMemory("conv-sr").messages())
+                .anySatisfy(message -> assertThat(message).isInstanceOf(ToolExecutionResultMessage.class));
+    }
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue

Relates to #1183

<!--
Partial: this PR delivers `SUSPEND`/resume and `CompletableFuture<T>` tool support.
Native `Mono`/`Flux` (the reactive part of the issue) is intentionally left to the
external `langchain4j-reactor` module, so the issue is not fully closed here.
-->


## Change

`ReturnBehavior.SUSPEND` pauses the AI Service execution loop after a tool runs, leaving the tool call **pending** in chat memory without producing a `ToolExecutionResultMessage`. The tool method is still executed (e.g. to kick off a long-running job), but its return value is discarded. Two marker interfaces — `ToolExecutionResumer` and `StreamingToolExecutionResumer` — let the caller fulfill the pending call later and re-enter the loop.

`@Tool` methods may now return `CompletableFuture<T>` (or any `CompletionStage<T>`). `DefaultToolExecutor` unwraps the future before result processing; the generic type argument is inspected to produce text or JSON, same as synchronous tools. Errors propagate through the same path as synchronous tool failures.

Key behaviours:

- **Partial state**: when the same `AiMessage` contains `SUSPEND` + non-`SUSPEND` tools, only the non-suspend tools are recorded; the `SUSPEND` tool call stays pending.
- **Error cancels suspension**: if any tool errors, the deferred results are written and the loop follows the normal error path.
- **Async threading**: returning a `CompletableFuture` lets a tool compose async work and integrate async clients without calling `.get()`/`.block()`; the framework joins it to obtain the result, so the AI Service call stays synchronous and, by default, tools run sequentially on the calling thread. This is **not** a parallelism mechanism — running tools in parallel is the separate, opt-in `executeToolsConcurrently(Executor)`, which applies to synchronous tools too.
- **Streaming**: `SUSPEND` in `TokenStream` completes after one LLM turn; `resumeStream` continues and emits the final text.

## General checklist

- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [x] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
