### PR TITLE
fix: preserve precision of long/BigInteger/BigDecimal tool arguments

### DIFF
--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -364,7 +364,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         }
 
         if (parameterClass == BigDecimal.class) {
-            return BigDecimal.valueOf(getDoubleValue(argument, parameterName, parameterClass));
+            return getBigDecimalValue(argument, parameterName, parameterClass);
         }
 
         if (parameterClass == Integer.class || parameterClass == int.class) {
@@ -386,8 +386,14 @@ public class DefaultToolExecutor implements ToolExecutor {
         }
 
         if (parameterClass == BigInteger.class) {
-            return BigDecimal.valueOf(getNonFractionalDoubleValue(argument, parameterName, parameterClass))
-                    .toBigInteger();
+            BigDecimal bigDecimalValue = getBigDecimalValue(argument, parameterName, parameterClass);
+            try {
+                return bigDecimalValue.toBigIntegerExact();
+            } catch (ArithmeticException e) {
+                throw new IllegalArgumentException(String.format(
+                        "Argument \"%s\" has non-integer value for %s: <%s>",
+                        parameterName, parameterClass.getName(), argument));
+            }
         }
 
         if (Collection.class.isAssignableFrom(parameterClass) || Map.class.isAssignableFrom(parameterClass)) {
@@ -423,16 +429,6 @@ public class DefaultToolExecutor implements ToolExecutor {
         return ((Number) argument).doubleValue();
     }
 
-    private static double getNonFractionalDoubleValue(Object argument, String parameterName, Class<?> parameterType) {
-        double doubleValue = getDoubleValue(argument, parameterName, parameterType);
-        if (!hasNoFractionalPart(doubleValue)) {
-            throw new IllegalArgumentException(String.format(
-                    "Argument \"%s\" has non-integer value for %s: <%s>",
-                    parameterName, parameterType.getName(), argument));
-        }
-        return doubleValue;
-    }
-
     private static void checkBounds(
             double doubleValue, String parameterName, Class<?> parameterType, double minValue, double maxValue) {
         if (doubleValue < minValue || doubleValue > maxValue) {
@@ -444,9 +440,58 @@ public class DefaultToolExecutor implements ToolExecutor {
 
     public static long getBoundedLongValue(
             Object argument, String parameterName, Class<?> parameterType, long minValue, long maxValue) {
-        double doubleValue = getNonFractionalDoubleValue(argument, parameterName, parameterType);
-        checkBounds(doubleValue, parameterName, parameterType, minValue, maxValue);
-        return (long) doubleValue;
+        // Convert via BigDecimal to preserve the exact integer value. Going through double would
+        // silently lose precision for magnitudes above 2^53 (e.g. a long 9007199254740993 would
+        // become 9007199254740992).
+        BigDecimal bigDecimalValue = getBigDecimalValue(argument, parameterName, parameterType);
+        BigInteger bigIntegerValue;
+        try {
+            bigIntegerValue = bigDecimalValue.toBigIntegerExact();
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException(String.format(
+                    "Argument \"%s\" has non-integer value for %s: <%s>",
+                    parameterName, parameterType.getName(), argument));
+        }
+        if (bigIntegerValue.compareTo(BigInteger.valueOf(minValue)) < 0
+                || bigIntegerValue.compareTo(BigInteger.valueOf(maxValue)) > 0) {
+            throw new IllegalArgumentException(String.format(
+                    "Argument \"%s\" is out of range for %s: <%s>", parameterName, parameterType.getName(), argument));
+        }
+        return bigIntegerValue.longValue();
+    }
+
+    /**
+     * Converts the argument to a {@link BigDecimal} preserving its exact value.
+     * Unlike converting through {@code double}, this does not lose precision for large integers
+     * or introduce floating-point representation error.
+     */
+    private static BigDecimal getBigDecimalValue(Object argument, String parameterName, Class<?> parameterType) {
+        if (argument instanceof BigDecimal bigDecimal) {
+            return bigDecimal;
+        }
+        if (argument instanceof BigInteger bigInteger) {
+            return new BigDecimal(bigInteger);
+        }
+        // Long/Integer/Short/Byte have exact string representations; Double/Float are rendered via
+        // Number.toString() (matching the behavior of IsEqualTo's numeric comparison).
+        if (argument instanceof Number number) {
+            return new BigDecimal(number.toString());
+        }
+        if (argument instanceof String) {
+            try {
+                // Trim to tolerate surrounding whitespace, matching the leniency of Double.parseDouble
+                // that the previous double-based conversion relied on.
+                return new BigDecimal(argument.toString().trim());
+            } catch (NumberFormatException e) {
+                // fall through to the error below
+            }
+        }
+        throw new IllegalArgumentException(String.format(
+                "Argument \"%s\" is not convertable to %s, got %s: <%s>",
+                parameterName,
+                parameterType.getName(),
+                argument == null ? "null" : argument.getClass().getName(),
+                argument));
     }
 
     static boolean hasNoFractionalPart(Double doubleValue) {

--- a/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
+++ b/langchain4j/src/main/java/dev/langchain4j/service/tool/DefaultToolExecutor.java
@@ -386,14 +386,7 @@ public class DefaultToolExecutor implements ToolExecutor {
         }
 
         if (parameterClass == BigInteger.class) {
-            BigDecimal bigDecimalValue = getBigDecimalValue(argument, parameterName, parameterClass);
-            try {
-                return bigDecimalValue.toBigIntegerExact();
-            } catch (ArithmeticException e) {
-                throw new IllegalArgumentException(String.format(
-                        "Argument \"%s\" has non-integer value for %s: <%s>",
-                        parameterName, parameterClass.getName(), argument));
-            }
+            return getBigIntegerValue(argument, parameterName, parameterClass);
         }
 
         if (Collection.class.isAssignableFrom(parameterClass) || Map.class.isAssignableFrom(parameterClass)) {
@@ -440,24 +433,29 @@ public class DefaultToolExecutor implements ToolExecutor {
 
     public static long getBoundedLongValue(
             Object argument, String parameterName, Class<?> parameterType, long minValue, long maxValue) {
-        // Convert via BigDecimal to preserve the exact integer value. Going through double would
-        // silently lose precision for magnitudes above 2^53 (e.g. a long 9007199254740993 would
-        // become 9007199254740992).
-        BigDecimal bigDecimalValue = getBigDecimalValue(argument, parameterName, parameterType);
-        BigInteger bigIntegerValue;
-        try {
-            bigIntegerValue = bigDecimalValue.toBigIntegerExact();
-        } catch (ArithmeticException e) {
-            throw new IllegalArgumentException(String.format(
-                    "Argument \"%s\" has non-integer value for %s: <%s>",
-                    parameterName, parameterType.getName(), argument));
-        }
+        BigInteger bigIntegerValue = getBigIntegerValue(argument, parameterName, parameterType);
         if (bigIntegerValue.compareTo(BigInteger.valueOf(minValue)) < 0
                 || bigIntegerValue.compareTo(BigInteger.valueOf(maxValue)) > 0) {
             throw new IllegalArgumentException(String.format(
                     "Argument \"%s\" is out of range for %s: <%s>", parameterName, parameterType.getName(), argument));
         }
         return bigIntegerValue.longValue();
+    }
+
+    /**
+     * Converts the argument to a {@link BigInteger} preserving its exact value.
+     * Going through {@code double} would silently lose precision for magnitudes above 2^53
+     * (e.g. a long 9007199254740993 would become 9007199254740992).
+     */
+    private static BigInteger getBigIntegerValue(Object argument, String parameterName, Class<?> parameterType) {
+        BigDecimal bigDecimalValue = getBigDecimalValue(argument, parameterName, parameterType);
+        try {
+            return bigDecimalValue.toBigIntegerExact();
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException(String.format(
+                    "Argument \"%s\" has non-integer value for %s: <%s>",
+                    parameterName, parameterType.getName(), argument));
+        }
     }
 
     /**
@@ -492,10 +490,6 @@ public class DefaultToolExecutor implements ToolExecutor {
                 parameterType.getName(),
                 argument == null ? "null" : argument.getClass().getName(),
                 argument));
-    }
-
-    static boolean hasNoFractionalPart(Double doubleValue) {
-        return doubleValue.equals(Math.floor(doubleValue));
     }
 
     public static Builder builder() {

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -28,14 +28,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 class DefaultToolExecutorTest implements WithAssertions {
 
-    @Test
-    void tesT_hasNoFractionalPart() {
-        assertThat(DefaultToolExecutor.hasNoFractionalPart(3.0)).isTrue();
-        assertThat(DefaultToolExecutor.hasNoFractionalPart(-3.0)).isTrue();
-        assertThat(DefaultToolExecutor.hasNoFractionalPart(3.5)).isFalse();
-        assertThat(DefaultToolExecutor.hasNoFractionalPart(-3.5)).isFalse();
-    }
-
     public enum ExampleEnum {
         A,
         B,

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/DefaultToolExecutorTest.java
@@ -284,6 +284,52 @@ class DefaultToolExecutorTest implements WithAssertions {
                 .isEqualTo(singletonMap("A", 1));
     }
 
+    @Test
+    void coerce_argument_preserves_precision_of_large_long() {
+        // A JSON integer above 2^53 is deserialized as a Long by Jackson. Converting via double
+        // would silently corrupt it (9007199254740993 -> 9007199254740992).
+        long largeLong = 9007199254740993L; // 2^53 + 1
+
+        assertThat(coerceArgument(largeLong, "arg", long.class, null)).isEqualTo(largeLong);
+        assertThat(coerceArgument(largeLong, "arg", Long.class, null)).isEqualTo(largeLong);
+        assertThat(coerceArgument(Long.MAX_VALUE, "arg", long.class, null)).isEqualTo(Long.MAX_VALUE);
+        assertThat(coerceArgument(Long.MIN_VALUE, "arg", long.class, null)).isEqualTo(Long.MIN_VALUE);
+    }
+
+    @Test
+    void coerce_argument_preserves_precision_of_large_big_integer() {
+        // A JSON integer larger than Long.MAX_VALUE is deserialized as a BigInteger by Jackson.
+        BigInteger largeBigInteger = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.TEN);
+
+        assertThat(coerceArgument(largeBigInteger, "arg", BigInteger.class, null))
+                .isEqualTo(largeBigInteger);
+        // A large integral value must not be routed through double for a BigInteger parameter.
+        BigInteger aboveDoublePrecision = new BigInteger("9007199254740993"); // 2^53 + 1
+        assertThat(coerceArgument(aboveDoublePrecision, "arg", BigInteger.class, null))
+                .isEqualTo(aboveDoublePrecision);
+    }
+
+    @Test
+    void coerce_argument_preserves_precision_of_big_decimal() {
+        // 0.1 has no exact double representation; converting via new BigDecimal(double) would yield
+        // 0.1000000000000000055511151231257827021181583404541015625. Rendering via Number.toString()
+        // (as BigDecimal.valueOf(double) does) keeps it as "0.1".
+        assertThat(coerceArgument(0.1, "arg", BigDecimal.class, null)).isEqualTo(new BigDecimal("0.1"));
+        // A BigDecimal argument must be preserved exactly.
+        BigDecimal preciseValue = new BigDecimal("1234567890.123456789");
+        assertThat(coerceArgument(preciseValue, "arg", BigDecimal.class, null)).isEqualTo(preciseValue);
+    }
+
+    @Test
+    void coerce_argument_rejects_fractional_value_for_integer_types() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> coerceArgument(1.5, "arg", long.class, null))
+                .withMessageContaining("has non-integer value");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> coerceArgument(1.5, "arg", BigInteger.class, null))
+                .withMessageContaining("has non-integer value");
+    }
+
     private static class TestTool {
 
         @Tool

--- a/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutorTest.java
+++ b/langchain4j/src/test/java/dev/langchain4j/service/tool/ToolExecutorTest.java
@@ -128,14 +128,17 @@ class ToolExecutorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(
-            strings = {
-                "{\"arg0\": 2, \"arg1\": 2}",
-                "{\"arg0\": 2.0, \"arg1\": 2.0}",
-                "{\"arg0\": 1.9, \"arg1\": 2.1}",
-            })
-    void should_execute_tool_with_parameters_of_type_BigDecimal(String arguments) throws NoSuchMethodException {
-        executeAndAssert(arguments, "bigDecimals", BigDecimal.class, BigDecimal.class, "4.0");
+    @CsvSource({
+        // BigDecimal arguments are now converted preserving their exact value/scale instead of being
+        // routed through double, so a JSON integer 2 becomes BigDecimal("2") (2 + 2 = 4) while a JSON
+        // decimal 2.0 becomes BigDecimal("2.0") (2.0 + 2.0 = 4.0).
+        "'{\"arg0\": 2, \"arg1\": 2}', 4",
+        "'{\"arg0\": 2.0, \"arg1\": 2.0}', 4.0",
+        "'{\"arg0\": 1.9, \"arg1\": 2.1}', 4.0",
+    })
+    void should_execute_tool_with_parameters_of_type_BigDecimal(String arguments, String expectedResult)
+            throws NoSuchMethodException {
+        executeAndAssert(arguments, "bigDecimals", BigDecimal.class, BigDecimal.class, expectedResult);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Issue
Closes #5754

## Change

`DefaultToolExecutor.coerceArgument(...)` converted `long`/`int`/`short`/`byte`/`BigInteger`/`BigDecimal` tool arguments by routing them through a `double`, which silently corrupts values that can't be represented exactly as a `double`:

- `getBoundedLongValue(...)` did `(long) ((Number) argument).doubleValue()`.
- The `BigInteger` branch did `BigDecimal.valueOf(getNonFractionalDoubleValue(...)).toBigInteger()`.
- The `BigDecimal` branch did `BigDecimal.valueOf(getDoubleValue(...))`.

Since tool-call argument JSON is deserialized into a `Map<String, Object>`, a JSON integer above 2^53 arrives as a `Long` (or a `BigInteger` above `Long.MAX_VALUE`), so this is reachable on a normal path. Examples of the corruption:

- `long` param, arg `9007199254740993` (2^53+1) → delivered as `9007199254740992`.
- `BigInteger` param, arg `9223372036854775817` → `9223372036854776000`.
- `BigDecimal` param, arg `1234567890.123456789` → `1234567890.1234567`.

This is the same class of bug as the already-merged #5503 (AwsDocumentConverter), but in the shared `DefaultToolExecutor` path.

The fix introduces a `getBigDecimalValue(...)` helper that converts the argument to a `BigDecimal` preserving its exact value, and:
- `long`/`int`/`short`/`byte` go through `BigDecimal.toBigIntegerExact()` + a `BigInteger` range check (no `double`).
- `BigInteger` uses `toBigIntegerExact()`.
- `BigDecimal` is built from the argument's exact value / string.

Care was taken to preserve existing behavior:
- The existing \"has non-integer value\" and \"is out of range\" error messages are kept.
- String input is trimmed before parsing, matching the whitespace leniency of the previous `Double.parseDouble` path — this path is also used by the numeric `*OutputParser`s (e.g. `LongOutputParser`), which call `getBoundedLongValue` as a fallback for whitespace-padded input.

One intentional, more-correct behavior change: `BigDecimal` arguments now preserve their exact scale — a JSON integer `2` becomes `BigDecimal(\"2\")` instead of `BigDecimal(\"2.0\")`. `ToolExecutorTest.should_execute_tool_with_parameters_of_type_BigDecimal` is updated to assert the corrected per-input results (`2 + 2 = 4`, `2.0 + 2.0 = 4.0`).

## General checklist
- [X] There are no breaking changes (API); the only behavior change is that numeric arguments are now converted *correctly* instead of being silently corrupted (plus BigDecimal scale is now preserved)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Test plan
- Added `coerce_argument_preserves_precision_of_large_long`, `coerce_argument_preserves_precision_of_large_big_integer`, `coerce_argument_preserves_precision_of_big_decimal`, and `coerce_argument_rejects_fractional_value_for_integer_types` to `DefaultToolExecutorTest`.
- Verified the three precision tests fail without the fix (`9007199254740993` → `...992`, `9223372036854775817` → `...776000`, `1234567890.123456789` → `...1234567`) and pass with it.
- Verified the existing comprehensive `coerce_argument` test and the numeric `*OutputParser` tests (which share `getBoundedLongValue`) still pass — the whitespace-tolerance fix was needed to keep them green.
- Ran the full `langchain4j` module suite (1262 tests) and `langchain4j-core` — all green.
- Ran `./mvnw spotless:check` — clean.