### PR TITLE
Add `MistralAiBatchChatModel` for the Mistral Batch API

### DIFF
--- a/docs/docs/integrations/language-models/mistral-ai.md
+++ b/docs/docs/integrations/language-models/mistral-ai.md
@@ -585,5 +585,49 @@ System.out.println(rawServerSentEvents.get(0).data());
 System.out.println(rawServerSentEvents.get(0).event());
 ```
 
+## Batch Processing
+
+`MistralAiBatchChatModel` implements the core `BatchChatModel` interface to process many chat requests
+asynchronously via the [Mistral Batch API](https://docs.mistral.ai/capabilities/batch/), at 50% of the
+standard per-token price. All requests in a batch run against the single model configured on the batch
+model.
+
+Submit a batch, poll until it reaches a terminal state, then read the per-request results (which preserve
+submission order):
+```java
+MistralAiBatchChatModel batchModel = MistralAiBatchChatModel.builder()
+        .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+        .modelName("mistral-small-latest")
+        .build();
+
+BatchResponse<ChatResponse> submitted = batchModel.submit(new BatchRequest<>(List.of(
+        ChatRequest.builder().messages(UserMessage.from("What is the capital of France?")).build(),
+        ChatRequest.builder().messages(UserMessage.from("What is the capital of Germany?")).build())));
+
+String batchId = submitted.batchId();
+
+// Poll until the batch reaches a terminal state (SUCCEEDED, FAILED, CANCELLED, EXPIRED).
+BatchResponse<ChatResponse> batch = batchModel.retrieve(batchId);
+while (!batch.state().isTerminal()) {
+    Thread.sleep(Duration.ofSeconds(30).toMillis());
+    batch = batchModel.retrieve(batchId);
+}
+
+for (BatchItemResult<ChatResponse> result : batch.results()) {
+    if (result.isSuccess()) {
+        System.out.println(result.response().aiMessage().text());
+    } else {
+        System.out.println("Failed: " + result.error().message());
+    }
+}
+```
+
+A running batch can be cancelled, and existing batches can be listed with pagination:
+```java
+batchModel.cancel(batchId);
+
+BatchPage<ChatResponse> page = batchModel.list(new BatchPagination(20, null));
+```
+
 ## Examples
 - [Mistral AI Examples](https://github.com/langchain4j/langchain4j-examples/tree/main/mistral-ai-examples/src/main/java)

--- a/langchain4j-mistral-ai/revapi.json
+++ b/langchain4j-mistral-ai/revapi.json
@@ -8,6 +8,26 @@
           "code": "java.field.removed",
           "old": "field dev.langchain4j.model.mistralai.MistralAiChatModelName.VOXTRAL_MINI_LATEST",
           "justification": "Mistral retired voxtral-mini on 2026-02-27; the API now rejects the model with 'Invalid model: voxtral-mini-latest', so the constant was non-functional. Removed intentionally; use VOXTRAL_SMALL_LATEST for audio chat."
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchPage",
+          "justification": "Core langchain4j batch type intentionally exposed by the BatchChatModel API implemented by MistralAiBatchChatModel"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchPagination",
+          "justification": "Core langchain4j batch type intentionally exposed by the BatchChatModel API implemented by MistralAiBatchChatModel"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchRequest",
+          "justification": "Core langchain4j batch type intentionally exposed by the BatchChatModel API implemented by MistralAiBatchChatModel"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "new": "missing-class dev.langchain4j.model.batch.BatchResponse",
+          "justification": "Core langchain4j batch type intentionally exposed by the BatchChatModel API implemented by MistralAiBatchChatModel"
         }
       ]
     }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiBatchChatModel.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/MistralAiBatchChatModel.java
@@ -1,0 +1,544 @@
+package dev.langchain4j.model.mistralai;
+
+import static dev.langchain4j.internal.RetryUtils.withRetryMappingExceptions;
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.model.mistralai.InternalMistralAIHelper.createMistralAiRequest;
+import static dev.langchain4j.model.mistralai.InternalMistralAIHelper.validate;
+import static dev.langchain4j.model.mistralai.internal.mapper.MistralAiMapper.aiMessageFrom;
+import static dev.langchain4j.model.mistralai.internal.mapper.MistralAiMapper.finishReasonFrom;
+import static dev.langchain4j.model.mistralai.internal.mapper.MistralAiMapper.tokenUsageFrom;
+
+import dev.langchain4j.Experimental;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.model.batch.BatchError;
+import dev.langchain4j.model.batch.BatchItemResult;
+import dev.langchain4j.model.batch.BatchPage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.batch.BatchState;
+import dev.langchain4j.model.chat.BatchChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiBatchJob;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiBatchJobRequest;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiBatchJobsResponse;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiBatchResultEntry;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiChatCompletionRequest;
+import dev.langchain4j.model.mistralai.internal.api.MistralAiChatCompletionResponse;
+import dev.langchain4j.model.mistralai.internal.client.MistralAiClient;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+
+/**
+ * A {@link BatchChatModel} for the Mistral
+ * <a href="https://docs.mistral.ai/capabilities/batch/">Batch API</a>, which processes multiple chat
+ * requests asynchronously at 50% of the standard per-token price.
+ *
+ * <p>Requests are submitted inline: each {@link ChatRequest} is mapped to a request identical to the one
+ * {@link MistralAiChatModel} would send, so per-request parameters (temperature, tools, response format, etc.)
+ * behave the same in a batch as in a single call. The returned {@link BatchResponse} carries the batch id and
+ * its current {@link BatchState}; results are fetched by {@link #retrieve(String)} once the job has produced
+ * them, preserving submission order.</p>
+ *
+ * <p>All requests in a batch run against the single model configured on this batch model
+ * (via {@link Builder#modelName(String)}), matching the Mistral constraint of one model per job.</p>
+ *
+ * @see BatchChatModel
+ * @see BatchResponse
+ */
+@Experimental
+public final class MistralAiBatchChatModel implements BatchChatModel {
+
+    private static final String CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions";
+    private static final String CUSTOM_ID_PREFIX = "request-";
+
+    private static final String STATUS_QUEUED = "QUEUED";
+    private static final String STATUS_RUNNING = "RUNNING";
+    private static final String STATUS_SUCCESS = "SUCCESS";
+    private static final String STATUS_FAILED = "FAILED";
+    private static final String STATUS_TIMEOUT_EXCEEDED = "TIMEOUT_EXCEEDED";
+    private static final String STATUS_CANCELLATION_REQUESTED = "CANCELLATION_REQUESTED";
+    private static final String STATUS_CANCELLED = "CANCELLED";
+
+    private final MistralAiClient client;
+    private final ChatRequestParameters defaultRequestParameters;
+    private final Boolean safePrompt;
+    private final Integer randomSeed;
+    private final boolean sendThinking;
+    private final boolean returnThinking;
+    private final boolean strictJsonSchema;
+    private final int maxRetries;
+    private final Integer timeoutHours;
+
+    public MistralAiBatchChatModel(Builder builder) {
+        this.client = MistralAiClient.builder()
+                .httpClientBuilder(builder.httpClientBuilder)
+                .baseUrl(getOrDefault(builder.baseUrl, "https://api.mistral.ai/v1"))
+                .apiKey(builder.apiKey)
+                .timeout(builder.timeout)
+                .logRequests(getOrDefault(builder.logRequests, false))
+                .logResponses(getOrDefault(builder.logResponses, false))
+                .logger(builder.logger)
+                .customHeaders(builder.customHeadersSupplier)
+                .build();
+        this.safePrompt = builder.safePrompt;
+        this.randomSeed = builder.randomSeed;
+        this.sendThinking = getOrDefault(builder.sendThinking, false);
+        this.returnThinking = getOrDefault(builder.returnThinking, false);
+        this.strictJsonSchema = getOrDefault(builder.strictJsonSchema, false);
+        this.maxRetries = getOrDefault(builder.maxRetries, 2);
+        this.timeoutHours = builder.timeoutHours;
+        this.defaultRequestParameters = initDefaultRequestParameters(builder);
+    }
+
+    private static ChatRequestParameters initDefaultRequestParameters(Builder builder) {
+        ChatRequestParameters commonParameters;
+        if (builder.defaultRequestParameters != null) {
+            validate(builder.defaultRequestParameters);
+            commonParameters = builder.defaultRequestParameters;
+        } else {
+            commonParameters = DefaultChatRequestParameters.EMPTY;
+        }
+        return DefaultChatRequestParameters.builder()
+                .modelName(getOrDefault(builder.modelName, commonParameters.modelName()))
+                .temperature(getOrDefault(builder.temperature, commonParameters.temperature()))
+                .topP(getOrDefault(builder.topP, commonParameters.topP()))
+                .frequencyPenalty(getOrDefault(builder.frequencyPenalty, commonParameters.frequencyPenalty()))
+                .presencePenalty(getOrDefault(builder.presencePenalty, commonParameters.presencePenalty()))
+                .maxOutputTokens(getOrDefault(builder.maxTokens, commonParameters.maxOutputTokens()))
+                .stopSequences(getOrDefault(builder.stopSequences, commonParameters.stopSequences()))
+                .toolSpecifications(commonParameters.toolSpecifications())
+                .toolChoice(commonParameters.toolChoice())
+                .responseFormat(getOrDefault(builder.responseFormat, commonParameters.responseFormat()))
+                .build();
+    }
+
+    @Override
+    public BatchResponse<ChatResponse> submit(BatchRequest<ChatRequest> request) {
+        List<ChatRequest> requests = request.requests();
+        List<MistralAiBatchJobRequest.Request> items = new ArrayList<>();
+        for (int i = 0; i < requests.size(); i++) {
+            items.add(new MistralAiBatchJobRequest.Request(CUSTOM_ID_PREFIX + i, toMistralAiRequest(requests.get(i))));
+        }
+        MistralAiBatchJobRequest jobRequest = MistralAiBatchJobRequest.builder()
+                .requests(items)
+                .endpoint(CHAT_COMPLETIONS_ENDPOINT)
+                .model(defaultRequestParameters.modelName())
+                .timeoutHours(timeoutHours)
+                .build();
+        MistralAiBatchJob job = withRetryMappingExceptions(() -> client.createBatchJob(jobRequest), maxRetries);
+        return toBatchResponse(job, List.of());
+    }
+
+    @Override
+    public BatchResponse<ChatResponse> retrieve(String batchId) {
+        MistralAiBatchJob job = withRetryMappingExceptions(() -> client.retrieveBatchJob(batchId), maxRetries);
+        List<BatchItemResult<ChatResponse>> results = List.of();
+        if (job.outputFile != null || job.errorFile != null) {
+            List<MistralAiBatchResultEntry> entries = new ArrayList<>();
+            if (job.outputFile != null) {
+                entries.addAll(
+                        withRetryMappingExceptions(() -> client.downloadBatchResults(job.outputFile), maxRetries));
+            }
+            if (job.errorFile != null) {
+                entries.addAll(
+                        withRetryMappingExceptions(() -> client.downloadBatchResults(job.errorFile), maxRetries));
+            }
+            entries.sort(Comparator.comparingInt(this::customIdIndex));
+            results = entries.stream().map(this::toBatchItemResult).toList();
+        }
+        return toBatchResponse(job, results);
+    }
+
+    @Override
+    public void cancel(String batchId) {
+        withRetryMappingExceptions(() -> client.cancelBatchJob(batchId), maxRetries);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The Mistral Batch API paginates by zero-based page index. When more pages remain, the returned
+     * {@link BatchPage#nextPageToken()} is the next page index (as a string) to pass back via
+     * {@link BatchPagination#pageToken()}.</p>
+     */
+    @Override
+    public BatchPage<ChatResponse> list(@Nullable BatchPagination pagination) {
+        Integer pageSize = pagination != null ? pagination.pageSize() : null;
+        Integer page =
+                pagination != null && pagination.pageToken() != null ? Integer.parseInt(pagination.pageToken()) : null;
+        MistralAiBatchJobsResponse response =
+                withRetryMappingExceptions(() -> client.listBatchJobs(page, pageSize), maxRetries);
+        List<BatchResponse<ChatResponse>> batches = new ArrayList<>();
+        if (response.data != null) {
+            for (MistralAiBatchJob job : response.data) {
+                batches.add(toBatchResponse(job, List.of()));
+            }
+        }
+        int currentPage = page != null ? page : 0;
+        String nextPageToken = null;
+        if (pageSize != null
+                && pageSize > 0
+                && response.total != null
+                && (long) (currentPage + 1) * pageSize < response.total) {
+            nextPageToken = String.valueOf(currentPage + 1);
+        }
+        return new BatchPage<>(batches, nextPageToken);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private MistralAiChatCompletionRequest toMistralAiRequest(ChatRequest chatRequest) {
+        ChatRequestParameters merged = defaultRequestParameters.overrideWith(chatRequest.parameters());
+        ChatRequest effectiveRequest = ChatRequest.builder()
+                .messages(chatRequest.messages())
+                .parameters(merged)
+                .build();
+        return createMistralAiRequest(effectiveRequest, safePrompt, randomSeed, false, sendThinking, strictJsonSchema);
+    }
+
+    private ChatResponse toChatResponse(MistralAiChatCompletionResponse response) {
+        return ChatResponse.builder()
+                .aiMessage(aiMessageFrom(response, returnThinking))
+                .metadata(MistralAiChatResponseMetadata.builder()
+                        .id(response.getId())
+                        .modelName(response.getModel())
+                        .tokenUsage(tokenUsageFrom(response.getUsage()))
+                        .finishReason(
+                                finishReasonFrom(response.getChoices().get(0).getFinishReason()))
+                        .build())
+                .build();
+    }
+
+    private BatchResponse<ChatResponse> toBatchResponse(
+            MistralAiBatchJob job, List<BatchItemResult<ChatResponse>> results) {
+        return BatchResponse.<ChatResponse>builder()
+                .batchId(job.id)
+                .state(toBatchState(job.status))
+                .results(results)
+                .build();
+    }
+
+    private static BatchState toBatchState(@Nullable String status) {
+        if (status == null) {
+            return BatchState.UNSPECIFIED;
+        }
+        return switch (status) {
+            case STATUS_QUEUED -> BatchState.PENDING;
+            case STATUS_RUNNING, STATUS_CANCELLATION_REQUESTED -> BatchState.RUNNING;
+            case STATUS_SUCCESS -> BatchState.SUCCEEDED;
+            case STATUS_FAILED -> BatchState.FAILED;
+            case STATUS_TIMEOUT_EXCEEDED -> BatchState.EXPIRED;
+            case STATUS_CANCELLED -> BatchState.CANCELLED;
+            default -> BatchState.UNSPECIFIED;
+        };
+    }
+
+    private BatchItemResult<ChatResponse> toBatchItemResult(MistralAiBatchResultEntry entry) {
+        MistralAiBatchResultEntry.Response response = entry.response;
+        boolean succeeded = entry.error == null
+                && response != null
+                && response.body != null
+                && (response.statusCode == null || response.statusCode < 400)
+                && hasChoices(response.body);
+        if (succeeded) {
+            return BatchItemResult.success(toChatResponse(response.body));
+        }
+        int code = response != null && response.statusCode != null ? response.statusCode : 0;
+        List<Map<String, Object>> details = entry.error != null ? List.of(entry.error) : null;
+        return BatchItemResult.failure(new BatchError(code, errorMessage(entry), details));
+    }
+
+    private static boolean hasChoices(MistralAiChatCompletionResponse body) {
+        return body.getChoices() != null && !body.getChoices().isEmpty();
+    }
+
+    private static String errorMessage(MistralAiBatchResultEntry entry) {
+        if (entry.error != null) {
+            Object message = entry.error.get("message");
+            return message != null ? message.toString() : entry.error.toString();
+        }
+        if (entry.response != null && entry.response.statusCode != null && entry.response.statusCode >= 400) {
+            return "Request failed with status code " + entry.response.statusCode;
+        }
+        return "Malformed batch result: no response body or choices";
+    }
+
+    private int customIdIndex(MistralAiBatchResultEntry entry) {
+        String customId = entry.customId;
+        if (customId != null && customId.startsWith(CUSTOM_ID_PREFIX)) {
+            try {
+                return Integer.parseInt(customId.substring(CUSTOM_ID_PREFIX.length()));
+            } catch (NumberFormatException ignored) {
+                // custom id not produced by this model; keep it last rather than failing
+            }
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    public static final class Builder {
+
+        private HttpClientBuilder httpClientBuilder;
+        private String baseUrl;
+        private String apiKey;
+        private String modelName;
+        private Double temperature;
+        private Double topP;
+        private Integer maxTokens;
+        private Double frequencyPenalty;
+        private Double presencePenalty;
+        private List<String> stopSequences;
+        private ResponseFormat responseFormat;
+        private Boolean safePrompt;
+        private Integer randomSeed;
+        private Boolean sendThinking;
+        private Boolean returnThinking;
+        private Boolean strictJsonSchema;
+        private Integer timeoutHours;
+        private Duration timeout;
+        private Integer maxRetries;
+        private Boolean logRequests;
+        private Boolean logResponses;
+        private Logger logger;
+        private Supplier<Map<String, String>> customHeadersSupplier;
+        private ChatRequestParameters defaultRequestParameters;
+
+        private Builder() {}
+
+        /**
+         * Sets a custom {@link HttpClientBuilder} for the underlying HTTP client.
+         *
+         * @return {@code this}
+         */
+        public Builder httpClientBuilder(HttpClientBuilder httpClientBuilder) {
+            this.httpClientBuilder = httpClientBuilder;
+            return this;
+        }
+
+        /**
+         * Sets the base URL of the Mistral API. Defaults to {@code https://api.mistral.ai/v1}.
+         *
+         * @return {@code this}
+         */
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        /**
+         * Sets the Mistral API key used to authenticate requests.
+         *
+         * @return {@code this}
+         */
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * Sets the model that every request in the batch runs against (one model per job).
+         *
+         * @return {@code this}
+         */
+        public Builder modelName(String modelName) {
+            this.modelName = modelName;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder temperature(Double temperature) {
+            this.temperature = temperature;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder topP(Double topP) {
+            this.topP = topP;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder maxTokens(Integer maxTokens) {
+            this.maxTokens = maxTokens;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder frequencyPenalty(Double frequencyPenalty) {
+            this.frequencyPenalty = frequencyPenalty;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder presencePenalty(Double presencePenalty) {
+            this.presencePenalty = presencePenalty;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder stopSequences(List<String> stopSequences) {
+            this.stopSequences = stopSequences;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder responseFormat(ResponseFormat responseFormat) {
+            this.responseFormat = responseFormat;
+            return this;
+        }
+
+        /**
+         * Injects a safety prompt in front of all conversations when {@code true}.
+         *
+         * @return {@code this}
+         */
+        public Builder safePrompt(Boolean safePrompt) {
+            this.safePrompt = safePrompt;
+            return this;
+        }
+
+        /**
+         * Sets the seed for deterministic sampling.
+         *
+         * @return {@code this}
+         */
+        public Builder randomSeed(Integer randomSeed) {
+            this.randomSeed = randomSeed;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder sendThinking(Boolean sendThinking) {
+            this.sendThinking = sendThinking;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder returnThinking(Boolean returnThinking) {
+            this.returnThinking = returnThinking;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder strictJsonSchema(Boolean strictJsonSchema) {
+            this.strictJsonSchema = strictJsonSchema;
+            return this;
+        }
+
+        /**
+         * Sets the job timeout in hours, after which unprocessed requests expire.
+         *
+         * @return {@code this}
+         */
+        public Builder timeoutHours(Integer timeoutHours) {
+            this.timeoutHours = timeoutHours;
+            return this;
+        }
+
+        /**
+         * Sets the HTTP request timeout for calls to the Mistral API.
+         *
+         * @return {@code this}
+         */
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        /**
+         * Sets the number of times to retry a request on transient errors. Defaults to {@code 2}.
+         *
+         * @return {@code this}
+         */
+        public Builder maxRetries(Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder logRequests(Boolean logRequests) {
+            this.logRequests = logRequests;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder logResponses(Boolean logResponses) {
+            this.logResponses = logResponses;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder logger(Logger logger) {
+            this.logger = logger;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder customHeaders(Map<String, String> customHeaders) {
+            this.customHeadersSupplier = () -> customHeaders;
+            return this;
+        }
+
+        /**
+         * @return {@code this}
+         */
+        public Builder customHeaders(Supplier<Map<String, String>> customHeadersSupplier) {
+            this.customHeadersSupplier = customHeadersSupplier;
+            return this;
+        }
+
+        /**
+         * Sets common default {@link ChatRequestParameters}; explicit builder setters take precedence over these.
+         *
+         * @return {@code this}
+         */
+        public Builder defaultRequestParameters(ChatRequestParameters defaultRequestParameters) {
+            this.defaultRequestParameters = defaultRequestParameters;
+            return this;
+        }
+
+        public MistralAiBatchChatModel build() {
+            return new MistralAiBatchChatModel(this);
+        }
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiBatchJob.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiBatchJob.java
@@ -1,0 +1,27 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * Metadata for a batch job returned by the Mistral Batch API
+ * (create, retrieve, cancel, and each entry of the list endpoint).
+ *
+ * <p>{@link #status} is one of {@code QUEUED}, {@code RUNNING}, {@code SUCCESS}, {@code FAILED},
+ * {@code TIMEOUT_EXCEEDED}, {@code CANCELLATION_REQUESTED}, or {@code CANCELLED}. Per-request outcomes
+ * are not carried here; once the job has completed they are fetched from the file referenced by
+ * {@link #outputFile} (and, for provider-level failures, {@link #errorFile}) via the Files API.</p>
+ *
+ * <p>Only the fields consumed by {@code MistralAiBatchChatModel} are declared; the remaining response
+ * fields are ignored via {@link JsonIgnoreProperties}.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiBatchJob {
+
+    public String id;
+    public String status;
+    public String outputFile;
+    public String errorFile;
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiBatchJobRequest.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiBatchJobRequest.java
@@ -1,0 +1,124 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Request body for creating a batch job via the Mistral Batch API ({@code POST /v1/batch/jobs}).
+ *
+ * <p>Requests are submitted inline rather than by referencing an uploaded file. Each {@link Request}
+ * pairs a {@code custom_id} with the body of a single {@code /v1/chat/completions} request; the
+ * {@code custom_id} correlates the request with its result once the job has completed.</p>
+ */
+@JsonInclude(NON_NULL)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiBatchJobRequest {
+
+    private final List<Request> requests;
+    private final String endpoint;
+    private final String model;
+    private final Map<String, Object> metadata;
+    private final Integer timeoutHours;
+
+    private MistralAiBatchJobRequest(Builder builder) {
+        this.requests = builder.requests;
+        this.endpoint = builder.endpoint;
+        this.model = builder.model;
+        this.metadata = builder.metadata;
+        this.timeoutHours = builder.timeoutHours;
+    }
+
+    public List<Request> getRequests() {
+        return requests;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public Integer getTimeoutHours() {
+        return timeoutHours;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private List<Request> requests;
+        private String endpoint;
+        private String model;
+        private Map<String, Object> metadata;
+        private Integer timeoutHours;
+
+        private Builder() {}
+
+        public Builder requests(List<Request> requests) {
+            this.requests = requests;
+            return this;
+        }
+
+        public Builder endpoint(String endpoint) {
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        public Builder model(String model) {
+            this.model = model;
+            return this;
+        }
+
+        public Builder metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public Builder timeoutHours(Integer timeoutHours) {
+            this.timeoutHours = timeoutHours;
+            return this;
+        }
+
+        public MistralAiBatchJobRequest build() {
+            return new MistralAiBatchJobRequest(this);
+        }
+    }
+
+    /**
+     * A single inline request within a batch job: a {@code custom_id} and the body of the underlying
+     * {@code /v1/chat/completions} request.
+     */
+    @JsonInclude(NON_NULL)
+    @JsonNaming(SnakeCaseStrategy.class)
+    public static class Request {
+
+        private final String customId;
+        private final MistralAiChatCompletionRequest body;
+
+        public Request(String customId, MistralAiChatCompletionRequest body) {
+            this.customId = customId;
+            this.body = body;
+        }
+
+        public String getCustomId() {
+            return customId;
+        }
+
+        public MistralAiChatCompletionRequest getBody() {
+            return body;
+        }
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiBatchJobsResponse.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiBatchJobsResponse.java
@@ -1,0 +1,21 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+
+/**
+ * Response body for the list endpoint of the Mistral Batch API ({@code GET /v1/batch/jobs}).
+ *
+ * <p>Uses page-based pagination: {@link #total} is the number of jobs matching the query across all
+ * pages, which {@code MistralAiBatchChatModel} combines with the requested page and page size to
+ * decide whether a next page exists.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiBatchJobsResponse {
+
+    public List<MistralAiBatchJob> data;
+    public Integer total;
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiBatchResultEntry.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/api/MistralAiBatchResultEntry.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.model.mistralai.internal.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Map;
+
+/**
+ * A single line of the JSONL document referenced by a completed batch job's {@code output_file}
+ * (or {@code error_file}).
+ *
+ * <p>{@link #customId} correlates the outcome with the originating request. Lines are returned in
+ * arbitrary order, so callers must key on {@code custom_id} rather than position. A successful line
+ * carries a {@link #response} whose {@link Response#body} is the {@code /v1/chat/completions} result;
+ * a failed line carries an {@link #error}.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(SnakeCaseStrategy.class)
+public class MistralAiBatchResultEntry {
+
+    public String customId;
+    public Response response;
+    public Map<String, Object> error;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(SnakeCaseStrategy.class)
+    public static class Response {
+
+        public Integer statusCode;
+        public MistralAiChatCompletionResponse body;
+    }
+}

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
@@ -19,6 +19,8 @@ import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.mistralai.internal.api.*;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -214,5 +216,102 @@ public class DefaultMistralAiClient extends MistralAiClient {
 
         SuccessfulHttpResponse successfulHttpResponse = httpClient.execute(httpRequest);
         return fromJson(successfulHttpResponse.body(), MistralAiModelResponse.class);
+    }
+
+    @Override
+    public MistralAiBatchJob createBatchJob(MistralAiBatchJobRequest request) {
+        HttpRequest httpRequest = HttpRequest.builder()
+                .method(POST)
+                .url(baseUrl, "batch/jobs")
+                .addHeader("Authorization", "Bearer " + apiKey)
+                .addHeader("Content-Type", "application/json")
+                .addHeader("User-Agent", "langchain4j-mistral-ai")
+                .addHeaders(buildRequestHeaders())
+                .body(toJson(request))
+                .build();
+
+        SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
+        return fromJson(rawResponse.body(), MistralAiBatchJob.class);
+    }
+
+    @Override
+    public MistralAiBatchJob retrieveBatchJob(String jobId) {
+        HttpRequest httpRequest = HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .url(baseUrl, "batch/jobs/" + jobId)
+                .addHeader("Authorization", "Bearer " + apiKey)
+                .addHeader("Content-Type", "application/json")
+                .addHeader("User-Agent", "langchain4j-mistral-ai")
+                .addHeaders(buildRequestHeaders())
+                .build();
+
+        SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
+        return fromJson(rawResponse.body(), MistralAiBatchJob.class);
+    }
+
+    @Override
+    public MistralAiBatchJob cancelBatchJob(String jobId) {
+        HttpRequest httpRequest = HttpRequest.builder()
+                .method(POST)
+                .url(baseUrl, "batch/jobs/" + jobId + "/cancel")
+                .addHeader("Authorization", "Bearer " + apiKey)
+                .addHeader("Content-Type", "application/json")
+                .addHeader("User-Agent", "langchain4j-mistral-ai")
+                .addHeaders(buildRequestHeaders())
+                .build();
+
+        SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
+        return fromJson(rawResponse.body(), MistralAiBatchJob.class);
+    }
+
+    @Override
+    public MistralAiBatchJobsResponse listBatchJobs(Integer page, Integer pageSize) {
+        StringBuilder path = new StringBuilder("batch/jobs");
+        List<String> queryParams = new ArrayList<>();
+        if (page != null) {
+            queryParams.add("page=" + page);
+        }
+        if (pageSize != null) {
+            queryParams.add("page_size=" + pageSize);
+        }
+        if (!queryParams.isEmpty()) {
+            path.append('?').append(String.join("&", queryParams));
+        }
+
+        HttpRequest httpRequest = HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .url(baseUrl, path.toString())
+                .addHeader("Authorization", "Bearer " + apiKey)
+                .addHeader("Content-Type", "application/json")
+                .addHeader("User-Agent", "langchain4j-mistral-ai")
+                .addHeaders(buildRequestHeaders())
+                .build();
+
+        SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
+        return fromJson(rawResponse.body(), MistralAiBatchJobsResponse.class);
+    }
+
+    @Override
+    public List<MistralAiBatchResultEntry> downloadBatchResults(String fileId) {
+        HttpRequest httpRequest = HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .url(baseUrl, "files/" + fileId + "/content")
+                .addHeader("Authorization", "Bearer " + apiKey)
+                .addHeader("User-Agent", "langchain4j-mistral-ai")
+                .addHeaders(buildRequestHeaders())
+                .build();
+
+        SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
+        List<MistralAiBatchResultEntry> results = new ArrayList<>();
+        String body = rawResponse.body();
+        if (body != null) {
+            for (String line : body.split("\n")) {
+                String trimmed = line.trim();
+                if (!trimmed.isEmpty()) {
+                    results.add(fromJson(trimmed, MistralAiBatchResultEntry.class));
+                }
+            }
+        }
+        return results;
     }
 }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/DefaultMistralAiClient.java
@@ -302,16 +302,14 @@ public class DefaultMistralAiClient extends MistralAiClient {
                 .build();
 
         SuccessfulHttpResponse rawResponse = httpClient.execute(httpRequest);
-        List<MistralAiBatchResultEntry> results = new ArrayList<>();
         String body = rawResponse.body();
-        if (body != null) {
-            for (String line : body.split("\n")) {
-                String trimmed = line.trim();
-                if (!trimmed.isEmpty()) {
-                    results.add(fromJson(trimmed, MistralAiBatchResultEntry.class));
-                }
-            }
+        if (body == null) {
+            return List.of();
         }
-        return results;
+        return body.lines()
+                .map(String::trim)
+                .filter(line -> !line.isEmpty())
+                .map(line -> fromJson(line, MistralAiBatchResultEntry.class))
+                .toList();
     }
 }

--- a/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiClient.java
+++ b/langchain4j-mistral-ai/src/main/java/dev/langchain4j/model/mistralai/internal/client/MistralAiClient.java
@@ -8,6 +8,7 @@ import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.mistralai.internal.api.*;
 import dev.langchain4j.spi.ServiceHelper;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -58,6 +59,50 @@ public abstract class MistralAiClient {
 
     public abstract void streamingFimCompletion(
             MistralAiFimCompletionRequest request, StreamingResponseHandler<String> handler);
+
+    /**
+     * Creates a batch job on the Mistral Batch API ({@code POST /v1/batch/jobs}).
+     *
+     * <p>Implemented as a non-abstract method that throws by default so that adding batch support does
+     * not break existing {@link MistralAiClient} implementations.</p>
+     */
+    public MistralAiBatchJob createBatchJob(MistralAiBatchJobRequest request) {
+        throw batchNotSupported();
+    }
+
+    /**
+     * Retrieves the current state of a batch job ({@code GET /v1/batch/jobs/{jobId}}).
+     */
+    public MistralAiBatchJob retrieveBatchJob(String jobId) {
+        throw batchNotSupported();
+    }
+
+    /**
+     * Requests cancellation of a batch job ({@code POST /v1/batch/jobs/{jobId}/cancel}).
+     */
+    public MistralAiBatchJob cancelBatchJob(String jobId) {
+        throw batchNotSupported();
+    }
+
+    /**
+     * Lists batch jobs with page-based pagination ({@code GET /v1/batch/jobs}).
+     */
+    public MistralAiBatchJobsResponse listBatchJobs(Integer page, Integer pageSize) {
+        throw batchNotSupported();
+    }
+
+    /**
+     * Downloads and parses the JSONL results of a completed batch job from the file referenced by its
+     * {@code output_file} or {@code error_file} id ({@code GET /v1/files/{fileId}/content}).
+     */
+    public List<MistralAiBatchResultEntry> downloadBatchResults(String fileId) {
+        throw batchNotSupported();
+    }
+
+    private UnsupportedFeatureException batchNotSupported() {
+        return new UnsupportedFeatureException("Batch operations are not supported by this client implementation: "
+                + getClass().getName());
+    }
 
     @SuppressWarnings({"rawtypes"})
     public static MistralAiClient.Builder builder() {

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiBatchChatModelIT.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiBatchChatModelIT.java
@@ -1,0 +1,82 @@
+package dev.langchain4j.model.mistralai;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.batch.BatchPage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.batch.BatchState;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+")
+class MistralAiBatchChatModelIT {
+
+    private final MistralAiBatchChatModel model = MistralAiBatchChatModel.builder()
+            .apiKey(System.getenv("MISTRAL_AI_API_KEY"))
+            .modelName("mistral-small-latest")
+            .maxTokens(32)
+            .build();
+
+    @Test
+    void should_submit_poll_and_retrieve_batch_results() throws InterruptedException {
+        BatchResponse<ChatResponse> submitted = model.submit(new BatchRequest<>(List.of(
+                ChatRequest.builder()
+                        .messages(UserMessage.from("What is the capital of France? Answer in one word."))
+                        .build(),
+                ChatRequest.builder()
+                        .messages(UserMessage.from("What is the capital of Germany? Answer in one word."))
+                        .build())));
+
+        assertThat(submitted.batchId()).isNotBlank();
+        assertThat(submitted.state()).isIn(BatchState.PENDING, BatchState.RUNNING);
+        assertThat(submitted.results()).isEmpty();
+
+        BatchResponse<ChatResponse> retrieved = pollUntilTerminal(submitted.batchId(), Duration.ofMinutes(15));
+
+        assertThat(retrieved.state()).isEqualTo(BatchState.SUCCEEDED);
+        assertThat(retrieved.results()).hasSize(2);
+        assertThat(retrieved.responses()).isNotEmpty();
+        retrieved.results().stream()
+                .filter(result -> result.isSuccess())
+                .forEach(result ->
+                        assertThat(result.response().aiMessage().text()).isNotBlank());
+    }
+
+    @Test
+    void should_list_batches() {
+        BatchPage<ChatResponse> page = model.list(new BatchPagination(5, null));
+
+        assertThat(page.batches()).isNotNull();
+    }
+
+    @Test
+    void should_submit_and_cancel_batch() {
+        BatchResponse<ChatResponse> submitted = model.submit(new BatchRequest<>(List.of(ChatRequest.builder()
+                .messages(UserMessage.from("Write a very long essay about the ocean."))
+                .build())));
+
+        model.cancel(submitted.batchId());
+
+        BatchResponse<ChatResponse> afterCancel = model.retrieve(submitted.batchId());
+        assertThat(afterCancel.state()).isNotNull();
+    }
+
+    private BatchResponse<ChatResponse> pollUntilTerminal(String batchId, Duration timeout)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        BatchResponse<ChatResponse> response = model.retrieve(batchId);
+        while (!response.state().isTerminal() && System.nanoTime() < deadline) {
+            SECONDS.sleep(10);
+            response = model.retrieve(batchId);
+        }
+        return response;
+    }
+}

--- a/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiBatchChatModelTest.java
+++ b/langchain4j-mistral-ai/src/test/java/dev/langchain4j/model/mistralai/MistralAiBatchChatModelTest.java
@@ -1,0 +1,231 @@
+package dev.langchain4j.model.mistralai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.batch.BatchItemResult;
+import dev.langchain4j.model.batch.BatchPage;
+import dev.langchain4j.model.batch.BatchPagination;
+import dev.langchain4j.model.batch.BatchRequest;
+import dev.langchain4j.model.batch.BatchResponse;
+import dev.langchain4j.model.batch.BatchState;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MistralAiBatchChatModelTest {
+
+    // language=json
+    private static final String QUEUED_RESPONSE = """
+            {"id":"batch_1","object":"batch","status":"QUEUED","total_requests":2}
+            """;
+
+    // language=json
+    private static final String SUCCESS_RESPONSE = """
+            {"id":"batch_1","object":"batch","status":"SUCCESS","output_file":"file_out_1",
+             "total_requests":2,"succeeded_requests":1,"failed_requests":1}
+            """;
+
+    // language=json
+    private static final String RUNNING_RESPONSE = """
+            {"id":"batch_running","object":"batch","status":"RUNNING","total_requests":2}
+            """;
+
+    // language=json
+    private static final String CANCEL_RESPONSE = """
+            {"id":"batch_1","object":"batch","status":"CANCELLATION_REQUESTED"}
+            """;
+
+    // language=json
+    private static final String LIST_RESPONSE = """
+            {"object":"list","data":[{"id":"batch_1","status":"SUCCESS","output_file":"file_out_1"}],"total":25}
+            """;
+
+    private static final String RESULTS_JSONL = "{\"custom_id\":\"request-1\",\"error\":{\"message\":\"boom\"}}\n"
+            + "{\"custom_id\":\"request-0\",\"response\":{\"status_code\":200,\"body\":{\"id\":\"cmpl_0\","
+            + "\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\","
+            + "\"content\":[{\"type\":\"text\",\"text\":\"A\"}]},\"finish_reason\":\"stop\"}],"
+            + "\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1,\"total_tokens\":6}}}}\n";
+
+    private static final String STATUS_FAIL_JSONL =
+            "{\"custom_id\":\"request-0\",\"response\":{\"status_code\":400,\"body\":{}}}\n";
+
+    // language=json
+    private static final String SUCCESS_WITH_ERRORS_RESPONSE = """
+            {"id":"batch_witherrors","object":"batch","status":"SUCCESS","output_file":"file_out_1","error_file":"file_err_1"}
+            """;
+
+    private static final String ERROR_FILE_JSONL =
+            "{\"custom_id\":\"request-2\",\"error\":{\"message\":\"rate limited\"}}\n";
+
+    private HttpServer server;
+    private String baseUrl;
+    private final AtomicReference<String> capturedCreateBody = new AtomicReference<>();
+    private final AtomicReference<String> capturedListQuery = new AtomicReference<>();
+    private final AtomicBoolean cancelCalled = new AtomicBoolean(false);
+    private final AtomicBoolean resultsFileFetched = new AtomicBoolean(false);
+
+    @BeforeEach
+    void setUp() throws Exception {
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        server = HttpServer.create(new InetSocketAddress(loopback, 0), 0);
+        server.createContext("/", exchange -> {
+            String path = exchange.getRequestURI().getPath();
+            String method = exchange.getRequestMethod();
+            String responseBody;
+            if (path.endsWith("/cancel")) {
+                cancelCalled.set(true);
+                responseBody = CANCEL_RESPONSE;
+            } else if (path.startsWith("/v1/files/") && path.endsWith("/content")) {
+                resultsFileFetched.set(true);
+                if (path.contains("file_statusfail")) {
+                    responseBody = STATUS_FAIL_JSONL;
+                } else if (path.contains("file_err_1")) {
+                    responseBody = ERROR_FILE_JSONL;
+                } else {
+                    responseBody = RESULTS_JSONL;
+                }
+            } else if (path.equals("/v1/batch/jobs") && method.equals("POST")) {
+                capturedCreateBody.set(read(exchange.getRequestBody()));
+                responseBody = QUEUED_RESPONSE;
+            } else if (path.equals("/v1/batch/jobs")) {
+                capturedListQuery.set(exchange.getRequestURI().getQuery());
+                responseBody = LIST_RESPONSE;
+            } else if (path.endsWith("batch_running")) {
+                responseBody = RUNNING_RESPONSE;
+            } else if (path.endsWith("batch_witherrors")) {
+                responseBody = SUCCESS_WITH_ERRORS_RESPONSE;
+            } else if (path.endsWith("batch_statusfail")) {
+                responseBody = SUCCESS_RESPONSE.replace("file_out_1", "file_statusfail");
+            } else {
+                responseBody = SUCCESS_RESPONSE;
+            }
+            byte[] bytes = responseBody.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.getResponseBody().close();
+        });
+        server.start();
+        baseUrl = "http://" + loopback.getHostAddress() + ":"
+                + server.getAddress().getPort() + "/v1";
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    private MistralAiBatchChatModel model() {
+        return MistralAiBatchChatModel.builder()
+                .baseUrl(baseUrl)
+                .apiKey("test-key")
+                .modelName("mistral-small-latest")
+                .maxTokens(16)
+                .build();
+    }
+
+    @Test
+    void submit_assigns_ordered_custom_ids_and_returns_pending_state() {
+        BatchResponse<ChatResponse> response = model().submit(new BatchRequest<>(List.of(
+                ChatRequest.builder().messages(UserMessage.from("first")).build(),
+                ChatRequest.builder().messages(UserMessage.from("second")).build())));
+
+        assertThat(response.batchId()).isEqualTo("batch_1");
+        assertThat(response.state()).isEqualTo(BatchState.PENDING);
+        assertThat(response.results()).isEmpty();
+        assertThat(capturedCreateBody.get())
+                .contains("\"custom_id\" : \"request-0\"", "\"custom_id\" : \"request-1\"")
+                .contains("\"endpoint\" : \"/v1/chat/completions\"")
+                .contains("\"model\" : \"mistral-small-latest\"");
+    }
+
+    @Test
+    void retrieve_reorders_results_to_submission_order_and_maps_success_and_error() {
+        BatchResponse<ChatResponse> response = model().retrieve("batch_1");
+
+        assertThat(response.state()).isEqualTo(BatchState.SUCCEEDED);
+        assertThat(response.results()).hasSize(2);
+
+        BatchItemResult<ChatResponse> first = response.results().get(0);
+        assertThat(first.isSuccess()).isTrue();
+        assertThat(first.response().aiMessage().text()).isEqualTo("A");
+
+        BatchItemResult<ChatResponse> second = response.results().get(1);
+        assertThat(second.isSuccess()).isFalse();
+        assertThat(second.error().message()).isEqualTo("boom");
+
+        assertThat(response.responses()).hasSize(1);
+        assertThat(response.errors()).hasSize(1);
+    }
+
+    @Test
+    void retrieve_merges_output_file_and_error_file_results_in_submission_order() {
+        BatchResponse<ChatResponse> response = model().retrieve("batch_witherrors");
+
+        assertThat(response.results()).hasSize(3);
+        assertThat(response.results().get(0).isSuccess()).isTrue();
+        assertThat(response.results().get(0).response().aiMessage().text()).isEqualTo("A");
+        assertThat(response.results().get(1).error().message()).isEqualTo("boom");
+        assertThat(response.results().get(2).error().message()).isEqualTo("rate limited");
+    }
+
+    @Test
+    void cancel_calls_the_cancel_endpoint() {
+        model().cancel("batch_1");
+        assertThat(cancelCalled).isTrue();
+    }
+
+    @Test
+    void list_maps_page_based_pagination_cursor() {
+        BatchPage<ChatResponse> page = model().list(new BatchPagination(10, null));
+
+        assertThat(page.batches()).hasSize(1);
+        assertThat(page.batches().get(0).state()).isEqualTo(BatchState.SUCCEEDED);
+        assertThat(page.nextPageToken()).isEqualTo("1");
+    }
+
+    @Test
+    void retrieve_while_running_returns_running_and_does_not_fetch_results() {
+        BatchResponse<ChatResponse> response = model().retrieve("batch_running");
+
+        assertThat(response.state()).isEqualTo(BatchState.RUNNING);
+        assertThat(response.results()).isEmpty();
+        assertThat(resultsFileFetched).isFalse();
+    }
+
+    @Test
+    void retrieve_maps_result_line_with_error_status_code_to_failure() {
+        BatchResponse<ChatResponse> response = model().retrieve("batch_statusfail");
+
+        assertThat(response.results()).hasSize(1);
+        BatchItemResult<ChatResponse> result = response.results().get(0);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.error().code()).isEqualTo(400);
+    }
+
+    @Test
+    void list_with_null_pagination_sends_no_query_params_and_returns_batches() {
+        BatchPage<ChatResponse> page = model().list(null);
+
+        assertThat(page.batches()).hasSize(1);
+        assertThat(capturedListQuery.get()).isNull();
+    }
+
+    private static String read(InputStream inputStream) throws IOException {
+        try (inputStream) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}


### PR DESCRIPTION
## Issue

Progresses #3916

## Change
Adds `MistralAiBatchChatModel`, an implementation of the core `BatchChatModel` interface for the
[Mistral Batch API](https://docs.mistral.ai/capabilities/batch/), which processes many chat requests
asynchronously at 50% of the standard per-token price. It follows the existing
`GoogleAiGeminiBatchChatModel`, so both providers expose the same `submit` / `retrieve` / `cancel` /
`list` surface.

Each `ChatRequest` is built through the same path `MistralAiChatModel` uses (`createMistralAiRequest`),
so per-request parameters (temperature, tools, response format, etc.) behave identically in a batch and
in a single call. Requests are submitted inline, so no separate file upload is needed; once a job
completes, its results are downloaded from the `output_file` / `error_file` and re-sorted back to
submission order using generated `custom_id`s. Mistral's job statuses map onto the core `BatchState`:

| Mistral status | `BatchState` |
|---|---|
| `QUEUED` | `PENDING` |
| `RUNNING`, `CANCELLATION_REQUESTED` | `RUNNING` |
| `SUCCESS` | `SUCCEEDED` |
| `FAILED` | `FAILED` |
| `TIMEOUT_EXCEEDED` | `EXPIRED` |
| `CANCELLED` | `CANCELLED` |

The batch operations (create / retrieve / cancel / list jobs, and downloading a result file) are added
to the existing hand-rolled `MistralAiClient`. They are non-abstract methods that throw
`UnsupportedFeatureException` by default, so existing `MistralAiClient` implementations keep compiling
and are unaffected. No new dependency is introduced.

Scope:
- Chat requests only.
- One model per job (a Mistral constraint): the model configured on the batch model applies to every
  request in the batch.
- Inline submission (the documented path for batches under 10,000 requests); the file-upload submission
  path is not included.

Verified with unit tests against a mock HTTP server  custom-id ordering, success/error mapping,
`output_file` + `error_file` merge, the running-state short-circuit (no results fetched until the job
produces them), status-code failures, and pagination  and with a key-gated integration test
(`MistralAiBatchChatModelIT`) run end-to-end against the live Batch API (submit → poll to completion →
read results, plus cancel and list).

## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the core and main modules, and they are all green
- [X] I have added/updated the documentation
- [ ] I have added an example in the examples repo (only for "big" features)
- [ ] I have added/updated Spring Boot starter(s) (if applicable)