### PR TITLE
Fix race condition in AgentMonitor.onAgentInvocationError with parallel sub-agents

### DIFF
--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/AgentMonitor.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/AgentMonitor.java
@@ -128,13 +128,16 @@ public class AgentMonitor implements AgentListener {
     @Override
     public void onAgentInvocationError(AgentInvocationError agentInvocationError) {
         Object memoryId = agentInvocationError.agenticScope().memoryId();
-        MonitoredExecution execution = ongoingExecutions.remove(memoryId);
+        MonitoredExecution execution = ongoingExecutions.get(memoryId);
         if (execution != null) {
             execution.onAgentInvocationError(agentInvocationError);
-            synchronized (failedExecutions) {
-                failedExecutions
-                        .computeIfAbsent(memoryId, k -> new ArrayList<>())
-                        .add(execution);
+            if (execution.ongoingInvocations().isEmpty()) {
+                ongoingExecutions.remove(memoryId, execution);
+                synchronized (failedExecutions) {
+                    failedExecutions
+                            .computeIfAbsent(memoryId, k -> new ArrayList<>())
+                            .add(execution);
+                }
             }
         }
     }

--- a/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/MonitoredExecution.java
+++ b/langchain4j-agentic/src/main/java/dev/langchain4j/agentic/observability/MonitoredExecution.java
@@ -56,6 +56,7 @@ public class MonitoredExecution {
 
     void onAgentInvocationError(AgentInvocationError agentInvocationError) {
         this.agentInvocationError = agentInvocationError;
+        ongoingInvocations.remove(agentInvocationError.agentId());
     }
 
     void afterToolExecution(AfterAgentToolExecution afterToolExecution) {

--- a/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/observability/AgentMonitorParallelErrorTest.java
+++ b/langchain4j-agentic/src/test/java/dev/langchain4j/agentic/observability/AgentMonitorParallelErrorTest.java
@@ -1,0 +1,163 @@
+package dev.langchain4j.agentic.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import dev.langchain4j.agentic.planner.AgentInstance;
+import dev.langchain4j.agentic.planner.AgenticSystemTopology;
+import dev.langchain4j.agentic.scope.AgenticScope;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link AgentMonitor#onAgentInvocationError} does not remove the
+ * {@link MonitoredExecution} from {@code ongoingExecutions} while parallel sibling
+ * sub-agents are still running. The erroring agent is removed from the execution's
+ * {@code ongoingInvocations}, but the execution itself stays available until all
+ * agents complete.
+ */
+class AgentMonitorParallelErrorTest {
+
+    /**
+     * When one parallel sub-agent errors, sibling sub-agents that complete afterwards
+     * must still find the shared {@link MonitoredExecution} in {@code ongoingExecutions}.
+     */
+    @Test
+    void parallel_sub_agent_error_should_not_cause_npe_for_sibling() {
+        AgentMonitor monitor = new AgentMonitor();
+
+        Object memoryId = "memory-parallel-error";
+        AgenticScope scope = stubScope(memoryId);
+
+        AgentInstance root = stubAgent("root", null);
+        AgentInstance subA = stubAgent("sub-a", root);
+        AgentInstance subB = stubAgent("sub-b", root);
+
+        // 1. Root agent starts
+        monitor.beforeAgentInvocation(new AgentRequest(scope, root, Map.of()));
+
+        // 2. Both sub-agents start (as a parallel agent would do)
+        monitor.beforeAgentInvocation(new AgentRequest(scope, subA, Map.of()));
+        monitor.beforeAgentInvocation(new AgentRequest(scope, subB, Map.of()));
+
+        // 3. Sub-agent A errors
+        monitor.onAgentInvocationError(
+                new AgentInvocationError(scope, subA, Map.of(), new RuntimeException("timeout")));
+
+        // 4. Sub-agent B completes successfully — this should NOT throw NPE
+        assertThatNoException().isThrownBy(() ->
+                monitor.afterAgentInvocation(new AgentResponse(scope, subB, Map.of(), "ok", null, null)));
+    }
+
+    /**
+     * Same scenario exercised with concurrent threads to verify thread-safety of the
+     * error and success paths when they overlap.
+     */
+    @Test
+    void concurrent_parallel_sub_agent_error_should_not_cause_npe_for_sibling() throws Exception {
+        AgentMonitor monitor = new AgentMonitor();
+
+        Object memoryId = "memory-concurrent-error";
+        AgenticScope scope = stubScope(memoryId);
+
+        AgentInstance root = stubAgent("root", null);
+        AgentInstance subA = stubAgent("sub-a", root);
+        AgentInstance subB = stubAgent("sub-b", root);
+
+        // Root and sub-agents register
+        monitor.beforeAgentInvocation(new AgentRequest(scope, root, Map.of()));
+        monitor.beforeAgentInvocation(new AgentRequest(scope, subA, Map.of()));
+        monitor.beforeAgentInvocation(new AgentRequest(scope, subB, Map.of()));
+
+        // Sub-agent A errors and sub-agent B succeeds concurrently
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> errorFuture = pool.submit(() -> {
+                awaitStart(start);
+                monitor.onAgentInvocationError(
+                        new AgentInvocationError(scope, subA, Map.of(), new RuntimeException("timeout")));
+            });
+
+            Future<?> successFuture = pool.submit(() -> {
+                awaitStart(start);
+                monitor.afterAgentInvocation(
+                        new AgentResponse(scope, subB, Map.of(), "ok", null, null));
+            });
+
+            start.countDown();
+
+            // Both should complete without exception
+            errorFuture.get(10, TimeUnit.SECONDS);
+            successFuture.get(10, TimeUnit.SECONDS);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * After one sub-agent errors, the root agent should still be able to complete
+     * the execution lifecycle (e.g., the parent catches the error and finishes).
+     */
+    @Test
+    void root_agent_can_complete_after_sub_agent_error() {
+        AgentMonitor monitor = new AgentMonitor();
+
+        Object memoryId = "memory-root-after-error";
+        AgenticScope scope = stubScope(memoryId);
+
+        AgentInstance root = stubAgent("root", null);
+        AgentInstance subA = stubAgent("sub-a", root);
+        AgentInstance subB = stubAgent("sub-b", root);
+
+        monitor.beforeAgentInvocation(new AgentRequest(scope, root, Map.of()));
+        monitor.beforeAgentInvocation(new AgentRequest(scope, subA, Map.of()));
+        monitor.beforeAgentInvocation(new AgentRequest(scope, subB, Map.of()));
+
+        // Sub-agent A errors
+        monitor.onAgentInvocationError(
+                new AgentInvocationError(scope, subA, Map.of(), new RuntimeException("timeout")));
+
+        // Sub-agent B succeeds
+        assertThatNoException().isThrownBy(() ->
+                monitor.afterAgentInvocation(new AgentResponse(scope, subB, Map.of(), "ok", null, null)));
+
+        // Root agent finishes — should not throw
+        assertThatNoException().isThrownBy(() ->
+                monitor.afterAgentInvocation(new AgentResponse(scope, root, Map.of(), "result", null, null)));
+
+        // The execution should be done and tracked (either as failed or successful)
+        assertThat(monitor.ongoingExecutionFor(memoryId)).isNull();
+    }
+
+    private static void awaitStart(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static AgentInstance stubAgent(String agentId, AgentInstance parent) {
+        AgentInstance agent = mock(AgentInstance.class);
+        when(agent.agentId()).thenReturn(agentId);
+        when(agent.name()).thenReturn(agentId);
+        when(agent.parent()).thenReturn(parent);
+        when(agent.topology()).thenReturn(AgenticSystemTopology.SEQUENCE);
+        return agent;
+    }
+
+    private static AgenticScope stubScope(Object memoryId) {
+        AgenticScope scope = mock(AgenticScope.class);
+        when(scope.memoryId()).thenReturn(memoryId);
+        return scope;
+    }
+}


### PR DESCRIPTION
<!--
Thank you so much for your contribution!

Please fill in all the sections below.
Please open the PR as ready for review (not as a draft), with tests and documentation already included.
Please note that PRs with breaking changes, or without tests and documentation, will be rejected.

Please note that PRs will be reviewed based on the priority of the issues they address.
We ask for your patience. We are doing our best to review your PR as quickly as possible.
Please refrain from pinging and asking when it will be reviewed. Thank you for understanding!
-->

## Issue
`AgentMonitor.onAgentInvocationError` unconditionally removed the entire `MonitoredExecution` from `ongoingExecutions` when any single agent errored. In a `ParallelAgent` scenario, if one sub-agent failed (e.g. a  `SocketTimeoutException`) while siblings were still running, those siblings would hit an `NPE` in `afterAgentInvocation` because the shared execution had already been removed.

Closes #

## Change

The fix makes `onAgentInvocationError` mirror the lifecycle of `afterAgentInvocation`: it removes only the erroring agent from the execution's `ongoingInvocations` and defers removal of the execution itself until all agents have completed.

## General checklist
<!-- Please double-check the following points and mark them like this: [X] -->
- [X] There are no breaking changes (API, behaviour)
- [X] I have added unit and/or integration tests for my change
- [X] The tests cover both positive and negative cases
- [X] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [ ] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)


## Checklist for adding new maven module
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added my new module in the root `pom.xml` and `langchain4j-bom/pom.xml`


## Checklist for adding new embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreIT` that extends from either `EmbeddingStoreIT` or `EmbeddingStoreWithFilteringIT`
- [ ] I have added a `{NameOfIntegration}EmbeddingStoreRemovalIT` that extends from `EmbeddingStoreWithRemovalIT`

## Checklist for changing existing embedding store integration
<!-- Please double-check the following points and mark them like this: [X] -->
- [ ] I have manually verified that the `{NameOfIntegration}EmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j
