### PR TITLE
fix: tear down previous MCP connection on reconnect to avoid resource leak

### DIFF
--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/http/HttpMcpTransport.java
@@ -45,7 +45,8 @@ public class HttpMcpTransport implements McpTransport {
     private final OkHttpClient client;
     private final boolean logResponses;
     private final boolean logRequests;
-    private EventSource mcpSseEventListener;
+    // (re)assigned by start(), which may be invoked again from the reconnect thread, so volatile
+    private volatile EventSource mcpSseEventListener;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String CONTENT_TYPE_JSON = "application/json";
@@ -74,6 +75,12 @@ public class HttpMcpTransport implements McpTransport {
 
     @Override
     public void start(McpOperationHandler messageHandler) {
+        // start() may be called again during reconnection. Cancel any previous SSE channel first,
+        // otherwise the old EventSource (and its connection) is leaked on every reconnect.
+        if (mcpSseEventListener != null) {
+            mcpSseEventListener.cancel();
+            mcpSseEventListener = null;
+        }
         this.messageHandler = messageHandler;
         mcpSseEventListener = startSseChannel(logResponses);
     }

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandler.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/ProcessStderrHandler.java
@@ -10,11 +10,15 @@ import org.slf4j.LoggerFactory;
 class ProcessStderrHandler implements Runnable, Closeable {
 
     private final Process process;
-    private static final Logger log = LoggerFactory.getLogger(ProcessStderrHandler.class);
+    // Resolved per instance (in the constructor) rather than in a static initializer so that the
+    // logger reflects any LoggerFactory configuration in effect when the handler is created, and is
+    // not fixed at class-load time (which also makes this class testable in isolation).
+    private final Logger log;
     private volatile boolean closed = false;
 
     public ProcessStderrHandler(final Process process) {
         this.process = process;
+        this.log = LoggerFactory.getLogger(ProcessStderrHandler.class);
     }
 
     @Override

--- a/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
+++ b/langchain4j-mcp/src/main/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransport.java
@@ -27,14 +27,16 @@ public class StdioMcpTransport implements McpTransport {
 
     private final List<String> command;
     private final Map<String, String> environment;
-    private Process process;
-    private JsonRpcIoHandler jsonRpcIoHandler;
+    // These are (re)assigned by start(), which may be invoked again from the health-check thread
+    // during reconnection, so they are volatile to ensure visibility across threads.
+    private volatile Process process;
+    private volatile JsonRpcIoHandler jsonRpcIoHandler;
     private final boolean logEvents;
     private final Logger logger;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Logger log = LoggerFactory.getLogger(StdioMcpTransport.class);
     private volatile McpOperationHandler messageHandler;
-    private ProcessStderrHandler stderrHandler;
+    private volatile ProcessStderrHandler stderrHandler;
     private ExecutorService executorService;
     private boolean shouldShutdownExecutorService;
 
@@ -52,6 +54,10 @@ public class StdioMcpTransport implements McpTransport {
 
     @Override
     public void start(McpOperationHandler messageHandler) {
+        // start() may be called again during reconnection (e.g. from the health-check thread).
+        // Tear down any previous process and I/O handlers first, otherwise the old subprocess and
+        // its handler tasks are leaked on every reconnect.
+        stopCurrentProcess();
         this.messageHandler = messageHandler;
         log.debug("Starting process: {}", command);
         ProcessBuilder processBuilder = new ProcessBuilder(command);
@@ -130,16 +136,35 @@ public class StdioMcpTransport implements McpTransport {
         // ignore, for stdio transport, we currently don't do reconnection attempts
     }
 
+    /**
+     * Closes the current I/O handlers and destroys the current subprocess, if any.
+     * Does not shut down the (potentially shared) executor service, so it is safe to call
+     * before starting a replacement process during reconnection.
+     */
+    private void stopCurrentProcess() {
+        if (stderrHandler != null) {
+            try {
+                stderrHandler.close();
+            } catch (Exception ignored) {
+            }
+            stderrHandler = null;
+        }
+        if (jsonRpcIoHandler != null) {
+            try {
+                jsonRpcIoHandler.close();
+            } catch (Exception ignored) {
+            }
+            jsonRpcIoHandler = null;
+        }
+        if (process != null) {
+            process.destroy();
+            process = null;
+        }
+    }
+
     @Override
     public void close() throws IOException {
-        try {
-            stderrHandler.close();
-        } catch (Exception ignored) {
-        }
-        try {
-            jsonRpcIoHandler.close();
-        } catch (Exception ignored) {
-        }
+        stopCurrentProcess();
         if (executorService != null && shouldShutdownExecutorService) {
             executorService.shutdown();
             try {
@@ -151,7 +176,6 @@ public class StdioMcpTransport implements McpTransport {
                 Thread.currentThread().interrupt();
             }
         }
-        process.destroy();
     }
 
     public static Builder builder() {

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransportTest.java
@@ -1,0 +1,49 @@
+package dev.langchain4j.mcp.client.transport.stdio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import dev.langchain4j.mcp.client.transport.McpOperationHandler;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+class StdioMcpTransportTest {
+
+    /**
+     * When {@link StdioMcpTransport#start} is called again (as happens during reconnection triggered
+     * by the health check), the previous subprocess must be destroyed instead of leaked.
+     */
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void restarting_should_destroy_the_previous_process() throws IOException, InterruptedException {
+        // 'cat' with no arguments reads stdin indefinitely, so the process stays alive until destroyed
+        StdioMcpTransport transport = new StdioMcpTransport.Builder()
+                .command(List.of("cat"))
+                .environment(Map.of())
+                .build();
+
+        McpOperationHandler messageHandler = mock(McpOperationHandler.class);
+
+        transport.start(messageHandler);
+        Process firstProcess = transport.getProcess();
+        assertThat(firstProcess.isAlive()).isTrue();
+
+        // Restart (simulating a reconnection)
+        transport.start(messageHandler);
+        Process secondProcess = transport.getProcess();
+
+        // The previous process must have been torn down, not leaked
+        assertThat(secondProcess).isNotSameAs(firstProcess);
+        assertThat(firstProcess.waitFor(5, java.util.concurrent.TimeUnit.SECONDS))
+                .as("the previous process should have been destroyed on restart")
+                .isTrue();
+        assertThat(firstProcess.isAlive()).isFalse();
+        assertThat(secondProcess.isAlive()).isTrue();
+
+        transport.close();
+    }
+}

--- a/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransportTest.java
+++ b/langchain4j-mcp/src/test/java/dev/langchain4j/mcp/client/transport/stdio/StdioMcpTransportTest.java
@@ -7,6 +7,9 @@ import dev.langchain4j.mcp.client.transport.McpOperationHandler;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -20,30 +23,39 @@ class StdioMcpTransportTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void restarting_should_destroy_the_previous_process() throws IOException, InterruptedException {
-        // 'cat' with no arguments reads stdin indefinitely, so the process stays alive until destroyed
-        StdioMcpTransport transport = new StdioMcpTransport.Builder()
-                .command(List.of("cat"))
-                .environment(Map.of())
-                .build();
+        // Use a private executor so the background I/O handler threads spawned for the subprocess do
+        // not leak into the shared default executor and interfere with other tests.
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        try {
+            // 'cat' with no arguments reads stdin indefinitely, so the process stays alive until destroyed
+            StdioMcpTransport transport = new StdioMcpTransport.Builder()
+                    .command(List.of("cat"))
+                    .environment(Map.of())
+                    .executorService(executorService)
+                    .build();
 
-        McpOperationHandler messageHandler = mock(McpOperationHandler.class);
+            McpOperationHandler messageHandler = mock(McpOperationHandler.class);
 
-        transport.start(messageHandler);
-        Process firstProcess = transport.getProcess();
-        assertThat(firstProcess.isAlive()).isTrue();
+            transport.start(messageHandler);
+            Process firstProcess = transport.getProcess();
+            assertThat(firstProcess.isAlive()).isTrue();
 
-        // Restart (simulating a reconnection)
-        transport.start(messageHandler);
-        Process secondProcess = transport.getProcess();
+            // Restart (simulating a reconnection)
+            transport.start(messageHandler);
+            Process secondProcess = transport.getProcess();
 
-        // The previous process must have been torn down, not leaked
-        assertThat(secondProcess).isNotSameAs(firstProcess);
-        assertThat(firstProcess.waitFor(5, java.util.concurrent.TimeUnit.SECONDS))
-                .as("the previous process should have been destroyed on restart")
-                .isTrue();
-        assertThat(firstProcess.isAlive()).isFalse();
-        assertThat(secondProcess.isAlive()).isTrue();
+            // The previous process must have been torn down, not leaked
+            assertThat(secondProcess).isNotSameAs(firstProcess);
+            assertThat(firstProcess.waitFor(5, TimeUnit.SECONDS))
+                    .as("the previous process should have been destroyed on restart")
+                    .isTrue();
+            assertThat(firstProcess.isAlive()).isFalse();
+            assertThat(secondProcess.isAlive()).isTrue();
 
-        transport.close();
+            transport.close();
+            secondProcess.waitFor(5, TimeUnit.SECONDS);
+        } finally {
+            executorService.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
## Issue
Closes #5756

## Change

When an MCP client reconnects (the built-in auto health check does this on failure, by default every 30s), `McpTransport.start(...)` is called again — but the stdio and legacy HTTP transports did not release the previous connection first, leaking it on every reconnect:

- **`StdioMcpTransport.start(...)`** overwrote `process` / `jsonRpcIoHandler` / `stderrHandler` without destroying/closing the previous ones. `close()` only destroyed the *last* process, so every prior subprocess (plus its two handler tasks) was leaked. Because the health check sends a `ping` (with `pingTimeout`) in addition to checking `process.isAlive()`, a slow-but-alive server whose ping exceeds `pingTimeout` triggers a reconnect while the old subprocess is still alive — leaking a live subprocess on every health-check interval.
- **`HttpMcpTransport.start(...)`** overwrote `mcpSseEventListener` with a new `EventSource` without cancelling the previous one, leaking an open SSE connection per reconnect.

The reconnect path: `DefaultMcpClient` health check → `checkHealth()` → on failure `triggerReconnection()` → `initialize()` → `transport.start(...)`.

The fix:
- `StdioMcpTransport.start(...)` calls a new `stopCurrentProcess()` helper first, which closes the current handlers and destroys the current process (if any). `close()` reuses the same helper, so it no longer NPEs if called before `start()`.
- `HttpMcpTransport.start(...)` cancels the previous `EventSource` before opening a new one.
- The fields written from the health-check thread (`process`, `jsonRpcIoHandler`, `stderrHandler`, `mcpSseEventListener`) are made `volatile` for visibility.

The newer `StreamableHttpMcpTransport.start(...)` only stores the operation handler and is not affected.

## General checklist
- [X] There are no breaking changes (API, behaviour) — reconnection now releases resources it previously leaked; `close()` behavior is preserved (and no longer NPEs if called before `start()`)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [X] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Test plan
- Added `StdioMcpTransportTest.restarting_should_destroy_the_previous_process`, which starts a real long-lived subprocess (`cat`), calls `start(...)` again (simulating a reconnect), and asserts the previous process is destroyed and the new one is alive.
- Verified the test fails without the fix (the first `cat` process is still alive after the restart — `waitFor(5s)` returns false) and passes with it.
- Ran the full `langchain4j-mcp` unit-test suite — all green (integration tests requiring a live MCP server / JBang are gated and skipped).
- Ran `./mvnw spotless:check` — clean.

Note: the test is `@DisabledOnOs(OS.WINDOWS)` since it relies on `cat`.