### PR TITLE
fix: redact API key from CohereClient.Builder toString()

### DIFF
--- a/langchain4j-cohere/src/main/java/dev/langchain4j/model/cohere/CohereClient.java
+++ b/langchain4j-cohere/src/main/java/dev/langchain4j/model/cohere/CohereClient.java
@@ -1,22 +1,21 @@
 package dev.langchain4j.model.cohere;
 
+import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import dev.langchain4j.internal.Utils;
-import okhttp3.OkHttpClient;
-import org.slf4j.Logger;
-import retrofit2.Retrofit;
-import retrofit2.converter.jackson.JacksonConverterFactory;
-
 import java.io.IOException;
 import java.net.Proxy;
 import java.time.Duration;
 import java.util.Objects;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
+import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 class CohereClient {
 
@@ -29,7 +28,14 @@ class CohereClient {
     private final CohereApi cohereApi;
     private final String authorizationHeader;
 
-    CohereClient(String baseUrl, String apiKey, Duration timeout, Proxy proxy, Boolean logRequests, Boolean logResponses, Logger logger) {
+    CohereClient(
+            String baseUrl,
+            String apiKey,
+            Duration timeout,
+            Proxy proxy,
+            Boolean logRequests,
+            Boolean logResponses,
+            Logger logger) {
 
         OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
                 .callTimeout(timeout)
@@ -64,8 +70,8 @@ class CohereClient {
 
     EmbedResponse embed(EmbedRequest request) {
         try {
-            retrofit2.Response<EmbedResponse> retrofitResponse
-                    = cohereApi.embed(request, authorizationHeader).execute();
+            retrofit2.Response<EmbedResponse> retrofitResponse =
+                    cohereApi.embed(request, authorizationHeader).execute();
 
             if (retrofitResponse.isSuccessful()) {
                 return retrofitResponse.body();
@@ -94,8 +100,8 @@ class CohereClient {
 
     RerankResponse rerank(RerankRequest request) {
         try {
-            retrofit2.Response<RerankResponse> retrofitResponse
-                    = cohereApi.rerank(request, authorizationHeader).execute();
+            retrofit2.Response<RerankResponse> retrofitResponse =
+                    cohereApi.rerank(request, authorizationHeader).execute();
 
             if (retrofitResponse.isSuccessful()) {
                 return retrofitResponse.body();
@@ -123,8 +129,7 @@ class CohereClient {
         private Boolean logResponses;
         private Logger logger;
 
-        CohereClientBuilder() {
-        }
+        CohereClientBuilder() {}
 
         public CohereClientBuilder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
@@ -162,11 +167,20 @@ class CohereClient {
         }
 
         public CohereClient build() {
-            return new CohereClient(this.baseUrl, this.apiKey, this.timeout, this.proxy, this.logRequests, this.logResponses, this.logger);
+            return new CohereClient(
+                    this.baseUrl,
+                    this.apiKey,
+                    this.timeout,
+                    this.proxy,
+                    this.logRequests,
+                    this.logResponses,
+                    this.logger);
         }
 
         public String toString() {
-            return "CohereClient.CohereClientBuilder(baseUrl=" + this.baseUrl + ", apiKey=" + this.apiKey + ", timeout=" + this.timeout + ", proxy=" + this.proxy + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
+            return "CohereClient.CohereClientBuilder(baseUrl=" + this.baseUrl + ", apiKey="
+                    + (this.apiKey == null ? null : "********") + ", timeout=" + this.timeout + ", proxy="
+                    + this.proxy + ", logRequests=" + this.logRequests + ", logResponses=" + this.logResponses + ")";
         }
     }
 }

--- a/langchain4j-cohere/src/test/java/dev/langchain4j/model/cohere/CohereModelBuilderTest.java
+++ b/langchain4j-cohere/src/test/java/dev/langchain4j/model/cohere/CohereModelBuilderTest.java
@@ -39,4 +39,18 @@ class CohereModelBuilderTest {
 
         assertThat(toString).contains("apiKey=null");
     }
+
+    @Test
+    void clientBuilder_toString_should_mask_api_key() {
+        String toString = CohereClient.builder().apiKey("secret-api-key").toString();
+
+        assertThat(toString).doesNotContain("secret-api-key").contains("apiKey=********");
+    }
+
+    @Test
+    void clientBuilder_toString_should_render_null_api_key_as_null() {
+        String toString = CohereClient.builder().toString();
+
+        assertThat(toString).contains("apiKey=null");
+    }
 }


### PR DESCRIPTION
## What
Masks the `apiKey` field in `CohereClient.CohereClientBuilder#toString()`.

## Why
Fixes #2139. I audited every class in the repo with a field named `apiKey`/`secretKey`/`token`/`password`/etc. to find real `toString()` leaks (not just fields with those names). Nearly all builders already mask `apiKey` as `********` (e.g. `JinaClient`, `NomicClient`, `CohereEmbeddingModel`, `CohereScoringModel`, the web-search-engine clients) — this appears to have been handled as part of the earlier Lombok-removal work referenced in this issue's discussion. `CohereClient`'s builder was the one place that was missed and still printed the raw key.

Note: I did not find any remaining classes using Lombok's `@Builder`/`@Data` — that migration is already complete repo-wide, so the original "Lombok auto-generates toString()" root cause no longer applies. I scoped this PR to the one genuine leak I found, rather than doing a speculative, code-review-only pass over dozens of already-safe builders.

## Changes
- `CohereClient.CohereClientBuilder#toString()` now renders `apiKey=********` (or `apiKey=null`) instead of the raw value, matching the convention used by every other builder in the codebase.
- Added `clientBuilder_toString_should_mask_api_key` and `clientBuilder_toString_should_render_null_api_key_as_null` to `CohereModelBuilderTest`, following the same `*BuilderTest` pattern already used for `JinaClient`, `NomicEmbeddingModel`, etc.

## Testing
`./mvnw test -pl langchain4j-cohere -Dtest=CohereModelBuilderTest` — 6/6 pass.