### PR TITLE
fix: Skills: Declare shell tool timeout_seconds as integer and route bad values through typed exception

### DIFF
--- a/experimental/langchain4j-experimental-skills-shell/src/main/java/dev/langchain4j/skills/shell/RunShellCommandToolExecutor.java
+++ b/experimental/langchain4j-experimental-skills-shell/src/main/java/dev/langchain4j/skills/shell/RunShellCommandToolExecutor.java
@@ -119,7 +119,15 @@ class RunShellCommandToolExecutor implements ToolExecutor {
         if (timeoutSeconds instanceof Integer i) {
             return i;
         }
-        return Integer.valueOf(timeoutSeconds.toString());
+        try {
+            return Integer.valueOf(timeoutSeconds.toString());
+        } catch (NumberFormatException e) {
+            throwException(
+                    "Invalid value for tool argument '%s': '%s'"
+                            .formatted(config.timeoutSecondsParameterName, timeoutSeconds),
+                    e);
+            return null; // unreachable
+        }
     }
 
     private String formatStdOut(String stdOut) {

--- a/experimental/langchain4j-experimental-skills-shell/src/main/java/dev/langchain4j/skills/shell/ShellSkills.java
+++ b/experimental/langchain4j-experimental-skills-shell/src/main/java/dev/langchain4j/skills/shell/ShellSkills.java
@@ -118,7 +118,7 @@ public class ShellSkills {
                 .description(rsc.description)
                 .parameters(JsonObjectSchema.builder()
                         .addStringProperty(rsc.commandParameterName, rsc.commandParameterDescription)
-                        .addStringProperty(rsc.timeoutSecondsParameterName, rsc.timeoutSecondsParameterDescription)
+                        .addIntegerProperty(rsc.timeoutSecondsParameterName, rsc.timeoutSecondsParameterDescription)
                         .required(rsc.commandParameterName)
                         .build())
                 .addMetadata(METADATA_SEARCH_BEHAVIOR, ALWAYS_VISIBLE)

--- a/experimental/langchain4j-experimental-skills-shell/src/test/java/dev/langchain4j/skills/shell/RunShellCommandToolExecutorTest.java
+++ b/experimental/langchain4j-experimental-skills-shell/src/test/java/dev/langchain4j/skills/shell/RunShellCommandToolExecutorTest.java
@@ -47,6 +47,26 @@ class RunShellCommandToolExecutorTest {
     }
 
     @Test
+    void should_throw_ToolExecutionException_when_timeout_seconds_is_not_a_number() {
+        RunShellCommandToolExecutor executor = executor(false);
+
+        assertThatThrownBy(() -> executor.executeWithContext(
+                        requestWithRawArguments("{\"command\": \"echo x\", \"timeout_seconds\": \"abc\"}"), null))
+                .isInstanceOf(ToolExecutionException.class)
+                .hasMessageContaining("Invalid value for tool argument");
+    }
+
+    @Test
+    void should_throw_ToolArgumentsException_when_timeout_seconds_is_not_a_number() {
+        RunShellCommandToolExecutor executor = executor(true);
+
+        assertThatThrownBy(() -> executor.executeWithContext(
+                        requestWithRawArguments("{\"command\": \"echo x\", \"timeout_seconds\": \"abc\"}"), null))
+                .isInstanceOf(ToolArgumentsException.class)
+                .hasMessageContaining("Invalid value for tool argument");
+    }
+
+    @Test
     @DisabledOnOs(OS.WINDOWS)
     void should_not_truncate_stdout_on_success_when_within_limit_on_unix() {
         ToolExecutionResult result = executor(100, 100).executeWithContext(request("echo hello"), null);


### PR DESCRIPTION
## Issue
Closes #5751

## Change

Two complementary changes so the run_shell_command tool handles timeout_seconds robustly — prevention at the schema level, containment at the parse level.

  1. Schema (prevention). ShellSkills registered timeout_seconds via addStringProperty, even though the value is semantically an integer (ShellCommandRunner.run(..., Integer timeoutSeconds, ...), described as
  "The command timeout in seconds"). Advertising it as a string invites the LLM to return non-integer text like "30 seconds", "1.5", or "". This changes it to addIntegerProperty, so the schema communicates the
  constraint to the model. RunShellCommandToolExecutor.resolveTimeout(...) already had a first-class Integer branch, so no executor change is needed for the happy path.

  2. Parse guard (containment). JSON-schema adherence is not guaranteed across providers — a model can still emit a string (or free text) for an integer property. resolveTimeout(...) parsed the value with
  Integer.valueOf(timeoutSeconds.toString()) and no guard, so a bad value produced a raw NumberFormatException that propagated out of executeWithContext, bypassing the tool's argument-error contract that every
  other argument error in this class honors. This wraps the parse and routes NumberFormatException through the existing throwException(...) path, mirroring parseArguments. A malformed timeout_seconds now yields
  ToolExecutionException by default (message returned to the LLM), or ToolArgumentsException when throwToolArgumentsExceptions(true).

  The string-parse fallback in resolveTimeout is intentionally kept — it remains the containment layer for providers that don't emit a strict integer. The two layers together mean bad timeout values become rare
  at the source and fail gracefully when they still occur.

  Signature, public Java API, and the normal path (null, Integer, valid numeric string) are unchanged. The schema type change affects only the tool specification advertised to the LLM, in an experimental module.

  Tests: two negative tests added — non-numeric timeout_seconds throws ToolExecutionException under the default config and ToolArgumentsException under throwToolArgumentsExceptions(true). The existing positive
  test_resolveTimeout still passes and covers both Integer (1) and String ("1") inputs, exercising the retained string fallback.


## General checklist
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green <!-- N/A — change is isolated to experimental/langchain4j-experimental-skills-shell; core/main untouched -->
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs) <!-- N/A — bug fix, no doc change -->
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features) <!-- N/A -->
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)
